### PR TITLE
disposing of original LoggerFactory after recreation

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -753,9 +753,11 @@ namespace Microsoft.Azure.WebJobs.Script
 
             // now the configuration has been read and applied re-create the logger
             // factory and loggers ensuring that filters and settings have been applied
+            ILoggerFactory oldLoggerFactory = _hostConfig.LoggerFactory;
             ConfigureLoggerFactory(recreate: true);
             _startupLogger = _hostConfig.LoggerFactory.CreateLogger(LogCategories.Startup);
             Logger = _hostConfig.LoggerFactory.CreateLogger(ScriptConstants.LogCategoryHostGeneral);
+            oldLoggerFactory.Dispose();
 
             // Allow tests to modify anything initialized by host.json
             ScriptConfig.OnConfigurationApplied?.Invoke(ScriptConfig);


### PR DESCRIPTION
Fixes #2638 

We create a logger pre-parsing of the configuration, in case we have to log parsing errors. Then we create a new one once we've parsed. We were never disposing of the first one, which caused this leak.