### PR TITLE
App Offline support

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/ExtensionsController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/ExtensionsController.cs
@@ -89,8 +89,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         public async Task<IActionResult> GetJobs()
         {
             IEnumerable<ExtensionsRestoreJob> jobs = await GetInProgressJobs();
+
             var jobContent = new { jobs };
             var result = ApiModelUtility.CreateApiModel(jobContent, Request);
+
             return Ok(result);
         }
 
@@ -155,7 +157,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                     { "version", package.Version }
                 }
             };
+
             await SaveJob(job);
+
             return job;
         }
 
@@ -171,6 +175,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         {
             string home = _settingsManager.GetSetting(EnvironmentSettingNames.AzureWebsiteHomePath);
             string basePath = null;
+
             if (!string.IsNullOrEmpty(home))
             {
                 basePath = Path.Combine(home, "data", "Functions", "extensions");
@@ -200,6 +205,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         {
             var jobPaths = await FileUtility.GetFilesAsync(GetJobBasePath(), "*.json");
             List<ExtensionsRestoreJob> jobs = new List<ExtensionsRestoreJob>();
+
             foreach (var jobPath in jobPaths)
             {
                 if (System.IO.File.Exists(jobPath))
@@ -212,6 +218,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                     }
                 }
             }
+
             return jobs;
         }
     }

