### PR TITLE
Enable NodeContentTests

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/NodeContentTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/NodeContentTests.cs
@@ -43,14 +43,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(str, content);
         }
 
-        [Fact( Skip = "unsupported" )]
-        public async Task StringTextPlainReturn()
-        {
-            var str = "asdf";
-            var content = await Return(str, "text/plain; charset=utf-8");
-            Assert.Equal(str, content);
-        }
-
         [Fact]
         public async Task StringTextPlain()
         {
@@ -76,17 +68,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(str, content);
         }
 
-        // consider supporting text/plain formatting for byte[] type
-        [Fact( Skip = "unsupported" )]
-        public async Task ByteArrayTextPlainReturn()
-        {
-            var str = "asdf";
-            var bytes = Encoding.UTF8.GetBytes(str);
-            var base64 = Convert.ToBase64String(bytes);
-            var content = await Return(bytes, "text/plain; charset=utf-8", "application/json; charset=utf-8");
-            Assert.Equal("\"" + base64 + "\"", content);
-        }
-
         [Fact]
         public async Task ByteArrayTextPlain()
         {
@@ -96,7 +77,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(str, content);
         }
 
-        [Fact( Skip = "unsupported" )]
+        [Fact(Skip = "unsupported")]
         public async Task ObjectTextPlainResponse_Conneg()
         {
             var obj = new { a = 1 };
@@ -105,17 +86,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(str, Regex.Replace(content, @"\s+", string.Empty));
         }
 
-        // consider supporting text/plain conversion for expandoobject type
-        [Fact( Skip = "unsupported" )]
-        public async Task ObjectTextPlainReturn()
-        {
-            var obj = new { a = 1 };
-            var str = "{\"a\":1}";
-            var content = await Return(obj, "text/plain; charset=utf-8", "application/json; charset=utf-8");
-            Assert.Equal(str, Regex.Replace(content, @"\s+", string.Empty));
-        }
-
-        [Fact( Skip = "unsupported" )]
+        [Fact]
         public async Task ObjectTextPlain()
         {
             var obj = new { a = 1 };
@@ -124,17 +95,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(str, Regex.Replace(content, @"\s+", string.Empty));
         }
 
-        [Fact( Skip = "unsupported" )]
+        [Fact(Skip = "unsupported")]
         public async Task StringJsonResponse_Conneg()
         {
             var content = await ResponseWithConneg("asdf", "application/json; charset=utf-8");
-            Assert.Equal("\"asdf\"", content);
-        }
-
-        [Fact( Skip = "unsupported" )]
-        public async Task StringJsonReturn()
-        {
-            var content = await Return("asdf", "application/json; charset=utf-8");
             Assert.Equal("\"asdf\"", content);
         }
 
@@ -145,23 +109,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal("asdf", content);
         }
 
-        [Fact( Skip = "unsupported" )]
+        [Fact(Skip = "unsupported")]
         public async Task ByteArrayJsonResponse_Conneg()
         {
             var str = "asdf";
             var bytes = Encoding.UTF8.GetBytes(str);
             var base64 = Convert.ToBase64String(bytes);
             var content = await ResponseWithConneg(bytes, "application/json; charset=utf-8");
-            Assert.Equal("\"" + base64 + "\"", content);
-        }
-
-        [Fact( Skip = "unsupported" )]
-        public async Task ByteArrayJsonReturn()
-        {
-            var str = "asdf";
-            var bytes = Encoding.UTF8.GetBytes(str);
-            var base64 = Convert.ToBase64String(bytes);
-            var content = await Return(bytes, "application/json; charset=utf-8");
             Assert.Equal("\"" + base64 + "\"", content);
         }
 
@@ -175,7 +129,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal("asdf", content);
         }
 
-        [Fact( Skip = "unsupported" )]
+        [Fact(Skip = "unsupported")]
         public async Task ObjectJsonResponse_Conneg()
         {
             var obj = new { a = 1 };
@@ -185,17 +139,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(str, content);
         }
 
-        [Fact( Skip = "unsupported" )]
-        public async Task ObjectJsonReturn()
-        {
-            var obj = new { a = 1 };
-            var str = "{\"a\":1}";
-            var content = await Return(obj, "application/json; charset=utf-8");
-            content = Regex.Replace(content, @"\s+", string.Empty);
-            Assert.Equal(str, content);
-        }
-
-        [Fact( Skip = "unsupported" )]
+        [Fact]
         public async Task ObjectJson()
         {
             var obj = new { a = 1 };
@@ -205,17 +149,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(str, content);
         }
 
-        [Fact( Skip = "unsupported" )]
+        [Fact(Skip = "unsupported")]
         public async Task StringXmlResponse_Conneg()
         {
             var content = await ResponseWithConneg("asdf", "application/xml; charset=utf-8");
-            Assert.Equal("<string xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/\">asdf</string>", content);
-        }
-
-        [Fact( Skip = "unsupported" )]
-        public async Task StringXmlReturn()
-        {
-            var content = await Return("asdf", "application/xml; charset=utf-8");
             Assert.Equal("<string xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/\">asdf</string>", content);
         }
 
