### PR TITLE
enabling most of App Insights E2E tests

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -37,13 +37,13 @@
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client.Contract" Version="0.3.1.1">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta4-11124" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta4-11241" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.0-beta4-10578" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.0-beta4-10578">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.0-beta4-11124" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0-beta4-11124" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.0-beta4-11241" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0-beta4-11241" />
     <PackageReference Include="Microsoft.Azure.WebSites.DataProtection" Version="2.1.88-alpha" />
     <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.6.0" />

--- a/src/WebJobs.Script/Config/ScriptHostConfiguration.cs
+++ b/src/WebJobs.Script/Config/ScriptHostConfiguration.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Extensibility;
 
@@ -86,6 +87,12 @@ namespace Microsoft.Azure.WebJobs.Script
         /// registered <see cref="ILoggerFactory"/>.
         /// </summary>
         public LogCategoryFilter LogFilter { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="SamplingPercentageEstimatorSettings"/> to be used for Application
+        /// Insights client-side sampling. If null, client-side sampling is disabled.
+        /// </summary>
+        public SamplingPercentageEstimatorSettings ApplicationInsightsSamplingSettings { get; set; }
 
         /// <summary>
         /// Gets or sets the set of <see cref="ScriptBindingProviders"/> to use when loading functions.

--- a/src/WebJobs.Script/Description/Rpc/WorkerLanguageInvoker.cs
+++ b/src/WebJobs.Script/Description/Rpc/WorkerLanguageInvoker.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 ExecutionContext = context.ExecutionContext,
                 Inputs = inputs,
                 ResultSource = new TaskCompletionSource<ScriptInvocationResult>(),
+                AsyncExecutionContext = System.Threading.ExecutionContext.Capture(),
 
                 // TODO: link up cancellation token to parameter descriptors
                 CancellationToken = CancellationToken.None,

--- a/src/WebJobs.Script/Diagnostics/DefaultLoggerProviderFactory.cs
+++ b/src/WebJobs.Script/Diagnostics/DefaultLoggerProviderFactory.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 metricsLogger?.LogEvent(MetricEventNames.ApplicationInsightsEnabled);
 
                 ITelemetryClientFactory clientFactory = scriptConfig.HostConfig.GetService<ITelemetryClientFactory>() ??
-                    new ScriptTelemetryClientFactory(settingsManager.ApplicationInsightsInstrumentationKey, scriptConfig.LogFilter.Filter);
+                    new ScriptTelemetryClientFactory(settingsManager.ApplicationInsightsInstrumentationKey, scriptConfig.ApplicationInsightsSamplingSettings, scriptConfig.LogFilter.Filter);
 
                 providers.Add(new ApplicationInsightsLoggerProvider(clientFactory));
             }

--- a/src/WebJobs.Script/Host/ScriptTelemetryClientFactory.cs
+++ b/src/WebJobs.Script/Host/ScriptTelemetryClientFactory.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
+using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation;
 using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
 using Microsoft.Extensions.Logging;
 
@@ -14,8 +15,8 @@ namespace Microsoft.Azure.WebJobs.Script
     /// </summary>
     internal class ScriptTelemetryClientFactory : DefaultTelemetryClientFactory
     {
-        public ScriptTelemetryClientFactory(string instrumentationKey, Func<string, LogLevel, bool> filter)
-            : base(instrumentationKey, filter)
+        public ScriptTelemetryClientFactory(string instrumentationKey, SamplingPercentageEstimatorSettings samplingSettings, Func<string, LogLevel, bool> filter)
+            : base(instrumentationKey, samplingSettings, filter)
         {
         }
 

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
@@ -256,8 +256,6 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 });
             }
 
-            context.AsyncExecutionContext = System.Threading.ExecutionContext.Capture();
-
             _executingInvocations.TryAdd(invocationRequest.InvocationId, context);
 
             Send(new StreamingMessage

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="FSharp.Core" Version="4.2.2" />
     <PackageReference Include="Google.Protobuf" Version="3.3.0" />
     <PackageReference Include="Grpc.Core" Version="1.4.1" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.0.1">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
@@ -25,13 +25,13 @@
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta1-10026">
       <PrivateAssets>None</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta4-11124" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta4-11241" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.0-beta4-10578" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.0-beta4-10578">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.0-beta4-11124" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0-beta4-11124" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.0-beta4-11241" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0-beta4-11241" />
     <PackageReference Include="Microsoft.Build" Version="15.3.409" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Node/HttpTrigger-Scenarios/function.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Node/HttpTrigger-Scenarios/function.json
@@ -4,7 +4,8 @@
             "type": "httpTrigger",
             "name": "req",
             "direction": "in",
-            "methods": [ "get", "post" ]
+            "methods": [ "get", "post" ],
+            "authLevel": "anonymous"
         },
         {
             "type": "http",

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Node/Scenarios/index.js
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Node/Scenarios/index.js
@@ -92,12 +92,16 @@ var assert = require('assert');
         };
 
         context.log(logPayload);
