### PR TITLE
Updating FileWatcherEventSource to avoid publishing events after dis…

### DIFF
--- a/src/WebJobs.Script/Eventing/File/FileWatcherEventSource.cs
+++ b/src/WebJobs.Script/Eventing/File/FileWatcherEventSource.cs
@@ -31,8 +31,11 @@ namespace Microsoft.Azure.WebJobs.Script.Eventing.File
 
         private void FileChanged(object sender, FileSystemEventArgs e)
         {
-            var fileEvent = new FileEvent(_source, e);
-            _eventManager.Publish(fileEvent);
+            if (!_disposed)
+            {
+                var fileEvent = new FileEvent(_source, e);
+                _eventManager.Publish(fileEvent);
+            }
         }
 
         private void Dispose(bool disposing)

--- a/src/WebJobs.Script/Eventing/ScriptEventManager.cs
+++ b/src/WebJobs.Script/Eventing/ScriptEventManager.cs
@@ -11,9 +11,27 @@ namespace Microsoft.Azure.WebJobs.Script.Eventing
         private readonly Subject<ScriptEvent> _subject = new Subject<ScriptEvent>();
         private bool _disposed = false;
 
-        public void Publish(ScriptEvent scriptEvent) => _subject.OnNext(scriptEvent);
+        public void Publish(ScriptEvent scriptEvent)
+        {
+            ThrowIfDisposed();
 
-        public IDisposable Subscribe(IObserver<ScriptEvent> observer) => _subject.Subscribe(observer);
+            _subject.OnNext(scriptEvent);
+        }
+
+        public IDisposable Subscribe(IObserver<ScriptEvent> observer)
+        {
+            ThrowIfDisposed();
+
+            return _subject.Subscribe(observer);
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(ScriptEventManager));
+            }
+        }
 
         private void Dispose(bool disposing)
         {


### PR DESCRIPTION
…posal. Throwing from ScriptEventManager if Publish or Subscribe are called after disposal.