### PR TITLE
Update Java Worker to 1.1.1-beta03

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -31,7 +31,7 @@
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.5350001-beta-fc119b98" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta9-10076" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.1-beta01" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta3-10073" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta8" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.0-beta8" />

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -31,7 +31,7 @@
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.5350001-beta-fc119b98" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.1-beta01" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.1-beta03" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta3-10073" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta8" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.0-beta8" />

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta3-10073" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0-beta8" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.0-beta9-10076" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.1-beta01" />
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta3-10073" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0-beta8" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.1-beta01" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.1-beta03" />
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />


### PR DESCRIPTION
Update Java Worker to [1.1.1-beta01](https://github.com/Azure/azure-functions-java-worker/releases/tag/v1.1.1-beta01) which uses latest java version on Azure zulu8.30.0.1-jdk8.0.172-win_x64/bin/java

Tested changes on Azure via site extension

Corresponding changes to worker.config.json
```
{
    "description": {
        "language": "java",
        "extensions": [".jar"],
        "defaultExecutablePath": "java",
        "defaultWorkerPath": "azure-functions-java-worker.jar",
        "arguments": ["-jar"]
    },
    "profiles": {
        "appServiceEnvironment": {
            "defaultExecutablePath": "../../../FunctionsJava/zulu8.30.0.1-jdk8.0.172-win_x64/bin/java"
        }
    }
}
```