### PR TITLE
Linux container specialization fix (#2718)

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -37,19 +36,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         {
             var containerKey = _settingsManager.GetSetting(EnvironmentSettingNames.ContainerEncryptionKey);
             var assignmentContext = encryptedAssignmentContext.Decrypt(containerKey);
-            return _instanceManager.StartAssignment(assignmentContext)
+            var result = _instanceManager.StartAssignment(assignmentContext);
+
+            return result
                 ? Accepted()
                 : StatusCode(StatusCodes.Status409Conflict, "Instance already assigned");
-        }
-
-        [HttpGet]
-        [Route("admin/instance/status")]
-        [Authorize(Policy = PolicyNames.AdminAuthLevel)]
-        public async Task<IActionResult> GetInstanceStatus([FromQuery] int timeout = int.MaxValue)
-        {
-            return await _scriptHostManager.DelayUntilHostReady(timeoutSeconds: timeout)
-                ? Ok()
-                : StatusCode(StatusCodes.Status503ServiceUnavailable);
         }
 
         [HttpGet]

--- a/src/WebJobs.Script.WebHost/Middleware/HostAvailabilityCheckMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/HostAvailabilityCheckMiddleware.cs
@@ -1,12 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Azure.WebJobs.Script.WebHost.Features;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
@@ -22,14 +18,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
             _logger = loggerFactory.CreateLogger<HostAvailabilityCheckMiddleware>();
         }
 
