### PR TITLE
Fully shutdown host on function timeout

### DIFF
--- a/src/WebJobs.Script.WebHost/WebScriptHostExceptionHandler.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostExceptionHandler.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             // Give the manager and all running tasks some time to shut down gracefully.
             await Task.Delay(timeoutGracePeriod);
 
+            // TODO: FACAVAL - PASS ENVIRONMENT AND INITIATE SHUTDWON
             Program.InitiateShutdown();
         }
 

--- a/src/WebJobs.Script.WebHost/WebScriptHostExceptionHandler.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostExceptionHandler.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Timers;
 using Microsoft.Extensions.Logging;
+using WebJobs.Script.WebHost.Core;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
 {
@@ -49,8 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             // Give the manager and all running tasks some time to shut down gracefully.
             await Task.Delay(timeoutGracePeriod);
 
-            // TODO: FACAVAL - PASS ENVIRONMENT AND INITIATE SHUTDWON
-            // HostingEnvironment.InitiateShutdown();
+            Program.InitiateShutdown();
         }
 
         public Task OnUnhandledExceptionAsync(ExceptionDispatchInfo exceptionInfo)


### PR DESCRIPTION
Using the same fix from https://github.com/Azure/azure-functions-host/commit/f308acc1b8dc72018475fafa9075395b2e1186cc

At the moment if timeout is expired, then the function app keeps running but there is no host available to consume requests as we stop it here: https://github.com/wilsonge/azure-functions-host/blob/0c1cd929a9411d3a1523eab41d56c2bf70c9d6af/src/WebJobs.Script.WebHost/WebScriptHostExceptionHandler.cs#L48