### PR TITLE
Reenabling 9 end to end tests (with fixes)

### DIFF
--- a/sample/HttpTrigger-CSharp-Poco/run.csx
+++ b/sample/HttpTrigger-CSharp-Poco/run.csx
@@ -1,25 +1,19 @@
-﻿#r "System.Runtime.Serialization"
+﻿using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
 
-using System.Net;
-using System.Runtime.Serialization;
-
-// DataContract attributes exist to demonstrate that
-// XML payloads are also supported
-[DataContract(Name = "RequestData", Namespace = "http://functions")]
 public class RequestData
 {
-    [DataMember]
     public string Id { get; set; }
-    [DataMember]
     public string Value { get; set; }
 }
 
-public static HttpResponseMessage Run(RequestData data, HttpRequestMessage req, out string outBlob, ExecutionContext context, TraceWriter log)
+public static IActionResult Run(RequestData data, HttpRequest req, out string outBlob, ExecutionContext context, TraceWriter log)
 {
-    log.Info($"C# HTTP trigger function processed a request. {req.RequestUri}");
+    log.Info($"C# HTTP trigger function processed a request. {req.Host.Host}{req.Path}");
     log.Info($"InvocationId: {context.InvocationId}");
 
     outBlob = data.Value;
 
-    return new HttpResponseMessage(HttpStatusCode.OK);
+    return new OkResult();
 }

