### PR TITLE
Adding ability to stop restart loop on fatal initialization failures. Updating language check to throw when in mixed mode

### DIFF
--- a/src/WebJobs.Script.WebHost/DefaultScriptHostBuilder.cs
+++ b/src/WebJobs.Script.WebHost/DefaultScriptHostBuilder.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Azure.WebJobs.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost
+{
+    public sealed class DefaultScriptHostBuilder : IScriptHostBuilder
+    {
+        private readonly IOptionsMonitor<ScriptApplicationHostOptions> _applicationHostOptions;
+        private readonly IServiceProvider _rootServiceProvider;
+        private readonly IServiceScopeFactory _rootScopeFactory;
+
+        public DefaultScriptHostBuilder(IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, IServiceProvider rootServiceProvider, IServiceScopeFactory rootScopeFactory)
+        {
+            _applicationHostOptions = applicationHostOptions ?? throw new ArgumentNullException(nameof(applicationHostOptions));
+            _rootServiceProvider = rootServiceProvider ?? throw new ArgumentNullException(nameof(rootServiceProvider));
+            _rootScopeFactory = rootScopeFactory ?? throw new ArgumentNullException(nameof(rootScopeFactory));
+        }
+
+        public IHost BuildHost(bool skipHostStartup, bool skipHostConfigurationParsing)
+        {
+            var builder = new HostBuilder();
+
+            if (skipHostConfigurationParsing)
+            {
+                builder.ConfigureAppConfiguration((context, _) =>
+                {
+                    context.Properties[ScriptConstants.SkipHostJsonConfigurationKey] = true;
+                });
+            }
+
+            builder.SetAzureFunctionsEnvironment()
+                .AddWebScriptHost(_rootServiceProvider, _rootScopeFactory, _applicationHostOptions.CurrentValue);
+
+            if (skipHostStartup)
+            {
+                builder.ConfigureServices(services =>
+                {
+                    // When offline, we need most general services registered so admin
+                    // APIs can function. However, we want to prevent the ScriptHost from
+                    // actually starting up. To accomplish this, we remove the host service
+                    // responsible for starting the job hst.
+                    var jobHostService = services.FirstOrDefault(p => p.ImplementationType == typeof(JobHostService));
+                    services.Remove(jobHostService);
+                });
+            }
+
+            return builder.Build();
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/IScriptHostBuilder.cs
+++ b/src/WebJobs.Script.WebHost/IScriptHostBuilder.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost
+{
+    public interface IScriptHostBuilder
+    {
+        IHost BuildHost(bool skipHostStartup, bool skipHostConfigurationParsing);
+    }
+}

--- a/src/WebJobs.Script.WebHost/JobHost/WebScriptJobHostEnvironment.cs
+++ b/src/WebJobs.Script.WebHost/JobHost/WebScriptJobHostEnvironment.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
+using ExtensionsHostingEnvironment = Microsoft.Extensions.Hosting.IHostingEnvironment;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
 {
@@ -14,14 +12,18 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
     {
         private readonly IApplicationLifetime _applicationLifetime;
         private readonly IScriptHostManager _hostManager;
+        private readonly ExtensionsHostingEnvironment _hostingEnvironment;
         private int _shutdownRequested;
         private int _restartRequested;
 
-        public WebScriptJobHostEnvironment(IApplicationLifetime applicationLifetime, IScriptHostManager hostManager)
+        public WebScriptJobHostEnvironment(IApplicationLifetime applicationLifetime, IScriptHostManager hostManager, ExtensionsHostingEnvironment hostingEnvironment)
         {
             _applicationLifetime = applicationLifetime ?? throw new ArgumentNullException(nameof(applicationLifetime));
             _hostManager = hostManager ?? throw new ArgumentNullException(nameof(hostManager));
+            _hostingEnvironment = hostingEnvironment ?? throw new ArgumentNullException(nameof(hostingEnvironment));
         }
+
+        public string EnvironmentName => _hostingEnvironment.EnvironmentName;
 
         public void RestartHost()
         {

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddSingleton<IScriptHostManager>(s => s.GetRequiredService<WebJobsScriptHostService>());
             services.AddSingleton<IScriptWebHostEnvironment, ScriptWebHostEnvironment>();
             services.AddSingleton<IStandbyManager, StandbyManager>();
+            services.TryAddSingleton<IScriptHostBuilder, DefaultScriptHostBuilder>();
 
             if (SystemEnvironment.Instance.IsLinuxContainerEnvironment())
             {

--- a/src/WebJobs.Script/ConsoleScriptJobHostEnvironment.cs
+++ b/src/WebJobs.Script/ConsoleScriptJobHostEnvironment.cs
@@ -7,12 +7,16 @@ namespace Microsoft.Azure.WebJobs.Script
 {
     public class ConsoleScriptJobHostEnvironment : IScriptJobHostEnvironment
     {
+        private readonly IHostingEnvironment _hostingEnvironment;
         private IApplicationLifetime _applicationLifetime;
 
-        public ConsoleScriptJobHostEnvironment(IApplicationLifetime applicationLifetime)
+        public ConsoleScriptJobHostEnvironment(IApplicationLifetime applicationLifetime, IHostingEnvironment hostingEnvironment)
         {
-            _applicationLifetime = applicationLifetime;
+            _applicationLifetime = applicationLifetime ?? throw new System.ArgumentNullException(nameof(applicationLifetime));
+            _hostingEnvironment = hostingEnvironment ?? throw new System.ArgumentNullException(nameof(hostingEnvironment));
         }
+
+        public string EnvironmentName => _hostingEnvironment.EnvironmentName;
 
         public void RestartHost()
         {

--- a/src/WebJobs.Script/Host/IScriptJobHostEnvironment.cs
+++ b/src/WebJobs.Script/Host/IScriptJobHostEnvironment.cs
@@ -15,6 +15,11 @@ namespace Microsoft.Azure.WebJobs.Script
     public interface IScriptJobHostEnvironment
     {
         /// <summary>
+        /// Gets the current environment name
+        /// </summary>
+        string EnvironmentName { get; }
+
+        /// <summary>
         /// Restarts the <see cref="IScriptJobHost"/>.
         /// </summary>
         void RestartHost();

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
             _hostLogPath = Path.Combine(ScriptOptions.RootLogPath, "Host");
 
-            _currentRuntimelanguage = _settingsManager.Configuration[LanguageWorkerConstants.FunctionWorkerRuntimeSettingName];
+            _currentRuntimelanguage = _environment.GetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName);
 
             _loggerFactory = loggerFactory;
             _logger = loggerFactory.CreateLogger(LogCategories.Startup);
@@ -660,10 +660,9 @@ namespace Microsoft.Azure.WebJobs.Script
             Collection<FunctionDescriptor> functionDescriptors = new Collection<FunctionDescriptor>();
             var httpFunctions = new Dictionary<string, HttpTriggerAttribute>();
 
-            if (!Utility.IsSingleLanguage(functions, _currentRuntimelanguage))
+            if (!_scriptHostEnvironment.IsDevelopment() && !Utility.IsSingleLanguage(functions, _currentRuntimelanguage))
             {
-                _logger.LogError($"Found functions with more than one language. Select a language for your function app by specifying {LanguageWorkerConstants.FunctionWorkerRuntimeSettingName} AppSetting");
-                return functionDescriptors;
+                throw new HostInitializationException($"Found functions with more than one language. Select a language for your function app by specifying {LanguageWorkerConstants.FunctionWorkerRuntimeSettingName} AppSetting");
             }
 
             foreach (FunctionMetadata metadata in functions)

--- a/src/WebJobs.Script/Host/ScriptJobHostEnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Host/ScriptJobHostEnvironmentExtensions.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.Azure.WebJobs.Script
+{
+    public static class ScriptJobHostEnvironmentExtensions
+    {
+        public static bool IsDevelopment(this IScriptJobHostEnvironment environment)
+        {
+            if (environment == null)
+            {
+                throw new ArgumentNullException(nameof(environment));
+            }
+
+            return environment.IsEnvironment(EnvironmentName.Development);
+        }
+
+        public static bool IsEnvironment(this IScriptJobHostEnvironment environment, string environmentName)
+        {
+            if (environment == null)
+            {
+                throw new ArgumentNullException(nameof(environment));
+            }
+
+            return string.Equals(environment.EnvironmentName, environmentName, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/WebJobs.Script/HostInitializationException.cs
+++ b/src/WebJobs.Script/HostInitializationException.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Script
+{
+    /// <summary>
+    /// An exception that indicates an issue initializing a ScriptHost.
+    /// </summary>
+    [Serializable]
+    public class HostInitializationException : Exception
+    {
+        public HostInitializationException() { }
+
+        public HostInitializationException(string message) : base(message) { }
+
+        public HostInitializationException(string message, Exception inner) : base(message, inner) { }
+
+        protected HostInitializationException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTestsLanguageEmpty.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTestsLanguageEmpty.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/plain"));
 
             HttpResponseMessage response = await _fixture.Host.HttpClient.SendAsync(request);
-            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
         }
         public class TestFixture : EndToEndTestFixture
         {

--- a/test/WebJobs.Script.Tests.Shared/NullScriptHostEnvironment.cs
+++ b/test/WebJobs.Script.Tests.Shared/NullScriptHostEnvironment.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class NullScriptHostEnvironment : IScriptJobHostEnvironment
     {
+        public string EnvironmentName => string.Empty;
+
         public void RestartHost()
         {
         }

--- a/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public class WebJobsScriptHostServiceTests
+    {
+        [Fact]
+        public async Task HostInitialization_OnInitializationException_MaintainsErrorInformation()
+        {
+            var options = new ScriptApplicationHostOptions
+            {
+                ScriptPath = @"c:\tests",
+                LogPath = @"c:\tests\logs",
+            };
+
+            var monitor = new ScriptApplicationHostOptionsMonitor(options);
+
+            var services = new ServiceCollection()
+                .AddLogging()
+                .BuildServiceProvider();
+
+            var host = new Mock<IHost>();
+            host.Setup(h => h.Services)
+                .Returns(services);
+            host.SetupSequence(h => h.StartAsync(It.IsAny<CancellationToken>()))
+                .Throws(new HostInitializationException("boom"))
+                .Returns(Task.CompletedTask);
+
+            var hostBuilder = new Mock<IScriptHostBuilder>();
+            hostBuilder.Setup(b => b.BuildHost(It.IsAny<bool>(), It.IsAny<bool>()))
+                .Returns(host.Object);
+
+            var hostService = new WebJobsScriptHostService(monitor, hostBuilder.Object, NullLoggerFactory.Instance);
+
+            await hostService.StartAsync(CancellationToken.None);
+
+            Assert.Equal(ScriptHostState.Error, hostService.State);
+            Assert.IsType<HostInitializationException>(hostService.LastError);
+        }
+    }
+}


### PR DESCRIPTION
Working on tests. Just getting this up for feedback.

This changes the behavior of the single language check so that it throws and places the host in an error state until the problem is resolved. This prevents the startup from running indefinitely when in a permanently broken state.