### PR TITLE
System Logging Improvements

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/SystemLoggerProvider.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/SystemLoggerProvider.cs
@@ -15,27 +15,29 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         private readonly string _hostInstanceId;
         private readonly IEventGenerator _eventGenerator;
         private readonly IEnvironment _environment;
+        private readonly IDebugStateProvider _debugStateProvider;
 
-        public SystemLoggerProvider(IOptions<ScriptJobHostOptions> scriptOptions, IEventGenerator eventGenerator, IEnvironment environment)
-            : this(scriptOptions.Value.InstanceId, eventGenerator, environment)
+        public SystemLoggerProvider(IOptions<ScriptJobHostOptions> scriptOptions, IEventGenerator eventGenerator, IEnvironment environment, IDebugStateProvider debugStateProvider)
+            : this(scriptOptions.Value.InstanceId, eventGenerator, environment, debugStateProvider)
         {
         }
 
-        protected SystemLoggerProvider(string hostInstanceId, IEventGenerator eventGenerator, IEnvironment environment)
+        protected SystemLoggerProvider(string hostInstanceId, IEventGenerator eventGenerator, IEnvironment environment, IDebugStateProvider debugStateProvider)
         {
             _eventGenerator = eventGenerator;
             _environment = environment;
             _hostInstanceId = hostInstanceId;
+            _debugStateProvider = debugStateProvider;
         }
 
         public ILogger CreateLogger(string categoryName)
         {
-            // The SystemLogger is not used for user logs.
             if (IsUserLogCategory(categoryName))
             {
+                // The SystemLogger is not used for user logs.
                 return NullLogger.Instance;
             }
-            return new SystemLogger(_hostInstanceId, categoryName, _eventGenerator, _environment);
+            return new SystemLogger(_hostInstanceId, categoryName, _eventGenerator, _environment, _debugStateProvider);
         }
 
         private bool IsUserLogCategory(string categoryName)

--- a/src/WebJobs.Script.WebHost/Diagnostics/WebHostSystemLoggerProvider.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/WebHostSystemLoggerProvider.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
     /// </summary>
     public class WebHostSystemLoggerProvider : SystemLoggerProvider
     {
-        public WebHostSystemLoggerProvider(IEventGenerator eventGenerator, IEnvironment environment)
-            : base(string.Empty, eventGenerator, environment)
+        public WebHostSystemLoggerProvider(IEventGenerator eventGenerator, IEnvironment environment, IDebugStateProvider debugStateProvider)
+            : base(string.Empty, eventGenerator, environment, debugStateProvider)
         {
         }
     }

--- a/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
                 string sanitizedJson = SanitizeHostJson(hostConfigObject);
                 string readFileMessage = $"Host configuration file read:{NewLine}{sanitizedJson}";
 
-                _logger.LogTrace("Host configuration applied.");
+                _logger.LogDebug("Host configuration applied.");
 
                 // Do not log these until after all the configuration is done so the proper filters are applied.
                 _logger.LogInformation(readingFileMessage);

