### PR TITLE
Cold start data

### DIFF
--- a/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
@@ -15,6 +15,10 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
         public const string HostStartupCreateMetadataProviderLatency = "host.startup.createmetadataprovider.latency";
         public const string HostStartupGetFunctionDescriptorsLatency = "host.startup.getfunctiondescriptors.latency";
 
+        // out-of-proc language worker level events
+        public const string OutOfProcWorkerLatency = "host.startup.outofproc.{0}.worker.latency";
+        public const string OutOfProcGrpcServerStartLatency = "host.startup.outofproc.grpcserverstart.latency";
+
         // function level events
         public const string FunctionInvokeLatency = "function.invoke.latency";
         public const string FunctionBindingTypeFormat = "function.binding.{0}";

--- a/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
@@ -14,10 +14,8 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
         public const string HostStartupInitializeBindingProvidersLatency = "host.startup.initializebindingproviders.latency";
         public const string HostStartupCreateMetadataProviderLatency = "host.startup.createmetadataprovider.latency";
         public const string HostStartupGetFunctionDescriptorsLatency = "host.startup.getfunctiondescriptors.latency";
-
-        // out-of-proc language worker level events
-        public const string OutOfProcWorkerLatency = "host.startup.outofproc.{0}.worker.latency";
-        public const string OutOfProcGrpcServerStartLatency = "host.startup.outofproc.grpcserverstart.latency";
+        public const string HostStartupInitializeWorkersLatency = "host.startup.outofproc.initializeworkers.latency";
+        public const string HostStartupGrpcServerLatency = "host.startup.outofproc.initializeworkers.grpcserver.latency";
 
         // function level events
         public const string FunctionInvokeLatency = "function.invoke.latency";

--- a/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
         public const string HostStartupGrpcServerLatency = "host.startup.outofproc.grpcserver.initialize.latency";
 
         // language worker level events
-        public const string WorkerInitializeLatency = "host.startup.outofproc.{0}worker.initialize.latency";
+        public const string WorkerInitializeLatency = "host.startup.outofproc.{0}worker.initialize.attempt{1}.latency";
 
         // function level events
         public const string FunctionInvokeLatency = "function.invoke.latency";

--- a/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
@@ -14,8 +14,10 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
         public const string HostStartupInitializeBindingProvidersLatency = "host.startup.initializebindingproviders.latency";
         public const string HostStartupCreateMetadataProviderLatency = "host.startup.createmetadataprovider.latency";
         public const string HostStartupGetFunctionDescriptorsLatency = "host.startup.getfunctiondescriptors.latency";
-        public const string HostStartupInitializeWorkersLatency = "host.startup.outofproc.initializeworkers.latency";
-        public const string HostStartupGrpcServerLatency = "host.startup.outofproc.initializeworkers.grpcserver.latency";
+        public const string HostStartupGrpcServerLatency = "host.startup.outofproc.grpcserver.initialize.latency";
+
+        // language worker level events
+        public const string WorkerInitializeLatency = "host.startup.outofproc.{0}worker.initialize.latency";
 
         // function level events
         public const string FunctionInvokeLatency = "function.invoke.latency";

--- a/src/WebJobs.Script/Extensions/IMetricsLoggerExtensions.cs
+++ b/src/WebJobs.Script/Extensions/IMetricsLoggerExtensions.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             private readonly object _metricEvent;
             private readonly IMetricsLogger _metricsLogger;
+            private bool _disposed;
 
             public DisposableEvent(string eventName, string functionName, IMetricsLogger metricsLogger)
             {
@@ -26,10 +27,14 @@ namespace Microsoft.Azure.WebJobs.Script
 
             public void Dispose()
             {
-                if (_metricsLogger != null && _metricEvent != null)
+                if (!_disposed)
                 {
-                    _metricsLogger.EndEvent(_metricEvent);
+                    if (_metricsLogger != null && _metricEvent != null)
+                    {
+                        _metricsLogger.EndEvent(_metricEvent);
+                    }
                 }
+                _disposed = true;
             }
         }
     }

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -468,7 +468,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 _startupLogger.LogWarning(e, "Unable to create process registry");
             }
 
