### PR TITLE
Include FunctionName in log file prefix when available

### DIFF
--- a/src/WebJobs.Script/Diagnostics/FileTraceWriter.cs
+++ b/src/WebJobs.Script/Diagnostics/FileTraceWriter.cs
@@ -153,7 +153,17 @@ namespace Microsoft.Azure.WebJobs.Script
                 return;
             }
 
-            AppendLine($"[{traceEvent.Level}] {traceEvent.Message}");
+            // format the trace line metadata prefix
+            var traceProperties = new List<string>()
+            {
+                traceEvent.Level.ToString()
+            };
+            if (traceEvent.Properties.TryGetValue(ScriptConstants.TracePropertyFunctionNameKey, out value))
+            {
+                traceProperties.Add((string)value);
+            }
+            string tracePrefix = string.Join(",", traceProperties);
+            AppendLine($"[{tracePrefix}] {traceEvent.Message}");
 
             if (traceEvent.Exception != null)
             {


### PR DESCRIPTION
Addendum to https://github.com/Azure/azure-functions-host/pull/2443

Ling requested that we also include FunctionName in the file log entries coming from ScaleController logs.