### PR TITLE
Removing host id property from host.json

### DIFF
--- a/schemas/json/host.json
+++ b/schemas/json/host.json
@@ -5,12 +5,6 @@
     "type": "object",
 
     "properties": {
-        "id": {
-            "description": "The unique ID for this job host. Can be a lower case GUID with dashes removed",
-            "type": "string",
-            "minLength": 1
-        },
-
         "functions": {
             "description": "The list of functions the host should load.",
             "type": "array",

--- a/src/WebJobs.Script.WebHost/Resources/Functions/host.json
+++ b/src/WebJobs.Script.WebHost/Resources/Functions/host.json
@@ -1,4 +1,3 @@
 {
-    "version": "2.0",
-    "id": "placeholder-host"
+    "version": "2.0"
 }

--- a/src/WebJobs.Script/Config/ConfigurationSectionNames.cs
+++ b/src/WebJobs.Script/Config/ConfigurationSectionNames.cs
@@ -10,5 +10,6 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
         public const string Logging = "logging";
         public const string Aggregator = "aggregator";
         public const string HealthMonitor = "healthMonitor";
+        public const string HostIdPath = WebHost + ":hostid";
     }
 }

--- a/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
         {
             private static readonly string[] WellKnownHostJsonProperties = new[]
             {
-                "version", "id", "functionTimeout", "functions", "http", "watchDirectories", "queues", "serviceBus",
+                "version", "functionTimeout", "functions", "http", "watchDirectories", "queues", "serviceBus",
                 "eventHub", "singleton", "logging", "aggregator", "healthMonitor"
             };
 
@@ -165,13 +165,6 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
                 // Do not log these until after all the configuration is done so the proper filters are applied.
                 _logger.LogInformation(readingFileMessage);
                 _logger.LogInformation(readFileMessage);
-
-                // TODO: DI (FACAVAL) Move this to a more appropriate place
-                // If they set the host id in the JSON, emit a warning that this could cause issues and they shouldn't do it.
-                if (hostConfigObject["id"] != null)
-                {
-                    _logger.LogWarning("Host id explicitly set in the host.json. It is recommended that you remove the \"id\" property in your host.json.");
-                }
 
                 // TODO: DI (FACAVAL) Move to setup
                 //if (string.IsNullOrEmpty(_hostOptions.HostId))

--- a/src/WebJobs.Script/Host/ScriptHostIdProvider.cs
+++ b/src/WebJobs.Script/Host/ScriptHostIdProvider.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Executors;
-using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
@@ -16,7 +15,6 @@ namespace Microsoft.Azure.WebJobs.Script
 {
     public class ScriptHostIdProvider : IHostIdProvider
     {
-        private const string HostIdPath = ConfigurationSectionNames.JobHost + ":id";
         private readonly IConfiguration _config;
         private readonly IEnvironment _environment;
         private readonly IOptionsMonitor<ScriptApplicationHostOptions> _options;
@@ -30,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public Task<string> GetHostIdAsync(CancellationToken cancellationToken)
         {
-            return Task.FromResult(_config[HostIdPath] ?? GetDefaultHostId(_environment, _options.CurrentValue));
+            return Task.FromResult(_config[ConfigurationSectionNames.HostIdPath] ?? GetDefaultHostId(_environment, _options.CurrentValue));
         }
 
         internal static string GetDefaultHostId(IEnvironment environment, ScriptApplicationHostOptions scriptOptions)

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/host.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/host.json
@@ -1,4 +1,3 @@
 {
-    "version":  "2.0",
-    "id": "function-tests-csharp"
+    "version":  "2.0"
 }

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/DirectLoad/host.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/DirectLoad/host.json
@@ -1,4 +1,3 @@
 ﻿{
-    "version": "2.0",
-    "id": "function-tests-dotnet-direct"
+    "version": "2.0"
 }

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/DotNet/host.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/DotNet/host.json
@@ -1,4 +1,3 @@
 {
-    "version": "2.0",
-    "id": "function-tests-dotnet"
+    "version": "2.0"
 }

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/FSharp/host.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/FSharp/host.json
@@ -1,4 +1,3 @@
 ﻿{
-    "version": "2.0",
-    "id": "function-tests-fsharp"
+    "version": "2.0"
 }

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/FunctionGeneration/host.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/FunctionGeneration/host.json
@@ -1,4 +1,3 @@
 ﻿{
-    "version": "2.0",
-    "id": "function-tests-functiongen"
+    "version": "2.0"
 }

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/ListenerExceptions/host.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/ListenerExceptions/host.json
@@ -1,4 +1,3 @@
 ﻿{
-    "version": "2.0",
-    "id": "function-listener-failues"
+    "version": "2.0"
 }

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Node/host.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Node/host.json
@@ -1,4 +1,3 @@
 ﻿{
-    "version": "2.0",
-    "id": "function-tests-node"
+    "version": "2.0"
 }

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Proxies/host.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Proxies/host.json
@@ -1,4 +1,3 @@
 ﻿{
-    "version": "2.0",
-    "id": "function-tests-proxies"
+    "version": "2.0"
 }

--- a/test/WebJobs.Script.Tests/ScriptHostIdProviderTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostIdProviderTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>
                 {
-                    { ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "id"), "test-host-id" }
+                    { ConfigurationPath.Combine(ConfigurationSectionNames.HostIdPath), "test-host-id" }
                 })
                 .Build();
 


### PR DESCRIPTION
@mathewc will share more context, but this is a change we discussed with @paulbatum and @brettsam to remove the ability to set host ID in host.json. As a fallback, I'm adding a way to override that ID through any of the other supported configuration sources that apply to the app (e.g. environment variables, app settings file, etc.), but those apply to the app, as opposed to a Job Host instance. One of the reasons for the change is the fact that our `IHostIdProvider` registration was moved to the root and other services depend on it, so ideally, that would be set (and stable) from the moment the app starts up.

The other motivation is that setting the host id has always been problematic and we keep warning that it shouldn't be done. Removing that takes care of the issue (we may even want to consider not supporting the config based approach as it reintroduces that)