### PR TITLE
Adding managed dependency support in the host

### DIFF
--- a/src/WebJobs.Script/Config/ConfigurationSectionNames.cs
+++ b/src/WebJobs.Script/Config/ConfigurationSectionNames.cs
@@ -12,5 +12,6 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
         public const string HealthMonitor = "healthMonitor";
         public const string HostIdPath = WebHost + ":hostid";
         public const string ExtensionBundle = "extensionBundle";
+        public const string ManagedDependency = "managedDependency";
     }
 }

--- a/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             private static readonly string[] WellKnownHostJsonProperties = new[]
             {
                 "version", "functionTimeout", "functions", "http", "watchDirectories", "queues", "serviceBus",
-                "eventHub", "singleton", "logging", "aggregator", "healthMonitor", "extensionBundle"
+                "eventHub", "singleton", "logging", "aggregator", "healthMonitor", "extensionBundle", "managedDependencies"
             };
 
             private readonly HostJsonFileConfigurationSource _configurationSource;

--- a/src/WebJobs.Script/ManagedDependencies/ManagedDependencyOptions.cs
+++ b/src/WebJobs.Script/ManagedDependencies/ManagedDependencyOptions.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.WebJobs.Script.ManagedDependencies
+{
+    public class ManagedDependencyOptions
+    {
+        public bool Enabled { get; set; }
+    }
+}

--- a/src/WebJobs.Script/ManagedDependencies/ManagedDependencyOptionsSetup.cs
+++ b/src/WebJobs.Script/ManagedDependencies/ManagedDependencyOptionsSetup.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.Azure.WebJobs.Script.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebJobs.Script.ManagedDependencies
+{
+    internal class ManagedDependencyOptionsSetup : IConfigureOptions<ManagedDependencyOptions>
+    {
+        private readonly IConfiguration _configuration;
+
+        public ManagedDependencyOptionsSetup(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public void Configure(ManagedDependencyOptions options)
+        {
+            IConfigurationSection jobHostSection = _configuration.GetSection(ConfigurationSectionNames.JobHost);
+            var managedDependencySection = jobHostSection.GetSection(ConfigurationSectionNames.ManagedDependency);
+            managedDependencySection.Bind(options);
+        }
+    }
+}

--- a/src/WebJobs.Script/Rpc/ILanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/ILanguageWorkerChannelManager.cs
@@ -6,7 +6,8 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
-
+using Microsoft.Azure.WebJobs.Script.ManagedDependencies;
+using Microsoft.Extensions.Options;
 using FunctionMetadata = Microsoft.Azure.WebJobs.Script.Description.FunctionMetadata;
 
 namespace Microsoft.Azure.WebJobs.Script.Rpc
@@ -25,6 +26,6 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         void ShutdownChannels();
 
-        ILanguageWorkerChannel CreateLanguageWorkerChannel(string workerId, string scriptRootPath, string language, IObservable<FunctionRegistrationContext> functionRegistrations, IMetricsLogger metricsLogger, int attemptCount, bool isWebhostChannel);
+        ILanguageWorkerChannel CreateLanguageWorkerChannel(string workerId, string scriptRootPath, string language, IObservable<FunctionRegistrationContext> functionRegistrations, IMetricsLogger metricsLogger, int attemptCount, bool isWebhostChannel, IOptions<ManagedDependencyOptions> managedDependencyOptions);
     }
 }

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -21,6 +21,7 @@ using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.Extensibility;
 using Microsoft.Azure.WebJobs.Script.Grpc;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using Microsoft.Azure.WebJobs.Script.ManagedDependencies;
 using Microsoft.Azure.WebJobs.Script.Rpc;
 using Microsoft.Azure.WebJobs.Script.Scale;
 using Microsoft.Extensions.Configuration;
@@ -58,7 +59,6 @@ namespace Microsoft.Azure.WebJobs.Script
             loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
 
             builder.SetAzureFunctionsConfigurationRoot();
