### PR TITLE
Add EnvironmentReadyCheckMiddleware

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
@@ -91,6 +91,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             {
                 // set a flag which will cause any incoming http requests to buffer
                 // until specialization is complete
+                // the host is guaranteed not to receive any requests until AFTER assign
+                // has been initiated, so setting this flag here is sufficient to ensure
+                // that any subsequent incoming requests while the assign is in progress
+                // will be delayed until complete
                 WebScriptHostManager.DelayRequests = true;
 
                 // first make all environment and file system changes required for

--- a/src/WebJobs.Script.WebHost/Middleware/EnvironmentReadyCheckMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/EnvironmentReadyCheckMiddleware.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
+{
+    /// <summary>
+    /// Middleware registered early in the request pipeline to check host
+    /// environment and delay requests as necessary.
+    /// </summary>
+    public partial class EnvironmentReadyCheckMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public EnvironmentReadyCheckMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task Invoke(HttpContext httpContext, WebHostResolver resolver)
+        {
+            await WebScriptHostManager.DelayUntilEnvironmentReady();
+
+            await _next.Invoke(httpContext);
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 builder.UseMiddleware<AppServiceHeaderFixupMiddleware>();
             }
 
+            builder.UseMiddleware<EnvironmentReadyCheckMiddleware>();
             builder.UseMiddleware<HttpExceptionMiddleware>();
             builder.UseMiddleware<ResponseBufferingMiddleware>();
             builder.UseMiddleware<HomepageMiddleware>();

--- a/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
@@ -330,6 +330,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         internal static async Task<bool> DelayUntilHostReady(WebHostResolver resolver)
         {
+            // need to ensure the host startup has been initiated
+            var manager = resolver.GetWebScriptHostManager();
+            var tIgnore = manager.EnsureHostStarted(CancellationToken.None);
+
+            // wait for the host to get into a running state
+            return await manager.DelayUntilHostReady(throwOnFailure: false);
+        }
+
+        internal static async Task DelayUntilEnvironmentReady()
+        {
             if (DelayRequests)
             {
                 // delay until we're ready to start processing requests
@@ -338,13 +348,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     return DelayRequests;
                 });
             }
-
-            // need to ensure the host startup has been initiated
-            var manager = resolver.GetWebScriptHostManager();
-            var tIgnore = manager.EnsureHostStarted(CancellationToken.None);
-
-            // wait for the host to get into a running state
-            return await manager.DelayUntilHostReady(throwOnFailure: false);
         }
     }
 }


### PR DESCRIPTION
Promoting checking of the previously added DelayRequests flag to a middleware component since it should apply to all requests, not just cases where the HostAvailabilityCheckMiddleware is running (or RequiresRunningHostAttribute is applied).

This came up in recent testing - we need to ensure that /admin/host/synctriggers calls wait until host assignment is complete.