### PR TITLE
updating Web.config redirects; adding regression test

### DIFF
--- a/src/WebJobs.Script.Host/App.config
+++ b/src/WebJobs.Script.Host/App.config
@@ -29,47 +29,7 @@
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Host" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.ServiceBus" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.DocumentDB" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.MobileApps" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.SendGrid" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.Twilio" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
-      </dependentAssembly>
+      </dependentAssembly>     
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.2.1.0" newVersion="7.2.1.0" />

--- a/src/WebJobs.Script.WebHost/Web.config
+++ b/src/WebJobs.Script.WebHost/Web.config
@@ -45,7 +45,7 @@
   </location>
   <system.webServer>
     <modules runAllManagedModulesForAllRequests="true">
-	    <remove name="ServiceModel-4.0" />
+      <remove name="ServiceModel-4.0" />
     </modules>
     
     <validation validateIntegratedModeConfiguration="false" />
@@ -100,35 +100,55 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.WebJobs.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.WebJobs.ServiceBus" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.ApiHub" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.BotFramework" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.DocumentDB" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.EventGrid" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.Http" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.MobileApps" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.SendGrid" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.Twilio" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/src/WebJobs.Script/app.config
+++ b/src/WebJobs.Script/app.config
@@ -41,47 +41,7 @@
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Host" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.ServiceBus" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.DocumentDB" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.MobileApps" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.SendGrid" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.Twilio" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0"/>
-      </dependentAssembly>
+      </dependentAssembly>     
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-7.2.1.0" newVersion="7.2.1.0"/>

--- a/test/WebJobs.Script.Scaling.Tests/App.config
+++ b/test/WebJobs.Script.Scaling.Tests/App.config
@@ -42,46 +42,6 @@
         <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Host" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.ServiceBus" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.DocumentDB" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.MobileApps" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.SendGrid" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.Twilio" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.2.1.0" newVersion="7.2.1.0" />
       </dependentAssembly>

--- a/test/WebJobs.Script.Tests.Integration/App.config
+++ b/test/WebJobs.Script.Tests.Integration/App.config
@@ -36,47 +36,7 @@
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Host" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.ServiceBus" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.DocumentDB" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.MobileApps" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.SendGrid" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.Twilio" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
-      </dependentAssembly>
+      </dependentAssembly>     
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.2.1.0" newVersion="7.2.1.0" />

