### PR TITLE
Proxy causes an infinite loop when the redirected URI is a targeted f…

### DIFF
--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -63,6 +63,9 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string DynamicSku = "Dynamic";
         public const string DefaultProductionSlotName = "production";
 
+        public const string AzureProxyFunctionLocalRedirectHeaderName = "X_PROXY_LOCAL_REDIRECT_COUNT";
+        public const int AzureProxyFunctionMaxLocalRedirects = 10;
+
         public const string FeatureFlagDisableShadowCopy = "DisableShadowCopy";
         public const string FeatureFlagsEnableDynamicExtensionLoading = "EnableDynamicExtensionLoading";
 

--- a/test/WebJobs.Script.Tests.Integration/ProxyEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ProxyEndToEndTests.cs
@@ -74,6 +74,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public async Task LocalFunctionInfiniteRedirectTest()
+        {
+            HttpResponseMessage response = await _fixture.HttpClient.GetAsync($"api/myloop");
+
+            string content = await response.Content.ReadAsStringAsync();
+            Assert.Equal("400", response.StatusCode.ToString("D"));
+            Assert.True(content.Contains("Infinite loop"));
+        }
+
+        [Fact]
         public async Task LocalFunctionCallWithoutProxy()
         {
             HttpResponseMessage response = await _fixture.HttpClient.GetAsync($"api/Ping");

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Proxies/proxies.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Proxies/proxies.json
@@ -69,7 +69,7 @@
     "catchAllRoutes": {
       "matchCondition": {
         "route": "/proxy/{*path}",
-        "methods": ["GET", "POST"]
+        "methods": [ "GET", "POST" ]
       },
       "backendUri": "http://localhost/{path}",
       "requestOverrides": {
@@ -105,6 +105,12 @@
       "requestOverrides": {
         "backend.request.headers.accept": "text/plain"
       }
+    },
+    "ProxyAvoidInfiniteRedirect": {
+      "matchCondition": {
+        "route": "/api/{*path}"
+      },
+      "backendUri": "https://localhost/api/{path}"
     }
   }
 }


### PR DESCRIPTION
Proxy causes an infinite loop when the redirected URI is a targeted for a local function or proxy
which doesn't exist

https://github.com/Azure/azure-functions-host/issues/2402