### PR TITLE
improving Update/RenameAndRestart tests

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/EndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/EndToEndTestFixture.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         private readonly ScriptSettingsManager _settingsManager;
         private readonly ManualResetEventSlim _hostStartedEvent = new ManualResetEventSlim();
 
-        protected EndToEndTestFixture(string rootPath, string testId, ProxyClientExecutor proxyClient = null)
+        protected EndToEndTestFixture(string rootPath, string testId, ProxyClientExecutor proxyClient = null, bool startHost = true)
         {
             _settingsManager = ScriptSettingsManager.Instance;
             FixtureId = testId;
@@ -71,9 +71,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             // Note: This has to be done after the call to Initialize or all file logging will be disabled.
             Host.ScriptConfig.HostConfig.Tracing.ConsoleLevel = TraceLevel.Off;
 
-            Host.HostStarted += (s, e) => _hostStartedEvent.Set();
-            Host.Start();
-            _hostStartedEvent.Wait(TimeSpan.FromSeconds(30));
+            if (startHost)
+            {
+                Host.HostStarted += (s, e) => _hostStartedEvent.Set();
+                Host.Start();
+                _hostStartedEvent.Wait(TimeSpan.FromSeconds(30));
+            }
         }
 
         public Mock<IScriptHostEnvironment> ScriptHostEnvironmentMock { get; }

--- a/test/WebJobs.Script.Tests.Integration/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/NodeEndToEndTests.cs
@@ -1297,7 +1297,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public class TestFixture : EndToEndTestFixture
         {
-            public TestFixture() : base(@"TestScripts\Node", "node")
+            public TestFixture()
+               : base(@"TestScripts\Node", "node")
+            {
+            }
+
+            internal TestFixture(bool startHost)
+                : base(@"TestScripts\Node", "node", startHost: startHost)
             {
             }
         }


### PR DESCRIPTION
~~Due to https://github.com/Azure/azure-webjobs-sdk/issues/1616, these two tests can sometimes fail to release their lock on the TimerTrigger Listener blob. This means subsequent tests that need this test to run can timeout as the trigger will never fire.~~

~~This change removes any patterns like:~~
~~1. Update a file, which restarts the host.~~
~~2. Immediately shut down or dispose of the host.~~

~~Now we'll do the final file update after the test has completed and the host has shut down.~~

Edit: Turns out that the real issue was that our tests were using this pattern:

```
CancellationTokenSource cts = new CancellationTokenSource();
StartBackgroundThread(() =>
{
    // Run test scenarios.
    cts.Cancel();
});
manager.RunAndBlock(cts.Token);
// Verify
```

But when you cancel the token to signal that RunAndBlock should exit, it fires off a untracked task to stop and dispose the ScriptHost. So the test exits without ensuring the host (specifically, the listener) is actually stopped. In this case, the TimerTrigger singleton blobs being held by this host were still being held by the time the next test started, which meant the trigger never fired. I've changed these tests to call `Stop()` instead of cancelling the token, which ensures that the listeners are all stopped before the test exits. I haven't seen it fail in the PR builds yet, so I'm going to go ahead and check it in.