### PR TITLE
SeaBreeze Logging Support

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/EtwEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/EtwEventGenerator.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 {
-    internal class EventGenerator : IEventGenerator
+    internal class EtwEventGenerator : IEventGenerator
     {
         private const string EventTimestamp = "MM/dd/yyyy hh:mm:ss.fff tt";
 

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxContainerEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxContainerEventGenerator.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
+{
+    internal class LinuxContainerEventGenerator : IEventGenerator
+    {
+        private const string EventTimestampFormat = "MM/dd/yyyy hh:mm:ss.fff tt";
+        private readonly Action<string> _writeEvent;
+
+        public LinuxContainerEventGenerator(Action<string> writeEvent = null)
+        {
+            _writeEvent = writeEvent ?? StdOutWriter;
+        }
+
+        public static string TraceEventRegex { get; } = $"^{ScriptConstants.LinuxLogEventStreamName} (?<Level>[^,]+),(?<SubscriptionId>[^,]*),(?<AppName>[^,]*),(?<FunctionName>[^,]*),(?<EventName>[^,]*),(?<Source>[^,]*),\"(?<Details>.*)\",\"(?<Summary>.*)\",(?<HostVersion>[^,]*),(?<EventTimestamp>[^,]+),(?<ExceptionType>[^,]*),\"(?<ExceptionMessage>.*)\",(?<FunctionInvocationId>[^,]*),(?<HostInstanceId>[^,]*),(?<ActivityId>[^,]*)$";
+
+        public static string MetricEventRegex { get; } = $"^{ScriptConstants.LinuxMetricEventStreamName} (?<SubscriptionId>[^,]*),(?<AppName>[^,]*),(?<FunctionName>[^,]*),(?<EventName>[^,]*),(?<Average>\\d*),(?<Min>\\d*),(?<Max>\\d*),(?<Count>\\d*),(?<HostVersion>[^,]*),(?<EventTimestamp>[^,]+)$";
+
+        public static string DetailsEventRegex { get; } = $"^{ScriptConstants.LinuxFunctionDetailsEventStreamName} (?<AppName>[^,]*),(?<FunctionName>[^,]*),\"(?<InputBindings>.*)\",\"(?<OutputBindings>.*)\",(?<ScriptType>[^,]*),(?<IsDisabled>[0|1]*)$";
+
+        public void LogFunctionTraceEvent(LogLevel level, string subscriptionId, string appName, string functionName, string eventName, string source, string details, string summary, string exceptionType, string exceptionMessage, string functionInvocationId, string hostInstanceId, string activityId)
+        {
+            string eventTimestamp = DateTime.UtcNow.ToString(EventTimestampFormat);
+            string hostVersion = ScriptHost.Version;
+            FunctionsSystemLogsEventSource.Instance.SetActivityId(activityId);
+
+            _writeEvent($"{ScriptConstants.LinuxLogEventStreamName} {level},{subscriptionId},{appName},{functionName},{eventName},{source},{QuoteString(details)},{QuoteString(summary)},{hostVersion},{eventTimestamp},{exceptionType},{QuoteString(exceptionMessage)},{functionInvocationId},{hostInstanceId},{activityId}");
+        }
+
+        public void LogFunctionMetricEvent(string subscriptionId, string appName, string functionName, string eventName, long average, long minimum, long maximum, long count, DateTime eventTimestamp)
+        {
+            string hostVersion = ScriptHost.Version;
+
+            _writeEvent($"{ScriptConstants.LinuxMetricEventStreamName} {subscriptionId},{appName},{functionName},{eventName},{average},{minimum},{maximum},{count},{hostVersion},{eventTimestamp.ToString(EventTimestampFormat)}");
+        }
+
+        public void LogFunctionDetailsEvent(string siteName, string functionName, string inputBindings, string outputBindings, string scriptType, bool isDisabled)
+        {
+            _writeEvent($"{ScriptConstants.LinuxFunctionDetailsEventStreamName} {siteName},{functionName},{QuoteString(inputBindings)},{QuoteString(outputBindings)},{scriptType},{(isDisabled ? 1 : 0)}");
+        }
+
+        public void LogFunctionExecutionAggregateEvent(string siteName, string functionName, long executionTimeInMs, long functionStartedCount, long functionCompletedCount, long functionFailedCount)
+        {
+        }
+
+        public void LogFunctionExecutionEvent(string executionId, string siteName, int concurrency, string functionName, string invocationId, string executionStage, long executionTimeSpan, bool success)
+        {
+        }
+
+        private static void StdOutWriter(string evt)
+        {
+            Console.WriteLine(evt);
+        }
+
+        internal static string QuoteString(string value)
+        {
+            // Wrap string literals in enclosing quotes
+            // For string columns that may contain quotes and/or
+            // our delimiter ',', before writing the value we
+            // enclose in quotes. This allows us to define matching
+            // groups based on quotes for these values.
+            return $"\"{value}\"";
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Diagnostics/WebHostMetricsLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/WebHostMetricsLogger.cs
@@ -13,7 +13,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         private bool disposed = false;
 
         public WebHostMetricsLogger()
-            : this(ScriptSettingsManager.Instance, new EventGenerator(), 5)
+            : this(ScriptSettingsManager.Instance, new EtwEventGenerator(), 5)
+        {
+        }
+
+        public WebHostMetricsLogger(IEventGenerator eventGenerator)
+            : this(ScriptSettingsManager.Instance, eventGenerator, 5)
         {
         }
 

--- a/src/WebJobs.Script.WebHost/WebHostResolver.cs
+++ b/src/WebJobs.Script.WebHost/WebHostResolver.cs
@@ -10,6 +10,7 @@ using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Properties;
 using Microsoft.Extensions.Logging;
 
@@ -26,6 +27,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         private readonly WebHostSettings _settings;
         private readonly ILoggerProviderFactory _loggerProviderFactory;
         private readonly ILoggerFactory _loggerFactory;
+        private readonly IEventGenerator _eventGenerator;
 
         private ScriptHostConfiguration _standbyScriptHostConfig;
         private WebScriptHostManager _standbyHostManager;
@@ -35,13 +37,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         public WebHostResolver(ScriptSettingsManager settingsManager, ISecretManagerFactory secretManagerFactory,
             IScriptEventManager eventManager, WebHostSettings settings, IWebJobsRouter router, ILoggerProviderFactory loggerProviderFactory,
-            ILoggerFactory loggerFactory)
+            ILoggerFactory loggerFactory, IEventGenerator eventGenerator)
         {
             _settingsManager = settingsManager;
             _secretManagerFactory = secretManagerFactory;
             _eventManager = eventManager;
             _router = router;
             _settings = settings;
+            _eventGenerator = eventGenerator;
 
             // _loggerProviderFactory is used for creating the LoggerFactory for each ScriptHost
             _loggerProviderFactory = loggerProviderFactory;
@@ -115,7 +118,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                         _activeScriptHostConfig = CreateScriptHostConfiguration(settings);
                         _activeHostManager = new WebScriptHostManager(_activeScriptHostConfig, _secretManagerFactory, _eventManager, _settingsManager, settings,
-                            _router, loggerProviderFactory: _loggerProviderFactory, loggerFactory: _loggerFactory);
+                            _router, loggerProviderFactory: _loggerProviderFactory, loggerFactory: _loggerFactory, eventGenerator: _eventGenerator);
                         //_activeReceiverManager = new WebHookReceiverManager(_activeHostManager.SecretManager);
                         InitializeFileSystem(settings, _settingsManager.FileSystemIsReadOnly);
 
@@ -150,7 +153,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                         var standbySettings = CreateStandbySettings(settings);
                         _standbyScriptHostConfig = CreateScriptHostConfiguration(standbySettings, true);
                         _standbyHostManager = new WebScriptHostManager(_standbyScriptHostConfig, _secretManagerFactory, _eventManager, _settingsManager, standbySettings,
-                            _router, loggerProviderFactory: _loggerProviderFactory, loggerFactory: _loggerFactory);
+                            _router, loggerProviderFactory: _loggerProviderFactory, loggerFactory: _loggerFactory, eventGenerator: _eventGenerator);
                         // _standbyReceiverManager = new WebHookReceiverManager(_standbyHostManager.SecretManager);
 
                         InitializeFileSystem(settings, _settingsManager.FileSystemIsReadOnly);

--- a/src/WebJobs.Script/Config/ScriptSettingsManager.cs
+++ b/src/WebJobs.Script/Config/ScriptSettingsManager.cs
@@ -44,6 +44,14 @@ namespace Microsoft.Azure.WebJobs.Script.Config
 
         public virtual bool FileSystemIsReadOnly => IsZipDeployment;
 
+        public bool IsLinuxContainer
+        {
+            get
+            {
+                return !IsAzureEnvironment && !string.IsNullOrEmpty(GetSetting(EnvironmentSettingNames.ContainerName));
+            }
+        }
+
         public virtual string AzureWebsiteDefaultSubdomain
         {
             get

--- a/src/WebJobs.Script/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/EnvironmentSettingNames.cs
@@ -26,5 +26,6 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AppInsightsInstrumentationKey = "APPINSIGHTS_INSTRUMENTATIONKEY";
         public const string ProxySiteExtensionEnabledKey = "ROUTING_EXTENSION_VERSION";
         public const string FunctionsExtensionVersion = "FUNCTIONS_EXTENSION_VERSION";
+        public const string ContainerName = "CONTAINER_NAME";
     }
 }

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -1074,7 +1074,6 @@ namespace Microsoft.Azure.WebJobs.Script
             try
             {
                 // read the function config
-                // read the function config
                 string functionConfigPath = Path.Combine(scriptDir, ScriptConstants.FunctionMetadataFileName);
                 string json = null;
                 try

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -103,6 +103,10 @@ namespace Microsoft.Azure.WebJobs.Script
         public const int HostPollingIntervalMilliseconds = 25;
         public const int MaximumSecretBackupCount = 10;
 
+        public const string LinuxLogEventStreamName = "MS_FUNCTION_LOGS";
+        public const string LinuxMetricEventStreamName = "MS_FUNCTION_METRICS";
+        public const string LinuxFunctionDetailsEventStreamName = "MS_FUNCTION_DETAILS";
+
         public static readonly ImmutableArray<string> HttpMethods = ImmutableArray.Create("get", "post", "delete", "head", "patch", "put", "options");
         public static readonly ImmutableArray<string> AssemblyFileTypes = ImmutableArray.Create(".dll", ".exe");
     }

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyModeTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyModeTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Properties;
 using Microsoft.Extensions.Logging;
 using Microsoft.WebJobs.Script.Tests;
@@ -31,9 +32,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(_loggerProvider);
 
+            Mock<IEventGenerator> eventGeneratorMock = new Mock<IEventGenerator>();
             _webHostResolver = new WebHostResolver(_settingsManager, new TestSecretManagerFactory(false), eventManagerMock.Object,
                 new WebHostSettings(), routerMock.Object, new TestLoggerProviderFactory(_loggerProvider),
-                loggerFactory);
+                loggerFactory, eventGeneratorMock.Object);
 
             WebScriptHostManager.ResetStandbyMode();
         }

