### PR TITLE
Enabling buffering for all requests. Fixes #3765.

### DIFF
--- a/LICENSE_APACHE.txt
+++ b/LICENSE_APACHE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright (c) .NET Foundation and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/WebJobs.Script.WebHost/GlobalSuppressions.cs
+++ b/src/WebJobs.Script.WebHost/GlobalSuppressions.cs
@@ -9,3 +9,4 @@
 */
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1313:Parameter names should begin with lower-case letter", Justification = "<Pending>", Scope = "type", Target = "~T:Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.EventGenerator.FunctionsSystemLogsEventSource")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1636:File header copyright text should match", Justification = "<Pending>")]

--- a/src/WebJobs.Script.WebHost/Middleware/Buffering/BufferingWriteStream.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/Buffering/BufferingWriteStream.cs
@@ -1,0 +1,219 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE_APACHE.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Buffering
+{
+    internal class BufferingWriteStream : Stream
+    {
+        private readonly Stream _innerStream;
+        private readonly MemoryStream _buffer = new MemoryStream();
+        private bool _isBuffering = true;
+
+        public BufferingWriteStream(Stream innerStream)
+        {
+            _innerStream = innerStream;
+        }
+
+        public override bool CanRead
+        {
+            get { return false; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return _isBuffering; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return _innerStream.CanWrite; }
+        }
+
+        public override long Length
+        {
+            get
+            {
+                if (_isBuffering)
+                {
+                    return _buffer.Length;
+                }
+                // May throw
+                return _innerStream.Length;
+            }
+        }
+
+        // Clear/Reset the buffer by setting Position, Seek, or SetLength to 0. Random access is not supported.
+        public override long Position
+        {
+            get
+            {
+                if (_isBuffering)
+                {
+                    return _buffer.Position;
+                }
+                // May throw
+                return _innerStream.Position;
+            }
+
+            set
+            {
+                if (_isBuffering)
+                {
+                    if (value != 0)
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(value), value, nameof(Position) + " can only be set to 0.");
+                    }
+                    _buffer.Position = value;
+                    _buffer.SetLength(value);
+                }
+                else
+                {
+                    // May throw
+                    _innerStream.Position = value;
+                }
+            }
+        }
+
+        // Clear/Reset the buffer by setting Position, Seek, or SetLength to 0. Random access is not supported.
+        public override void SetLength(long value)
+        {
+            if (_isBuffering)
+            {
+                if (value != 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), value, nameof(Length) + " can only be set to 0.");
+                }
+                _buffer.Position = value;
+                _buffer.SetLength(value);
+            }
+            else
+            {
+                // May throw
+                _innerStream.SetLength(value);
+            }
+        }
+
+        // Clear/Reset the buffer by setting Position, Seek, or SetLength to 0. Random access is not supported.
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            if (_isBuffering)
+            {
+                if (origin != SeekOrigin.Begin)
+                {
+                    throw new ArgumentException(nameof(origin), nameof(Seek) + " can only be set to " + nameof(SeekOrigin.Begin) + ".");
+                }
+                if (offset != 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(offset), offset, nameof(Seek) + " can only be set to 0.");
+                }
+                _buffer.SetLength(offset);
+                return _buffer.Seek(offset, origin);
+            }
+            // Try the inner stream instead, but this will usually fail.
+            return _innerStream.Seek(offset, origin);
+        }
+
+        internal void DisableBuffering()
+        {
+            _isBuffering = false;
+            if (_buffer.Length > 0)
+            {
+                Flush();
+            }
+        }
+
+        internal Task DisableBufferingAsync(CancellationToken cancellationToken)
+        {
+            _isBuffering = false;
+            if (_buffer.Length > 0)
+            {
+                return FlushAsync(cancellationToken);
+            }
+            return Task.CompletedTask;
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            if (_isBuffering)
+            {
+                _buffer.Write(buffer, offset, count);
+            }
+            else
+            {
+                _innerStream.Write(buffer, offset, count);
+            }
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            if (_isBuffering)
+            {
+                return _buffer.WriteAsync(buffer, offset, count, cancellationToken);
+            }
+            else
+            {
+                return _innerStream.WriteAsync(buffer, offset, count, cancellationToken);
+            }
+        }
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            if (_isBuffering)
+            {
+                return _buffer.BeginWrite(buffer, offset, count, callback, state);
+            }
+            else
+            {
+                return _innerStream.BeginWrite(buffer, offset, count, callback, state);
+            }
+        }
+
+        public override void EndWrite(IAsyncResult asyncResult)
+        {
+            if (_isBuffering)
+            {
+                _buffer.EndWrite(asyncResult);
+            }
+            else
+            {
+                _innerStream.EndWrite(asyncResult);
+            }
+        }
+
+        public override void Flush()
+        {
+            _isBuffering = false;
+            if (_buffer.Length > 0)
+            {
+                _buffer.Seek(0, SeekOrigin.Begin);
+                _buffer.CopyTo(_innerStream);
+                _buffer.Seek(0, SeekOrigin.Begin);
+                _buffer.SetLength(0);
+            }
+            _innerStream.Flush();
+        }
+
+        public override async Task FlushAsync(CancellationToken cancellationToken)
+        {
+            _isBuffering = false;
+            if (_buffer.Length > 0)
+            {
+                _buffer.Seek(0, SeekOrigin.Begin);
+                await _buffer.CopyToAsync(_innerStream, 1024 * 16, cancellationToken);
+                _buffer.Seek(0, SeekOrigin.Begin);
+                _buffer.SetLength(0);
+            }
+            await _innerStream.FlushAsync(cancellationToken);
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException("This Stream only supports Write operations.");
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Middleware/Buffering/HttpBufferingFeature.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/Buffering/HttpBufferingFeature.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE_APACHE.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Microsoft.AspNetCore.Buffering
+{
+    internal class HttpBufferingFeature : IHttpBufferingFeature, IScriptHttpBufferedStream
+    {
+        private readonly BufferingWriteStream _buffer;
+        private readonly IHttpBufferingFeature _innerFeature;
+
+        internal HttpBufferingFeature(BufferingWriteStream buffer, IHttpBufferingFeature innerFeature)
+        {
+            _buffer = buffer;
+            _innerFeature = innerFeature;
+        }
+
+        public Task DisableBufferingAsync(CancellationToken cancellationToken)
+        {
+            return _buffer.DisableBufferingAsync(cancellationToken);
+        }
+
+        public void DisableRequestBuffering()
+        {
+            _innerFeature?.DisableRequestBuffering();
+        }
+
+        public void DisableResponseBuffering()
+        {
+            _buffer.DisableBuffering();
+            _innerFeature?.DisableResponseBuffering();
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Middleware/Buffering/IScriptHttpBufferedStream.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/Buffering/IScriptHttpBufferedStream.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE_APACHE.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Http.Features
+{
+    public interface IScriptHttpBufferedStream
+    {
+        Task DisableBufferingAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/WebJobs.Script.WebHost/Middleware/Buffering/ResponseBufferingMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/Buffering/ResponseBufferingMiddleware.cs
@@ -1,0 +1,59 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE_APACHE.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Microsoft.AspNetCore.Buffering
+{
+    public class ResponseBufferingMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public ResponseBufferingMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task Invoke(HttpContext httpContext)
+        {
+            var originalResponseBody = httpContext.Response.Body;
+
+            // no-op if buffering is already available.
+            if (originalResponseBody.CanSeek)
+            {
+                await _next(httpContext);
+                return;
+            }
+
+            var originalBufferingFeature = httpContext.Features.Get<IHttpBufferingFeature>();
+            try
+            {
+                // Shim the response stream
+                var bufferStream = new BufferingWriteStream(originalResponseBody);
+                httpContext.Response.Body = bufferStream;
+                httpContext.Features.Set<IHttpBufferingFeature>(new HttpBufferingFeature(bufferStream, originalBufferingFeature));
+
+                await _next(httpContext);
+
+                // If we're still buffered, set the content-length header and flush the buffer.
+                // Only if the content-length header is not already set, and some content was buffered.
+                if (!httpContext.Response.HasStarted && bufferStream.CanSeek && bufferStream.Length > 0)
+                {
+                    if (!httpContext.Response.ContentLength.HasValue)
+                    {
+                        httpContext.Response.ContentLength = bufferStream.Length;
+                    }
+                    await bufferStream.FlushAsync();
+                }
+            }
+            finally
+            {
+                // undo everything
+                httpContext.Features.Set(originalBufferingFeature);
+                httpContext.Response.Body = originalResponseBody;
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Middleware/FunctionInvocationMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/FunctionInvocationMiddleware.cs
@@ -84,9 +84,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
             if (functionExecution != null && !functionExecution.Descriptor.Metadata.IsProxy && nestedProxiesCount == null)
             {
                 // HttpBufferingService is disabled for non-proxy functions.
-                var bufferingFeature = context.Features.Get<IHttpBufferingFeature>();
-                bufferingFeature?.DisableRequestBuffering();
-                bufferingFeature?.DisableResponseBuffering();
+                var bufferingFeature = context.Features.Get<IScriptHttpBufferedStream>();
+                bufferingFeature?.DisableBufferingAsync(CancellationToken.None);
             }
 
             if (nestedProxiesCount != null)

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -50,7 +50,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Buffering" Version="0.4.0-preview2-28189" />
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.6830001-df202c6c" />
     <PackageReference Include="Microsoft.AspNetCore.Server.IIS" Version="2.1.0-a-oob-2-1-oob-17297" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="3.0.3" />

--- a/test/WebJobs.Script.Tests/GlobalSuppressions.cs
+++ b/test/WebJobs.Script.Tests/GlobalSuppressions.cs
@@ -7,3 +7,4 @@
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1636:File header copyright text must match", Justification = "<Pending>")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element must begin with upper-case letter", Justification = "<Pending>", Scope = "type", Target = "~T:Microsoft.Azure.WebJobs.Extensibility.Tests.ScriptBindingContextTests.Test")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1201:Elements must appear in the correct order", Justification = "<Pending>", Scope = "type", Target = "~T:Microsoft.Azure.WebJobs.Extensibility.Tests.ScriptBindingContextTests.Test")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1636:File header copyright text should match", Justification = "<Pending>")]

--- a/test/WebJobs.Script.Tests/Middleware/ResponseBufferingMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Middleware/ResponseBufferingMiddlewareTests.cs
@@ -1,0 +1,315 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE_APACHE.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.TestHost;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Buffering.Tests
+{
+    public class ResponseBufferingMiddlewareTests
+    {
+        [Fact]
+        public async Task BufferResponse_SetsContentLength()
+        {
+            var builder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseMiddleware<ResponseBufferingMiddleware>();
+                    app.Run(async context =>
+                    {
+                        Assert.False(context.Response.HasStarted);
+                        Assert.True(context.Response.Body.CanSeek);
+                        await context.Response.WriteAsync("Hello World");
+                        Assert.False(context.Response.HasStarted);
+                        Assert.True(context.Response.Body.CanSeek);
+                    });
+                });
+            var server = new TestServer(builder);
+
+            var response = await server.CreateClient().GetAsync(string.Empty);
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("Hello World", await response.Content.ReadAsStringAsync());
+
+            // Set automatically by buffer
+            IEnumerable<string> values;
+            Assert.True(response.Content.Headers.TryGetValues("Content-Length", out values));
+            Assert.Equal("11", values.FirstOrDefault());
+        }
+
+        [Fact]
+        public async Task BufferResponseWithManualContentLength_NotReplaced()
+        {
+            var builder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseMiddleware<ResponseBufferingMiddleware>();
+                    app.Run(async context =>
+                    {
+                        context.Response.ContentLength = 12;
+                        Assert.False(context.Response.HasStarted);
+                        Assert.True(context.Response.Body.CanSeek);
+                        await context.Response.WriteAsync("Hello World");
+                        Assert.False(context.Response.HasStarted);
+                        Assert.True(context.Response.Body.CanSeek);
+                    });
+                });
+            var server = new TestServer(builder);
+
+            var response = await server.CreateClient().GetAsync(string.Empty);
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("Hello World", await response.Content.ReadAsStringAsync());
+
+            IEnumerable<string> values;
+            Assert.True(response.Content.Headers.TryGetValues("Content-Length", out values));
+            Assert.Equal("12", values.FirstOrDefault());
+        }
+
+        [Fact]
+        public async Task Seek_AllowsResttingBuffer()
+        {
+            var builder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseMiddleware<ResponseBufferingMiddleware>();
+                    app.Run(async context =>
+                    {
+                        var body = context.Response.Body;
+                        Assert.False(context.Response.HasStarted);
+                        Assert.True(body.CanSeek);
+                        Assert.Equal(0, body.Position);
+                        Assert.Equal(0, body.Length);
+
+                        await context.Response.WriteAsync("Hello World");
+                        Assert.False(context.Response.HasStarted);
+                        Assert.True(context.Response.Body.CanSeek);
+                        Assert.Equal(11, body.Position);
+                        Assert.Equal(11, body.Length);
+
+                        Assert.Throws<ArgumentOutOfRangeException>(() => body.Seek(1, SeekOrigin.Begin));
+                        Assert.Throws<ArgumentException>(() => body.Seek(0, SeekOrigin.Current));
+                        Assert.Throws<ArgumentException>(() => body.Seek(0, SeekOrigin.End));
+
+                        Assert.Equal(0, body.Seek(0, SeekOrigin.Begin));
+                        Assert.Equal(0, body.Position);
+                        Assert.Equal(0, body.Length);
+
+                        await context.Response.WriteAsync("12345");
+                        Assert.Equal(5, body.Position);
+                        Assert.Equal(5, body.Length);
+                    });
+                });
+            var server = new TestServer(builder);
+
+            var response = await server.CreateClient().GetAsync(string.Empty);
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("12345", await response.Content.ReadAsStringAsync());
+
+            // Set automatically by buffer
+            IEnumerable<string> values;
+            Assert.True(response.Content.Headers.TryGetValues("Content-Length", out values));
+            Assert.Equal("5", values.FirstOrDefault());
+        }
+
+        [Fact]
+        public async Task SetPosition_AllowsResttingBuffer()
+        {
+            var builder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseMiddleware<ResponseBufferingMiddleware>();
+                    app.Run(async context =>
+                    {
+                        var body = context.Response.Body;
+                        Assert.False(context.Response.HasStarted);
+                        Assert.True(body.CanSeek);
+                        Assert.Equal(0, body.Position);
+                        Assert.Equal(0, body.Length);
+
+                        await context.Response.WriteAsync("Hello World");
+                        Assert.False(context.Response.HasStarted);
+                        Assert.True(context.Response.Body.CanSeek);
+                        Assert.Equal(11, body.Position);
+                        Assert.Equal(11, body.Length);
+
+                        Assert.Throws<ArgumentOutOfRangeException>(() => body.Position = 1);
+
+                        body.Position = 0;
+                        Assert.Equal(0, body.Position);
+                        Assert.Equal(0, body.Length);
+
+                        await context.Response.WriteAsync("12345");
+                        Assert.Equal(5, body.Position);
+                        Assert.Equal(5, body.Length);
+                    });
+                });
+            var server = new TestServer(builder);
+
+            var response = await server.CreateClient().GetAsync(string.Empty);
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("12345", await response.Content.ReadAsStringAsync());
+
+            // Set automatically by buffer
+            IEnumerable<string> values;
+            Assert.True(response.Content.Headers.TryGetValues("Content-Length", out values));
+            Assert.Equal("5", values.FirstOrDefault());
+        }
+
+        [Fact]
+        public async Task SetLength_AllowsResttingBuffer()
+        {
+            var builder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseMiddleware<ResponseBufferingMiddleware>();
+                    app.Run(async context =>
+                    {
+                        var body = context.Response.Body;
+                        Assert.False(context.Response.HasStarted);
+                        Assert.True(body.CanSeek);
+                        Assert.Equal(0, body.Position);
+                        Assert.Equal(0, body.Length);
+
+                        await context.Response.WriteAsync("Hello World");
+                        Assert.False(context.Response.HasStarted);
+                        Assert.True(context.Response.Body.CanSeek);
+                        Assert.Equal(11, body.Position);
+                        Assert.Equal(11, body.Length);
+
+                        Assert.Throws<ArgumentOutOfRangeException>(() => body.SetLength(1));
+
+                        body.SetLength(0);
+                        Assert.Equal(0, body.Position);
+                        Assert.Equal(0, body.Length);
+
+                        await context.Response.WriteAsync("12345");
+                        Assert.Equal(5, body.Position);
+                        Assert.Equal(5, body.Length);
+                    });
+                });
+            var server = new TestServer(builder);
+
+            var response = await server.CreateClient().GetAsync(string.Empty);
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("12345", await response.Content.ReadAsStringAsync());
+
+            // Set automatically by buffer
+            IEnumerable<string> values;
+            Assert.True(response.Content.Headers.TryGetValues("Content-Length", out values));
+            Assert.Equal("5", values.FirstOrDefault());
+        }
+
+        [Fact]
+        public async Task DisableBufferingViaFeature()
+        {
+            var builder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseMiddleware<ResponseBufferingMiddleware>();
+                    app.Run(async context =>
+                    {
+                        Assert.False(context.Response.HasStarted);
+                        Assert.True(context.Response.Body.CanSeek);
+
+                        var bufferingFeature = context.Features.Get<IHttpBufferingFeature>();
+                        Assert.NotNull(bufferingFeature);
+                        bufferingFeature.DisableResponseBuffering();
+
+                        Assert.False(context.Response.HasStarted);
+                        Assert.False(context.Response.Body.CanSeek);
+
+                        await context.Response.WriteAsync("Hello World");
+
+                        Assert.True(context.Response.HasStarted);
+                        Assert.False(context.Response.Body.CanSeek);
+                    });
+                });
+            var server = new TestServer(builder);
+
+            var response = await server.CreateClient().GetAsync(string.Empty);
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("Hello World", await response.Content.ReadAsStringAsync());
+            IEnumerable<string> values;
+            Assert.False(response.Content.Headers.TryGetValues("Content-Length", out values));
+        }
+
+        [Fact]
+        public async Task DisableBufferingViaFeatureAfterFirstWrite_Flushes()
+        {
+            var builder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseMiddleware<ResponseBufferingMiddleware>();
+                    app.Run(async context =>
+                    {
+                        Assert.False(context.Response.HasStarted);
+                        Assert.True(context.Response.Body.CanSeek);
+
+                        await context.Response.WriteAsync("Hello");
+
+                        Assert.False(context.Response.HasStarted);
+                        Assert.True(context.Response.Body.CanSeek);
+
+                        var bufferingFeature = context.Features.Get<IHttpBufferingFeature>();
+                        Assert.NotNull(bufferingFeature);
+                        bufferingFeature.DisableResponseBuffering();
+
+                        Assert.True(context.Response.HasStarted);
+                        Assert.False(context.Response.Body.CanSeek);
+
+                        await context.Response.WriteAsync(" World");
+
+                        Assert.True(context.Response.HasStarted);
+                        Assert.False(context.Response.Body.CanSeek);
+                    });
+                });
+            var server = new TestServer(builder);
+
+            var response = await server.CreateClient().GetAsync(string.Empty);
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("Hello World", await response.Content.ReadAsStringAsync());
+            IEnumerable<string> values;
+            Assert.False(response.Content.Headers.TryGetValues("Content-Length", out values));
+        }
+
+        [Fact]
+        public async Task FlushDisablesBuffering()
+        {
+            var builder = new WebHostBuilder()
+                .Configure(app =>
+                {
+                    app.UseMiddleware<ResponseBufferingMiddleware>();
+                    app.Run(async context =>
+                    {
+                        Assert.False(context.Response.HasStarted);
+                        Assert.True(context.Response.Body.CanSeek);
+
+                        context.Response.Body.Flush();
+
+                        Assert.True(context.Response.HasStarted);
+                        Assert.False(context.Response.Body.CanSeek);
+
+                        await context.Response.WriteAsync("Hello World");
+
+                        Assert.True(context.Response.HasStarted);
+                        Assert.False(context.Response.Body.CanSeek);
+                    });
+                });
+            var server = new TestServer(builder);
+
+            var response = await server.CreateClient().GetAsync(string.Empty);
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("Hello World", await response.Content.ReadAsStringAsync());
+            IEnumerable<string> values;
+            Assert.False(response.Content.Headers.TryGetValues("Content-Length", out values));
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -49,6 +49,7 @@
 
   <ItemGroup>
     <PackageReference Include="appinsights.testlogger" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.9.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" />


### PR DESCRIPTION
Fixes #3765 
New ANCM disables gzip compression on "DisableRequestBuffering" call. With this change we will buffer all requests, not only proxy requests.