### PR TITLE
Reverting WEBSITE_CONFIGURATION_READY check

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
@@ -102,7 +102,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 _logger.LogInformation("Triggering specialization");
                 _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
                 _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
-                _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsiteConfigurationReady, "1");
             }
             catch (Exception ex)
             {

--- a/src/WebJobs.Script.WebHost/WebHostResolver.cs
+++ b/src/WebJobs.Script.WebHost/WebHostResolver.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     // 1) We _were_ in standby mode and now we're ready to specialize
                     // 2) We're doing non-specialization normal initialization
                     if (_activeHostManager == null &&
-                        (_standbyHostManager == null || (_settingsManager.ContainerReady && _settingsManager.ConfigurationReady)))
+                        (_standbyHostManager == null || _settingsManager.ContainerReady))
                     {
                         _specializationTimer?.Dispose();
                         _specializationTimer = null;

--- a/src/WebJobs.Script/Config/ScriptSettingsManager.cs
+++ b/src/WebJobs.Script/Config/ScriptSettingsManager.cs
@@ -48,8 +48,6 @@ namespace Microsoft.Azure.WebJobs.Script.Config
 
         public virtual bool ContainerReady => !string.IsNullOrEmpty(GetSetting(EnvironmentSettingNames.AzureWebsiteContainerReady));
 
-        public virtual bool ConfigurationReady => !string.IsNullOrEmpty(GetSetting(EnvironmentSettingNames.AzureWebsiteConfigurationReady));
-
         public string WebsiteSku => GetSetting(EnvironmentSettingNames.AzureWebsiteSku);
 
         public bool IsDynamicSku => WebsiteSku == ScriptConstants.DynamicSku;

--- a/src/WebJobs.Script/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/EnvironmentSettingNames.cs
@@ -38,13 +38,6 @@ namespace Microsoft.Azure.WebJobs.Script
         /// </summary>
         public const string AzureWebsiteContainerReady = "WEBSITE_CONTAINER_READY";
 
-        /// <summary>
-        /// Environment variable dynamically set by the platform when configuration has been
-        /// completely initialized (e.g. EnvSettings module has ran) and it is safe to read
-        /// configuration values.
-        /// </summary>
-        public const string AzureWebsiteConfigurationReady = "WEBSITE_CONFIGURATION_READY";
-
         public const string ContainerStartContext = "CONTAINER_START_CONTEXT";
         public const string ContainerStartContextSasUri = "CONTAINER_START_CONTEXT_SAS_URI";
     }

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyManagerTests.cs
@@ -110,7 +110,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 { EnvironmentSettingNames.AzureWebsiteContainerReady, null },
                 { EnvironmentSettingNames.AzureWebsiteSku, "Dynamic" },
                 { EnvironmentSettingNames.AzureWebsiteHomePath, null },
-                { EnvironmentSettingNames.AzureWebsiteConfigurationReady, null },
                 { EnvironmentSettingNames.AzureWebsiteInstanceId, "87654639876900123453445678890144" },
                 { "AzureWebEncryptionKey", "0F75CA46E7EBDD39E4CA6B074D1F9A5972B849A55F91A248" }
             };
@@ -124,7 +123,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 // now specialize the host
                 ScriptSettingsManager.Instance.SetSetting(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
                 ScriptSettingsManager.Instance.SetSetting(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
-                ScriptSettingsManager.Instance.SetSetting(EnvironmentSettingNames.AzureWebsiteConfigurationReady, "1");
 
                 Assert.False(WebScriptHostManager.InStandbyMode);
                 Assert.True(ScriptSettingsManager.Instance.ContainerReady);
@@ -168,7 +166,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 { EnvironmentSettingNames.AzureWebsiteName, "TestApp" },
                 { EnvironmentSettingNames.ContainerEncryptionKey, encryptionKey },
                 { EnvironmentSettingNames.AzureWebsiteContainerReady, null },
-                { EnvironmentSettingNames.AzureWebsiteConfigurationReady, null },
                 { EnvironmentSettingNames.AzureWebsiteSku, "Dynamic" },
                 { EnvironmentSettingNames.AzureWebsiteZipDeployment, null },
                 { "AzureWebEncryptionKey", "0F75CA46E7EBDD39E4CA6B074D1F9A5972B849A55F91A248" }

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyModeTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyModeTests.cs
@@ -113,7 +113,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
                 _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
                 _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
-                _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsiteConfigurationReady, "1");
                 Assert.False(WebScriptHostManager.InStandbyMode);
                 _webHostResolver.EnsureInitialized(settings);
 
@@ -141,7 +140,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
                     _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
                     _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
-                    _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsiteConfigurationReady, "1");
                     current = func(settings);
                     Assert.NotNull(current);
                     Assert.NotSame(prev, current);


### PR DESCRIPTION
Reverting the change that was ported from the v1 branch https://github.com/Azure/azure-functions-host/commit/58d1a70799253cf9d4ff57aca0e11770cf9bedf1

For v2, the EnvSettings IIS module doesn't run, so this check doesn't work for .NET Core (and isn't actually needed). @safihamid found in testing that this check causes specialization not to happen.