### PR TITLE
[pack] fixing LanguageWorker console.log()

### DIFF
--- a/src/WebJobs.Script/Rpc/ILanguageWorkerConsoleLogSource.cs
+++ b/src/WebJobs.Script/Rpc/ILanguageWorkerConsoleLogSource.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks.Dataflow;
+
+namespace Microsoft.Azure.WebJobs.Script.Rpc
+{
+    public interface ILanguageWorkerConsoleLogSource
+    {
+        ISourceBlock<string> LogStream { get; }
+
+        void Log(string consoleLog);
+    }
+}

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannelManager.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         private readonly TimeSpan processStartTimeout = TimeSpan.FromSeconds(40);
         private readonly TimeSpan workerInitTimeout = TimeSpan.FromSeconds(30);
         private readonly IOptionsMonitor<ScriptApplicationHostOptions> _applicationHostOptions = null;
+        private readonly ILanguageWorkerConsoleLogSource _consoleLogSource;
         private readonly IScriptEventManager _eventManager = null;
         private readonly IEnvironment _environment;
         private readonly ILoggerFactory _loggerFactory = null;
@@ -35,7 +36,8 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         private Action _shutdownStandbyWorkerChannels;
         private IDictionary<string, ILanguageWorkerChannel> _workerChannels = new Dictionary<string, ILanguageWorkerChannel>();
 
-        public LanguageWorkerChannelManager(IScriptEventManager eventManager, IEnvironment environment, IRpcServer rpcServer, ILoggerFactory loggerFactory, IOptions<LanguageWorkerOptions> languageWorkerOptions, IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions)
+        public LanguageWorkerChannelManager(IScriptEventManager eventManager, IEnvironment environment, IRpcServer rpcServer, ILoggerFactory loggerFactory, IOptions<LanguageWorkerOptions> languageWorkerOptions,
+            IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, ILanguageWorkerConsoleLogSource consoleLogSource)
         {
             _rpcServer = rpcServer;
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
@@ -44,6 +46,8 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             _logger = loggerFactory.CreateLogger(ScriptConstants.LanguageWorkerChannelManager);
             _workerConfigs = languageWorkerOptions.Value.WorkerConfigs;
             _applicationHostOptions = applicationHostOptions;
+            _consoleLogSource = consoleLogSource;
+
             _processFactory = new DefaultWorkerProcessFactory();
             try
             {
@@ -78,7 +82,8 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                          _rpcServer.Uri,
                          _loggerFactory,
                          metricsLogger,
-                         attemptCount);
+                         attemptCount,
+                         _consoleLogSource);
         }
 
         public async Task InitializeChannelAsync(string runtime)

