### PR TITLE
Storage MaxConnectionsPerServer temporary workaround

### DIFF
--- a/src/WebJobs.Script.WebHost/MaxConnectionHelper.cs
+++ b/src/WebJobs.Script.WebHost/MaxConnectionHelper.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+using Microsoft.WindowsAzure.Storage;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost
+{
+    internal static class MaxConnectionHelper
+    {
+        private const string AzureWebsiteSku = "WEBSITE_SKU";
+        private const string DynamicSku = "Dynamic";
+
+        private static bool isSet = false;
+
+        // Temporary helper until https://github.com/Azure/azure-storage-net/issues/580 is fixed.
+        public static void SetMaxConnectionsPerServer(ILogger logger)
+        {
+            if (IsDynamicSku() && !isSet)
+            {
+                Assembly storageAssembly = typeof(CloudStorageAccount).Assembly;
+                Type httpHandlerType = storageAssembly.GetType("Microsoft.WindowsAzure.Storage.Auth.Protocol.StorageAuthenticationHttpHandler");
+                PropertyInfo instanceProp = httpHandlerType?.GetProperty("Instance", BindingFlags.Static | BindingFlags.Public);
+
+                if (instanceProp?.GetValue(null) is HttpClientHandler handler)
+                {
+                    // This is a best-effort attempt. It's possible that the StorageClient
+                    // is already in-use and this will throw.
+                    try
+                    {
+                        handler.MaxConnectionsPerServer = 50;
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogWarning($"Azure Storage HttpClientHandler was not updated: '{ex}'. Current value: {handler.MaxConnectionsPerServer}");
+                    }
+                }
+                else
+                {
+                    logger.LogWarning($"Azure Storage HttpClientHandler was not found in assembly: '{storageAssembly.FullName}'.");
+                }
+
+                isSet = true;
+            }
+        }
+
+        private static bool IsDynamicSku()
+        {
+            string sku = Environment.GetEnvironmentVariable(AzureWebsiteSku);
+            return sku != null && sku == DynamicSku;
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Startup.cs
+++ b/src/WebJobs.Script.WebHost/Startup.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IApplicationLifetime applicationLifetime, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
+            MaxConnectionHelper.SetMaxConnectionsPerServer(loggerFactory.CreateLogger($"Host.{nameof(MaxConnectionHelper)}"));
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();


### PR DESCRIPTION
Similar workaround to this: https://github.com/Azure/azure-functions-durable-extension/pull/486.

This will be removed once Storage provides us a proper way to do this (next release) -- https://github.com/Azure/azure-storage-net/issues/580.