### PR TITLE
add feature to run in single language mode

### DIFF
--- a/src/WebJobs.Script.Grpc/Abstractions/IWorkerProvider.cs
+++ b/src/WebJobs.Script.Grpc/Abstractions/IWorkerProvider.cs
@@ -25,5 +25,11 @@ namespace Microsoft.Azure.WebJobs.Script.Abstractions
         /// <param name="logger">The startup ILogger.</param>
         /// <returns>A bool that indicates if the args were configured successfully.</returns>
         bool TryConfigureArguments(ArgumentsDescription args, IConfiguration config, ILogger logger);
+
+        /// <summary>
+        /// Get the worker directory path
+        /// </summary>
+        /// <returns>A string which is the full path to the worker directory</returns>
+        string GetWorkerDirectoryPath();
     }
 }

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -297,7 +297,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 ApplyEnvironmentSettings();
                 var hostConfig = ApplyHostConfiguration();
                 InitializeFileWatchers();
-                InitializeWorkers();
+                InitializeWorkers(_settingsManager.Configuration.GetSection(ScriptConstants.SingleLanguageModeSettingName).Value);
 
                 var functionMetadata = LoadFunctionMetadata();
                 var directTypes = LoadBindingExtensions(functionMetadata, hostConfig);
@@ -493,11 +493,21 @@ namespace Microsoft.Azure.WebJobs.Script
         /// </summary>
         private void InitializeFunctionDescriptors(Collection<FunctionMetadata> functionMetadata)
         {
-            _descriptorProviders = new List<FunctionDescriptorProvider>()
+            var language = _settingsManager.Configuration.GetSection(ScriptConstants.SingleLanguageModeSettingName).Value;
+            _descriptorProviders = new List<FunctionDescriptorProvider>();
+            if (string.IsNullOrEmpty(language))
             {
-                new DotNetFunctionDescriptorProvider(this, ScriptConfig),
-                new WorkerFunctionDescriptorProvider(this, ScriptConfig, _functionDispatcher),
-            };
+                _descriptorProviders.Add(new DotNetFunctionDescriptorProvider(this, ScriptConfig));
+                _descriptorProviders.Add(new WorkerFunctionDescriptorProvider(this, ScriptConfig, _functionDispatcher));
+            }
+            else if (language.Equals(ScriptConstants.DotNetLanguageName, StringComparison.OrdinalIgnoreCase))
+            {
+                _descriptorProviders.Add(new DotNetFunctionDescriptorProvider(this, ScriptConfig));
+            }
+            else
+            {
+                _descriptorProviders.Add(new WorkerFunctionDescriptorProvider(this, ScriptConfig, _functionDispatcher));
+            }
 
             Collection<FunctionDescriptor> functions;
             using (_metricsLogger.LatencyEvent(MetricEventNames.HostStartupGetFunctionDescriptorsLatency))
@@ -684,7 +694,7 @@ namespace Microsoft.Azure.WebJobs.Script
             return hostConfigObject;
         }
 
-        private void InitializeWorkers()
+        private void InitializeWorkers(string language)
         {
             var serverImpl = new FunctionRpcService(EventManager);
             var server = new GrpcServer(serverImpl);
@@ -714,13 +724,34 @@ namespace Microsoft.Azure.WebJobs.Script
                     server.Uri,
                     _hostConfig.LoggerFactory);
             };
-            var providers = new List<IWorkerProvider>()
-                {
-                    new NodeWorkerProvider(),
-                    new JavaWorkerProvider()
-                };
 