-            CreateChannel channelFactory = (languageWorkerConfig, registrations) =>
+            CreateChannel channelFactory = (languageWorkerConfig, registrations, attemptCount) =>
             {
                 return new LanguageWorkerChannel(
                     ScriptOptions,
@@ -479,7 +479,8 @@ namespace Microsoft.Azure.WebJobs.Script
                     languageWorkerConfig,
                     server.Uri,
                     _loggerFactory, // TODO: DI (FACAVAL) Pass appropriate logger. Channel facory should likely be a service.
-                    _metricsLogger);
+                    _metricsLogger,
+                    attemptCount);
             };
             var configFactory = new WorkerConfigFactory(ScriptSettingsManager.Instance.Configuration, _startupLogger);
             var providers = new List<IWorkerProvider>();

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -246,7 +246,10 @@ namespace Microsoft.Azure.WebJobs.Script
             using (_metricsLogger.LatencyEvent(MetricEventNames.HostStartupLatency))
             {
                 PreInitialize();
-                await InitializeWorkersAsync();
+                using (_metricsLogger.LatencyEvent(MetricEventNames.OutOfProcWorkerLatency))
+                {
+                    await InitializeWorkersAsync();
+                }
 
                 // Generate Functions
                 IEnumerable<FunctionMetadata> functions = GetFunctionsMetadata();
@@ -452,7 +455,10 @@ namespace Microsoft.Azure.WebJobs.Script
             var serverImpl = new FunctionRpcService(EventManager);
             var server = new GrpcServer(serverImpl, ScriptOptions.MaxMessageLengthBytes);
 
-            await server.StartAsync();
+            using (_metricsLogger.LatencyEvent(MetricEventNames.OutOfProcGrpcServerStartLatency))
+            {
+                await server.StartAsync();
+            }
 
             var processFactory = new DefaultWorkerProcessFactory();
 

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -246,7 +246,7 @@ namespace Microsoft.Azure.WebJobs.Script
             using (_metricsLogger.LatencyEvent(MetricEventNames.HostStartupLatency))
             {
                 PreInitialize();
-                using (_metricsLogger.LatencyEvent(MetricEventNames.OutOfProcWorkerLatency))
+                using (_metricsLogger.LatencyEvent(MetricEventNames.HostStartupInitializeWorkersLatency))
                 {
                     await InitializeWorkersAsync();
                 }
@@ -455,7 +455,7 @@ namespace Microsoft.Azure.WebJobs.Script
             var serverImpl = new FunctionRpcService(EventManager);
             var server = new GrpcServer(serverImpl, ScriptOptions.MaxMessageLengthBytes);
 
-            using (_metricsLogger.LatencyEvent(MetricEventNames.OutOfProcGrpcServerStartLatency))
+            using (_metricsLogger.LatencyEvent(MetricEventNames.HostStartupGrpcServerLatency))
             {
                 await server.StartAsync();
             }

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -246,10 +246,7 @@ namespace Microsoft.Azure.WebJobs.Script
             using (_metricsLogger.LatencyEvent(MetricEventNames.HostStartupLatency))
             {
                 PreInitialize();
-                using (_metricsLogger.LatencyEvent(MetricEventNames.HostStartupInitializeWorkersLatency))
-                {
-                    await InitializeWorkersAsync();
-                }
+                await InitializeWorkersAsync();
 
                 // Generate Functions
                 IEnumerable<FunctionMetadata> functions = GetFunctionsMetadata();
@@ -481,7 +478,8 @@ namespace Microsoft.Azure.WebJobs.Script
                     registrations,
                     languageWorkerConfig,
                     server.Uri,
-                    _loggerFactory); // TODO: DI (FACAVAL) Pass appropriate logger. Channel facory should likely be a service.
+                    _loggerFactory, // TODO: DI (FACAVAL) Pass appropriate logger. Channel facory should likely be a service.
+                    _metricsLogger);
             };
             var configFactory = new WorkerConfigFactory(ScriptSettingsManager.Instance.Configuration, _startupLogger);
             var providers = new List<IWorkerProvider>();

--- a/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
+++ b/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         private ConcurrentDictionary<WorkerConfig, LanguageWorkerState> _channelStates = new ConcurrentDictionary<WorkerConfig, LanguageWorkerState>();
         private IDisposable _workerErrorSubscription;
         private IList<IDisposable> _workerStateSubscriptions = new List<IDisposable>();
