### PR TITLE
Adding docker files

### DIFF
--- a/docker/2.0.0/runtime/jessie/amd64/Dockerfile
+++ b/docker/2.0.0/runtime/jessie/amd64/Dockerfile
@@ -19,4 +19,6 @@ COPY --from=installer-env ["/azure-functions-runtime", "/azure-functions-runtime
 
 ENV AzureWebJobsScriptRoot=/app
 
+ENV WEBSITE_HOSTNAME=localhost:80
+
 CMD ["dotnet", "/azure-functions-runtime/Microsoft.Azure.WebJobs.Script.WebHost.dll"]

--- a/docker/2.0.0/runtime/jessie/amd64/Dockerfile
+++ b/docker/2.0.0/runtime/jessie/amd64/Dockerfile
@@ -1,0 +1,22 @@
+FROM microsoft/dotnet:2.0-sdk-jessie AS installer-env
+
+ENV PublishWithAspNetCoreTargetManifest false
+ENV ScriptTag v2.0.11415-alpha
+
+RUN apt-get update && \
+    apt-get install git -y && \
+    git clone https://github.com/Azure/azure-webjobs-sdk-script --depth 1 && \
+    cd azure-webjobs-sdk-script && \
+    git fetch --all --tags && \
+    git checkout tags/${ScriptTag} && \
+    dotnet build WebJobs.Script.sln && \
+    dotnet publish src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj --output /azure-functions-runtime
+
+# Runtime image
+FROM microsoft/dotnet:2.0-runtime-jessie
+
+COPY --from=installer-env ["/azure-functions-runtime", "/azure-functions-runtime"]
+
+ENV AzureWebJobsScriptRoot=/app
+
+CMD ["dotnet", "/azure-functions-runtime/Microsoft.Azure.WebJobs.Script.WebHost.dll"]

--- a/docker/2.0.0/runtime/nanoserver-1709/amd64/Dockerfile
+++ b/docker/2.0.0/runtime/nanoserver-1709/amd64/Dockerfile
@@ -1,0 +1,51 @@
+# escape=`
+
+# Installer image
+FROM microsoft/windowsservercore:1709 AS installer-env
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# Retrieve .NET Core SDK
+ENV DOTNET_SDK_VERSION 2.0.2
+ENV DOTNET_SDK_DOWNLOAD_URL https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-win-x64.zip
+ENV DOTNET_SDK_DOWNLOAD_SHA 4864A36D3BE9D460A17D0EBE9D03B17CE224EC18880BCDBC087889F32DDFC2CF3753A1AB7D0414B1E73E863E0D10F5A8381E80EFFC7F7C0A50600DD82A1F0048
+
+# Trigger the population of the local package cache
+ENV NUGET_XMLDOC_MODE skip
+
+RUN Invoke-WebRequest $Env:DOTNET_SDK_DOWNLOAD_URL -OutFile dotnet.zip; `
+    if ((Get-FileHash dotnet.zip -Algorithm sha512).Hash -ne $Env:DOTNET_SDK_DOWNLOAD_SHA) { `
+        Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
+        exit 1; `
+    }; `
+    `
+    Expand-Archive dotnet.zip -DestinationPath $Env:ProgramFiles\dotnet; `
+    Remove-Item -Force dotnet.zip; `
+    setx /M PATH $($Env:PATH + ';' + $Env:ProgramFiles + '\dotnet')
+
+RUN New-Item -Type Directory warmup;; `
+    cd warmup; `
+    dotnet new; `
+    cd .. ;`
+    Remove-Item -Force -Recurse warmup
+
+ENV PublishWithAspNetCoreTargetManifest false
+RUN iwr https://github.com/Azure/azure-webjobs-sdk-script/archive/dev.zip -OutFile dev.zip; `
+    Expand-Archive dev.zip .; `
+    cd azure-webjobs-sdk-script-dev; `
+    dotnet restore WebJobs.Script.sln; `
+    mkdir src\WebJobs.Script.Grpc\Messages\DotNet; `
+    cd src\WebJobs.Script.Grpc; `
+    Invoke-Command -ScriptBlock {cmd /c '%UserProfile%\.nuget\packages\grpc.tools\1.4.1\tools\windows_x64\protoc.exe Proto\FunctionRpc.proto --csharp_out Messages\DotNet --grpc_out=Messages\DotNet --plugin=protoc-gen-grpc="%UserProfile%\.nuget\packages\grpc.tools\1.4.1\tools\windows_x64\grpc_csharp_plugin.exe" --proto_path=Proto'}; `
+    cd ..\.. ; `
+    dotnet build WebJobs.Script.sln; `
+    dotnet publish src\WebJobs.Script.WebHost\WebJobs.Script.WebHost.csproj --output C:\runtime
+
+# Runtime image
+FROM microsoft/dotnet:2.0.0-runtime-nanoserver-1709
+
+COPY --from=installer-env ["c:\\runtime", "C:\\runtime"]
+
+ENV AzureWebJobsScriptRoot=C:\approot
+
+CMD ["dotnet", "C:\\runtime\\Microsoft.Azure.WebJobs.Script.WebHost.dll"]

--- a/docker/2.0.0/runtime/nanoserver-1709/amd64/Dockerfile
+++ b/docker/2.0.0/runtime/nanoserver-1709/amd64/Dockerfile
@@ -48,4 +48,6 @@ COPY --from=installer-env ["c:\\runtime", "C:\\runtime"]
 
 ENV AzureWebJobsScriptRoot=C:\approot
 
+ENV WEBSITE_HOSTNAME=localhost:80
+
 CMD ["dotnet", "C:\\runtime\\Microsoft.Azure.WebJobs.Script.WebHost.dll"]

--- a/docker/2.0.0/runtime/stretch/amd64/Dockerfile
+++ b/docker/2.0.0/runtime/stretch/amd64/Dockerfile
@@ -19,4 +19,6 @@ COPY --from=installer-env ["/azure-functions-runtime", "/azure-functions-runtime
 
 ENV AzureWebJobsScriptRoot=/app
 
+ENV WEBSITE_HOSTNAME=localhost:80
+
 CMD ["dotnet", "/azure-functions-runtime/Microsoft.Azure.WebJobs.Script.WebHost.dll"]

--- a/docker/2.0.0/runtime/stretch/amd64/Dockerfile
+++ b/docker/2.0.0/runtime/stretch/amd64/Dockerfile
@@ -1,0 +1,22 @@
+FROM microsoft/dotnet:2.0-sdk-stretch AS installer-env
+
+ENV PublishWithAspNetCoreTargetManifest false
+ENV ScriptTag v2.0.11415-alpha
+
+RUN apt-get update && \
+    apt-get install git -y && \
+    git clone https://github.com/Azure/azure-webjobs-sdk-script --depth 1 && \
+    cd azure-webjobs-sdk-script && \
+    git fetch --all --tags && \
+    git checkout tags/${ScriptTag} && \
+    dotnet build WebJobs.Script.sln && \
+    dotnet publish src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj --output /azure-functions-runtime
+
+# Runtime image
+FROM microsoft/dotnet:2.0-sdk-stretch
+
+COPY --from=installer-env ["/azure-functions-runtime", "/azure-functions-runtime"]
+
+ENV AzureWebJobsScriptRoot=/app
+
+CMD ["dotnet", "/azure-functions-runtime/Microsoft.Azure.WebJobs.Script.WebHost.dll"]

--- a/docker/2.0.0/runtime/stretch/arm32v7/Dockerfile
+++ b/docker/2.0.0/runtime/stretch/arm32v7/Dockerfile
@@ -16,4 +16,6 @@ ENV AzureWebJobsScriptRoot=/app
 
 EXPOSE 80
 
+ENV WEBSITE_HOSTNAME=localhost:80
+
 CMD ["dotnet", "/azure-functions-runtime/Microsoft.Azure.WebJobs.Script.WebHost.dll"]

--- a/docker/2.0.0/runtime/stretch/arm32v7/Dockerfile
+++ b/docker/2.0.0/runtime/stretch/arm32v7/Dockerfile
@@ -1,0 +1,19 @@
+FROM microsoft/dotnet:2.0.0-runtime-stretch-arm32v7
+
+RUN apt-get update && \
+    apt-get install curl tar xz-utils -y && \
+    curl -LO https://nodejs.org/dist/v8.9.1/node-v8.9.1-linux-armv7l.tar.xz && \
+    ls -al && \
+    tar -xvf node-v8.9.1-linux-armv7l.tar.xz && \
+    ln -s /node-v8.9.1-linux-armv7l/bin/node /usr/bin/node && \
+    ln -s /node-v8.9.1-linux-armv7l/bin/npm /usr/bin/npm && \
+    node --version && \
+    npm --version
+
+COPY ["azure-functions-runtime", "/azure-functions-runtime"]
+
+ENV AzureWebJobsScriptRoot=/app
+
+EXPOSE 80
+
+CMD ["dotnet", "/azure-functions-runtime/Microsoft.Azure.WebJobs.Script.WebHost.dll"]


### PR DESCRIPTION
This PR adds the Dockerfiles I use to build the containers. The build process clones this repo, checks out tag in envvar `ScriptTag` and builds the container from there. 

**Question:** do we want these files in this repo, or in a separate new `azure-webjobs-sdk-script-docker` repo? (or maybe an `azure-functions-runtime-docker` repo)

other projects have separate repos for their docker files, like [dotnet-docker](https://github.com/dotnet/dotnet-docker) and [azure-cli-docker](https://github.com/Azure/azure-cli-docker) for example. I'm not sure if we need to do too. what do you think?

/cc @paulbatum @davidebbo  to take your opinion regarding the question above.