### PR TITLE
Fix metadata generator so that extensions.json is included when publishing

### DIFF
--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets
@@ -28,6 +28,13 @@
           ContinueOnError="true"/>
   </Target>
 
+  <Target Name="_GenerateFunctionsExtensionsMetadataPostPublish"
+          AfterTargets="Publish">
+    <GenerateFunctionsExtensionsMetadata
+          SourcePath="$(PublishDir)bin"
+          OutputPath="$(PublishDir)bin"/>
+  </Target>
+
   <Target Name="_ResolveAdditionalReferenceCopyLocalPathsForFunctionsExtensions"
           AfterTargets="ResolveReferences"
           Condition="$(_IsFunctionsSdkBuild) != 'true'">


### PR DESCRIPTION
Turns out that extensions.json was never included in the publish output (because MSBuild is stupid, really).
I verified this works both by doing a right click publish gesture on a function app in VS and by running `dotnet build /t:publish`.