+
+        /* currently not supported in Node
         context.log.metric("TestMetric", 1234, {
             count: 50,
             min: 10.4,
             max: 23,
             MyCustomMetricProperty: 100
         });
+        */
+
         context.done();
     }
     else {

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.3">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.1" />
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client.Contract" Version="0.3.1.1">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>

--- a/test/WebJobs.Script.Tests.Shared/TestChannelLoggerProviderFactory.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestChannelLoggerProviderFactory.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation;
 using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
 using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Config;
@@ -60,7 +61,7 @@ namespace Microsoft.WebJobs.Script.Tests
         private TestTelemetryChannel _channel;
 
         public TestTelemetryClientFactory(Func<string, LogLevel, bool> filter, TestTelemetryChannel channel)
-            : base(TestChannelLoggerProviderFactory.ApplicationInsightsKey, filter)
+            : base(TestChannelLoggerProviderFactory.ApplicationInsightsKey, new SamplingPercentageEstimatorSettings(), filter)
         {
             _channel = channel;
         }

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -111,11 +111,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         private static bool IsHostRunning(HttpClient client)
         {
-            using (HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, string.Empty))
+            // Workaround for https://github.com/Azure/azure-functions-host/issues/2397 as the base URL
+            // doesn't currently start the host. 
+            // Note: the master key "1234" is from the TestSecretManager.
+            using (HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "/admin/functions/dummyName/status?code=1234"))
             {
                 using (HttpResponseMessage response = client.SendAsync(request).Result)
                 {
-                    return response.StatusCode == HttpStatusCode.NoContent || response.StatusCode == HttpStatusCode.OK;
+                    return response.StatusCode == HttpStatusCode.NoContent || response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.NotFound;
                 }
             }
         }

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -746,79 +746,79 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
         }
 