-            providers.AddRange(GenericWorkerProvider.ReadWorkerProviderFromConfig(ScriptConfig, _startupLogger));
+            var providers = new List<IWorkerProvider>();
+
+            if (!string.IsNullOrEmpty(language))
+            {
+                _startupLogger.LogInformation($"Single language mode enabled, only {language} will be enabled");
+                // TODO: We still have some hard coded languages, so we need to handle them. Remove this switch once we've moved away from that.
+                switch (language)
+                {
+                    case ScriptConstants.NodeLanguageName:
+                        providers.Add(new NodeWorkerProvider());
+                        break;
+                    case ScriptConstants.JavaLanguageName:
+                        providers.Add(new JavaWorkerProvider());
+                        break;
+                    default:
+                        // Pass the language to the provider loader to filter
+                        providers.AddRange(GenericWorkerProvider.ReadWorkerProviderFromConfig(ScriptConfig, _startupLogger, language: language));
+                        break;
+                }
+            }
+            else
+            {
+                // load all providers if no specific language is specified
+                providers.Add(new NodeWorkerProvider()); // TODO: Should move these worker providers to Generic model
+                providers.Add(new JavaWorkerProvider());
+                providers.AddRange(GenericWorkerProvider.ReadWorkerProviderFromConfig(ScriptConfig, _startupLogger));
+            }
 
             var configFactory = new WorkerConfigFactory(ScriptSettingsManager.Instance.Configuration, _startupLogger);
             var workerConfigs = configFactory.GetConfigs(providers);
@@ -1358,11 +1389,14 @@ namespace Microsoft.Azure.WebJobs.Script
                         }
                     }
 
-                    ValidateFunction(descriptor, httpFunctions);
-
                     if (descriptor != null)
                     {
+                        ValidateFunction(descriptor, httpFunctions);
                         functionDescriptors.Add(descriptor);
+                    }
+                    else
+                    {
+                        throw new Exception("Could not find a valid provider. Check that you have the correct language provider installed and enabled.");
                     }
                 }
                 catch (Exception ex)

--- a/src/WebJobs.Script/Rpc/Configuration/JavaWorkerProvider.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/JavaWorkerProvider.cs
@@ -13,9 +13,11 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 {
     internal class JavaWorkerProvider : IWorkerProvider
     {
+        private string pathToWorkerDir = WorkerProviderHelper.BuildWorkerDirectoryPath(ScriptConstants.JavaLanguageName);
+
         public WorkerDescription GetDescription() => new WorkerDescription
         {
-            Language = "Java",
+            Language = ScriptConstants.JavaLanguageName,
             Extension = ".jar",
             DefaultWorkerPath = "azure-functions-java-worker.jar",
         };
@@ -53,6 +55,11 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 args.ExecutableArguments.Add(env.JAVA_OPTS);
             }
             return true;
+        }
+
+        public string GetWorkerDirectoryPath()
+        {
+            return pathToWorkerDir;
         }
 
         private class JavaEnvironment

--- a/src/WebJobs.Script/Rpc/Configuration/NodeWorkerProvider.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/NodeWorkerProvider.cs
@@ -14,9 +14,11 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 {
     internal class NodeWorkerProvider : IWorkerProvider
     {
+        private string pathToWorkerDir = WorkerProviderHelper.BuildWorkerDirectoryPath(ScriptConstants.NodeLanguageName);
+
         public WorkerDescription GetDescription() => new WorkerDescription
         {
-            Language = "Node",
+            Language = ScriptConstants.NodeLanguageName,
             Extension = ".js",
             DefaultExecutablePath = "node",
             DefaultWorkerPath = Path.Combine("dist", "src", "nodejsWorker.js"),
@@ -31,6 +33,11 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 args.ExecutableArguments.Add($"--inspect={debugPort}");
             }
             return true;
+        }
+
+        public string GetWorkerDirectoryPath()
+        {
+            return pathToWorkerDir;
         }
     }
 }

--- a/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
@@ -31,20 +31,8 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 var description = provider.GetDescription();
                 var languageSection = _config.GetSection($"workers:{description.Language}");
 
