### PR TITLE
[regression]Fix WorkerConfig parsing

### DIFF
--- a/src/WebJobs.Script.Grpc/Abstractions/WorkerDescriptionExtensions.cs
+++ b/src/WebJobs.Script.Grpc/Abstractions/WorkerDescriptionExtensions.cs
@@ -1,31 +1,30 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.Azure.WebJobs.Script.Abstractions
 {
     public static class WorkerDescriptionExtensions
     {
-        public static bool IsValid(this WorkerDescription workerDescription)
+        public static void Validate(this WorkerDescription workerDescription)
         {
             if (string.IsNullOrEmpty(workerDescription.Language))
             {
-                throw new ArgumentNullException(nameof(workerDescription.Language));
+                throw new ValidationException($"WorkerDescription {nameof(workerDescription.Language)} cannot be empty");
             }
             if (workerDescription.Extensions == null)
             {
-                throw new ArgumentNullException(nameof(workerDescription.Extensions));
+                throw new ValidationException($"WorkerDescription {nameof(workerDescription.Extensions)} cannot be null");
             }
             if (string.IsNullOrEmpty(workerDescription.DefaultExecutablePath))
             {
-                throw new ArgumentNullException(nameof(workerDescription.DefaultExecutablePath));
+                throw new ValidationException($"WorkerDescription {nameof(workerDescription.DefaultExecutablePath)} cannot be empty");
             }
             if (string.IsNullOrEmpty(workerDescription.DefaultWorkerPath))
             {
-                throw new ArgumentNullException(nameof(workerDescription.DefaultWorkerPath));
+                throw new ValidationException($"WorkerDescription {nameof(workerDescription.DefaultWorkerPath)} cannot be empty");
             }
-            return true;
         }
     }
 }

--- a/src/WebJobs.Script.Grpc/Abstractions/WorkerDescriptionExtensions.cs
+++ b/src/WebJobs.Script.Grpc/Abstractions/WorkerDescriptionExtensions.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Script.Abstractions
+{
+    public static class WorkerDescriptionExtensions
+    {
+        public static bool IsValid(this WorkerDescription workerDescription)
+        {
+            if (string.IsNullOrEmpty(workerDescription.Language))
+            {
+                throw new ArgumentNullException(nameof(workerDescription.Language));
+            }
+            if (workerDescription.Extensions == null)
+            {
+                throw new ArgumentNullException(nameof(workerDescription.Extensions));
+            }
+            if (string.IsNullOrEmpty(workerDescription.DefaultExecutablePath))
+            {
+                throw new ArgumentNullException(nameof(workerDescription.DefaultExecutablePath));
+            }
+            if (string.IsNullOrEmpty(workerDescription.DefaultWorkerPath))
+            {
+                throw new ArgumentNullException(nameof(workerDescription.DefaultWorkerPath));
+            }
+            return true;
+        }
+    }
+}

--- a/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
+++ b/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
@@ -36,6 +36,9 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>C:\Program Files\dotnet\sdk\NuGetFallbackFolder\newtonsoft.json\11.0.2\lib\netstandard2.0\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="System.ComponentModel.Annotations">
+      <HintPath>C:\Program Files\dotnet\sdk\NuGetFallbackFolder\system.componentmodel.annotations\4.5.0\ref\netstandard2.0\System.ComponentModel.Annotations.dll</HintPath>
+    </Reference>
   </ItemGroup>
   
   <Target Name="GenerateProtoFiles" BeforeTargets="BeforeBuild" Inputs="azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto" Outputs="Messages/DotNet/FunctionRpc.cs;Messages/DotNet/FunctionRpcGrpc.cs">

--- a/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
+++ b/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
   </ItemGroup>
   
   <ItemGroup>
@@ -35,9 +36,6 @@
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">
       <HintPath>C:\Program Files\dotnet\sdk\NuGetFallbackFolder\newtonsoft.json\11.0.2\lib\netstandard2.0\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="System.ComponentModel.Annotations">
-      <HintPath>C:\Program Files\dotnet\sdk\NuGetFallbackFolder\system.componentmodel.annotations\4.5.0\ref\netstandard2.0\System.ComponentModel.Annotations.dll</HintPath>
     </Reference>
   </ItemGroup>
   

