### PR TITLE
Defaulting many to be data type string[]

### DIFF
--- a/sample/EventHubTrigger/index.js
+++ b/sample/EventHubTrigger/index.js
@@ -1,17 +1,18 @@
 var util = require('util');
 
 module.exports = function (context, input) {
-    context.log(util.format("Node.js script processed %d events", input.length));
-    context.log("IsArray", util.isArray(input));
+    var parsedInput = JSON.parse(input);
+    context.log(util.format("Node.js script processed %d events", parsedInput.length));
+    context.log("IsArray", util.isArray(parsedInput));
 
-    for (i = 0; i < input.length; i++)
+    for (i = 0; i < parsedInput.length; i++)
     {
         // EventData properties can be accessed via binding data,
         // including custom properties, system properties, etc.
         var bindingData = context.bindingData,
             eventProperties = bindingData.propertiesArray[i],
             systemProperties = bindingData.systemPropertiesArray[i],
-            id = input[i].value;
+            id = parsedInput[i].value;
 
         context.log('EventId: %s, EnqueuedTime: %s, Sequence: %d, Index: %s',
             id,

--- a/sample/EventHubTrigger/index.js
+++ b/sample/EventHubTrigger/index.js
@@ -1,18 +1,17 @@
 var util = require('util');
 
 module.exports = function (context, input) {
-    var parsedInput = JSON.parse(input);
-    context.log(util.format("Node.js script processed %d events", parsedInput.length));
-    context.log("IsArray", util.isArray(parsedInput));
+    context.log(util.format("Node.js script processed %d events", input.length));
+    context.log("IsArray", util.isArray(input));
 
-    for (i = 0; i < parsedInput.length; i++)
+    for (i = 0; i < input.length; i++)
     {
         // EventData properties can be accessed via binding data,
         // including custom properties, system properties, etc.
         var bindingData = context.bindingData,
             eventProperties = bindingData.propertiesArray[i],
             systemProperties = bindingData.systemPropertiesArray[i],
-            id = parsedInput[i].value;
+            id = JSON.parse(input[i]).value;
 
         context.log('EventId: %s, EnqueuedTime: %s, Sequence: %d, Index: %s',
             id,

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/ListenerExceptions/ListenerStartupException/index.js
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/ListenerExceptions/ListenerStartupException/index.js
@@ -1,7 +1,6 @@
 ﻿var util = require('util');
 
 module.exports = function (context, input) {
-    var parsedInput = JSON.parse(input);
-    context.log(util.format("Node.js script processed %d events", parsedInput.length));
+    context.log(util.format("Node.js script processed %d events", input.length));
     context.done();
 }

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/ListenerExceptions/ListenerStartupException/index.js
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/ListenerExceptions/ListenerStartupException/index.js
@@ -1,6 +1,7 @@
 ﻿var util = require('util');
 
 module.exports = function (context, input) {
-    context.log(util.format("Node.js script processed %d events", input.length));
+    var parsedInput = JSON.parse(input);
+    context.log(util.format("Node.js script processed %d events", parsedInput.length));
     context.done();
 }

--- a/test/WebJobs.Script.Tests/Binding/GeneralScriptBindingProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Binding/GeneralScriptBindingProviderTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
     {
         [Theory]
         [InlineData(null, null, typeof(object))]
-        [InlineData(null, "many", typeof(object[]))]
+        [InlineData(null, "many", typeof(string[]))]
         [InlineData("string", null, typeof(string))]
         [InlineData("StRing", null, typeof(string))] // case insenstive
         [InlineData("string", "mANy", typeof(string[]))] // case insensitve


### PR DESCRIPTION
When "cardinality": "many" is set on an Event Hubs trigger (as it should be for best perf), the error below is thrown unless the original input is _valid json_. This conflicts with v1 behavior and breaks [the template example](https://github.com/Azure/azure-functions-templates/blob/dev/Functions.Templates/Templates/EventHubTrigger-JavaScript/sample.dat)

```
System.Private.CoreLib: Exception while executing function: Functions.eventhub. Microsoft.Azure.WebJobs.Host: Exception binding parameter 'myEventHubMessages'. Microsoft.Azure.WebJobs.Host: Binding parameters to complex objects (such as 'Object') uses Json.NET serialization.
1. Bind the parameter type as 'string' instead of 'Object' to get the raw values and avoid JSON deserialization, or
2. Change the queue payload to be valid json. The JSON parser failed: Unexpected character encountered while parsing value: E. Path '', line 0, position 0.
```

The fix is to default the "many" input to be a string array.

Here's a more complete stacktrace:
```
      => System.Collections.Generic.Dictionary`2[System.String,System.Object]
Microsoft.Azure.WebJobs.Host.FunctionInvocationException: Exception while executing function: Functions.eventhub ---> System.InvalidOperationException: Exception binding parameter 'myEventHubMessages' ---> System.InvalidOperationException: Binding parameters to complex objects (such as 'Object') uses Json.NET serialization.
1. Bind the parameter type as 'string' instead of 'Object' to get the raw values and avoid JSON deserialization, or
2. Change the queue payload to be valid json. The JSON parser failed: Unexpected character encountered while parsing value: T. Path '', line 0, position 0.

   at Microsoft.Azure.WebJobs.Host.Triggers.PocoTriggerArgumentBinding`2.ConvertAsync(TMessage value, Dictionary`2 bindingData, ValueBindingContext context) in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Triggers\TriggerArgumentBinding\PocoTriggerArgumentBinding.cs:line 57
   at Microsoft.Azure.WebJobs.Host.ArrayTriggerArgumentBinding`2.BindAsync(TTriggerValue value, ValueBindingContext context) in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Triggers\TriggerArgumentBinding\ArraryTriggerArgumentBinding.cs:line 37
   at Microsoft.Azure.WebJobs.Host.Triggers.TriggeredFunctionBinding`1.BindCoreAsync(ValueBindingContext context, Object value, IDictionary`2 parameters) in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Triggers\TriggeredFunctionBinding.cs:line 57
   --- End of inner exception stack trace ---
   at Microsoft.Azure.WebJobs.Host.Executors.DelayedException.Throw() in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Executors\DelayedException.cs:line 27
   at Microsoft.Azure.WebJobs.Host.Executors.FunctionExecutor.ExecuteWithWatchersAsync(IFunctionInstance instance, ParameterHelper parameterHelper, ILogger logger, CancellationTokenSource functionCancellationTokenSource) in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Executors\FunctionExecutor.cs:line 460
   at Microsoft.Azure.WebJobs.Host.Executors.FunctionExecutor.ExecuteWithLoggingAsync(IFunctionInstance instance, ParameterHelper parameterHelper, IFunctionOutputDefinition outputDefinition, ILogger logger, CancellationTokenSource functionCancellationTokenSource) in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Executors\FunctionExecutor.cs:line 426
   at Microsoft.Azure.WebJobs.Host.Executors.FunctionExecutor.ExecuteWithLoggingAsync(IFunctionInstance instance, FunctionStartedMessage message, FunctionInstanceLogEntry instanceLogEntry, ParameterHelper parameterHelper, ILogger logger, CancellationToken cancellationToken) in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Executors\FunctionExecutor.cs:line 231
   --- End of inner exception stack trace ---
   at Microsoft.Azure.WebJobs.Host.Executors.FunctionExecutor.ExecuteWithLoggingAsync(IFunctionInstance instance, FunctionStartedMessage message, FunctionInstanceLogEntry instanceLogEntry, ParameterHelper parameterHelper, ILogger logger, CancellationToken cancellationToken) in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Executors\FunctionExecutor.cs:line 275
   at Microsoft.Azure.WebJobs.Host.Executors.FunctionExecutor.TryExecuteAsync(IFunctionInstance functionInstance, CancellationToken cancellationToken) in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Executors\FunctionExecutor.cs:line 75
fail: Function.eventhub[0]
```