-                // Resolve worker path
-                // 1. If workers.{language}.path is set, use that explicitly
-                // 2. If workers.path is set, use that as the base directory + language + default path
-                // 3. Else, use the default workers directory
-
-                // get explicit worker path from config, or build relative path from default
-                var workerPath = languageSection.GetSection("path").Value;
-                if (string.IsNullOrEmpty(workerPath))
-                {
-                    var baseWorkerPath = !string.IsNullOrEmpty(_config.GetSection("workers:path").Value) ?
-                            _config.GetSection("workers:path").Value :
-                            Path.Combine(_assemblyDir, "workers");
-                    workerPath = Path.Combine(baseWorkerPath, description.Language.ToLower(), description.DefaultWorkerPath);
-                }
+                // Can override the path we load from, or we use the default path from where we loaded the config
+                var workerPath = languageSection.GetSection("path").Value ?? Path.Combine(provider.GetWorkerDirectoryPath(), description.DefaultWorkerPath);
 
                 var arguments = new ArgumentsDescription()
                 {

--- a/src/WebJobs.Script/Rpc/Configuration/WorkerProviderHelper.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/WorkerProviderHelper.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.Azure.WebJobs.Script.Rpc
+{
+    internal class WorkerProviderHelper
+    {
+        public static string BuildWorkerDirectoryPath(string languageName)
+        {
+            return Path.Combine(Path.GetDirectoryName(new Uri(typeof(WorkerConfigFactory).Assembly.CodeBase).LocalPath), ScriptConstants.DefaultWorkersDirectoryName, languageName);
+        }
+    }
+}

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -65,6 +65,11 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string DefaultMasterKeyName = "master";
         public const string DefaultFunctionKeyName = "default";
         public const string ColdStartEventName = "ColdStart";
+        public const string SingleLanguageModeSettingName = "workers:language";
+        public const string DotNetLanguageName = "DotNet";
+        public const string NodeLanguageName = "Node";
+        public const string JavaLanguageName = "Java";
+        public const string DefaultWorkersDirectoryName = "workers";
 
         public const string AntaresLogIdHeaderName = "X-ARR-LOG-ID";
         public const string AntaresScaleOutHeaderName = "X-FUNCTION-SCALEOUT";

--- a/test/WebJobs.Script.Tests.Shared/TestWorkerProvider.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestWorkerProvider.cs
@@ -26,6 +26,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             DefaultWorkerPath = this.DefaultWorkerPath,
         };
 
+        public string GetWorkerDirectoryPath()
+        {
+            return string.Empty;
+        }
+
         public bool TryConfigureArguments(ArgumentsDescription args, IConfiguration config, ILogger logger)
         {
             // make no modifications

--- a/test/WebJobs.Script.Tests/Rpc/GenericWorkerProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/GenericWorkerProviderTests.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
+using System.Linq;
 using Microsoft.Azure.WebJobs.Script.Abstractions;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Rpc;
@@ -20,8 +20,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         [Fact]
         public void Constructor_ThrowsNullArgument()
         {
-            Assert.Throws<ArgumentNullException>(() => new GenericWorkerProvider(null, new List<string>()));
-            Assert.Throws<ArgumentNullException>(() => new GenericWorkerProvider(new WorkerDescription(), null));
+            Assert.Throws<ArgumentNullException>(() => new GenericWorkerProvider(null, new List<string>(), string.Empty));
+            Assert.Throws<ArgumentNullException>(() => new GenericWorkerProvider(new WorkerDescription(), null, string.Empty));
+            Assert.Throws<ArgumentNullException>(() => new GenericWorkerProvider(new WorkerDescription(), new List<string>(), null));
         }
 
         [Fact]
@@ -29,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         {
             var workerDescription = new WorkerDescription();
             var arguments = new List<string>();
-            var provider = new GenericWorkerProvider(workerDescription, arguments);
+            var provider = new GenericWorkerProvider(workerDescription, arguments, string.Empty);
 
             Assert.Equal(workerDescription, provider.GetDescription());
         }
@@ -37,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         [Fact]
         public void TryConfigureArguments_ReturnsTrue()
         {
-            var provider = new GenericWorkerProvider(new WorkerDescription(), new List<string>());
+            var provider = new GenericWorkerProvider(new WorkerDescription(), new List<string>(), string.Empty);
             var args = new ArgumentsDescription();
 
             Assert.True(provider.TryConfigureArguments(args, null, null));
@@ -72,7 +73,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
                 It.IsAny<Func<object, Exception, string>>()));
 
             // Creates temp directory w/ worker.config.json and runs ReadWorkerProviderFromConfig
