### PR TITLE
Disabling AzureMonitor logger

### DIFF
--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -14,8 +14,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
 {
@@ -52,21 +50,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                     loggingBuilder.AddWebJobsSystem<SystemLoggerProvider>();
                     loggingBuilder.Services.AddSingleton<ILoggerProvider, UserLogMetricsLoggerProvider>();
-                    loggingBuilder.Services.AddSingleton<ILoggerProvider>(services =>
-                    {
-                        IEnvironment environment = services.GetService<IEnvironment>();
-                        IScriptWebHostEnvironment hostEnvironment = services.GetService<IScriptWebHostEnvironment>();
-
-                        if (!hostEnvironment.InStandbyMode &&
-                            !string.IsNullOrEmpty(environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName)))
-                        {
-                            IEventGenerator eventGenerator = services.GetService<IEventGenerator>();
-                            IOptions<ScriptJobHostOptions> options = services.GetService<IOptions<ScriptJobHostOptions>>();
-                            return new AzureMonitorDiagnosticLoggerProvider(options, eventGenerator, environment);
-                        }
-
-                        return NullLoggerProvider.Instance;
-                    });
 
                     ConfigureRegisteredBuilders(loggingBuilder, rootServiceProvider);
                 })

--- a/test/WebJobs.Script.Tests/Configuration/LoggingConfigurationTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/LoggingConfigurationTests.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
@@ -178,12 +177,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 
             IEnumerable<ILoggerProvider> loggerProviders = host.Services.GetService<IEnumerable<ILoggerProvider>>();
 
-            Assert.Equal(5, loggerProviders.Count());
+            Assert.Equal(4, loggerProviders.Count());
             loggerProviders.OfType<SystemLoggerProvider>().Single();
             loggerProviders.OfType<HostFileLoggerProvider>().Single();
             loggerProviders.OfType<FunctionFileLoggerProvider>().Single();
             loggerProviders.OfType<UserLogMetricsLoggerProvider>().Single();
-            loggerProviders.OfType<NullLoggerProvider>().Single();
         }
 
         [Fact]
@@ -196,13 +194,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 
             IEnumerable<ILoggerProvider> loggerProviders = host.Services.GetService<IEnumerable<ILoggerProvider>>();
 
-            Assert.Equal(6, loggerProviders.Count());
+            Assert.Equal(5, loggerProviders.Count());
             loggerProviders.OfType<SystemLoggerProvider>().Single();
             loggerProviders.OfType<HostFileLoggerProvider>().Single();
             loggerProviders.OfType<FunctionFileLoggerProvider>().Single();
             loggerProviders.OfType<ConsoleLoggerProvider>().Single();
             loggerProviders.OfType<UserLogMetricsLoggerProvider>().Single();
-            loggerProviders.OfType<NullLoggerProvider>().Single();
         }
 
         [Fact]
@@ -221,13 +218,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 
             IEnumerable<ILoggerProvider> loggerProviders = host.Services.GetService<IEnumerable<ILoggerProvider>>();
 
-            Assert.Equal(6, loggerProviders.Count());
+            Assert.Equal(5, loggerProviders.Count());
             loggerProviders.OfType<SystemLoggerProvider>().Single();
             loggerProviders.OfType<HostFileLoggerProvider>().Single();
             loggerProviders.OfType<FunctionFileLoggerProvider>().Single();
             loggerProviders.OfType<ConsoleLoggerProvider>().Single();
             loggerProviders.OfType<UserLogMetricsLoggerProvider>().Single();
-            loggerProviders.OfType<NullLoggerProvider>().Single();
         }
 
         [Fact]
@@ -246,36 +242,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 
             IEnumerable<ILoggerProvider> loggerProviders = host.Services.GetService<IEnumerable<ILoggerProvider>>();
 
-            Assert.Equal(6, loggerProviders.Count());
+            Assert.Equal(5, loggerProviders.Count());
             loggerProviders.OfType<SystemLoggerProvider>().Single();
             loggerProviders.OfType<HostFileLoggerProvider>().Single();
             loggerProviders.OfType<FunctionFileLoggerProvider>().Single();
             loggerProviders.OfType<ApplicationInsightsLoggerProvider>().Single();
             loggerProviders.OfType<UserLogMetricsLoggerProvider>().Single();
-            loggerProviders.OfType<NullLoggerProvider>().Single();
-        }
-
-        [Fact]
-        public void LoggerProviders_AzureMonitor()
-        {
-            IHost host = new HostBuilder()
-              .ConfigureDefaultTestWebScriptHost()
-              .ConfigureServices(s =>
-              {
-                  TestEnvironment environment = new TestEnvironment();
-                  environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName, "something.azurewebsites.net");
-                  s.AddSingleton<IEnvironment>(environment);
-              })
-              .Build();
-
-            IEnumerable<ILoggerProvider> loggerProviders = host.Services.GetService<IEnumerable<ILoggerProvider>>();
-
-            Assert.Equal(5, loggerProviders.Count());
-            loggerProviders.OfType<SystemLoggerProvider>().Single();
-            loggerProviders.OfType<HostFileLoggerProvider>().Single();
-            loggerProviders.OfType<FunctionFileLoggerProvider>().Single();
-            loggerProviders.OfType<UserLogMetricsLoggerProvider>().Single();
-            loggerProviders.OfType<AzureMonitorDiagnosticLoggerProvider>().Single();
         }
     }
 }


### PR DESCRIPTION
This reverts commit 700aa23ba8185e408d78fac00a722e0d010dd02a as launching x64 processes from the 32-bit runtime does not work
