### PR TITLE
Fix Invoke handler to raise exception on error

### DIFF
--- a/src/WebJobs.Script/Eventing/Rpc/InboundEvent.cs
+++ b/src/WebJobs.Script/Eventing/Rpc/InboundEvent.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 
 namespace Microsoft.Azure.WebJobs.Script.Eventing.Rpc

--- a/src/WebJobs.Script/Rpc/MessageExtensions/StatusResultExtensions.cs
+++ b/src/WebJobs.Script/Rpc/MessageExtensions/StatusResultExtensions.cs
@@ -9,13 +9,12 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 {
     internal static class StatusResultExtensions
     {
-        public static bool IsFailure(this StatusResult status, out Exception exception)
+        public static bool IsFailure(this StatusResult statusResult, out Exception exception)
         {
-            switch (status.Status)
+            switch (statusResult.Status)
             {
                 case StatusResult.Types.Status.Failure:
-                    var exc = status.Exception;
-                    exception = new RpcException(status.Result, exc.Message, exc.StackTrace);
+                    exception = GetRpcException(statusResult);
                     return true;
 
                 case StatusResult.Types.Status.Cancelled:
@@ -33,8 +32,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             switch (status.Status)
             {
                 case StatusResult.Types.Status.Failure:
-                    var exc = status.Exception;
-                    tcs.SetException(new RpcException(status.Result, exc.Message, exc.StackTrace));
+                    tcs.SetException(GetRpcException(status));
                     return false;
 
                 case StatusResult.Types.Status.Cancelled:
@@ -44,6 +42,17 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 default:
                     return true;
             }
+        }
+
+        public static RpcException GetRpcException(StatusResult statusResult)
+        {
+            var ex = statusResult?.Exception;
+            var status = statusResult?.Status.ToString();
+            if (ex != null)
+            {
+                return new RpcException(status, ex.Message, ex.StackTrace);
+            }
+            return new RpcException(status, string.Empty, string.Empty);
         }
     }
 }


### PR DESCRIPTION
When worker sends a log message with exception, only log the message and do not set result. 
Additional logging Fixes #2433, Fixes #2510 , Fixes #2321, Fixes #2588, Fixes #2244 . Root cause is the same. Bug  manifested in various logging issues
Note: Intentionally did not close issues listed here as dups. Will need to revisit them if issues are resolved by logging errors.