### PR TITLE
Consume/Monitor new Sandbox counters/limits (#3797)

### DIFF
--- a/src/WebJobs.Script/Scale/ApplicationPerformanceCounters.cs
+++ b/src/WebJobs.Script/Scale/ApplicationPerformanceCounters.cs
@@ -31,6 +31,14 @@ namespace Microsoft.Azure.WebJobs.Script.Scale
 
         public long NamedPipeLimit { get; set; }
 
+        public long RemoteDirMonitors { get; set; }
+
+        public long RemoteDirMonitorLimit { get; set; }
+
+        public long ActiveConnections { get; set; }
+
+        public long ActiveConnectionLimit { get; set; }
+
         public long ReadIoOperations { get; set; }
 
         public long WriteIoOperations { get; set; }

--- a/src/WebJobs.Script/Scale/HostPerformanceManager.cs
+++ b/src/WebJobs.Script/Scale/HostPerformanceManager.cs
@@ -45,11 +45,13 @@ namespace Microsoft.Azure.WebJobs.Script.Scale
             bool exceeded = false;
 
             // determine all counters whose limits have been exceeded
+            exceeded |= ThresholdExceeded("ActiveConnections", counters.ActiveConnections, counters.ActiveConnectionLimit, threshold, exceededCounters);
             exceeded |= ThresholdExceeded("Connections", counters.Connections, counters.ConnectionLimit, threshold, exceededCounters);
             exceeded |= ThresholdExceeded("Threads", counters.Threads, counters.ThreadLimit, threshold, exceededCounters);
             exceeded |= ThresholdExceeded("Processes", counters.Processes, counters.ProcessLimit, threshold, exceededCounters);
             exceeded |= ThresholdExceeded("NamedPipes", counters.NamedPipes, counters.NamedPipeLimit, threshold, exceededCounters);
             exceeded |= ThresholdExceeded("Sections", counters.Sections, counters.SectionLimit, threshold, exceededCounters);
+            exceeded |= ThresholdExceeded("RemoteDirMonitors", counters.RemoteDirMonitors, counters.RemoteDirMonitorLimit, threshold, exceededCounters);
 
             return exceeded;
         }


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-functions-host/issues/3797

Both of these new Sandbox counters are in the ANT 79 payload. While it wouldn't be problematic for this change to go in before 79 rolls out, I'll likely wait until it hits the beta stamp to test e2e first.

Also, once the changes are live, I'll update https://github.com/Azure/azure-functions-host/wiki/Host-Health-Monitor with the new counters.