### PR TITLE
Fix Accessviolation on x86

### DIFF
--- a/src/WebJobs.Script/Rpc/ProcessManagement/JobObjectRegistry.cs
+++ b/src/WebJobs.Script/Rpc/ProcessManagement/JobObjectRegistry.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         public JobObjectRegistry()
         {
-            _handle = CreateJobObject(IntPtr.Zero, null);
+            _handle = CreateJobObject(null, null);
 
             var info = new JOBOBJECT_BASIC_LIMIT_INFORMATION
             {


### PR DESCRIPTION
JobRegistration reference from stack overflow: [kill-child-process-when-parent-process-is-killed](https://stackoverflow.com/questions/3342941/kill-child-process-when-parent-process-is-killed)

Process handle needs to be set to IntPtr.zero only when disposing/closing the child process.

Fixes #2525