### PR TITLE
Add logging for Linux AppService Containers

### DIFF
--- a/src/WebJobs.Script.WebHost/Configuration/WebScriptHostConfigurationSource.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/WebScriptHostConfigurationSource.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
 
         public bool IsLinuxContainerEnvironment { get; set; }
 
+        public bool IsLinuxAppServiceEnvironment { get; set; }
+
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         {
             return new WebScriptHostConfigurationProvider(this);
@@ -46,7 +48,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
                     // Running in App Service
                     string home = GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHomePath);
                     Data[WebHostScriptPathProperty] = Path.Combine(home, "site", "wwwroot");
-                    Data[LogPathProperty] = Path.Combine(home, "LogFiles", "Application", "Functions");
+
+                    if (_configurationSource.IsLinuxAppServiceEnvironment)
+                    {
+                        Data[LogPathProperty] = GetEnvironmentVariable(EnvironmentSettingNames.FunctionsLogsMountPath);
+                    }
+                    else
+                    {
+                        Data[LogPathProperty] = Path.Combine(home, "LogFiles", "Application", "Functions");
+                    }
+
                     Data[SecretsPathProperty] = Path.Combine(home, "data", "Functions", "secrets");
                     Data[TestDataPathProperty] = Path.Combine(home, "data", "Functions", "sampledata");
                 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
