### PR TITLE
Worker config updates to make path to jave.exe configurable

### DIFF
--- a/src/WebJobs.Script.Grpc/Abstractions/WorkerDescription.cs
+++ b/src/WebJobs.Script.Grpc/Abstractions/WorkerDescription.cs
@@ -12,25 +12,25 @@ namespace Microsoft.Azure.WebJobs.Script.Abstractions
         /// <summary>
         /// Gets or sets the name of the supported language. This is the same name as the IConfiguration section for the worker.
         /// </summary>
-        [JsonProperty(PropertyName = "language", Required = Required.Always)]
+        [JsonProperty(PropertyName = "language")]
         public string Language { get; set; }
 
         /// <summary>
         /// Gets or sets the supported file extension type. Functions are registered with workers based on extension.
         /// </summary>
-        [JsonProperty(PropertyName = "extension", Required = Required.Always)]
+        [JsonProperty(PropertyName = "extension")]
         public string Extension { get; set; }
 
         /// <summary>
         /// Gets or sets the default executable path.
         /// </summary>
-        [JsonProperty(PropertyName = "defaultExecutablePath", Required = Required.Always)]
+        [JsonProperty(PropertyName = "defaultExecutablePath")]
         public string DefaultExecutablePath { get; set; }
 
         /// <summary>
         /// Gets or sets the default path to the worker (relative to the bin/workers/{language} directory)
         /// </summary>
-        [JsonProperty(PropertyName = "defaultWorkerPath", Required = Required.Always)]
+        [JsonProperty(PropertyName = "defaultWorkerPath")]
         public string DefaultWorkerPath { get; set; }
 
         /// <summary>

--- a/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 if (ScriptSettingsManager.Instance.IsAppServiceEnvironment)
                 {
                     //Overwrite default Description with AppServiceEnv profile
-                    workerDescription = GetWorkerDescriptionFromProfiles(LanguageWorkerConstants.AppServiceEnvDescription, descriptionProfiles, workerDescription);
+                    workerDescription = GetWorkerDescriptionFromProfiles(LanguageWorkerConstants.WorkerDescriptionAppServiceEnvProfileName, descriptionProfiles, workerDescription);
                 }
                 GetDefaultExecutablePathFromAppSettings(workerDescription, languageSection);
                 AddArgumentsFromAppSettings(workerDescription, languageSection);

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
@@ -337,11 +337,11 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 // TODO: per language stdout/err parser?
                 if (e.Data != null)
                 {
-                    if (e.Data.IndexOf("warn", StringComparison.OrdinalIgnoreCase) > 0)
+                    if (e.Data.IndexOf("warn", StringComparison.OrdinalIgnoreCase) > -1)
                     {
                         _logger.LogWarning(e.Data);
                     }
-                    else if (e.Data.IndexOf("error", StringComparison.OrdinalIgnoreCase) > 0)
+                    else if (e.Data.IndexOf("error", StringComparison.OrdinalIgnoreCase) > -1)
                     {
                         _logger.LogError(e.Data);
                     }

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
@@ -341,9 +341,13 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                     {
                         _logger.LogWarning(e.Data);
                     }
-                    else
+                    else if (e.Data.IndexOf("error", StringComparison.OrdinalIgnoreCase) > 0)
                     {
                         _logger.LogError(e.Data);
+                    }
+                    else
+                    {
+                        _logger.LogInformation(e.Data);
                     }
                 }
             };
@@ -371,9 +375,9 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                     HandleWorkerError(new Exception("Worker process is not attached"));
                 }
             };
-            _logger.LogInformation($"Starting {process.StartInfo.FileName} language worker process with Arguments={process.StartInfo.Arguments}");
+            _logger.LogInformation($"Starting language worker process: {process.StartInfo.FileName} {process.StartInfo.Arguments}");
             process.Start();
-            _logger.LogInformation($"{process.StartInfo.FileName} process with Id={process.Id} started");
+            _logger.LogInformation($"{process.StartInfo.FileName} process with Id: {process.Id} started");
             process.BeginErrorReadLine();
             process.BeginOutputReadLine();
         }

--- a/src/WebJobs.Script/Rpc/LanguageWorkerConstants.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerConstants.cs
@@ -27,6 +27,6 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         // Profiles
         public const string WorkerDescriptionProfiles = "profiles";
-        public const string AppServiceEnvDescription = "AppServiceEnvironment";
+        public const string WorkerDescriptionAppServiceEnvProfileName = "AppServiceEnvironment";
     }
 }

