### PR TITLE
Modify the list/get function definition APIs to allow for client requested host wait

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         [HttpGet]
         [Route("admin/functions")]
         [Authorize(Policy = PolicyNames.AdminAuthLevel)]
+        [ClientCanRequestRunningHost]
         public async Task<IActionResult> List()
         {
             return Ok(await _functionsManager.GetFunctionsMetadata(Request, _webJobsRouter));
@@ -54,6 +55,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         [HttpGet]
         [Route("admin/functions/{name}")]
         [Authorize(Policy = PolicyNames.AdminAuthLevel)]
+        [ClientCanRequestRunningHost]
         public async Task<IActionResult> Get(string name)
         {
             (var success, var function) = await _functionsManager.TryGetFunction(name, Request, _webJobsRouter);

--- a/src/WebJobs.Script.WebHost/Filters/WaitForHostAttribute.cs
+++ b/src/WebJobs.Script.WebHost/Filters/WaitForHostAttribute.cs
@@ -11,34 +11,6 @@ using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Filters
 {
-    /// <summary>
-    /// Filter applied to actions that require the host instance to be in a state
-    /// where functions can be invoked.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
-    public sealed class RequiresRunningHostAttribute : WaitForHostAttribute
-    {
-        public RequiresRunningHostAttribute(
-            int timeoutSeconds = ScriptConstants.HostTimeoutSeconds,
-            int pollingIntervalMilliseconds = ScriptConstants.HostPollingIntervalMilliseconds) : base(timeoutSeconds, pollingIntervalMilliseconds, false)
-        {
-        }
-    }
-
-    /// <remarks>
-    /// Filter applied to actions that might return different results based on whether the host has started or not and the client might want to request to wait (up to some server specified timeout) for the host to start.
-    /// Do not use this on an API that requires a running host to execute successfully.
-    /// </remarks>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
-    public sealed class ClientCanRequestRunningHost : WaitForHostAttribute
-    {
-        public ClientCanRequestRunningHost(
-            int timeoutSeconds = ScriptConstants.HostTimeoutSeconds,
-            int pollingIntervalMilliseconds = ScriptConstants.HostPollingIntervalMilliseconds) : base(timeoutSeconds, pollingIntervalMilliseconds, true)
-        {
-        }
-    }
-
     public abstract class WaitForHostAttribute : Attribute, IFilterFactory
     {
         private ObjectFactory _factory;
@@ -118,6 +90,34 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Filters
 
                 await next();
             }
+        }
+    }
+
+    /// <summary>
+    /// Filter applied to actions that require the host instance to be in a state
+    /// where functions can be invoked.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    public sealed class RequiresRunningHostAttribute : WaitForHostAttribute
+    {
+        public RequiresRunningHostAttribute(
+            int timeoutSeconds = ScriptConstants.HostTimeoutSeconds,
+            int pollingIntervalMilliseconds = ScriptConstants.HostPollingIntervalMilliseconds) : base(timeoutSeconds, pollingIntervalMilliseconds, false)
+        {
+        }
+    }
+
+    /// <remarks>
+    /// Filter applied to actions that might return different results based on whether the host has started or not and the client might want to request to wait (up to some server specified timeout) for the host to start.
+    /// Do not use this on an API that requires a running host to execute successfully.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    public sealed class ClientCanRequestRunningHost : WaitForHostAttribute
+    {
+        public ClientCanRequestRunningHost(
+            int timeoutSeconds = ScriptConstants.HostTimeoutSeconds,
+            int pollingIntervalMilliseconds = ScriptConstants.HostPollingIntervalMilliseconds) : base(timeoutSeconds, pollingIntervalMilliseconds, true)
+        {
         }
     }
 }


### PR DESCRIPTION
Added to address the logic apps scenario where the invoke uri template is null because the host hasn't started yet. Logic apps would specify ?waitForHost=1 so that they are more likely to receive a valid invoke uri template. Saves them from having to implement a state machine for checking the host state via the API, without impacting the portal usage of this API that does not need the invoke template.

Need to test a little more but looking for feedback on whether this implementation is clean enough.