### PR TITLE
Read storage connection in host.json for DurableFunctions

### DIFF
--- a/schemas/json/host.json
+++ b/schemas/json/host.json
@@ -282,6 +282,23 @@
           }
         }
       }
+    },
+
+    "durableTask": {
+      "description": "Configuration settings for 'orchestration'/'activity' triggers.",
+      "type": "object",
+
+      "properties": {
+        "hubName": {
+          "description": "The logical container for Azure Storage resources that are used for orchestrations.",
+          "type": "string",
+          "default": "DurableFunctionsHub"
+        },
+
+        "azureStorageConnectionStringName": {
+          "description": "An app setting (or environment variable) with the storage connection string to be used by the orchestration/activity trigger.",
+          "type": "string"
+        }
+      }
     }
-  }
 }


### PR DESCRIPTION
Adding support to read storage connection string from host.json. Customers of Durable Functions can now configure their Durable Functions to use a separate storage connection string for better perf. Sample configuration is as follows, where OrchestrationConnection is an app setting:

```
{
    "durableTask" : {
        "connection" : "OrchestrationConnection"
    }
}
```

Mirroring changes made in Kudu repo. See https://github.com/projectkudu/kudu/pull/2749#issuecomment-384035361