### PR TITLE
Relaxing EF dependency restricion

### DIFF
--- a/src/WebJobs.Script/runtimeassemblies.json
+++ b/src/WebJobs.Script/runtimeassemblies.json
@@ -171,10 +171,6 @@
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
-      "name": "Microsoft.AspNetCore.Identity.EntityFrameworkCore",
-      "resolutionPolicy": "minorMatchOrLower"
-    },
-    {
       "name": "Microsoft.AspNetCore.Identity.UI",
       "resolutionPolicy": "minorMatchOrLower"
     },


### PR DESCRIPTION
Removing runtime restriction on `Microsoft.AspNetCore.Identity.EntityFrameworkCore`.