### PR TITLE
Change Blobs.CentralizedPoisonQueue default (#1106)

### DIFF
--- a/src/WebJobs.Script/Binding/WebJobsCoreScriptBindingProvider.cs
+++ b/src/WebJobs.Script/Binding/WebJobsCoreScriptBindingProvider.cs
@@ -26,8 +26,6 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
         public override void Initialize()
         {
             // Apply Blobs configuration
-            // TODO: FACAVAL - Follow up on TEMP comment below
-            Config.Blobs.CentralizedPoisonQueue = true;   // TEMP : In the next release we'll remove this and accept the core SDK default
             var configSection = (JObject)Metadata["blobs"];
             JToken value = null;
             if (configSection != null)

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -577,14 +577,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             WebJobsCoreScriptBindingProvider provider = new WebJobsCoreScriptBindingProvider(hostConfig, config, null);
             provider.Initialize();
 
-            Assert.True(hostConfig.Blobs.CentralizedPoisonQueue);
+            Assert.False(hostConfig.Blobs.CentralizedPoisonQueue);
 
-            blobsConfig["centralizedPoisonQueue"] = false;
+            blobsConfig["centralizedPoisonQueue"] = true;
 
             provider = new WebJobsCoreScriptBindingProvider(hostConfig, config, null);
             provider.Initialize();
 
-            Assert.False(hostConfig.Blobs.CentralizedPoisonQueue);
+            Assert.True(hostConfig.Blobs.CentralizedPoisonQueue);
         }
 
         [Fact]


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-functions-host/issues/1106. With this change, poison messages for blobs will be co-located in the storage account of the source blob container.

When I fixed this in core SDK, we couldn't take the breaking change for v1, hence this switch default.