### PR TITLE
Adding a utility to round TimeSpan instances and using it in tests where rounding was performed

### DIFF
--- a/test/WebJobs.Script.Tests.Shared/TimeSpanExtensions.cs
+++ b/test/WebJobs.Script.Tests.Shared/TimeSpanExtensions.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.WebJobs.Script.Tests
+{
+    public static class TimeSpanExtensions
+    {
+        public static TimeSpan RoundSeconds(this TimeSpan timeSpan, int digits, MidpointRounding rounding = MidpointRounding.ToEven)
+        {
+            return TimeSpan.FromSeconds(Math.Round(timeSpan.TotalSeconds, digits, rounding));
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Shared/WebJobs.Script.Tests.Shared.projitems
+++ b/test/WebJobs.Script.Tests.Shared/WebJobs.Script.Tests.Shared.projitems
@@ -25,5 +25,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)TestScopedSettings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestSecretManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestSecretManagerFactory.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TimeSpanExtensions.cs" />
   </ItemGroup>
 </Project>

--- a/test/WebJobs.Script.Tests/IO/AutoRecoveringFileSystemWatcherTests.cs
+++ b/test/WebJobs.Script.Tests/IO/AutoRecoveringFileSystemWatcherTests.cs
@@ -127,12 +127,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.IO
                     long expectedInterval = Convert.ToInt64((Math.Pow(2, i + 1) - 1) / 2);
                     LogMessage currentEvent = retryEvents[i];
 
-                    var actualInterval = currentEvent.Timestamp - previoustTimeStamp;
+                    TimeSpan actualInterval = currentEvent.Timestamp - previoustTimeStamp;
+                    TimeSpan roundedInterval = actualInterval.RoundSeconds(digits: 0);
                     previoustTimeStamp = currentEvent.Timestamp;
 
-                    int roundedIntervalInSeconds = (int)Math.Round(actualInterval.TotalSeconds, 0, MidpointRounding.ToEven);
-                    Assert.True(expectedInterval == roundedIntervalInSeconds,
-                        $"Recovering interval did not meet the expected interval (expected '{expectedInterval}', rounded '{roundedIntervalInSeconds}', actual '{actualInterval.Seconds}')");
+                    Assert.True(expectedInterval == roundedInterval.TotalSeconds,
+                        $"Recovering interval did not meet the expected interval (expected '{expectedInterval}', rounded '{roundedInterval.TotalSeconds}', actual '{actualInterval.TotalSeconds}')");
                 }
 
                 Assert.True(loggerProvider.GetAllLogMessages().All(t => t.FormattedMessage.EndsWith(fileWatcherLogSuffix)));

--- a/test/WebJobs.Script.Tests/UtilityTests.cs
+++ b/test/WebJobs.Script.Tests/UtilityTests.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.WebJobs.Script.Tests;
 using Moq;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -72,7 +73,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             // Workaround annoying test failures such as "Expected sw.Elapsed >= TimeSpan.FromSeconds(2); Actual: 1999.4092" by waiting slightly less than 2 seconds
             // Not sure what causes it, but either Task.Delay sometimes doesn't wait quite long enough or there is some clock skew.
-            Assert.True(sw.Elapsed >= TimeSpan.FromMilliseconds(1990), $"Expected sw.Elapsed >= TimeSpan.FromMilliseconds(1990); Actual: {sw.Elapsed.TotalMilliseconds}");
+            TimeSpan roundedElapsedSpan = sw.Elapsed.RoundSeconds(digits: 1);
+            Assert.True(roundedElapsedSpan >= TimeSpan.FromSeconds(2), $"Expected roundedElapsedSpan >= TimeSpan.FromSeconds(2); Actual: {roundedElapsedSpan.TotalSeconds}");
         }
 
         [Theory]


### PR DESCRIPTION
Adding a `TimeSpan` rounding extension as we're likely to need it in a couple of other spots. Updated code that would benefit from that logic to use it.