### PR TITLE
Strip query params with no value

### DIFF
--- a/src/WebJobs.Script/Rpc/MessageExtensions/RpcMessageConversionExtensions.cs
+++ b/src/WebJobs.Script/Rpc/MessageExtensions/RpcMessageConversionExtensions.cs
@@ -79,12 +79,18 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
                 foreach (var pair in request.Query)
                 {
-                    http.Query.Add(pair.Key, pair.Value.ToString());
+                    if (pair.Value != null)
+                    {
+                        http.Query.Add(pair.Key, pair.Value.ToString());
+                    }
                 }
 
                 foreach (var pair in request.Headers)
                 {
-                    http.Headers.Add(pair.Key.ToLowerInvariant(), pair.Value.ToString());
+                    if (pair.Value != null)
+                    {
+                        http.Headers.Add(pair.Key.ToLowerInvariant(), pair.Value.ToString());
+                    }
                 }
 
                 if (request.HttpContext.Items.TryGetValue(HttpExtensionConstants.AzureWebJobsHttpRouteDataKey, out object routeData))

--- a/src/WebJobs.Script/Rpc/MessageExtensions/RpcMessageConversionExtensions.cs
+++ b/src/WebJobs.Script/Rpc/MessageExtensions/RpcMessageConversionExtensions.cs
@@ -76,10 +76,9 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 typedData.Http = http;
 
                 http.RawBody = null;
-
                 foreach (var pair in request.Query)
                 {
-                    if (pair.Value != null)
+                    if (!string.IsNullOrEmpty(pair.Value.ToString()))
                     {
                         http.Query.Add(pair.Key, pair.Value.ToString());
                     }
@@ -87,10 +86,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
                 foreach (var pair in request.Headers)
                 {
-                    if (pair.Value != null)
-                    {
-                        http.Headers.Add(pair.Key.ToLowerInvariant(), pair.Value.ToString());
-                    }
+                    http.Headers.Add(pair.Key.ToLowerInvariant(), pair.Value.ToString());
                 }
 
                 if (request.HttpContext.Items.TryGetValue(HttpExtensionConstants.AzureWebJobsHttpRouteDataKey, out object routeData))

--- a/test/WebJobs.Script.Tests/Rpc/RpcMessageConversionExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/RpcMessageConversionExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Script.Rpc;
 using Microsoft.WebJobs.Script.Tests;
@@ -24,6 +25,26 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             string contentType;
             rpcRequestObject.Http.Headers.TryGetValue("content-type", out contentType);
             Assert.Equal(expectedContentType, contentType);
+        }
+
+        [Theory]
+        [InlineData("say=Hi&to=Mom", new string[] { "say", "to" }, new string[] { "Hi", "Mom" })]
+        [InlineData("say=Hi", new string[] { "say" }, new string[] { "Hi" })]
+        [InlineData("say=Hi&to=", new string[] { "say" }, new string[] { "Hi" })] // Removes empty value query params
+        public void HttpObjects_Query(string queryString, string[] expectedKeys, string[] expectedValues)
+        {
+            HttpRequest request = HttpTestHelpers.CreateHttpRequest("GET", $"http://localhost/api/httptrigger-scenarios?{queryString}");
+
+            var rpcRequestObject = request.ToRpc();
+            // Same number of expected key value pairs
+            Assert.Equal(rpcRequestObject.Http.Query.Count, expectedKeys.Length);
+            Assert.Equal(rpcRequestObject.Http.Query.Count, expectedValues.Length);
+            // Same key and value strings for each pair
+            for (int i = 0; i < expectedKeys.Length; i++)
+            {
+                Assert.True(rpcRequestObject.Http.Query.ContainsKey(expectedKeys[i]));
+                Assert.Equal(rpcRequestObject.Http.Query.GetValueOrDefault(expectedKeys[i]), expectedValues[i]);
+            }
         }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-functions-nodejs-worker/issues/142

However, we need a better and more complete implementation of this, as an empty query is value is valid. Note that this is also an issue with null value'd HTTP headers.