### PR TITLE
ISO datetime strings unexpectedly change in out of proc Http responses

### DIFF
--- a/src/WebJobs.Script/Rpc/MessageExtensions/RpcMessageConversionExtensions.cs
+++ b/src/WebJobs.Script/Rpc/MessageExtensions/RpcMessageConversionExtensions.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 {
     internal static class RpcMessageConversionExtensions
     {
+        private static readonly JsonSerializerSettings _verboseSerializerSettings = new JsonSerializerSettings { DateParseHandling = DateParseHandling.None };
+
         public static object ToObject(this TypedData typedData)
         {
             switch (typedData.DataCase)
@@ -27,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 case RpcDataType.String:
                     return typedData.String;
                 case RpcDataType.Json:
-                    return JsonConvert.DeserializeObject(typedData.Json);
+                    return JsonConvert.DeserializeObject(typedData.Json, _verboseSerializerSettings);
                 case RpcDataType.Http:
                     return Utilities.ConvertFromHttpMessageToExpando(typedData.Http);
                 case RpcDataType.Int:

--- a/src/WebJobs.Script/Rpc/MessageExtensions/RpcMessageConversionExtensions.cs
+++ b/src/WebJobs.Script/Rpc/MessageExtensions/RpcMessageConversionExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 {
     internal static class RpcMessageConversionExtensions
     {
-        private static readonly JsonSerializerSettings _verboseSerializerSettings = new JsonSerializerSettings { DateParseHandling = DateParseHandling.None };
+        private static readonly JsonSerializerSettings _datetimeSerializerSettings = new JsonSerializerSettings { DateParseHandling = DateParseHandling.None };
 
         public static object ToObject(this TypedData typedData)
         {
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 case RpcDataType.String:
                     return typedData.String;
                 case RpcDataType.Json:
-                    return JsonConvert.DeserializeObject(typedData.Json, _verboseSerializerSettings);
+                    return JsonConvert.DeserializeObject(typedData.Json, _datetimeSerializerSettings);
                 case RpcDataType.Http:
                     return Utilities.ConvertFromHttpMessageToExpando(typedData.Http);
                 case RpcDataType.Int:

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/NodeEndToEndTests.cs
@@ -311,6 +311,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         [Theory(Skip = "Needs investigation")]
         [InlineData("application/json", "{\"name\": \"test\" }", "rawresponse")]
         [InlineData("application/json", 1, "rawresponse")]
+        [InlineData("application/json", "{\"test_time\": \"2026-04-20T00:00:00.000Z\", \"test_bool\": \"true\" }", "rawresponse")]
+        [InlineData("application/json", "{\"test_time\": \"2016-03-31T07:02:00+07:00\", \"test_bool\": \"true\" }", "rawresponse")]
         [InlineData("application/xml", "<root>XML payload</string>", "rawresponse")]
         [InlineData("text/plain", "plain text input", "rawresponse")]
         [InlineData("text/plain", "{\"name\": \"test\" }", "rawresponsenocontenttype")]


### PR DESCRIPTION
Resolves #2665 

For 2.0-beta functions in non-.NET languages, ISO datetime strings unexpectedly change in Http responses from Newtonsoft.Json deserialization. There are two points where .NET content magic kicks in for an Http output binding. The first is when we deserialize a JSON object (such as body). The second is from the type of IActionResult we return as an Http response (with no content negotiation, if "isRaw"). This issue comes from the first step (JSON deserialization).

Regardless of the "isRaw" flag, we always want to set DateParseHandling to DateParseHandling.None for javascript/python/java, since manipulating strings that look like a datetime appears to be Json.NET-specific behavior.

_NOTE: test failures due to flaky V2 tests; unrelated to PR changes_