### PR TITLE
Adding a service to manage proxy metadata creation.

### DIFF
--- a/src/WebJobs.Script.WebHost/Configuration/WebScriptHostConfigurationSource.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/WebScriptHostConfigurationSource.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
 
             public override void Load()
             {
-                Data[SelfHostProperty] = (_configurationSource.IsAppServiceEnvironment && !_configurationSource.IsLinuxContainerEnvironment).ToString();
+                Data[SelfHostProperty] = (!_configurationSource.IsAppServiceEnvironment && !_configurationSource.IsLinuxContainerEnvironment).ToString();
 
                 if (_configurationSource.IsAppServiceEnvironment)
                 {

--- a/src/WebJobs.Script/Host/IProxyMetadataManager.cs
+++ b/src/WebJobs.Script/Host/IProxyMetadataManager.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Text;
+
+namespace Microsoft.Azure.WebJobs.Script
+{
+    public interface IProxyMetadataManager
+    {
+        ProxyMetadataInfo ProxyMedatada { get; }
+    }
+}

--- a/src/WebJobs.Script/Host/ProxyMetadataInfo.cs
+++ b/src/WebJobs.Script/Host/ProxyMetadataInfo.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.Azure.WebJobs.Script.Description;
+
+namespace Microsoft.Azure.WebJobs.Script
+{
+    public class ProxyMetadataInfo
+    {
+        public ProxyMetadataInfo(ImmutableArray<FunctionMetadata> functions, ImmutableDictionary<string, ImmutableArray<string>> errors, ProxyClientExecutor client)
+        {
+            Functions = functions;
+            Errors = errors;
+            ProxyClient = client;
+        }
+
+        public ImmutableArray<FunctionMetadata> Functions { get; }
+
+        public ImmutableDictionary<string, ImmutableArray<string>> Errors { get; }
+
+        public ProxyClientExecutor ProxyClient { get; }
+    }
+}

--- a/src/WebJobs.Script/Host/ProxyMetadataManager.cs
+++ b/src/WebJobs.Script/Host/ProxyMetadataManager.cs
@@ -1,0 +1,142 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.Azure.AppService.Proxy.Client;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Script
+{
+    public class ProxyMetadataManager : IProxyMetadataManager
+    {
+        private static readonly Regex ProxyNameValidationRegex = new Regex(@"[^a-zA-Z0-9_-]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private readonly Lazy<ProxyMetadataInfo> _metadata;
+        private readonly IOptions<ScriptJobHostOptions> _scriptOptions;
+        private readonly IEnvironment _environment;
+        private readonly ILogger _logger;
+
+        public ProxyMetadataManager(IOptions<ScriptJobHostOptions> scriptOptions, IEnvironment environment, ILoggerFactory loggerFactory)
+        {
+            _scriptOptions = scriptOptions;
+            _environment = environment;
+            _logger = loggerFactory.CreateLogger(LogCategories.Startup);
+            _metadata = new Lazy<ProxyMetadataInfo>(LoadFunctionMetadata);
+        }
+
+        public ProxyMetadataInfo ProxyMedatada => _metadata.Value;
+
+        private ProxyMetadataInfo LoadFunctionMetadata()
+        {
+            var functionErrors = new Dictionary<string, ICollection<string>>();
+            (Collection<FunctionMetadata> proxies, ProxyClientExecutor client) = ReadProxyMetadata(functionErrors);
+
+            ImmutableArray<FunctionMetadata> metadata;
+            if (proxies != null && proxies.Any())
+            {
+                metadata = proxies.ToImmutableArray();
+            }
+
+            var errors = functionErrors.ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray());
+            return new ProxyMetadataInfo(metadata, errors, client);
+        }
+
+        internal (Collection<FunctionMetadata>, ProxyClientExecutor) ReadProxyMetadata(Dictionary<string, ICollection<string>> functionErrors)
+        {
+            // read the proxy config
+            string proxyConfigPath = Path.Combine(_scriptOptions.Value.RootScriptPath, ScriptConstants.ProxyMetadataFileName);
+            if (!File.Exists(proxyConfigPath))
+            {
+                return (null, null);
+            }
+
+            var proxyAppSettingValue = _environment.GetEnvironmentVariable(EnvironmentSettingNames.ProxySiteExtensionEnabledKey);
+
+            // This is for backward compatibility only, if the file is present but the value of proxy app setting(ROUTING_EXTENSION_VERSION) is explicitly set to 'disabled' we will ignore loading the proxies.
+            if (!string.IsNullOrWhiteSpace(proxyAppSettingValue) && proxyAppSettingValue.Equals("disabled", StringComparison.OrdinalIgnoreCase))
+            {
+                return (null, null);
+            }
+
+            string proxiesJson = File.ReadAllText(proxyConfigPath);
+
+            if (!string.IsNullOrWhiteSpace(proxiesJson))
+            {
+                return LoadProxyMetadata(proxiesJson, functionErrors);
+            }
+
+            return (null, null);
+        }
+
+        private (Collection<FunctionMetadata>, ProxyClientExecutor) LoadProxyMetadata(string proxiesJson, Dictionary<string, ICollection<string>> functionErrors)
+        {
+            var proxies = new Collection<FunctionMetadata>();
+            ProxyClientExecutor client = null;
+
+            var rawProxyClient = ProxyClientFactory.Create(proxiesJson, _logger);
+            if (rawProxyClient != null)
+            {
+                client = new ProxyClientExecutor(rawProxyClient);
+            }
+
+            if (client == null)
+            {
+                return (proxies, null);
+            }
+
+            var routes = client.GetProxyData();
+
+            foreach (var route in routes.Routes)
+            {
+                try
+                {
+                    // Proxy names should follow the same naming restrictions as in function names. If not, invalid characters will be removed.
+                    var proxyName = NormalizeProxyName(route.Name);
+
+                    var proxyMetadata = new FunctionMetadata();
+
+                    var json = new JObject
+                    {
+                        { "authLevel", "anonymous" },
+                        { "name", "req" },
+                        { "type", "httptrigger" },
+                        { "direction", "in" },
+                        { "Route", route.UrlTemplate.TrimStart('/') },
+                        { "Methods",  new JArray(route.Methods.Select(m => m.Method.ToString()).ToArray()) }
+                    };
+
+                    BindingMetadata bindingMetadata = BindingMetadata.Create(json);
+
+                    proxyMetadata.Bindings.Add(bindingMetadata);
+
+                    proxyMetadata.Name = proxyName;
+                    proxyMetadata.ScriptType = ScriptType.Unknown;
+                    proxyMetadata.IsProxy = true;
+
+                    proxies.Add(proxyMetadata);
+                }
+                catch (Exception ex)
+                {
+                    // log any unhandled exceptions and continue
+                    Utility.AddFunctionError(functionErrors, route.Name, Utility.FlattenException(ex, includeSource: false), isFunctionShortName: true);
+                }
+            }
+
+            return (proxies, client);
+        }
+
+        internal static string NormalizeProxyName(string name)
+        {
+            return ProxyNameValidationRegex.Replace(name, string.Empty);
+        }
+    }
+}

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -91,6 +91,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 services.AddSingleton<IScriptJobHost>(p => p.GetRequiredService<ScriptHost>());
                 services.AddSingleton<IJobHost>(p => p.GetRequiredService<ScriptHost>());
                 services.AddSingleton<IFunctionMetadataManager, FunctionMetadataManager>();
+                services.AddSingleton<IProxyMetadataManager, ProxyMetadataManager>();
                 services.AddSingleton<ITypeLocator, ScriptTypeLocator>();
                 services.AddSingleton<IHostIdProvider, ScriptHostIdProvider>();
                 services.AddSingleton<ScriptSettingsManager>();

--- a/test/WebJobs.Script.Tests/Description/Proxy/ProxyFunctionDescriptorProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/Proxy/ProxyFunctionDescriptorProviderTests.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -32,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         private readonly ScriptSettingsManager _settingsManager;
         private readonly IHost _host;
         private readonly ProxyClientExecutor _proxyClient;
-        private Collection<FunctionMetadata> _metadataCollection;
+        private ImmutableArray<FunctionMetadata> _metadataCollection;
 
         public ProxyFunctionDescriptorProviderTests()
         {
@@ -59,7 +61,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public async Task InitializeAsync()
         {
             await _scriptHost.StartAsync();
-            _metadataCollection = _scriptHost.ReadProxyMetadata(_scriptHost.ScriptOptions, _settingsManager);
+
+            _metadataCollection = _host.Services.GetService<IProxyMetadataManager>()
+                .ProxyMedatada.Functions;
         }
 
         public async Task DisposeAsync()

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -1028,7 +1028,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [InlineData("my proxy %")]
         public void UpdateProxyName(string proxyName)
         {
-            Assert.Equal("myproxy", ScriptHost.NormalizeProxyName(proxyName));
+            Assert.Equal("myproxy", ProxyMetadataManager.NormalizeProxyName(proxyName));
         }
 
 #if WEBROUTING


### PR DESCRIPTION
This addresses an issue on how the proxies metadata is managed, which allows other services to have access to that information without requiring a dependency on the script host.