### PR TITLE
Fix #2205 - make sure assembly resolution handler can't throw (V2)

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoader.cs
+++ b/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoader.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             {
                 return ResolveAssemblyCore(sender, args);
             }
-            catch
+            catch (Exception exc) when (!exc.IsFatal())
             {
                 // Do not allow an exception to prevent other registered handlers from attempting to resolve the assembly.
                 return null;

--- a/test/WebJobs.Script.Tests/Description/DotNet/FunctionAssemblyLoaderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/FunctionAssemblyLoaderTests.cs
@@ -4,21 +4,31 @@
 using System;
 using System.Collections.ObjectModel;
 using System.Reflection;
+using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Extensibility;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Internal;
 using Moq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
-    public class FunctionAssemblyLoaderTests
+    public class FunctionAssemblyLoaderTests : IDisposable
     {
+        private readonly FunctionAssemblyLoader resolver;
+
+        public FunctionAssemblyLoaderTests()
+        {
+            resolver = new FunctionAssemblyLoader("c:\\");
+        }
+
+        public void Dispose() => resolver?.Dispose();
+
         [Fact]
         public void ResolveAssembly_WithIndirectPrivateDependency_IsResolved()
         {
             TestLogger testLogger = new TestLogger("Test");
-
-            var resolver = new FunctionAssemblyLoader("c:\\");
 
             var metadata1Directory = @"c:\testroot\test1";
             var metadata1 = new FunctionMetadata { Name = "Test1", ScriptFile = $@"{metadata1Directory}\test.tst" };
@@ -42,8 +52,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             TestLogger testLogger = new TestLogger("Test");
 
-            var resolver = new FunctionAssemblyLoader("c:\\");
-
             var metadata1Directory = @"c:\testroot\test1";
             var metadata1 = new FunctionMetadata { Name = "Test1", ScriptFile = $@"{metadata1Directory}\test.tst" };
             var metadata2 = new FunctionMetadata { Name = "Test2", ScriptFile = @"c:\testroot\test2\test.tst" };
@@ -61,6 +69,32 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Null(result);
             Assert.Equal(1, testLogger.GetLogMessages().Count);
             Assert.Contains("MyTestAssembly.dll", testLogger.GetLogMessages()[0].FormattedMessage);
+        }
+
+        [Fact]
+        public void ResolveAssembly_SwallowsNonFatalException()
+        {
+            // Set up a context to be resolved correctly
+            var metadata1Directory = @"c:\testroot\test1";
+            var metadata1 = new FunctionMetadata { Name = "Test1", ScriptFile = $@"{metadata1Directory}\test.tst" };
+
+            // Set up for an error to occur when resolving the assembly
+            var mockResolver = new Mock<IFunctionMetadataResolver>();
+            mockResolver.Setup(m => m.ResolveAssembly("MyTestAssembly.dll"))
+              .Throws(new System.IO.FileNotFoundException());
+
+            // Set up for an error to occur in the error handling path!
+            var mockLogger = new Mock<ILogger>();
+            mockLogger.Setup(m => m.Log(LogLevel.Warning, It.IsAny<EventId>(), It.IsAny<FormattedLogValues>(), It.IsAny<Exception>(), It.IsAny<Func<object, Exception, string>>()))
+                .Throws(new NullReferenceException());
+
+            resolver.CreateOrUpdateContext(metadata1, this.GetType().Assembly, mockResolver.Object, mockLogger.Object);
+
+            Assembly result = resolver.ResolveAssembly(AppDomain.CurrentDomain, new System.ResolveEventArgs("MyTestAssembly.dll",
+                new TestAssembly(new AssemblyName("MyDirectReference"), @"file:///c:/testroot/test1/bin/MyDirectReference.dll")));
+
+            // The error in the error handling path should have been swallowed and we just get a null back
+            Assert.Null(result);
         }
 
         private class TestAssembly : Assembly


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-functions-host/issues/2205