### PR TITLE
Runtime specific native assets resolution

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -44,6 +44,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.0-beta6-11301" />
     <PackageReference Include="Microsoft.Build" Version="15.3.409" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.4.0" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.0.4" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />


### PR DESCRIPTION
With this changes, native assets deployed in platform/runtime specific folders will be automatically resolved without the need to move files. This will be done using the appropriate RID, as it will be the currently executing runtime. This means that users developing on Windows and deploying on Linux (or vice-versa) will have the appropriate library loaded at runtime.

Lacking tests, validated this with a few scenarios, including the most common one for us, which is CosmosDB. Prior to this change, using the CosmosDB query support would fail.