### PR TITLE
Use TryGetValue to lookup worker channel

### DIFF
--- a/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionRegistry.cs
+++ b/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionRegistry.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         public void WorkerError(WorkerErrorEvent workerError)
         {
             ILanguageWorkerChannel erroredChannel;
-            if (_channelsDictionary.TryGetValue(workerError.WorkerId, out erroredChannel) && erroredChannel != null)
+            if (_channelsDictionary.TryGetValue(workerError.WorkerId, out erroredChannel))
             {
                 // TODO: move retry logic, possibly into worker channel decorator
                 _channelState.AddOrUpdate(erroredChannel.Config,

--- a/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionRegistry.cs
+++ b/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionRegistry.cs
@@ -66,8 +66,8 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         public void WorkerError(WorkerErrorEvent workerError)
         {
-            ILanguageWorkerChannel erroredChannel = _channelsDictionary[workerError.WorkerId];
-            if (erroredChannel != null)
+            ILanguageWorkerChannel erroredChannel;
+            if (_channelsDictionary.TryGetValue(workerError.WorkerId, out erroredChannel) && erroredChannel != null)
             {
                 // TODO: move retry logic, possibly into worker channel decorator
                 _channelState.AddOrUpdate(erroredChannel.Config,


### PR DESCRIPTION
CI test runs aborting with following exception:

```
dotnet.exe : The active test run was aborted. Reason: Unhandled Exception: System.Collections.Generic.KeyNotFoundException: The given key '9efeea97-8545-465e-90b4-d6e454dbe390' was not present in the dictionary.

At C:\azure-webjobs-sdk-script\run-tests.ps1:21 char:5

+     & dotnet $cmdargs | Out-Host
    + CategoryInfo          : NotSpecified: (The active test...the dictionary.:String) [], RemoteException

    + FullyQualifiedErrorId : NativeCommandError
   at System.Collections.Concurrent.ConcurrentDictionary`2.ThrowKeyNotFoundException(Object key)
   at System.Collections.Concurrent.ConcurrentDictionary`2.get_Item(TKey key)
   at Microsoft.Azure.WebJobs.Script.Rpc.FunctionRegistry.WorkerError(WorkerErrorEvent workerError) in C:\azure-webjobs-sdk-script\src\WebJobs.Script\Rpc\FunctionRegistration\FunctionRegistry.cs:line 69
   at System.Reactive.AnonymousSafeObserver`1.OnNext(T value)
   at System.Reactive.Observer`1.OnNext(T value)
   at Microsoft.Azure.WebJobs.Script.Eventing.ScriptEventManager.Publish(ScriptEvent scriptEvent) in C:\azure-webjobs-sdk-script\src\WebJobs.Script\Eventing\ScriptEventManager.cs:line 14
   at Microsoft.Azure.WebJobs.Script.Rpc.LanguageWorkerChannel.HandleWorkerError(Exception exc) in C:\azure-webjobs-sdk-script\src\WebJobs.Script\Rpc\LanguageWorkerChannel.cs:line 329
   at System.Reactive.AnonymousSafeObserver`1.OnError(Exception error)
   at System.Reactive.Linq.ObservableImpl.Take`1._.OnError(Exception error)
   at System.Reactive.Sink`1._.OnError(Exception error)
   at System.Reactive.Linq.ObservableImpl.Throw`1._.Invoke()
   at System.Reactive.Concurrency.Scheduler.Invoke(IScheduler scheduler, Action action)
   at System.Reactive.Producer`1.Run(IScheduler _, State x)
   at System.Reactive.Concurrency.ScheduledItem`2.InvokeCore()
   at System.Reactive.Concurrency.CurrentThreadScheduler.Trampoline.Run(SchedulerQueue`1 queue)
   at System.Reactive.Concurrency.CurrentThreadScheduler.Schedule[TState](TState state, TimeSpan dueTime, Func`3 action)
   at System.Reactive.Concurrency.LocalScheduler.Schedule[TState](TState state, Func`3 action)
   at System.Reactive.Producer`1.SubscribeRaw(IObserver`1 observer, Boolean enableSafeguard)
   at System.Reactive.Linq.ObservableImpl.Timeout`1.TimeR.Timeout(IScheduler _, UInt64 myid)
   at System.Reactive.Concurrency.DefaultScheduler.<>c__DisplayClass6_0`1.<Schedule>b__0(Object _)
   at System.Reactive.Concurrency.ConcurrencyAbstractionLayerImpl.Timer.Tick(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location where exception was thrown ---

```