--- a/src/WebJobs.Script.WebHost/Extensions/HttpResponseExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Extensions/HttpResponseExtensions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Http
+{
+    public static class HttpResponseExtensions
+    {
+        public static bool HasStarted(this HttpResponse response)
+        {
+            // TODO - remove the need for this
+            // in some cases HttpResponse.HasStarted isn't returning the correct
+            // value. This extension is a workaround.
+            if (response.HasStarted || response.ContentLength > 0 || (response.Body != null && response.Body.Length > 0))
+            {
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Middleware/FunctionInvocationMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/FunctionInvocationMiddleware.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
             }
 
             IFunctionExecutionFeature functionExecution = context.Features.Get<IFunctionExecutionFeature>();
-            if (functionExecution != null && !context.Response.HasStarted)
+            if (functionExecution != null && !context.Response.HasStarted())
             {
                 int nestedProxiesCount = GetNestedProxiesCount(context, functionExecution);
                 IActionResult result = await GetResultAsync(context, functionExecution);

--- a/src/WebJobs.Script.WebHost/Middleware/HomepageMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/HomepageMiddleware.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
                     };
                 }
 
-                if (!context.Response.HasStarted)
+                if (!context.Response.HasStarted())
                 {
                     var actionContext = new ActionContext
                     {

--- a/src/WebJobs.Script.WebHost/Middleware/HostAvailabilityCheckMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/HostAvailabilityCheckMiddleware.cs
@@ -1,9 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.IO;
+using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
 {
@@ -11,33 +15,46 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
     {
         private readonly RequestDelegate _next;
         private readonly ILogger<HostAvailabilityCheckMiddleware> _logger;
+        private readonly IOptions<ScriptApplicationHostOptions> _applicationHostOptions;
 
-        public HostAvailabilityCheckMiddleware(RequestDelegate next, ILoggerFactory loggerFactory)
+        public HostAvailabilityCheckMiddleware(RequestDelegate next, ILoggerFactory loggerFactory, IOptions<ScriptApplicationHostOptions> applicationHostOptions)
         {
             _next = next;
             _logger = loggerFactory.CreateLogger<HostAvailabilityCheckMiddleware>();
+            _applicationHostOptions = applicationHostOptions;
         }
 
         public async Task Invoke(HttpContext httpContext, IScriptHostManager scriptHostManager)
         {
-            using (Logger.VerifyingHostAvailabilityScope(_logger, httpContext.TraceIdentifier))
+            if (scriptHostManager.State != ScriptHostState.Offline)
             {
-                Logger.InitiatingHostAvailabilityCheck(_logger);
-
-                bool hostReady = await scriptHostManager.DelayUntilHostReady();
-                if (!hostReady)
+                using (Logger.VerifyingHostAvailabilityScope(_logger, httpContext.TraceIdentifier))
                 {
-                    Logger.HostUnavailableAfterCheck(_logger);
+                    Logger.InitiatingHostAvailabilityCheck(_logger);
 
-                    httpContext.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
-                    await httpContext.Response.WriteAsync("Function host is not running.");
+                    bool hostReady = await scriptHostManager.DelayUntilHostReady();
+                    if (!hostReady)
+                    {
+                        Logger.HostUnavailableAfterCheck(_logger);
 
-                    return;
+                        httpContext.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                        await httpContext.Response.WriteAsync("Function host is not running.");
+
+                        return;
+                    }
+
+                    Logger.HostAvailabilityCheckSucceeded(_logger);
+
+                    await _next.Invoke(httpContext);
                 }
-
-                Logger.HostAvailabilityCheckSucceeded(_logger);
-
-                await _next.Invoke(httpContext);
+            }
+            else
+            {
+                // host is offline so return the app_offline.htm file content
+                var offlineFilePath = Path.Combine(_applicationHostOptions.Value.ScriptPath, ScriptConstants.AppOfflineFileName);
+                httpContext.Response.ContentType = "text/html";
+                httpContext.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                await httpContext.Response.SendFileAsync(offlineFilePath);
             }
         }
     }

--- a/src/WebJobs.Script.WebHost/Resources/app_offline.htm
+++ b/src/WebJobs.Script.WebHost/Resources/app_offline.htm
@@ -1,0 +1,136 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" >
+<head>
+    <title>Host Offline</title>
+    <style type="text/css">
+        * {
+            margin: 0;
+            padding: 0;
+        }
+
+        a {
+            text-decoration: underline;
+            color: #FF381A;
+        }
+
+        a:hover {
+            text-decoration: none;
+        }
+
+        body {
+            line-height: 1.75em;
+            background: #fff;
+            font-size: 11.5pt;
+            color: #5A6466;
+        }
+
+        body,input {
+            font-family: Kreon, serif;
+        }
+
+        br.clearfix {
+            clear: both;
+        }
+
+        h1,h2,h3,h4 {
+            text-transform: uppercase;
+            font-weight: normal;
+        }
+
+        h2 {
+            font-size: 1.5em;
+        }
+
+        h2,h3,h4 {
+            font-family: "Open Sans", sans-serif;
+            color: #2A3436;
+            margin-bottom: 1em;
+        }
+
+        h3 {
+            font-size: 1.25em;
+        }
+
+        h4 {
+            font-size: 1em;
+        }
+
+        img.alignleft {
+            float: left;
+            margin: 5px 30px 20px 0;
+        }
+
+        img.aligntop {
+            margin: 5px 0 20px 0;
+        }
+
+        p {
+            margin-bottom: 1.5em;
+        }
+
+        a {
+            color: #2A3436;
+        }
+
+        .box {
+            margin: 0 0 250px 0;
+        }
+
+        img.alignleft {
+            float: left;
+            margin: 5px 30px 30px 0;
+            border-radius: 6px;
+        }
+
+        img.aligntop {
+            margin: 5px 0 20px 0;
+            border-radius: 6px;
+        }
+
+        #content {
+            padding: 0;
+            width: 815px;
+            margin: 0 0 0 0px;
+        }
+
+
+        #page {
+            margin: 0;
+            position: relative;
+            width: 900px;
+            padding: 20px 40px 0 40px;
+        }
+
+
+        #wrapper {
+            width: 978px;
+            position: relative;
+            background: #FFF;
+            margin: 0 auto 0 auto;
+            box-shadow: 0px 0px 300px 0px rgba(0,0,0,0.15);
+            border: solid 1px #82A7AD;
+            
+        }
+
+        
+    </style>
+</head>
+<body>
+    <div>&nbsp;</div>
+    <div id="wrapper">
+        
+        <div id="page">
+            <div id="content">
+
+                <div class="box">
+                    <h2>This Azure Functions app is down for maintenance</h2>
+                    <p>
+                        Host is offline
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+</body>
+</html>

--- a/src/WebJobs.Script.WebHost/StandbyManager.cs
+++ b/src/WebJobs.Script.WebHost/StandbyManager.cs
@@ -4,11 +4,9 @@
 using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
@@ -59,27 +57,17 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 FileUtility.DeleteDirectoryAsync(scriptPath, true).GetAwaiter().GetResult();
                 FileUtility.EnsureDirectoryExists(scriptPath);
 
-                string content = ReadResourceString("Functions.host.json");
+                string content = FileUtility.ReadResourceString($"{ScriptConstants.ResourcePath}.Functions.Functions.host.json");
                 File.WriteAllText(Path.Combine(scriptPath, "host.json"), content);
 
                 string functionPath = Path.Combine(scriptPath, WarmUpFunctionName);
                 Directory.CreateDirectory(functionPath);
-                content = ReadResourceString($"Functions.{WarmUpFunctionName}.function.json");
+                content = FileUtility.ReadResourceString($"{ScriptConstants.ResourcePath}.Functions.{WarmUpFunctionName}.function.json");
                 File.WriteAllText(Path.Combine(functionPath, "function.json"), content);
-                content = ReadResourceString($"Functions.{WarmUpFunctionName}.run.csx");
+                content = FileUtility.ReadResourceString($"{ScriptConstants.ResourcePath}.Functions.{WarmUpFunctionName}.run.csx");
                 File.WriteAllText(Path.Combine(functionPath, "run.csx"), content);
 
                 logger.LogInformation($"StandbyMode placeholder function directory created");
-            }
-        }
-
-        private static string ReadResourceString(string fileName)
-        {
-            string resourcePath = string.Format("Microsoft.Azure.WebJobs.Script.WebHost.Resources.{0}", fileName);
-            Assembly assembly = Assembly.GetExecutingAssembly();
-            using (StreamReader reader = new StreamReader(assembly.GetManifestResourceStream(resourcePath)))
-            {
-                return reader.ReadToEnd();
             }
         }
     }

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Remove="applicationHost.xdt" />
+    <None Remove="Resources\app_offline.htm" />
     <None Remove="Resources\Functions\WarmUp\run.csx" />
     <None Remove="web.InProcess.win-x64.xdt" />
     <None Remove="web.InProcess.win-x86.xdt" />