--- a/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
@@ -143,7 +143,10 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 if (File.Exists(workerDescription.GetWorkerPath()))
                 {
                     logger.LogTrace($"Will load worker provider for language: {workerDescription.Language}");
-                    _workerProviderDictionary[workerDescription.Language] = new GenericWorkerProvider(workerDescription, workerDir);
+                    if (workerDescription.IsValid())
+                    {
+                        _workerProviderDictionary[workerDescription.Language] = new GenericWorkerProvider(workerDescription, workerDir);
+                    }
                 }
                 else
                 {
@@ -181,7 +184,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 profileDescription.Arguments = profileDescription.Arguments?.Count > 0 ? profileDescription.Arguments : defaultWorkerDescription.Arguments;
                 profileDescription.DefaultExecutablePath = string.IsNullOrEmpty(profileDescription.DefaultExecutablePath) ? defaultWorkerDescription.DefaultExecutablePath : profileDescription.DefaultExecutablePath;
                 profileDescription.DefaultWorkerPath = string.IsNullOrEmpty(profileDescription.DefaultWorkerPath) ? defaultWorkerDescription.DefaultWorkerPath : profileDescription.DefaultWorkerPath;
-                profileDescription.Extensions = (profileDescription.Extensions != null && profileDescription.Extensions.Count > 0) ? defaultWorkerDescription.Extensions : profileDescription.Extensions;
+                profileDescription.Extensions = profileDescription.Extensions ?? defaultWorkerDescription.Extensions;
                 profileDescription.Language = string.IsNullOrEmpty(profileDescription.Language) ? defaultWorkerDescription.Language : profileDescription.Language;
                 profileDescription.WorkerDirectory = string.IsNullOrEmpty(profileDescription.WorkerDirectory) ? defaultWorkerDescription.WorkerDirectory : profileDescription.WorkerDirectory;
                 return profileDescription;

--- a/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
@@ -143,10 +143,8 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 if (File.Exists(workerDescription.GetWorkerPath()))
                 {
                     logger.LogTrace($"Will load worker provider for language: {workerDescription.Language}");
-                    if (workerDescription.IsValid())
-                    {
-                        _workerProviderDictionary[workerDescription.Language] = new GenericWorkerProvider(workerDescription, workerDir);
-                    }
+                    workerDescription.Validate();
+                    _workerProviderDictionary[workerDescription.Language] = new GenericWorkerProvider(workerDescription, workerDir);
                 }
                 else
                 {

--- a/src/WebJobs.Script/Rpc/LanguageWorkerConstants.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerConstants.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         // Worker description constants
         public const string WorkerDescriptionLanguage = "language";
-        public const string WorkerDescriptionExtension = "extension";
         public const string WorkerDescriptionDefaultExecutablePath = "defaultExecutablePath";
         public const string WorkerDescriptionDefaultWorkerPath = "defaultWorkerPath";
         public const string WorkerDescription = "description";

--- a/test/WebJobs.Script.Tests/Rpc/GenericWorkerProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/GenericWorkerProviderTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.IO;
 using System.Linq;
 using Microsoft.Azure.WebJobs.Script.Abstractions;
@@ -257,14 +258,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         [MemberData(nameof(InvalidWorkerDescriptions))]
         public void InvalidWorkerDescription_Throws(WorkerDescription workerDescription)
         {
-            Assert.Throws<ArgumentNullException>(() => workerDescription.IsValid());
+            Assert.Throws<ValidationException>(() => workerDescription.Validate());
         }
 
         [Theory]
         [MemberData(nameof(ValidWorkerDescriptions))]
-        public void ValidWorkerDescription_Returns_True(WorkerDescription workerDescription)
+        public void ValidateWorkerDescription_Succeeds(WorkerDescription workerDescription)
         {
-            Assert.True(workerDescription.IsValid());
+            workerDescription.Validate();
         }
 
         private IEnumerable<IWorkerProvider> TestReadWorkerProviderFromConfig(IEnumerable<TestLanguageWorkerConfig> configs, ILogger testLogger, string language = null, Dictionary<string, string> keyValuePairs = null, bool appSvcEnv = false)


### PR DESCRIPTION
Recently, worker.config.json is updated to accept a list of extensions. This introduced a regression here
[WorkerConfigFactory.cs#L184](https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs#L184) where default list of extensions was overidden by [appServiceEnvironment profile](https://github.com/Azure/azure-functions-java-worker/blob/dev/worker.config.json#L10)  when parsing Java worker config on a deployed function app.
This resulted in following null ref exception which blocked indexing of all functions except c#

[FunctionDispatcher.cs#L48](https://na01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FAzure%2Fazure-functions-host%2Fblob%2Fdev%2Fsrc%2FWebJobs.Script%2FRpc%2FFunctionRegistration%2FFunctionDispatcher.cs%23L48&data=02%7C01%7C%7Ccc4ad3697631414df1b508d6086094d2%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C636705608226619225&sdata=BsjhX2E0Xyzp4PqcN%2BeovyzUzzemkH0s1fkaaRsPnW0%3D&reserved=0)
```
System.NullReferenceException : Object reference not set to an instance of an object.
   at Microsoft.Azure.WebJobs.Script.Rpc.FunctionDispatcher.<>c__DisplayClass13_0.<IsSupported>b__0(WorkerConfig config) at D:\AzureGit\azure-functions-host\src\WebJobs.Script\Rpc\FunctionRegistration\FunctionDispatcher.cs : 59
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source,Func`2 predicate)
   at Microsoft.Azure.WebJobs.Script.Rpc.FunctionDispatcher.IsSupported(FunctionMetadata functionMetadata) at D:\AzureGit\azure-functions-host\src\WebJobs.Script\Rpc\FunctionRegistration\FunctionDispatcher.cs : 59
```
- Fixed parsing logic
- Added validation to worker description to throw exception on required fields
- Added tests and updated existing test to specifically verify this fix
- Also, manually tested fix via private site extension