-            var providers = TestReadWorkerProviderFromConfig(language, json, arguments, mockLogger);
+            (var workerPath, var providers) = TestReadWorkerProviderFromConfig(language, json, arguments, mockLogger);
 
             mockLogger.Verify(x => x.Log<object>(
                It.IsAny<LogLevel>(),
@@ -82,6 +83,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
                It.IsAny<Func<object, Exception, string>>()), Times.Never());
 
             Assert.Single(providers);
+
+            Assert.Equal(workerPath, providers.Single().GetWorkerDirectoryPath());
         }
 
         [Fact]
@@ -113,7 +116,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
                 It.IsAny<Func<object, Exception, string>>()));
 
             // Creates temp directory w/ worker.config.json and runs ReadWorkerProviderFromConfig
-            var providers = TestReadWorkerProviderFromConfig(language, json, arguments, mockLogger);
+            (var workerPath, var providers) = TestReadWorkerProviderFromConfig(language, json, arguments, mockLogger);
 
             mockLogger.Verify(x => x.Log<object>(
                It.IsAny<LogLevel>(),
@@ -123,21 +126,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
                It.IsAny<Func<object, Exception, string>>()), Times.Never());
 
             Assert.Single(providers);
+
+            Assert.Equal(workerPath, providers.Single().GetWorkerDirectoryPath());
         }
 
         [Fact]
         public void ReadWorkerProviderFromConfig_BadConfigFile()
         {
             string language = "test";
-            var description = new WorkerDescription()
-            {
-                DefaultExecutablePath = "foopath",
-                DefaultWorkerPath = "./src/index.test",
-                Language = "test",
-                Extension = ".test"
-            };
-
-            var arguments = new string[] { };
 
             string json = "garbage";
 
@@ -150,7 +146,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
                 It.IsAny<Func<object, Exception, string>>()));
 
             // Creates temp directory w/ worker.config.json and runs ReadWorkerProviderFromConfig
-            var providers = TestReadWorkerProviderFromConfig(language, json, arguments, mockLogger);
+            (var workerPath, var providers) = TestReadWorkerProviderFromConfig(language, json, null, mockLogger);
 
             mockLogger.Verify(x => x.Log<object>(
                 It.IsAny<LogLevel>(),
@@ -162,7 +158,41 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             Assert.Empty(providers);
         }
 
-        private IEnumerable<IWorkerProvider> TestReadWorkerProviderFromConfig(string language, string json, string[] arguments, Mock<ILogger<object>> mockLogger)
+        [Fact]
+        public void ReadWorkerProviderFromConfig_SingleLanguage()
+        {
+            var language1 = "language1";
+            var language2 = "language2";
+
+            var language1Config = MakeTestConfig(language1);
+            var language2Config = MakeTestConfig(language2);
+
+            var configs = new List<TestLanguageWorkerConfig>() { language1Config, language2Config };
+
+            var mockLogger = new Mock<ILogger<object>>(MockBehavior.Loose);
+            mockLogger.Setup(x => x.Log<object>(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<object>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<object, Exception, string>>()));
+
+            // Creates temp directory w/ worker.config.json and runs ReadWorkerProviderFromConfig
+            (var workerPath, var providers) = TestReadWorkerProviderFromConfig(configs, mockLogger, language: language1);
+
+            mockLogger.Verify(x => x.Log<object>(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<object>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<object, Exception, string>>()), Times.Never());
+
+            Assert.Single(providers);
+
+            Assert.Equal(language1, providers.Single().GetDescription().Language);
+        }
+
+        private (string workerPath, IEnumerable<IWorkerProvider> providers) TestReadWorkerProviderFromConfig(string language, string json, string[] arguments, Mock<ILogger<object>> mockLogger)
         {
             string rootPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             string workerPath = Path.Combine(rootPath, language);
@@ -180,7 +210,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
                 };
                 scriptSettingsManager.SetConfigurationFactory(() => new ConfigurationBuilder()
                     .AddInMemoryCollection(settings).Build());
-                return GenericWorkerProvider.ReadWorkerProviderFromConfig(scriptHostConfig, mockLogger.Object, scriptSettingsManager);
+                return (workerPath, GenericWorkerProvider.ReadWorkerProviderFromConfig(scriptHostConfig, mockLogger.Object, scriptSettingsManager));
             }
             finally
             {
@@ -189,6 +219,69 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
                     Directory.Delete(rootPath, true);
                 }
             }