@@ -65,6 +66,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Home.html" />
+    <EmbeddedResource Include="Resources\app_offline.htm" />
     <EmbeddedResource Include="Resources\Functions\host.json" />
     <EmbeddedResource Include="Resources\Functions\WarmUp\function.json" />
     <EmbeddedResource Include="Resources\Functions\WarmUp\run.csx" />

--- a/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
@@ -20,14 +20,14 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
     {
         private readonly ILogger _logger;
 
-        public HostJsonFileConfigurationSource(IOptions<ScriptApplicationHostOptions> scriptHostOptions, ILoggerFactory loggerFactory)
+        public HostJsonFileConfigurationSource(IOptions<ScriptApplicationHostOptions> applicationHostOptions, ILoggerFactory loggerFactory)
         {
             if (loggerFactory == null)
             {
                 throw new ArgumentNullException(nameof(loggerFactory));
             }
 
-            HostOptions = scriptHostOptions;
+            HostOptions = applicationHostOptions;
             _logger = loggerFactory.CreateLogger(LogCategories.Startup);
         }
 

--- a/src/WebJobs.Script/Config/ScriptHostOptionsSetup.cs
+++ b/src/WebJobs.Script/Config/ScriptHostOptionsSetup.cs
@@ -13,17 +13,17 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
     {
         private readonly IConfiguration _configuration;
         private readonly IEnvironment _environment;
-        private readonly IOptions<ScriptApplicationHostOptions> _webHostOptions;
+        private readonly IOptions<ScriptApplicationHostOptions> _applicationHostOptions;
 
         internal static readonly TimeSpan MinFunctionTimeout = TimeSpan.FromSeconds(1);
         internal static readonly TimeSpan DefaultFunctionTimeout = TimeSpan.FromMinutes(5);
         internal static readonly TimeSpan MaxFunctionTimeout = TimeSpan.FromMinutes(10);
 
-        public ScriptHostOptionsSetup(IConfiguration configuration, IEnvironment environment, IOptions<ScriptApplicationHostOptions> webHostOptions)
+        public ScriptHostOptionsSetup(IConfiguration configuration, IEnvironment environment, IOptions<ScriptApplicationHostOptions> applicationHostOptions)
         {
             _configuration = configuration;
             _environment = environment;
-            _webHostOptions = webHostOptions;
+            _applicationHostOptions = applicationHostOptions;
         }
 
         public void Configure(ScriptJobHostOptions options)
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             ConfigureLanguageWorkers(jobHostSection, options);
 
             // Set the root script path to the value the runtime was initialized with:
-            ScriptApplicationHostOptions webHostOptions = _webHostOptions.Value;
+            ScriptApplicationHostOptions webHostOptions = _applicationHostOptions.Value;
             options.RootScriptPath = webHostOptions.ScriptPath;
             options.RootLogPath = webHostOptions.LogPath;
             options.IsSelfHost = webHostOptions.IsSelfHost;

--- a/src/WebJobs.Script/Config/ScriptSettingsManager.cs
+++ b/src/WebJobs.Script/Config/ScriptSettingsManager.cs
@@ -31,15 +31,11 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         /// </summary>
         public virtual bool IsAppServiceEnvironment => !string.IsNullOrEmpty(GetSetting(EnvironmentSettingNames.AzureWebsiteInstanceId));
 
-        public virtual bool IsZipDeployment => !string.IsNullOrEmpty(GetSetting(EnvironmentSettingNames.AzureWebsiteZipDeployment));
-
         public virtual bool ContainerReady => !string.IsNullOrEmpty(GetSetting(EnvironmentSettingNames.AzureWebsiteContainerReady));
 
         public string WebsiteSku => GetSetting(EnvironmentSettingNames.AzureWebsiteSku);
 
         public bool IsDynamicSku => WebsiteSku == ScriptConstants.DynamicSku;
-
-        public virtual bool FileSystemIsReadOnly => IsZipDeployment;
 
         public virtual string AzureWebsiteDefaultSubdomain
         {

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -25,6 +25,16 @@ namespace Microsoft.Azure.WebJobs.Script
             return !string.IsNullOrEmpty(environment.GetEnvironmentVariable(RemoteDebuggingPort));
         }
 
+        public static bool IsZipDeployment(this IEnvironment environment)
+        {
+            return !string.IsNullOrEmpty(environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteZipDeployment));
+        }
+
+        public static bool FileSystemIsReadOnly(this IEnvironment environment)
+        {
+            return environment.IsZipDeployment();
+        }
+
         /// <summary>
         /// Gets a value indicating whether the application is running in a Dynamic
         /// App Service environment.

--- a/src/WebJobs.Script/Extensions/FileUtility.cs
+++ b/src/WebJobs.Script/Extensions/FileUtility.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -19,6 +20,15 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             get { return _instance ?? _default; }
             set { _instance = value; }
+        }
+
+        public static string ReadResourceString(string resourcePath)
+        {
+            Assembly assembly = Assembly.GetCallingAssembly();
+            using (StreamReader reader = new StreamReader(assembly.GetManifestResourceStream(resourcePath)))
+            {
+                return reader.ReadToEnd();
+            }
         }
 
         public static void EnsureDirectoryExists(string path)

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Azure.WebJobs.Script
         private readonly List<FunctionDescriptorProvider> _descriptorProviders = new List<FunctionDescriptorProvider>();
         private readonly ILoggerFactory _loggerFactory = null;
         private readonly string _instanceId;
