### PR TITLE
Changing FunctionDescriptorProvider creation to avoid blocking calls in async paths

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/DotNetFunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/DotNet/DotNetFunctionDescriptorProvider.cs
@@ -49,22 +49,20 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
         }
 
-        public override bool TryCreate(FunctionMetadata functionMetadata, out FunctionDescriptor functionDescriptor)
+        public override async Task<(bool, FunctionDescriptor)> TryCreate(FunctionMetadata functionMetadata)
         {
             if (functionMetadata == null)
             {
                 throw new ArgumentNullException("functionMetadata");
             }
 
-            functionDescriptor = null;
-
             // We can only handle script types supported by the current compilation service factory
             if (!_compilationServiceFactory.SupportedLanguages.Contains(functionMetadata.Language))
             {
-                return false;
+                return (false, null);
             }
 
-            return base.TryCreate(functionMetadata, out functionDescriptor);
+            return await base.TryCreate(functionMetadata);
         }
 
         protected override IFunctionInvoker CreateFunctionInvoker(string scriptFilePath, BindingMetadata triggerMetadata, FunctionMetadata functionMetadata, Collection<FunctionBinding> inputBindings, Collection<FunctionBinding> outputBindings)
@@ -80,7 +78,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 BindingProviders);
         }
 
-        protected override Collection<ParameterDescriptor> GetFunctionParameters(IFunctionInvoker functionInvoker, FunctionMetadata functionMetadata,
+        protected override async Task<Collection<ParameterDescriptor>> GetFunctionParametersAsync(IFunctionInvoker functionInvoker, FunctionMetadata functionMetadata,
             BindingMetadata triggerMetadata, Collection<CustomAttributeBuilder> methodAttributes, Collection<FunctionBinding> inputBindings, Collection<FunctionBinding> outputBindings)
         {
             if (functionInvoker == null)
@@ -110,7 +108,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             {
                 ApplyMethodLevelAttributes(functionMetadata, triggerMetadata, methodAttributes);
 
-                MethodInfo functionTarget = dotNetInvoker.GetFunctionTargetAsync().Result;
+                MethodInfo functionTarget = await dotNetInvoker.GetFunctionTargetAsync();
                 ParameterInfo[] parameters = functionTarget.GetParameters();
                 Collection<ParameterDescriptor> descriptors = new Collection<ParameterDescriptor>();
                 IEnumerable<FunctionBinding> bindings = inputBindings.Union(outputBindings);
@@ -191,7 +189,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             // We were unable to compile the function to get its signature,
             // setup the descriptor with the default parameters
             methodAttributes.Clear();
-            return base.GetFunctionParameters(functionInvoker, functionMetadata, triggerMetadata, methodAttributes, inputBindings, outputBindings);
+            return await base.GetFunctionParametersAsync(functionInvoker, functionMetadata, triggerMetadata, methodAttributes, inputBindings, outputBindings);
         }
 
         internal static bool TryCreateReturnValueParameterDescriptor(Type functionReturnType, IEnumerable<FunctionBinding> bindings, out ParameterDescriptor descriptor)

--- a/src/WebJobs.Script/Description/Proxies/ProxyFunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/Proxies/ProxyFunctionDescriptorProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Binding;
 using Microsoft.Azure.WebJobs.Script.Extensibility;
 using Microsoft.Extensions.Logging;
@@ -23,21 +24,19 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             _loggerFactory = loggerFactory;
         }
 
-        public override bool TryCreate(FunctionMetadata functionMetadata, out FunctionDescriptor functionDescriptor)
+        public override Task<(bool, FunctionDescriptor)> TryCreate(FunctionMetadata functionMetadata)
         {
             if (functionMetadata == null)
             {
                 throw new ArgumentNullException("functionMetadata");
             }
 
-            functionDescriptor = null;
-
             if (functionMetadata.IsProxy)
             {
-                return base.TryCreate(functionMetadata, out functionDescriptor);
+                return base.TryCreate(functionMetadata);
             }
 
-            return false;
+            return Task.FromResult<(bool, FunctionDescriptor)>((false, null));
         }
 
         protected override IFunctionInvoker CreateFunctionInvoker(string scriptFilePath, BindingMetadata triggerMetadata, FunctionMetadata functionMetadata, Collection<FunctionBinding> inputBindings, Collection<FunctionBinding> outputBindings)

--- a/test/WebJobs.Script.Tests/Description/Proxy/ProxyFunctionDescriptorProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/Proxy/ProxyFunctionDescriptorProviderTests.cs
@@ -97,14 +97,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-        public void ValidateProxyFunctionDescriptor()
+        public async Task ValidateProxyFunctionDescriptor()
         {
             var proxy = _proxyClient as ProxyClientExecutor;
             Assert.NotNull(proxy);
 
             var proxyFunctionDescriptor = new ProxyFunctionDescriptorProvider(_scriptHost, _scriptHost.ScriptOptions, _host.Services.GetService<ICollection<IScriptBindingProvider>>(), proxy, NullLoggerFactory.Instance);
 
-            Assert.True(proxyFunctionDescriptor.TryCreate(_metadataCollection[0], out FunctionDescriptor functionDescriptor));
+            var (created, functionDescriptor) = await proxyFunctionDescriptor.TryCreate(_metadataCollection[0]);
+
+            Assert.True(created);
 
             var proxyInvoker = functionDescriptor.Invoker as ProxyFunctionInvoker;
 
@@ -116,7 +118,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             var proxyFunctionDescriptor = new ProxyFunctionDescriptorProvider(_scriptHost, _scriptHost.ScriptOptions, _host.Services.GetService<ICollection<IScriptBindingProvider>>(), _proxyClient, NullLoggerFactory.Instance);
 
-            proxyFunctionDescriptor.TryCreate(_metadataCollection[0], out FunctionDescriptor functionDescriptor);
+            var (created, functionDescriptor) = await proxyFunctionDescriptor.TryCreate(_metadataCollection[0]);
 
             var proxyInvoker = functionDescriptor.Invoker as ProxyFunctionInvoker;
 


### PR DESCRIPTION
This addresses an issue found during @safihamid 's tests and avoids a blocking call.