--- a/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
             catch (Exception ex)
             {
-                Host.Logger.LogTrace(ex, $"Creating function descriptor for function {functionMetadata.Name} failed");
+                Host.Logger.LogDebug(ex, $"Creating function descriptor for function {functionMetadata.Name} failed");
                 IDisposable disposableInvoker = invoker as IDisposable;
                 if (disposableInvoker != null)
                 {

--- a/src/WebJobs.Script/Eventing/DiagnosticNotification.cs
+++ b/src/WebJobs.Script/Eventing/DiagnosticNotification.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Eventing;
+
+namespace Microsoft.Azure.WebJobs.Script
+{
+    public class DiagnosticNotification : ScriptEvent
+    {
+        public DiagnosticNotification(string source, DateTime notificationTime)
+            : base(nameof(DiagnosticNotification), source)
+        {
+            NotificationTime = notificationTime;
+        }
+
+        public DateTime NotificationTime { get; }
+    }
+}

--- a/src/WebJobs.Script/Host/IDebugStateProvider.cs
+++ b/src/WebJobs.Script/Host/IDebugStateProvider.cs
@@ -5,10 +5,30 @@ using System;
 
 namespace Microsoft.Azure.WebJobs
 {
+    /// <summary>
+    /// Interface for a service providing real time debug/diagnostic mode
+    /// notifications and status.
+    /// </summary>
     public interface IDebugStateProvider
     {
+        /// <summary>
+        /// Gets or sets the last time the host has received a debug notification
+        /// </summary>
         DateTime LastDebugNotify { get; set; }
 
+        /// <summary>
+        /// Gets a value indicating whether the host is in diagnostic mode.
+        /// </summary>
         bool InDebugMode { get; }
+
+        /// <summary>
+        /// Gets or sets the last time the host has received a diagnostic notification
+        /// </summary>
+        DateTime LastDiagnosticNotify { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the host is in debug mode.
+        /// </summary>
+        bool InDiagnosticMode { get; }
     }
 }

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -188,6 +188,11 @@ namespace Microsoft.Azure.WebJobs.Script
         /// </summary>
         public virtual bool InDebugMode => _debugManager.InDebugMode;
 
+        /// <summary>
+        /// Gets a value indicating whether the host is in diagnostic mode.
+        /// </summary>
+        public virtual bool InDiagnosticMode => _debugManager.InDiagnosticMode;
+
         internal IFunctionDispatcher FunctionDispatcher => _functionDispatcher;
 
         /// <summary>
@@ -284,7 +289,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
             string extensionVersion = _environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsExtensionVersion);
             string hostId = await _hostIdProvider.GetHostIdAsync(CancellationToken.None);
-            string message = $"Starting Host (HostId={hostId}, InstanceId={InstanceId}, Version={Version}, ProcessId={Process.GetCurrentProcess().Id}, AppDomainId={AppDomain.CurrentDomain.Id}, Debug={InDebugMode}, FunctionsExtensionVersion={extensionVersion})";
+            string message = $"Starting Host (HostId={hostId}, InstanceId={InstanceId}, Version={Version}, ProcessId={Process.GetCurrentProcess().Id}, AppDomainId={AppDomain.CurrentDomain.Id}, InDebugMode={InDebugMode}, InDiagnosticMode={InDiagnosticMode}, FunctionsExtensionVersion={extensionVersion})";
             _logger.LogInformation(message);
         }
 
@@ -449,13 +454,13 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             if (string.IsNullOrEmpty(_currentRuntimelanguage))
             {
-                _logger.LogTrace("Adding Function descriptor providers for all languages.");
+                _logger.LogDebug("Adding Function descriptor providers for all languages.");
                 _descriptorProviders.Add(new DotNetFunctionDescriptorProvider(this, ScriptOptions, _bindingProviders, _metricsLogger, _loggerFactory));
                 _descriptorProviders.Add(new WorkerFunctionDescriptorProvider(this, ScriptOptions, _bindingProviders, _functionDispatcher, _loggerFactory));
             }
             else
             {
-                _logger.LogTrace($"Adding Function descriptor provider for language {_currentRuntimelanguage}.");
+                _logger.LogDebug($"Adding Function descriptor provider for language {_currentRuntimelanguage}.");
                 if (string.Equals(_currentRuntimelanguage, LanguageWorkerConstants.DotNetLanguageWorkerName, StringComparison.OrdinalIgnoreCase))
                 {
                     _descriptorProviders.Add(new DotNetFunctionDescriptorProvider(this, ScriptOptions, _bindingProviders, _metricsLogger, _loggerFactory));
@@ -469,9 +474,9 @@ namespace Microsoft.Azure.WebJobs.Script
             Collection<FunctionDescriptor> functions;
             using (_metricsLogger.LatencyEvent(MetricEventNames.HostStartupGetFunctionDescriptorsLatency))
             {
-                _logger.LogTrace("Creating function descriptors.");
+                _logger.LogDebug("Creating function descriptors.");
                 functions = await GetFunctionDescriptorsAsync(functionMetadata, _descriptorProviders);
-                _logger.LogTrace("Function descriptors created.");
+                _logger.LogDebug("Function descriptors created.");
             }
 
             Functions = functions;

--- a/src/WebJobs.Script/Rpc/Configuration/LanguageWorkerOptionsSetup.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/LanguageWorkerOptionsSetup.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         public LanguageWorkerOptionsSetup(IConfiguration configuration, ILoggerFactory loggerFactory)
         {
             _configuration = configuration;
-            _logger = loggerFactory.CreateLogger("Host.LanguageWorkerConfigOptionsSetup");
+            _logger = loggerFactory.CreateLogger("Host.LanguageWorkerConfig");
         }
 
         public void Configure(LanguageWorkerOptions options)

--- a/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             foreach (var provider in WorkerProviders)
             {
                 var description = provider.GetDescription();
-                _logger.LogTrace($"Worker path for language worker {description.Language}: {description.WorkerDirectory}");
+                _logger.LogDebug($"Worker path for language worker {description.Language}: {description.WorkerDirectory}");
 
                 var arguments = new WorkerProcessArguments()
                 {
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         internal void AddProviders()
         {
             var providers = new List<IWorkerProvider>();
-            _logger.LogTrace($"Workers Directory set to: {WorkersDirPath}");
+            _logger.LogDebug($"Workers Directory set to: {WorkersDirPath}");
 
             foreach (var workerDir in Directory.EnumerateDirectories(WorkersDirPath))
             {
@@ -120,10 +120,10 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 string workerConfigPath = Path.Combine(workerDir, LanguageWorkerConstants.WorkerConfigFileName);
                 if (!File.Exists(workerConfigPath))
                 {
-                    _logger.LogTrace($"Did not find worker config file at: {workerConfigPath}");
+                    _logger.LogDebug($"Did not find worker config file at: {workerConfigPath}");
                     return;
                 }
-                _logger.LogTrace($"Found worker config: {workerConfigPath}");
+                _logger.LogDebug($"Found worker config: {workerConfigPath}");
                 string json = File.ReadAllText(workerConfigPath);
                 JObject workerConfig = JObject.Parse(json);
                 WorkerDescription workerDescription = workerConfig.Property(LanguageWorkerConstants.WorkerDescription).Value.ToObject<WorkerDescription>();
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 AddArgumentsFromAppSettings(workerDescription, languageSection);
                 if (File.Exists(workerDescription.GetWorkerPath()))
                 {
-                    _logger.LogTrace($"Will load worker provider for language: {workerDescription.Language}");
+                    _logger.LogDebug($"Will load worker provider for language: {workerDescription.Language}");
                     workerDescription.Validate();
                     _workerProviderDictionary[workerDescription.Language] = new GenericWorkerProvider(workerDescription, workerDir);
                 }

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                     .Subscribe(msg =>
                     {
                         var jsonMsg = JsonConvert.SerializeObject(msg, _verboseSerializerSettings);
-                        _userLogsConsoleLogger.LogTrace(jsonMsg);
+                        _userLogsConsoleLogger.LogDebug(jsonMsg);
                     }));
 
             _eventSubscriptions.Add(_eventManager.OfType<FileEvent>()
@@ -384,7 +384,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             {
                 if (_functionLoadErrors.ContainsKey(context.FunctionMetadata.FunctionId))
                 {
-                    _workerChannelLogger.LogTrace($"Function {context.FunctionMetadata.Name} failed to load");
+                    _workerChannelLogger.LogDebug($"Function {context.FunctionMetadata.Name} failed to load");
                     context.ResultSource.TrySetException(_functionLoadErrors[context.FunctionMetadata.FunctionId]);
                     _executingInvocations.TryRemove(context.ExecutionContext.InvocationId.ToString(), out ScriptInvocationContext _);
                 }

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string SystemLoggerParameterName = "_logger";
 
         public const string DebugSentinelFileName = "debug_sentinel";
+        public const string DiagnosticSentinelFileName = "diagnostic_sentinel";
         public const string HostMetadataFileName = "host.json";
         public const string FunctionMetadataFileName = "function.json";
         public const string ProxyMetadataFileName = "proxies.json";

--- a/test/WebJobs.Script.Tests.Integration/Host/WebJobsScriptHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/WebJobsScriptHostServiceTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Host
                 "Information Host configuration file read",
                 @"Information Generating 2 job function\(s\)",
                 "Host initialization: ConsecutiveErrors=0, StartupCount=1",
-                @"Information Starting Host \(HostId=(.*), InstanceId=(.*), Version=(.+), ProcessId=[0-9]+, AppDomainId=[0-9]+, Debug=False, FunctionsExtensionVersion=\)",
+                @"Information Starting Host \(HostId=(.*), InstanceId=(.*), Version=(.+), ProcessId=[0-9]+, AppDomainId=[0-9]+, InDebugMode=False, InDiagnosticMode=False, FunctionsExtensionVersion=\)",
                 "Information Found the following functions:",
                 "Information Job host started",
             };

--- a/test/WebJobs.Script.Tests/Diagnostics/DebugStateProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/DebugStateProviderTests.cs
@@ -33,7 +33,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         [Fact]
         public void LastDebugNotify_IsRefreshed_OnOptionsChange()
         {
-            // Put a file in "DebugPath2"
             var newLogPath = Path.Combine(Directory.GetCurrentDirectory(), "DebugPath2");
             var newHostLogPath = Path.Combine(newLogPath, "Host");
 
@@ -50,6 +49,32 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 
                 Assert.Equal(DateTime.UtcNow, _provider.LastDebugNotify, TimeSpan.FromMinutes(5));
                 Assert.True(_provider.InDebugMode);
+            }
+            finally
+            {
+                Directory.Delete(newLogPath, true);
+            }
+        }
+
+        [Fact]
+        public void LastDiagnosticNotify_IsRefreshed_OnOptionsChange()
+        {
+            var newLogPath = Path.Combine(Directory.GetCurrentDirectory(), "DiagnosticPath1");
+            var newHostLogPath = Path.Combine(newLogPath, "Host");
+
+            try
+            {
+                Directory.CreateDirectory(newHostLogPath);
+                File.WriteAllText(Path.Combine(newHostLogPath, ScriptConstants.DiagnosticSentinelFileName), string.Empty);
+
+                Assert.Equal(DateTime.MinValue, _provider.LastDiagnosticNotify);
+                Assert.False(_provider.InDiagnosticMode);
+
+                _options.LogPath = newLogPath;
+                _tokenSource.SignalChange();
+
+                Assert.Equal(DateTime.UtcNow, _provider.LastDiagnosticNotify, TimeSpan.FromMinutes(5));
+                Assert.True(_provider.InDiagnosticMode);
             }
             finally
             {


### PR DESCRIPTION
Our current SystemLogger logs ALL trace levels to our system logs. This can lead to log noise. I'm making the following changes:

- defaulting the system log level to **Debug**. That leaves only the Trace level as being unlogged, which we reserve for our own diagnostic use
- adding support for a new **diagnostic_sentinel** file. When added to a site (or modified recently) this will transition the host into "diagnostic mode". We can tie other behaviors of the host to this in the future to aid debugging. E.g. taking crash dumps on failures, etc.
- when in diagnostic mode, we log ALL trace levels to our system logs. This allows us to start instrumenting the host + SDK more deeply without fear of overloading our regular system logs
- fix up some of our existing system logs. Many startup logs were being logged at a Trace level, when they really should be Information

If you look in our system logs, you'll see some logs that arguably we don't want to be seeing by default. These changes will give us a reserved Trace level that we can use for such logs to exclude them normally, without losing them entirely.