### PR TITLE
 Ignore ssl errors when SCM_SKIP_SSL_VALIDATION is set

### DIFF
--- a/src/WebJobs.Script/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/EnvironmentSettingNames.cs
@@ -31,5 +31,6 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string WebSiteAuthEncryptionKey = "WEBSITE_AUTH_ENCRYPTION_KEY";
         public const string ContainerEncryptionKey = "CONTAINER_ENCRYPTION_KEY";
         public const string ConsoleLoggingDisabled = "CONSOLE_LOGGING_DISABLED";
+        public const string SkipSslValidation = "SCM_SKIP_SSL_VALIDATION";
     }
 }

--- a/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
@@ -52,6 +52,25 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             }
         }
 
+        [Theory]
+        [InlineData(1, "http://sitename/operations/settriggers")]
+        [InlineData(0, "https://sitename/operations/settriggers")]
+        public void Disables_Ssl_If_SkipSslValidation_Enabled(int skipSslValidation, string syncTriggersUri)
+        {
+            var vars = new Dictionary<string, string>
+            {
+                { EnvironmentSettingNames.SkipSslValidation, skipSslValidation.ToString() },
+                { EnvironmentSettingNames.AzureWebsiteHostName, "sitename" },
+            };
+
+            using (var env = new TestScopedEnvironmentVariable(vars))
+            {
+                var httpRequest = WebFunctionsManager.BuildSyncTriggersRequest();
+                Assert.Equal(syncTriggersUri, httpRequest.RequestUri.AbsoluteUri);
+                Assert.Equal(HttpMethod.Post, httpRequest.Method);
+            }
+        }
+
         private static HttpClient CreateHttpClient(StringBuilder writeContent)
         {
             return new HttpClient(new MockHttpHandler(writeContent));


### PR DESCRIPTION
This is mostly to enable synctriggers on private stamps where we don't have ssl enabled. Kudu uses the same appsetting ( SCM_SKIP_SSL_VALIDATION ) to ignore ssl errors.