+{
+    internal class LinuxAppServiceEventGenerator : LinuxEventGenerator
+    {
+        private readonly LinuxAppServiceFileLoggerFactory _loggerFactory;
+
+        public LinuxAppServiceEventGenerator(LinuxAppServiceFileLoggerFactory loggerFactory)
+        {
+            _loggerFactory = loggerFactory;
+        }
+
+        public static string TraceEventRegex { get; } = $"(?<Level>[0-6]),(?<SubscriptionId>[^,]*),(?<AppName>[^,]*),(?<FunctionName>[^,]*),(?<EventName>[^,]*),(?<Source>[^,]*),\"(?<Details>.*)\",\"(?<Summary>.*)\",(?<HostVersion>[^,]*),(?<EventTimestamp>[^,]+),(?<ExceptionType>[^,]*),\"(?<ExceptionMessage>.*)\",(?<FunctionInvocationId>[^,]*),(?<HostInstanceId>[^,]*),(?<ActivityId>[^,\"]*)";
+
+        public static string MetricEventRegex { get; } = $"(?<SubscriptionId>[^,]*),(?<AppName>[^,]*),(?<FunctionName>[^,]*),(?<EventName>[^,]*),(?<Average>\\d*),(?<Min>\\d*),(?<Max>\\d*),(?<Count>\\d*),(?<HostVersion>[^,]*),(?<EventTimestamp>[^,\"]+)";
+
+        public static string DetailsEventRegex { get; } = $"(?<AppName>[^,]*),(?<FunctionName>[^,]*),\"(?<InputBindings>.*)\",\"(?<OutputBindings>.*)\",(?<ScriptType>[^,]*),(?<IsDisabled>[0|1])";
+
+        public override void LogFunctionTraceEvent(LogLevel level, string subscriptionId, string appName, string functionName, string eventName,
+            string source, string details, string summary, string exceptionType, string exceptionMessage,
+            string functionInvocationId, string hostInstanceId, string activityId)
+        {
+            var eventTimestamp = DateTime.UtcNow.ToString(EventTimestampFormat);
+            var hostVersion = ScriptHost.Version;
+            FunctionsSystemLogsEventSource.Instance.SetActivityId(activityId);
+
+            var logger = _loggerFactory.GetOrCreate(FunctionsLogsCategory);
+            WriteEvent(logger, $"{(int)ToEventLevel(level)},{subscriptionId},{appName},{functionName},{eventName},{source},{NormalizeString(details)},{NormalizeString(summary)},{hostVersion},{eventTimestamp},{exceptionType},{NormalizeString(exceptionMessage)},{functionInvocationId},{hostInstanceId},{activityId}");
+        }
+
+        public override void LogFunctionMetricEvent(string subscriptionId, string appName, string functionName, string eventName, long average,
+            long minimum, long maximum, long count, DateTime eventTimestamp)
+        {
+            var hostVersion = ScriptHost.Version;
+            var logger = _loggerFactory.GetOrCreate(FunctionsMetricsCategory);
+            WriteEvent(logger, $"{subscriptionId},{appName},{functionName},{eventName},{average},{minimum},{maximum},{count},{hostVersion},{eventTimestamp.ToString(EventTimestampFormat)}");
+        }
+
+        public override void LogFunctionDetailsEvent(string siteName, string functionName, string inputBindings, string outputBindings,
+            string scriptType, bool isDisabled)
+        {
+            var logger = _loggerFactory.GetOrCreate(FunctionsDetailsCategory);
+            WriteEvent(logger, $"{siteName},{functionName},{NormalizeString(inputBindings)},{NormalizeString(outputBindings)},{scriptType},{(isDisabled ? 1 : 0)}");
+        }
+
+        public override void LogFunctionExecutionAggregateEvent(string siteName, string functionName, long executionTimeInMs,
+            long functionStartedCount, long functionCompletedCount, long functionFailedCount)
+        {
+        }
+
+        public override void LogFunctionExecutionEvent(string executionId, string siteName, int concurrency, string functionName,
+            string invocationId, string executionStage, long executionTimeSpan, bool success)
+        {
+        }
+
+        private static void WriteEvent(LinuxAppServiceFileLogger logger, string evt)
+        {
+            logger.Log(evt);
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceFileLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceFileLogger.cs
@@ -1,0 +1,173 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
+{
+    public class LinuxAppServiceFileLogger
+    {
+        private readonly string _logFileName;
+        private readonly string _logFileDirectory;
+        private readonly string _logFilePath;
+        private readonly BlockingCollection<string> _buffer;
+        private readonly List<string> _currentBatch;
+        private readonly IFileSystem _fileSystem;
+        private readonly CancellationTokenSource _cancellationTokenSource;
+        private Task _outputTask;
+
+        public LinuxAppServiceFileLogger(string logFileName, string logFileDirectory, IFileSystem fileSystem, bool startOnCreate = true)
+        {
+            _logFileName = logFileName;
+            _logFileDirectory = logFileDirectory;
+            _logFilePath = Path.Combine(_logFileDirectory, _logFileName + ".log");
+            _buffer = new BlockingCollection<string>(new ConcurrentQueue<string>());
+            _currentBatch = new List<string>();
+            _fileSystem = fileSystem;
+            _cancellationTokenSource = new CancellationTokenSource();
+
+            if (startOnCreate)
+            {
+                Start();
+            }
+        }
+
+        // Maximum number of files
+        public int MaxFileCount { get; set; } = 3;
+
+        // Maximum size of individual log file in MB
+        public int MaxFileSizeMb { get; set; } = 10;
+
+        // Maximum time between successive flushes (seconds)
+        public int FlushFrequencySeconds { get; set; } = 30;
+
+        public virtual void Log(string message)
+        {
+            try
+            {
+                _buffer.Add(message);
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+        }
+
+        public void Start()
+        {
+            if (_outputTask == null)
+            {
+                _outputTask = Task.Factory.StartNew(ProcessLogQueue, null, TaskCreationOptions.LongRunning);
+            }
+        }
+
+        public void Stop(TimeSpan timeSpan)
+        {
+            _cancellationTokenSource.Cancel();
+
+            try
+            {
+                _outputTask?.Wait(timeSpan);
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+        }
+
+        public virtual async Task ProcessLogQueue(object state)
+        {
+            while (!_cancellationTokenSource.IsCancellationRequested)
+            {
+                await InternalProcessLogQueue();
+                await Task.Delay(TimeSpan.FromSeconds(FlushFrequencySeconds), _cancellationTokenSource.Token).ContinueWith(task => { });
+            }
+            // ReSharper disable once FunctionNeverReturns
+        }
+
+        // internal for unittests
+        internal async Task InternalProcessLogQueue()
+        {
+            string currentMessage;
+            while (_buffer.TryTake(out currentMessage))
+            {
+                _currentBatch.Add(currentMessage);
+            }
+
+            if (_currentBatch.Any())
+            {
+                try
+                {
+                    await WriteLogs(_currentBatch);
+                }
+                catch (Exception)
+                {
+                    // Ignored
+                }
+
+                _currentBatch.Clear();
+            }
+        }
+
+        private async Task WriteLogs(IEnumerable<string> currentBatch)
+        {
+            _fileSystem.Directory.CreateDirectory(_logFileDirectory);
+
+            var fileInfo = _fileSystem.FileInfo.FromFileName(_logFilePath);
+            if (fileInfo.Exists)
+            {
+                if (fileInfo.Length / (1024 * 1024) >= MaxFileSizeMb)
+                {
+                    RollFiles();
+                }
+            }
+
+            await AppendLogs(_logFilePath, currentBatch);
+        }
+
+        private async Task AppendLogs(string filePath, IEnumerable<string> logs)
+        {
+            using (var streamWriter = _fileSystem.File.AppendText(filePath))
+            {
+                foreach (var log in logs)
+                {
+                    await streamWriter.WriteLineAsync(log);
+                }
+            }
+        }
+
+        private void RollFiles()
+        {
+            // Rename current file to older file.
+            // Empty current file.
+            // Delete oldest file if exceeded configured max no. of files.
+
+            _fileSystem.File.Move(_logFilePath, GetCurrentFileName(DateTime.UtcNow));
+
+            var fileInfoBases = ListFiles(_logFileDirectory, _logFileName + "*", SearchOption.TopDirectoryOnly);
+
+            if (fileInfoBases.Length >= MaxFileCount)
+            {
+                var oldestFile = fileInfoBases.OrderByDescending(f => f.Name).Last();
+                oldestFile.Delete();
+            }
+        }
+
+        private FileInfoBase[] ListFiles(string directoryPath, string pattern, SearchOption searchOption)
+        {
+            return _fileSystem.DirectoryInfo.FromDirectoryName(directoryPath).GetFiles(pattern, searchOption);
+        }
+
+        public string GetCurrentFileName(DateTime dateTime)
+        {
+            return Path.Combine(_logFileDirectory, $"{_logFileName}{dateTime:yyyyMMddHHmmss}.log");
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceFileLoggerFactory.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceFileLoggerFactory.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.IO.Abstractions;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
+{
+    public class LinuxAppServiceFileLoggerFactory
+    {
+        private static readonly ConcurrentDictionary<string, Lazy<LinuxAppServiceFileLogger>> Loggers = new ConcurrentDictionary<string, Lazy<LinuxAppServiceFileLogger>>();
+        private readonly string _logRootPath;
+
+        public LinuxAppServiceFileLoggerFactory()
+        {
+            _logRootPath = Environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsLogsMountPath);
+        }
+
+        public virtual LinuxAppServiceFileLogger GetOrCreate(string category)
+        {
+            return Loggers.GetOrAdd(category,
+                c => new Lazy<LinuxAppServiceFileLogger>(() => new LinuxAppServiceFileLogger(category, _logRootPath, new FileSystem()))).Value;
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxContainerEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxContainerEventGenerator.cs
@@ -2,14 +2,12 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics.Tracing;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 {
-    internal class LinuxContainerEventGenerator : IEventGenerator
+    internal class LinuxContainerEventGenerator : LinuxEventGenerator
     {
-        private const string EventTimestampFormat = "MM/dd/yyyy hh:mm:ss.fff tt";
         private readonly Action<string> _writeEvent;
         private readonly bool _consoleEnabled = true;
 
@@ -31,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public static string DetailsEventRegex { get; } = $"{ScriptConstants.LinuxFunctionDetailsEventStreamName} (?<AppName>[^,]*),(?<FunctionName>[^,]*),\\\\\"(?<InputBindings>.*)\\\\\",\\\\\"(?<OutputBindings>.*)\\\\\",(?<ScriptType>[^,]*),(?<IsDisabled>[0|1])";
 
-        public void LogFunctionTraceEvent(LogLevel level, string subscriptionId, string appName, string functionName, string eventName, string source, string details, string summary, string exceptionType, string exceptionMessage, string functionInvocationId, string hostInstanceId, string activityId)
+        public override void LogFunctionTraceEvent(LogLevel level, string subscriptionId, string appName, string functionName, string eventName, string source, string details, string summary, string exceptionType, string exceptionMessage, string functionInvocationId, string hostInstanceId, string activityId)
         {
             string eventTimestamp = DateTime.UtcNow.ToString(EventTimestampFormat);
             string hostVersion = ScriptHost.Version;
@@ -40,23 +38,23 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             _writeEvent($"{ScriptConstants.LinuxLogEventStreamName} {(int)ToEventLevel(level)},{subscriptionId},{appName},{functionName},{eventName},{source},{NormalizeString(details)},{NormalizeString(summary)},{hostVersion},{eventTimestamp},{exceptionType},{NormalizeString(exceptionMessage)},{functionInvocationId},{hostInstanceId},{activityId}");
         }
 
-        public void LogFunctionMetricEvent(string subscriptionId, string appName, string functionName, string eventName, long average, long minimum, long maximum, long count, DateTime eventTimestamp)
+        public override void LogFunctionMetricEvent(string subscriptionId, string appName, string functionName, string eventName, long average, long minimum, long maximum, long count, DateTime eventTimestamp)
         {
             string hostVersion = ScriptHost.Version;
 
             _writeEvent($"{ScriptConstants.LinuxMetricEventStreamName} {subscriptionId},{appName},{functionName},{eventName},{average},{minimum},{maximum},{count},{hostVersion},{eventTimestamp.ToString(EventTimestampFormat)}");
         }
 
-        public void LogFunctionDetailsEvent(string siteName, string functionName, string inputBindings, string outputBindings, string scriptType, bool isDisabled)
+        public override void LogFunctionDetailsEvent(string siteName, string functionName, string inputBindings, string outputBindings, string scriptType, bool isDisabled)
         {
             _writeEvent($"{ScriptConstants.LinuxFunctionDetailsEventStreamName} {siteName},{functionName},{NormalizeString(inputBindings)},{NormalizeString(outputBindings)},{scriptType},{(isDisabled ? 1 : 0)}");
         }
 
-        public void LogFunctionExecutionAggregateEvent(string siteName, string functionName, long executionTimeInMs, long functionStartedCount, long functionCompletedCount, long functionFailedCount)
+        public override void LogFunctionExecutionAggregateEvent(string siteName, string functionName, long executionTimeInMs, long functionStartedCount, long functionCompletedCount, long functionFailedCount)
         {
         }
 
-        public void LogFunctionExecutionEvent(string executionId, string siteName, int concurrency, string functionName, string invocationId, string executionStage, long executionTimeSpan, bool success)
+        public override void LogFunctionExecutionEvent(string executionId, string siteName, int concurrency, string functionName, string invocationId, string executionStage, long executionTimeSpan, bool success)
         {
         }
 
@@ -65,44 +63,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             if (_consoleEnabled)
             {
                 Console.WriteLine(evt);
-            }
-        }
-
-        internal static string NormalizeString(string value)
-        {
-            // need to remove newlines for csv output
-            value = value.Replace(Environment.NewLine, " ");
-
-            // Wrap string literals in enclosing quotes
-            // For string columns that may contain quotes and/or
-            // our delimiter ',', before writing the value we
-            // enclose in quotes. This allows us to define matching
-            // groups based on quotes for these values.
-            return $"\"{value}\"";
-        }
-
-        /// <summary>
-        /// Performs the same mapping from <see cref="LogLevel"/> to <see cref="EventLevel"/>
-        /// that is performed for ETW event logging in <see cref="EtwEventGenerator"/>, so we
-        /// have consistent log levels across platforms.
-        /// </summary>
-        internal static EventLevel ToEventLevel(LogLevel level)
-        {
-            switch (level)
-            {
-                case LogLevel.Trace:
-                case LogLevel.Debug:
-                    return EventLevel.Verbose;
-                case LogLevel.Information:
-                    return EventLevel.Informational;
-                case LogLevel.Warning:
-                    return EventLevel.Warning;
-                case LogLevel.Error:
-                    return EventLevel.Error;
-                case LogLevel.Critical:
-                    return EventLevel.Critical;
-                default:
-                    return EventLevel.LogAlways;
             }
         }
     }

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxEventGenerator.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics.Tracing;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
+{
+    public abstract class LinuxEventGenerator : IEventGenerator
+    {
+        public static readonly string EventTimestampFormat = "MM/dd/yyyy hh:mm:ss.fff tt";
+
+        // These names should match the source file names for fluentd
+        public static readonly string FunctionsLogsCategory = "functionslogs";
+        public static readonly string FunctionsMetricsCategory = "functionsmetrics";
+        public static readonly string FunctionsDetailsCategory = "functionsdetails";
+
+        internal static string NormalizeString(string value)
+        {
+            // need to remove newlines for csv output
+            value = value.Replace(Environment.NewLine, " ");
+
+            // Wrap string literals in enclosing quotes
+            // For string columns that may contain quotes and/or
+            // our delimiter ',', before writing the value we
+            // enclose in quotes. This allows us to define matching
+            // groups based on quotes for these values.
+            return $"\"{value}\"";
+        }
+
+        /// <summary>
+        /// Performs the same mapping from <see cref="LogLevel"/> to <see cref="EventLevel"/>
+        /// that is performed for ETW event logging in <see cref="EtwEventGenerator"/>, so we
+        /// have consistent log levels across platforms.
+        /// </summary>
+        internal static EventLevel ToEventLevel(LogLevel level)
+        {
+            switch (level)
+            {
+                case LogLevel.Trace:
+                case LogLevel.Debug:
+                    return EventLevel.Verbose;
+                case LogLevel.Information:
+                    return EventLevel.Informational;
+                case LogLevel.Warning:
+                    return EventLevel.Warning;
+                case LogLevel.Error:
+                    return EventLevel.Error;
+                case LogLevel.Critical:
+                    return EventLevel.Critical;
+                default:
+                    return EventLevel.LogAlways;
+            }
+        }
+
+        public abstract void LogFunctionTraceEvent(LogLevel level, string subscriptionId, string appName,
+            string functionName, string eventName,
+            string source, string details, string summary, string exceptionType, string exceptionMessage,
+            string functionInvocationId, string hostInstanceId, string activityId);
+
+        public abstract void LogFunctionMetricEvent(string subscriptionId, string appName, string functionName,
+            string eventName, long average,
+            long minimum, long maximum, long count, DateTime eventTimestamp);
+
+        public abstract void LogFunctionExecutionAggregateEvent(string siteName, string functionName,
+            long executionTimeInMs,
+            long functionStartedCount, long functionCompletedCount, long functionFailedCount);
+
+        public abstract void LogFunctionDetailsEvent(string siteName, string functionName, string inputBindings,
+            string outputBindings,
+            string scriptType, bool isDisabled);
+
+        public abstract void LogFunctionExecutionEvent(string executionId, string siteName, int concurrency,
+            string functionName,
+            string invocationId, string executionStage, long executionTimeSpan, bool success);
+    }
+}

--- a/src/WebJobs.Script.WebHost/Program.cs
+++ b/src/WebJobs.Script.WebHost/Program.cs
@@ -63,7 +63,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     config.Add(new WebScriptHostConfigurationSource
                     {
                         IsAppServiceEnvironment = SystemEnvironment.Instance.IsAppServiceEnvironment(),
-                        IsLinuxContainerEnvironment = SystemEnvironment.Instance.IsLinuxContainerEnvironment()
+                        IsLinuxContainerEnvironment = SystemEnvironment.Instance.IsLinuxContainerEnvironment(),
+                        IsLinuxAppServiceEnvironment = SystemEnvironment.Instance.IsLinuxAppServiceEnvironment()
                     });
                 })
                 .ConfigureLogging((context, loggingBuilder) =>

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -86,6 +86,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 {
                     return new LinuxContainerEventGenerator();
                 }
+                else if (SystemEnvironment.Instance.IsLinuxAppServiceEnvironment())
+                {
+                    return new LinuxAppServiceEventGenerator(new LinuxAppServiceFileLoggerFactory());
+                }
                 else
                 {
                     return new EtwEventGenerator();

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -18,6 +18,11 @@ namespace Microsoft.Azure.WebJobs.Script
             return !environment.IsAppServiceEnvironment() && !string.IsNullOrEmpty(environment.GetEnvironmentVariable(ContainerName));
         }
 
+        public static bool IsLinuxAppServiceEnvironment(this IEnvironment environment)
+        {
+            return environment.IsAppServiceEnvironment() && !string.IsNullOrEmpty(environment.GetEnvironmentVariable(FunctionsLogsMountPath));
+        }
+
         public static bool IsPlaceholderModeEnabled(this IEnvironment environment)
         {
             return environment.GetEnvironmentVariable(AzureWebsitePlaceholderMode) == "1";

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public const string ContainerStartContext = "CONTAINER_START_CONTEXT";
         public const string ContainerStartContextSasUri = "CONTAINER_START_CONTEXT_SAS_URI";
+        public const string FunctionsLogsMountPath = "FUNCTIONS_LOGS_MOUNT_PATH";
 
         // unfortunately there are 3 versions of this setting that have to be supported
         // due to renames

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxAppServiceFileLoggerTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxAppServiceFileLoggerTests.cs
@@ -1,0 +1,229 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
+{
+    public class LinuxAppServiceFileLoggerTests
+    {
+        private const string LogDirectoryPath = @"C:\temp\logs";
+        private const string LogFileName = "FunctionLog";
+
+        [Fact]
+        public async void Writes_Logs_to_Files()
+        {
+            var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
+            var dirBase = new Mock<DirectoryBase>(MockBehavior.Strict);
+            var fileInfoFactory = new Mock<IFileInfoFactory>(MockBehavior.Strict);
+            var fileInfoBase = new Mock<FileInfoBase>(MockBehavior.Strict);
+            var fileBase = new Mock<FileBase>(MockBehavior.Strict);
+            var stream = new Mock<Stream>();
+            stream.Setup(s => s.CanWrite).Returns(true);
+            var streamWriter = new Mock<StreamWriter>(MockBehavior.Default, stream.Object);
+
+            fileSystem.SetupGet(fs => fs.Directory).Returns(dirBase.Object);
+            dirBase.Setup(d => d.CreateDirectory(It.Is<string>(s => string.Equals(s, LogDirectoryPath)))).Returns(new DirectoryInfo(LogDirectoryPath));
+
+            fileSystem.SetupGet(fs => fs.FileInfo).Returns(fileInfoFactory.Object);
+            fileInfoFactory.Setup(f => f.FromFileName(It.Is<string>(s => MatchesLogFilePath(s))))
+                .Returns(fileInfoBase.Object);
+            fileInfoBase.Setup(f => f.Exists).Returns(false);
+
+            fileSystem.SetupGet(fs => fs.File).Returns(fileBase.Object);
+            fileBase.Setup(f => f.AppendText(It.Is<string>(s => MatchesLogFilePath(s)))).Returns(streamWriter.Object);
+
+            var expectedLogs = GetLogs();
+            for (var i = 0; i < expectedLogs.Count; i++)
+            {
+                var i1 = i;
+                streamWriter.Setup(s => s.WriteLineAsync(It.Is<string>(log => log.Equals(expectedLogs[i1])))).Returns(Task.FromResult(true));
+            }
+
+            var fileLogger = new LinuxAppServiceFileLogger(LogFileName, LogDirectoryPath, fileSystem.Object, false);
+
+            foreach (var log in GetLogs())
+            {
+                fileLogger.Log(log);
+            }
+
+            await fileLogger.InternalProcessLogQueue();
+
+            fileSystem.VerifyGet(fs => fs.Directory, Times.Once);
+            dirBase.Verify(d => d.CreateDirectory(It.Is<string>(s => string.Equals(s, LogDirectoryPath))), Times.Once);
+
+            fileInfoFactory.Verify(f => f.FromFileName(It.Is<string>(s => MatchesLogFilePath(s))), Times.Once);
+            fileInfoBase.Verify(f => f.Exists, Times.Once);
+
+            fileSystem.VerifyGet(fs => fs.File, Times.Once);
+            fileBase.Verify(f => f.AppendText(It.Is<string>(s => MatchesLogFilePath(s))), Times.Once);
+            for (var i = 0; i < expectedLogs.Count; i++)
+            {
+                var i1 = i;
+                streamWriter.Verify(s => s.WriteLineAsync(It.Is<string>(log => log.Equals(expectedLogs[i1]))), Times.Once);
+            }
+        }
+
+        [Fact]
+        public async void Does_Not_Modify_Files_When_No_logs()
+        {
+            // Expect no methods to be called on ILinuxAppServiceFileSystem
+            var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
+            var fileLogger = new LinuxAppServiceFileLogger(LogFileName, LogDirectoryPath, fileSystem.Object, false);
+            await fileLogger.InternalProcessLogQueue();
+        }
+
+        [Fact]
+        public async void Rolls_Files_If_File_Size_Exceeds_Limit()
+        {
+            var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
+            var fileLogger = new LinuxAppServiceFileLogger(LogFileName, LogDirectoryPath, fileSystem.Object, false);
+            var dirBase = new Mock<DirectoryBase>(MockBehavior.Strict);
+            var fileInfoFactory = new Mock<IFileInfoFactory>(MockBehavior.Strict);
+            var fileInfoBase = new Mock<FileInfoBase>(MockBehavior.Strict);
+            var fileBase = new Mock<FileBase>(MockBehavior.Strict);
+            var directoryInfoFactory = new Mock<IDirectoryInfoFactory>(MockBehavior.Strict);
+            var directoryInfoBase = new Mock<DirectoryInfoBase>(MockBehavior.Strict);
+
+            fileSystem.SetupGet(fs => fs.Directory).Returns(dirBase.Object);
+            dirBase.Setup(d => d.CreateDirectory(It.Is<string>(s => string.Equals(s, LogDirectoryPath)))).Returns(new DirectoryInfo(LogDirectoryPath));
+
+            fileSystem.SetupGet(fs => fs.FileInfo).Returns(fileInfoFactory.Object);
+            fileInfoFactory.Setup(f => f.FromFileName(It.Is<string>(s => MatchesLogFilePath(s))))
+                .Returns(fileInfoBase.Object);
+            fileInfoBase.Setup(f => f.Exists).Returns(true);
+
+            fileInfoBase.SetupGet(f => f.Length).Returns((fileLogger.MaxFileSizeMb * 1024 * 1024) + 1);
+
+            fileSystem.SetupGet(fs => fs.File).Returns(fileBase.Object);
+            fileBase.Setup(f => f.Move(It.Is<string>(s => MatchesLogFilePath(s)), It.IsAny<string>()));
+
+            fileSystem.SetupGet(fs => fs.DirectoryInfo).Returns(directoryInfoFactory.Object);
+            directoryInfoFactory.Setup(d => d.FromDirectoryName(It.Is<string>(s => string.Equals(s, LogDirectoryPath))))
+                .Returns(directoryInfoBase.Object);
+            directoryInfoBase
+                .Setup(d => d.GetFiles(It.Is<string>(s => s.StartsWith(LogFileName)), SearchOption.TopDirectoryOnly))
+                .Returns(new FileInfoBase[0]);
+
+            fileLogger.Log("LogMessgae");
+            await fileLogger.InternalProcessLogQueue();
+
+            fileSystem.VerifyGet(fs => fs.Directory, Times.Once);
+            dirBase.Verify(d => d.CreateDirectory(It.Is<string>(s => string.Equals(s, LogDirectoryPath))), Times.Once);
+
+            fileInfoFactory.Verify(f => f.FromFileName(It.Is<string>(s => MatchesLogFilePath(s))), Times.Once);
+            fileInfoBase.Verify(f => f.Exists, Times.Once);
+
+            fileInfoBase.VerifyGet(f => f.Length, Times.Once);
+
+            fileBase.Verify(f => f.Move(It.Is<string>(s => MatchesLogFilePath(s)), It.IsAny<string>()), Times.Once);
+
+            directoryInfoFactory.Verify(d => d.FromDirectoryName(It.Is<string>(s => string.Equals(s, LogDirectoryPath))), Times.Once);
+            directoryInfoBase
+                .Verify(d => d.GetFiles(It.Is<string>(s => s.StartsWith(LogFileName)), SearchOption.TopDirectoryOnly),
+                    Times.Once);
+        }
+
+        [Fact]
+        public async void Deletes_Oldest_File_If_Exceeds_Limit()
+        {
+            var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
+            var fileLogger = new LinuxAppServiceFileLogger(LogFileName, LogDirectoryPath, fileSystem.Object, false);
+            var dirBase = new Mock<DirectoryBase>(MockBehavior.Strict);
+            var fileInfoFactory = new Mock<IFileInfoFactory>(MockBehavior.Strict);
+            var fileInfoBase = new Mock<FileInfoBase>(MockBehavior.Strict);
+            var fileBase = new Mock<FileBase>(MockBehavior.Strict);
+            var directoryInfoFactory = new Mock<IDirectoryInfoFactory>(MockBehavior.Strict);
+            var directoryInfoBase = new Mock<DirectoryInfoBase>(MockBehavior.Strict);
+
+            fileSystem.SetupGet(fs => fs.Directory).Returns(dirBase.Object);
+            dirBase.Setup(d => d.CreateDirectory(It.Is<string>(s => string.Equals(s, LogDirectoryPath))));
+
+            fileSystem.SetupGet(fs => fs.FileInfo).Returns(fileInfoFactory.Object);
+            fileInfoFactory.Setup(f => f.FromFileName(It.Is<string>(s => MatchesLogFilePath(s))))
+                .Returns(fileInfoBase.Object);
+            fileInfoBase.Setup(f => f.Exists).Returns(true);
+
+            fileInfoBase.SetupGet(f => f.Length).Returns((fileLogger.MaxFileSizeMb * 1024 * 1024) + 1);
+
+            fileSystem.SetupGet(fs => fs.File).Returns(fileBase.Object);
+            fileBase.Setup(f => f.Move(It.Is<string>(s => MatchesLogFilePath(s)), It.IsAny<string>()));
+
+            var fileCount = fileLogger.MaxFileCount + 1;
+            var fileInfosMock = new Mock<FileInfoBase>[fileCount];
+            for (var i = 0; i < fileCount; i++)
+            {
+                fileInfosMock[i] = new Mock<FileInfoBase>(MockBehavior.Strict);
+            }
+
+            fileSystem.SetupGet(fs => fs.DirectoryInfo).Returns(directoryInfoFactory.Object);
+            directoryInfoFactory.Setup(d => d.FromDirectoryName(It.Is<string>(s => string.Equals(s, LogDirectoryPath))))
+                .Returns(directoryInfoBase.Object);
+            directoryInfoBase
+                .Setup(d => d.GetFiles(It.Is<string>(s => s.StartsWith(LogFileName)), SearchOption.TopDirectoryOnly))
+                .Returns(fileInfosMock.Select(f => f.Object).ToArray);
+
+            fileInfosMock[0].Setup(f => f.Delete());
+
+            fileLogger.Log("LogMessgae");
+            await fileLogger.InternalProcessLogQueue();
+
+            fileSystem.SetupGet(fs => fs.Directory).Returns(dirBase.Object);
+            dirBase.Setup(d => d.CreateDirectory(It.Is<string>(s => string.Equals(s, LogDirectoryPath))));
+
+            fileSystem.SetupGet(fs => fs.FileInfo).Returns(fileInfoFactory.Object);
+            fileInfoFactory.Setup(f => f.FromFileName(It.Is<string>(s => MatchesLogFilePath(s))))
+                .Returns(fileInfoBase.Object);
+            fileInfoBase.Setup(f => f.Exists).Returns(true);
+
+            fileInfoBase.SetupGet(f => f.Length).Returns((fileLogger.MaxFileSizeMb * 1024 * 1024) + 1);
+
+            fileSystem.SetupGet(fs => fs.File).Returns(fileBase.Object);
+            fileBase.Setup(f => f.Move(It.Is<string>(s => MatchesLogFilePath(s)), It.IsAny<string>()));
+
+            fileSystem.SetupGet(fs => fs.DirectoryInfo).Returns(directoryInfoFactory.Object);
+            directoryInfoFactory.Setup(d => d.FromDirectoryName(It.Is<string>(s => string.Equals(s, LogDirectoryPath))))
+                .Returns(directoryInfoBase.Object);
+            directoryInfoBase
+                .Setup(d => d.GetFiles(It.Is<string>(s => s.StartsWith(LogFileName)), SearchOption.TopDirectoryOnly))
+                .Returns(fileInfosMock.Select(f => f.Object).ToArray);
+
+            fileInfosMock[0].Setup(f => f.Delete());
+        }
+
+        private static bool MatchesLogFilePath(string filePath)
+        {
+            if (!string.Equals(".log", Path.GetExtension(filePath)))
+            {
+                return false;
+            }
+
+            if (!string.Equals(LogFileName, Path.GetFileNameWithoutExtension(filePath)))
+            {
+                return false;
+            }
+
+            if (!string.Equals(LogDirectoryPath, Path.GetDirectoryName(filePath)))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static List<string> GetLogs()
+        {
+            return new List<string>
+            {
+                "Message 1", "Msg2", "end"
+            };
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxEventGeneratorTestData.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxEventGeneratorTestData.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
+{
+    public static class LinuxEventGeneratorTestData
+    {
+        public static IEnumerable<object[]> GetDetailsEvents()
+        {
+            yield return new object[] { "TestApp", "TestFunction", "{ foo: 123, bar: \"Test\" }", "{ foo: \"Mathew\", bar: \"Charles\" }", "CSharp", 0 };
+            yield return new object[] { string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, 0 };
+        }
+
+        public static IEnumerable<object[]> GetMetricEvents()
+        {
+            yield return new object[] { "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction", "TestEvent", 15, 2, 18, 5 };
+            yield return new object[] { string.Empty, string.Empty, string.Empty, string.Empty, 0, 0, 0, 0 };
+        }
+
+        public static IEnumerable<object[]> GetLogEvents()
+        {
+            yield return new object[] { LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53" };
+            yield return new object[] { LogLevel.Information, string.Empty, "TestApp", "TestFunction", "TestEvent", string.Empty, "This string includes a quoted \"substring\" in the middle", "Another \"quoted substring\"", "TestExceptionType", "Another \"quoted substring\"", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53" };
+            yield return new object[] { LogLevel.Information, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty };
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Diagnostics/MockLinuxAppServiceFileLogger.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/MockLinuxAppServiceFileLogger.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
+{
+    public class MockLinuxAppServiceFileLogger : LinuxAppServiceFileLogger
+    {
+        public MockLinuxAppServiceFileLogger(string category, string logFileDirectory, IFileSystem fileSystem) : base(category, logFileDirectory, fileSystem)
+        {
+            Events = new List<string>();
+        }
+
+        public List<string> Events { get; }
+
+        public override void Log(string evt)
+        {
+            Events.Add(evt);
+        }
+
+        public override Task ProcessLogQueue(object state)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
When running on appservice containers, use the mounted log folder to write logs. To avoid using up too much space on the worker, support rolling of log files.