### PR TITLE
Wiring up Development mode

### DIFF
--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -78,6 +78,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, FileMonitoringService>());
                 });
 
+            var debugStateProvider = rootServiceProvider.GetService<IDebugStateProvider>();
+            if (debugStateProvider.InDebugMode)
+            {
+                builder.UseEnvironment(EnvironmentName.Development);
+            }
+
             return builder;
         }
 

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AzureWebsitePlaceholderMode = "WEBSITE_PLACEHOLDER_MODE";
         public const string AzureWebsiteHomePath = "HOME";
         public const string AzureWebJobsScriptRoot = "AzureWebJobsScriptRoot";
-        public const string AzureWebJobsEnvironment = "AzureWebJobsEnv";
         public const string CompilationReleaseMode = "AzureWebJobsDotNetReleaseCompilation";
         public const string AzureWebJobsDisableHomepage = "AzureWebJobsDisableHomepage";
         public const string TypeScriptCompilerPath = "AzureWebJobs_TypeScriptPath";

--- a/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
@@ -36,6 +36,7 @@ namespace Microsoft.WebJobs.Script.Tests
 
             // Register root services
             var services = new ServiceCollection();
+            AddMockedSingleton<IDebugStateProvider>(services);
             AddMockedSingleton<IScriptHostManager>(services);
             AddMockedSingleton<IScriptWebHostEnvironment>(services);
             AddMockedSingleton<IEventGenerator>(services);

--- a/test/WebJobs.Script.Tests/Configuration/LoggingConfigurationTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/LoggingConfigurationTests.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         public void LoggerProviders_ConsoleEnabled_IfDevelopmentEnvironment()
         {
             IHost host = new HostBuilder()
-                .UseEnvironment("Development")
+                .UseEnvironment(EnvironmentName.Development)
                 .ConfigureDefaultTestWebScriptHost()
                 .Build();
 


### PR DESCRIPTION
In v1 we correctly wired up portal induced debug mode here: https://github.com/Azure/azure-functions-host/blob/0dc5ffdddd739cebc41fc9e55d31fe4a2161d4b8/src/WebJobs.Script/Host/ScriptHost.cs#L716. This was lost in the v2 migration.

Related to https://github.com/Azure/azure-webjobs-sdk/pull/1907 where I added back Debug mode handling/optimization in the core SDK. I had assumed it was wired up in Functions already.