### PR TITLE
improving GetHostSecrets test

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/Host/ScriptHostManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/ScriptHostManagerTests.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     {
                         // don't start until the manager is running
                         TestHelpers.Await(() => manager.State == ScriptHostState.Running,
-                            userMessage: "Host did not start in time.").Wait();
+                            userMessageCallback: () => "Host did not start in time.").Wait();
 
                         // Wait for initial execution.
                         TestHelpers.Await(() =>
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                             bool exists = blob.Exists();
                             pollMessages.Add($"TimerTrigger: [{DateTime.UtcNow.ToString("HH:mm:ss.fff")}] '{blob.Uri}' exists: {exists}");
                             return exists;
-                        }, timeout: 10 * 1000, userMessage: $"Blob '{blob.Uri}' was not created by 'TimerTrigger' in time.").Wait();
+                        }, timeout: 10 * 1000, userMessageCallback: () => $"Blob '{blob.Uri}' was not created by 'TimerTrigger' in time.").Wait();
 
                         // find __dirname from blob
                         string text;
@@ -186,7 +186,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                             bool exists = blob.Exists();
                             pollMessages.Add($"MovedTrigger: [{DateTime.UtcNow.ToString("HH:mm:ss.fff")}] '{blob.Uri}' exists: {exists}");
                             return exists;
-                        }, timeout: 30 * 1000, userMessage: $"Blob '{blob.Uri}' was not created by 'MovedTrigger' in time.").Wait();
+                        }, timeout: 30 * 1000, userMessageCallback: () => $"Blob '{blob.Uri}' was not created by 'MovedTrigger' in time.").Wait();
 
                         using (var stream = new MemoryStream())
                         {

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyManagerTests.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     // wait for the trace indicating that the host has been specialized
                     logLines = traceWriter.GetTraces().Select(p => p.Message).ToArray();
                     return logLines.Contains("Generating 0 job function(s)");
-                });
+                }, userMessageCallback: () => string.Join(Environment.NewLine, traceWriter.GetTraces().Select(p => p.Message)));
 
                 // verify the rest of the expected logs
                 string text = string.Join(Environment.NewLine, logLines);

--- a/test/WebJobs.Script.Tests.Integration/Host/WebScriptHostManagerTimeoutTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/WebScriptHostManagerTimeoutTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Host
 
             await RunTimeoutExceptionTest(trace, handleCancellation: false);
 
-            await TestHelpers.Await(() => !(_manager.State == ScriptHostState.Running), userMessage: "Expected host to not be running");
+            await TestHelpers.Await(() => !(_manager.State == ScriptHostState.Running), userMessageCallback: () => "Expected host to not be running");
 
             var traces = trace.GetTraces();
             Assert.DoesNotContain(traces, t => t.Message.StartsWith("Done"));
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Host
 
             // wait a few seconds to make sure the manager doesn't die
             await Assert.ThrowsAsync<ApplicationException>(() => TestHelpers.Await(() => !(_manager.State == ScriptHostState.Running),
-                timeout: 3000, throwWhenDebugging: true, userMessage: "Expected host manager not to die"));
+                timeout: 3000, throwWhenDebugging: true, userMessageCallback: () => "Expected host manager not to die"));
 
             var traces = trace.GetTraces();
             Assert.Contains(traces, t => t.Message.StartsWith("Done"));
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Host
             var mockEventManager = new Mock<IScriptEventManager>();
             var manager = new WebScriptHostManager(config, new TestSecretManagerFactory(), mockEventManager.Object, ScriptSettingsManager.Instance, new WebHostSettings { SecretsPath = _secretsDirectory.Path });
             Task task = Task.Run(() => { manager.RunAndBlock(); });
-            await TestHelpers.Await(() => manager.State == ScriptHostState.Running, userMessage: "Expected host to be running");
+            await TestHelpers.Await(() => manager.State == ScriptHostState.Running, userMessageCallback: () => "Expected host to be running");
 
             return manager;
         }

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     .ToArray());
         }
 
-        public static async Task Await(Func<bool> condition, int timeout = 60 * 1000, int pollingInterval = 2 * 1000, bool throwWhenDebugging = false, string userMessage = null)
+        public static async Task Await(Func<bool> condition, int timeout = 60 * 1000, int pollingInterval = 2 * 1000, bool throwWhenDebugging = false, Func<string> userMessageCallback = null)
         {
             DateTime start = DateTime.Now;
             while (!condition())
@@ -55,9 +55,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 if (shouldThrow && (DateTime.Now - start).TotalMilliseconds > timeout)
                 {
                     string error = "Condition not reached within timeout.";
-                    if (userMessage != null)
+                    if (userMessageCallback != null)
                     {
-                        error += " " + userMessage;
+                        error += " " + userMessageCallback();
                     }
                     throw new ApplicationException(error);
                 }

--- a/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
@@ -615,14 +615,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                     InvalidOperationException ioe = null;
                     try
                     {
-                        for (int i = 0; i < ScriptConstants.MaximumSecretBackupCount + 10; i++)
+                        for (int i = 0; i < ScriptConstants.MaximumSecretBackupCount + 20; i++)
                         {
                             File.WriteAllText(Path.Combine(directory.Path, functionName + ".json"), functionSecretsJson);
-                            functionSecrets = await secretManager.GetFunctionSecretsAsync(functionName);
-                            if (i > ScriptConstants.MaximumSecretBackupCount)
+
+                            // If we haven't hit the exception yet, pause to ensure the file contents are being flushed.
+                            if (i >= ScriptConstants.MaximumSecretBackupCount)
                             {
                                 await Task.Delay(500);
                             }
+
+                            functionSecrets = await secretManager.GetFunctionSecretsAsync(functionName);
                         }
                     }
                     catch (InvalidOperationException ex)


### PR DESCRIPTION
The `GetHostSecrets_WhenTooManyBackups_ThrowsException` was having issues due to file writes on AppVeyor. It looks like `File.WriteAllText()` returns when the write operation is queued up for the OS, not necessarily when it's completely flushed to disk. I added some logging that showed that we'd loop through 10 times writing the 'bad' file and the test never saw it as 'bad'. There was already a test to slow this down if we'd tried 10 times, but I extend that and slowed it down after every write. Hopefully this fixes it.