### PR TITLE
using new proxy nugets for backend url fixes

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Buffering" Version="0.4.0-preview2-28189" />
-    <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.4100001-beta-d5a48cb8" />
+    <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.4780001-beta-0fed1b79" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta5" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.0-beta5-10609" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.0-beta5-10609">

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.0.2">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
-    <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.4100001-beta-d5a48cb8" />
+    <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.4780001-beta-0fed1b79" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta2-10014">
       <PrivateAssets>None</PrivateAssets>
     </PackageReference>

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Proxies/PingRoute/run.csx
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Proxies/PingRoute/run.csx
@@ -1,1 +1,11 @@
-﻿public static string Run(HttpRequestMessage req) => "Pong";
+﻿public static string Run(HttpRequestMessage req)
+{
+    if (req.Headers.Contains("return_incoming_url"))
+    {
+        return req.RequestUri.OriginalString;
+    }
+    else
+    {
+        return "Pong";
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Proxies/proxies.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Proxies/proxies.json
@@ -123,7 +123,7 @@
       "responseOverrides": {
         "response.statusCode": "201",
         "response.statusReason": "test",
-        "response.body": "{\"test\":\"123\"}"
+        "response.body": "{\"test\":\"{{{b}}}{{123}}{1}\"}"
       }
     },
     "ExternalCallBodyOverride": {
@@ -139,7 +139,35 @@
         "response.statusReason": "test",
         "response.body": "{\"test\":\"123\"}"
       }
+    },
+    "staticBackendUrlTest": {
+      "matchCondition": {
+        "route": "staticBackendUrlTest/{*path}"
+      },
+      "backendUri": "http://localhost/api/myroute/mysubroute?a=1",
+      "requestOverrides": {
+        "backend.request.headers.accept": "text/plain"
+      }
+    },
+    "wildcardBackendUrlTest": {
+      "matchCondition": {
+        "route": "wildcardBackendUrlTest/{*path}"
+      },
+      "backendUri": "http://localhost/api/{path}?a=1",
+      "requestOverrides": {
+        "backend.request.headers.accept": "text/plain"
+      }
+    },
+    "simpleParamBackendUrlTest": {
+      "matchCondition": {
+        "route": "simpleParamBackendUrlTest/myroute/{path}"
+      },
+      "backendUri": "http://localhost/api/myroute/{path}?a=1",
+      "requestOverrides": {
+        "backend.request.headers.accept": "text/plain"
+      }
     }
+
   }
 }
   

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/ProxyEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/ProxyEndToEndTests.cs
@@ -128,6 +128,54 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        //backend set as constant - no trailing slash should be added
+        public async Task TrailingSlashRemoved()
+        {
+            HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Get, $"staticBackendUrlTest/blahblah/");
+            req.Headers.Add("return_incoming_url","1");
+            HttpResponseMessage response = await _fixture.HttpClient.SendAsync(req);
+            string content = await response.Content.ReadAsStringAsync();
+            Assert.Equal("200", response.StatusCode.ToString("D"));
+            Assert.Equal(@"http://localhost/api/myroute/mysubroute?a=1", content);
+        }
+
+        [Fact]
+        //backend ended with simple param - no trailing slash should be added
+        public async Task TrailingSlashRemoved2()
+        {
+            HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Get, $"simpleParamBackendUrlTest/myroute/mysubroute/");
+            req.Headers.Add("return_incoming_url", "1");
+            HttpResponseMessage response = await _fixture.HttpClient.SendAsync(req);
+            string content = await response.Content.ReadAsStringAsync();
+            Assert.Equal("200", response.StatusCode.ToString("D"));
+            Assert.Equal(@"http://localhost/api/myroute/mysubroute?a=1", content);
+        }
+
+        [Fact]
+        //backend path ended with wildcard param - slash should be kept
+        public async Task TrailingSlashKept()
+        {
+            HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Get, $"wildcardBackendUrlTest/myroute/mysubroute/");
+            req.Headers.Add("return_incoming_url", "1");
+            HttpResponseMessage response = await _fixture.HttpClient.SendAsync(req);
+            string content = await response.Content.ReadAsStringAsync();
+            Assert.Equal("200", response.StatusCode.ToString("D"));
+            Assert.Equal(@"http://localhost/api/myroute/mysubroute/?a=1", content);
+        }
+
+        [Fact]
+        //backend path ended with wildcard param - slash should be kept
+        public async Task TrailingSlashKept2()
+        {
+            var req = new HttpRequestMessage(HttpMethod.Get, $"wildcardBackendUrlTest/myroute/mysubroute");
+            req.Headers.Add("return_incoming_url", "1");
+            var response = await _fixture.HttpClient.SendAsync(req);
+            var content = await response.Content.ReadAsStringAsync();
+            Assert.Equal("200", response.StatusCode.ToString("D"));
+            Assert.Equal(@"http://localhost/api/myroute/mysubroute?a=1", content);
+        }
+
+        [Fact]
         public async Task CatchAllWithCustomRoutes()
         {
             HttpResponseMessage response = await _fixture.HttpClient.GetAsync($"proxy/api/myroute/mysubroute");
@@ -189,7 +237,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var content = await response.Content.ReadAsStringAsync();
             Assert.Equal("201", response.StatusCode.ToString("D"));
             Assert.Equal("test", response.ReasonPhrase);
-            Assert.Equal("{\"test\":\"123\"}", content);
+            Assert.Equal("{\"test\":\"{}{123}\"}", content);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -19,7 +19,7 @@
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.4100001-beta-d5a48cb8" />
+    <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.4780001-beta-0fed1b79" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.9.1" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.0.3" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta2-10014" />


### PR DESCRIPTION
Referencing new proxy nugets containing these changes:
1.Add trailing slash only if wildcard parameter used in backed path.
2.Add parameter to unescape slash in backen url
3.Add possibility to set values like "{sometext}" in set-body.