--- a/test/WebJobs.Script.Tests.Integration/Host/WebScriptHostManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/WebScriptHostManagerTests.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var settingsManager = ScriptSettingsManager.Instance;
             var eventManager = new Mock<IScriptEventManager>();
             var managerMock = new Mock<WebScriptHostManager>(MockBehavior.Strict, new ScriptHostConfiguration(), new TestSecretManagerFactory(),
-                eventManager.Object, settingsManager, new WebHostSettings { SecretsPath = _secretsDirectory.Path }, null, NullLoggerFactory.Instance, null, null, null, null, 1, 50);
+                eventManager.Object, settingsManager, new WebHostSettings { SecretsPath = _secretsDirectory.Path }, null, NullLoggerFactory.Instance, null, null, null, null, null, 1, 50);
 
             managerMock.SetupGet(p => p.State).Returns(ScriptHostState.Error);
             managerMock.SetupGet(p => p.LastError).Returns(new Exception());
@@ -226,7 +226,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var eventManager = new Mock<IScriptEventManager>();
             var managerMock = new Mock<WebScriptHostManager>(MockBehavior.Strict, new ScriptHostConfiguration(),
                 new TestSecretManagerFactory(), eventManager.Object, settingsManager, new WebHostSettings { SecretsPath = _secretsDirectory.Path },
-                null, NullLoggerFactory.Instance, null, null, null, null, 1, 50);
+                null, NullLoggerFactory.Instance, null, null, null, null, null, 1, 50);
 
             managerMock.SetupGet(p => p.State).Returns(ScriptHostState.Default);
             managerMock.SetupGet(p => p.LastError).Returns((Exception)null);

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxContainerEventGeneratorTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxContainerEventGeneratorTests.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
+{
+    public class LinuxContainerEventGeneratorTests
+    {
+        private readonly LinuxContainerEventGenerator _generator;
+        private readonly List<string> _events;
+
+        public LinuxContainerEventGeneratorTests()
+        {
+            _events = new List<string>();
+            Action<string> writer = (s) =>
+            {
+                _events.Add(s);
+            };
+            _generator = new LinuxContainerEventGenerator(writer);
+        }
+
+        public static IEnumerable<object[]> GetLogEvents()
+        {
+            yield return new object[] { LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53" };
+            yield return new object[] { LogLevel.Information, string.Empty, "TestApp", "TestFunction", "TestEvent", string.Empty, "This string includes a quoted \"substring\" in the middle", "Another \"quoted substring\"", "TestExceptionType", "Another \"quoted substring\"", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53" };
+            yield return new object[] { LogLevel.Information, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty };
+        }
+
+        public static IEnumerable<object[]> GetMetricEvents()
+        {
+            yield return new object[] { "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction", "TestEvent", 15, 2, 18, 5 };
+            yield return new object[] { string.Empty, string.Empty, string.Empty, string.Empty, 0, 0, 0, 0 };
+        }
+
+        public static IEnumerable<object[]> GetDetailsEvents()
+        {
+            yield return new object[] { "TestApp", "TestFunction", "{ foo: 123, bar: \"Test\" }", "{ foo: \"Mathew\", bar: \"Charles\" }", "CSharp", 0 };
+            yield return new object[] { string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, 0 };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetLogEvents))]
+        public void ParseLogEvents(LogLevel level, string subscriptionId, string appName, string functionName, string eventName, string source, string details, string summary, string exceptionType, string exceptionMessage, string functionInvocationId, string hostInstanceId, string activityId)
+        {
+            _generator.LogFunctionTraceEvent(level, subscriptionId, appName, functionName, eventName, source, details, summary, exceptionType, exceptionMessage, functionInvocationId, hostInstanceId, activityId);
+
+            string evt = _events.Single();
+
+            Regex regex = new Regex(LinuxContainerEventGenerator.TraceEventRegex);
+            var match = regex.Match(evt);
+
+            Assert.True(match.Success);
+            Assert.Equal(16, match.Groups.Count);
+
+            DateTime dt;
+            var groupMatches = match.Groups.Select(p => p.Value).Skip(1).ToArray();
+            Assert.Collection(groupMatches,
+                p => Assert.Equal(level.ToString(), p),
+                p => Assert.Equal(subscriptionId, p),
+                p => Assert.Equal(appName, p),
+                p => Assert.Equal(functionName, p),
+                p => Assert.Equal(eventName, p),
+                p => Assert.Equal(source, p),
+                p => Assert.Equal(details, p),
+                p => Assert.Equal(summary, p),
+                p => Assert.Equal(ScriptHost.Version, p),
+                p => Assert.True(DateTime.TryParse(p, out dt)),
+                p => Assert.Equal(exceptionType, p),
+                p => Assert.Equal(exceptionMessage, p),
+                p => Assert.Equal(functionInvocationId, p),
+                p => Assert.Equal(hostInstanceId, p),
+                p => Assert.Equal(activityId, p));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetMetricEvents))]
+        public void ParseMetricEvents(string subscriptionId, string appName, string functionName, string eventName, long average, long minimum, long maximum, long count)
+        {
+            _generator.LogFunctionMetricEvent(subscriptionId, appName, functionName, eventName, average, minimum, maximum, count, DateTime.Now);
+
+            string evt = _events.Single();
+
+            Regex regex = new Regex(LinuxContainerEventGenerator.MetricEventRegex);
+            var match = regex.Match(evt);
+
+            Assert.True(match.Success);
+            Assert.Equal(11, match.Groups.Count);
+
+            DateTime dt;
+            var groupMatches = match.Groups.Select(p => p.Value).Skip(1).ToArray();
+            Assert.Collection(groupMatches,
+                p => Assert.Equal(subscriptionId, p),
+                p => Assert.Equal(appName, p),
+                p => Assert.Equal(functionName, p),
+                p => Assert.Equal(eventName, p),
+                p => Assert.Equal(average, long.Parse(p)),
+                p => Assert.Equal(minimum, long.Parse(p)),
+                p => Assert.Equal(maximum, long.Parse(p)),
+                p => Assert.Equal(count, long.Parse(p)),
+                p => Assert.Equal(ScriptHost.Version, p),
+                p => Assert.True(DateTime.TryParse(p, out dt)));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetDetailsEvents))]
+        public void ParseDetailsEvents(string siteName, string functionName, string inputBindings, string outputBindings, string scriptType, bool isDisabled)
+        {
+            _generator.LogFunctionDetailsEvent(siteName, functionName, inputBindings, outputBindings, scriptType, isDisabled);
+
+            string evt = _events.Single();
+
+            Regex regex = new Regex(LinuxContainerEventGenerator.DetailsEventRegex);
+            var match = regex.Match(evt);
+
+            Assert.True(match.Success);
+            Assert.Equal(7, match.Groups.Count);
+
+            bool b;
+            var groupMatches = match.Groups.Select(p => p.Value).Skip(1).ToArray();
+            Assert.Collection(groupMatches,
+                p => Assert.Equal(siteName, p),
+                p => Assert.Equal(functionName, p),
+                p => Assert.Equal(inputBindings, p),
+                p => Assert.Equal(outputBindings, p),
+                p => Assert.Equal(scriptType, p),
+                p => Assert.Equal(isDisabled ? "1" : "0", p));
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/WebHostResolverTests.cs
+++ b/test/WebJobs.Script.Tests/WebHostResolverTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.WebJobs.Script.Tests;
 using Moq;
@@ -38,8 +39,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     SecretsPath = @"c:\secrets\path"
                 };
 
+                Mock<IEventGenerator> eventGeneratorMock = new Mock<IEventGenerator>();
                 var resolver = new WebHostResolver(settingsManager, secretManagerFactoryMock.Object, eventManagerMock.Object, settings, routerMock.Object,
-                    new TestLoggerProviderFactory(null), NullLoggerFactory.Instance);
+                    new TestLoggerProviderFactory(null), NullLoggerFactory.Instance, eventGeneratorMock.Object);
 
                 ScriptHostConfiguration configuration = resolver.GetScriptHostConfiguration(settings);
 


### PR DESCRIPTION
When running in a linux container, write logs/metrics to stdout. We're logging in the agreed upon CSV format, with a unique identifier for the various event streams.