-        public async Task Invoke(HttpContext httpContext, WebScriptHostManager manager)
+        public async Task Invoke(HttpContext httpContext, WebHostResolver resolver)
         {
             using (Logger.VerifyingHostAvailabilityScope(_logger, httpContext.TraceIdentifier))
             {
                 Logger.InitiatingHostAvailabilityCheck(_logger);
 
-                bool hostReady = await manager.DelayUntilHostReady(throwOnFailure: false);
-
+                bool hostReady = await WebScriptHostManager.DelayUntilHostReady(resolver);
                 if (!hostReady)
                 {
                     Logger.HostUnavailableAfterCheck(_logger);

--- a/src/WebJobs.Script.WebHost/WebHostResolver.cs
+++ b/src/WebJobs.Script.WebHost/WebHostResolver.cs
@@ -245,7 +245,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             // concurrently by incoming http requests, but the initialization
             // here ensures that it takes place in the absence of any http
             // traffic.
-            _activeHostManager?.RunAsync(CancellationToken.None);
+            _activeHostManager?.EnsureHostStarted(CancellationToken.None);
         }
 
         private static void InitializeFileSystem(WebHostSettings settings, bool readOnlyFileSystem)

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         public Task StartAsync(CancellationToken cancellationToken)
         {
             _logger.LogInformation("Initializing WebScriptHostManager.");
-            _hostTask = _scriptHostManager.RunAsync(_cancellationTokenSource.Token);
+            _hostTask = _scriptHostManager.EnsureHostStarted(_cancellationTokenSource.Token);
 
             return Task.CompletedTask;
         }

--- a/src/WebJobs.Script/Host/ScriptHostManager.cs
+++ b/src/WebJobs.Script/Host/ScriptHostManager.cs
@@ -244,7 +244,7 @@ namespace Microsoft.Azure.WebJobs.Script
                     // We need to keep the host running, so we catch and log any errors
                     // then restart the host
                     string message = "A ScriptHost error has occurred";
-                    Instance?.Logger.LogError(0, ex, message);
+                    Instance?.Logger?.LogError(0, ex, message);
 
                     if (ShutdownHostIfUnhealthy())
                     {

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -45,6 +45,26 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
+        /// Delays while the specified condition remains true.
+        /// </summary>
+        /// <param name="timeoutSeconds">The maximum number of seconds to delay.</param>
+        /// <param name="pollingIntervalMilliseconds">The polling interval.</param>
+        /// <param name="condition">The condition to check</param>
+        /// <returns>A Task representing the delay.</returns>
+        internal static async Task DelayAsync(int timeoutSeconds, int pollingIntervalMilliseconds, Func<bool> condition)
+        {
+            TimeSpan timeout = TimeSpan.FromSeconds(timeoutSeconds);
+            TimeSpan delay = TimeSpan.FromMilliseconds(pollingIntervalMilliseconds);
+            TimeSpan timeWaited = TimeSpan.Zero;
+
+            while (condition() && (timeWaited < timeout))
+            {
+                await Task.Delay(delay);
+                timeWaited += delay;
+            }
+        }
+
+        /// <summary>
         /// Implements a configurable exponential backoff strategy.
         /// </summary>
         /// <param name="exponent">The backoff exponent. E.g. for backing off in a retry loop,

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyManagerTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -11,6 +12,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Web.Http;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
@@ -18,7 +20,10 @@ using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.WebJobs.Script.Tests;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
@@ -26,11 +31,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
     public class StandbyManagerTests : IDisposable
     {
         private readonly ScriptSettingsManager _settingsManager;
+        private TestLoggerProvider _loggerProvider;
+        private HttpClient _httpClient;
+        private TestServer _httpServer;
+        private string _expectedHostId;
 
         public StandbyManagerTests()
         {
             _settingsManager = ScriptSettingsManager.Instance;
-            WebScriptHostManager.ResetStandbyMode();
+            ResetEnvironment();
         }
 
         [Fact]
@@ -93,83 +102,35 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 { EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1" },
                 { EnvironmentSettingNames.AzureWebsiteContainerReady, null },
+                { EnvironmentSettingNames.AzureWebsiteSku, "Dynamic" },
                 { EnvironmentSettingNames.AzureWebsiteInstanceId, "87654639876900123453445678890144" },
                 { "AzureWebEncryptionKey", "0F75CA46E7EBDD39E4CA6B074D1F9A5972B849A55F91A248" }
             };
             using (var env = new TestScopedEnvironmentVariable(vars))
             {
-                var httpConfig = new HttpConfiguration();
+                await InitializeTestHost("StandbyModeTest");
 
-                var testRootPath = Path.Combine(Path.GetTempPath(), "StandbyModeTest");
-                await FileUtility.DeleteDirectoryAsync(testRootPath, true);
+                await VerifyWarmupSucceeds();
+                await VerifyWarmupSucceeds(restart: true);
 
-                var loggerProvider = new TestLoggerProvider();
-                var loggerProviderFactory = new TestLoggerProviderFactory(loggerProvider);
-                var webHostSettings = new WebHostSettings
-                {
-                    IsSelfHost = true,
-                    LogPath = Path.Combine(testRootPath, "Logs"),
-                    SecretsPath = Path.Combine(testRootPath, "Secrets"),
-                    ScriptPath = Path.Combine(testRootPath, "WWWRoot")
-                };
-
-                var loggerFactory = new LoggerFactory();
-                loggerFactory.AddProvider(loggerProvider);
-
-                var webHostBuilder = Program.CreateWebHostBuilder()
-                    .ConfigureServices(c => {
-                        c.AddSingleton(webHostSettings)
-                        .AddSingleton<ILoggerProviderFactory>(loggerProviderFactory)
-                        .AddSingleton<ILoggerFactory>(loggerFactory);
-                        });
-
-                var httpServer = new TestServer(webHostBuilder);
-                var httpClient = httpServer.CreateClient();
-                httpClient.BaseAddress = new Uri("https://localhost/");
-
-                TestHelpers.WaitForWebHost(httpClient);
-
-                var traces = loggerProvider.GetAllLogMessages().ToArray();
-                Assert.NotNull(traces.Single(p => p.FormattedMessage.StartsWith("Starting Host (HostId=placeholder-host")));
-                Assert.NotNull(traces.Single(p => p.FormattedMessage.StartsWith("Host is in standby mode")));
-
-                // issue warmup request and verify
-                var request = new HttpRequestMessage(HttpMethod.Get, "api/warmup");
-                var response = await httpClient.SendAsync(request);
-                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                string responseBody = await response.Content.ReadAsStringAsync();
-                Assert.Equal("WarmUp complete.", responseBody);
-
-                // issue warmup request with restart and verify
-                request = new HttpRequestMessage(HttpMethod.Get, "api/warmup?restart=1");
-                response = await httpClient.SendAsync(request);
-                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                responseBody = await response.Content.ReadAsStringAsync();
-                Assert.Equal("WarmUp complete.", responseBody);
-
-                // Now specialize the host
+                // now specialize the host
                 ScriptSettingsManager.Instance.SetSetting(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
                 ScriptSettingsManager.Instance.SetSetting(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
 
                 Assert.False(WebScriptHostManager.InStandbyMode);
                 Assert.True(ScriptSettingsManager.Instance.ContainerReady);
 
+                _httpServer.Dispose();
+                _httpClient.Dispose();
+
                 // give time for the specialization to happen
                 string[] logLines = null;
                 await TestHelpers.Await(() =>
                 {
                     // wait for the trace indicating that the host has been specialized
-                    logLines = loggerProvider.GetAllLogMessages().Where(p => p.FormattedMessage != null).Select(p => p.FormattedMessage).ToArray();
+                    logLines = _loggerProvider.GetAllLogMessages().Where(p => p.FormattedMessage != null).Select(p => p.FormattedMessage).ToArray();
                     return logLines.Contains("Generating 0 job function(s)");
-                }, userMessageCallback: () => string.Join(Environment.NewLine, loggerProvider.GetAllLogMessages().Select(p => $"[{p.Timestamp.ToString("HH:mm:ss.fff")}] {p.FormattedMessage}")));
-
-                httpServer.Dispose();
-                httpClient.Dispose();
-
-                await Task.Delay(2000);
-
-                var hostConfig = WebHostResolver.CreateScriptHostConfiguration(webHostSettings, true);
-                var expectedHostId = hostConfig.HostConfig.HostId;
+                }, userMessageCallback: () => string.Join(Environment.NewLine, _loggerProvider.GetAllLogMessages().Select(p => $"[{p.Timestamp.ToString("HH:mm:ss.fff")}] {p.FormattedMessage}")));
 
                 // verify the rest of the expected logs
                 string text = string.Join(Environment.NewLine, logLines);
@@ -180,7 +141,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Assert.Equal(2, logLines.Count(p => p.Contains("Host is in standby mode")));
                 Assert.Equal(2, logLines.Count(p => p.Contains("Executed 'Functions.WarmUp' (Succeeded")));
                 Assert.Equal(1, logLines.Count(p => p.Contains("Starting host specialization")));
-                Assert.Equal(1, logLines.Count(p => p.Contains($"Starting Host (HostId={expectedHostId}")));
+                Assert.Equal(1, logLines.Count(p => p.Contains($"Starting Host (HostId={_expectedHostId}")));
                 Assert.Contains("Generating 0 job function(s)", logLines);
 
                 WebScriptHostManager.ResetStandbyMode();
@@ -198,97 +159,40 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 { EnvironmentSettingNames.ContainerName, "TestContainer" },
                 { EnvironmentSettingNames.ContainerEncryptionKey, encryptionKey },
                 { EnvironmentSettingNames.AzureWebsiteContainerReady, null },
+                { EnvironmentSettingNames.AzureWebsiteSku, "Dynamic" },
+                { EnvironmentSettingNames.AzureWebsiteZipDeployment, null },
                 { "AzureWebEncryptionKey", "0F75CA46E7EBDD39E4CA6B074D1F9A5972B849A55F91A248" }
             };
             using (var env = new TestScopedEnvironmentVariable(vars))
             {
-                var httpConfig = new HttpConfiguration();
+                await InitializeTestHost("StandbyModeTest_Linux");
 
-                var testRootPath = Path.Combine(Path.GetTempPath(), "StandbyModeTest_Linux");
-                await FileUtility.DeleteDirectoryAsync(testRootPath, true);
+                await VerifyWarmupSucceeds();
+                await VerifyWarmupSucceeds(restart: true);
 
-                var loggerProvider = new TestLoggerProvider();
-                var loggerProviderFactory = new TestLoggerProviderFactory(loggerProvider);
-                var webHostSettings = new WebHostSettings
-                {
-                    IsSelfHost = true,
-                    LogPath = Path.Combine(testRootPath, "Logs"),
-                    SecretsPath = Path.Combine(testRootPath, "Secrets"),
-                    ScriptPath = Path.Combine(testRootPath, "WWWRoot")
-                };
+                // now specialize the site
+                await Assign(encryptionKey);
 
-                var loggerFactory = new LoggerFactory();
-                loggerFactory.AddProvider(loggerProvider);
-
-                var webHostBuilder = Program.CreateWebHostBuilder()
-                    .ConfigureServices(c =>
-                    {
-                        c.AddSingleton(webHostSettings)
-                        .AddSingleton<ILoggerProviderFactory>(loggerProviderFactory)
-                        .AddSingleton<ILoggerFactory>(loggerFactory);
-                    });
-
-                var httpServer = new TestServer(webHostBuilder);
-                var httpClient = httpServer.CreateClient();
-                httpClient.BaseAddress = new Uri("https://localhost/");
-
-                TestHelpers.WaitForWebHost(httpClient);
-
-                var traces = loggerProvider.GetAllLogMessages().ToArray();
-                Assert.NotNull(traces.Single(p => p.FormattedMessage.StartsWith("Starting Host (HostId=placeholder-host")));
-                Assert.NotNull(traces.Single(p => p.FormattedMessage.StartsWith("Host is in standby mode")));
-
-                // issue warmup request and verify
-                var request = new HttpRequestMessage(HttpMethod.Get, "api/warmup");
-                var response = await httpClient.SendAsync(request);
+                // immediately call a function - expect the call to block until
+                // the host is fully specialized
+                var request = new HttpRequestMessage(HttpMethod.Get, "api/httptrigger");
+                request.Headers.Add(ScriptConstants.AntaresColdStartHeaderName, "1");
+                var response = await _httpClient.SendAsync(request);
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                string responseBody = await response.Content.ReadAsStringAsync();
-                Assert.Equal("WarmUp complete.", responseBody);
 
-                // issue warmup request with restart and verify
-                request = new HttpRequestMessage(HttpMethod.Get, "api/warmup?restart=1");
-                response = await httpClient.SendAsync(request);
-                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                responseBody = await response.Content.ReadAsStringAsync();
-                Assert.Equal("WarmUp complete.", responseBody);
+                Assert.False(WebScriptHostManager.InStandbyMode);
+                Assert.True(ScriptSettingsManager.Instance.ContainerReady);
 
-                // Now specialize the host by invoking assign
-                var secretManager = httpServer.Host.Services.GetService<ISecretManager>();
-                var masterKey = (await secretManager.GetHostSecretsAsync()).MasterKey;
-                string uri = "admin/instance/assign";
-                request = new HttpRequestMessage(HttpMethod.Post, uri);
-                var environment = new Dictionary<string, string>();
-                var assignmentContext = new HostAssignmentContext
-                {
-                    SiteId = 1234,
-                    SiteName = "TestSite",
-                    Environment = environment
-                };
-                var encryptedAssignmentContext = EncryptedHostAssignmentContext.Create(assignmentContext, encryptionKey);
-                string json = JsonConvert.SerializeObject(encryptedAssignmentContext);
-                request.Content = new StringContent(json, Encoding.UTF8, "application/json");
-                request.Headers.Add(AuthenticationLevelHandler.FunctionsKeyHeaderName, masterKey);
-                response = await httpClient.SendAsync(request);
-                Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+                // verify warmup function no longer there
+                request = new HttpRequestMessage(HttpMethod.Get, "api/warmup");
+                response = await _httpClient.SendAsync(request);
+                Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
 
-                // give time for the specialization to happen
-                string[] logLines = null;
-                await TestHelpers.Await(() =>
-                {
-                    // wait for the trace indicating that the host has been specialized
-                    logLines = loggerProvider.GetAllLogMessages().Where(p => p.FormattedMessage != null).Select(p => p.FormattedMessage).ToArray();
-                    return logLines.Contains("Generating 0 job function(s)");
-                }, userMessageCallback: () => string.Join(Environment.NewLine, loggerProvider.GetAllLogMessages().Select(p => $"[{p.Timestamp.ToString("HH:mm:ss.fff")}] {p.FormattedMessage}")));
+                _httpServer.Dispose();
+                _httpClient.Dispose();
 
-                httpServer.Dispose();
-                httpClient.Dispose();
-
-                await Task.Delay(2000);
-
-                var hostConfig = WebHostResolver.CreateScriptHostConfiguration(webHostSettings, true);
-                var expectedHostId = hostConfig.HostConfig.HostId;
-
-                // verify the rest of the expected logs
+                // verify the expected logs
+                var logLines = _loggerProvider.GetAllLogMessages().Where(p => p.FormattedMessage != null).Select(p => p.FormattedMessage).ToArray();
                 string text = string.Join(Environment.NewLine, logLines);
                 Assert.True(logLines.Count(p => p.Contains("Stopping Host")) >= 1);
                 Assert.Equal(1, logLines.Count(p => p.Contains("Creating StandbyMode placeholder function directory")));
@@ -297,16 +201,160 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Assert.Equal(2, logLines.Count(p => p.Contains("Host is in standby mode")));
                 Assert.Equal(2, logLines.Count(p => p.Contains("Executed 'Functions.WarmUp' (Succeeded")));
                 Assert.Equal(1, logLines.Count(p => p.Contains("Starting host specialization")));
-                Assert.Equal(1, logLines.Count(p => p.Contains($"Starting Host (HostId={expectedHostId}")));
-                Assert.Contains("Generating 0 job function(s)", logLines);
+                Assert.Equal(1, logLines.Count(p => p.Contains($"Starting Host (HostId={_expectedHostId}")));
+                Assert.Contains("Node.js HttpTrigger function invoked.", logLines);
+
+                // verify cold start log entry
+                var coldStartLog = _loggerProvider.GetAllLogMessages().FirstOrDefault(p => p.Category == ScriptConstants.LogCategoryHostMetrics);
+                JObject coldStartData = JObject.Parse(coldStartLog.FormattedMessage);
+                Assert.Equal("Dynamic", coldStartData["sku"]);
+                Assert.True((int)coldStartData["dispatchDuration"] > 0);
+                Assert.True((int)coldStartData["functionDuration"] > 0);
 
                 WebScriptHostManager.ResetStandbyMode();
             }
         }
 
+        private async Task InitializeTestHost(string testDirName)
+        {
+            var httpConfig = new HttpConfiguration();
+            var testRootPath = Path.Combine(Path.GetTempPath(), testDirName);
+            await FileUtility.DeleteDirectoryAsync(testRootPath, true);
+
+            _loggerProvider = new TestLoggerProvider();
+            var loggerProviderFactory = new TestLoggerProviderFactory(_loggerProvider);
+            var webHostSettings = new WebHostSettings
+            {
+                IsSelfHost = true,
+                LogPath = Path.Combine(testRootPath, "Logs"),
+                SecretsPath = Path.Combine(testRootPath, "Secrets"),
+                ScriptPath = Path.Combine(testRootPath, "WWWRoot")
+            };
+
+            var loggerFactory = new LoggerFactory();
+            loggerFactory.AddProvider(_loggerProvider);
+
+            var webHostBuilder = Program.CreateWebHostBuilder()
+                .ConfigureServices(c =>
+                {
+                    c.AddSingleton(webHostSettings)
+                    .AddSingleton<ILoggerProviderFactory>(loggerProviderFactory)
+                    .AddSingleton<ILoggerFactory>(loggerFactory);
+                });
+
+            _httpServer = new TestServer(webHostBuilder);
+            _httpClient = _httpServer.CreateClient();
+            _httpClient.BaseAddress = new Uri("https://localhost/");
+
+            TestHelpers.WaitForWebHost(_httpClient);
+
+            var traces = _loggerProvider.GetAllLogMessages().ToArray();
+            Assert.NotNull(traces.Single(p => p.FormattedMessage.StartsWith("Starting Host (HostId=placeholder-host")));
+            Assert.NotNull(traces.Single(p => p.FormattedMessage.StartsWith("Host is in standby mode")));
+
+            var hostConfig = WebHostResolver.CreateScriptHostConfiguration(webHostSettings, true);
+            _expectedHostId = hostConfig.HostConfig.HostId;
+        }
+
+        private async Task Assign(string encryptionKey)
+        {
+            // create a zip package
+            var contentRoot = Path.Combine(Path.GetTempPath(), @"FunctionsTest");
+            var sourcePath = Path.Combine(Directory.GetCurrentDirectory(), @"TestScripts\Node\HttpTrigger");
+            var zipFilePath = Path.Combine(contentRoot, "content.zip");
+            await CreateContentZip(contentRoot, zipFilePath, @"TestScripts\Node\HttpTrigger");
+
+            // upload the blob and get a SAS uri
+            var sasUri = await CreateBlobSas(zipFilePath, "azure-functions-test", "appcontents.zip");
+
+            // Now specialize the host by invoking assign
+            var secretManager = _httpServer.Host.Services.GetService<ISecretManager>();
+            var masterKey = (await secretManager.GetHostSecretsAsync()).MasterKey;
+            string uri = "admin/instance/assign";
+            var request = new HttpRequestMessage(HttpMethod.Post, uri);
+            var environment = new Dictionary<string, string>()
+                {
+                    { EnvironmentSettingNames.AzureWebsiteZipDeployment, sasUri.ToString() }
+                };
+            var assignmentContext = new HostAssignmentContext
+            {
+                SiteId = 1234,
+                SiteName = "TestSite",
+                Environment = environment
+            };
+            var encryptedAssignmentContext = EncryptedHostAssignmentContext.Create(assignmentContext, encryptionKey);
+            string json = JsonConvert.SerializeObject(encryptedAssignmentContext);
+            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+            request.Headers.Add(AuthenticationLevelHandler.FunctionsKeyHeaderName, masterKey);
+            var response = await _httpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        }
+
+        private async Task VerifyWarmupSucceeds(bool restart = false)
+        {
+            string uri = "api/warmup";
+            if (restart)
+            {
+                uri += "?restart=1";
+            }
+
+            // issue warmup request and verify
+            var request = new HttpRequestMessage(HttpMethod.Get, uri);
+            var response = await _httpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            string responseBody = await response.Content.ReadAsStringAsync();
+            Assert.Equal("WarmUp complete.", responseBody);
+        }
+
+        private static async Task CreateContentZip(string contentRoot, string zipPath, params string[] copyDirs)
+        {
+            var contentTemp = Path.Combine(contentRoot, @"ZipContent");
+            await FileUtility.DeleteDirectoryAsync(contentTemp, true);
+
+            foreach (var sourceDir in copyDirs)
+            {
+                var directoryName = Path.GetFileName(sourceDir);
+                var targetPath = Path.Combine(contentTemp, directoryName);
+                FileUtility.EnsureDirectoryExists(targetPath);
+                var sourcePath = Path.Combine(Directory.GetCurrentDirectory(), sourceDir);
+                FileUtility.CopyDirectory(sourcePath, targetPath);
+            }
+
+            FileUtility.DeleteFileSafe(zipPath);
+            ZipFile.CreateFromDirectory(contentTemp, zipPath);
+        }
+
+        private static async Task<Uri> CreateBlobSas(string filePath, string blobContainer, string blobName)
+        {
+            string connectionString = AmbientConnectionStringProvider.Instance.GetConnectionString(ConnectionStringNames.Storage);
+            CloudStorageAccount storageAccount = CloudStorageAccount.Parse(connectionString);
+            var blobClient = storageAccount.CreateCloudBlobClient();
+            var container = blobClient.GetContainerReference(blobContainer);
+            await container.CreateIfNotExistsAsync();
+            var blob = container.GetBlockBlobReference(blobName);
+            await blob.UploadFromFileAsync(filePath);
+            var policy = new SharedAccessBlobPolicy
+            {
+                SharedAccessStartTime = DateTime.UtcNow,
+                SharedAccessExpiryTime = DateTime.UtcNow.AddHours(1),
+                Permissions = SharedAccessBlobPermissions.Read | SharedAccessBlobPermissions.List
+            };
+            var sas = blob.GetSharedAccessSignature(policy);
+            var sasUri = new Uri(blob.Uri, sas);
+
+            return sasUri;
+        }
+
         public void Dispose()
         {
+            ResetEnvironment();
+        }
+
+        private void ResetEnvironment()
+        {
             Environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, string.Empty);
+            Environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteZipDeployment, string.Empty);
+            WebScriptHostManager.ResetStandbyMode();
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Description/DotNet/DynamicFunctionAssemblyLoadContextTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/DynamicFunctionAssemblyLoadContextTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Description.DotNet
         {
             private readonly FunctionAssemblyLoadContext _sharedContext;
 
-            public TestDynamicAssemblyLoadContext(WebJobs.Script.Description.FunctionMetadata functionMetadata, 
+            public TestDynamicAssemblyLoadContext(WebJobs.Script.Description.FunctionMetadata functionMetadata,
                 IFunctionMetadataResolver resolver, ILogger logger, FunctionAssemblyLoadContext sharedContext)
                 : base(functionMetadata, resolver, logger)
             {

--- a/test/WebJobs.Script.Tests/Managment/InstanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Managment/InstanceManagerTests.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             };
             bool result = instanceManager.StartAssignment(context);
             Assert.True(result);
+            Assert.True(WebScriptHostManager.InStandbyMode);
 
             // specialization is done in the background
             await Task.Delay(500);


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-functions-host/issues/2718. Also addresses https://github.com/Azure/azure-functions-host/issues/2773.

The issue was that the Assign call returns immediately after starting the background assign process, but before any of the specialization has taken place. That means if a request comes in immediately after the Assign but before the specialization, target functions may not exist, resulting in 404s.

The fix is to buffer incoming requests while specialization is happening, and allow them to complete once the specialized host is ready.

I updated the end to end specialization test to include a user function, and issue a request to it immediately after assign. This would repro the 404 every time before the fix.