### PR TITLE
Allow defaultWorkerPath to be empty

### DIFF
--- a/src/WebJobs.Script.Grpc/Abstractions/WorkerDescription.cs
+++ b/src/WebJobs.Script.Grpc/Abstractions/WorkerDescription.cs
@@ -47,7 +47,14 @@ namespace Microsoft.Azure.WebJobs.Script.Abstractions
 
         public string GetWorkerPath()
         {
-            return Path.Combine(WorkerDirectory, DefaultWorkerPath);
+            if (string.IsNullOrEmpty(DefaultWorkerPath))
+            {
+                return null;
+            }
+            else
+            {
+                return Path.Combine(WorkerDirectory, DefaultWorkerPath);
+            }
         }
     }
 }

--- a/src/WebJobs.Script.Grpc/Abstractions/WorkerDescriptionExtensions.cs
+++ b/src/WebJobs.Script.Grpc/Abstractions/WorkerDescriptionExtensions.cs
@@ -21,10 +21,6 @@ namespace Microsoft.Azure.WebJobs.Script.Abstractions
             {
                 throw new ValidationException($"WorkerDescription {nameof(workerDescription.DefaultExecutablePath)} cannot be empty");
             }
-            if (string.IsNullOrEmpty(workerDescription.DefaultWorkerPath))
-            {
-                throw new ValidationException($"WorkerDescription {nameof(workerDescription.DefaultWorkerPath)} cannot be empty");
-            }
         }
     }
 }

--- a/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
@@ -142,7 +142,8 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 GetDefaultExecutablePathFromAppSettings(workerDescription, languageSection);
                 AddArgumentsFromAppSettings(workerDescription, languageSection);
 
-                if (File.Exists(workerDescription.GetWorkerPath()))
+                string workerPath = workerDescription.GetWorkerPath();
+                if (string.IsNullOrEmpty(workerPath) || File.Exists(workerPath))
                 {
                     _logger.LogDebug($"Will load worker provider for language: {workerDescription.Language}");
                     workerDescription.Validate();
@@ -150,7 +151,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 }
                 else
                 {
-                    throw new FileNotFoundException($"Did not find worker for for language: {workerDescription.Language}", workerDescription.GetWorkerPath());
+                    throw new FileNotFoundException($"Did not find worker for for language: {workerDescription.Language}", workerPath);
                 }
             }
             catch (Exception ex)

--- a/src/WebJobs.Script/Rpc/ProcessManagement/DefaultWorkerProcessFactory.cs
+++ b/src/WebJobs.Script/Rpc/ProcessManagement/DefaultWorkerProcessFactory.cs
@@ -30,7 +30,10 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         public string GetArguments(WorkerCreateContext context)
         {
             var argumentsBuilder = context.Arguments.ExecutableArguments.Aggregate(new StringBuilder(), MergeArguments);
-            argumentsBuilder.AppendFormat(" \"{0}\"", context.Arguments.WorkerPath);
+            if (!string.IsNullOrEmpty(context.Arguments.WorkerPath))
+            {
+                argumentsBuilder.AppendFormat(" \"{0}\"", context.Arguments.WorkerPath);
+            }
             context.Arguments.WorkerArguments.Aggregate(argumentsBuilder, MergeArguments);
             argumentsBuilder.AppendFormat(" --host {0} --port {1} --workerId {2} --requestId {3} --grpcMaxMessageLength {4}",
                 context.ServerUri.Host, context.ServerUri.Port, context.WorkerId, context.RequestId, context.MaxMessageLength);

--- a/test/WebJobs.Script.Tests/Rpc/GenericWorkerProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/GenericWorkerProviderTests.cs
@@ -384,7 +384,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
 
             if (emptyWorkerPath)
             {
-                config[LanguageWorkerConstants.WorkerDescriptionDefaultWorkerPath] = null;
+                config[LanguageWorkerConstants.WorkerDescription][LanguageWorkerConstants.WorkerDescriptionDefaultWorkerPath] = null;
             }
 
             return config;

--- a/test/WebJobs.Script.Tests/Rpc/GenericWorkerProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/GenericWorkerProviderTests.cs
@@ -113,6 +113,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         }
 
         [Fact]
