### PR TITLE
Cosmos DB ConnectionMode configuration

### DIFF
--- a/schemas/json/host.json
+++ b/schemas/json/host.json
@@ -258,29 +258,41 @@
         },
 
         "applicationInsights": {
-            "description": "Configuration settings for Application Insights logging.",
-            "type": "object",
+          "description": "Configuration settings for Application Insights logging.",
+          "type": "object",
 
-            "properties": {
-                "sampling": {
-                    "description": "Configuration settings for Application Insights client-side adaptive sampling.",
-                    "type": "object",
+          "properties": {
+            "sampling": {
+              "description": "Configuration settings for Application Insights client-side adaptive sampling.",
+              "type": "object",
 
-                    "properties": {
-                        "isEnabled": {
-                            "description": "If true, client-side adaptive sampling is enabled.",
-                            "type": "boolean",
-                            "default": true
-                        },
+              "properties": {
+                "isEnabled": {
+                  "description": "If true, client-side adaptive sampling is enabled.",
+                  "type": "boolean",
+                  "default": true
+                },
 
-                        "maxTelemetryItemsPerSecond": {
-                            "description": "The target rate that the adaptive algorithm aims for on each instance",
-                            "type": "integer",
-                            "default": 5
-                        }
-                    }
+                "maxTelemetryItemsPerSecond": {
+                  "description": "The target rate that the adaptive algorithm aims for on each instance",
+                  "type": "integer",
+                  "default": 5
                 }
+              }
             }
+          }
+        },
+
+        "documentDB": {
+          "description": "Configuration settings for Azure Cosmos DB bindings and triggers.",
+          "type": "object",
+          "properties": {
+            "connectionMode": {
+              "description": "ConnectionMode to be used on the DocumentClients.",
+              "enum": [ "Gateway", "Direct" ],
+              "default": "Gateway"
+            }
+          }
         }
     }
 }

--- a/src/WebJobs.Script.Host/WebJobs.Script.Host.csproj
+++ b/src/WebJobs.Script.Host/WebJobs.Script.Host.csproj
@@ -108,7 +108,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.3.0-beta1-11288\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.3.0-beta1-10620\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.ApiHub, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.ApiHub.1.0.0-beta8\lib\net45\Microsoft.Azure.WebJobs.Extensions.ApiHub.dll</HintPath>
@@ -117,7 +117,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.BotFramework.1.0.15-beta\lib\net46\Microsoft.Azure.WebJobs.Extensions.BotFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.DocumentDB, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.2.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.3.0-beta1-10620\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.EventGrid, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.EventGrid.1.0.0-beta3-10022\lib\net46\Microsoft.Azure.WebJobs.Extensions.EventGrid.dll</HintPath>

--- a/src/WebJobs.Script.Host/packages.config
+++ b/src/WebJobs.Script.Host/packages.config
@@ -19,10 +19,10 @@
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs" version="2.3.0-beta1-11288" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Core" version="2.3.0-beta1-11288" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Extensions" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Extensions" version="2.3.0-beta1-10620" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta8" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.2.0" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.3.0-beta1-10620" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.EventGrid" version="1.0.0-beta3-10022" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.2.0" targetFramework="net471" />

--- a/src/WebJobs.Script.NuGet/WebJobs.Script.nuspec
+++ b/src/WebJobs.Script.NuGet/WebJobs.Script.nuspec
@@ -23,7 +23,7 @@
       <dependency id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" />
       <dependency id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta8" />
       <dependency id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" />
-      <dependency id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.2.0" />
+      <dependency id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.3.0-beta1-10620" />
       <dependency id="Microsoft.Azure.WebJobs.Extensions.Http" version="1.1.0" />
       <dependency id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.2.0" />
       <dependency id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.2.0" />

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -181,7 +181,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.3.0-beta1-11288\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.3.0-beta1-10620\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.ApiHub, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.ApiHub.1.0.0-beta8\lib\net45\Microsoft.Azure.WebJobs.Extensions.ApiHub.dll</HintPath>
@@ -190,7 +190,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.BotFramework.1.0.15-beta\lib\net46\Microsoft.Azure.WebJobs.Extensions.BotFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.DocumentDB, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.2.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.3.0-beta1-10620\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.EventGrid, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.EventGrid.1.0.0-beta3-10022\lib\net46\Microsoft.Azure.WebJobs.Extensions.EventGrid.dll</HintPath>

--- a/src/WebJobs.Script.WebHost/packages.config
+++ b/src/WebJobs.Script.WebHost/packages.config
@@ -47,10 +47,10 @@
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs" version="2.3.0-beta1-11288" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Core" version="2.3.0-beta1-11288" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Extensions" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Extensions" version="2.3.0-beta1-10620" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta8" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.2.0" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.3.0-beta1-10620" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.EventGrid" version="1.0.0-beta3-10022" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Http" version="1.1.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.2.0" targetFramework="net471" />

