### PR TITLE
 Use ContainerEncyryptionKey for Authenticating internal requests.

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
@@ -214,9 +214,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             var content = JsonConvert.SerializeObject(triggers);
             var token = SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddMinutes(5));
 
-            // This will be a problem for national clouds. However, Antares isn't injecting the
-            // WEBSITE_HOSTNAME yet for linux apps. So until then will use this.
-            var url = $"https://{Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME")}.azurewebsites.net/operations/settriggers";
+            var url = $"https://{Environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName)}/operations/settriggers";
 
             using (var request = new HttpRequestMessage(HttpMethod.Post, url))
             {

--- a/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             FileUtility.Instance = fileSystem;
 
             Environment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestHelpers.GenerateKeyHexString());
-            Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", "appName");
+            Environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName, "appName.azurewebsites.net");
 
             // Act
             (var success, var error) = await webManager.TrySyncTriggers();


### PR DESCRIPTION
 WebSiteAuth Key will be available only after a site is assigned to the container.