### PR TITLE
Run-From-Zip readonly file mode checks (#2230)

### DIFF
--- a/src/WebJobs.Script/Config/ScriptSettingsManager.cs
+++ b/src/WebJobs.Script/Config/ScriptSettingsManager.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Azure.WebJobs.Script.Config
 
         public bool IsDynamicSku => WebsiteSku == ScriptConstants.DynamicSku;
 
+        public bool FileSystemIsReadOnly => IsZipDeployment;
+
         public virtual string AzureWebsiteDefaultSubdomain
         {
             get

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -288,9 +288,9 @@ namespace Microsoft.Azure.WebJobs.Script
                 // read host.json and apply to JobHostConfiguration
                 string hostConfigFilePath = Path.Combine(ScriptConfig.RootScriptPath, ScriptConstants.HostMetadataFileName);
 
-                // If it doesn't exist, create an empty JSON file
-                if (!File.Exists(hostConfigFilePath))
+                if (!_settingsManager.FileSystemIsReadOnly && !File.Exists(hostConfigFilePath))
                 {
+                    // If it doesn't exist, create an empty JSON file
                     File.WriteAllText(hostConfigFilePath, "{}");
                 }
 


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-functions-host/issues/2230

I reviewed all our file operations. Most are to temp/log dirs which are still writeable in zip mode.