--- a/sample/HttpTrigger-Disabled/function.json
+++ b/sample/HttpTrigger-Disabled/function.json
@@ -1,5 +1,4 @@
 ﻿{
-    "disabled": true,
     "bindings": [
         {
             "type": "httpTrigger",

--- a/src/WebJobs.Script.WebHost/Middleware/HomepageMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/HomepageMiddleware.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Extensions;
 using Microsoft.Azure.WebJobs.Script.WebHost.Features;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
@@ -39,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
             {
                 IActionResult result = null;
 
-                if (IsHomepageDisabled)
+                if (IsHomepageDisabled || context.Request.IsAntaresInternalRequest())
                 {
                     result = new NoContentResult();
                 }

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -41,8 +41,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Buffering" Version="0.4.0-preview2-28189" />
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.4100001-beta-d5a48cb8" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta6-11301" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.0-beta6-10614" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.0-beta6-10614">
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.0-beta6-10615" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.0-beta6-10615">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.0-beta6-11301" />

--- a/src/WebJobs.Script.WebHost/WebJobsServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
 {
@@ -62,6 +63,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         {
             services.AddWebJobsScriptHostRouting();
             services.AddMvc()
+                .AddJsonOptions(options => options.SerializerSettings.ContractResolver = new DefaultContractResolver())
                 .AddXmlDataContractSerializerFormatters();
 
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, WebJobsScriptHostService>());

--- a/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs
+++ b/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -36,8 +36,8 @@
       <PrivateAssets>None</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta6-11301" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.0-beta6-10614" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.0-beta6-10614">
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.0-beta6-10615" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.0-beta6-10615">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.0-beta6-11301" />

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             }
         }
 
-        [Fact(Skip = "Needs investigation")]
+        [Fact]
         public async Task Home_Get_InAzureEnvironment_AsInternalRequest_ReturnsNoContent()
         {
             // Pings to the site root should not return the homepage content if they are internal requests.
@@ -146,7 +146,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             }
         }
 
-        [Fact(Skip = "Needs investigation")]
+        [Fact]
         public async Task HttpTrigger_CSharp_Poco_Post_Succeeds()
         {
             string functionKey = await _fixture.Host.GetFunctionSecretAsync("HttpTrigger-CSharp-POCO");
@@ -174,29 +174,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal("Testing", TestHelpers.RemoveByteOrderMarkAndWhitespace(result));
         }
 
-        [Fact(Skip = "Needs investigation")]
-        public async Task HttpTrigger_CSharp_Poco_Post_Xml_Succeeds()
-        {
-            string functionKey = await _fixture.Host.GetFunctionSecretAsync("HttpTrigger-CSharp-POCO");
-
-            string uri = $"api/httptrigger-csharp-poco?code={functionKey}";
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
-            string id = Guid.NewGuid().ToString();
-            request.Content = new StringContent(string.Format("<RequestData xmlns=\"http://functions\"><Id>{0}</Id><Value>Testing</Value></RequestData>", id));
-            request.Content.Headers.ContentType = new MediaTypeHeaderValue("text/xml");
-
-            HttpResponseMessage response = await _fixture.Host.HttpClient.SendAsync(request);
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-            // wait for function to execute and produce its result blob
-            CloudBlobContainer outputContainer = _fixture.BlobClient.GetContainerReference("samples-output");
-            CloudBlockBlob outputBlob = outputContainer.GetBlockBlobReference(id);
-            string result = await TestHelpers.WaitForBlobAndGetStringAsync(outputBlob);
-
-            Assert.Equal("Testing", TestHelpers.RemoveByteOrderMarkAndWhitespace(result));
-        }
-
-        [Fact(Skip = "Needs investigation")]
+        [Fact]
         public async Task HttpTrigger_CSharp_Poco_Get_Succeeds()
         {
             string functionKey = await _fixture.Host.GetFunctionSecretAsync("HttpTrigger-CSharp-Poco");
@@ -236,7 +214,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
-        [Fact(Skip = "Needs investigation")]
+        [Fact(Skip = "Node language worker isn't handling duplicate query params properly")]
         public async Task HttpTrigger_DuplicateQueryParams_Succeeds()
         {
             string functionKey = await _fixture.Host.GetFunctionSecretAsync("httptrigger");
@@ -377,7 +355,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal(initialTimestamp, timestamp);
         }
 
-        [Fact(Skip = "Needs investigation. JSON is coming back lower-case.")]
+        [Fact]
         public async Task HttpTrigger_CSharp_CustomRoute_ReturnsExpectedResponse()
         {
             string functionName = "HttpTrigger-CSharp-CustomRoute";
@@ -430,7 +408,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.True(logs.Any(p => p.FormattedMessage.Contains("ProductInfo: Category=electronics Id=123")));
         }
 
-        [Fact(Skip = "Needs investigation.")]
+        [Fact]
         public async Task HttpTrigger_Disabled_SucceedsWithAdminKey()
         {
             // first try with function key only - expect 404
@@ -499,7 +477,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal("Unresolved", jsonObject["status"]);
         }
 
-        [Fact(Skip = "Needs investigation")]
+        [Fact]
         public async Task HttpTriggerWithObject_CSharp_Post_Succeeds()
         {
             string functionKey = await _fixture.Host.GetFunctionSecretAsync("HttpTriggerWithObject-CSharp");
@@ -845,7 +823,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Contains(error, "An array of log entry objects is expected.");
         }
 
-        [Fact(Skip = "Needs investigation")]
+        [Fact]
         public async Task HostStatus_AdminLevel_Succeeds()
         {
             string uri = "admin/host/status";
@@ -858,13 +836,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             string content = await response.Content.ReadAsStringAsync();
             JObject jsonContent = JObject.Parse(content);
 
-            Assert.Equal(3, jsonContent.Properties().Count());
+            Assert.Equal(4, jsonContent.Properties().Count());
             AssemblyFileVersionAttribute fileVersionAttr = typeof(HostStatus).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>();
-            string expectedVersion = fileVersionAttr.Version;
             Assert.True(((string)jsonContent["id"]).Length > 0);
-            Assert.Equal(expectedVersion, jsonContent["version"].ToString());
+            string expectedVersion = fileVersionAttr.Version;
+            Assert.Equal(expectedVersion, (string)jsonContent["version"]);
+            string expectedVersionDetails = Utility.GetInformationalVersion(typeof(ScriptHost));
+            Assert.Equal(expectedVersionDetails, (string)jsonContent["versionDetails"]);
             var state = (string)jsonContent["state"];
-            Assert.True(state == "Running" || state == "Created");
+            Assert.True(state == "Running" || state == "Created" || state == "Initialized");
 
             // Now ensure XML content works
             request = new HttpRequestMessage(HttpMethod.Get, uri);
@@ -878,10 +858,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             XDocument doc = XDocument.Parse(content);
             var node = doc.Descendants(XName.Get("Version", ns)).Single();
             Assert.Equal(expectedVersion, node.Value);
+            node = doc.Descendants(XName.Get("VersionDetails", ns)).Single();
+            Assert.Equal(expectedVersionDetails, node.Value);
             node = doc.Descendants(XName.Get("Id", ns)).Single();
             Assert.True(node.Value.Length > 0);
             node = doc.Descendants(XName.Get("State", ns)).Single();
-            Assert.True(node.Value == "Running" || node.Value == "Created");
+            Assert.True(node.Value == "Running" || node.Value == "Created" || node.Value == "Initialized");
 
             node = doc.Descendants(XName.Get("Errors", ns)).Single();
             Assert.True(node.IsEmpty);
@@ -907,12 +889,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 
         public class TestFixture : EndToEndTestFixture
         {
+            static TestFixture()
+            {
+                Environment.SetEnvironmentVariable("AzureWebJobs.HttpTrigger-Disabled.Disabled", "1");
+            }
+
             public TestFixture() :
                 base(Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample"), "samples")
             {
             }
-
-            // public NamespaceManager NamespaceManager { get; set; }
 
             protected override async Task CreateTestStorageEntities()
             {
@@ -929,10 +914,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                 batch.InsertOrReplace(new TestEntity { PartitionKey = "samples-python", RowKey = "6", Title = "Test Entity 6", Status = 0 });
                 batch.InsertOrReplace(new TestEntity { PartitionKey = "samples-python", RowKey = "7", Title = "Test Entity 7", Status = 0 });
                 await table.ExecuteBatchAsync(batch);
-
-                // TODO: This currently throws
-                // string connectionString = AmbientConnectionStringProvider.Instance.GetConnectionString(ConnectionStringNames.ServiceBus);
-                // NamespaceManager = NamespaceManager.CreateFromConnectionString(connectionString);
             }
 
             private class TestEntity : TableEntity

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     .ToArray());
         }
 
-        public static Task Await(Func<bool> condition, int timeout = 60 * 1000, int pollingInterval = 2 * 1000, bool throwWhenDebugging = false, Func<string> userMessageCallback = null)
+        public static Task Await(Func<bool> condition, int timeout = 30 * 1000, int pollingInterval = 2 * 1000, bool throwWhenDebugging = false, Func<string> userMessageCallback = null)
         {
             return Await(() => Task.FromResult(condition()), timeout, pollingInterval, throwWhenDebugging, userMessageCallback);
         }


### PR DESCRIPTION
Supporting fixes here: https://github.com/Azure/azure-webjobs-sdk-extensions/pull/407. I did local testing with that fixed version of the http extension.