### PR TITLE
Changing utility method that resolves the subscription ID to avoid reliance on the static settings manager instance. Changing tests to pass a scoped instance

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         {
             // we read these in the ctor (not static ctor) since it can change on the fly
             appName = GetNormalizedString(settingsManager.AzureWebsiteUniqueSlotName);
-            subscriptionId = Utility.GetSubscriptionId() ?? string.Empty;
+            subscriptionId = Utility.GetSubscriptionId(settingsManager) ?? string.Empty;
 
             _eventGenerator = generator;
             _functionActivityFlushIntervalSeconds = functionActivityFlushIntervalSeconds;

--- a/src/WebJobs.Script.WebHost/Diagnostics/SystemLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/SystemLogger.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         {
             _settingsManager = settingsManager;
             _appName = _settingsManager.AzureWebsiteUniqueSlotName;
-            _subscriptionId = Utility.GetSubscriptionId();
+            _subscriptionId = Utility.GetSubscriptionId(settingsManager);
             _eventGenerator = eventGenerator;
             _categoryName = categoryName ?? string.Empty;
             _functionName = LogCategories.IsFunctionCategory(_categoryName) ? _categoryName.Split('.')[1] : string.Empty;

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -115,9 +115,9 @@ namespace Microsoft.Azure.WebJobs.Script
             }
         }
 
-        public static string GetSubscriptionId()
+        public static string GetSubscriptionId(ScriptSettingsManager settingsManager)
         {
-            string ownerName = ScriptSettingsManager.Instance.GetSetting(EnvironmentSettingNames.AzureWebsiteOwnerName) ?? string.Empty;
+            string ownerName = settingsManager.GetSetting(EnvironmentSettingNames.AzureWebsiteOwnerName) ?? string.Empty;
             if (!string.IsNullOrEmpty(ownerName))
             {
                 int idx = ownerName.IndexOf('+');


### PR DESCRIPTION
Making this change primarily to address test reliability issues.