### PR TITLE
Add PowerShell function artifacts for perf test

### DIFF
--- a/test/WebJobs.Script.Tests.Perf/Functions/wwwroot/PSPing/function.json
+++ b/test/WebJobs.Script.Tests.Perf/Functions/wwwroot/PSPing/function.json
@@ -1,0 +1,19 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/test/WebJobs.Script.Tests.Perf/Functions/wwwroot/PSPing/run.ps1
+++ b/test/WebJobs.Script.Tests.Perf/Functions/wwwroot/PSPing/run.ps1
@@ -1,0 +1,6 @@
+param($req)
+
+Push-OutputBinding -Name res -Value @{
+    StatusCode = 200
+    Body = "Pong"
+}

--- a/test/WebJobs.Script.Tests.Perf/ThroughputTests.cs
+++ b/test/WebJobs.Script.Tests.Perf/ThroughputTests.cs
@@ -57,6 +57,15 @@ namespace WebJobs.Script.Tests.Perf
             await ExecutePS("win-java-ping.jmx", "Java Ping");
         }
 
+        [Fact]
+        [TestTrace]
+        public async Task TestPowerShell()
+        {
+            await ChangeLanguage("powershell");
+
+            await ExecutePS("win-powershell-ping.jmx", "PS Ping");
+        }
+
         private async Task ExecutePS(string scriptName, string description)
         {
             _fixture.Logger.LogInformation($"Execute: {scriptName}, {description}");


### PR DESCRIPTION
Add the necessary PowerShell function artifact to on board PowerShell worker to the perf test. /cc @alrod 

I will need help from @alrod to author the .jmx file for PowerShell and finish the rest on-boarding steps.