+        private readonly IEnvironment _environment;
 
         private IPrimaryHostStateProvider _primaryHostStateProvider;
         public static readonly string Version = GetAssemblyFileVersion(typeof(ScriptHost).Assembly);
@@ -71,6 +72,7 @@ namespace Microsoft.Azure.WebJobs.Script
         // Map from BindingType to the Assembly Qualified Type name for its IExtensionConfigProvider object.
 
         public ScriptHost(IOptions<JobHostOptions> options,
+            IEnvironment environment,
             IJobHostContextFactory jobHostContextFactory,
             IConfiguration configuration,
             IDistributedLockManager distributedLockManager,
@@ -89,6 +91,7 @@ namespace Microsoft.Azure.WebJobs.Script
             ScriptSettingsManager settingsManager = null)
             : base(options, jobHostContextFactory)
         {
+            _environment = environment;
             _typeLocator = typeLocator as ScriptTypeLocator
                 ?? throw new ArgumentException(nameof(typeLocator), $"A {nameof(ScriptTypeLocator)} instance is required.");
 
@@ -380,7 +383,7 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             FileUtility.EnsureDirectoryExists(_hostLogPath);
 
-            if (!_settingsManager.FileSystemIsReadOnly)
+            if (!_environment.FileSystemIsReadOnly())
             {
                 FileUtility.EnsureDirectoryExists(ScriptOptions.RootScriptPath);
             }

--- a/src/WebJobs.Script/Host/ScriptHostState.cs
+++ b/src/WebJobs.Script/Host/ScriptHostState.cs
@@ -40,6 +40,11 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <summary>
         /// The host is stopped.
         /// </summary>
-        Stopped
+        Stopped,
+
+        /// <summary>
+        /// The host is offline
+        /// </summary>
+        Offline
     }
 }

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -65,6 +65,8 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FunctionMetadataFileName = "function.json";
         public const string ProxyMetadataFileName = "proxies.json";
         public const string ExtensionsMetadataFileName = "extensions.json";
