### PR TITLE
HealthMonitor improvements (#2972)

### DIFF
--- a/src/WebJobs.Script.WebHost/JobHost/WebScriptJobHostEnvironment.cs
+++ b/src/WebJobs.Script.WebHost/JobHost/WebScriptJobHostEnvironment.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using Microsoft.AspNetCore.Hosting;
 using ExtensionsHostingEnvironment = Microsoft.Extensions.Hosting.IHostingEnvironment;
@@ -33,11 +34,20 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
         }
 
-        public void Shutdown()
+        public void Shutdown(bool hard = false)
         {
             if (Interlocked.Exchange(ref _shutdownRequested, 1) == 0)
             {
-                _applicationLifetime.StopApplication();
+                if (hard)
+                {
+                    // shut down the process
+                    Process.GetCurrentProcess().Kill();
+                }
+                else
+                {
+                    // recycle the app domain
+                    _applicationLifetime.StopApplication();
+                }
             }
         }
     }

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddStandbyServices();
 
             // Core script host services
+            services.TryAddSingleton<IScriptJobHostEnvironment, WebScriptJobHostEnvironment>();
             services.AddSingleton<WebJobsScriptHostService>();
             services.AddSingleton<IHostedService>(s => s.GetRequiredService<WebJobsScriptHostService>());
             services.AddSingleton<IScriptHostManager>(s => s.GetRequiredService<WebJobsScriptHostService>());

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -6,6 +6,7 @@ using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Host.Timers;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
 using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
@@ -58,7 +59,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     services.AddSingleton<HttpRequestQueue>();
                     services.AddSingleton<IHostLifetime, JobHostHostLifetime>();
                     services.TryAddSingleton<IWebJobsExceptionHandler, WebScriptHostExceptionHandler>();
-                    services.AddSingleton<IScriptJobHostEnvironment, WebScriptJobHostEnvironment>();
 
                     services.AddSingleton<DefaultScriptWebHookProvider>();
                     services.TryAddSingleton<IScriptWebHookProvider>(p => p.GetService<DefaultScriptWebHookProvider>());

--- a/src/WebJobs.Script/Diagnostics/FileWriter.cs
+++ b/src/WebJobs.Script/Diagnostics/FileWriter.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public FileWriter(string logFilePath)
         {
             _logFilePath = logFilePath;
-            _instanceId = GetInstanceId();
+            _instanceId = Utility.GetInstanceId();
             _logDirectory = new DirectoryInfo(logFilePath);
 
             // start a timer to flush accumulated logs in batches
@@ -270,19 +270,6 @@ namespace Microsoft.Azure.WebJobs.Script
                     // best effort
                 }
             }
-        }
-
-        internal static string GetInstanceId()
-        {
-            string instanceId = ScriptSettingsManager.Instance.GetSetting(EnvironmentSettingNames.AzureWebsiteInstanceId);
-            if (string.IsNullOrEmpty(instanceId))
-            {
-                instanceId = Environment.MachineName;
-            }
-
-            instanceId = instanceId.Length > 10 ? instanceId.Substring(0, 10) : instanceId;
-
-            return instanceId.ToLowerInvariant();
         }
     }
 }

--- a/src/WebJobs.Script/Host/IScriptJobHostEnvironment.cs
+++ b/src/WebJobs.Script/Host/IScriptJobHostEnvironment.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <summary>
         /// Stops the <see cref="IScriptJobHost"/> and shuts down the hosting environment.
         /// </summary>
-        void Shutdown();
+        /// <param name="hard">True if the shutdown should be "hard" - i.e. shut down process.</param>
+        void Shutdown(bool hard = false);
     }
 }

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public const string DebugSentinelFileName = "debug_sentinel";
         public const string DiagnosticSentinelFileName = "diagnostic_sentinel";
+        public const string ShutdownSentinelFileName = "shutdown_sentinel";
         public const string HostMetadataFileName = "host.json";
         public const string FunctionMetadataFileName = "function.json";
         public const string ProxyMetadataFileName = "proxies.json";

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -13,6 +13,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Rpc;
 using Microsoft.Extensions.Logging;
@@ -464,6 +465,19 @@ namespace Microsoft.Azure.WebJobs.Script
                 return true;
             }
             return ContainsNonDotNetFunctions(functionsListWithoutProxies);
+        }
+
+        internal static string GetInstanceId()
+        {
+            string instanceId = ScriptSettingsManager.Instance.GetSetting(EnvironmentSettingNames.AzureWebsiteInstanceId);
+            if (string.IsNullOrEmpty(instanceId))
+            {
+                instanceId = Environment.MachineName;
+            }
+
+            instanceId = instanceId.Length > 10 ? instanceId.Substring(0, 10) : instanceId;
+
+            return instanceId.ToLowerInvariant();
         }
 
         private static bool ContainsNonDotNetFunctions(IEnumerable<FunctionMetadata> functions)

--- a/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/RawAssemblyEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/RawAssemblyEndToEndTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public void AssemblyChange_TriggersEnvironmentShutdown()
         {
             var manualResetEvent = new ManualResetEvent(false);
-            _fixture.ScriptJobHostEnvironmentMock.Setup(e => e.Shutdown())
+            _fixture.ScriptJobHostEnvironmentMock.Setup(e => e.Shutdown(false))
                 .Callback(() => manualResetEvent.Set());
 
             string sourceFile = TestFixture.SharedAssemblyPath;

--- a/test/WebJobs.Script.Tests.Shared/NullScriptHostEnvironment.cs
+++ b/test/WebJobs.Script.Tests.Shared/NullScriptHostEnvironment.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
         }
 
-        public void Shutdown()
+        public void Shutdown(bool hard = false)
         {
         }
     }

--- a/test/WebJobs.Script.Tests/Description/DotNet/DotNetFunctionInvokerTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/DotNetFunctionInvokerTests.cs
@@ -401,7 +401,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 // and won't be made immediately
                 await Task.Delay(1000);
 
-                environmentMock.Verify(e => e.Shutdown(), Times.Exactly(shutdownExpected ? 1 : 0));
+                environmentMock.Verify(e => e.Shutdown(false), Times.Exactly(shutdownExpected ? 1 : 0));
             }
         }
 

--- a/test/WebJobs.Script.Tests/Diagnostics/FileWriterTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/FileWriterTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var logFiles = new List<FileInfo>();
             for (int i = 0; i < 5; i++)
             {
-                string fileName = string.Format("{0}-{1}.log", i, FileWriter.GetInstanceId());
+                string fileName = string.Format("{0}-{1}.log", i, Utility.GetInstanceId());
                 string path = Path.Combine(_logFilePath, fileName);
                 File.WriteAllText(path, "Test Logs");
                 logFiles.Add(new FileInfo(path));


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-functions-host/issues/2972. With these changes, the behavor will be:

- if the host remains unhealthy for a period of time and host restarts aren't fixing it, an app shutdown is initiated (based on HostHealthMonitor config settings)
- before we shutdown, we write an app instance specific marker file to signal to the restarted app that a shutdown was initiated
- if after this shutdown the app remains unhealthy and a shutdown is triggered *again*, the presence of the marker file will cause us to initiate a *hard* shutdown

So in summary: previously we'd continue in a "soft" shutdown loop, recycling the app domain in an attempt to correct. Now, after 2 full cycles we'll escalate to a "hard" shutdown which will recycle the process.

I'll make the same changes in the v1 branch as well.