### PR TITLE
Fix Host header and request scheme for non-appservice environments

### DIFF
--- a/src/WebJobs.Script.WebHost/Middleware/AppServiceHeaderFixupMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/AppServiceHeaderFixupMiddleware.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Script.Extensions;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
+{
+    public class AppServiceHeaderFixupMiddleware
+    {
+        private const string DisguisedHostHeader = "DISGUISED-HOST";
+        private const string HostHeader = "HOST";
+        private const string ForwardedProtocolHeader = "X-Forwarded-Proto";
+        private readonly RequestDelegate _next;
+
+        public AppServiceHeaderFixupMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task Invoke(HttpContext httpContext)
+        {
+            if (httpContext.Request.Headers.TryGetValue(DisguisedHostHeader, out StringValues value))
+            {
+                httpContext.Request.Headers[HostHeader] = value;
+            }
+
+            if (httpContext.Request.Headers.TryGetValue(ForwardedProtocolHeader, out value))
+            {
+                httpContext.Request.Scheme = value;
+            }
+
+            await _next(httpContext);
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Buffering;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.WebHost.Middleware;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
@@ -19,6 +20,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         public static IApplicationBuilder UseWebJobsScriptHost(this IApplicationBuilder builder, IApplicationLifetime applicationLifetime, Action<WebJobsRouteBuilder> routes)
         {
+            if (!ScriptSettingsManager.Instance.IsAppServiceEnvironment)
+            {
+                builder.UseMiddleware<AppServiceHeaderFixupMiddleware>();
+            }
+
             builder.UseMiddleware<HttpExceptionMiddleware>();
             builder.UseMiddleware<ResponseBufferingMiddleware>();
             builder.UseMiddleware<HomepageMiddleware>();

--- a/test/WebJobs.Script.Tests.Integration/Middlewares/AppServiceHeaderFixupMiddlewareEndToEnd.cs
+++ b/test/WebJobs.Script.Tests.Integration/Middlewares/AppServiceHeaderFixupMiddlewareEndToEnd.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Middlewares
+{
+    [Trait("Category", "E2E")]
+    [Trait("E2E", nameof(AppServiceHeaderFixupMiddlewareEndToEnd))]
+    public class AppServiceHeaderFixupMiddlewareEndToEnd : EndToEndTestsBase<AppServiceHeaderFixupMiddlewareEndToEnd.TestFixture>
+    {
+        public AppServiceHeaderFixupMiddlewareEndToEnd(TestFixture fixture) : base(fixture)
+        {
+        }
+
+        [Fact]
+        public async Task HostHeaderIsCorrect()
+        {
+            const string actualHost = "actual-host";
+            const string actualProtocol = "https";
+            const string functionPath = "api/httpTriggerHeaderCheck";
+            HttpRequestMessage request = new HttpRequestMessage
+            {
+                RequestUri = new Uri(string.Format($"http://localhost/{functionPath}")),
+                Method = HttpMethod.Get
+            };
+
+            request.Headers.TryAddWithoutValidation("DISGUISED-HOST", actualHost);
+            request.Headers.TryAddWithoutValidation("X-Forwarded-Proto", actualProtocol);
+
+            var response = await Fixture.Host.HttpClient.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+
+            var url = await response.Content.ReadAsStringAsync();
+            Assert.Equal($"{actualProtocol}://{actualHost}/{functionPath}", url);
+        }
+
+        public class TestFixture : EndToEndTestFixture
+        {
+            private const string ScriptRoot = @"TestScripts\CSharp";
+
+            public TestFixture() : base(ScriptRoot, "middleware")
+            {
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/HttpTriggerHeaderCheck/function.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/HttpTriggerHeaderCheck/function.json
@@ -1,0 +1,19 @@
+﻿{
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "name": "req",
+      "type": "httpTrigger",
+      "direction": "in",
+      "methods": [
+        "get"
+      ]
+    },
+    {
+      "name": "$return",
+      "type": "http",
+      "direction": "out"
+    }
+  ]
+}

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/HttpTriggerHeaderCheck/run.csx
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/HttpTriggerHeaderCheck/run.csx
@@ -1,0 +1,9 @@
+﻿#r "Microsoft.AspNetCore.Http.Extensions"
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http.Extensions;
+
+public static IActionResult Run(HttpRequest req, TraceWriter log)
+{
+    return new OkObjectResult(req.GetDisplayUrl());
+}


### PR DESCRIPTION
Closes #2713

In Antares, When you send a `GET https://app.azurewebsites.net`, the frontEnd gets
```
GET / HTTP/1.1
HOST: app.azurewebsites.net
```

then it forwards it to the worker over http (not https)

```
GET / HTTP/1.1
HOST: app
DISGUISED-HOST: app.azurewebsites.net
X-Forwarded-Proto: https
```

In Antares workers there is a module that sits before ASP.NET in w3wp, that updates `HOST` with the value of `DISGUISED-HOST`, and set scheme to match `X-Forwarded-Proto`.

When running on a host that's not app service we need to do that ourselves. 