### PR TITLE
Enhancements to assembly unification/resolution in FunctionAssemblyLoadContext

### DIFF
--- a/test/WebJobs.Script.Tests/Description/DotNet/DynamicFunctionAssemblyLoadContextTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/DynamicFunctionAssemblyLoadContextTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Description.DotNet
     public class DynamicFunctionAssemblyLoadContextTests
     {
         [Fact]
-        public void SharedAssembly_IsLoadedIntoSharedContext()
+        public void DefaultContextAssembly_LoadedIntoSharedContext_UsesRuntimeAssembly()
         {
             using (var tempFolder = new TempDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())))
             using (var env = new TestScopedEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsScriptRoot, tempFolder.Path))
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Description.DotNet
 
                 // Assert
                 Assert.NotNull(result);
-                Assert.Same(sharedContext, AssemblyLoadContext.GetLoadContext(result));
+                Assert.Same(AssemblyLoadContext.Default, AssemblyLoadContext.GetLoadContext(result));
             }
         }
 


### PR DESCRIPTION
Enhancements to assembly unification/resolution in FunctionAssemblyLoadContext

This is a small  set of changes to enhance the recently introduced functionality, adding:

- Unification with runtime assemblies when the assembly version is the same.
- Fallback behavior to ensure assembly unification/loading when runtime assemblies differ version by patch only