--- a/src/WebJobs.Script/Rpc/LanguageWorkerConsoleLogService.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerConsoleLogService.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.Rpc
+{
+    internal class LanguageWorkerConsoleLogService : IHostedService, IDisposable
+    {
+        private readonly ILogger _logger;
+        private readonly ILanguageWorkerConsoleLogSource _source;
+        private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+        private Task _processingTask;
+        private bool _disposed = false;
+
+        public LanguageWorkerConsoleLogService(ILoggerFactory loggerFactory, ILanguageWorkerConsoleLogSource consoleLogSource)
+        {
+            if (loggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            _source = consoleLogSource ?? throw new ArgumentNullException(nameof(consoleLogSource));
+            _logger = loggerFactory.CreateLogger(LanguageWorkerConstants.FunctionConsoleLogCategoryName);
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            _processingTask = ProcessLogs();
+            return Task.CompletedTask;
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            _cts.Cancel();
+            await _processingTask;
+        }
+
+        private async Task ProcessLogs()
+        {
+            ISourceBlock<string> source = _source.LogStream;
+            try
+            {
+                while (await source.OutputAvailableAsync(_cts.Token))
+                {
+                    _logger.LogInformation(await source.ReceiveAsync());
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // This occurs during shutdown.
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _cts?.Dispose();
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script/Rpc/LanguageWorkerConsoleLogSource.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerConsoleLogSource.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks.Dataflow;
+
+namespace Microsoft.Azure.WebJobs.Script.Rpc
+{
+    internal class LanguageWorkerConsoleLogSource : ILanguageWorkerConsoleLogSource
+    {
+        private readonly BufferBlock<string> _buffer = new BufferBlock<string>();
+
+        public ISourceBlock<string> LogStream => _buffer;
+
+        public void Log(string consoleLog)
+        {
+            _buffer.Post(consoleLog);
+        }
+    }
+}

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -161,6 +161,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 }
 
                 // Hosted services
+                services.AddSingleton<IHostedService, LanguageWorkerConsoleLogService>();
                 services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, PrimaryHostCoordinator>());
             });
 
@@ -182,6 +183,7 @@ namespace Microsoft.Azure.WebJobs.Script
             services.AddSingleton<IHostedService, RpcInitializationService>();
             services.AddSingleton<FunctionRpc.FunctionRpcBase, FunctionRpcService>();
             services.AddSingleton<IRpcServer, GrpcServer>();
+            services.TryAddSingleton<ILanguageWorkerConsoleLogSource, LanguageWorkerConsoleLogSource>();
             services.TryAddSingleton<ILanguageWorkerChannelManager, LanguageWorkerChannelManager>();
 
             services.TryAddSingleton<IDebugManager, DebugManager>();

--- a/test/WebJobs.Script.Tests.Integration/CosmosDB/CosmosDBEndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/CosmosDB/CosmosDBEndToEndTestsBase.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.CosmosDB
 
             // now wait for function to be invoked
             string result = await TestHelpers.WaitForBlobAndGetStringAsync(resultBlob,
-                () => string.Join(Environment.NewLine, Fixture.Host.GetLogMessages()));
+                () => string.Join(Environment.NewLine, Fixture.Host.GetScriptHostLogMessages()));
 
             if (collectionsCreated)
             {

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Node/Scenarios/index.js
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Node/Scenarios/index.js
@@ -41,6 +41,8 @@ module.exports = function (context, input) {
         context.log.warn('loglevel warn');
         context.log.error('loglevel error');
 
+        console.log('console log');
+
         context.done();
     }
     else if (scenario === 'bindingData') {

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpEndToEndTests.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             IList<string> logs = null;
             await TestHelpers.Await(() =>
             {
-                logs = Fixture.Host.GetLogMessages().Select(p => p.FormattedMessage).Where(p => p != null).ToArray();
+                logs = Fixture.Host.GetScriptHostLogMessages().Select(p => p.FormattedMessage).Where(p => p != null).ToArray();
                 return logs.Any(p => p.Contains(guid2));
             });
 
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             // Assert.Equal(2, Fixture.MetricsLogger.LoggedEvents.Where(p => p == key).Count());
 
             // Make sure we've gotten a log from the aggregator
-            IEnumerable<LogMessage> getAggregatorLogs() => Fixture.Host.GetLogMessages().Where(p => p.Category == LogCategories.Aggregator);
+            IEnumerable<LogMessage> getAggregatorLogs() => Fixture.Host.GetScriptHostLogMessages().Where(p => p.Category == LogCategories.Aggregator);
 
             await TestHelpers.Await(() => getAggregatorLogs().Any());
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestsBase.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             await TestHelpers.Await(() =>
             {
                 // make sure the input string made it all the way through
-                var logs = Fixture.Host.GetLogMessages();
+                var logs = Fixture.Host.GetScriptHostLogMessages();
                 return logs.Any(p => p.FormattedMessage != null && p.FormattedMessage.Contains(testData));
             }, userMessageCallback: Fixture.Host.GetLog);
         }
@@ -352,7 +352,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             userMessageCallback: () =>
             {
                 // AppVeyor only shows 4096 chars
-                var s = string.Join(Environment.NewLine, Fixture.Host.GetLogMessages());
+                var s = string.Join(Environment.NewLine, Fixture.Host.GetScriptHostLogMessages());
                 return s.Length < 4096 ? s : s.Substring(s.Length - 4096);
             });
 
@@ -376,7 +376,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             await TestHelpers.Await(() =>
             {
-                logMessage = Fixture.Host.GetLogMessages(LogCategories.CreateFunctionUserCategory(functionName)).SingleOrDefault(filter);
+                logMessage = Fixture.Host.GetScriptHostLogMessages(LogCategories.CreateFunctionUserCategory(functionName)).SingleOrDefault(filter);
                 return logMessage != null;
             });
 
@@ -389,7 +389,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             await TestHelpers.Await(() =>
             {
-                logMessage = Fixture.Host.GetLogMessages().SingleOrDefault(filter);
+                logMessage = Fixture.Host.GetScriptHostLogMessages().SingleOrDefault(filter);
                 return logMessage != null;
             });
 
@@ -403,7 +403,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             await TestHelpers.Await(() =>
            {
                // search the logs for token "TestResult:" and parse the following JSON
-               var logs = Fixture.Host.GetLogMessages(LogCategories.CreateFunctionUserCategory(functionName));
+               var logs = Fixture.Host.GetScriptHostLogMessages(LogCategories.CreateFunctionUserCategory(functionName));
                if (logs != null)
                {
                    logEntry = logs.Select(p => p.FormattedMessage).SingleOrDefault(p => p != null && p.Contains("TestResult:"));

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 
             await Task.Delay(1000);
 
-            var hostLogs = _fixture.Host.GetLogMessages();
+            var hostLogs = _fixture.Host.GetScriptHostLogMessages();
             foreach (var expectedLog in logs.Select(p => p.Message))
             {
                 Assert.Equal(1, hostLogs.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains(expectedLog)));
@@ -589,7 +589,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                 var product = JObject.Parse(json);
                 Assert.Equal("electronics", (string)product["category"]);
                 Assert.Equal(123, (int?)product["id"]);
-                var logs = _fixture.Host.GetLogMessages("Function.HttpTrigger-CustomRoute.User");
+                var logs = _fixture.Host.GetScriptHostLogMessages("Function.HttpTrigger-CustomRoute.User");
                 Assert.Contains(logs, l => string.Equals(l.FormattedMessage, "Parameters: category=electronics id=123 extra=extra"));
                 Assert.True(logs.Any(p => p.FormattedMessage.Contains("ProductInfo: Category=electronics Id=123")));
 
@@ -604,7 +604,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                 product = JObject.Parse(json);
                 Assert.Equal("electronics", (string)product["category"]);
                 Assert.Null((int?)product["id"]);
-                logs = _fixture.Host.GetLogMessages("Function.HttpTrigger-CustomRoute.User");
+                logs = _fixture.Host.GetScriptHostLogMessages("Function.HttpTrigger-CustomRoute.User");
                 Assert.Contains(logs, l => string.Equals(l.FormattedMessage, "Parameters: category=electronics id= extra="));
 
                 // test optional category parameter
@@ -617,7 +617,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                 product = JObject.Parse(json);
                 Assert.Null((string)product["category"]);
                 Assert.Null((int?)product["id"]);
-                logs = _fixture.Host.GetLogMessages("Function.HttpTrigger-CustomRoute.User");
+                logs = _fixture.Host.GetScriptHostLogMessages("Function.HttpTrigger-CustomRoute.User");
                 Assert.Contains(logs, l => string.Equals(l.FormattedMessage, "Parameters: category= id= extra="));
 
                 // test a constraint violation (invalid id)

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node.cs
@@ -327,7 +327,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             json = await response.Content.ReadAsStringAsync();
             products = JArray.Parse(json);
             Assert.Equal(2, products.Count);
-            var logs = _fixture.Host.GetLogMessages(LogCategories.CreateFunctionUserCategory("HttpTrigger-CustomRoute-Get"));
+            var logs = _fixture.Host.GetScriptHostLogMessages(LogCategories.CreateFunctionUserCategory("HttpTrigger-CustomRoute-Get"));
             var log = logs.Single(p => p.FormattedMessage.Contains($"category: electronics id: <empty>"));
             _fixture.Host.ClearLogMessages();
 
@@ -340,7 +340,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             json = await response.Content.ReadAsStringAsync();
             products = JArray.Parse(json);
             Assert.Equal(3, products.Count);
-            logs = _fixture.Host.GetLogMessages(LogCategories.CreateFunctionUserCategory("HttpTrigger-CustomRoute-Get"));
+            logs = _fixture.Host.GetScriptHostLogMessages(LogCategories.CreateFunctionUserCategory("HttpTrigger-CustomRoute-Get"));
             log = logs.Single(p => p.FormattedMessage.Contains($"category: <empty> id: <empty>"));
 
             // test a constraint violation (invalid id)

--- a/test/WebJobs.Script.Tests/Rpc/LanguageWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/LanguageWorkerChannelManagerTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         [Fact]
         public void CreateChannel_Succeeds()
         {
-            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor);
+            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, null);
             string workerId = Guid.NewGuid().ToString();
             string language = LanguageWorkerConstants.JavaLanguageWorkerName;
 
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         public void ShutdownStandByChannels_Succeeds()
         {
             _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName, LanguageWorkerConstants.JavaLanguageWorkerName);
-            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor);
+            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, null);
 
             string javaWorkerId = Guid.NewGuid().ToString();
             ILanguageWorkerChannel javaWorkerChannel = CreateTestChannel(javaWorkerId, LanguageWorkerConstants.JavaLanguageWorkerName);
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         public void ShutdownStandByChannels_WorkerRuntinmeDotNet_Succeeds()
         {
             _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName, LanguageWorkerConstants.DotNetLanguageWorkerName);
-            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor);
+            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, null);
 
             string javaWorkerId = Guid.NewGuid().ToString();
             ILanguageWorkerChannel javaWorkerChannel = CreateTestChannel(javaWorkerId, LanguageWorkerConstants.JavaLanguageWorkerName);
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         [Fact]
         public void ShutdownChannels_Succeeds()
         {
-            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor);
+            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, null);
 
             string javaWorkerId = Guid.NewGuid().ToString();
             ILanguageWorkerChannel javaWorkerChannel = CreateTestChannel(javaWorkerId, LanguageWorkerConstants.JavaLanguageWorkerName);
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             _testEnvironment = new TestEnvironment();
             _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName, LanguageWorkerConstants.NodeLanguageWorkerName);
 
