### PR TITLE
Single instance of worker configs

### DIFF
--- a/src/WebJobs.Script/Rpc/Configuration/LanguageWorkerOptions.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/LanguageWorkerOptions.cs
@@ -7,6 +7,6 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 {
     public class LanguageWorkerOptions
     {
-        public IEnumerable<WorkerConfig> WorkerConfigs { get; set; }
+        public IList<WorkerConfig> WorkerConfigs { get; set; }
     }
 }

--- a/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
@@ -41,6 +41,8 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         public IEnumerable<WorkerConfig> GetConfigs()
         {
             BuildWorkerProviderDictionary();
+            var result = new List<WorkerConfig>();
+
             foreach (var provider in WorkerProviders)
             {
                 var description = provider.GetDescription();
@@ -59,17 +61,20 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
                 if (provider.TryConfigureArguments(arguments, _logger))
                 {
-                    yield return new WorkerConfig()
+                    var config = new WorkerConfig()
                     {
                         Description = description,
                         Arguments = arguments
                     };
+                    result.Add(config);
                 }
                 else
                 {
                     _logger.LogError($"Could not configure language worker {description.Language}.");
                 }
             }
+
+            return result;
         }
 
         internal void BuildWorkerProviderDictionary()

--- a/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         public string WorkersDirPath { get; }
 
-        public IEnumerable<WorkerConfig> GetConfigs()
+        public IList<WorkerConfig> GetConfigs()
         {
             BuildWorkerProviderDictionary();
             var result = new List<WorkerConfig>();

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -239,7 +239,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
         }
 
-        public static IEnumerable<WorkerConfig> GetTestWorkerConfigs()
+        public static IList<WorkerConfig> GetTestWorkerConfigs()
         {
             var nodeWorkerDesc = GetTestWorkerDescription("node", ".js");
             var javaWorkerDesc = GetTestWorkerDescription("java", ".jar");


### PR DESCRIPTION
Fixing the worker config comparison so that it doesn't check against new instances.

This bug materialized as many language worker processes being spun up (one per function)