### PR TITLE
Update node worker to beta4-10081

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -32,7 +32,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.5350001-beta-fc119b98" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.1-beta03" />
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta3-10073" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta4-10081" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.0-beta8" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.0-beta8" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.0-beta8" />

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.9.1" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta3-10073" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta4-10081" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0-beta8" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.1.1-beta03" />
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />


### PR DESCRIPTION
In this node update
 - Remove buffer deprecation warnings
 - Array data in context object (specifically context.bindingData) deserializes correctly to a JavaScript array.