### PR TITLE
HealthMonitor improvements (#2972)

### DIFF
--- a/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
@@ -434,14 +434,24 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
         }
 
-        public override void Shutdown()
+        public override void Shutdown(bool hard = false)
         {
             string message = "Environment shutdown has been triggered. Stopping host and signaling shutdown.";
             Instance?.TraceWriter.Info(message);
             Instance?.Logger?.LogInformation(message);
 
             Stop();
-            HostingEnvironment.InitiateShutdown();
+
+            if (hard)
+            {
+                // "hard" shutdown recycles the process
+                Process.GetCurrentProcess().Kill();
+            }
+            else
+            {
+                // "soft" shutdown recycles the AppDomain
+                HostingEnvironment.InitiateShutdown();
+            }
         }
 
         public async Task DelayUntilHostReady()

--- a/src/WebJobs.Script/Host/IScriptHostEnvironment.cs
+++ b/src/WebJobs.Script/Host/IScriptHostEnvironment.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <summary>
         /// Stops the <see cref="ScriptHost"/> and shuts down the hosting environment.
         /// </summary>
-        void Shutdown();
+        /// <param name="hard">True if the shutdown should be "hard" - i.e. shut down process.</param>
+        void Shutdown(bool hard = false);
     }
 }

--- a/src/WebJobs.Script/Host/NullScriptHostEnvironment.cs
+++ b/src/WebJobs.Script/Host/NullScriptHostEnvironment.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Script
         {
         }
 
-        public void Shutdown()
+        public void Shutdown(bool hard = false)
         {
         }
     }

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string DefaultMasterKeyName = "master";
         public const string DefaultFunctionKeyName = "default";
         public const string ColdStartEventName = "ColdStart";
+        public const string ShutdownRecoveryEventName = "ShutdownRecovery";
 
         public const string AntaresLogIdHeaderName = "X-ARR-LOG-ID";
         public const string AntaresScaleOutHeaderName = "X-FUNCTION-SCALEOUT";

--- a/test/WebJobs.Script.Tests.Integration/Host/ScriptHostManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/ScriptHostManagerTests.cs
@@ -403,7 +403,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var environmentMock = new Mock<IScriptHostEnvironment>(MockBehavior.Strict);
             bool shutdownCalled = false;
-            environmentMock.Setup(p => p.Shutdown()).Callback(() => shutdownCalled = true);
+            environmentMock.Setup(p => p.Shutdown(true)).Callback(() => shutdownCalled = true);
 
             var mockSettings = new Mock<ScriptSettingsManager>();
             mockSettings.Setup(p => p.IsAzureEnvironment).Returns(true);
@@ -431,7 +431,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             await TestHelpers.Await(() => hostManager.State == ScriptHostState.Error && shutdownCalled);
 
-            environmentMock.Verify(p => p.Shutdown(), Times.Once);
+            environmentMock.Verify(p => p.Shutdown(true), Times.Once);
 
             var traces = testTraceWriter.GetTraces();
 
@@ -441,7 +441,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var log = traces.Last();
             Assert.True(traces.Count(p => p.Message == "Host is unhealthy. Initiating a restart." && p.Level == TraceLevel.Error) > 0);
-            Assert.Equal("Host unhealthy count exceeds the threshold of 5 for time window 00:00:01. Initiating shutdown.", log.Message);
+            Assert.Equal("Host unhealthy count exceeds the threshold of 5 for time window 00:00:01. Initiating hard shutdown.", log.Message);
+            Assert.Equal(ScriptConstants.ShutdownRecoveryEventName, log.Properties[ScriptConstants.TracePropertyEventNameKey]);
             Assert.Equal(TraceLevel.Error, log.Level);
         }
 

--- a/test/WebJobs.Script.Tests.Integration/RawAssemblyEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/RawAssemblyEndToEndTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public void AssemblyChange_TriggersEnvironmentShutdown()
         {
             var manualResetEvent = new ManualResetEvent(false);
-            Fixture.ScriptHostEnvironmentMock.Setup(e => e.Shutdown())
+            Fixture.ScriptHostEnvironmentMock.Setup(e => e.Shutdown(false))
                 .Callback(() => manualResetEvent.Set());
 
             string sourceFile = TestFixture.SharedAssemblyPath;

--- a/test/WebJobs.Script.Tests/Description/DotNet/DotNetFunctionInvokerTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/DotNetFunctionInvokerTests.cs
@@ -346,7 +346,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 // and won't be made immediately
                 await Task.Delay(1000);
 
-                environmentMock.Verify(e => e.Shutdown(), Times.Exactly(shutdownExpected ? 1 : 0));
+                environmentMock.Verify(e => e.Shutdown(false), Times.Exactly(shutdownExpected ? 1 : 0));
             }
         }
 


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-functions-host/issues/2972. With these changes, I'm changing the behavior so that we do a "hard" shutdown when the host has been unhealthy for a period and host restarts haven't helped. As the issue indicates, often we see AppDomain recycles NOT helping, so we'll just do a process recycle in these cases. Note that in Functions v2 there are no AppDomains, so this same shutdown code is already working this way - doing a process recycle. This will make the 2 versions consistent.