### PR TITLE
[WIP] Host offline support (#1521)

### DIFF
--- a/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
+++ b/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
@@ -12,6 +12,11 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="Messages\**" />
+    <EmbeddedResource Remove="Messages\**" />
+    <None Remove="Messages\**" />
+  </ItemGroup>
   
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.5.1" />
@@ -26,10 +31,6 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-  </ItemGroup>
-  
-  <ItemGroup>
-    <Folder Include="Messages\DotNet\" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/WebJobs.Script.WebHost/Controllers/ExtensionsController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/ExtensionsController.cs
@@ -89,8 +89,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         public async Task<IActionResult> GetJobs()
         {
             IEnumerable<ExtensionsRestoreJob> jobs = await GetInProgressJobs();
+
             var jobContent = new { jobs };
             var result = ApiModelUtility.CreateApiModel(jobContent, Request);
+
             return Ok(result);
         }
 
@@ -155,7 +157,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                     { "version", package.Version }
                 }
             };
+
             await SaveJob(job);
+
             return job;
         }
 
@@ -179,6 +183,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
             {
                 basePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".azurefunctions", "extensions");
             }
+
             return basePath;
         }
 
@@ -212,6 +217,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                     }
                 }
             }
+
             return jobs;
         }
     }

--- a/src/WebJobs.Script.WebHost/Models/ExtensionsRestoreJob.cs
+++ b/src/WebJobs.Script.WebHost/Models/ExtensionsRestoreJob.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
 {

--- a/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             builder.UseMiddleware<FunctionInvocationMiddleware>();
             builder.UseMiddleware<HostWarmupMiddleware>();
 
-            builder.UseWhen(context => !context.Request.Path.StartsWithSegments("/admin"), config =>
+            builder.UseWhen(context => !context.Request.Path.StartsWithSegments("/admin") && !context.Request.Path.Equals("/"), config =>
             {
                 config.UseMiddleware<HostAvailabilityCheckMiddleware>();
             });

--- a/src/WebJobs.Script.WebHost/WebJobsServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsServiceCollectionExtensions.cs
@@ -25,7 +25,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
 {
@@ -115,8 +114,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             // Temporary - This should be replaced with a simple type registration.
             builder.Register<IExtensionsManager>(c =>
             {
-                var hostInstance = c.Resolve<WebScriptHostManager>().Instance;
-                return new ExtensionsManager(hostInstance.ScriptConfig.RootScriptPath, hostInstance.Logger, hostInstance.ScriptConfig.NugetFallBackPath);
+                var webHostSettings = c.Resolve<WebHostSettings>();
+                var loggerFactory = c.Resolve<ILoggerFactory>();
+                var logger = loggerFactory.CreateLogger(ScriptConstants.LogCategoryExtensionsController);
+                return new ExtensionsManager(webHostSettings.ScriptPath, logger);
             });
 
             // The services below need to be scoped to a pseudo-tenant (warm/specialized environment)

--- a/src/WebJobs.Script/BindingExtensions/ExtensionsManager.cs
+++ b/src/WebJobs.Script/BindingExtensions/ExtensionsManager.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml;

--- a/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
+++ b/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 throw new ArgumentNullException(nameof(basePath));
             }
 
-            _probingPaths.Add(basePath);
+            AddProbingPath(basePath);
         }
 
         public static FunctionAssemblyLoadContext Shared => _defaultContext.Value;
@@ -181,7 +181,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
                 if (Directory.Exists(directory))
                 {
-                    _probingPaths.Add(directory);
+                    AddProbingPath(directory);
                 }
             }
 
@@ -297,6 +297,14 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
 
             return Path.Combine(basePath, "bin");
+        }
+
+        private void AddProbingPath(string path)
+        {
+            if (!_probingPaths.Contains(path))
+            {
+                _probingPaths.Add(path);
+            }
         }
     }
 }

--- a/src/WebJobs.Script/Host/ScriptHostManager.cs
+++ b/src/WebJobs.Script/Host/ScriptHostManager.cs
@@ -137,9 +137,9 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
-        /// Gets the current state of the host.
+        /// Gets or sets the current state of the host.
         /// </summary>
-        public virtual ScriptHostState State { get; private set; }
+        public virtual ScriptHostState State { get; protected set; }
 
         /// <summary>
         /// Gets the last host <see cref="Exception"/> that has occurred.

--- a/src/WebJobs.Script/Host/ScriptHostState.cs
+++ b/src/WebJobs.Script/Host/ScriptHostState.cs
@@ -23,8 +23,13 @@ namespace Microsoft.Azure.WebJobs.Script
         Running,
 
         /// <summary>
-        /// The host is in an error state
+        /// The host is in an error state.
         /// </summary>
-        Error
+        Error,
+
+        /// <summary>
+        /// The host is offline and will not run.
+        /// </summary>
+        Offline
     }
 }

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string LoggerHttpRequest = "MS_HttpRequest";
 
         public const string LogCategoryHostController = "Host.Controllers.Host";
+        public const string LogCategoryExtensionsController = "Host.Controllers.Extensions";
         public const string LogCategoryFunctionsController = "Host.Controllers.Functions";
         public const string LogCategoryInstanceController = "Host.Controllers.Instance";
         public const string LogCategoryKeysController = "Host.Controllers.Keys";
@@ -86,6 +87,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AdminJwtValidAudienceFormat = "https://{0}.azurewebsites.net/azurefunctions";
         public const string AdminJwtValidIssuerFormat = "https://{0}.scm.azurewebsites.net";
 
+        public const string HostOfflineFileName = "host_offline";
         public const string AzureFunctionsSystemDirectoryName = ".azurefunctions";
         public const string HttpMethodConstraintName = "httpMethod";
         public const string Snapshot = "snapshot";


### PR DESCRIPTION
Creating an early PR for design discussion. Haven't added tests yet.

These changes are intended to address the following issues:

- https://github.com/Azure/azure-functions-host/issues/2548
- https://github.com/Azure/azure-functions-host/issues/2700
- https://github.com/Azure/azure-functions-host/issues/1521

The portal extensions manager can then use the new API added here to install extensions w/o running into file locking issues:

- Portal Extension Install calls `admin/host/offline?isOffline=true` to take the host offline
- Host receives this request, writes a host_offline file to script root dir
- All hosts are watching for creation/deletion of this offline file: 
  - When created (take offline) – web app is recycled, causing the app domain to unload. When the app restarts, it sees the offline file and skips all host startup/init. I.e. in offline mode, no assemblies are loaded from bin, and only our admin type APIs are available (no functions are running).
  - When deleted (bring online) – if the host was offline and this file is deleted, it is brought back online and allowed to initialize normally
- While offline, extension APIs can be called to install one or more extensions. The `admin/host/status` endpoint also returns “Offline” as the host status.
- Once installs are done, app is brought back online by calling `admin/host/offline?isOffline=false`