### PR TITLE
Set RootScriptPath on ScriptOptions when running WebHost locally

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHostIdProvider.cs
+++ b/src/WebJobs.Script/Host/ScriptHostIdProvider.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Azure.WebJobs.Script
             _config = config;
             _environment = environment;
             _options = options;
-            // _options.RootScriptPath = _options.RootScriptPath ?? config[EnvironmentSettingNames.AzureWebJobsScriptRoot];
         }
 
         public Task<string> GetHostIdAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
Fixes null ref when generating secrets
```
System.AggregateException: One or more errors occurred. (Value cannot be null.
Parameter name: siteSlotName) ---> System.ArgumentNullException: Value cannot be null.
Parameter name: siteSlotName
   at Microsoft.Azure.WebJobs.Script.WebHost.BlobStorageSecretsRepository..ctor(String secretSentinelDirectoryPath, String accountConnectionString, String siteSlotName) in D:\pgopaGit\azure-functions-host\src\WebJobs.Script.WebHost\Security\KeyManagement\BlobStorageSecretsRepository.cs:line 47
   at Microsoft.Azure.WebJobs.Script.WebHost.BlobStorageSecretsMigrationRepository.BlobStorageSecretsRepositoryFactory() in D:\pgopaGit\azure-functions-host\src\WebJobs.Script.WebHost\Security\KeyManagement\BlobStorageSecretsMigrationRepository.cs:line 43 
```