### PR TITLE
Updating the maxQueryString and maxUrl length for http requests

### DIFF
--- a/src/WebJobs.Script.WebHost/web.config
+++ b/src/WebJobs.Script.WebHost/web.config
@@ -9,6 +9,11 @@
       <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified"/>
     </handlers>
     <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" />
+    <security>
+      <requestFiltering>
+        <requestLimits maxQueryString="4069" maxUrl="8192" maxAllowedContentLength="104857600"/>
+      </requestFiltering>
+    </security>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">


### PR DESCRIPTION
Fixes #3023 

The config handles the response codes as per
https://docs.microsoft.com/en-us/iis/configuration/system.webserver/security/requestfiltering/requestlimits/