### PR TITLE
update PowerShell to 63-preview

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.6830001-df202c6c" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.3.0-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.52-alpha" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.63-preview" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.4" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2" />


### PR DESCRIPTION
This adds:

* the Managed Dependencies path to the PSModulePath
* the ability to grab the version of the worker using:

```powershell
Get-Item Microsoft.Azure.Functions.PowerShellWorker.dll | % VersionInfo
```

Note the name has been changed from `alpha` to `preview`