### PR TITLE
Make App Offline file management more robust

### DIFF
--- a/src/WebJobs.Script.WebHost/Extensions/HttpContextExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Extensions/HttpContextExtensions.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Script.Extensions;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Extensions
 {
@@ -14,11 +12,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Extensions
     {
         public static async Task SetOfflineResponseAsync(this HttpContext httpContext, string scriptPath)
         {
-            // host is offline so return the app_offline.htm file content
-            var offlineFilePath = Path.Combine(scriptPath, ScriptConstants.AppOfflineFileName);
-            httpContext.Response.ContentType = "text/html";
             httpContext.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
-            await httpContext.Response.SendFileAsync(offlineFilePath);
+
+            if (!httpContext.Request.IsAppServiceInternalRequest())
+            {
+                // host is offline so return the app_offline.htm file content
+                var offlineFilePath = Path.Combine(scriptPath, ScriptConstants.AppOfflineFileName);
+                httpContext.Response.ContentType = "text/html";
+                await httpContext.Response.SendFileAsync(offlineFilePath);
+            }
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/FileMonitoringService.cs
+++ b/src/WebJobs.Script.WebHost/FileMonitoringService.cs
@@ -263,7 +263,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             else if (!offline && offlineFileExists)
             {
                 // delete the app_offline.htm file
-                FileUtility.DeleteFileSafe(path);
+                await Utility.InvokeWithRetriesAsync(() =>
+                {
+                    if (File.Exists(path))
+                    {
+                        File.Delete(path);
+                    }
+                }, maxRetries: 3, retryInterval: TimeSpan.FromSeconds(1));
             }
         }
     }

--- a/src/WebJobs.Script.WebHost/Middleware/HomepageMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/HomepageMiddleware.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
             {
                 IActionResult result = null;
 
-                if (IsHomepageDisabled || context.Request.IsAntaresInternalRequest())
+                if (IsHomepageDisabled || context.Request.IsAppServiceInternalRequest())
                 {
                     result = new NoContentResult();
                 }

--- a/src/WebJobs.Script.WebHost/Middleware/HostWarmupMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/HostWarmupMiddleware.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
         public static bool IsWarmUpRequest(HttpRequest request, IScriptWebHostEnvironment webHostEnvironment, IEnvironment environment)
         {
             return webHostEnvironment.InStandbyMode &&
-                ((environment.IsAppServiceEnvironment() && request.IsAntaresInternalRequest(environment)) || environment.IsLinuxContainerEnvironment()) &&
+                ((environment.IsAppServiceEnvironment() && request.IsAppServiceInternalRequest(environment)) || environment.IsLinuxContainerEnvironment()) &&
                 (request.Path.StartsWithSegments(new PathString($"/api/{WarmUpConstants.FunctionName}")) ||
                 request.Path.StartsWithSegments(new PathString($"/api/{WarmUpConstants.AlternateRoute}")));
         }

--- a/src/WebJobs.Script.WebHost/Security/Authorization/Policies/AuthorizationOptionsExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authorization/Policies/AuthorizationOptionsExtensions.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies
                 {
                     if (c.Resource is AuthorizationFilterContext filterContext)
                     {
-                        if (filterContext.HttpContext.Request.IsAntaresInternalRequest())
+                        if (filterContext.HttpContext.Request.IsAppServiceInternalRequest())
                         {
                             return true;
                         }

--- a/src/WebJobs.Script/Extensions/FileUtility.cs
+++ b/src/WebJobs.Script/Extensions/FileUtility.cs
@@ -22,9 +22,9 @@ namespace Microsoft.Azure.WebJobs.Script
             set { _instance = value; }
         }
 
-        public static string ReadResourceString(string resourcePath)
+        public static string ReadResourceString(string resourcePath, Assembly assembly = null)
         {
-            Assembly assembly = Assembly.GetCallingAssembly();
+            assembly = assembly ?? Assembly.GetCallingAssembly();
             using (StreamReader reader = new StreamReader(assembly.GetManifestResourceStream(resourcePath)))
             {
                 return reader.ReadToEnd();

--- a/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs
+++ b/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
             return default(TValue);
         }
 
-        public static bool IsAntaresInternalRequest(this HttpRequest request, IEnvironment environment = null)
+        public static bool IsAppServiceInternalRequest(this HttpRequest request, IEnvironment environment = null)
         {
             environment = environment ?? SystemEnvironment.Instance;
             if (!environment.IsAppServiceEnvironment())

--- a/test/WebJobs.Script.Tests/Extensions/HttpContextExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/HttpContextExtensionsTests.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Azure.WebJobs.Script.Extensions;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Extensions;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
+{
+    public class HttpContextExtensionsTests
+    {
+        [Fact]
+        public async Task SetOfflineResponseAsync_ReturnsCorrectResponse()
+        {
+            // create a test offline file
+            var rootPath = Path.GetTempPath();
+            var offlineFilePath = Path.Combine(Path.GetTempPath(), ScriptConstants.AppOfflineFileName);
+            string content = FileUtility.ReadResourceString($"{ScriptConstants.ResourcePath}.{ScriptConstants.AppOfflineFileName}", typeof(HttpException).Assembly);
+            File.WriteAllText(offlineFilePath, content);
+
+            var sendFileFeatureMock = new Mock<IHttpSendFileFeature>();
+            sendFileFeatureMock.Setup(s => s.SendFileAsync(offlineFilePath, 0, null, CancellationToken.None)).Returns(Task.FromResult<int>(0));
+
+            // simulate an App Service request
+            var vars = new Dictionary<string, string>
+            {
+                { EnvironmentSettingNames.AzureWebsiteInstanceId, "123" }
+            };
+            using (var env = new TestScopedEnvironmentVariable(vars))
+            {
+                // without header (thus an internal request)
+                var context = new DefaultHttpContext();
+                context.Features.Set(sendFileFeatureMock.Object);
+                Assert.True(context.Request.IsAppServiceInternalRequest());
+                await context.SetOfflineResponseAsync(rootPath);
+                Assert.Equal(StatusCodes.Status503ServiceUnavailable, context.Response.StatusCode);
+                Assert.Equal(0, context.Response.Body.Length);
+                sendFileFeatureMock.Verify(p => p.SendFileAsync(offlineFilePath, 0, null, CancellationToken.None), Times.Never);
+
+                // with header (thus an external request)
+                context = new DefaultHttpContext();
+                context.Features.Set(sendFileFeatureMock.Object);
+                context.Request.Headers.Add(ScriptConstants.AntaresLogIdHeaderName, new StringValues("456"));
+                Assert.False(context.Request.IsAppServiceInternalRequest());
+                await context.SetOfflineResponseAsync(rootPath);
+                Assert.Equal(StatusCodes.Status503ServiceUnavailable, context.Response.StatusCode);
+                Assert.Equal("text/html", context.Response.Headers["Content-Type"]);
+                sendFileFeatureMock.Verify(p => p.SendFileAsync(offlineFilePath, 0, null, CancellationToken.None), Times.Once);
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Extensions/HttpRequestExtensionsTest.cs
+++ b/test/WebJobs.Script.Tests/Extensions/HttpRequestExtensionsTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
         {
             // not running under Azure
             var request = HttpTestHelpers.CreateHttpRequest("GET", "http://foobar");
-            Assert.False(request.IsAntaresInternalRequest());
+            Assert.False(request.IsAppServiceInternalRequest());
 
             // running under Azure
             var vars = new Dictionary<string, string>
@@ -33,10 +33,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
                 headers.Add(ScriptConstants.AntaresLogIdHeaderName, "123");
 
                 request = HttpTestHelpers.CreateHttpRequest("GET", "http://foobar", headers);
-                Assert.False(request.IsAntaresInternalRequest());
+                Assert.False(request.IsAppServiceInternalRequest());
 
                 request = HttpTestHelpers.CreateHttpRequest("GET", "http://foobar");
-                Assert.True(request.IsAntaresInternalRequest());
+                Assert.True(request.IsAppServiceInternalRequest());
             }
         }
     }

--- a/test/WebJobs.Script.Tests/Security/SecretManagerProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Security/SecretManagerProviderTests.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Threading;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
-using System.Threading;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Security


### PR DESCRIPTION
We're seeing some cases where apps aren't coming back online after being offline. Logs indicate that this is due to failure to delete the offline file. Previously we were swallowing errors on that codepath. I've added retries, and if the delete doesn't fail after retries the exception is propagated, allowing the caller to retry.