-            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor);
+            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, null);
             string javaWorkerId = Guid.NewGuid().ToString();
             ILanguageWorkerChannel javaWorkerChannel = CreateTestChannel(javaWorkerId, LanguageWorkerConstants.JavaLanguageWorkerName);
 
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         {
             _testEnvironment = new TestEnvironment();
 
-            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor);
+            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, null);
             string javaWorkerId = Guid.NewGuid().ToString();
             ILanguageWorkerChannel javaWorkerChannel = CreateTestChannel(javaWorkerId, LanguageWorkerConstants.JavaLanguageWorkerName);
 
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         {
             _testEnvironment = new TestEnvironment();
             _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName, LanguageWorkerConstants.NodeLanguageWorkerName);
-            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor);
+            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, null);
             string javaWorkerId = Guid.NewGuid().ToString();
             ILanguageWorkerChannel javaWorkerChannel = CreateTestChannel(javaWorkerId, LanguageWorkerConstants.JavaLanguageWorkerName);
 
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         public void ShutdownStandbyChannels_OnlyProxies()
         {
             _testEnvironment = new TestEnvironment();
-            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor);
+            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, null);
             string javaWorkerId = Guid.NewGuid().ToString();
             ILanguageWorkerChannel javaWorkerChannel = CreateTestChannel(javaWorkerId, LanguageWorkerConstants.JavaLanguageWorkerName);
 

