### PR TITLE
Skip file watching in ReadOnly mode

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -371,6 +371,12 @@ namespace Microsoft.Azure.WebJobs.Script
 
                 ApplyConfiguration(hostConfigObject, ScriptConfig);
 
+                if (_settingsManager.FileSystemIsReadOnly)
+                {
+                    // we're in read-only mode so source files can't change
+                    ScriptConfig.FileWatchingEnabled = false;
+                }
+
                 // now the configuration has been read and applied re-create the logger
                 // factory and loggers ensuring that filters and settings have been applied
                 ConfigureLoggerFactory(recreate: true);
@@ -415,6 +421,9 @@ namespace Microsoft.Azure.WebJobs.Script
                     _fileEventsSubscription = EventManager.OfType<FileEvent>()
                         .Where(f => string.Equals(f.Source, EventSources.ScriptFiles, StringComparison.Ordinal))
                         .Subscribe(e => OnFileChanged(e.FileChangeArguments));
+
+                    // take a snapshot so we can detect function additions/removals
+                    _directorySnapshot = Directory.EnumerateDirectories(ScriptConfig.RootScriptPath).ToImmutableArray();
                 }
 
                 // If a file change should result in a restart, we debounce the event to
@@ -427,9 +436,6 @@ namespace Microsoft.Azure.WebJobs.Script
 
                 _shutdown = Shutdown;
                 _shutdown = _shutdown.Debounce(500);
-
-                // take a snapshot so we can detect function additions/removals
-                _directorySnapshot = Directory.EnumerateDirectories(ScriptConfig.RootScriptPath).ToImmutableArray();
 
                 // Scan the function.json early to determine the binding extensions used
                 var functionMetadata = ReadFunctionMetadata(ScriptConfig, TraceWriter, _startupLogger, FunctionErrors, _settingsManager);

--- a/src/WebJobs.Script/Host/ScriptHostManager.cs
+++ b/src/WebJobs.Script/Host/ScriptHostManager.cs
@@ -55,14 +55,6 @@ namespace Microsoft.Azure.WebJobs.Script
         public ScriptHostManager(ScriptHostConfiguration config, IScriptEventManager eventManager = null, IScriptHostEnvironment environment = null, HostPerformanceManager hostPerformanceManager = null)
             : this(config, ScriptSettingsManager.Instance, new ScriptHostFactory(), eventManager, environment, hostPerformanceManager)
         {
-            if (config.FileWatchingEnabled)
-            {
-                // We only setup a subscription here as the actual ScriptHost will create the publisher
-                // when initialized.
-                _fileEventSubscription = EventManager.OfType<FileEvent>()
-                     .Where(f => string.Equals(f.Source, EventSources.ScriptFiles, StringComparison.Ordinal))
-                     .Subscribe(e => OnScriptFileChanged(null, e.FileChangeArguments));
-            }
         }
 
         public ScriptHostManager(ScriptHostConfiguration config,
@@ -91,6 +83,15 @@ namespace Microsoft.Azure.WebJobs.Script
 
             _structuredLogWriter = new StructuredLogWriter(EventManager, config.RootLogPath);
             _performanceManager = hostPerformanceManager ?? new HostPerformanceManager(settingsManager, _config.HostHealthMonitor);
+
+            if (config.FileWatchingEnabled && !settingsManager.FileSystemIsReadOnly)
+            {
+                // We only setup a subscription here as the actual ScriptHost will create the publisher
+                // when initialized.
+                _fileEventSubscription = EventManager.OfType<FileEvent>()
+                     .Where(f => string.Equals(f.Source, EventSources.ScriptFiles, StringComparison.Ordinal))
+                     .Subscribe(e => OnScriptFileChanged(null, e.FileChangeArguments));
+            }
 
             if (ShouldMonitorHostHealth)
             {


### PR DESCRIPTION
Another change related to https://github.com/Azure/azure-functions-host/issues/2230. If we're in ReadOnly mode, we don't need to be monitoring script files for changes. The other set of changes were in https://github.com/Azure/azure-functions-host/pull/2428.