### PR TITLE
Changing default sharing access mode in FileUtility.WriteAsync

### DIFF
--- a/src/WebJobs.Script/Extensions/FileUtility.cs
+++ b/src/WebJobs.Script/Extensions/FileUtility.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Script
             }
 
             encoding = encoding ?? Encoding.UTF8;
-            using (Stream fileStream = OpenFile(path, FileMode.Create, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete))
+            using (Stream fileStream = OpenFile(path, FileMode.Create, FileAccess.Write, FileShare.Read))
             using (var writer = new StreamWriter(fileStream, encoding, 4096))
             {
                 await writer.WriteAsync(contents);


### PR DESCRIPTION
Resolves #3059

This PR resolves the corruption issue. We need a separate issue to track recovery when/if an invalid file is found.