### PR TITLE
Fixing test logging consumption to avoid working against the live underlying collections

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
         }
 
-        public IEnumerable<LogMessage> GetLogMessages() => _loggerProvider.GetAllLogMessages();
+        public IList<LogMessage> GetLogMessages() => _loggerProvider.GetAllLogMessages();
 
         public IEnumerable<LogMessage> GetLogMessages(string category) => GetLogMessages().Where(p => p.Category == category);
 

--- a/test/WebJobs.Script.Tests.Shared/TestLoggerProvider.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestLoggerProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.WebJobs.Script.Tests
             return logger;
         }
 
-        public IEnumerable<LogMessage> GetAllLogMessages() => CreatedLoggers.SelectMany(l => l.GetLogMessages()).OrderBy(p => p.Timestamp);
+        public IList<LogMessage> GetAllLogMessages() => CreatedLoggers.SelectMany(l => l.GetLogMessages()).OrderBy(p => p.Timestamp).ToList();
 
         public void ClearAllLogMessages()
         {


### PR DESCRIPTION
Changes to improve test reliability.