### PR TITLE
Debug mode fix (#2520)

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/AdminController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/AdminController.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         [HttpPost]
         [RequiresRunningHost]
         [Route("admin/functions/{name}")]
+        [EnableDebugMode]
         public HttpResponseMessage Invoke(string name, [FromBody] FunctionInvocation invocation)
         {
             if (invocation == null)
@@ -98,6 +99,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         [HttpGet]
         [Route("admin/host/status")]
         [AllowAnonymous]
+        [EnableDebugMode]
         public IHttpActionResult GetHostStatus()
         {
             var authorizationLevel = Request.GetAuthorizationLevel();
@@ -182,6 +184,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
         [HttpPost]
         [Route("admin/host/debug")]
+        [EnableDebugMode]
         public HttpResponseMessage LaunchDebugger()
         {
             if (_webHostSettings.IsSelfHost)
@@ -197,16 +200,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                 }
             }
             return new HttpResponseMessage(HttpStatusCode.NotImplemented);
-        }
-
-        public override Task<HttpResponseMessage> ExecuteAsync(HttpControllerContext controllerContext, CancellationToken cancellationToken)
-        {
-            // For all admin api requests, we'll update the ScriptHost debug timeout
-            // For now, we'll enable debug mode on ANY admin requests. Since the Portal interacts through
-            // the admin API this is sufficient for identifying when the Portal is connected.
-            _scriptHostManager.Instance?.NotifyDebug();
-
-            return base.ExecuteAsync(controllerContext, cancellationToken);
         }
 
         [Route("admin/extensions/{name}/{*extra}")]

--- a/src/WebJobs.Script.WebHost/Filters/EnableDebugModeAttribute.cs
+++ b/src/WebJobs.Script.WebHost/Filters/EnableDebugModeAttribute.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Http.Controllers;
+using System.Web.Http.Filters;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Filters
+{
+    /// <summary>
+    /// Filter applied to actions that should enable "Debug Mode".
+    /// </summary>
+    /// <remarks>
+    /// This attribute is applied to actions that the Portal/CLI invoke
+    /// as part of their normal interactions. This puts the host in debug
+    /// mode at the right time. E.g. the portal polls the admin/host/status
+    /// when it is running.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    public sealed class EnableDebugModeAttribute : ActionFilterAttribute
+    {
+        public override Task OnActionExecutingAsync(HttpActionContext actionContext, CancellationToken cancellationToken)
+        {
+            var resolver = actionContext.ControllerContext.Configuration.DependencyResolver;
+            var scriptHostManager = resolver.GetService<WebScriptHostManager>();
+
+            scriptHostManager.Instance?.NotifyDebug();
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -503,6 +503,7 @@
     <Compile Include="Diagnostics\Sanitizer.cs" />
     <Compile Include="Extensions\HttpRouteCollectionExtensions.cs" />
     <Compile Include="Extensions\HttpRouteFactoryExtensions.cs" />
+    <Compile Include="Filters\EnableDebugModeAttribute.cs" />
     <Compile Include="Filters\RequiresRunningHostAttribute.cs" />
     <Compile Include="Security\SecretsUtility.cs" />
     <Compile Include="StandbyManager.cs" />


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-functions-host/issues/2520

A long time ago we made a simplifying decision to enable debug mode on any admin requests, since the portal interacts with the runtime via admin APIs during portal debug/development. However over time we've added new admin APIs that should not enable debug mode.

So here I'm moving to an explicit per action opt in model.