### PR TITLE
move pragma warning disable logic to generate_protos script

### DIFF
--- a/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
+++ b/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
@@ -8,7 +8,7 @@
     <Ext Condition="'$(OS)' == 'Windows_NT'">bat</Ext>
     <Ext Condition="'$(OS)' != 'Windows_NT'">sh</Ext>
   </PropertyGroup>
-
+  
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.3.0" />
     <PackageReference Include="Grpc.Core" Version="1.4.1" />
@@ -32,14 +32,4 @@
       <Compile Include="**/*$(DefaultLanguageSourceExtension)" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);$(BaseIntermediateOutputPath)**;$(BaseOutputPath)**;@(Compile)" />
     </ItemGroup>
   </Target>
-
-<Target Name="CodeWarningRemover" AfterTargets="GenerateProtoFiles">
-    <ItemGroup>
-        <Content Include="./Messages/DotNet/*" />
-    </ItemGroup>
-    <Exec Command="for %%f in (@(Content)) do echo #pragma warning disable&gt; %%f.temp" />
-    <Exec Command="for %%f in (@(Content)) do type %%f &gt;&gt; %%f.temp" />
-    <Exec Command="for %%f in (@(Content)) do copy /y %%f.temp %%f" />
-    <Exec Command="for %%f in (@(Content)) do del %%f.temp" />
-</Target>
 </Project>

--- a/src/WebJobs.Script.Grpc/generate_protos.bat
+++ b/src/WebJobs.Script.Grpc/generate_protos.bat
@@ -45,4 +45,15 @@ set OUTDIR=%MSGDIR%\DotNet
 mkdir %OUTDIR%
 %NUGET_PATH%\protoc.exe %PROTO% --csharp_out %OUTDIR% --grpc_out=%OUTDIR% --plugin=protoc-gen-grpc=%NUGET_PATH%\grpc_csharp_plugin.exe --proto_path=.\Proto
 
+@rem add pragma warning disable labels to generated files
+
+cd ./Messages/DotNet/
+
+for %%f in ("*.cs") do echo #pragma warning disable> %%f.temp
+for %%f in ("*.cs") do type %%f >> %%f.temp
+for %%f in ("*.cs") do copy /y %%f.temp %%f
+for %%f in ("*.temp") do del %%f
+
+cd ../..
+
 endlocal

--- a/src/WebJobs.Script.Grpc/generate_protos.sh
+++ b/src/WebJobs.Script.Grpc/generate_protos.sh
@@ -33,15 +33,28 @@
 
 # enter Script.Rpc directory
 
+echo "OS: $OSTYPE"
 if [[ $OSTYPE == "darwin"* ]]; then
      PLATFORM="macosx_x86"
 elif [[ $OSTYPE == "linux"* ]];then
-    PLATFORM="linux_x64"
+     PLATFORM="linux_x64"
+else
+     echo "Platform not recognized!"
+	 exit 1
 fi
 
-NUGET_PATH=$HOME/.nuget/packages/grpc.tools/1.4.1/tools/$PLATFORM
+if [ -z "$NUGET_ROOT" ]; then
+	NUGET_PATH=$HOME/.nuget/packages/grpc.tools/1.4.1/tools/$PLATFORM
+else
+	NUGET_PATH=$NUGET_ROOT/packages/grpc.tools/1.4.1/tools/$PLATFORM
+fi
 PROTO=./Proto/FunctionRpc.proto
 MSGDIR=./Messages
+
+if [ ! -d "$NUGET_PATH" ]; then
+	echo "Could not find grpc.tools package. Try setting \$NUGET_PATH to your NUGET directory root and checking you've installed the grpc.tools nuget"
+	exit 1
+fi
 
 rm -rf $MSGDIR
 mkdir $MSGDIR
@@ -49,3 +62,19 @@ mkdir $MSGDIR
 OUTDIR=$MSGDIR/DotNet
 mkdir $OUTDIR
 $NUGET_PATH/protoc $PROTO --csharp_out $OUTDIR --grpc_out=$OUTDIR --plugin=protoc-gen-grpc=$NUGET_PATH/grpc_csharp_plugin --proto_path=./Proto
+
+# add #pragma warning disable labels
+
+cd $OUTDIR
+
+for f in *.cs; do
+	echo '#pragma warning disable' > "$f.temp"
+done
+for f in *.cs; do
+	cat $f >> "$f.temp"
+done
+for f in *.cs; do
+	mv --force "$f.temp" $f
+done 
+
+cd ../..


### PR DESCRIPTION
MSBuild was failing due to weird issues with how the script was set up to add the "#pragma warning disable" flags. Moved the logic into batch and shell.