@@ -226,23 +163,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal("asdf", content);
         }
 
-        [Fact( Skip = "unsupported" )]
+        [Fact(Skip = "unsupported")]
         public async Task ByteArrayXmlResponse_Conneg()
         {
             var str = "asdf";
             var bytes = Encoding.UTF8.GetBytes(str);
             var base64 = Convert.ToBase64String(bytes);
             var content = await ResponseWithConneg(bytes, "application/xml; charset=utf-8");
-            Assert.Equal("<base64Binary xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/\">YXNkZg==</base64Binary>", content);
-        }
-
-        [Fact( Skip = "unsupported" )]
-        public async Task ByteArrayXmlReturn()
-        {
-            var str = "asdf";
-            var bytes = Encoding.UTF8.GetBytes(str);
-            var base64 = Convert.ToBase64String(bytes);
-            var content = await Return(bytes, "application/xml; charset=utf-8");
             Assert.Equal("<base64Binary xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/\">YXNkZg==</base64Binary>", content);
         }
 
@@ -256,7 +183,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal("asdf", content);
         }
 
-        [Fact( Skip = "unsupported" )]
+        [Fact(Skip = "unsupported")]
         public async Task ObjectXmlResponse_Conneg()
         {
             var obj = new { a = 1 };
@@ -268,19 +195,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(str, content);
         }
 
-        [Fact( Skip = "unsupported" )]
-        public async Task ObjectXmlReturn()
-        {
-            var obj = new { a = 1 };
-
-            // consider using fabiocav custom xml formatter
-            var str = "<ArrayOfKeyValueOfstringanyTypexmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"><KeyValueOfstringanyType><Key>a</Key><Valuexmlns:d3p1=\"http://www.w3.org/2001/XMLSchema\"i:type=\"d3p1:long\">1</Value></KeyValueOfstringanyType></ArrayOfKeyValueOfstringanyType>";
-            var content = await Return(obj, "application/xml; charset=utf-8");
-            content = Regex.Replace(content, @"\s+", string.Empty);
-            Assert.Equal(str, content);
-        }
-
-        [Fact( Skip = "unsupported" )]
+        [Fact]
         public async Task ObjectXml()
         {
             var obj = new { a = 1 };
@@ -293,20 +208,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         // Get response with default ObjectResult content negotiation enabled 
         protected Task<string> ResponseWithConneg<Req>(Req content, string contentType, string expectedContentType = null)
         {
-            return CreateTest(content, contentType, true, false, expectedContentType);
-        }
-
-        protected Task<string> Return<Req>(Req content, string contentType, string expectedContentType = null)
-        {
-            return CreateTest(content, contentType, false, true, expectedContentType);
+            return CreateTest(content, contentType, true, expectedContentType);
         }
 
         protected Task<string> Response<Req>(Req content, string contentType, string expectedContentType = null)
         {
-            return CreateTest(content, contentType, false, false, expectedContentType);
+            return CreateTest(content, contentType, false, expectedContentType);
         }
 
-        protected async Task<string> CreateTest<Req>(Req content, string contentType, bool contentNegotiation, bool isReturn, string expectedContentType = null)
+        protected async Task<string> CreateTest<Req>(Req content, string contentType, bool contentNegotiation, string expectedContentType = null)
         {
             IHeaderDictionary headers = new HeaderDictionary();
 
@@ -318,14 +228,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 headers.Add("negotiation", "true");
             }
 
-            if (isReturn)
-            {
-                headers.Add("scenario", "return-content");
-            }
-            else
-            {
-                headers.Add("scenario", "content");
-            }
+            headers.Add("scenario", "content");
 
             HttpRequest request = HttpTestHelpers.CreateHttpRequest("POST", "http://localhost/api/httptrigger", headers, content);
 

--- a/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/NodeContentTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/NodeContentTests.cs
@@ -77,15 +77,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(str, content);
         }
 
-        [Fact(Skip = "unsupported")]
-        public async Task ObjectTextPlainResponse_Conneg()
-        {
-            var obj = new { a = 1 };
-            var str = "{\"a\":1}";
-            var content = await ResponseWithConneg(obj, "text/plain; charset=utf-8");
-            Assert.Equal(str, Regex.Replace(content, @"\s+", string.Empty));
-        }
-
         [Fact]
         public async Task ObjectTextPlain()
         {
@@ -95,28 +86,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(str, Regex.Replace(content, @"\s+", string.Empty));
         }
 
-        [Fact(Skip = "unsupported")]
-        public async Task StringJsonResponse_Conneg()
-        {
-            var content = await ResponseWithConneg("asdf", "application/json; charset=utf-8");
-            Assert.Equal("\"asdf\"", content);
-        }
-
         [Fact]
         public async Task StringJson()
         {
             var content = await Response("asdf", "application/json; charset=utf-8");
             Assert.Equal("asdf", content);
-        }
-
-        [Fact(Skip = "unsupported")]
-        public async Task ByteArrayJsonResponse_Conneg()
-        {
-            var str = "asdf";
-            var bytes = Encoding.UTF8.GetBytes(str);
-            var base64 = Convert.ToBase64String(bytes);
-            var content = await ResponseWithConneg(bytes, "application/json; charset=utf-8");
-            Assert.Equal("\"" + base64 + "\"", content);
         }
 
         [Fact]
