### PR TITLE
Fixing secrets retrieval bug (#2861)

### DIFF
--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                 if (hostSecrets == null)
                 {
+                    // host secrets do not yet exist so generate them
                     _logger.LogDebug(Resources.TraceHostSecretGeneration);
                     hostSecrets = GenerateHostSecrets();
                     await PersistSecretsAsync(hostSecrets);
@@ -122,6 +123,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 FunctionSecrets secrets = await LoadFunctionSecretsAsync(functionName);
                 if (secrets == null)
                 {
+                    // no secrets exist for this function so generate them
                     string message = string.Format(Resources.TraceFunctionSecretGeneration, functionName);
                     _logger.LogDebug(message);
                     secrets = new FunctionSecrets

--- a/src/WebJobs.Script/Binding/ExtensionLoader.cs
+++ b/src/WebJobs.Script/Binding/ExtensionLoader.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
 
                             if (File.Exists(path))
                             {
-                                return FunctionAssemblyLoadContext.Shared.LoadFromAssemblyPath(path);
+                                return Assembly.LoadFrom(path);
                             }
 
                             return null;

--- a/test/WebJobs.Script.Tests/Controllers/Admin/KeysControllerTests.cs
+++ b/test/WebJobs.Script.Tests/Controllers/Admin/KeysControllerTests.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -14,7 +14,6 @@ using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Controllers;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Newtonsoft.Json.Linq;
 using WebJobs.Script.Tests;
@@ -26,8 +25,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
     {
         private readonly ScriptSettingsManager _settingsManager;
         private readonly TempDirectory _secretsDirectory = new TempDirectory();
-        private Mock<ScriptHost> _hostMock;
-        private Mock<WebScriptHostManager> _managerMock;
         private Collection<FunctionDescriptor> _testFunctions;
         private Dictionary<string, Collection<string>> _testFunctionErrors;
         private KeysController _testController;
@@ -43,39 +40,34 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var environment = new NullScriptHostEnvironment();
             var eventManager = new Mock<IScriptEventManager>();
             var mockRouter = new Mock<IWebJobsRouter>();
-            _hostMock = new Mock<ScriptHost>(MockBehavior.Strict, new object[] { environment, eventManager.Object, config, null, null, null });
-            _hostMock.Setup(p => p.Functions).Returns(_testFunctions);
-            _hostMock.Setup(p => p.FunctionErrors).Returns(_testFunctionErrors);
 
             WebHostSettings settings = new WebHostSettings();
             settings.SecretsPath = _secretsDirectory.Path;
             _secretsManagerMock = new Mock<ISecretManager>(MockBehavior.Strict);
 
-            _managerMock = new Mock<WebScriptHostManager>(MockBehavior.Strict, new object[] { config, new TestSecretManagerFactory(_secretsManagerMock.Object), eventManager.Object, _settingsManager, settings, mockRouter.Object, NullLoggerFactory.Instance });
-
-            _managerMock.SetupGet(p => p.Instance).Returns(_hostMock.Object);
-
-            _testController = new KeysController(_managerMock.Object, _secretsManagerMock.Object, new LoggerFactory());
-
-            // setup some test functions
-            string errorFunction = "ErrorFunction";
-            var errors = new Collection<string>();
-            errors.Add("A really really bad error!");
-            _testFunctionErrors.Add(errorFunction, errors);
+            _testController = new KeysController(_secretsManagerMock.Object, new LoggerFactory());
 
             var keys = new Dictionary<string, string>
             {
                 { "key1", "secret1" }
             };
-            _secretsManagerMock.Setup(p => p.GetFunctionSecretsAsync(errorFunction, false)).ReturnsAsync(keys);
+            _secretsManagerMock.Setup(p => p.GetFunctionSecretsAsync("TestFunction1", false)).ReturnsAsync(keys);
+
+            keys = new Dictionary<string, string>
+            {
+                { "key1", "secret1" }
+            };
+            _secretsManagerMock.Setup(p => p.GetFunctionSecretsAsync("TestFunction2", false)).ReturnsAsync(keys);
+
+            _secretsManagerMock.Setup(p => p.GetFunctionSecretsAsync("DNE", false)).ReturnsAsync((IDictionary<string, string>)null);
+
+            SetHttpContext();
         }
 
         [Fact]
-        public async Task GetKeys_FunctionInError_ReturnsKeys()
+        public async Task GetKeys_ReturnsKeys()
         {
-            SetHttpContext();
-
-            ObjectResult result = (ObjectResult)await _testController.Get("ErrorFunction");
+            ObjectResult result = (ObjectResult)await _testController.Get("TestFunction1");
 
             var content = (JObject)result.Value;
             var keys = content["keys"];
@@ -84,28 +76,32 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-        public async Task PutKey_FunctionInError_Succeeds()
+        public async Task GetKeys_NoSecrets_ReturnsNotFound()
         {
-            SetHttpContext();
+            var result = (StatusCodeResult)await _testController.Get("DNE");
 
+            Assert.Equal(StatusCodes.Status404NotFound, result.StatusCode);
+        }
+
+        [Fact]
+        public async Task PutKey_Succeeds()
+        {
             var key = new Key("key2", "secret2");
             var keyOperationResult = new KeyOperationResult(key.Value, OperationResult.Updated);
-            _secretsManagerMock.Setup(p => p.AddOrUpdateFunctionSecretAsync(key.Name, key.Value, "ErrorFunction", ScriptSecretsType.Function)).ReturnsAsync(keyOperationResult);
+            _secretsManagerMock.Setup(p => p.AddOrUpdateFunctionSecretAsync(key.Name, key.Value, "TestFunction1", ScriptSecretsType.Function)).ReturnsAsync(keyOperationResult);
 
-            ObjectResult result = (ObjectResult)await _testController.Put("ErrorFunction", key.Name, key);
+            ObjectResult result = (ObjectResult)await _testController.Put("TestFunction1", key.Name, key);
             var content = (JObject)result.Value;
             Assert.Equal("key2", content["name"]);
             Assert.Equal("secret2", content["value"]);
         }
 
         [Fact]
-        public async Task DeleteKey_FunctionInError_Succeeds()
+        public async Task DeleteKey_Succeeds()
         {
-            SetHttpContext();
+            _secretsManagerMock.Setup(p => p.DeleteSecretAsync("key2", "TestFunction1", ScriptSecretsType.Function)).ReturnsAsync(true);
 
-            _secretsManagerMock.Setup(p => p.DeleteSecretAsync("key2", "ErrorFunction", ScriptSecretsType.Function)).ReturnsAsync(true);
-
-            var result = (StatusCodeResult)(await _testController.Delete("ErrorFunction", "key2"));
+            var result = (StatusCodeResult)(await _testController.Delete("TestFunction1", "key2"));
             Assert.Equal(StatusCodes.Status204NoContent, result.StatusCode);
         }
 


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-functions-host/issues/2861.

It looks like for quite a while now in both v1 and v2, access to keys has required the host to be up and running. However it didn't have the RequiresRunningHostAttribute applied, so the requirement was loose. This leads to random unpredictable behavior as in the issue. Keys (like source code) should be accessible even when the host is not running.

Changing so KeysController is no longer dependent on the runtime host instance. 