### PR TITLE
Update Node Worker

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -30,7 +30,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.5150001-beta-b9e0da04" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta2-10041" />
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta1-10031" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta2" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta7" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.0-beta7" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.0-beta7">

--- a/test/WebJobs.Script.Tests.Integration/EventHubs/EventHubsEndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/EventHubs/EventHubsEndToEndTestsBase.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.EventHubs
             var bindingData = payload["bindingData"];
             int sequenceNumber = (int)bindingData["sequenceNumber"];
             var systemProperties = bindingData["systemProperties"];
-            Assert.Equal(sequenceNumber, (int)systemProperties["SequenceNumber"]);
+            Assert.Equal(sequenceNumber, (int)systemProperties["sequenceNumber"]);
         }
 
         public class TestFixture : EndToEndTestFixture

--- a/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/NodeContentTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/NodeContentTests.cs
@@ -60,12 +60,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-        public async Task BadContentType_ThrowsExpectedException_Conneg()
+        public async Task NullContentType_Ignored_Conneg()
         {
-            await Assert.ThrowsAsync<FunctionInvocationException>(async () =>
-            {
-                var content = await ResponseWithConneg("asdf", null);
-            });
+            var str = "asdf";
+            var content = await ResponseWithConneg("asdf", null);
+            Assert.Equal(str, content);
         }
 
         [Fact]
@@ -342,7 +341,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 ObjectResult objResult = result as ObjectResult;
                 Assert.NotNull(objResult);
-                Assert.Equal(contentType, objResult.ContentTypes[0]);
+                if (contentType == null)
+                {
+                    Assert.Equal(0, objResult.ContentTypes.Count);
+                }
+                else
+                {
+                    Assert.Equal(contentType, objResult.ContentTypes[0]);
+                }
                 Assert.Equal(200, objResult.StatusCode);
                 if (content is byte[])
                 {

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Node/Scenarios/index.js
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Node/Scenarios/index.js
@@ -1,7 +1,7 @@
 var util = require('util');
 var assert = require('assert');
 
-﻿module.exports = function (context, input) {
+module.exports = function (context, input) {
     var scenario = input.scenario;
 
     if (scenario === 'nextTick') {

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/NodeEndToEndTests.cs
@@ -64,12 +64,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal($"test-input-node/{name}", (string)blobMetadata["path"]);
 
             var metadata = (JObject)blobMetadata["metadata"];
-            Assert.Equal("TestMetadataValue", (string)metadata["TestMetadataKey"]);
+            Assert.Equal("TestMetadataValue", (string)metadata["testMetadataKey"]);
 
             var properties = (JObject)blobMetadata["properties"];
-            Assert.Equal("application/octet-stream", (string)properties["ContentType"]);
-            Assert.Equal("BlockBlob", Enum.Parse(typeof(BlobType), (string)properties["BlobType"]).ToString());
-            Assert.Equal(5, properties["Length"]);
+            Assert.Equal("application/octet-stream", (string)properties["contentType"]);
+            Assert.Equal("BlockBlob", Enum.Parse(typeof(BlobType), (string)properties["blobType"]).ToString());
+            Assert.Equal(5, properties["length"]);
 
             string invocationId = (string)testResult["invocationId"];
             Guid.Parse(invocationId);

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.9.1" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.0.3" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta2-10041" />
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta1-10036" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta2" />
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.0" />

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.9.1" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.0.3" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta2-10041" />
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta1-10031" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta1-10036" />
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.0" />


### PR DESCRIPTION
Release notes  https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v1.0.0-beta2
Changes include:
- throw informative error if using unsupported version of node (not 8.x)
- recursively camelCase binding trigger metadata
- update headers to try to convert values to string type (null / undefined values are ignored altogether)