--- a/test/WebJobs.Script.Tests/SlidingWindowTests.cs
+++ b/test/WebJobs.Script.Tests/SlidingWindowTests.cs
@@ -59,16 +59,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public async Task AddEvent_RemovesExpiredItems()
         {
             var window = new SlidingWindow<MyItem>(TimeSpan.FromSeconds(1));
-
+            StringBuilder log = new StringBuilder();
             for (int i = 0; i < 5; i++)
             {
                 window.AddEvent(new MyItem { Data = i });
+                log.AppendLine($"{DateTime.UtcNow}: Added item: {i}");
                 await Task.Delay(100);
             }
 
             var eventsField = window.GetType().GetField("_events", BindingFlags.Instance | BindingFlags.NonPublic);
             var events = (List<SlidingWindow<MyItem>.Event>)eventsField.GetValue(window);
-            Assert.Equal(5, events.Count);
+            int count = events.Count;
+            Assert.True(count == 5, $"{DateTime.UtcNow} | Expected 5. Actual {count}.{Environment.NewLine}{log.ToString()}");
 
             // now let the items expire
             await Task.Delay(1000);


### PR DESCRIPTION
Fixes #3930 

My original intention was to fix this by overhauling how our two LoggerFactories are constructed, but specialization/placeholders threw a wrench into that. While possible, it'd mean re-writing all of our LoggerProviders to be able to be refreshed when specialization occurs. While possible, it'll be finicky and take a while to test and get right.

So this is a tactical fix to get the user's console.log() output piped into the current ScriptHost's logger. It's using the same method as I used here: https://github.com/Azure/azure-webjobs-sdk/pull/2020. It's a very similar scenario -- we want to write logs to an `ILogger` that may not exist yet.