### PR TITLE
Reinitialize containers on restart

### DIFF
--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -42,7 +42,7 @@ $tests = @(
   @{project ="WebJobs.Script.Tests.Integration"; description="Raw assembly end to end tests"; filter ="Group=RawAssemblyEndToEndTests"},
   @{project ="WebJobs.Script.Tests.Integration"; description="Samples end to end tests"; filter ="Group=SamplesEndToEndTests"}
   @{project ="WebJobs.Script.Tests.Integration"; description="Standby mode end to end tests"; filter ="Group=StandbyModeEndToEndTests"}
-  @{project ="WebJobs.Script.Tests.Integration"; description="InstanceManager end to end tests"; filter ="Group=InstanceManagerTests"}
+  @{project ="WebJobs.Script.Tests.Integration"; description="Linux Container end to end tests"; filter ="Group=ContainerInstanceTests"}
 )
 
 $success = $true

--- a/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerInitializationHostService.cs
+++ b/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerInitializationHostService.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.WebHost.Management;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
+{
+    public class LinuxContainerInitializationHostService : IHostedService
+    {
+        private readonly ScriptSettingsManager _settingsManager;
+        private readonly IInstanceManager _instanceManager;
+        private readonly ILogger _logger;
+        private CancellationToken _cancellationToken;
+
+        public LinuxContainerInitializationHostService(ScriptSettingsManager settingsManager, IInstanceManager instanceManager, ILoggerFactory loggerFactory)
+        {
+            _settingsManager = settingsManager;
+            _instanceManager = instanceManager;
+            _logger = loggerFactory.CreateLogger(ScriptConstants.LogCategoryHostGeneral);
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Initializing LinuxContainerInitializationService.");
+            _cancellationToken = cancellationToken;
+
+            // The service should be registered in IsLinuxContainerEnvironment only. But do additional check here.
+            if (_settingsManager.IsLinuxContainerEnvironment)
+            {
+                await ApplyContextIfPresent();
+            }
+        }
+
+        private async Task ApplyContextIfPresent()
+        {
+            var startContext = _settingsManager.GetSetting(EnvironmentSettingNames.ContainerStartContext);
+
+            // Container start context is not available directly
+            if (string.IsNullOrEmpty(startContext))
+            {
+                // Check if the context is available in blob
+                var sasUri = _settingsManager.GetSetting(EnvironmentSettingNames.ContainerStartContextSasUri);
+
+                if (!string.IsNullOrEmpty(sasUri))
+                {
+                    _logger.LogInformation("Host context specified via CONTAINER_START_CONTEXT_SAS_URI");
+                    startContext = await GetAssignmentContextFromSasUri(sasUri);
+                }
+            }
+            else
+            {
+                _logger.LogInformation("Host context specified via CONTAINER_START_CONTEXT");
+            }
+
+            if (!string.IsNullOrEmpty(startContext))
+            {
+                _logger.LogInformation("Applying host context");
+
+                var encryptedAssignmentContext = JsonConvert.DeserializeObject<EncryptedHostAssignmentContext>(startContext);
+                var containerKey = _settingsManager.GetSetting(EnvironmentSettingNames.ContainerEncryptionKey);
+                var assignmentContext = encryptedAssignmentContext.Decrypt(containerKey);
+                if (_instanceManager.StartAssignment(assignmentContext))
+                {
+                    _logger.LogInformation("Start assign HostAssignmentContext success");
+                }
+                else
+                {
+                    _logger.LogError("Start assign HostAssignmentContext failed");
+                }
+            }
+            else
+            {
+                _logger.LogInformation("No host context specified. Waiting for host assignment");
+            }
+        }
+
+        private async Task<string> GetAssignmentContextFromSasUri(string sasUri)
+        {
+            try
+            {
+                return await Read(sasUri);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, $"Error calling {nameof(GetAssignmentContextFromSasUri)}");
+            }
+
+            return string.Empty;
+        }
+
+        // virtual for unit testing
+        public virtual async Task<string> Read(string uri)
+        {
+            // Note: ContainerStartContextSasUri will always be available for Zip based containers.
+            // But the blob pointed to by the uri will not exist until the container is specialized.
+            // When the blob doesn't exist it just means the container is waiting for specialization.
+            // Don't treat this as a failure.
+            var cloudBlockBlob = new CloudBlockBlob(new Uri(uri));
+            if (await cloudBlockBlob.ExistsAsync(null, null, _cancellationToken))
+            {
+                return await cloudBlockBlob.DownloadTextAsync(null, null, null, null, _cancellationToken);
+            }
+
+            return string.Empty;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Models/EncryptedHostAssignmentContext.cs
+++ b/src/WebJobs.Script.WebHost/Models/EncryptedHostAssignmentContext.cs
@@ -23,9 +23,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
 
         public HostAssignmentContext Decrypt(string key)
         {
-            var encryptionKey = Convert.FromBase64String(key);
-            var decrypted = SimpleWebTokenHelper.Decrypt(encryptionKey, EncryptedContext);
-
+            var decrypted = SimpleWebTokenHelper.Decrypt(key.ToKeyBytes(), EncryptedContext);
             return JsonConvert.DeserializeObject<HostAssignmentContext>(decrypted);
         }
     }

--- a/src/WebJobs.Script.WebHost/Security/SimpleWebTokenHelper.cs
+++ b/src/WebJobs.Script.WebHost/Security/SimpleWebTokenHelper.cs
@@ -141,20 +141,23 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security
                 return false;
             }
 
