### PR TITLE
Use correct JObject.FromObject() API instead of new JObject()

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             if (FileUtility.FileExists(Path.Combine(hostOptions.RootScriptPath, ScriptConstants.ProxyMetadataFileName)))
             {
                 // This is because we still need to scale function apps that are proxies only
-                functionsTriggers = functionsTriggers.Append(new JObject(new { type = "routingTrigger" }));
+                functionsTriggers = functionsTriggers.Append(JObject.FromObject(new { type = "routingTrigger" }));
             }
 
             return await InternalSyncTriggers(functionsTriggers);


### PR DESCRIPTION
old code would always throw this error 


```
Unhandled Exception: System.ArgumentException: Could not determine JSON object type for type <>f__AnonymousType0`1[System.String].
   at Newtonsoft.Json.Linq.JValue.GetValueType(Nullable`1 current, Object value)
   at Newtonsoft.Json.Linq.JContainer.CreateFromContent(Object content)
   at Newtonsoft.Json.Linq.JContainer.AddInternal(Int32 index, Object content, Boolean skipParentCheck)
```