-        private List<ILanguageWorkerChannel> _erroredChannels = new List<ILanguageWorkerChannel>();
         private ConcurrentDictionary<string, ILanguageWorkerChannel> _channelsDictionary = new ConcurrentDictionary<string, ILanguageWorkerChannel>();
         private bool disposedValue = false;
 
@@ -74,7 +73,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                     CreateWorkerState,
                     (config, state) =>
                     {
-                        _erroredChannels.Add(state.Channel);
+                        erroredChannel.Dispose();
                         state.Errors.Add(workerError.Exception);
                         if (state.Errors.Count < 3)
                         {
@@ -114,12 +113,9 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                     }
                     foreach (var pair in _channelStates)
                     {
+                        // TODO #3296 - send WorkerTerminate message to shut down language worker process gracefully (instead of just a killing)
                         pair.Value.Channel.Dispose();
                         pair.Value.Functions.Dispose();
-                    }
-                    foreach (var channel in _erroredChannels)
-                    {
-                        channel.Dispose();
                     }
                     _server.ShutdownAsync().GetAwaiter().GetResult();
                 }

--- a/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
+++ b/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         internal LanguageWorkerState CreateWorkerState(WorkerConfig config)
         {
             var state = new LanguageWorkerState();
-            state.Channel = _channelFactory(config, state.Functions);
+            state.Channel = _channelFactory(config, state.Functions, 0);
             _channelsDictionary[state.Channel.Id] = state.Channel;
             return state;
         }
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                         state.Errors.Add(workerError.Exception);
                         if (state.Errors.Count < 3)
                         {
-                            state.Channel = _channelFactory(config, state.Functions);
+                            state.Channel = _channelFactory(config, state.Functions, state.Errors.Count);
                             _channelsDictionary[state.Channel.Id] = state.Channel;
                         }
                         else

--- a/src/WebJobs.Script/Rpc/ILanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/ILanguageWorkerChannel.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Azure.WebJobs.Script.Rpc
 {
-    internal delegate ILanguageWorkerChannel CreateChannel(WorkerConfig conf, IObservable<FunctionRegistrationContext> registrations);
+    internal delegate ILanguageWorkerChannel CreateChannel(WorkerConfig conf, IObservable<FunctionRegistrationContext> registrations, int attemptCount);
 
     internal interface ILanguageWorkerChannel : IDisposable
     {

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
@@ -302,6 +302,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         internal void WorkerReady(RpcEvent initEvent)
         {
             _startLatencyMetric.Dispose();
+            _startLatencyMetric = null;
 
             var initMessage = initEvent.Message.WorkerInitResponse;
             if (initMessage.Result.IsFailure(out Exception exc))
@@ -508,6 +509,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             {
                 if (disposing)
                 {
+                    _startLatencyMetric?.Dispose();
                     // best effort process disposal
                     try
                     {

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
@@ -77,7 +77,8 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             WorkerConfig workerConfig,
             Uri serverUri,
             ILoggerFactory loggerFactory,
-            IMetricsLogger metricsLogger)
+            IMetricsLogger metricsLogger,
+            int attemptCount)
         {
             _workerId = Guid.NewGuid().ToString();
 
@@ -112,7 +113,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 .Throttle(TimeSpan.FromMilliseconds(300)) // debounce
                 .Subscribe(msg => _eventManager.Publish(new HostRestartEvent())));
 
-            _startLatencyMetric = metricsLogger.LatencyEvent(string.Format(MetricEventNames.WorkerInitializeLatency, workerConfig.Language));
+            _startLatencyMetric = metricsLogger.LatencyEvent(string.Format(MetricEventNames.WorkerInitializeLatency, workerConfig.Language, attemptCount));
 
             StartWorker();
         }
@@ -477,6 +478,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             {
                 if (!_disposed)
                 {
+                    _startLatencyMetric?.Dispose();
                     _startSubscription?.Dispose();
                     _process?.Dispose();
 


### PR DESCRIPTION
Captures GRPC start time and GRPC client start times (one metric per retry).


~~Cheapest fix for (partially?) resolving this issue: https://github.com/Azure/azure-functions-nodejs-worker/issues/19~~

~~The next step is to log the time it takes for an individual language worker to be up and running/ready to process requests. The [WorkerReady method in LanguageWorkerChannel](https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs#L298) is when we have received a response from the language worker confirming that it is up and running (ready to receive messages and process functions).~~

~~`InitializeWorkersAsync` does not block on receiving a "language worker client ready" RpcEvent.~~