-
             // Host configuration
             builder.ConfigureLogging((context, loggingBuilder) =>
             {
@@ -89,7 +89,6 @@ namespace Microsoft.Azure.WebJobs.Script
         public static IHostBuilder AddScriptHostCore(this IHostBuilder builder, ScriptApplicationHostOptions applicationHostOptions, Action<IWebJobsBuilder> configureWebJobs = null)
         {
             var skipHostInitialization = builder.Properties.ContainsKey(ScriptConstants.SkipHostInitializationKey);
-
             builder.ConfigureWebJobs(webJobsBuilder =>
             {
                 // Built in binding registrations
@@ -144,6 +143,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 // TODO: pgopa only add this to WebHostServiceCollection
                 services.ConfigureOptions<LanguageWorkerOptionsSetup>();
                 services.ConfigureOptions<ExtensionBundleOptionsSetup>();
+                services.ConfigureOptions<ManagedDependencyOptionsSetup>();
                 services.AddOptions<FunctionResultAggregatorOptions>()
                     .Configure<IConfiguration>((o, c) =>
                     {
@@ -185,7 +185,6 @@ namespace Microsoft.Azure.WebJobs.Script
             services.AddSingleton<IRpcServer, GrpcServer>();
             services.TryAddSingleton<ILanguageWorkerConsoleLogSource, LanguageWorkerConsoleLogSource>();
             services.TryAddSingleton<ILanguageWorkerChannelManager, LanguageWorkerChannelManager>();
-
             services.TryAddSingleton<IDebugManager, DebugManager>();
             services.TryAddSingleton<IDebugStateProvider, DebugStateProvider>();
             services.TryAddSingleton<IEnvironment>(SystemEnvironment.Instance);

--- a/test/WebJobs.Script.Tests/ManagedDependencies/ManagedDependencyOptionsSetupTest.cs
+++ b/test/WebJobs.Script.Tests/ManagedDependencies/ManagedDependencyOptionsSetupTest.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Azure.WebJobs.Script.Configuration;
+using Microsoft.Azure.WebJobs.Script.ManagedDependencies;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.WebJobs.Script.Tests;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.ManagedDependencies
+{
+    public class ManagedDependencyOptionsSetupTest
+    {
+        private readonly ScriptApplicationHostOptions _options;
+        private readonly string _hostJsonFilePath;
+        private readonly TestLoggerProvider _loggerProvider;
+
+        public ManagedDependencyOptionsSetupTest()
+        {
+            _loggerProvider = new TestLoggerProvider();
+
+            var scriptPath = Path.Combine(Path.GetTempPath(), "managed_dependency_test");
+            if (!Directory.Exists(scriptPath))
+            {
+                Directory.CreateDirectory(scriptPath);
+            }
+
+            _hostJsonFilePath = Path.Combine(scriptPath, "host.json");
+            if (File.Exists(_hostJsonFilePath))
+            {
+                File.Delete(_hostJsonFilePath);
+            }
+
+            _options = new ScriptApplicationHostOptions
+            {
+                ScriptPath = scriptPath
+            };
+        }
+
+        [Theory]
+        [InlineData(@"{
+                    'version': '2.0'
+                    }")]
+        [InlineData(@"{
+                    'version': '2.0',
+                    'managedDependency':{}
+                        }")]
+        public void Test_ManagedDependencyOptionsSetup_Empty_Or_No_ManagedDependencies_InHostJson(string hostJson)
+        {
+            File.WriteAllText(_hostJsonFilePath, hostJson);
+            Assert.True(File.Exists(_hostJsonFilePath));
+            var managedDependencyOptions = new ManagedDependencyOptions();
+            var configuration = BuildHostJsonConfiguration();
+            ManagedDependencyOptionsSetup managedDependencyOptionsSetup = new ManagedDependencyOptionsSetup(configuration);
+            managedDependencyOptionsSetup.Configure(managedDependencyOptions);
+            Assert.True(managedDependencyOptions.Enabled == false);
+        }
+
+        [Theory]
+        [InlineData(@"{
+                    'version': '2.0',
+                    'managedDependency':
+                          {
+                            'enabled': true
+                          }
+                        }")]
+        [InlineData(@"{
+                    'version': '2.0',
+                    'managedDependency':
+                          {
+                            'enabled': false
+                          }
+                        }")]
+        public void Test_ManagedDependencyOptionsSetup_Valid_ManagedDependencies_InHostFile(string hostJson)
+        {
+            File.WriteAllText(_hostJsonFilePath, hostJson);
+            Assert.True(File.Exists(_hostJsonFilePath));
+
+            var managedDependencyOptions = new ManagedDependencyOptions();
+            var configuration = BuildHostJsonConfiguration();
+            ManagedDependencyOptionsSetup managedDependencyOptionsSetup = new ManagedDependencyOptionsSetup(configuration);
+            managedDependencyOptionsSetup.Configure(managedDependencyOptions);
+            if (managedDependencyOptions.Enabled)
+            {
+                Assert.True(true);
+            }
+            else
+            {
+                Assert.True(managedDependencyOptions.Enabled == false);
+            }
+        }
+
+        private IConfiguration BuildHostJsonConfiguration(IEnvironment environment = null)
+        {
+            environment = environment ?? new TestEnvironment();
+
+            var loggerFactory = new LoggerFactory();
+            loggerFactory.AddProvider(_loggerProvider);
+
+            var configSource = new HostJsonFileConfigurationSource(_options, environment, loggerFactory);
+
+            var configurationBuilder = new ConfigurationBuilder()
+                .Add(configSource);
+
+            return configurationBuilder.Build();
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Rpc/FunctionDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/FunctionDispatcherTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             {
                 WorkerConfigs = TestHelpers.GetTestWorkerConfigs()
             };
-            return new FunctionDispatcher(scriptOptions, metricsLogger.Object, eventManager.Object, loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(workerConfigOptions), languageWorkerChannelManager.Object);
+            return new FunctionDispatcher(scriptOptions, metricsLogger.Object, eventManager.Object, loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(workerConfigOptions), languageWorkerChannelManager.Object, null);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Rpc/LanguageWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/LanguageWorkerChannelManagerTests.cs
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
 
         private ILanguageWorkerChannel CreateTestChannel(string workerId, string language)
         {
-            var testChannel = _languageWorkerChannelManager.CreateLanguageWorkerChannel(workerId, _scriptRootPath, language, null, null, 0);
+            var testChannel = _languageWorkerChannelManager.CreateLanguageWorkerChannel(workerId, _scriptRootPath, language, null, null, 0, false, null);
             // Generate event to mock language worker response
             RpcWebHostChannelReadyEvent javaReadyEvent = new RpcWebHostChannelReadyEvent(workerId, language, testChannel, "testVersion", _capabilities);
             _eventManager.Publish(javaReadyEvent);


### PR DESCRIPTION
The PR is to enable the functionality to support the automated dependency management in the function app. Currently this feature support will be provided to powershell function app. For this feature to work, the function host through a flag in the host.json file has to indicate that the managed dependency is enabled, an example is shown below:

{
    "version": "2.0",
    "managedDependency": 
        {
	    "enabled": true
        }  
}

So, the customer (app developer) needs to only specify the flag indicating if the dependency needs to be managed by the functions platform and the language worker process will take care of downloading and installing these modules for the customer.
- The the host process reads host.json file and look for if managed dependency option is enabled in function app's host.json 
- Based upon that host sends a protobuf message only to the managed dependency language worker function load event. 