### PR TITLE
Removing SettingsManager caching

### DIFF
--- a/src/WebJobs.Script.WebHost/App_Start/WebHostResolver.cs
+++ b/src/WebJobs.Script.WebHost/App_Start/WebHostResolver.cs
@@ -139,7 +139,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     if (_activeHostManager == null && 
                         (_standbyHostManager == null || _settingsManager.ContainerReady))
                     {
-                        _settingsManager.Reset();
                         _specializationTimer?.Dispose();
                         _specializationTimer = null;
 

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Configuration;
 using System.IO;
 using System.Net.Http;
 using System.Web.Http;
@@ -41,7 +42,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
             var resolver = _config.DependencyResolver;
             var hostConfig = resolver.GetService<WebHostResolver>().GetScriptHostConfiguration(HostSettings);
 
-            _settingsManager.ApplicationInsightsInstrumentationKey = TestChannelLoggerFactoryBuilder.ApplicationInsightsKey;
+            // configure via AppSettings, because the test project has configured an
+            // empty value in app.config which we need to override
+            ConfigurationManager.AppSettings[EnvironmentSettingNames.AppInsightsInstrumentationKey] = TestChannelLoggerFactoryBuilder.ApplicationInsightsKey;
 
             InitializeConfig(hostConfig);
 
@@ -74,6 +77,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
 
         public void Dispose()
         {
+            ConfigurationManager.AppSettings[EnvironmentSettingNames.AppInsightsInstrumentationKey] = string.Empty;
+
             _httpServer?.Dispose();
             HttpClient?.Dispose();
         }


### PR DESCRIPTION
Applying to v1 similar changes that were made in v2 in https://github.com/Azure/azure-functions-host/commit/29397abfc80b2850164cf2c3da4ec380f4ede607.

We have some arbitrary unnecessary caching logic that can cause issues. It came up recently in the context of a runtime specialization bug, where incorrect app settings were being read and cached, and even though the values were subsequently corrected as part of specialization, the old incorrect cached value remained. There are some fixes that we need to make to address the underlying issue of that problem, but it pointed out this odd caching behavior to me and I want to clean it up.