### PR TITLE
Update EventHub test

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/EventHubs/EventHubsEndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/EventHubs/EventHubsEndToEndTestsBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Azure.EventHubs;
 using Microsoft.Extensions.DependencyInjection;
@@ -46,8 +47,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.EventHubs
 
             var bindingData = payload["bindingData"];
             int sequenceNumber = (int)bindingData["sequenceNumber"];
-            var systemProperties = bindingData["systemProperties"];
-            Assert.Equal(sequenceNumber, (int)systemProperties["x-opt-sequence-number"]);
+            IDictionary<string, object> systemProperties = bindingData["systemProperties"].ToObject<Dictionary<string, object>>();
+            Assert.Equal(sequenceNumber, (long)systemProperties["sequenceNumber"]);
         }
 
         public class TestFixture : EndToEndTestFixture

--- a/test/WebJobs.Script.Tests.Integration/EventHubs/EventHubsEndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/EventHubs/EventHubsEndToEndTestsBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Azure.EventHubs;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json.Linq;
@@ -19,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.EventHubs
             _fixture = fixture;
         }
 
-        [Fact(Skip = "Assertion on system properties is failing since the update to 2.1. Investigate")]
+        [Fact]
         public async Task EventHub()
         {
             // Event Hub needs the following environment vars:
@@ -46,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.EventHubs
             var bindingData = payload["bindingData"];
             int sequenceNumber = (int)bindingData["sequenceNumber"];
             var systemProperties = bindingData["systemProperties"];
-            Assert.Equal(sequenceNumber, (int)systemProperties["sequenceNumber"]);
+            Assert.Equal(sequenceNumber, (int)systemProperties["x-opt-sequence-number"]);
         }
 
         public class TestFixture : EndToEndTestFixture


### PR DESCRIPTION
Fixes #3289. Updated reference to Microsoft.Azure.Eventhubs to 2.1.0
Implementation of SystemPropertiesCollection changed from v 1.0.3
Here is the reference to SystemPropertiesCollection from .Net reflector

```
public sealed class SystemPropertiesCollection : Dictionary<string, object>
        {
            internal SystemPropertiesCollection()
            {
            }
            
            public long SequenceNumber
            {
                get
                {
                    object obj2;
                    if (base.TryGetValue("x-opt-sequence-number", ref obj2))
                    {
                        return (long) obj2;
                    }
                    object[] args = new object[] { "x-opt-sequence-number" };
                    throw new ArgumentException(Resources.MissingSystemProperty.FormatForUser(args));
                }
            }
            
            public DateTime EnqueuedTimeUtc
            {
                get
                {
                    object obj2;
                    if (base.TryGetValue("x-opt-enqueued-time", ref obj2))
                    {
                        return (DateTime) obj2;
                    }
                    object[] args = new object[] { "x-opt-enqueued-time" };
                    throw new ArgumentException(Resources.MissingSystemProperty.FormatForUser(args));
                }
            }
            
            public string Offset
            {
                get
                {
                    object obj2;
                    if (base.TryGetValue("x-opt-offset", ref obj2))
                    {
                        return (string) obj2;
                    }
                    object[] args = new object[] { "x-opt-offset" };
                    throw new ArgumentException(Resources.MissingSystemProperty.FormatForUser(args));
                }
            }
            
            public string PartitionKey
            {
                get
                {
                    object obj2;
                    if (base.TryGetValue("x-opt-partition-key", ref obj2))
                    {
                        return (string) obj2;
                    }
                    return null;
                }
            }
        }
```