### PR TITLE
re-enabling Event Hubs tests; moving extensions tests to their own classes

### DIFF
--- a/sample/EventHubTrigger/function.json
+++ b/sample/EventHubTrigger/function.json
@@ -6,7 +6,7 @@
             "cardinality": "many",
             "direction": "in",
             "connection": "AzureWebJobsEventHubReceiver",
-            "path": "%AzureWebJobsEventHubPath%"
+            "eventHubName": "%AzureWebJobsEventHubPath%"
         }
     ]
 }

--- a/test/WebJobs.Script.Tests.Integration/CosmosDB/CosmosDBCSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/CosmosDB/CosmosDBCSharpEndToEndTests.cs
@@ -4,12 +4,12 @@
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Microsoft.Azure.WebJobs.Script.Tests.CosmosDBTrigger
+namespace Microsoft.Azure.WebJobs.Script.Tests.CosmosDB
 {
-    public class CosmosDBTriggerCSharpEndToEndTests :
-        CosmosDBTriggerEndToEndTestsBase<CosmosDBTriggerCSharpEndToEndTests.TestFixture>
+    public class CosmosDBCSharpEndToEndTests :
+        CosmosDBEndToEndTestsBase<CosmosDBCSharpEndToEndTests.TestFixture>
     {
-        public CosmosDBTriggerCSharpEndToEndTests(TestFixture fixture) : base(fixture)
+        public CosmosDBCSharpEndToEndTests(TestFixture fixture) : base(fixture)
         {
         }
 
@@ -19,7 +19,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.CosmosDBTrigger
             return CosmosDBTriggerToBlobTest();
         }
 
-        public class TestFixture : CosmosDBTriggerTestFixture
+        [Fact]
+        public Task CosmosDB()
+        {
+            return CosmosDBTest();
+        }
+
+        public class TestFixture : CosmosDBTestFixture
         {
             private const string ScriptRoot = @"TestScripts\CSharp";
 

--- a/test/WebJobs.Script.Tests.Integration/CosmosDB/CosmosDBNodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/CosmosDB/CosmosDBNodeEndToEndTests.cs
@@ -4,12 +4,12 @@
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Microsoft.Azure.WebJobs.Script.Tests.CosmosDBTrigger
+namespace Microsoft.Azure.WebJobs.Script.Tests.CosmosDB
 {
-    public class CosmosDBTriggerNodeEndToEndTests :
-        CosmosDBTriggerEndToEndTestsBase<CosmosDBTriggerNodeEndToEndTests.TestFixture>
+    public class CosmosDBNodeEndToEndTests :
+        CosmosDBEndToEndTestsBase<CosmosDBNodeEndToEndTests.TestFixture>
     {
-        public CosmosDBTriggerNodeEndToEndTests(TestFixture fixture) : base(fixture)
+        public CosmosDBNodeEndToEndTests(TestFixture fixture) : base(fixture)
         {
         }
 
@@ -19,7 +19,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.CosmosDBTrigger
             return CosmosDBTriggerToBlobTest();
         }
 
-        public class TestFixture : CosmosDBTriggerTestFixture
+        [Fact]
+        public Task CosmosDB()
+        {
+            return CosmosDBTest();
+        }
+
+        public class TestFixture : CosmosDBTestFixture
         {
             private const string ScriptRoot = @"TestScripts\Node";
 

--- a/test/WebJobs.Script.Tests.Integration/EventHubs/EventHubSamplesEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/EventHubs/EventHubSamplesEndToEndTests.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.EventHubs
+{
+    public class EventHubSamplesEndToEndTests : IClassFixture<EventHubSamplesEndToEndTests.TestFixture>
+    {
+        private TestFixture _fixture;
+
+        public EventHubSamplesEndToEndTests(TestFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task EventHubTrigger()
+        {
+            // write 3 events
+            List<EventData> events = new List<EventData>();
+            string[] ids = new string[3];
+            for (int i = 0; i < 3; i++)
+            {
+                ids[i] = Guid.NewGuid().ToString();
+                JObject jo = new JObject
+                {
+                    { "value", ids[i] }
+                };
+                var evt = new EventData(Encoding.UTF8.GetBytes(jo.ToString(Formatting.None)));
+                evt.Properties.Add("TestIndex", i);
+                events.Add(evt);
+            }
+
+            string connectionString = Environment.GetEnvironmentVariable("AzureWebJobsEventHubSender");
+            EventHubsConnectionStringBuilder builder = new EventHubsConnectionStringBuilder(connectionString);
+
+            if (string.IsNullOrWhiteSpace(builder.EntityPath))
+            {
+                string eventHubPath = ScriptSettingsManager.Instance.GetSetting("AzureWebJobsEventHubPath");
+                builder.EntityPath = eventHubPath;
+            }
+
+            EventHubClient eventHubClient = EventHubClient.CreateFromConnectionString(builder.ToString());
+
+            await eventHubClient.SendAsync(events);
+
+            string logs = null;
+            await TestHelpers.Await(() =>
+            {
+                // wait until all of the 3 of the unique IDs sent
+                // above have been processed
+                logs = _fixture.Host.GetLog();
+                return ids.All(p => logs.Contains(p));
+            });
+
+            Assert.True(logs.Contains("IsArray true"));
+        }
+
+        public class TestFixture : EndToEndTestFixture
+        {
+            public TestFixture() :
+                base(Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample"), "samples", "Microsoft.Azure.WebJobs.Extensions.EventHubs", "3.0.0-beta4-11268")
+            {
+            }
+
+            protected override IEnumerable<string> GetActiveFunctions() => new[] { "EventHubTrigger" };
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/EventHubs/EventHubsEndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/EventHubs/EventHubsEndToEndTestsBase.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.EventHubs
+{
+    public class EventHubsEndToEndTestsBase : IClassFixture<EventHubsEndToEndTestsBase.TestFixture>
+    {
+        private EndToEndTestFixture _fixture;
+
+        public EventHubsEndToEndTestsBase(TestFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task EventHub()
+        {
+            // Event Hub needs the following environment vars:
+            // "AzureWebJobsEventHubSender" - the connection string for the send rule
+            // "AzureWebJobsEventHubReceiver"  - the connection string for the receiver rule
+            // "AzureWebJobsEventHubPath" - the path
+
+            // Test both sending and receiving from an EventHub.
+            // First, manually invoke a function that has an output binding to send EventDatas to an EventHub.
+            //  This tests the ability to queue eventhhubs
+            string testData = Guid.NewGuid().ToString();
+
+            await _fixture.Host.BeginFunctionAsync("EventHubSender", testData);
+
+            // Second, there's an EventHub trigger listener on the events which will write a blob.
+            // Once the blob is written, we know both sender & listener are working.
+            var resultBlob = _fixture.TestOutputContainer.GetBlockBlobReference(testData);
+            string result = await TestHelpers.WaitForBlobAndGetStringAsync(resultBlob);
+
+            var payload = JObject.Parse(result);
+            Assert.Equal(testData, (string)payload["id"]);
+
+            var bindingData = payload["bindingData"];
+            int sequenceNumber = (int)bindingData["sequenceNumber"];
+            var systemProperties = bindingData["systemProperties"];
+            Assert.Equal(sequenceNumber, (int)systemProperties["SequenceNumber"]);
+        }
+
+        public class TestFixture : EndToEndTestFixture
+        {
+            public TestFixture() :
+                base(@"TestScripts\Node", "node", "Microsoft.Azure.WebJobs.Extensions.EventHubs", "3.0.0-beta4-11268")
+            {
+            }
+
+            protected override IEnumerable<string> GetActiveFunctions() => new[] { "EventHubSender", "EventHubTrigger" };
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Node/EventHubSender/function.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Node/EventHubSender/function.json
@@ -10,7 +10,7 @@
             "name": "output",
             "direction": "out",
             "connection": "AzureWebJobsEventHubSender",
-            "path": "%AzureWebJobsEventHubPath%"
+            "eventHubName": "%AzureWebJobsEventHubPath%"
         }
     ]
 }

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Node/EventHubTrigger/function.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Node/EventHubTrigger/function.json
@@ -5,7 +5,7 @@
             "name": "workItem",
             "direction": "in",
             "connection": "AzureWebJobsEventHubReceiver",
-            "path": "%AzureWebJobsEventHubPath%",
+            "eventHubName": "%AzureWebJobsEventHubPath%",
             "consumerGroup": "$Default"
         },
         {

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Node/host.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Node/host.json
@@ -1,3 +1,3 @@
 ﻿{
-  "id": "function-tests-node",
+  "id": "function-tests-node"
 }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpEndToEndTests.cs
@@ -52,12 +52,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             // await MobileTablesTest(isDotNet: true);
         }
 
-        [Fact]
-        public async Task CosmosDB()
-        {
-            await CosmosDBTest();
-        }
-
         [Fact(Skip = "Not yet enabled.")]
         public void NotificationHub()
         {

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
     {
         private string _copiedRootPath;
 
-        protected EndToEndTestFixture(string rootPath, string testId)
+        protected EndToEndTestFixture(string rootPath, string testId, string extensionName = null, string extensionVersion = null)
         {
             FixtureId = testId;
             string connectionString = AmbientConnectionStringProvider.Instance.GetConnectionString(ConnectionStringNames.Storage);
@@ -46,11 +46,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             File.WriteAllText(hostJsonPath, hostJson.ToString());
 
             Host = new TestFunctionHost(_copiedRootPath);
-            Host.SetNugetPackageSources("http://www.myget.org/F/azure-appservice/api/v2", "https://api.nuget.org/v3/index.json");
-            Host.InstallBindingExtension("Microsoft.Azure.WebJobs.Extensions.CosmosDB", "3.0.0-beta7-10602").Wait();
 
-            // TODO: Find a better way to ensure extensions have installed and host has initiated restart.
-            Task.Delay(3000).Wait();
+            // We can currently only support a single extension.
+            if (extensionName != null && extensionVersion != null)
+            {
+                Host.SetNugetPackageSources("http://www.myget.org/F/azure-appservice/api/v2", "https://api.nuget.org/v3/index.json");
+                Host.InstallBindingExtension(extensionName, extensionVersion).Wait();
+            }
+
             Host.StartAsync().Wait();
         }
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestsBase.cs
@@ -228,30 +228,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         //    }
         //}
 
-        protected async Task CosmosDBTest()
-        {
-            // DocumentDB tests need the following environment vars:
-            // "AzureWebJobsDocumentDBConnectionString" -- the connection string to the account
-            string id = Guid.NewGuid().ToString();
-
-            await Fixture.Host.BeginFunctionAsync("CosmosDBOut", id);
-
-            Document doc = await WaitForDocumentAsync(id);
-
-            Assert.Equal(doc.Id, id);
-
-            // Now add that Id to a Queue, in an object to test binding
-            var queue = await Fixture.GetNewQueue("documentdb-input");
-            string messageContent = string.Format("{{ \"documentId\": \"{0}\" }}", id);
-            await queue.AddMessageAsync(new CloudQueueMessage(messageContent));
-
-            // And wait for the text to be updated
-            Document updatedDoc = await WaitForDocumentAsync(id, "This was updated!");
-
-            Assert.Equal(updatedDoc.Id, doc.Id);
-            Assert.NotEqual(doc.ETag, updatedDoc.ETag);
-        }
-
         //protected async Task ServiceBusQueueTriggerToBlobTestImpl()
         //{
         //    var resultBlob = Fixture.TestOutputContainer.GetBlockBlobReference("completed");

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/NodeEndToEndTests.cs
@@ -130,11 +130,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             await TableOutputTest();
         }
 
-        [Fact]
-        public async Task CosmosDB()
-        {
-            await CosmosDBTest();
-        }
 
         [Fact(Skip = "Not yet enabled.")]
         public void NotificationHub()
@@ -152,38 +147,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         public void MobileTables()
         {
             //await MobileTablesTest();
-        }
-
-        [Fact(Skip = "Not yet enabled.")]
-        public void EventHub()
-        {
-            // Event Hub needs the following environment vars:
-            // "AzureWebJobsEventHubSender" - the connection string for the send rule
-            // "AzureWebJobsEventHubReceiver"  - the connection string for the receiver rule
-            // "AzureWebJobsEventHubPath" - the path
-
-            // Test both sending and receiving from an EventHub.
-            // First, manually invoke a function that has an output binding to send EventDatas to an EventHub.
-            //  This tests the ability to queue eventhhubs
-            //string testData = Guid.NewGuid().ToString();
-            //Dictionary<string, object> arguments = new Dictionary<string, object>
-            //{
-            //    { "input", testData }
-            //};
-            //await Fixture.Host.CallAsync("EventHubSender", arguments);
-
-            //// Second, there's an EventHub trigger listener on the events which will write a blob.
-            //// Once the blob is written, we know both sender & listener are working.
-            //var resultBlob = Fixture.TestOutputContainer.GetBlockBlobReference(testData);
-            //string result = await TestHelpers.WaitForBlobAndGetStringAsync(resultBlob);
-
-            //var payload = JObject.Parse(result);
-            //Assert.Equal(testData, (string)payload["id"]);
-
-            //var bindingData = payload["bindingData"];
-            //int sequenceNumber = (int)bindingData["sequenceNumber"];
-            //var systemProperties = bindingData["systemProperties"];
-            //Assert.Equal(sequenceNumber, (int)systemProperties["sequenceNumber"]);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -23,6 +23,7 @@
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.9.1" />
+    <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.0.3" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta2-10009" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta1-10026" />
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />
@@ -31,7 +32,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="WindowsAzure.ServiceBus" Version="4.1.7" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>


### PR DESCRIPTION
We can't install more than one extension into a host. I'm working around this by separating out the tests into their own classes, which will run their own host.