### PR TITLE
Catch unhandled exceptions coming from background process logging

### DIFF
--- a/src/WebJobs.Script/Description/Script/ScriptFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Script/ScriptFunctionInvoker.cs
@@ -93,11 +93,18 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             {
                 if (e.Data != null)
                 {
-                    // the user's TraceWriter will automatically log to ILogger as well
-                    TraceEvent traceEvent = new TraceEvent(TraceLevel.Info, e.Data, ScriptConstants.TraceSourceScriptFunctionExecution);
+                    var traceEvent = new TraceEvent(TraceLevel.Info, e.Data, ScriptConstants.TraceSourceScriptFunctionExecution);
                     traceEvent.Properties.Add(ScriptConstants.TracePropertyFunctionInvocationIdKey, invocationId);
                     traceEvent.Properties.Add(ScriptConstants.TracePropertyFunctionNameKey, context.ExecutionContext.FunctionName);
-                    userTraceWriter.Trace(traceEvent);
+
+                    try
+                    {
+                        userTraceWriter.Trace(traceEvent);
+                    }
+                    catch
+                    {
+                        // best effort
+                    }
                 }
             };
 


### PR DESCRIPTION
Test runs showing intermittent failures, e.g. https://ci.appveyor.com/project/appsvc/azure-webjobs-sdk-script-y8o14/build/20180706-0700. The below stack trace shows the error.

Here's what I believe is happening: The EndToEndTimeoutTests exercise our function timeout logic. When a timeout occurs it happens on a different thread than the function execution thread, which starts initiating a host shutdown concurrently with the in process function execution. In the stack below, this can lead to the Process.OutputDataReceived event handler accessing a disposed object [here](https://github.com/Azure/azure-functions-host/blob/dc13b18acd68f1bb39f2453b7f83e1e4c829e0f9/src/WebJobs.Script/Description/Script/ScriptFunctionInvoker.cs#L100) and killing the process.

```
System.ObjectDisposedException: Cannot write to a closed TextWriter.
   at System.IO.__Error.WriterClosed()
   at System.IO.StringWriter.Write(Char[] buffer, Int32 index, Int32 count)
   at System.IO.TextWriter.WriteLine(String value)
   at System.IO.TextWriter.SyncTextWriter.WriteLine(String value)
   at Microsoft.Azure.WebJobs.Host.CompositeTraceWriter.InvokeTextWriter(TraceEvent traceEvent)
   at Microsoft.Azure.WebJobs.Host.CompositeTraceWriter.Trace(TraceEvent traceEvent)
   at Microsoft.Azure.WebJobs.Host.CompositeTraceWriter.InvokeTraceWriters(TraceEvent traceEvent)
   at Microsoft.Azure.WebJobs.Host.CompositeTraceWriter.Trace(TraceEvent traceEvent)
   at Microsoft.Azure.WebJobs.Script.CompositeTraceWriter.Trace(TraceEvent traceEvent) in C:\projects\azure-webjobs-sdk-script\src\WebJobs.Script\Diagnostics\CompositeTraceWriter.cs:line 35
   at Microsoft.Azure.WebJobs.Script.InterceptingTraceWriter.Trace(TraceEvent traceEvent) in C:\projects\azure-webjobs-sdk-script\src\WebJobs.Script\Diagnostics\InterceptingTraceWriter.cs:line 31
   at Microsoft.Azure.WebJobs.Script.Description.ScriptFunctionInvoker.<>c__DisplayClass10_0.<ExecuteScriptAsync>b__0(Object s, DataReceivedEventArgs e) in C:\projects\azure-webjobs-sdk-script\src\WebJobs.Script\Description\Script\ScriptFunctionInvoker.cs:line 100
   at System.Diagnostics.Process.OutputReadNotifyUser(String data)
   at System.Diagnostics.AsyncStreamReader.FlushMessageQueue()
   at System.Diagnostics.AsyncStreamReader.ReadBuffer(IAsyncResult ar)
   at System.IO.Stream.ReadWriteTask.InvokeAsyncCallback(Object completedTask)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.IO.Stream.ReadWriteTask.System.Threading.Tasks.ITaskCompletionAction.Invoke(Task completingTask)
   at System.Threading.Tasks.Task.FinishContinuations()
   at System.Threading.Tasks.Task.FinishStageThree()
   at System.Threading.Tasks.Task.FinishStageTwo()
   at System.Threading.Tasks.Task.Finish(Boolean bUserDelegateExecuted)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot)
   at System.Threading.Tasks.Task.ExecuteEntry(Boolean bPreventDoubleExecution)
   at System.Threading.Tasks.Task.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback()
```