+            encryptionKey = hexOrBase64.ToKeyBytes();
+
+            return true;
+        }
+
+        public static byte[] ToKeyBytes(this string hexOrBase64)
+        {
             // only support 32 bytes (256 bits) key length
             if (hexOrBase64.Length == 64)
             {
-                encryptionKey = Enumerable.Range(0, hexOrBase64.Length)
+                return Enumerable.Range(0, hexOrBase64.Length)
                     .Where(x => x % 2 == 0)
                     .Select(x => Convert.ToByte(hexOrBase64.Substring(x, 2), 16))
                     .ToArray();
             }
-            else
-            {
-                encryptionKey = Convert.FromBase64String(hexOrBase64);
-            }
 
-            return true;
+            return Convert.FromBase64String(hexOrBase64);
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/WebJobsServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsServiceCollectionExtensions.cs
@@ -14,6 +14,7 @@ using Microsoft.Azure.WebJobs.Script.BindingExtensions;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
 using Microsoft.Azure.WebJobs.Script.WebHost.Middleware;
@@ -67,6 +68,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 .AddXmlDataContractSerializerFormatters();
 
             services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, WebJobsScriptHostService>());
+
+            if (ScriptSettingsManager.Instance.IsLinuxContainerEnvironment)
+            {
+                services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, LinuxContainerInitializationHostService>());
+            }
 
             // TODO: This is a direct port from the current model.
             // Some of those services (or the way we register them) may need to change

--- a/src/WebJobs.Script/Config/ScriptSettingsManager.cs
+++ b/src/WebJobs.Script/Config/ScriptSettingsManager.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         /// <summary>
         /// Gets a value indicating whether we are running in a Linux container
         /// </summary>
