### PR TITLE
Fixed PropertyGroup being defined too early, closes #4051

### DIFF
--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets
@@ -6,9 +6,6 @@
     <_FunctionsExtensionsTasksDir Condition=" '$(_FunctionsExtensionsTasksDir)'=='' ">$(MSBuildThisFileDirectory)..\tools\$(_FunctionsExtensionsTaskFramework)</_FunctionsExtensionsTasksDir>
     <_FunctionsExtensionsTaskAssemblyFullPath Condition=" '$(_FunctionsExtensionsTaskAssemblyFullPath)'=='' ">$(_FunctionsExtensionsTasksDir)\Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.dll</_FunctionsExtensionsTaskAssemblyFullPath>
     <IsPackable>false</IsPackable>
-    <_IsFunctionsSdkBuild Condition="$(_FunctionsTaskFramework) != ''">true</_IsFunctionsSdkBuild>
-    <_FunctionsExtensionsDir>$(TargetDir)</_FunctionsExtensionsDir>
-    <_FunctionsExtensionsDir Condition="$(_IsFunctionsSdkBuild) == 'true'">$(_FunctionsExtensionsDir)bin</_FunctionsExtensionsDir>
   </PropertyGroup>
 
   <UsingTask TaskName="GenerateFunctionsExtensionsMetadata"
@@ -16,7 +13,13 @@
 
   <Target Name="_GenerateFunctionsExtensionsMetadataPostBuild"
           AfterTargets="Build">
-    
+
+    <PropertyGroup>
+      <_IsFunctionsSdkBuild Condition="$(_FunctionsTaskFramework) != ''">true</_IsFunctionsSdkBuild>
+      <_FunctionsExtensionsDir>$(TargetDir)</_FunctionsExtensionsDir>
+      <_FunctionsExtensionsDir Condition="$(_IsFunctionsSdkBuild) == 'true'">$(_FunctionsExtensionsDir)bin</_FunctionsExtensionsDir>
+    </PropertyGroup>
+
     <GenerateFunctionsExtensionsMetadata
       SourcePath="$(_FunctionsExtensionsDir)"
       OutputPath="$(_FunctionsExtensionsDir)"/>
@@ -27,7 +30,7 @@
           OverwriteReadOnlyFiles="true" 
           ContinueOnError="true"/>
   </Target>
-
+  
   <Target Name="_GenerateFunctionsExtensionsMetadataPostPublish"
           AfterTargets="Publish">
     <GenerateFunctionsExtensionsMetadata
@@ -39,6 +42,12 @@
           AfterTargets="ResolveReferences"
           Condition="$(_IsFunctionsSdkBuild) != 'true'"
           DependsOnTargets="RunResolvePublishAssemblies">
+
+    <PropertyGroup>
+      <_IsFunctionsSdkBuild Condition="$(_FunctionsTaskFramework) != ''">true</_IsFunctionsSdkBuild>
+      <_FunctionsExtensionsDir>$(TargetDir)</_FunctionsExtensionsDir>
+      <_FunctionsExtensionsDir Condition="$(_IsFunctionsSdkBuild) == 'true'">$(_FunctionsExtensionsDir)bin</_FunctionsExtensionsDir>
+    </PropertyGroup>
 
     <!--
       Copy publish assemblies that not already included in ReferenceCopyLocalPaths


### PR DESCRIPTION
Because the PropertyGroup is defined in the parent it causes the values to be set before [Microsoft.Net.SDK.Functions.Build.targets](https://github.com/Azure/azure-functions-vs-build-sdk/blob/6c6361ed159866999ee95850ae2bed0e81652d8b/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.Build.targets#L150) changes the `TargetPath` to `/bin.

This means that the Console app within this target is executed over the wrong directory, leading to empty `extension.json` files to be generated. This PR moves the PropertyGroup to within the Target so that they're defined after the other target files.