### PR TITLE
initializing ScriptHost before adding it to _liveInstances collection

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHostManager.cs
+++ b/src/WebJobs.Script/Host/ScriptHostManager.cs
@@ -170,16 +170,16 @@ namespace Microsoft.Azure.WebJobs.Script
 
                     newInstance = _scriptHostFactory.Create(_environment, EventManager, _settingsManager, _config);
                     _currentInstance = newInstance;
-                    lock (_liveInstances)
-                    {
-                        _liveInstances.Add(newInstance);
-                        _hostStartCount++;
-                    }
 
                     newInstance.HostInitializing += OnHostInitializing;
                     newInstance.HostInitialized += OnHostInitialized;
                     newInstance.HostStarted += OnHostStarted;
                     newInstance.Initialize();
+
+                    lock (_liveInstances)
+                    {
+                        _liveInstances.Add(newInstance);
+                    }
 
                     newInstance.StartAsync(cancellationToken).GetAwaiter().GetResult();
 
@@ -286,7 +286,7 @@ namespace Microsoft.Azure.WebJobs.Script
             var host = (ScriptHost)sender;
             string extensionVersion = _settingsManager.GetSetting(EnvironmentSettingNames.FunctionsExtensionVersion);
             string hostId = host.ScriptConfig.HostConfig.HostId;
-            string message = $"Starting Host (HostId={hostId}, Version={ScriptHost.Version}, InstanceId={host.InstanceId}, ProcessId={Process.GetCurrentProcess().Id}, AppDomainId={AppDomain.CurrentDomain.Id}, Debug={host.InDebugMode}, ConsecutiveErrors={_consecutiveErrorCount}, StartupCount={_hostStartCount}, FunctionsExtensionVersion={extensionVersion})";
+            string message = $"Starting Host (HostId={hostId}, Version={ScriptHost.Version}, InstanceId={host.InstanceId}, ProcessId={Process.GetCurrentProcess().Id}, AppDomainId={AppDomain.CurrentDomain.Id}, Debug={host.InDebugMode}, ConsecutiveErrors={_consecutiveErrorCount}, StartupCount={++_hostStartCount}, FunctionsExtensionVersion={extensionVersion})";
             host.TraceWriter.Info(message);
             host.Logger.LogInformation(message);
 


### PR DESCRIPTION
Fixes #1690.

Prior to commit https://github.com/Azure/azure-functions-host/commit/88360e7d1db3e75361bf93b424a076c043346d40, we were initializing the `ScriptHost` in the `ScriptHostFactory`. That means that it was always initialized before being added to `_liveInstances` collection. Once the host is in that collection, it is available to be disposed of via calls to `Shutdown()`. If this happens before/during initialization, you can end up with `ObjectDisposedException`s.

It looks like this can happen deployments. We'll see a wave of file changes that signal for host restarts as well as environment shutdowns. If the host restarts (and is mid-initialization) when the call to `Shutdown()` occurs, you'll see these errors. 

This effectively puts the ordering back to the way it was before the commit linked above.