--- a/src/WebJobs.Script/Binding/DocumentDBScriptBindingProvider.cs
+++ b/src/WebJobs.Script/Binding/DocumentDBScriptBindingProvider.cs
@@ -56,6 +56,15 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
                 {
                     documentDBConfiguration.LeaseOptions = leaseOptions.ToObject<ChangeFeedHostOptions>();
                 }
+
+                JToken connectionMode = configSection["connectionMode"];
+                if (connectionMode != null)
+                {
+                    if (Enum.TryParse<ConnectionMode>(connectionMode.Value<string>(), out ConnectionMode connectionModeValue))
+                    {
+                        documentDBConfiguration.ConnectionMode = connectionModeValue;
+                    }
+                }
             }
 
             Config.UseDocumentDB(documentDBConfiguration);

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -114,7 +114,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.3.0-beta1-11288\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.3.0-beta1-10620\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.ApiHub, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.ApiHub.1.0.0-beta8\lib\net45\Microsoft.Azure.WebJobs.Extensions.ApiHub.dll</HintPath>
@@ -123,7 +123,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.BotFramework.1.0.15-beta\lib\net46\Microsoft.Azure.WebJobs.Extensions.BotFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.DocumentDB, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.2.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.3.0-beta1-10620\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.EventGrid, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.EventGrid.1.0.0-beta3-10022\lib\net46\Microsoft.Azure.WebJobs.Extensions.EventGrid.dll</HintPath>

--- a/src/WebJobs.Script/packages.config
+++ b/src/WebJobs.Script/packages.config
@@ -23,10 +23,10 @@
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs" version="2.3.0-beta1-11288" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Core" version="2.3.0-beta1-11288" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Extensions" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Extensions" version="2.3.0-beta1-10620" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta8" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.2.0" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.3.0-beta1-10620" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.EventGrid" version="1.0.0-beta3-10022" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Http" version="1.1.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.2.0" targetFramework="net471" />

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -130,7 +130,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.3.0-beta1-11288\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.3.0-beta1-10620\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.ApiHub, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.ApiHub.1.0.0-beta8\lib\net45\Microsoft.Azure.WebJobs.Extensions.ApiHub.dll</HintPath>
@@ -139,7 +139,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.BotFramework.1.0.15-beta\lib\net46\Microsoft.Azure.WebJobs.Extensions.BotFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.DocumentDB, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.2.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.3.0-beta1-10620\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.EventGrid, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.EventGrid.1.0.0-beta3-10022\lib\net46\Microsoft.Azure.WebJobs.Extensions.EventGrid.dll</HintPath>

--- a/test/WebJobs.Script.Tests.Integration/packages.config
+++ b/test/WebJobs.Script.Tests.Integration/packages.config
@@ -31,10 +31,10 @@
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs" version="2.3.0-beta1-11288" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Core" version="2.3.0-beta1-11288" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Extensions" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Extensions" version="2.3.0-beta1-10620" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta8" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.2.0" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.3.0-beta1-10620" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.EventGrid" version="1.0.0-beta3-10022" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Http" version="1.1.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.2.0" targetFramework="net471" />

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -136,7 +136,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.3.0-beta1-11288\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.2.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.3.0-beta1-10620\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.ApiHub, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.ApiHub.1.0.0-beta8\lib\net45\Microsoft.Azure.WebJobs.Extensions.ApiHub.dll</HintPath>
@@ -145,7 +145,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.BotFramework.1.0.15-beta\lib\net46\Microsoft.Azure.WebJobs.Extensions.BotFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.DocumentDB, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.2.0\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.DocumentDB.1.3.0-beta1-10620\lib\net45\Microsoft.Azure.WebJobs.Extensions.DocumentDB.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions.EventGrid, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.EventGrid.1.0.0-beta3-10022\lib\net46\Microsoft.Azure.WebJobs.Extensions.EventGrid.dll</HintPath>

--- a/test/WebJobs.Script.Tests/packages.config
+++ b/test/WebJobs.Script.Tests/packages.config
@@ -32,10 +32,10 @@
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs" version="2.3.0-beta1-11288" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Core" version="2.3.0-beta1-11288" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Extensions" version="2.2.0" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Extensions" version="2.3.0-beta1-10620" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta8" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.2.0" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Extensions.DocumentDB" version="1.3.0-beta1-10620" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Http" version="1.1.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.MobileApps" version="1.2.0" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.2.0" targetFramework="net471" />


### PR DESCRIPTION
This PR is based on https://github.com/Azure/azure-webjobs-sdk-extensions/pull/400 and adds mapping to the `DocumentDBBindingProvider` for a new `connectionMode` attribute in the `documentDB` attribute in `host.json`.