### PR TITLE
protecting TestLogger from collection modifications

### DIFF
--- a/test/WebJobs.Script.Tests.Shared/TestLogger.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestLogger.cs
@@ -13,6 +13,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         private readonly Func<string, LogLevel, bool> _filter;
         private IList<LogMessage> _logMessages = new List<LogMessage>();
 
+        // protect against changes to _logMessages while enumerating
+        private object _syncLock = new object();
+
         public TestLogger(string category, Func<string, LogLevel, bool> filter = null)
         {
             Category = category;
@@ -31,9 +34,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             return _filter?.Invoke(Category, logLevel) ?? true;
         }
 
-        public IList<LogMessage> GetLogMessages() => _logMessages.ToList();
+        public IList<LogMessage> GetLogMessages()
+        {
+            lock (_syncLock)
+            {
+                return _logMessages.ToList();
+            }
+        }
 
-        public void ClearLogMessages() => _logMessages.Clear();
+        public void ClearLogMessages()
+        {
+            lock (_syncLock)
+            {
+                _logMessages.Clear();
+            }
+        }
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
@@ -53,7 +68,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Timestamp = DateTime.UtcNow
             };
 
-            _logMessages.Add(logMessage);
+            lock (_syncLock)
+            {
+                _logMessages.Add(logMessage);
+            }
         }
     }
 


### PR DESCRIPTION
This fixes some flaky tests. Note we already do this in SDK: https://github.com/Azure/azure-webjobs-sdk/blob/dev/test/Microsoft.Azure.WebJobs.Host.TestCommon/TestLogger.cs#L18