### PR TITLE
Fix NullReferenceException in Orphan() codepath

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -368,7 +368,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         /// <param name="instance">The <see cref="IHost"/> instance to remove</param>
         private async Task Orphan(IHost instance, ILogger logger, CancellationToken cancellationToken = default)
         {
-            var scriptHost = (ScriptHost)instance.Services.GetService<ScriptHost>();
+            var scriptHost = (ScriptHost)instance?.Services.GetService<ScriptHost>();
             if (scriptHost != null)
             {
                 scriptHost.HostInitializing -= OnHostInitializing;


### PR DESCRIPTION
I ran into a `NullReferenceException` in this code path when locally debugging a function app in Visual Studio (source-linking brought me here). I don't know exactly what the side-effects of this null-ref are, but it seems wrong, especially since other parts of this method are correctly checking for a null `instance` method.