### PR TITLE
 Delay synctriggers until specialization is complete.

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -131,6 +131,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         [HttpPost]
         [Route("admin/host/synctriggers")]
         [Authorize(Policy = PolicyNames.AdminAuthLevel)]
+        [RequiresRunningHost]
         public async Task<IActionResult> SyncTriggers()
         {
             (var success, var error) = await _functionsManager.TrySyncTriggers();


### PR DESCRIPTION
  When synctriggers is the first request to a container, synctriggers can complete before specialization leading to empty function triggers.