### PR TITLE
Increase process start timeout

### DIFF
--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
@@ -28,8 +28,8 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 {
     internal class LanguageWorkerChannel : ILanguageWorkerChannel
     {
-        private readonly TimeSpan timeoutStart = TimeSpan.FromSeconds(20);
-        private readonly TimeSpan timeoutInit = TimeSpan.FromSeconds(20);
+        private readonly TimeSpan processStartTimeout = TimeSpan.FromSeconds(40);
+        private readonly TimeSpan workerInitTimeout = TimeSpan.FromSeconds(30);
         private readonly ScriptJobHostOptions _scriptConfig;
         private readonly IScriptEventManager _eventManager;
         private readonly IWorkerProcessFactory _processFactory;
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         internal void StartWorker()
         {
             _startSubscription = _inboundWorkerEvents.Where(msg => msg.MessageType == MsgType.StartStream)
-                .Timeout(timeoutStart)
+                .Timeout(processStartTimeout)
                 .Take(1)
                 .Subscribe(InitWorker, HandleWorkerError);
 
@@ -286,7 +286,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         internal void InitWorker(RpcEvent startEvent)
         {
             _inboundWorkerEvents.Where(msg => msg.MessageType == MsgType.WorkerInitResponse)
-                .Timeout(timeoutInit)
+                .Timeout(workerInitTimeout)
                 .Take(1)
                 .Subscribe(WorkerReady, HandleWorkerError);
 


### PR DESCRIPTION
From Kusto logs, starting java.exe takes about 30secs due to lazy loading. More details here https://github.com/Azure/azure-functions-host/issues/3081
Increasing woker initialization timeout should help with most cases. 
Long term fix is to preinstall latest java version. This is being tracked in Antares