### PR TITLE
Add support to configure java.exe by specifying full path

### DIFF
--- a/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         internal string GetExecutablePathForJava(string defaultExecutablePath)
         {
                 string javaHome = ScriptSettingsManager.Instance.GetSetting("JAVA_HOME");
-                if (string.IsNullOrEmpty(javaHome))
+                if (string.IsNullOrEmpty(javaHome) || Path.IsPathRooted(defaultExecutablePath))
                 {
                     return defaultExecutablePath;
                 }

--- a/test/WebJobs.Script.Tests/Rpc/WorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/WorkerConfigFactoryTests.cs
@@ -102,6 +102,29 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         }
 
         [Fact]
+        public void JavaPath_JavaHome_Set_DefaultExePathSet()
+        {
+            var configBuilder = ScriptSettingsManager.CreateDefaultConfigurationBuilder()
+                  .AddInMemoryCollection(new Dictionary<string, string>
+                  {
+                      ["languageWorker"] = "test"
+                  });
+            var config = configBuilder.Build();
+            var scriptSettingsManager = new ScriptSettingsManager(config);
+            var testLogger = new TestLogger("test");
+            var configFactory = new WorkerConfigFactory(config, testLogger);
+            var testEnvVariables = new Dictionary<string, string>
+            {
+                { "JAVA_HOME", @"D:\Program Files\Java\jdk1.7.0_51" }
+            };
+            using (var variables = new TestScopedSettings(scriptSettingsManager, testEnvVariables))
+            {
+                var javaPath = configFactory.GetExecutablePathForJava(@"D:\MyCustomPath\Java");
+                Assert.Equal(@"D:\MyCustomPath\Java", javaPath);
+            }
+        }
+
+        [Fact]
         public void JavaPath_JavaHome_NotSet()
         {
             var configBuilder = ScriptSettingsManager.CreateDefaultConfigurationBuilder()


### PR DESCRIPTION
Users can now configure path to java.exe by specifying an appsetting 

| APP SETTING NAME  | VALUE |
| ------------- | ------------- |
| languageWorkers:java:defaultExecutablePath   | ../../../../Home/Site/Tools/bin/java  |   

**Note: Value is relative to JAVA_HOME path.**

This fix adds support to just specify full path