### PR TITLE
Add linux build CI to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ![Azure Functions Logo](https://raw.githubusercontent.com/Azure/azure-functions-cli/master/src/Azure.Functions.Cli/npm/assets/azure-functions-logo-color-raster.png)
 
-|Branch|Status|
-|---|---|
-|master|[![Build status](https://ci.appveyor.com/api/projects/status/a6j46j1tawdfs3js?svg=true&branch=master)](https://ci.appveyor.com/project/appsvc/azure-webjobs-sdk-script-y8o14?branch=master)|
-|dev|[![Build status](https://ci.appveyor.com/api/projects/status/a6j46j1tawdfs3js?svg=true&branch=dev)](https://ci.appveyor.com/project/appsvc/azure-webjobs-sdk-script-y8o14?branch=dev)|
-|v1.x|[![Build status](https://ci.appveyor.com/api/projects/status/a6j46j1tawdfs3js?svg=true&branch=v1.x)](https://ci.appveyor.com/project/appsvc/azure-webjobs-sdk-script-y8o14?branch=v1.x)|
+|Branch|Windows|Linux|
+|---|---|---|
+|master|[![Build status](https://ci.appveyor.com/api/projects/status/a6j46j1tawdfs3js?svg=true&branch=master)](https://ci.appveyor.com/project/appsvc/azure-webjobs-sdk-script-y8o14?branch=master)|[![Build status](https://ci.appveyor.com/api/projects/status/03j5j88yk9489y33/branch/master?svg=true)](https://ci.appveyor.com/project/appsvc/azure-functions-host-l70a7/branch/master)|
+|dev|[![Build status](https://ci.appveyor.com/api/projects/status/a6j46j1tawdfs3js?svg=true&branch=dev)](https://ci.appveyor.com/project/appsvc/azure-webjobs-sdk-script-y8o14?branch=dev)|[![Build status](https://ci.appveyor.com/api/projects/status/03j5j88yk9489y33/branch/dev?svg=true)](https://ci.appveyor.com/project/appsvc/azure-functions-host-l70a7/branch/dev)|
+|v1.x|[![Build status](https://ci.appveyor.com/api/projects/status/a6j46j1tawdfs3js?svg=true&branch=v1.x)](https://ci.appveyor.com/project/appsvc/azure-webjobs-sdk-script-y8o14?branch=v1.x)| `NA` |
 
 WebJobs.Script
 ===


### PR DESCRIPTION
The CI does build only for now. Most tests are failing, so there is no point. I just want to make sure the dev branch always builds on linux since there has been recent changes that were fine on Windows but won't build on linux 