### PR TITLE
Partial Host Startup support for transient startup failures (#2497)

### DIFF
--- a/src/WebJobs.Script.Host/WebJobs.Script.Host.csproj
+++ b/src/WebJobs.Script.Host/WebJobs.Script.Host.csproj
@@ -104,8 +104,8 @@
     <Reference Include="Microsoft.Azure.NotificationHubs, Version=2.16.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.NotificationHubs.1.0.7\lib\net45-full\Microsoft.Azure.NotificationHubs.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.2.0\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.3.0-beta1-11286\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -134,14 +134,14 @@
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.Twilio, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.2.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.3.0-beta1-11286\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.3.0-beta1-11286\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.2.0\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.3.0-beta1-11286\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bot.Connector.DirectLine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Bot.Connector.DirectLine.3.0.0-beta\lib\net45\Microsoft.Bot.Connector.DirectLine.dll</HintPath>

--- a/src/WebJobs.Script.Host/packages.config
+++ b/src/WebJobs.Script.Host/packages.config
@@ -17,8 +17,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net471" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net471" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs" version="2.2.0" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs" version="2.3.0-beta1-11286" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.3.0-beta1-11286" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta8" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net471" />
@@ -28,8 +28,8 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.2.0" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.2.0" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.3.0-beta1-11286" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.3.0-beta1-11286" targetFramework="net471" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net471" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net471" />
   <package id="Microsoft.Bot.Connector.DirectLine" version="3.0.0-beta" targetFramework="net471" />

--- a/src/WebJobs.Script.NuGet/WebJobs.Script.nuspec
+++ b/src/WebJobs.Script.NuGet/WebJobs.Script.nuspec
@@ -17,7 +17,7 @@
       <dependency id="Edge.js" version="6.11.3" />
       <dependency id="FSharp.Compiler.Service" version="9.0.1" />
       <dependency id="FSharp.Core" version="4.0.0.1" />
-      <dependency id="Microsoft.Azure.WebJobs" version="2.2.0" />
+      <dependency id="Microsoft.Azure.WebJobs" version="2.3.0-beta1-11286" />
       <dependency id="Microsoft.ApplicationInsights.WindowsServer" version="2.4.1" />
       <dependency id="Microsoft.Azure.AppService.Proxy" version="1.0.0.1" />
       <dependency id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" />

--- a/src/WebJobs.Script.WebHost/Web.config
+++ b/src/WebJobs.Script.WebHost/Web.config
@@ -92,19 +92,19 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.WebJobs.Host" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.WebJobs" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.WebJobs.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions" culture="neutral" />
@@ -112,7 +112,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.WebJobs.ServiceBus" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.WebJobs.Extensions.ApiHub" culture="neutral" />

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -177,8 +177,8 @@
     <Reference Include="Microsoft.Azure.NotificationHubs, Version=2.16.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.NotificationHubs.1.0.7\lib\net45-full\Microsoft.Azure.NotificationHubs.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.2.0\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.3.0-beta1-11286\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -210,17 +210,17 @@
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.Twilio, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.2.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.3.0-beta1-11286\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.3.0-beta1-11284\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.3.0-beta1-11286\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.2.0\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.3.0-beta1-11286\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.81-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>

--- a/src/WebJobs.Script.WebHost/packages.config
+++ b/src/WebJobs.Script.WebHost/packages.config
@@ -45,8 +45,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net471" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net471" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs" version="2.2.0" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs" version="2.3.0-beta1-11286" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.3.0-beta1-11286" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta8" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net471" />
@@ -57,9 +57,9 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.2.0" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Logging" version="2.2.0" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.2.0" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging" version="2.3.0-beta1-11284" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.3.0-beta1-11286" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.3.0-beta1-11286" targetFramework="net471" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.81-alpha" targetFramework="net471" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net471" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net471" />

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -1527,6 +1527,15 @@ namespace Microsoft.Azure.WebJobs.Script
                 hostConfig.HostId = (string)hostId;
             }
 