-        public bool IsLinuxContainerEnvironment
+        public virtual bool IsLinuxContainerEnvironment
         {
             get
             {

--- a/src/WebJobs.Script/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/EnvironmentSettingNames.cs
@@ -44,5 +44,8 @@ namespace Microsoft.Azure.WebJobs.Script
         /// configuration values.
         /// </summary>
         public const string AzureWebsiteConfigurationReady = "WEBSITE_CONFIGURATION_READY";
+
+        public const string ContainerStartContext = "CONTAINER_START_CONTEXT";
+        public const string ContainerStartContextSasUri = "CONTAINER_START_CONTEXT_SAS_URI";
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/ContainerManagement/LinuxContainerInitializationHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ContainerManagement/LinuxContainerInitializationHostServiceTests.cs
@@ -1,0 +1,148 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement;
+using Microsoft.Azure.WebJobs.Script.WebHost.Management;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.WebJobs.Script.Tests;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ContainerManagement
+{
+    [Trait(TestTraits.Category, TestTraits.EndToEnd)]
+    [Trait(TestTraits.Group, TestTraits.ContainerInstanceTests)]
+    public class LinuxContainerInitializationHostServiceTests : IDisposable
+    {
+        private const string Containerstartcontexturi = "https://containerstartcontexturi";
+        private readonly Mock<IInstanceManager> _instanceManagerMock;
+        private readonly LinuxContainerInitializationHostService _initializationHostService;
+
+        public LinuxContainerInitializationHostServiceTests()
+        {
+            _instanceManagerMock = new Mock<IInstanceManager>(MockBehavior.Strict);
+            _initializationHostService = new LinuxContainerInitializationHostService(new ScriptSettingsManager(), _instanceManagerMock.Object, NullLoggerFactory.Instance);
+        }
+
+        [Fact]
+        public async Task Runs_In_Linux_Container_Mode_Only()
+        {
+            var settingsManagerMock = new Mock<ScriptSettingsManager>(MockBehavior.Strict, null);
+            var initializationHostService = new LinuxContainerInitializationHostService(settingsManagerMock.Object, _instanceManagerMock.Object, NullLoggerFactory.Instance);
+            settingsManagerMock.Setup(manager => manager.IsLinuxContainerEnvironment).Returns(false);
+            await initializationHostService.StartAsync(CancellationToken.None);
+            settingsManagerMock.Verify(settingsManager => settingsManager.GetSetting(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Assigns_Context_From_CONTAINER_START_CONTEXT()
+        {
+            var containerEncryptionKey = TestHelpers.GenerateKeyHexString();
+            var hostAssignmentContext = GetHostAssignmentContext();
+            var encryptedHostAssignmentContext = GetEncryptedHostAssignmentContext(hostAssignmentContext, containerEncryptionKey);
+            var serializedContext = JsonConvert.SerializeObject(new { encryptedContext = encryptedHostAssignmentContext });
+
+            var vars = new Dictionary<string, string>
+            {
+                { EnvironmentSettingNames.ContainerStartContext, serializedContext },
+                { EnvironmentSettingNames.ContainerEncryptionKey, containerEncryptionKey },
+            };
+
+            // Enable Linux Container
+            AddLinuxContainerSettings(vars);
+
+            _instanceManagerMock.Setup(manager => manager.StartAssignment(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context)))).Returns(true);
+
+            using (var env = new TestScopedEnvironmentVariable(vars))
+            {
+                await _initializationHostService.StartAsync(CancellationToken.None);
+            }
+
+            _instanceManagerMock.Verify(manager => manager.StartAssignment(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context))), Times.Once);
+        }
+
+        [Fact]
+        public async Task Assigns_Context_From_CONTAINER_START_CONTEXT_SAS_URI_If_CONTAINER_START_CONTEXT_Absent()
+        {
+            var containerEncryptionKey = TestHelpers.GenerateKeyHexString();
+            var hostAssignmentContext = GetHostAssignmentContext();
+            var encryptedHostAssignmentContext = GetEncryptedHostAssignmentContext(hostAssignmentContext, containerEncryptionKey);
+            var serializedContext = JsonConvert.SerializeObject(new { encryptedContext = encryptedHostAssignmentContext });
+
+            var vars = new Dictionary<string, string>
+            {
+                { EnvironmentSettingNames.ContainerStartContextSasUri, Containerstartcontexturi },
+                { EnvironmentSettingNames.ContainerEncryptionKey, containerEncryptionKey },
+            };
+
+            AddLinuxContainerSettings(vars);
+
+            var initializationHostService = new Mock<LinuxContainerInitializationHostService>(MockBehavior.Strict, new ScriptSettingsManager(), _instanceManagerMock.Object, NullLoggerFactory.Instance);
+
+            initializationHostService.Setup(service => service.Read(Containerstartcontexturi))
+                .Returns(Task.FromResult(serializedContext));
+
+            _instanceManagerMock.Setup(manager => manager.StartAssignment(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context)))).Returns(true);
+
+            using (var env = new TestScopedEnvironmentVariable(vars))
+            {
+                await initializationHostService.Object.StartAsync(CancellationToken.None);
+            }
+
+            _instanceManagerMock.Verify(manager => manager.StartAssignment(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context))), Times.Once);
+        }
+
+        [Fact]
+        public async Task Does_Not_Assign_If_Context_Not_Available()
+        {
+            var vars = new Dictionary<string, string>();
+            AddLinuxContainerSettings(vars);
+
+            using (var env = new TestScopedEnvironmentVariable(vars))
+            {
+                await _initializationHostService.StartAsync(CancellationToken.None);
+            }
+
+            _instanceManagerMock.Verify(manager => manager.StartAssignment(It.IsAny<HostAssignmentContext>()), Times.Never);
+        }
+
+        private static string GetEncryptedHostAssignmentContext(HostAssignmentContext hostAssignmentContext, string containerEncryptionKey)
+        {
+            using (var env = new TestScopedEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, containerEncryptionKey))
+            {
+                var serializeObject = JsonConvert.SerializeObject(hostAssignmentContext);
+                return SimpleWebTokenHelper.Encrypt(serializeObject);
+            }
+        }
+
+        private static HostAssignmentContext GetHostAssignmentContext()
+        {
+            var hostAssignmentContext = new HostAssignmentContext();
+            hostAssignmentContext.SiteId = 1;
+            hostAssignmentContext.SiteName = "sitename";
+            hostAssignmentContext.LastModifiedTime = DateTime.UtcNow.Add(TimeSpan.FromMinutes(new Random().Next()));
+            hostAssignmentContext.Environment = new Dictionary<string, string>();
+            hostAssignmentContext.Environment.Add(EnvironmentSettingNames.AzureWebsiteAltZipDeployment, "https://zipurl.zip");
+            return hostAssignmentContext;
+        }
+
+        private static void AddLinuxContainerSettings(IDictionary<string, string> existing)
+        {
+            existing[EnvironmentSettingNames.AzureWebsiteInstanceId] = string.Empty;
+            existing[EnvironmentSettingNames.ContainerName] = "ContainerName";
+        }
+
+        public void Dispose()
+        {
+            _instanceManagerMock.Reset();
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
@@ -18,7 +18,7 @@ using Xunit;
 namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 {
     [Trait(TestTraits.Category, TestTraits.EndToEnd)]
-    [Trait(TestTraits.Group, nameof(InstanceManagerTests))]
+    [Trait(TestTraits.Group, TestTraits.ContainerInstanceTests)]
     public class InstanceManagerTests : IDisposable
     {
         private readonly TestLoggerProvider _loggerProvider;

--- a/test/WebJobs.Script.Tests.Shared/TestTraits.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestTraits.cs
@@ -22,5 +22,10 @@ namespace Microsoft.WebJobs.Script.Tests
         /// static state, and benefit from test isolation.
         /// </summary>
         public const string StandbyModeTests = "StandbyModeEndToEndTests";
+
+        /// <summary>
+        /// These are Linux container environment specific tests.
+        /// </summary>
+        public const string ContainerInstanceTests = "ContainerInstanceTests";
     }
 }


### PR DESCRIPTION
 When containers restart, site context which was injected via controller apis will be lost. This change identifies when a container is restarted and will reinitialize with the original site context.
    This handles 2 types of scenarios.
       1) For Zip based containers - the zip contents are hosted in storage account and SAS uri passed as env variable when container starts.
       2) For containers with azure files or custom containers with inbuilt site context, the entire site context is available as an environment variable.