+        public const string AppOfflineFileName = "app_offline.htm";
+        public const string ResourcePath = "Microsoft.Azure.WebJobs.Script.WebHost.Resources";
 
         public const string DefaultMasterKeyName = "master";
         public const string DefaultFunctionKeyName = "default";

--- a/test/WebJobs.Script.Tests.Shared/TestLogger.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestLogger.cs
@@ -13,9 +13,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class TestLogger : ILogger
     {
-        // protect against changes to _logMessages while enumerating
         private readonly object _syncLock = new object();
-
         private IList<LogMessage> _logMessages = new List<LogMessage>();
 
         public TestLogger(string category)

--- a/test/WebJobs.Script.Tests/Controllers/Admin/HostControllerTests.cs
+++ b/test/WebJobs.Script.Tests/Controllers/Admin/HostControllerTests.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs.Script.WebHost.Controllers;
+using Microsoft.Azure.WebJobs.Script.WebHost.Management;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.WebJobs.Script.Tests;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public class HostControllerTests
+    {
+        private readonly string _scriptPath;
+        private readonly string _appOfflineFilePath;
+        private readonly HostController _hostController;
+        private readonly Mock<IScriptHostManager> _mockScriptHostManager;
+        private readonly Mock<IEnvironment> _mockEnvironment;
+
+        public HostControllerTests()
+        {
+            _scriptPath = Path.GetTempPath();
+            var applicationHostOptions = new ScriptApplicationHostOptions();
+            applicationHostOptions.ScriptPath = _scriptPath;
+            var optionsWrapper = new OptionsWrapper<ScriptApplicationHostOptions>(applicationHostOptions);
+            var hostOptions = new OptionsWrapper<JobHostOptions>(new JobHostOptions());
+            var loggerProvider = new TestLoggerProvider();
+            var loggerFactory = new LoggerFactory();
+            loggerFactory.AddProvider(loggerProvider);
+            var mockAuthorizationService = new Mock<IAuthorizationService>(MockBehavior.Strict);
+            var mockWebFunctionsManager = new Mock<IWebFunctionsManager>(MockBehavior.Strict);
+            _mockEnvironment = new Mock<IEnvironment>(MockBehavior.Strict);
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(It.IsAny<string>())).Returns<string>(null);
+            _mockScriptHostManager = new Mock<IScriptHostManager>(MockBehavior.Strict);
+
+            _hostController = new HostController(optionsWrapper, hostOptions, loggerFactory, mockAuthorizationService.Object, mockWebFunctionsManager.Object, _mockEnvironment.Object, _mockScriptHostManager.Object);
+
+            _appOfflineFilePath = Path.Combine(_scriptPath, ScriptConstants.AppOfflineFileName);
+            if (File.Exists(_appOfflineFilePath))
+            {
+                File.Delete(_appOfflineFilePath);
+            }
+        }
+
+        [Theory]
+        [InlineData("blah", ScriptHostState.Running, HttpStatusCode.BadRequest)]
+        [InlineData("Stopped", ScriptHostState.Running, HttpStatusCode.BadRequest)]
+        [InlineData("offline", ScriptHostState.Running, HttpStatusCode.Accepted)]
+        [InlineData("running", ScriptHostState.Offline, HttpStatusCode.Accepted)]
+        [InlineData("OFFLINE", ScriptHostState.Offline, HttpStatusCode.OK)]
+        [InlineData("running", ScriptHostState.Running, HttpStatusCode.OK)]
+        public async Task SetState_Succeeds(string desiredState, ScriptHostState currentState, HttpStatusCode statusCode)
+        {
+            _mockScriptHostManager.SetupGet(p => p.State).Returns(currentState);
+
+            var result = await _hostController.SetState(desiredState);
+            var resultStatus = HttpStatusCode.InternalServerError;
+            if (result is StatusCodeResult)
+            {
+                resultStatus = (HttpStatusCode)((StatusCodeResult)result).StatusCode;
+            }
+            else if (result is ObjectResult)
+            {
+                resultStatus = (HttpStatusCode)((ObjectResult)result).StatusCode;
+            }
+            else
+            {
+                Assert.True(false);
+            }
+            Assert.Equal(statusCode, resultStatus);
+
+            bool fileExists = File.Exists(_appOfflineFilePath);
+            if (string.Compare("offline", desiredState) == 0 && currentState != ScriptHostState.Offline)
+            {
+                // verify file was created
+                Assert.True(fileExists);
+            }
+            else
+            {
+                // verify file does not exist
+                Assert.False(fileExists);
+            }
+        }
+    }
+}


### PR DESCRIPTION
These changes are intended to address the following issues:

- https://github.com/Azure/azure-functions-host/issues/2548
- https://github.com/Azure/azure-functions-host/issues/2700
- https://github.com/Azure/azure-functions-host/issues/1521

The portal extensions manager can then use the new API added here to install extensions w/o running into file locking issues:

- Portal Extension PUTs "offline" to `admin/host/state` to take the host offline
- Host receives this request, writes an app_offline.htm file to script root dir
- All hosts are watching for creation/deletion of this offline file: 
  - When created (take offline) – web app is recycled, causing the app domain to unload. When the app restarts, it sees the offline file and skips all host startup/init. I.e. in offline mode, no assemblies are loaded from bin, and only our admin type APIs are available (no functions are running).
  - When deleted (bring online) – if the host was offline and this file is deleted, it is brought back online and allowed to initialize normally
- While offline, extension APIs can be called to install one or more extensions. The `admin/host/status` endpoint also returns “Offline” as the host status.
- Once installs are done, app is brought back online via a PUT of value "running" to `admin/host/state`

VS managed app_offline.htm files are therefore also supported. E.g. if app offline is enabled for a WebDeploy, the runtime will see the file added by VS and go offline, freeing any locked files.