--- a/src/WebJobs.Script/Rpc/LanguageWorkerConstants.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerConstants.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         public const string FunctionWorkerRuntimeSettingName = "FUNCTIONS_WORKER_RUNTIME";
         public const string DotNetLanguageWorkerName = "dotnet";
         public const string NodeLanguageWorkerName = "node";
+        public const string JavaLanguageWorkerName = "java";
         public const string WorkerConfigFileName = "worker.config.json";
         public const string DefaultWorkersDirectoryName = "workers";
 
@@ -24,8 +25,8 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         public const string WorkerDescription = "Description";
         public const string WorkerDescriptionArguments = "arguments";
 
-        // Java
-        public const string AppServiceEnvJavaVersion = "zulu8.23.0.3-jdk8.0.144-win_x64";
-        public const string JavaLanguageWorkerName = "java";
+        // Profiles
+        public const string WorkerDescriptionProfiles = "profiles";
+        public const string AppServiceEnvDescription = "AppServiceEnvironment";
     }
 }

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -31,7 +31,7 @@
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.5350001-beta-fc119b98" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta8" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta9" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta3" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta7-11351" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.0-beta7-10629" />

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             await InvokeHttpTrigger("HttpTrigger");
         }
 
-        [Fact(Skip = "Investigate test failure")]
+        [Fact]
         public async Task HttpTrigger_Java_Get_Succeeds()
         {
             await InvokeHttpTrigger("HttpTrigger-Java");

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.9.1" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.0.3" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta8" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta9" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta3" />
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="2.0.0" />

--- a/test/WebJobs.Script.Tests/Rpc/GenericWorkerProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/GenericWorkerProviderTests.cs
@@ -172,6 +172,73 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             Assert.Empty(providers);
         }
 
+        [Fact]
+        public void ReadWorkerProviderFromConfig_AddAppSvcProfile_ReturnsAppServiceEnvDescription()
+        {
+            var configBuilder = ScriptSettingsManager.CreateDefaultConfigurationBuilder();
+            var config = configBuilder.Build();
+            var scriptSettingsManager = new ScriptSettingsManager(config);
+            var testEnvVariables = new Dictionary<string, string>
+            {
+                { EnvironmentSettingNames.AzureWebsiteInstanceId, "123" },
+            };
+            using (var variables = new TestScopedSettings(scriptSettingsManager, testEnvVariables))
+            {
+                var expectedArguments = new string[] { "-v", "verbose" };
+                var configs = new List<TestLanguageWorkerConfig>() { MakeTestConfig(testLanguage, expectedArguments, false, LanguageWorkerConstants.AppServiceEnvDescription) };
+                var testLogger = new TestLogger(testLanguage);
+
+                // Creates temp directory w/ worker.config.json and runs ReadWorkerProviderFromConfig
+                IEnumerable<IWorkerProvider> providers = TestReadWorkerProviderFromConfig(configs, testLogger);
+                Assert.Single(providers);
+
+                IWorkerProvider worker = providers.FirstOrDefault();
+                Assert.Equal("myFooPath", worker.GetDescription().DefaultExecutablePath);
+            }
+        }
+
+        [Fact]
+        public void ReadWorkerProviderFromConfig_AddProfile_ReturnsDefaultDescription()
+        {
+            var configBuilder = ScriptSettingsManager.CreateDefaultConfigurationBuilder();
+            var config = configBuilder.Build();
+            var scriptSettingsManager = new ScriptSettingsManager(config);
+            var testEnvVariables = new Dictionary<string, string>
+            {
+                { EnvironmentSettingNames.AzureWebsiteInstanceId, "123" },
+            };
+            using (var variables = new TestScopedSettings(scriptSettingsManager, testEnvVariables))
+            {
+                var expectedArguments = new string[] { "-v", "verbose" };
+                var configs = new List<TestLanguageWorkerConfig>() { MakeTestConfig(testLanguage, expectedArguments, false, "TestProfile") };
+                var testLogger = new TestLogger(testLanguage);
+
+                // Creates temp directory w/ worker.config.json and runs ReadWorkerProviderFromConfig
+                IEnumerable<IWorkerProvider> providers = TestReadWorkerProviderFromConfig(configs, testLogger);
+                Assert.Single(providers);
+
+                IWorkerProvider worker = providers.FirstOrDefault();
+                Assert.Equal("foopath", worker.GetDescription().DefaultExecutablePath);
+            }
+        }
+
+        [Fact]
+        public void ReadWorkerProviderFromConfig_AddProfile_OverrideDefaultExePath_AppSetting()
+        {
+            var configs = new List<TestLanguageWorkerConfig>() { MakeTestConfig(testLanguage, new string[0], false, LanguageWorkerConstants.AppServiceEnvDescription) };
+            var testLogger = new TestLogger(testLanguage);
+            var testExePath = "./mySrc/myIndex";
+            Dictionary<string, string> keyValuePairs = new Dictionary<string, string>
+            {
+                [$"{LanguageWorkerConstants.LanguageWorkersSectionName}:{testLanguage}:{LanguageWorkerConstants.WorkerDescriptionDefaultExecutablePath}"] = testExePath
+            };
+            var providers = TestReadWorkerProviderFromConfig(configs, new TestLogger(testLanguage), null, keyValuePairs);
+            Assert.Single(providers);
+
+            IWorkerProvider worker = providers.FirstOrDefault();
+            Assert.Equal(testExePath, worker.GetDescription().DefaultExecutablePath);
+        }
+
         private IEnumerable<IWorkerProvider> TestReadWorkerProviderFromConfig(IEnumerable<TestLanguageWorkerConfig> configs, ILogger testLogger, string language = null, Dictionary<string, string> keyValuePairs = null)
         {
             var workerPathSection = $"{LanguageWorkerConstants.LanguageWorkersSectionName}:{LanguageWorkerConstants.WorkersDirectorySectionName}";
@@ -187,8 +254,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
                 var scriptHostConfig = new ScriptHostConfiguration();
                 var scriptSettingsManager = new ScriptSettingsManager(config);
                 var configFactory = new WorkerConfigFactory(config, testLogger);
+                var testEnvVariables = new Dictionary<string, string>
+            {
+                { EnvironmentSettingNames.AzureWebsiteInstanceId, "123" },
+            };
+                using (var variables = new TestScopedSettings(scriptSettingsManager, testEnvVariables))
+                {
+                    return configFactory.GetWorkerProviders(testLogger, scriptSettingsManager, language: language);
+                }
 
-                return configFactory.GetWorkerProviders(testLogger, scriptSettingsManager, language: language);
             }
             finally
             {
@@ -240,9 +314,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             return config;
         }
 