+            // Default AllowHostPartialStartup to true, but allow it
+            // to be overridden by config
+            hostConfig.AllowPartialHostStartup = true;
+            JToken allowPartialHostStartup = (JToken)config["allowPartialHostStartup"];
+            if (allowPartialHostStartup != null && allowPartialHostStartup.Type == JTokenType.Boolean)
+            {
+                hostConfig.AllowPartialHostStartup = (bool)allowPartialHostStartup;
+            }
+
             JToken fileWatchingEnabled = (JToken)config["fileWatchingEnabled"];
             if (fileWatchingEnabled != null && fileWatchingEnabled.Type == JTokenType.Boolean)
             {
@@ -1795,9 +1804,6 @@ namespace Microsoft.Azure.WebJobs.Script
                 // Also notify the invoker so the error can also be written to the function
                 // log file
                 NotifyInvoker(functionException.MethodName, functionException);
-
-                // Mark the error as handled so execution will continue with this function disabled
-                functionException.Handled = true;
             }
             else
             {

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -108,8 +108,8 @@
     <Reference Include="Microsoft.Azure.NotificationHubs, Version=2.16.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.NotificationHubs.1.0.7\lib\net45-full\Microsoft.Azure.NotificationHubs.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.2.0\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.3.0-beta1-11286\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -141,14 +141,14 @@
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.Twilio, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.2.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.3.0-beta1-11286\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.3.0-beta1-11286\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.2.0\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.3.0-beta1-11286\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bot.Connector.DirectLine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Bot.Connector.DirectLine.3.0.0-beta\lib\net45\Microsoft.Bot.Connector.DirectLine.dll</HintPath>

--- a/src/WebJobs.Script/packages.config
+++ b/src/WebJobs.Script/packages.config
@@ -21,8 +21,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net471" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net471" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs" version="2.2.0" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs" version="2.3.0-beta1-11286" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.3.0-beta1-11286" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta8" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net471" />
@@ -33,8 +33,8 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.2.0" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.2.0" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.3.0-beta1-11286" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.3.0-beta1-11286" targetFramework="net471" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net471" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net471" />
   <package id="Microsoft.Bot.Connector.DirectLine" version="3.0.0-beta" targetFramework="net471" />

--- a/test/WebJobs.Script.Tests.Integration/App.config
+++ b/test/WebJobs.Script.Tests.Integration/App.config
@@ -145,6 +145,14 @@
         <assemblyIdentity name="System.Diagnostics.StackTrace" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.WebJobs.Host" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.WebJobs" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <appSettings>

--- a/test/WebJobs.Script.Tests.Integration/ListenerFailureTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ListenerFailureTests.cs
@@ -42,6 +42,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 return logs.Any(l => l.Contains(logToFind));
             });
 
+            // assert that the host is retrying to start the
+            // listener in the background
+            await TestHelpers.Await(() =>
+            {
+                logs = TestHelpers.GetHostLogsAsync().Result;
+                string logToFind = "Retrying to start listener for function 'Functions.ListenerStartupException' (Attempt 2)";
+                return logs.Any(l => l.Contains(logToFind));
+            });
+
             // assert that Stop does not throw error
             Fixture.Host.Stop();
         }

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -126,8 +126,8 @@
     <Reference Include="Microsoft.Azure.NotificationHubs, Version=2.16.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.NotificationHubs.1.0.7\lib\net45-full\Microsoft.Azure.NotificationHubs.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.2.0\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.3.0-beta1-11286\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -159,17 +159,17 @@
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.Twilio, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.2.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.3.0-beta1-11286\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.3.0-beta1-11284\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.3.0-beta1-11286\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.2.0\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.3.0-beta1-11286\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.81-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>

