### PR TITLE
Fixing Specialization bug in List API

### DIFF
--- a/test/WebJobs.Script.Tests/Extensions/HttpRequestExtensionsTest.cs
+++ b/test/WebJobs.Script.Tests/Extensions/HttpRequestExtensionsTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
     public class HttpRequestExtensionsTest
     {
         [Fact]
-        public void IsAntaresInternalRequest_ReturnsExpectedResult()
+        public void IsAppServiceInternalRequest_ReturnsExpectedResult()
         {
             // not running under Azure
             var request = HttpTestHelpers.CreateHttpRequest("GET", "http://foobar");


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-functions-host/issues/3541.

I was able to reproduce this issue in the standby e2e test. The issue was WebFunctionsManager was caching pre-specialization options, so was using a placeholder RootScriptPath after specialization to list functions, thus returning the WarmUp function.
