### PR TITLE
Avoid potential NullRef on a race condition.

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHostManager.cs
+++ b/src/WebJobs.Script/Host/ScriptHostManager.cs
@@ -106,8 +106,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
             if (ShouldMonitorHostHealth)
             {
-                _hostHealthCheckTimer = new Timer(OnHostHealthCheckTimer, null, TimeSpan.Zero, _config.HostHealthMonitor.HealthCheckInterval);
                 _healthCheckWindow = new SlidingWindow<bool>(_config.HostHealthMonitor.HealthCheckWindow);
+                _hostHealthCheckTimer = new Timer(OnHostHealthCheckTimer, null, TimeSpan.Zero, _config.HostHealthMonitor.HealthCheckInterval);
             }
         }
 


### PR DESCRIPTION
I was randomly seeing this exception on linux 

```
Unhandled Exception: System.NullReferenceException: Object reference not set to an instance of an object.
    at Microsoft.Azure.WebJobs.Script.ScriptHostManager.OnHostHealthCheckTimer(Object state) in /azure-webjobs-sdk-script/src/WebJobs.Script/Host/ScriptHostManager.cs:line 516
    at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
    at System.Threading.TimerQueueTimer.CallCallback()
    at System.Threading.TimerQueueTimer.Fire()
    at System.Threading.TimerQueue.FireNextTimers()
```
which is pointing to this line 
https://github.com/Azure/azure-functions-host/blob/93453636381e2a4f2c39c3534b19cceb7c8c55f3/src/WebJobs.Script/Host/ScriptHostManager.cs#L516


I'm not actually sure if this will fix it or not. It seemed like the only possible way it could throw a null ref if for some reason the timer gets to run before the next line somehow. I don't really know. 