### PR TITLE
Update Node and Java Language Workers

### DIFF
--- a/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/README.md
+++ b/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/README.md
@@ -52,10 +52,19 @@ set OUTDIR=%MSGDIR%\DotNet
 mkdir %OUTDIR%
 %GRPC_TOOLS_PATH%\protoc.exe %PROTO% --csharp_out %OUTDIR% --grpc_out=%OUTDIR% --plugin=protoc-gen-grpc=%GRPC_TOOLS_PATH%\grpc_csharp_plugin.exe --proto_path=%PROTO_PATH% --proto_path=%PROTOBUF_TOOLS% 
 ```
-## Java
---TODO--
-
 ## JavaScript
+In package.json, add to the build script the following commands to build .js files and to build .ts files. Use and install npm package `protobufjs`.
+
+Generate JavaScript files:
+```
+pbjs -t json-module -w commonjs -o azure-functions-language-worker-protobuf/src/rpc.js azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
+```
+Generate TypeScript files:
+```
+pbjs -t static-module azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto -o azure-functions-language-worker-protobuf/src/rpc_static.js && pbts -o azure-functions-language-worker-protobuf/src/rpc.d.ts azure-functions-language-worker-protobuf/src/rpc_static.js
+```
+
+## Java
 Maven plugin : [protobuf-maven-plugin](https://www.xolstice.org/protobuf-maven-plugin/)
 In pom.xml add following under configuration for this plugin
 <protoSourceRoot>${basedir}/<path to this repo>/azure-functions-language-worker-protobuf/src/proto</protoSourceRoot>

--- a/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
+++ b/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
@@ -4,10 +4,9 @@ syntax = "proto3";
 option java_multiple_files = true;
 option java_package = "com.microsoft.azure.functions.rpc.messages";
 option java_outer_classname = "FunctionProto";
-option objc_class_prefix = "FunctionRpc";
 option csharp_namespace = "Microsoft.Azure.WebJobs.Script.Grpc.Messages";
 
-package FunctionRpc;
+package AzureFunctionsRpcMessages;
 
 import "google/protobuf/duration.proto";
 

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -31,7 +31,7 @@
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.5150001-beta-b9e0da04" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta2-10041" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta6" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta2-10054" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta7" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.0-beta7" />

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -32,7 +32,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.5150001-beta-b9e0da04" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta6" />
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta2-10054" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta3" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta7" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.0-beta7" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.0-beta7">

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.9.1" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.0.3" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta2-10041" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta6" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta2-10054" />
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="2.0.0" />

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.9.1" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.0.3" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta6" />
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta2-10054" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta3" />
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.0" />


### PR DESCRIPTION
Consumed latest protobuf changes from https://github.com/Azure/azure-functions-language-worker-protobuf/commit/a42a580e5211f89d5cc605a869a48425fccbd880

**Node Language Worker:**
Release notes: https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v1.0.0-beta3
 - **Node v10 support** (_note: node v8 will be deprecated in the near future_)
 - Debug tips with changing node version locally
 - Adding worker.config.json for use in https://github.com/Azure/azure-functions-host

**Java Language Worker:**
Release notes: https://github.com/Azure/azure-functions-java-worker/releases/tag/v1.1.0-beta6
- Updated grpc dependencies to 1.12.0
- Updated other dependencies to their latest versions