+        }
+
+        private (string workerPath, IEnumerable<IWorkerProvider> providers) TestReadWorkerProviderFromConfig(IEnumerable<TestLanguageWorkerConfig> configs, Mock<ILogger<object>> mockLogger, string language = null)
+        {
+            string rootPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            try
+            {
+                foreach (var config in configs)
+                {
+                    string workerPath = Path.Combine(rootPath, config.Language);
+                    Directory.CreateDirectory(workerPath);
+
+                    File.WriteAllText(Path.Combine(workerPath, ScriptConstants.WorkerConfigFileName), config.Json);
+                }
+
+                var scriptHostConfig = new ScriptHostConfiguration();
+                var scriptSettingsManager = new ScriptSettingsManager();
+                var settings = new List<KeyValuePair<string, string>>
+                {
+                    new KeyValuePair<string, string>("workers:config:path", rootPath)
+                };
+                scriptSettingsManager.SetConfigurationFactory(() => new ConfigurationBuilder()
+                    .AddInMemoryCollection(settings).Build());
+                return (rootPath, GenericWorkerProvider.ReadWorkerProviderFromConfig(scriptHostConfig, mockLogger.Object, scriptSettingsManager, language: language));
+            }
+            finally
+            {
+                if (Directory.Exists(rootPath))
+                {
+                    Directory.Delete(rootPath, true);
+                }
+            }
+        }
+
+        private static TestLanguageWorkerConfig MakeTestConfig(string language)
+        {
+            var description = new WorkerDescription()
+            {
+                DefaultExecutablePath = "foopath",
+                DefaultWorkerPath = $"./src/index.{language}",
+                Language = language,
+                Extension = $".{language}"
+            };
+
+            var arguments = new string[] { };
+
+            JObject config = new JObject();
+            config["Description"] = JObject.FromObject(description);
+            config["Arguments"] = JArray.FromObject(arguments);
+
+            string json = config.ToString();
+            return new TestLanguageWorkerConfig()
+            {
+                Json = json,
+                Language = language
+            };
+        }
+
+        private class TestLanguageWorkerConfig
+        {
+            public string Language { get; set; }
+
+            public string Json { get; set; }
         }
     }
 }


### PR DESCRIPTION
If you set `workers:config:language` to a language (e.g. `Node`), it will only load workers for that given language.

If you try to use a Function from a language which hasn't been loaded, it will now give you a helpful hint instead of an nullref exception.

There are some `TODO:`s here associated with moving Java, DotNet, and Node.js to the generic language worker model (rather than Java/Node's current class based approach and DotNet running the same process as the host).

fixes https://github.com/Azure/azure-functions-host/issues/2541
fixes https://github.com/Azure/azure-functions-host/issues/2542