@@ -129,16 +103,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal("asdf", content);
         }
 
-        [Fact(Skip = "unsupported")]
-        public async Task ObjectJsonResponse_Conneg()
-        {
-            var obj = new { a = 1 };
-            var str = "{\"a\":1}";
-            var content = await ResponseWithConneg(obj, "application/json; charset=utf-8");
-            content = Regex.Replace(content, @"\s+", string.Empty);
-            Assert.Equal(str, content);
-        }
-
         [Fact]
         public async Task ObjectJson()
         {
@@ -149,28 +113,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(str, content);
         }
 
-        [Fact(Skip = "unsupported")]
-        public async Task StringXmlResponse_Conneg()
-        {
-            var content = await ResponseWithConneg("asdf", "application/xml; charset=utf-8");
-            Assert.Equal("<string xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/\">asdf</string>", content);
-        }
-
         [Fact]
         public async Task StringXml()
         {
             var content = await Response("asdf", "application/xml; charset=utf-8");
             Assert.Equal("asdf", content);
-        }
-
-        [Fact(Skip = "unsupported")]
-        public async Task ByteArrayXmlResponse_Conneg()
-        {
-            var str = "asdf";
-            var bytes = Encoding.UTF8.GetBytes(str);
-            var base64 = Convert.ToBase64String(bytes);
-            var content = await ResponseWithConneg(bytes, "application/xml; charset=utf-8");
-            Assert.Equal("<base64Binary xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/\">YXNkZg==</base64Binary>", content);
         }
 
         [Fact]
@@ -181,18 +128,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var base64 = Convert.ToBase64String(bytes);
             var content = await Response(bytes, "application/xml; charset=utf-8");
             Assert.Equal("asdf", content);
-        }
-
-        [Fact(Skip = "unsupported")]
-        public async Task ObjectXmlResponse_Conneg()
-        {
-            var obj = new { a = 1 };
-
-            // consider using fabiocav custom xml formatter
-            var str = "<ArrayOfKeyValueOfstringanyTypexmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"xmlns=\"http://schemas.microsoft.com/2003/10/Serialization/Arrays\"><KeyValueOfstringanyType><Key>a</Key><Valuexmlns:d3p1=\"http://www.w3.org/2001/XMLSchema\"i:type=\"d3p1:long\">1</Value></KeyValueOfstringanyType></ArrayOfKeyValueOfstringanyType>";
-            var content = await ResponseWithConneg(obj, "application/xml; charset=utf-8");
-            content = Regex.Replace(content, @"\s+", string.Empty);
-            Assert.Equal(str, content);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Node/HttpTrigger-Scenarios/index.js
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Node/HttpTrigger-Scenarios/index.js
@@ -6,7 +6,7 @@ module.exports = function (context, req) {
 
     switch (scenario) {
         case "echo":
-            context.res.send(req.body.value);
+            context.res = req.body.value;
             break;
 
         case "buffer":

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Node/HttpTrigger-Scenarios/index.js
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Node/HttpTrigger-Scenarios/index.js
@@ -6,7 +6,7 @@ module.exports = function (context, req) {
 
     switch (scenario) {
         case "echo":
-            context.res = req.body.value;
+            context.res.send(req.body.value);
             break;
 
         case "buffer":
@@ -28,11 +28,6 @@ module.exports = function (context, req) {
                 status: 200,
                 body: req.body.value
             };
-            break;
-
-        case "return-content":
-            context.res = req.body;
-            context.res.enableContentNegotiation = enableContentNegotiation;
             break;
 
         case "content":

--- a/test/WebJobs.Script.Tests.Shared/HttpTestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/HttpTestHelpers.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Newtonsoft.Json;
 
 namespace Microsoft.WebJobs.Script.Tests
 {
@@ -39,6 +41,11 @@ namespace Microsoft.WebJobs.Script.Tests
                 else if (body is byte[] bodyBytes)
                 {
                     bytes = bodyBytes;
+                }
+                else
+                {
+                    string bodyJson = JsonConvert.SerializeObject(body);
+                    bytes = Encoding.UTF8.GetBytes(bodyJson);
                 }
 
                 requestFeature.Body = new MemoryStream(bytes);


### PR DESCRIPTION
Some tests (involving "Return") were broken due to this breaking change to simplify node http response logic: https://github.com/Azure/azure-functions-host/issues/997. Those tests are deleted since these scenarios are no longer supported.

There are still a number of tests that I've kept as "unsupported", because they deal with content negotiation (which we're trying to move people away from - it's a hidden opt-in flag). I can put some more work into figuring out why these tests are broken or if these scenarios are broken, but I wasn't sure if it's worthwhile.

Resolves #2871