### PR TITLE
Override AppServiceEnv Java path if Java_Home is valid

### DIFF
--- a/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
@@ -224,10 +224,21 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             {
                 return defaultExecutablePath;
             }
+            else if (IsJavaHomeValid())
+            {
+                // TODO: pgopa default to using JAVA_HOME after ANT78 rolls out
+                return Path.GetFullPath(Path.Combine(javaHome, "bin", "java"));
+            }
             else
             {
                 return Path.GetFullPath(Path.Combine(javaHome, "bin", defaultExecutablePath));
             }
+        }
+
+        internal bool IsJavaHomeValid()
+        {
+            string javaHome = ScriptSettingsManager.Instance.GetSetting("JAVA_HOME");
+            return string.IsNullOrEmpty(javaHome) ? false : javaHome.Contains("8.0");
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Rpc/WorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/WorkerConfigFactoryTests.cs
@@ -80,6 +80,30 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         }
 
         [Fact]
+        public void JavaPath_AppServiceEnv_JavaHomeOverrides()
+        {
+            var configBuilder = ScriptSettingsManager.CreateDefaultConfigurationBuilder()
+                  .AddInMemoryCollection(new Dictionary<string, string>
+                  {
+                      ["languageWorker"] = "test"
+                  });
+            var config = configBuilder.Build();
+            var scriptSettingsManager = new ScriptSettingsManager(config);
+            var testLogger = new TestLogger("test");
+            var configFactory = new WorkerConfigFactory(config, testLogger);
+            var testEnvVariables = new Dictionary<string, string>
+            {
+                { EnvironmentSettingNames.AzureWebsiteInstanceId, "123" },
+                { "JAVA_HOME", @"D:\Program Files\Java\zulu8.31.0.2-jre8.0.181-win_x64" }
+            };
+            using (var variables = new TestScopedSettings(scriptSettingsManager, testEnvVariables))
+            {
+                var javaPath = configFactory.GetExecutablePathForJava("../../zulu8.23.0.3-jdk8.0.144-win_x64/bin/java");
+                Assert.Equal(@"D:\Program Files\Java\zulu8.31.0.2-jre8.0.181-win_x64\bin\java", javaPath);
+            }
+        }
+
+        [Fact]
         public void JavaPath_JavaHome_Set()
         {
             var configBuilder = ScriptSettingsManager.CreateDefaultConfigurationBuilder()


### PR DESCRIPTION
Starting ANT78, JAVA_HOME environment variable will start pointing to Java 1.8
This PR is to override hardcoded Java path provided in [Java worker.config.json ](https://github.com/Azure/azure-functions-java-worker/blob/dev/worker.config.json#L11)