### PR TITLE
Concurrency improvements for FileTraceWriter

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/ApiHubTestHelper.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApiHubTestHelper.cs
@@ -25,9 +25,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         private const string DataSetName = "default";
         private const string TableName = "SampleTable";
         private const string PrimaryKeyColumn = "Id";
-        private const string Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-
-        private static readonly Random Random = new Random();
 
         private static readonly ScriptSettingsManager SettingsManager = ScriptSettingsManager.Instance;
 
@@ -59,14 +56,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 //          CONSTRAINT PK_Id PRIMARY KEY(Id)
                 //      )
             }
-        }
-
-        public static string NewRandomString()
-        {
-            return new string(
-                Enumerable.Repeat('x', 10) // nvarchar(10)
-                    .Select(c => Chars[Random.Next(Chars.Length)])
-                    .ToArray());
         }
 
         public static async Task EnsureEntityAsync(int entityId, string text = null)

--- a/test/WebJobs.Script.Tests.Integration/CSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/CSharpEndToEndTests.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public async Task ApiHubTableClientBindingTest()
         {
-            var textArgValue = ApiHubTestHelper.NewRandomString();
+            var textArgValue = TestHelpers.NewRandomString();
 
             // Ensure the test entity exists.
             await ApiHubTestHelper.EnsureEntityAsync(ApiHubTestHelper.EntityId1);
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public async Task ApiHubTableBindingTest()
         {
-            var textArgValue = ApiHubTestHelper.NewRandomString();
+            var textArgValue = TestHelpers.NewRandomString();
 
             // Ensure the test entity exists.
             await ApiHubTestHelper.EnsureEntityAsync(ApiHubTestHelper.EntityId2);
@@ -221,7 +221,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public async Task ApiHubTableEntityBindingTest()
         {
-            var textArgValue = ApiHubTestHelper.NewRandomString();
+            var textArgValue = TestHelpers.NewRandomString();
 
             // Ensure the test entity exists.
             await ApiHubTestHelper.EnsureEntityAsync(ApiHubTestHelper.EntityId3);

--- a/test/WebJobs.Script.Tests.Integration/FSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/FSharpEndToEndTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public async Task ApiHubTableClientBindingTest()
         {
-            var textArgValue = ApiHubTestHelper.NewRandomString();
+            var textArgValue = TestHelpers.NewRandomString();
 
             // Ensure the test entity exists.
             await ApiHubTestHelper.EnsureEntityAsync(ApiHubTestHelper.EntityId1);
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public async Task ApiHubTableBindingTest()
         {
-            var textArgValue = ApiHubTestHelper.NewRandomString();
+            var textArgValue = TestHelpers.NewRandomString();
 
             // Ensure the test entity exists.
             await ApiHubTestHelper.EnsureEntityAsync(ApiHubTestHelper.EntityId2);
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public async Task ApiHubTableEntityBindingTest()
         {
-            var textArgValue = ApiHubTestHelper.NewRandomString();
+            var textArgValue = TestHelpers.NewRandomString();
 
             // Ensure the test entity exists.
             await ApiHubTestHelper.EnsureEntityAsync(ApiHubTestHelper.EntityId3);

--- a/test/WebJobs.Script.Tests.Integration/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/NodeEndToEndTests.cs
@@ -1115,7 +1115,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public async Task ApiHubTableEntityOut()
         {
-            var textArgValue = ApiHubTestHelper.NewRandomString();
+            var textArgValue = TestHelpers.NewRandomString();
 
             // Delete the test entity if it exists.
             await ApiHubTestHelper.DeleteEntityAsync(ApiHubTestHelper.EntityId5);

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -21,6 +21,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public static class TestHelpers
     {
+        private const string Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        private static readonly Random Random = new Random();
+
         /// <summary>
         /// Gets the common root directory that functions tests create temporary directories under.
         /// This enables us to clean up test files by deleting this single directory.
@@ -31,6 +34,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 return Path.Combine(Path.GetTempPath(), "FunctionsTest");
             }
+        }
+
+        public static string NewRandomString(int length = 10)
+        {
+            return new string(
+                Enumerable.Repeat('x', length)
+                    .Select(c => Chars[Random.Next(Chars.Length)])
+                    .ToArray());
         }
 
         public static async Task Await(Func<bool> condition, int timeout = 60 * 1000, int pollingInterval = 2 * 1000, bool throwWhenDebugging = false, string userMessage = null)

--- a/test/WebJobs.Script.Tests/Diagnostics/FileTraceWriterTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/FileTraceWriterTests.cs
@@ -31,14 +31,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public async Task MultipleConcurrentInstances_WritesAreSerialized()
         {
-            int numLines = 100;
-
             // first ensure the file exists by writing a single entry
             // this ensures all the instances below will be operating on
             // the same file
             WriteLogs(_logFilePath, 1);
 
             // start 3 concurrent instances
+            int numLines = 100;
             await Task.WhenAll(
                 Task.Run(() => WriteLogs(_logFilePath, numLines)),
                 Task.Run(() => WriteLogs(_logFilePath, numLines)),
@@ -50,62 +49,77 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-        public async Task SetNewLogFile_PurgesOldLogFiles()
+        public async Task SetLogFile_PurgesOldLogFiles()
         {
-            DirectoryInfo directory = new DirectoryInfo(_logFilePath);
+            var directory = new DirectoryInfo(_logFilePath);
             directory.Create();
 
             // below test expects the retention days to be set to 1
             Assert.Equal(1, FileTraceWriter.LastModifiedCutoffDays);
 
             // create some log files
-            List<FileInfo> logFiles = new List<FileInfo>();
-            int initialCount = 5;
-            for (int i = 0; i < initialCount; i++)
+            var logFiles = new List<FileInfo>();
+            for (int i = 0; i < 5; i++)
             {
                 string fileName = string.Format("{0}-{1}.log", i, FileTraceWriter.GetInstanceId());
                 string path = Path.Combine(_logFilePath, fileName);
-                Thread.Sleep(50);
                 File.WriteAllText(path, "Test Logs");
                 logFiles.Add(new FileInfo(path));
             }
 
-            // mark some of the files as old - we expect
-            // all of these to be purged
-            File.SetLastWriteTime(logFiles[2].FullName, DateTime.Now.Subtract(TimeSpan.FromDays(1)));
-            File.SetLastWriteTime(logFiles[1].FullName, DateTime.Now.Subtract(TimeSpan.FromDays(1)));
-            File.SetLastWriteTime(logFiles[0].FullName, DateTime.Now.Subtract(TimeSpan.FromDays(2)));
+            // push all but the last file over size limit
+            string maxLog = TestHelpers.NewRandomString((int)FileTraceWriter.MaxLogFileSizeBytes + 1);
+            File.AppendAllText(logFiles[3].FullName, maxLog);
+            File.AppendAllText(logFiles[2].FullName, maxLog);
+            File.AppendAllText(logFiles[1].FullName, maxLog);
+            File.AppendAllText(logFiles[0].FullName, maxLog);
 
-            await Task.Delay(2000);
+            // mark all the files as old to simulate the passage of time
+            File.SetLastWriteTime(logFiles[4].FullName, DateTime.Now.Subtract(TimeSpan.FromDays(2)));
+            File.SetLastWriteTime(logFiles[3].FullName, DateTime.Now.Subtract(TimeSpan.FromDays(2)));
+            File.SetLastWriteTime(logFiles[2].FullName, DateTime.Now.Subtract(TimeSpan.FromDays(3)));
+            File.SetLastWriteTime(logFiles[1].FullName, DateTime.Now.Subtract(TimeSpan.FromDays(4)));
+            File.SetLastWriteTime(logFiles[0].FullName, DateTime.Now.Subtract(TimeSpan.FromDays(5)));
 
             var files = directory.GetFiles().OrderByDescending(p => p.LastWriteTime).ToArray();
-            Assert.Equal(initialCount, files.Length);
+            Assert.Equal(5, files.Length);
 
-            FileTraceWriter traceWriter = new FileTraceWriter(_logFilePath, TraceLevel.Verbose, LogType.Host);
-            traceWriter.SetNewLogFile();
+            // now cause a new log file to be created by writing a huge
+            // log pushing the current file over limit
+            var traceWriter = new FileTraceWriter(_logFilePath, TraceLevel.Verbose, LogType.Host);
+            traceWriter.Info(maxLog);
 
-            files = directory.GetFiles().OrderByDescending(p => p.LastWriteTime).ToArray();
-
+            // wait for the new file to be created and the old files to be purged
             await TestHelpers.Await(() =>
             {
                 files = directory.GetFiles().OrderByDescending(p => p.LastWriteTime).ToArray();
                 return files.Length == 2;
-            }, timeout: 2000);
+            }, timeout: 5000);
 
-            // verify the correct log files were purged and the 2
-            // most recent files were retained
-            Assert.True(files[0].Name.StartsWith("4"));
-            Assert.True(files[1].Name.StartsWith("3"));
+            // expect only 2 files to remain - the new file we just created, as well
+            // as the oversize file we just wrote to last (it has a new timestamp now so
+            // wasn't purged)
+            Assert.True(files[1].Length > FileTraceWriter.MaxLogFileSizeBytes);
+
+            // expect the new file to be empty because everything was flushed
+            // to the previous file before it was created
+            var fileLines = File.ReadAllLines(files[0].FullName);
+            Assert.Equal(0, fileLines.Length);
+
+            // make sure the new log is written to the new file
+            traceWriter.Info("test message");
+            traceWriter.Flush();
+            fileLines = File.ReadAllLines(files[0].FullName);
+            Assert.Equal(1, fileLines.Length);
         }
 
         [Fact]
-        public void SetNewLogFile_EmptyDirectory_Succeeds()
+        public void Constructor_EmptyDirectory_DelayCreatesLogFile()
         {
-            DirectoryInfo directory = new DirectoryInfo(_logFilePath);
+            var directory = new DirectoryInfo(_logFilePath);
             directory.Create();
 
-            FileTraceWriter traceWriter = new FileTraceWriter(_logFilePath, TraceLevel.Verbose, LogType.Host);
-            traceWriter.SetNewLogFile();
+            var traceWriter = new FileTraceWriter(_logFilePath, TraceLevel.Verbose, LogType.Host);
 
             var files = directory.GetFiles().OrderByDescending(p => p.LastWriteTime).ToArray();
             Assert.Equal(0, files.Length);
@@ -113,27 +127,57 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             traceWriter.Verbose("Test log");
             traceWriter.Flush();
 
+            // log file is delay created
             files = directory.GetFiles().OrderByDescending(p => p.LastWriteTime).ToArray();
             Assert.Equal(1, files.Length);
         }
 
         [Fact]
-        public void Trace_ReusesLastFile()
+        public async Task SetLogFile_EmptyDirectory_MultipleInstances_Staggered_CreatesOneFile()
         {
-            DirectoryInfo directory = new DirectoryInfo(_logFilePath);
-            directory.Create();
-
-            int count = directory.EnumerateFiles().Count();
-            Assert.Equal(0, count);
-
-            for (int i = 0; i < 3; i++)
+            var writers = new List<FileTraceWriter>();
+            for (int i = 0; i < 5; i++)
             {
-                FileTraceWriter traceWriter = new FileTraceWriter(_logFilePath, TraceLevel.Verbose, LogType.Host);
-                traceWriter.Verbose("Testing");
-                traceWriter.Flush();
+                writers.Add(new FileTraceWriter(_logFilePath, TraceLevel.Verbose, LogType.Host));
+                await Task.Delay(400);
             }
 
-            count = directory.EnumerateFiles().Count();
+            writers.ForEach(p => p.Info($"test message"));
+            writers.ForEach(p => p.Flush());
+
+            var directory = new DirectoryInfo(_logFilePath);
+            var files = directory.GetFiles().OrderByDescending(p => p.LastWriteTime).ToArray();
+            Assert.Equal(1, files.Length);
+
+            var fileLines = File.ReadAllLines(files.Single().FullName);
+            Assert.Equal(5, fileLines.Length);
+        }
+
+        [Fact]
+        public async Task SetLogFile_EmptyDirectory_MultipleInstances_Concurrent_CreatesOneFile()
+        {
+            var tasks = new List<Task>();
+            for (int i = 0; i < 10; i++)
+            {
+                tasks.Add(Task.Run(() => WriteLogs(_logFilePath, 10)));
+            }
+            await Task.WhenAll(tasks);
+
+            var directory = new DirectoryInfo(_logFilePath);
+            var files = directory.GetFiles().OrderByDescending(p => p.LastWriteTime).ToArray();
+            Assert.Equal(1, files.Length);
+
+            var fileLines = File.ReadAllLines(files.Single().FullName);
+            Assert.Equal(100, fileLines.Length);
+        }
+
+        [Fact]
+        public void Trace_ReusesLastFile()
+        {
+            WriteLogs(_logFilePath, 3);
+
+            var directory = new DirectoryInfo(_logFilePath);
+            int count = directory.EnumerateFiles().Count();
             Assert.Equal(1, count);
 
             string logFile = directory.EnumerateFiles().First().FullName;
@@ -144,9 +188,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public async Task Trace_ThrottlesLogs()
         {
-            DirectoryInfo directory = new DirectoryInfo(_logFilePath);
-            directory.Create();
-
             int numLogs = 10000;
             int numIterations = 3;
             for (int i = 0; i < numIterations; i++)
@@ -155,6 +196,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 await Task.Delay(1000);
             }
 
+            var directory = new DirectoryInfo(_logFilePath);
             string logFile = directory.EnumerateFiles().First().FullName;
             string[] fileLines = File.ReadAllLines(logFile);
             Assert.True(fileLines.Length == ((FileTraceWriter.MaxLogLinesPerFlushInterval * numIterations) + 3));
@@ -164,13 +206,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public void Trace_WritesExpectedLogs()
         {
-            DirectoryInfo directory = new DirectoryInfo(_logFilePath);
-            directory.Create();
-
-            int count = directory.EnumerateFiles().Count();
-            Assert.Equal(0, count);
-
-            FileTraceWriter traceWriter = new FileTraceWriter(_logFilePath, TraceLevel.Info, LogType.Host);
+            var traceWriter = new FileTraceWriter(_logFilePath, TraceLevel.Info, LogType.Host);
 
             traceWriter.Verbose("Test Verbose");
             traceWriter.Info("Test Info");
@@ -190,6 +226,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             traceWriter.Flush();
 
+            var directory = new DirectoryInfo(_logFilePath);
             string logFile = directory.EnumerateFiles().First().FullName;
             string[] lines = File.ReadAllLines(logFile);
             Assert.Equal(4, lines.Length);
@@ -213,6 +250,37 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             prefix = FileTraceWriter.GetTracePrefix(evt, LogType.Structured);
             Assert.Equal("Info", prefix);
+        }
+
+        [Fact]
+        public async Task Trace_LogFileDeleted_CreatesNewFile()
+        {
+            var traceWriter = new FileTraceWriter(_logFilePath, TraceLevel.Info, LogType.Host);
+
+            traceWriter.Info("test trace");
+            traceWriter.Flush();
+
+            var directory = new DirectoryInfo(_logFilePath);
+            var firstLogFile = directory.EnumerateFiles().Single();
+
+            // delete the first log file to force another one to be
+            // created
+            File.Delete(firstLogFile.FullName);
+
+            // wait at least a second to ensure the file gets a distinct timestamp
+            await Task.Delay(1000);
+            await TestHelpers.Await(() => !File.Exists(firstLogFile.FullName));
+
+            traceWriter.Info("test trace");
+            traceWriter.Flush();
+
+            var secondLogFile = directory.EnumerateFiles().Single();
+
+            // verify that a new log file was created with a different
+            // timestamp
+            Assert.NotEqual(firstLogFile.Name, secondLogFile.Name);
+            var logLine = File.ReadAllLines(secondLogFile.FullName).Single();
+            Assert.True(logLine.EndsWith("[Info] test trace"));
         }
 
         private void WriteLogs(string logFilePath, int numLogs)


### PR DESCRIPTION
In some recent testing I'm noticing that occasionally on startup if the log directory is empty the host will create two log files with a timestamp a second apart. One file has a few logs in it, the other has the bulk. This is because on startup the logger determines it's log file name, which means if two different instances are started a second apart this will happen. This became more pronounced after my changes for https://github.com/Azure/azure-functions-host/pull/2445 where we have a default host logger that is being used until the actual host spins up (so there are 2 loggers active for a period).

In this PR I'm fixing that issue and a few other things while I'm in there.