### PR TITLE
Enforce Functions Java when running in AppServiceEnv

### DIFF
--- a/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Rpc/Configuration/WorkerConfigFactory.cs
@@ -224,21 +224,10 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             {
                 return defaultExecutablePath;
             }
-            else if (IsJavaHomeValid())
-            {
-                // TODO: pgopa default to using JAVA_HOME after ANT78 rolls out
-                return Path.GetFullPath(Path.Combine(javaHome, "bin", "java"));
-            }
             else
             {
                 return Path.GetFullPath(Path.Combine(javaHome, "bin", defaultExecutablePath));
             }
-        }
-
-        internal bool IsJavaHomeValid()
-        {
-            string javaHome = ScriptSettingsManager.Instance.GetSetting("JAVA_HOME");
-            return string.IsNullOrEmpty(javaHome) ? false : javaHome.Contains("8.0");
         }
     }
 }

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -35,7 +35,7 @@
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.5350001-beta-fc119b98" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.2.0-beta01-SNAPSHOT" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.2.0-beta01-SNAPSHOT-10147" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta6" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.1" />

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.0-beta6" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.2.0-beta01-SNAPSHOT" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.2.0-beta01-SNAPSHOT-10147" />
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />

--- a/test/WebJobs.Script.Tests/Rpc/WorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/WorkerConfigFactoryTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         }
 
         [Fact]
-        public void JavaPath_AppServiceEnv_JavaHomeOverrides()
+        public void JavaPath_AppServiceEnv_JavaHomeSet_AppServiceEnvOverrides()
         {
             var configBuilder = ScriptSettingsManager.CreateDefaultConfigurationBuilder()
                   .AddInMemoryCollection(new Dictionary<string, string>
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             using (var variables = new TestScopedSettings(scriptSettingsManager, testEnvVariables))
             {
                 var javaPath = configFactory.GetExecutablePathForJava("../../zulu8.23.0.3-jdk8.0.144-win_x64/bin/java");
-                Assert.Equal(@"D:\Program Files\Java\zulu8.31.0.2-jre8.0.181-win_x64\bin\java", javaPath);
+                Assert.Equal(@"D:\Program Files\Java\zulu8.23.0.3-jdk8.0.144-win_x64\bin\java", javaPath);
             }
         }
 


### PR DESCRIPTION
- Use Functions Java in AppServiceEnv
- Update Java Worker to the to [1.2.0-beta01-SNAPSHOT-10147](https://github.com/Azure/azure-functions-java-worker/releases/tag/1.2.0-beta01-SNAPSHOT-10147). 