### PR TITLE
Fix for specialization (#2392)

### DIFF
--- a/src/WebJobs.Script.WebHost/App_Start/WebHostResolver.cs
+++ b/src/WebJobs.Script.WebHost/App_Start/WebHostResolver.cs
@@ -130,11 +130,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         {
             lock (_syncLock)
             {
+                // Determine whether we should do normal or standby initialization
                 if (!WebScriptHostManager.InStandbyMode)
                 {
-                    // standby mode can only change from true to false
-                    // when standby mode changes, we reset all instances
-                    if (_activeHostManager == null)
+                    // We're not in standby mode. There are two cases to consider:
+                    // 1) We _were_ in standby mode and now we're ready to specialize
+                    // 2) We're doing non-specialization normal initialization
+                    if (_activeHostManager == null && 
+                        (_standbyHostManager == null || _settingsManager.ContainerReady))
                     {
                         _settingsManager.Reset();
                         _specializationTimer?.Dispose();
@@ -170,7 +173,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 }
                 else
                 {
-                    // we're in standby (placeholder) mode
+                    // We're in standby (placeholder) mode. Initialize the standby services.
                     if (_standbyHostManager == null)
                     {
                         var standbySettings = CreateStandbySettings(settings);
@@ -293,13 +296,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         private void OnSpecializationTimerTick(object state)
         {
-            if (_settingsManager.IsZipDeployment)
-            {
-                // TEMP - when in Zip deploy mode, temporarily disabling timer based specialization
-                // until issue https://github.com/Azure/azure-functions-host/issues/2392 is fixed.
-                return;
-            }
-
             EnsureInitialized((WebHostSettings)state);
 
             // We know we've just specialized, since this timer only runs

--- a/src/WebJobs.Script/Config/ScriptSettingsManager.cs
+++ b/src/WebJobs.Script/Config/ScriptSettingsManager.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Azure.WebJobs.Script.Config
 
         public virtual bool IsZipDeployment => !string.IsNullOrEmpty(GetSetting(EnvironmentSettingNames.AzureWebsiteZipDeployment));
 
+        public virtual bool ContainerReady => !string.IsNullOrEmpty(GetSetting(EnvironmentSettingNames.AzureWebsiteContainerReady));
+
         public string WebsiteSku => GetSetting(EnvironmentSettingNames.AzureWebsiteSku);
 
         public bool IsDynamicSku => WebsiteSku == ScriptConstants.DynamicSku;

--- a/src/WebJobs.Script/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/EnvironmentSettingNames.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AzureWebsiteZipDeployment = "WEBSITE_USE_ZIP";
         public const string RemoteDebuggingPort = "REMOTEDEBUGGINGPORT";
         public const string AzureWebsitePlaceholderMode = "WEBSITE_PLACEHOLDER_MODE";
+        public const string AzureWebsiteContainerReady = "WEBSITE_CONTAINER_READY";
         public const string AzureWebsiteHomePath = "HOME";
         public const string AzureWebJobsScriptRoot = "AzureWebJobsScriptRoot";
         public const string CompilationReleaseMode = "AzureWebJobsDotNetReleaseCompilation";

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyManagerTests.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var vars = new Dictionary<string, string>
             {
                 { EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1" },
+                { EnvironmentSettingNames.AzureWebsiteContainerReady, null },
                 { EnvironmentSettingNames.AzureWebsiteInstanceId, "87654639876900123453445678890144" }
             };
             using (var env = new TestScopedEnvironmentVariable(vars))
@@ -112,6 +113,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
                 // Now specialize the host
                 ScriptSettingsManager.Instance.SetSetting(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+                ScriptSettingsManager.Instance.SetSetting(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
 
                 // give time for the specialization to happen
                 string[] logLines = null;

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyModeTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyModeTests.cs
@@ -116,6 +116,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 _webHostResolver.EnsureInitialized(settings);
 
                 _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+                _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
                 Assert.False(WebScriptHostManager.InStandbyMode);
                 _webHostResolver.EnsureInitialized(settings);
 
@@ -142,6 +143,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     Assert.NotNull(prev);
 
                     _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+                    _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
                     current = func(settings);
                     Assert.NotNull(current);
                     Assert.NotSame(prev, current);


### PR DESCRIPTION
This is the proper fix for https://github.com/Azure/azure-functions-host/issues/2392.

We have to wait until the **next release of Antares** is complete before checking this in however, since it relies on the new WEBSITE_CONTAINER_READY environment variable