### PR TITLE
Fixing IConfiguration environment variable caching

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
@@ -17,14 +17,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         private static HostAssignmentContext _assignmentContext;
         private static object _assignmentLock = new object();
 
-        private readonly ScriptHostManager _scriptHostManager;
         private readonly WebHostSettings _webHostSettings;
         private readonly ILogger _logger;
         private readonly HttpClient _client;
 
-        public InstanceManager(WebScriptHostManager scriptHostManager, WebHostSettings webHostSettings, ILoggerFactory loggerFactory, HttpClient client)
+        public InstanceManager(WebHostSettings webHostSettings, ILoggerFactory loggerFactory, HttpClient client)
         {
-            _scriptHostManager = scriptHostManager;
             _webHostSettings = webHostSettings;
             _logger = loggerFactory.CreateLogger(nameof(InstanceManager));
             _client = client;
@@ -77,8 +75,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                     assignmentContext.ApplyAppSettings();
                 }
 
-                // Restart runtime.
-                _scriptHostManager.RestartHost();
+                // TODO: specialize
             }
             catch (Exception ex)
             {

--- a/src/WebJobs.Script.WebHost/Models/HostAssignmentContext.cs
+++ b/src/WebJobs.Script.WebHost/Models/HostAssignmentContext.cs
@@ -53,12 +53,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
 
         public void ApplyAppSettings()
         {
-            // apply app settings
             foreach (var pair in Environment)
             {
                 System.Environment.SetEnvironmentVariable(pair.Key, pair.Value);
             }
-            ScriptSettingsManager.Instance.Reset();
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Program.cs
+++ b/src/WebJobs.Script.WebHost/Program.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
+using System.Linq;
 using System.Threading;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
 {
@@ -18,10 +20,27 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 .Wait();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
-            Microsoft.AspNetCore.WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
-                .Build();
+        public static IWebHost BuildWebHost(string[] args)
+        {
+            return CreateWebHostBuilder(args).Build();
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args = null)
+        {
+            return Microsoft.AspNetCore.WebHost.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration((builderContext, config) =>
+                {
+                    // replace the default environment source with our own
+                    IConfigurationSource envVarsSource = config.Sources.OfType<EnvironmentVariablesConfigurationSource>().FirstOrDefault();
+                    if (envVarsSource != null)
+                    {
+                        config.Sources.Remove(envVarsSource);
+                    }
+                    envVarsSource = new ScriptEnvironmentVariablesConfigurationSource();
+                    config.Sources.Add(envVarsSource);
+                })
+                .UseStartup<Startup>();
+        }
 
         internal static void InitiateShutdown()
         {

--- a/src/WebJobs.Script.WebHost/WebHostResolver.cs
+++ b/src/WebJobs.Script.WebHost/WebHostResolver.cs
@@ -112,7 +112,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     if (_activeHostManager == null &&
                         (_standbyHostManager == null || _settingsManager.ContainerReady))
                     {
-                        _settingsManager.Reset();
                         _specializationTimer?.Dispose();
                         _specializationTimer = null;
 

--- a/src/WebJobs.Script/Config/ScriptEnvironmentVariablesConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/ScriptEnvironmentVariablesConfigurationSource.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
+
+namespace Microsoft.Azure.WebJobs.Script
+{
+    /// <summary>
+    /// This source exists to replace the default <see cref="EnvironmentVariablesConfigurationSource"/> to allow
+    /// us to override caching behavior.
+    /// </summary>
+    public class ScriptEnvironmentVariablesConfigurationSource : IConfigurationSource
+    {
+        public IConfigurationProvider Build(IConfigurationBuilder builder)
+        {
+            return new WebHostEnvironmentVariablesProvider();
+        }
+
+        private class WebHostEnvironmentVariablesProvider : EnvironmentVariablesConfigurationProvider
+        {
+            public WebHostEnvironmentVariablesProvider() : base()
+            {
+            }
+
+            public override bool TryGet(string key, out string value)
+            {
+                value = Environment.GetEnvironmentVariable(key);
+
+                return value != null;
+            }
+
+            public override void Set(string key, string value)
+            {
+                Environment.SetEnvironmentVariable(key, value);
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script/Config/ScriptSettingsManager.cs
+++ b/src/WebJobs.Script/Config/ScriptSettingsManager.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
 using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.WebJobs.Script.Config
@@ -10,19 +9,16 @@ namespace Microsoft.Azure.WebJobs.Script.Config
     public class ScriptSettingsManager
     {
         private static ScriptSettingsManager _instance = new ScriptSettingsManager();
-        private readonly ConcurrentDictionary<string, string> _settingsCache = new ConcurrentDictionary<string, string>();
-        private Func<IConfiguration> _configurationFactory = BuildConfiguration;
-        private Lazy<IConfiguration> _configuration = new Lazy<IConfiguration>(BuildConfiguration);
 
-        // for testing
-        public ScriptSettingsManager()
+        public ScriptSettingsManager(IConfiguration config = null)
         {
+            Configuration = config ?? BuildDefaultConfiguration();
         }
 
         /// <summary>
         /// Gets the underlying configuration object used by this instance of the <see cref="ScriptSettingsManager"/>.
         /// </summary>
-        internal IConfiguration Configuration => _configuration.Value;
+        internal IConfiguration Configuration { get;  }
 
         public static ScriptSettingsManager Instance
         {
@@ -62,19 +58,15 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         {
             get
             {
-                return _settingsCache.GetOrAdd(nameof(AzureWebsiteDefaultSubdomain), k =>
+                string siteHostName = GetSetting(EnvironmentSettingNames.AzureWebsiteHostName);
+
+                int? periodIndex = siteHostName?.IndexOf('.');
+                if (periodIndex != null && periodIndex > 0)
                 {
-                    string siteHostName = GetSetting(EnvironmentSettingNames.AzureWebsiteHostName);
+                    return siteHostName.Substring(0, periodIndex.Value);
+                }
 
-                    int? periodIndex = siteHostName?.IndexOf('.');
-
-                    if (periodIndex != null && periodIndex > 0)
-                    {
-                        return siteHostName.Substring(0, periodIndex.Value);
-                    }
-
-                    return null;
-                });
+                return null;
             }
         }
 
@@ -111,42 +103,8 @@ namespace Microsoft.Azure.WebJobs.Script.Config
 
         public virtual string ApplicationInsightsInstrumentationKey
         {
-            get => GetSettingFromCache(EnvironmentSettingNames.AppInsightsInstrumentationKey);
-            set => UpdateSettingInCache(EnvironmentSettingNames.AppInsightsInstrumentationKey, value);
-        }
-
-        public void SetConfigurationFactory(Func<IConfiguration> configurationRootFactory)
-        {
-            _configurationFactory = configurationRootFactory;
-            Reset();
-        }
-
-        private string GetSettingFromCache(string settingKey)
-        {
-            if (string.IsNullOrEmpty(settingKey))
-            {
-                throw new ArgumentNullException(nameof(settingKey));
-            }
-
-            return _settingsCache.GetOrAdd(settingKey, (key) => GetSetting(key));
-        }
-
-        private void UpdateSettingInCache(string settingKey, string settingValue)
-        {
-            if (string.IsNullOrEmpty(settingKey))
-            {
-                throw new ArgumentNullException(nameof(settingKey));
-            }
-
-            _settingsCache.AddOrUpdate(settingKey, settingValue, (a, b) => settingValue);
-        }
-
-        public virtual void Reset()
-        {
-            Lazy<IConfiguration> current = _configuration;
-            _configuration = new Lazy<IConfiguration>(() => InitializeConfiguration(current));
-
-            _settingsCache.Clear();
+            get => GetSetting(EnvironmentSettingNames.AppInsightsInstrumentationKey);
+            set => SetSetting(EnvironmentSettingNames.AppInsightsInstrumentationKey, value);
         }
 
         public virtual string GetSetting(string settingKey)
@@ -164,35 +122,19 @@ namespace Microsoft.Azure.WebJobs.Script.Config
             if (!string.IsNullOrEmpty(settingKey))
             {
                 Environment.SetEnvironmentVariable(settingKey, settingValue);
-                Reset();
             }
         }
 
-        private IConfiguration InitializeConfiguration(Lazy<IConfiguration> currentConfiguration)
+        public static IConfiguration BuildDefaultConfiguration()
         {
-            var configuration = _configurationFactory();
-
-            // If the factory returned a cached instance
-            // that is the same as the instance we previously had,
-            // reload the configuration on that instance.
-            if (configuration is IConfigurationRoot root &&
-                currentConfiguration != null &&
-                currentConfiguration.IsValueCreated &&
-                object.ReferenceEquals(currentConfiguration.Value, root))
-            {
-                root.Reload();
-            }
-
-            return configuration;
+            return CreateDefaultConfigurationBuilder().Build();
         }
 
-        private static IConfigurationRoot BuildConfiguration()
+        internal static IConfigurationBuilder CreateDefaultConfigurationBuilder()
         {
-            var configurationBuilder = new ConfigurationBuilder()
+            return new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json", optional: true)
-                .AddEnvironmentVariables();
-
-            return configurationBuilder.Build();
+                .Add(new ScriptEnvironmentVariablesConfigurationSource());
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/Host/ScriptHostManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/ScriptHostManagerTests.cs
@@ -351,7 +351,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal("Unable to parse host.json file.", ex.Message);
 
             var logger = loggerProvider.CreatedLoggers.Last();
-            Assert.Equal(3, logger.GetLogMessages().Count);
             Assert.StartsWith("A ScriptHost error has occurred", logger.GetLogMessages()[1].FormattedMessage);
             Assert.Equal("Unable to parse host.json file.", logger.GetLogMessages()[1].Exception.Message);
         }
@@ -384,7 +383,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var environmentMock = new Mock<IScriptHostEnvironment>(MockBehavior.Strict);
             environmentMock.Setup(p => p.Shutdown());
 
-            var mockSettings = new Mock<ScriptSettingsManager>();
+            var mockSettings = new Mock<ScriptSettingsManager>(null);
             mockSettings.Setup(p => p.IsAppServiceEnvironment).Returns(true);
 
             var eventManagerMock = new Mock<IScriptEventManager>();
@@ -471,7 +470,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 RootScriptPath = Environment.CurrentDirectory
             };
 
-            var mockSettings = new Mock<ScriptSettingsManager>(MockBehavior.Strict);
+            var mockSettings = new Mock<ScriptSettingsManager>(MockBehavior.Strict, null);
             var eventManager = new Mock<IScriptEventManager>();
             var hostMock = new Mock<ScriptHost>(new NullScriptHostEnvironment(), eventManager.Object, config, null, null, null);
             var factoryMock = new Mock<IScriptHostFactory>();

--- a/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/ScriptHostEndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/ScriptHostEndToEndTestFixture.cs
@@ -72,7 +72,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Func<string, FunctionDescriptor> funcLookup = (name) => this.Host.GetFunctionOrNull(name);
             var fastLogger = new FunctionInstanceLogger(funcLookup, new MetricsLogger());
             config.HostConfig.AddService<IAsyncCollector<FunctionInstanceLogEntry>>(fastLogger);
-            _settingsManager.Reset();
             Host = new ScriptHost(ScriptHostEnvironmentMock.Object, EventManager, config, _settingsManager,
                 proxyClient: proxyClient, loggerProviderFactory: loggerProviderFactory);
             Host.Initialize();

--- a/test/WebJobs.Script.Tests.Shared/TestLogger.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestLogger.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 return;
             }
 
-            _logMessages.Add(new LogMessage
+            var logMessage = new LogMessage
             {
                 Level = logLevel,
                 EventId = eventId,
@@ -52,7 +52,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 FormattedMessage = formatter(state, exception),
                 Category = Category,
                 Timestamp = DateTime.UtcNow
-            });
+            };
+
+            _logMessages.Add(logMessage);
         }
     }
 

--- a/test/WebJobs.Script.Tests/Description/FunctionDescriptorProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/FunctionDescriptorProviderTests.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var environment = new Mock<IScriptHostEnvironment>();
             var eventManager = new Mock<IScriptEventManager>();
             _settingsManager = ScriptSettingsManager.Instance;
-            _settingsManager.Reset();
             _host = new ScriptHost(environment.Object, eventManager.Object, config, _settingsManager);
             _host.Initialize();
             _provider = new TestDescriptorProvider(_host, config);

--- a/test/WebJobs.Script.Tests/Description/Proxy/ProxyFunctionDescriptorProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/Proxy/ProxyFunctionDescriptorProviderTests.cs
@@ -41,7 +41,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             _proxyClient = GetMockProxyClient();
             _settingsManager = ScriptSettingsManager.Instance;
-            _settingsManager.Reset();
             _host = new ScriptHost(environment.Object, eventManager.Object, _config, _settingsManager, proxyClient: _proxyClient);
             _host.Initialize();
             _metadataCollection = _host.ReadProxyMetadata(_config, _settingsManager);

--- a/test/WebJobs.Script.Tests/Diagnostics/HostPerformanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/HostPerformanceManagerTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         [Fact]
         public void GetCounters_ReturnsExpectedResult()
         {
-            var mockSettings = new Mock<ScriptSettingsManager>(MockBehavior.Strict);
+            var mockSettings = new Mock<ScriptSettingsManager>(MockBehavior.Strict, null);
             string value = string.Empty;
             var logger = new TestLogger("Test");
             mockSettings.Setup(p => p.GetSetting(EnvironmentSettingNames.AzureWebsiteAppCountersName)).Returns(() => value);

--- a/test/WebJobs.Script.Tests/Eventing/SystemLoggerTests.cs
+++ b/test/WebJobs.Script.Tests/Eventing/SystemLoggerTests.cs
@@ -32,20 +32,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             _mockEventGenerator = new Mock<IEventGenerator>(MockBehavior.Strict);
 
-            _settingsManager = new ScriptSettingsManager();
-            _settingsManager.SetConfigurationFactory(() =>
-            {
-                var configurationBuilder = new ConfigurationBuilder()
-                .AddJsonFile("appsettings.json", optional: true)
-                .AddEnvironmentVariables()
+            var configBuilder = ScriptSettingsManager.CreateDefaultConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>
                 {
                     { EnvironmentSettingNames.AzureWebsiteOwnerName,  $"{_subscriptionId}+westuswebspace" },
                     { EnvironmentSettingNames.AzureWebsiteName,  _websiteName },
                 });
-
-                return configurationBuilder.Build();
-            });
+            var config = configBuilder.Build();
+            _settingsManager = new ScriptSettingsManager(config);
 
             _category = LogCategories.CreateFunctionCategory(_functionName);
             _logger = new SystemLogger(_hostInstanceId, _category, _mockEventGenerator.Object, _settingsManager);

--- a/test/WebJobs.Script.Tests/Extensions/HttpRequestExtensionsTest.cs
+++ b/test/WebJobs.Script.Tests/Extensions/HttpRequestExtensionsTest.cs
@@ -28,8 +28,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
             };
             using (var env = new TestScopedEnvironmentVariable(vars))
             {
-                ScriptSettingsManager.Instance.Reset();
-
                 // with header
                 var headers = new HeaderDictionary();
                 headers.Add(ScriptConstants.AntaresLogIdHeaderName, "123");

--- a/test/WebJobs.Script.Tests/Managment/InstanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Managment/InstanceManagerTests.cs
@@ -5,13 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Script.Config;
-using Microsoft.Azure.WebJobs.Script.Eventing;
-using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
-using Moq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
@@ -22,30 +18,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         public async Task StartAssignmentShouldUpdateEnvironmentVariables()
         {
             var loggerFactory = MockNullLogerFactory.CreateLoggerFactory();
-            var scriptHostManager = new Mock<WebScriptHostManager>(new ScriptHostConfiguration(),
-                Mock.Of<ISecretManagerFactory>(),
-                Mock.Of<IScriptEventManager>(),
-                new ScriptSettingsManager(),
-                new WebHostSettings { SecretsPath = Path.GetTempPath() },
-                Mock.Of<IWebJobsRouter>(),
-                loggerFactory,
-                null, null, null, null, null, 30, 500);
 
-            var scriptSettingManager = new Mock<ScriptSettingsManager>();
-            var restartCalled = false;
-            var resetCalled = false;
-
-            scriptHostManager
-                .Setup(m => m.RestartHost())
-                .Callback(() => restartCalled = true);
-
-            scriptSettingManager
-                .Setup(m => m.Reset())
-                .Callback(() => resetCalled = true);
-
-            ScriptSettingsManager.Instance = scriptSettingManager.Object;
-            var instanceManager = new InstanceManager(scriptHostManager.Object, null, loggerFactory, null);
-
+            var instanceManager = new InstanceManager(null, loggerFactory, null);
             var envValue = new
             {
                 Name = Path.GetTempFileName().Replace(".", string.Empty),
@@ -60,11 +34,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 }
             });
 
-            // TryAssign does the specialization in the background
+            // specialization is done in the background
             await Task.Delay(500);
 
-            Assert.True(restartCalled, userMessage: "calling assign should call restart on the host");
-            Assert.True(resetCalled, userMessage: "calling assign should call reset on the settings manager");
             var value = Environment.GetEnvironmentVariable(envValue.Name);
             Assert.Equal(value, envValue.Value);
         }

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -1664,7 +1664,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 var environment = new Mock<IScriptHostEnvironment>();
                 var eventManager = new Mock<IScriptEventManager>();
 
-                ScriptSettingsManager.Instance.Reset();
                 Host = new ScriptHost(environment.Object, eventManager.Object, config);
                 Host.Initialize();
             }

--- a/test/WebJobs.Script.Tests/ScriptSettingsManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptSettingsManagerTests.cs
@@ -25,8 +25,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             var settingsManager = ScriptSettingsManager.Instance;
 
-            settingsManager.Reset();
-
             var variables = new Dictionary<string, string>
             {
                 { EnvironmentSettingNames.AzureWebsiteName, siteName },
@@ -40,20 +38,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-        public void Reset_ReloadsEnvironmentChanges()
+        public void SettingsAreNotCached()
         {
-            using (var variable = new TestScopedEnvironmentVariable(nameof(Reset_ReloadsEnvironmentChanges), "foo"))
+            using (var variable = new TestScopedEnvironmentVariable(nameof(SettingsAreNotCached), "foo"))
             {
-                var configuration = new ConfigurationBuilder()
-                    .AddEnvironmentVariables()
-                    .Build();
+                Assert.Equal("foo", ScriptSettingsManager.Instance.GetSetting(nameof(SettingsAreNotCached)));
 
-                ScriptSettingsManager.Instance.SetConfigurationFactory(() => configuration);
-                Assert.Equal("foo", ScriptSettingsManager.Instance.GetSetting(nameof(Reset_ReloadsEnvironmentChanges)));
-
-                Environment.SetEnvironmentVariable(nameof(Reset_ReloadsEnvironmentChanges), "bar");
-                ScriptSettingsManager.Instance.Reset();
-                Assert.Equal("bar", ScriptSettingsManager.Instance.GetSetting(nameof(Reset_ReloadsEnvironmentChanges)));
+                Environment.SetEnvironmentVariable(nameof(SettingsAreNotCached), "bar");
+                Assert.Equal("bar", ScriptSettingsManager.Instance.GetSetting(nameof(SettingsAreNotCached)));
             }
         }
     }

--- a/test/WebJobs.Script.Tests/UtilityTests.cs
+++ b/test/WebJobs.Script.Tests/UtilityTests.cs
@@ -323,7 +323,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public void GetDefaultHostId_AzureHost_ReturnsExpectedResult(string input, string expected)
         {
             var config = new ScriptHostConfiguration();
-            var scriptSettingsManagerMock = new Mock<ScriptSettingsManager>(MockBehavior.Strict);
+            var scriptSettingsManagerMock = new Mock<ScriptSettingsManager>(MockBehavior.Strict, null);
             scriptSettingsManagerMock.SetupGet(p => p.AzureWebsiteUniqueSlotName).Returns(() => input);
 
             string hostId = Utility.GetDefaultHostId(scriptSettingsManagerMock.Object, config);
@@ -339,7 +339,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 RootScriptPath = @"c:\testing\FUNCTIONS-TEST\test$#"
             };
 
-            var scriptSettingsManagerMock = new Mock<ScriptSettingsManager>(MockBehavior.Strict);
+            var scriptSettingsManagerMock = new Mock<ScriptSettingsManager>(MockBehavior.Strict, null);
 
             string hostId = Utility.GetDefaultHostId(scriptSettingsManagerMock.Object, config);
 


### PR DESCRIPTION
Overriding the default environment configuration provider to remove caching behavior. Caching causes problems for us in specialization scenarios, where the settings are updated in the process dynamically.