-        private static TestLanguageWorkerConfig MakeTestConfig(string language, string[] arguments, bool invalid = false)
+        private static TestLanguageWorkerConfig MakeTestConfig(string language, string[] arguments, bool invalid = false, string addAppSvcProfile = "")
         {
-            string json = GetTestWorkerConfig(language, arguments, invalid).ToString();
+            string json = GetTestWorkerConfig(language, arguments, invalid, addAppSvcProfile).ToString();
             return new TestLanguageWorkerConfig()
             {
                 Json = json,
@@ -250,7 +324,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             };
         }
 
-        private static JObject GetTestWorkerConfig(string language, string[] arguments, bool invalid)
+        private static JObject GetTestWorkerConfig(string language, string[] arguments, bool invalid, string profileName)
         {
             var description = new WorkerDescription()
             {
@@ -263,6 +337,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
 
             JObject config = new JObject();
             config["Description"] = JObject.FromObject(description);
+
+            if (!string.IsNullOrEmpty(profileName))
+            {
+                var appSvcDescription = new WorkerDescription()
+                {
+                    DefaultExecutablePath = "myFooPath",
+                };
+
+                JObject profiles = new JObject();
+                profiles[profileName] = JObject.FromObject(appSvcDescription);
+                config[LanguageWorkerConstants.WorkerDescriptionProfiles] = profiles;
+            }
+
             if (invalid)
             {
                 config["Description"] = "invalidWorkerConfig";

--- a/test/WebJobs.Script.Tests/Rpc/GenericWorkerProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/GenericWorkerProviderTests.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         public void ReadWorkerProviderFromConfig_AddAppSvcProfile_ReturnsAppServiceEnvDescription()
         {
             var expectedArguments = new string[] { "-v", "verbose" };
-            var configs = new List<TestLanguageWorkerConfig>() { MakeTestConfig(testLanguage, expectedArguments, false, LanguageWorkerConstants.AppServiceEnvDescription) };
+            var configs = new List<TestLanguageWorkerConfig>() { MakeTestConfig(testLanguage, expectedArguments, false, LanguageWorkerConstants.WorkerDescriptionAppServiceEnvProfileName) };
             var testLogger = new TestLogger(testLanguage);
 
             // Creates temp directory w/ worker.config.json and runs ReadWorkerProviderFromConfig
@@ -205,7 +205,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         [Fact]
         public void ReadWorkerProviderFromConfig_OverrideDefaultExePath()
         {
-            var configs = new List<TestLanguageWorkerConfig>() { MakeTestConfig(testLanguage, new string[0], false, LanguageWorkerConstants.AppServiceEnvDescription) };
+            var configs = new List<TestLanguageWorkerConfig>() { MakeTestConfig(testLanguage, new string[0], false, LanguageWorkerConstants.WorkerDescriptionAppServiceEnvProfileName) };
             var testLogger = new TestLogger(testLanguage);
             var testExePath = "./mySrc/myIndex";
             Dictionary<string, string> keyValuePairs = new Dictionary<string, string>

--- a/test/WebJobs.Script.Tests/Rpc/GenericWorkerProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/GenericWorkerProviderTests.cs
@@ -175,55 +175,35 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         [Fact]
         public void ReadWorkerProviderFromConfig_AddAppSvcProfile_ReturnsAppServiceEnvDescription()
         {
-            var configBuilder = ScriptSettingsManager.CreateDefaultConfigurationBuilder();
-            var config = configBuilder.Build();
-            var scriptSettingsManager = new ScriptSettingsManager(config);
-            var testEnvVariables = new Dictionary<string, string>
-            {
-                { EnvironmentSettingNames.AzureWebsiteInstanceId, "123" },
-            };
-            using (var variables = new TestScopedSettings(scriptSettingsManager, testEnvVariables))
-            {
-                var expectedArguments = new string[] { "-v", "verbose" };
-                var configs = new List<TestLanguageWorkerConfig>() { MakeTestConfig(testLanguage, expectedArguments, false, LanguageWorkerConstants.AppServiceEnvDescription) };
-                var testLogger = new TestLogger(testLanguage);
+            var expectedArguments = new string[] { "-v", "verbose" };
+            var configs = new List<TestLanguageWorkerConfig>() { MakeTestConfig(testLanguage, expectedArguments, false, LanguageWorkerConstants.AppServiceEnvDescription) };
+            var testLogger = new TestLogger(testLanguage);
 
-                // Creates temp directory w/ worker.config.json and runs ReadWorkerProviderFromConfig
-                IEnumerable<IWorkerProvider> providers = TestReadWorkerProviderFromConfig(configs, testLogger);
-                Assert.Single(providers);
+            // Creates temp directory w/ worker.config.json and runs ReadWorkerProviderFromConfig
+            IEnumerable<IWorkerProvider> providers = TestReadWorkerProviderFromConfig(configs, testLogger, null, null, true);
+            Assert.Single(providers);
 
-                IWorkerProvider worker = providers.FirstOrDefault();
-                Assert.Equal("myFooPath", worker.GetDescription().DefaultExecutablePath);
-            }
+            IWorkerProvider worker = providers.FirstOrDefault();
+            Assert.Equal("myFooPath", worker.GetDescription().DefaultExecutablePath);
         }
 
         [Fact]
         public void ReadWorkerProviderFromConfig_AddProfile_ReturnsDefaultDescription()
         {
-            var configBuilder = ScriptSettingsManager.CreateDefaultConfigurationBuilder();
-            var config = configBuilder.Build();
-            var scriptSettingsManager = new ScriptSettingsManager(config);
-            var testEnvVariables = new Dictionary<string, string>
-            {
-                { EnvironmentSettingNames.AzureWebsiteInstanceId, "123" },
-            };
-            using (var variables = new TestScopedSettings(scriptSettingsManager, testEnvVariables))
-            {
-                var expectedArguments = new string[] { "-v", "verbose" };
-                var configs = new List<TestLanguageWorkerConfig>() { MakeTestConfig(testLanguage, expectedArguments, false, "TestProfile") };
-                var testLogger = new TestLogger(testLanguage);
+            var expectedArguments = new string[] { "-v", "verbose" };
+            var configs = new List<TestLanguageWorkerConfig>() { MakeTestConfig(testLanguage, expectedArguments, false, "TestProfile") };
+            var testLogger = new TestLogger(testLanguage);
 
-                // Creates temp directory w/ worker.config.json and runs ReadWorkerProviderFromConfig
-                IEnumerable<IWorkerProvider> providers = TestReadWorkerProviderFromConfig(configs, testLogger);
-                Assert.Single(providers);
+            // Creates temp directory w/ worker.config.json and runs ReadWorkerProviderFromConfig
+            IEnumerable<IWorkerProvider> providers = TestReadWorkerProviderFromConfig(configs, testLogger);
+            Assert.Single(providers);
 
-                IWorkerProvider worker = providers.FirstOrDefault();
-                Assert.Equal("foopath", worker.GetDescription().DefaultExecutablePath);
-            }
+            IWorkerProvider worker = providers.FirstOrDefault();
+            Assert.Equal("foopath", worker.GetDescription().DefaultExecutablePath);
         }
 
         [Fact]
-        public void ReadWorkerProviderFromConfig_AddProfile_OverrideDefaultExePath_AppSetting()
+        public void ReadWorkerProviderFromConfig_OverrideDefaultExePath()
         {
             var configs = new List<TestLanguageWorkerConfig>() { MakeTestConfig(testLanguage, new string[0], false, LanguageWorkerConstants.AppServiceEnvDescription) };
             var testLogger = new TestLogger(testLanguage);
@@ -232,14 +212,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             {
                 [$"{LanguageWorkerConstants.LanguageWorkersSectionName}:{testLanguage}:{LanguageWorkerConstants.WorkerDescriptionDefaultExecutablePath}"] = testExePath
             };
-            var providers = TestReadWorkerProviderFromConfig(configs, new TestLogger(testLanguage), null, keyValuePairs);
+            var providers = TestReadWorkerProviderFromConfig(configs, new TestLogger(testLanguage), null, keyValuePairs, true);
             Assert.Single(providers);
 
             IWorkerProvider worker = providers.FirstOrDefault();
             Assert.Equal(testExePath, worker.GetDescription().DefaultExecutablePath);
         }
 
-        private IEnumerable<IWorkerProvider> TestReadWorkerProviderFromConfig(IEnumerable<TestLanguageWorkerConfig> configs, ILogger testLogger, string language = null, Dictionary<string, string> keyValuePairs = null)
+        private IEnumerable<IWorkerProvider> TestReadWorkerProviderFromConfig(IEnumerable<TestLanguageWorkerConfig> configs, ILogger testLogger, string language = null, Dictionary<string, string> keyValuePairs = null, bool appSvcEnv = false)
         {
             var workerPathSection = $"{LanguageWorkerConstants.LanguageWorkersSectionName}:{LanguageWorkerConstants.WorkersDirectorySectionName}";
             try
@@ -254,15 +234,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
                 var scriptHostConfig = new ScriptHostConfiguration();
                 var scriptSettingsManager = new ScriptSettingsManager(config);
                 var configFactory = new WorkerConfigFactory(config, testLogger);
-                var testEnvVariables = new Dictionary<string, string>
-            {
-                { EnvironmentSettingNames.AzureWebsiteInstanceId, "123" },
-            };
-                using (var variables = new TestScopedSettings(scriptSettingsManager, testEnvVariables))
+                if (appSvcEnv)
                 {
-                    return configFactory.GetWorkerProviders(testLogger, scriptSettingsManager, language: language);
+                    var testEnvVariables = new Dictionary<string, string>
+                    {
+                        { EnvironmentSettingNames.AzureWebsiteInstanceId, "123" },
+                    };
+                    using (var variables = new TestScopedSettings(scriptSettingsManager, testEnvVariables))
+                    {
+                        return configFactory.GetWorkerProviders(testLogger, scriptSettingsManager, language: language);
+                    }
                 }
-
+                return configFactory.GetWorkerProviders(testLogger, scriptSettingsManager, language: language);
             }
             finally
             {

--- a/test/WebJobs.Script.Tests/Rpc/WorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/WorkerConfigFactoryTests.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using Microsoft.Azure.WebJobs.Script.Abstractions;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Rpc;
 using Microsoft.Extensions.Configuration;
@@ -75,7 +73,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             };
             using (var variables = new TestScopedSettings(scriptSettingsManager, testEnvVariables))
             {
-                var javaPath = configFactory.GetExecutablePathForJava();
+                var javaPath = configFactory.GetExecutablePathForJava("../../zulu8.23.0.3-jdk8.0.144-win_x64/bin/java");
                 Assert.Equal(@"D:\Program Files\Java\zulu8.23.0.3-jdk8.0.144-win_x64\bin\java", javaPath);
             }
         }
@@ -98,7 +96,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             };
             using (var variables = new TestScopedSettings(scriptSettingsManager, testEnvVariables))
             {
-                var javaPath = configFactory.GetExecutablePathForJava();
+                var javaPath = configFactory.GetExecutablePathForJava("java");
                 Assert.Equal(@"D:\Program Files\Java\jdk1.7.0_51\bin\java", javaPath);
             }
         }
@@ -121,7 +119,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             };
             using (var variables = new TestScopedSettings(scriptSettingsManager, testEnvVariables))
             {
-                var javaPath = configFactory.GetExecutablePathForJava();
+                var javaPath = configFactory.GetExecutablePathForJava("java");
                 Assert.Equal("java", javaPath);
             }
         }


### PR DESCRIPTION
- Added support to provide worker description profiles
- Added support to override default worker process path by specifying app setting languageWorkers:language:defaultExecutablePath

Fixes #3187, Fixes #3048