### PR TITLE
Reserving "runtime" route

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
@@ -121,14 +121,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         [HttpGet]
         [Route("admin/functions/{name}/status")]
         [Authorize(Policy = PolicyNames.AdminAuthLevel)]
-        public async Task<IActionResult> GetFunctionStatus(string name, [FromServices] IScriptJobHost scriptHost)
+        public async Task<IActionResult> GetFunctionStatus(string name, [FromServices] IScriptJobHost scriptHost = null)
         {
             FunctionStatus status = new FunctionStatus();
 
             // first see if the function has any errors
             // if the host is not running or is offline
             // there will be no error info
-            if (scriptHost.FunctionErrors.TryGetValue(name, out ICollection<string> functionErrors))
+            if (scriptHost != null &&
+                scriptHost.FunctionErrors.TryGetValue(name, out ICollection<string> functionErrors))
             {
                 status.Errors = functionErrors;
             }

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -764,7 +764,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
             // disallow custom routes in our own reserved route space
             string httpRoute = httpTrigger.Route.Trim('/').ToLowerInvariant();
-            if (httpRoute.StartsWith("admin"))
+            if (httpRoute.StartsWith("admin") ||
+                httpRoute.StartsWith("runtime"))
             {
                 throw new InvalidOperationException("The specified route conflicts with one or more built in routes.");
             }


### PR DESCRIPTION
A long time ago in v2 we changed the webhook extension route from an /admin route to /runtime/webhooks 
https://github.com/Azure/azure-functions-host/blob/122c169a76cca640a7e34251e83b3394de16bd67/src/WebJobs.Script.WebHost/Controllers/HostController.cs#L219

So in addition to /admin, we want to reserve /runtime for our own use.