### PR TITLE
Add Breaking_Changes.md file to track breaking changes from v1 => v2 across repos

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,20 +1,22 @@
 # Breaking Changes
-These changes list where implementation differs between versions. Note that 
+These changes list where the experience differs between Functions versions.
 
 ## Functions 2.x (changes from 1.x)
 ### Contract Changes
+#### Function.json
+Topic         | V1      | V2 
+---         | ---       | --- 
+Disabling functions | Set `disabled: false` in function.json  | Set environment/App Settings variable `<FunctionName>.Disabled = true` 
 
 
 ### Behavior changes 
-These changes en
-Pull Request         | Issue      | Pretty
----         | ---       | ---
-*Still*     |        | **nicely**
-1 | 2 | 3
+Topic         | V1      | V2 
+---         | ---       | --- 
+Using triggers and bindings (except HTTP, Timer, and Azure Storage) | N/A  | See [documentation](https://docs.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings#register-binding-extensions) on registering binding extensions
 
 ### External Dependency Changes
-Some changes are due to
--Markdown   | Less      | Pretty
----         | ---       | ---
-*Still*     | `renders` | **nicely**
-1           | 2         | 3
+Some changes are due to changes in our dependencies.
+Topic         | V1      | V2 
+---         | ---       | --- 
+ServiceBus SDK binding object in C# | [`BrokeredMessage`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.brokeredmessage?view=azure-dotnet) class  | [`Message`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.servicebus.message?view=azure-dotnet) class
+Twilio SDK binding object in C# | `SMSMessage` class | [`CreateMessageOptions`](https://www.twilio.com/docs/libraries/reference/twilio-php/5.7.3/class-Twilio.Rest.Api.V2010.Account.CreateMessageOptions.html) class

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,0 +1,8 @@
+These changes list where implementation differs between versions.
+
+# Functions 2.x #
+## Runtime Changes ##
+
+## External Dependency Changes ##
+Some changes are due to
+- 

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -6,7 +6,7 @@ These changes list where the experience differs between Functions versions.
 #### Function.json
 Topic         | V1      | V2 
 ---         | ---       | --- 
-Disabling functions | Set `disabled: false` in function.json  | Set environment/App Settings variable `<FunctionName>.Disabled = true` 
+Disabling functions | Set `disabled: true` in function.json  | Set environment/App Settings variable `<FunctionName>.Disabled = true` 
 
 
 ### Behavior changes 
@@ -16,7 +16,8 @@ Using triggers and bindings (except HTTP, Timer, and Azure Storage) | N/A  | See
 
 ### External Dependency Changes
 Some changes are due to changes in our dependencies.
+
 Topic         | V1      | V2 
----         | ---       | --- 
+---          | ---       | --- 
 ServiceBus SDK binding object in C# | [`BrokeredMessage`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.brokeredmessage?view=azure-dotnet) class  | [`Message`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.servicebus.message?view=azure-dotnet) class
 Twilio SDK binding object in C# | `SMSMessage` class | [`CreateMessageOptions`](https://www.twilio.com/docs/libraries/reference/twilio-php/5.7.3/class-Twilio.Rest.Api.V2010.Account.CreateMessageOptions.html) class

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,8 +1,20 @@
-These changes list where implementation differs between versions.
+# Breaking Changes
+These changes list where implementation differs between versions. Note that 
 
-# Functions 2.x #
-## Runtime Changes ##
+## Functions 2.x (changes from 1.x)
+### Contract Changes
 
-## External Dependency Changes ##
+
+### Behavior changes 
+These changes en
+Pull Request         | Issue      | Pretty
+---         | ---       | ---
+*Still*     |        | **nicely**
+1 | 2 | 3
+
+### External Dependency Changes
 Some changes are due to
-- 
+-Markdown   | Less      | Pretty
+---         | ---       | ---
+*Still*     | `renders` | **nicely**
+1           | 2         | 3

--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -19,5 +19,6 @@ Some changes are due to changes in our dependencies.
 
 Topic         | V1      | V2 
 ---          | ---       | --- 
-ServiceBus SDK binding object in C# | [`BrokeredMessage`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.brokeredmessage?view=azure-dotnet) class  | [`Message`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.servicebus.message?view=azure-dotnet) class
+ServiceBus/EventHubs SDK binding object in C# | [`BrokeredMessage`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.brokeredmessage?view=azure-dotnet) class  | [`Message`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.servicebus.message?view=azure-dotnet) class
 Twilio SDK binding object in C# | `SMSMessage` class | [`CreateMessageOptions`](https://www.twilio.com/docs/libraries/reference/twilio-php/5.7.3/class-Twilio.Rest.Api.V2010.Account.CreateMessageOptions.html) class
+Extension WebHook URL (e.g. for EventGrid and Microsoft Graph) | `https://<myapp>.azurewebsites.net/runtime/webhooks/EventGridExtensionConfig` | `https://<myapp>.azurewebsites.net/runtime/webhooks/eventgrid`


### PR DESCRIPTION
WIP 

==
**Updated Summary:**
"The goal is to have documentation covering breaking changes in a nicely digested format" (Fabio).
Right now, this is in the form of a BREAKING_CHANGES.md file in the functions-host repo, but could be in a Wiki page (or in some other form?) instead. The idea is to have a document that is a one-stop shop for all differences in user experience that is continuously updated _by the feature owner_. 