--- a/test/WebJobs.Script.Tests.Integration/packages.config
+++ b/test/WebJobs.Script.Tests.Integration/packages.config
@@ -29,8 +29,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net471" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net471" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs" version="2.2.0" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs" version="2.3.0-beta1-11286" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.3.0-beta1-11286" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta8" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net471" />
@@ -41,9 +41,9 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.2.0" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Logging" version="2.2.0" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.2.0" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging" version="2.3.0-beta1-11284" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.3.0-beta1-11286" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.3.0-beta1-11286" targetFramework="net471" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.81-alpha" targetFramework="net471" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net471" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net471" />

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -673,6 +673,33 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public void ApplyConfiguration_AllowPartialHostStartup()
+        {
+            JObject config = new JObject();
+            config["id"] = ID;
+
+            ScriptHostConfiguration scriptConfig = new ScriptHostConfiguration();
+            Assert.False(scriptConfig.HostConfig.AllowPartialHostStartup);
+
+            // we default it to true
+            scriptConfig = new ScriptHostConfiguration();
+            ScriptHost.ApplyConfiguration(config, scriptConfig);
+            Assert.True(scriptConfig.HostConfig.AllowPartialHostStartup);
+
+            // explicit setting can override our default
+            scriptConfig = new ScriptHostConfiguration();
+            config["allowPartialHostStartup"] = new JValue(true);
+            ScriptHost.ApplyConfiguration(config, scriptConfig);
+            Assert.True(scriptConfig.HostConfig.AllowPartialHostStartup);
+
+            // explicit setting can override our default
+            scriptConfig = new ScriptHostConfiguration();
+            config["allowPartialHostStartup"] = new JValue(false);
+            ScriptHost.ApplyConfiguration(config, scriptConfig);
+            Assert.False(scriptConfig.HostConfig.AllowPartialHostStartup);
+        }
+
+        [Fact]
         public void ApplyConfiguration_AppliesFunctionsFilter()
         {
             JObject config = new JObject();

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -130,8 +130,8 @@
     <Reference Include="Microsoft.Azure.NotificationHubs, Version=2.16.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.NotificationHubs.1.0.7\lib\net45-full\Microsoft.Azure.NotificationHubs.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.2.0\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.3.0-beta1-11286\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -163,17 +163,17 @@
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.Twilio, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.2.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.3.0-beta1-11286\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.3.0-beta1-11284\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.3.0-beta1-11286\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.2.0\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+    <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.3.0-beta1-11286\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.81-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>

--- a/test/WebJobs.Script.Tests/app.config
+++ b/test/WebJobs.Script.Tests/app.config
@@ -142,6 +142,14 @@
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.WebJobs.Host" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Azure.WebJobs" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1" /></startup>

--- a/test/WebJobs.Script.Tests/packages.config
+++ b/test/WebJobs.Script.Tests/packages.config
@@ -30,8 +30,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net471" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net471" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs" version="2.2.0" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs" version="2.3.0-beta1-11286" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.3.0-beta1-11286" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta8" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net471" />
@@ -41,9 +41,9 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.2.0" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Logging" version="2.2.0" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.2.0" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging" version="2.3.0-beta1-11284" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.3.0-beta1-11286" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.3.0-beta1-11286" targetFramework="net471" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.81-alpha" targetFramework="net471" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net471" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net471" />


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-functions-host/issues/2497. See details in PR for SDK feature here: https://github.com/Azure/azure-webjobs-sdk/pull/1647.

The main impact for Functions is that now listener level exceptions will be retried behind the scenes. E.g. you could see these changes in action if you modify the EventHubTrigger sample function by changing the 'path' property of the trigger binding to an invalid value. Previously we would log the error and start the host with that function disabled. Now, we'll still allow the host to start, but we'll also **continue trying to start that function's listener in the background**, exponentially backing off. While the host is up and retrying, if you went and added that path to your EventHub the listener would start and the function would be active.

As the issue indicates this is intended to address **transient listener failures**. However we will now be retrying all listener exceptions, meaning if a function is permanently broken and the failure is a listener level failure, we'll retry. Most broken functions will result in indexing failures not listener failures, so hopefully this won't generate too much background activity in general. People should be fixing (or disabling) their broken functions anyways.

Another change here is that the new host.json config setting `'allowPartialHostStartup'` can now be set by the user, so people can turn this behavior off if they wanted too.