### PR TITLE
Allow configuration of full worker debug address string

### DIFF
--- a/src/WebJobs.Script.Grpc/Abstractions/DefaultWorkerOptions.cs
+++ b/src/WebJobs.Script.Grpc/Abstractions/DefaultWorkerOptions.cs
@@ -11,10 +11,8 @@ namespace Microsoft.Azure.WebJobs.Script.Abstractions
         public string Path { get; set; } = string.Empty;
 
         /// <summary>
-        /// Gets or sets the debugging port
+        /// Gets or sets the debugging address
         /// </summary>
         public string Debug { get; set; } = string.Empty;
-
-        public bool TryGetDebugPort(out int result) => int.TryParse(Debug, out result);
     }
 }

--- a/src/WebJobs.Script/Rpc/Configuration/JavaWorkerProvider.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/JavaWorkerProvider.cs
@@ -35,16 +35,16 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             args.ExecutablePath = Path.GetFullPath(Path.Combine(env.ResolveJavaHome(), "bin", "java"));
             args.ExecutableArguments.Add("-jar");
 
-            if (options.TryGetDebugPort(out int debugPort))
+            if (!string.IsNullOrWhiteSpace(options.Debug))
             {
                 if (!env.HasJavaOpts)
                 {
-                    var debugOpts = $"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={debugPort}";
+                    var debugOpts = $"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address={options.Debug}";
                     args.ExecutableArguments.Add(debugOpts);
                 }
                 else
                 {
-                    logger.LogWarning("Both JAVA_OPTS and debug port settings found. Defaulting to JAVA_OPTS.");
+                    logger.LogWarning("Both JAVA_OPTS and debug address settings found. Defaulting to JAVA_OPTS.");
                 }
             }
 

--- a/src/WebJobs.Script/Rpc/Configuration/NodeWorkerProvider.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/NodeWorkerProvider.cs
@@ -26,9 +26,10 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         {
             var options = new DefaultWorkerOptions();
             config.GetSection("workers:node").Bind(options);
-            if (options.TryGetDebugPort(out int debugPort))
+
+            if (!string.IsNullOrWhiteSpace(options.Debug))
             {
-                args.ExecutableArguments.Add($"--inspect={debugPort}");
+                args.ExecutableArguments.Add($"--inspect={options.Debug}");
             }
             return true;
         }

--- a/test/WebJobs.Script.Tests/Rpc/JavaWorkerProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/JavaWorkerProviderTests.cs
@@ -14,13 +14,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
     public class JavaWorkerProviderTests
     {
         [Fact]
-        public void SetsDebugPort()
+        public void SetsDebugAddress()
         {
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new List<KeyValuePair<string, string>>()
                 {
                     new KeyValuePair<string, string>("JAVA_HOME", "asdf"),
-                    new KeyValuePair<string, string>("workers:java:debug", "1000")
+                    new KeyValuePair<string, string>("workers:java:debug", "localhost:1000")
                 })
                 .Build();
 
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             var result = provider.TryConfigureArguments(args, config, new TestLogger("test"));
 
             Assert.True(result);
-            Assert.Contains(args.ExecutableArguments, (exeArg) => exeArg.Contains("1000"));
+            Assert.Contains(args.ExecutableArguments, (exeArg) => exeArg.Contains("address=localhost:1000"));
         }
 
         [Fact]
@@ -54,13 +54,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         }
 
         [Fact]
-        public void DisablesDebugIfInvalid()
+        public void DisablesDebugIfNotConfigured()
         {
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new List<KeyValuePair<string, string>>()
                 {
                     new KeyValuePair<string, string>("JAVA_HOME", "asdf"),
-                    new KeyValuePair<string, string>("workers:java:debug", "false")
                 })
                 .Build();
 

--- a/test/WebJobs.Script.Tests/Rpc/NodeWorkerProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/NodeWorkerProviderTests.cs
@@ -15,12 +15,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
     public class NodeWorkerProviderTests
     {
         [Fact]
-        public void SetsDebugPort()
+        public void SetsDebugAddress()
         {
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new List<KeyValuePair<string, string>>()
                 {
-                    new KeyValuePair<string, string>("workers:node:debug", "2020"),
+                    new KeyValuePair<string, string>("workers:node:debug", "localhost:2020"),
                 })
                 .Build();
 
@@ -29,7 +29,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             var result = provider.TryConfigureArguments(args, config, new TestLogger("test"));
 
             Assert.True(result);
-            Assert.Contains(args.ExecutableArguments, (exeArgs) => exeArgs.Contains("--inspect=2020"));
+            Assert.Contains(args.ExecutableArguments, (exeArgs) => exeArgs.Contains("--inspect=localhost:2020"));
+        }
+
+        [Fact]
+        public void DisablesDebugIfNotConfigured()
+        {
+            var config = new ConfigurationBuilder().Build();
+
+            var provider = new NodeWorkerProvider();
+            var args = new ArgumentsDescription();
+            var result = provider.TryConfigureArguments(args, config, new TestLogger("test"));
+
+            Assert.True(result);
+            Assert.DoesNotContain(args.ExecutableArguments, (exeArgs) => exeArgs.Contains("--inspect"));
         }
     }
 }


### PR DESCRIPTION
The `workers:{lang}:port` configuration currently only supports setting a port number as an integer, which is then passed as a command line argument to the workers.

There are situations where it is important to set a full debug address instead of just a port number, for example `localhost:1234` or `0.0.0.0:1234`.

This change relaxes the configuration to allow any string to be passed through, instead of just integers.