-        [Fact(Skip = "Sampling not supported")]
+        [Fact]
         public void ApplyApplicationInsightsConfig_SamplingDisabled_CreatesNullSettings()
         {
-            // JObject config = JObject.Parse(@"
-            // {
-            //     'applicationInsights': {
-            //         'sampling': {
-            //             'isEnabled': false
-            //         }
-            //     }
-            // }");
+            JObject config = JObject.Parse(@"
+             {
+                 'applicationInsights': {
+                     'sampling': {
+                         'isEnabled': false
+                     }
+                 }
+             }");
 
-            // ScriptHostConfiguration scriptConfig = new ScriptHostConfiguration();
-            // ScriptHost.ApplyApplicationInsightsConfig(config, scriptConfig);
+            ScriptHostConfiguration scriptConfig = new ScriptHostConfiguration();
+            ScriptHost.ApplyApplicationInsightsConfig(config, scriptConfig);
 
-            // Assert.Null(scriptConfig.ApplicationInsightsSamplingSettings);
+            Assert.Null(scriptConfig.ApplicationInsightsSamplingSettings);
         }
 
-        [Fact(Skip = "Sampling not supported")]
+        [Fact]
         public void ApplyApplicationInsightsConfig_SamplingDisabled_IgnoresOtherSettings()
         {
-            // JObject config = JObject.Parse(@"
-            // {
-            //     'applicationInsights': {
-            //         'sampling': {
-            //             'isEnabled': false,
-            //             'maxTelemetryItemsPerSecond': 25
-            //         }
-            //     }
-            // }");
+            JObject config = JObject.Parse(@"
+             {
+                 'applicationInsights': {
+                     'sampling': {
+                         'isEnabled': false,
+                         'maxTelemetryItemsPerSecond': 25
+                     }
+                 }
+             }");
 
-            // ScriptHostConfiguration scriptConfig = new ScriptHostConfiguration();
-            // ScriptHost.ApplyApplicationInsightsConfig(config, scriptConfig);
+            ScriptHostConfiguration scriptConfig = new ScriptHostConfiguration();
+            ScriptHost.ApplyApplicationInsightsConfig(config, scriptConfig);
 
-            // Assert.Null(scriptConfig.ApplicationInsightsSamplingSettings);
+            Assert.Null(scriptConfig.ApplicationInsightsSamplingSettings);
         }
 
-        [Fact(Skip = "Sampling not supported")]
+        [Fact]
         public void ApplyApplicationInsightsConfig_SamplingEnabled_CreatesDefaultSettings()
         {
-            // JObject config = JObject.Parse(@"
-            // {
-            //     'applicationInsights': {
-            //         'sampling': {
-            //             'isEnabled': true
-            //         }
-            //     }
-            // }");
+            JObject config = JObject.Parse(@"
+             {
+                 'applicationInsights': {
+                     'sampling': {
+                         'isEnabled': true
+                     }
+                 }
+             }");
 
-            // ScriptHostConfiguration scriptConfig = new ScriptHostConfiguration();
-            // ScriptHost.ApplyApplicationInsightsConfig(config, scriptConfig);
+            ScriptHostConfiguration scriptConfig = new ScriptHostConfiguration();
+            ScriptHost.ApplyApplicationInsightsConfig(config, scriptConfig);
 
-            // Assert.NotNull(scriptConfig.ApplicationInsightsSamplingSettings);
-            // Assert.Equal(5, scriptConfig.ApplicationInsightsSamplingSettings.MaxTelemetryItemsPerSecond);
+            Assert.NotNull(scriptConfig.ApplicationInsightsSamplingSettings);
+            Assert.Equal(5, scriptConfig.ApplicationInsightsSamplingSettings.MaxTelemetryItemsPerSecond);
         }
 
-        [Fact(Skip = "Sampling not supported")]
+        [Fact]
         public void ApplyApplicationInsightsConfig_Sets_MaxTelemetryItemsPerSecond()
         {
-            // JObject config = JObject.Parse(@"
-            // {
-            //     'applicationInsights': {
-            //         'sampling': {
-            //             'maxTelemetryItemsPerSecond': 25
-            //         }
-            //     }
-            // }");
+            JObject config = JObject.Parse(@"
+             {
+                 'applicationInsights': {
+                     'sampling': {
+                         'maxTelemetryItemsPerSecond': 25
+                     }
+                 }
+             }");
 
-            // ScriptHostConfiguration scriptConfig = new ScriptHostConfiguration();
-            // ScriptHost.ApplyApplicationInsightsConfig(config, scriptConfig);
+            ScriptHostConfiguration scriptConfig = new ScriptHostConfiguration();
+            ScriptHost.ApplyApplicationInsightsConfig(config, scriptConfig);
 
-            // Assert.NotNull(scriptConfig.ApplicationInsightsSamplingSettings);
-            // Assert.Equal(25, scriptConfig.ApplicationInsightsSamplingSettings.MaxTelemetryItemsPerSecond);
+            Assert.NotNull(scriptConfig.ApplicationInsightsSamplingSettings);
+            Assert.Equal(25, scriptConfig.ApplicationInsightsSamplingSettings.MaxTelemetryItemsPerSecond);
         }
 
         [Fact]
@@ -868,16 +868,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(0.77F, scriptConfig.HostHealthMonitor.CounterThreshold);
         }
 
-        [Fact(Skip = "Sampling not supported")]
+        [Fact]
         public void ApplyApplicationInsightsConfig_NoSettings_CreatesDefaultSettings()
         {
-            // JObject config = JObject.Parse("{ }");
+            JObject config = JObject.Parse("{ }");
 
-            // ScriptHostConfiguration scriptConfig = new ScriptHostConfiguration();
-            // ScriptHost.ApplyApplicationInsightsConfig(config, scriptConfig);
+            ScriptHostConfiguration scriptConfig = new ScriptHostConfiguration();
+            ScriptHost.ApplyApplicationInsightsConfig(config, scriptConfig);
 
-            // Assert.NotNull(scriptConfig.ApplicationInsightsSamplingSettings);
-            // Assert.Equal(5, scriptConfig.ApplicationInsightsSamplingSettings.MaxTelemetryItemsPerSecond);
+            Assert.NotNull(scriptConfig.ApplicationInsightsSamplingSettings);
+            Assert.Equal(5, scriptConfig.ApplicationInsightsSamplingSettings.MaxTelemetryItemsPerSecond);
         }
 
         [Fact]


### PR DESCRIPTION
Also:
- Enables sampling configuration in host.json
- Disables special App Insights HTTP logging. This actually happened in the SDK branch, but I'm skipping the relevant tests here. #2447 is tracking this.

Fixes #2019