--- a/test/WebJobs.Script.Tests/WebConfigTests/WebConfigTests.cs
+++ b/test/WebJobs.Script.Tests/WebConfigTests/WebConfigTests.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
+using Microsoft.Azure.WebJobs.Extensions.BotFramework;
+using Microsoft.Azure.WebJobs.Extensions.EventGrid;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public class WebConfigTests
+    {
+        private static XmlNamespaceManager _namespace = CreateNamespace();
+
+        [Fact]
+        public void TestConfig()
+        {
+            XDocument config = GetWebConfig();
+
+            AssertNewVersion(config, "System.Net.Http", "4.0.0.0");
+            AssertNewVersion(config, "System.IO.Compression", "4.0.0.0");
+
+            AssertVersionRedirects(config, typeof(QueueAttribute)); // Microsoft.Azure.WebJobs
+            AssertVersionRedirects(config, typeof(JobHost)); // Microsoft.Azure.WebJobs.Host
+            AssertVersionRedirects(config, typeof(ILogReader)); // Microsoft.Azure.WebJobs.Logging
+            AssertVersionRedirects(config, typeof(DefaultTelemetryClientFactory)); // Microsoft.Azure.WebJobs.Logging.ApplicationInsights
+            AssertVersionRedirects(config, typeof(ServiceBusAttribute)); // Microsoft.Azure.WebJobs.ServiceBus
+
+            AssertVersionRedirects(config, typeof(TimerTriggerAttribute)); // Microsoft.Azure.WebJobs.Extensions
+            AssertVersionRedirects(config, typeof(ApiHubFileAttribute)); // Microsoft.Azure.WebJobs.Extensions.ApiHub
+            AssertVersionRedirects(config, typeof(BotAttribute)); // Microsoft.Azure.WebJobs.Extensions.BotFramework
+            AssertVersionRedirects(config, typeof(DocumentDBAttribute)); // Microsoft.Azure.WebJobs.Extensions.DocumentDB
+            AssertVersionRedirects(config, typeof(EventGridTriggerAttribute)); // Microsoft.Azure.WebJobs.Extensions.EventGrid
+            AssertVersionRedirects(config, typeof(HttpTriggerAttribute)); // Microsoft.Azure.WebJobs.Extensions.Http
+            AssertVersionRedirects(config, typeof(MobileTableAttribute)); // Microsoft.Azure.WebJobs.MobileApps
+            AssertVersionRedirects(config, typeof(NotificationHubAttribute)); // Microsoft.Azure.WebJobs.NotificationHubs
+            AssertVersionRedirects(config, typeof(SendGridAttribute)); // Microsoft.Azure.WebJobs.SendGrid
+            AssertVersionRedirects(config, typeof(TwilioSmsAttribute)); // Microsoft.Azure.WebJobs.Twilio
+        }
+
+        private static XmlNamespaceManager CreateNamespace()
+        {
+            var namespaceManager = new XmlNamespaceManager(new NameTable());
+            namespaceManager.AddNamespace("nnn", "urn:schemas-microsoft-com:asm.v1");
+            return namespaceManager;
+        }
+
+        private static void AssertVersionRedirects(XDocument config, Type type)
+        {
+            AssemblyName assemblyDetails = type.Assembly.GetName();
+            string assemblyName = assemblyDetails.Name;
+            string redirectVersion = assemblyDetails.Version.ToString();
+
+            AssertNewVersion(config, assemblyName, redirectVersion);
+            AssertOldVersion(config, assemblyName, redirectVersion);
+        }
+
+        private static void AssertNewVersion(XDocument config, string assemblyName, string expectedNewVersion)
+        {
+            var path = $"/configuration/runtime/nnn:assemblyBinding/nnn:dependentAssembly/" +
+                $"nnn:assemblyIdentity[@name='{assemblyName}']" +
+                $"/following-sibling::nnn:bindingRedirect/" +
+                $"@newVersion";
+
+            string version = config.XPathEvaluate("string(" + path + ")", _namespace).ToString();
+            Assert.True(version == expectedNewVersion,
+                $"Web.config 'newVersion' does not match for binding redirect '{assemblyName}'. Expected '{expectedNewVersion}'. Actual '{version}'.");
+        }
+
+        private static void AssertOldVersion(XDocument config, string assemblyName, string expectedRedirectVersion)
+        {
+            var path = $"/configuration/runtime/nnn:assemblyBinding/nnn:dependentAssembly/" +
+                $"nnn:assemblyIdentity[@name='{assemblyName}']" +
+                $"/following-sibling::nnn:bindingRedirect/" +
+                $"@oldVersion";
+
+            string version = config.XPathEvaluate("string(" + path + ")", _namespace).ToString();
+            string expectedVersion = $"0.0.0.0-{expectedRedirectVersion}";
+            Assert.True(version == expectedVersion,
+                $"Web.config 'oldVersion' does not match for binding redirect '{assemblyName}'. Expected '{expectedVersion}'. Actual '{version}'.");
+        }
+
+        private static XDocument GetWebConfig()
+        {
+            string path = "Microsoft.Azure.WebJobs.Script.Tests.WebConfigTests.Web.config";
+            using (var stream = Assembly.GetCallingAssembly().GetManifestResourceStream(path))
+            {
+                return XDocument.Load(stream);
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -145,6 +145,9 @@
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.DocumentDB, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.2.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Azure.WebJobs.Extensions.EventGrid, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.EventGrid.1.0.0-beta3-10022\lib\net46\Microsoft.Azure.WebJobs.Extensions.EventGrid.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.Http, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Http.1.1.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.Http.dll</HintPath>
     </Reference>
@@ -162,6 +165,9 @@
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
@@ -587,6 +593,7 @@
     <Compile Include="TestMetricsLogger.cs" />
     <Compile Include="UtilityTests.cs" />
     <Compile Include="WebApiApplicationTests.cs" />
+    <Compile Include="WebConfigTests\WebConfigTests.cs" />
     <Compile Include="WebHooks\DynamicWebHookReceiverConfigTests.cs" />
     <Compile Include="Handlers\WebScriptHostHandlerTests.cs" />
     <Compile Include="WebHooks\WebHookReceiverManagerTests.cs" />
@@ -595,6 +602,9 @@
     <AdditionalFiles Include="..\..\stylecop.json">
       <Link>stylecop.json</Link>
     </AdditionalFiles>
+    <EmbeddedResource Include="..\..\src\WebJobs.Script.WebHost\Web.config">
+      <Link>WebConfigTests\Web.config</Link>
+    </EmbeddedResource>
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
@@ -628,7 +638,9 @@
     <None Include="Description\DotNet\TestFiles\PackageReferences\ProjectWithoutLock\project.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/test/WebJobs.Script.Tests/app.config
+++ b/test/WebJobs.Script.Tests/app.config
@@ -37,47 +37,7 @@
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Host" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.ServiceBus" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.DocumentDB" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.MobileApps" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.SendGrid" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.Twilio" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
-      </dependentAssembly>
+      </dependentAssembly>      
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-7.2.1.0" newVersion="7.2.1.0" />

--- a/test/WebJobs.Script.Tests/packages.config
+++ b/test/WebJobs.Script.Tests/packages.config
@@ -41,6 +41,7 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.2.0" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.81-alpha" targetFramework="net471" />


### PR DESCRIPTION
In addition to updating the redirects, I'm resurrecting an old Web.config unit test (https://github.com/Azure/azure-functions-host/pull/1727) that had since been deleted and adding verification for every assembly we control.

I went through one-by-one and made sure the test caught each one if it was wrong or missing. Now they all pass.