### PR TITLE
Add Function checks back to KeysController

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobsServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.IO.Abstractions;
 using System.Linq;
 using System.Net.Http;
 using Autofac;
@@ -119,6 +120,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             builder.RegisterType<WebFunctionsManager>().As<IWebFunctionsManager>().SingleInstance();
             builder.RegisterType<InstanceManager>().As<IInstanceManager>().SingleInstance();
             builder.Register(_ => new HttpClient()).SingleInstance();
+            builder.Register<IFileSystem>(_ => FileUtility.Instance).SingleInstance();
             builder.RegisterType<VirtualFileSystem>();
             builder.RegisterType<VirtualFileSystemMiddleware>();
 


### PR DESCRIPTION
Ammendment to recent PR https://github.com/Azure/azure-functions-host/pull/2876 based on discussion. Adding back the "is function" checks in a file based manner (as opposed to requiring a running host as we did before).