+        public void ReadWorkerProviderFromConfig_EmptyWorkerPath()
+        {
+            var configs = new List<TestLanguageWorkerConfig>() { MakeTestConfig(testLanguage, new string[0], false, string.Empty, true) };
+            // Creates temp directory w/ worker.config.json and runs ReadWorkerProviderFromConfig
+            Dictionary<string, string> keyValuePairs = new Dictionary<string, string>
+            {
+                [$"{LanguageWorkerConstants.LanguageWorkersSectionName}:{testLanguage}:{LanguageWorkerConstants.WorkerDescriptionArguments}"] = "--inspect=5689  --no-deprecation"
+            };
+            var providers = TestReadWorkerProviderFromConfig(configs, new TestLogger(testLanguage));
+            Assert.Single(providers);
+            Assert.True(providers.Single().GetDescription().GetWorkerPath() == null);
+        }
+
+        [Fact]
         public void ReadWorkerProviderFromConfig_Concatenate_ArgsFromSettings_ArgsFromWorkerConfig()
         {
             string[] argsFromConfig = new string[] { "--expose-http2", "--no-deprecation" };
@@ -334,9 +348,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             return config;
         }
 
-        private static TestLanguageWorkerConfig MakeTestConfig(string language, string[] arguments, bool invalid = false, string addAppSvcProfile = "")
+        private static TestLanguageWorkerConfig MakeTestConfig(string language, string[] arguments, bool invalid = false, string addAppSvcProfile = "", bool emptyWorkerPath = false)
         {
-            string json = GetTestWorkerConfig(language, arguments, invalid, addAppSvcProfile).ToString();
+            string json = GetTestWorkerConfig(language, arguments, invalid, addAppSvcProfile, emptyWorkerPath).ToString();
             return new TestLanguageWorkerConfig()
             {
                 Json = json,
@@ -344,7 +358,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             };
         }
 
-        private static JObject GetTestWorkerConfig(string language, string[] arguments, bool invalid, string profileName)
+        private static JObject GetTestWorkerConfig(string language, string[] arguments, bool invalid, string profileName, bool emptyWorkerPath = false)
         {
             WorkerDescription description = GetTestDefaultWorkerDescription(language, arguments);
 
@@ -366,6 +380,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             if (invalid)
             {
                 config[LanguageWorkerConstants.WorkerDescription] = "invalidWorkerConfig";
+            }
+
+            if (emptyWorkerPath)
+            {
+                config[LanguageWorkerConstants.WorkerDescriptionDefaultWorkerPath] = null;
             }
 
             return config;

--- a/test/WebJobs.Script.Tests/Rpc/GenericWorkerProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/GenericWorkerProviderTests.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
                 yield return new object[] { new WorkerDescription() { Extensions = new List<string>() } };
                 yield return new object[] { new WorkerDescription() { Language = testLanguage } };
                 yield return new object[] { new WorkerDescription() { Language = testLanguage, Extensions = new List<string>() } };
-                yield return new object[] { new WorkerDescription() { Language = testLanguage, Extensions = new List<string>(), DefaultExecutablePath = "test.exe" } };
             }
         }
 
@@ -39,6 +38,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         {
             get
             {
+                yield return new object[] { new WorkerDescription() { Language = testLanguage, Extensions = new List<string>(), DefaultExecutablePath = "test.exe" } };
                 yield return new object[] { new WorkerDescription() { Language = testLanguage, Extensions = new List<string>(), DefaultExecutablePath = "test.exe", DefaultWorkerPath = testWorkerPathInWorkerConfig } };
                 yield return new object[] { new WorkerDescription() { Language = testLanguage, Extensions = new List<string>(), DefaultExecutablePath = "test.exe", DefaultWorkerPath = testWorkerPathInWorkerConfig, Arguments = new List<string>() } };
             }


### PR DESCRIPTION
`language-executable <file>` should not be only way to launch the
language worker.  For most natively compiled languages the executable by
itself is sufficient. For other languages, like Python, launching a
package as a program is often done using its module path instead of
a file path, e.g. `python -m azure.functions_worker`.  In the latter
case, the launch parameters are passed in "arguments" and
"defaultWorkerPath" is not needed.