### PR TITLE
fixing cosmos test failure

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/CosmosDB/CosmosDBNodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/CosmosDB/CosmosDBNodeEndToEndTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.CosmosDB
             return CosmosDBTriggerToBlobTest();
         }
 
-        [Fact(Skip = "Frequent failures when running in CI. Passes locally needs to be investigated https://github.com/Azure/azure-functions-host/issues/2837")]
+        [Fact]
         public Task CosmosDB()
         {
             return CosmosDBTest();

--- a/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/LanguageWorkerSelectionEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/LanguageWorkerSelectionEndToEndTests.cs
@@ -24,10 +24,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ScriptHostEndToEnd
         [InlineData("dotNet")]
         public async Task HttpTrigger_Get(string functionsWorkerLanguage)
         {
+            NodeScriptHostTests.TestFixture fixture = null;
+
             try
             {
                 string functionName = "HttpTrigger";
-                var fixture = new NodeScriptHostTests.TestFixture(new Collection<string> { functionName }, functionsWorkerLanguage);
+                fixture = new NodeScriptHostTests.TestFixture(new Collection<string> { functionName }, functionsWorkerLanguage);
+
                 string url = $"http://localhost/api/{functionName}?name=test";
                 var request = HttpTestHelpers.CreateHttpRequest("GET", url);
 
@@ -51,6 +54,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ScriptHostEndToEnd
             finally
             {
                 Environment.SetEnvironmentVariable(ScriptConstants.FunctionWorkerRuntimeSettingName, string.Empty);
+                fixture?.Dispose();
             }
         }
     }

--- a/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/ScriptHostEndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/ScriptHostEndToEndTestFixture.cs
@@ -51,9 +51,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 RootScriptPath = rootPath,
                 FileLoggingMode = FileLoggingMode.Always,
             };
+
             if (functions != null)
             {
-                config.Functions = functions;
+                config.OnConfigurationApplied = c => c.Functions = functions;
             }
 
             RequestConfiguration = new HttpConfiguration();


### PR DESCRIPTION
Fixes #2837.

Turns out it wasn't this test that was flaky. Another set of tests was:
1. Starting up hosts and not stopping them. These hosts also were running the same function, watching the same queue. That meant that 50% of the time, that host would steal the message.
2. Not correctly filtering functions out. It only cared about a single function, but was loading all of them.