### PR TITLE
Add powershell e2e test similar to Java

### DIFF
--- a/sample/PowerShell/HttpTrigger/function.json
+++ b/sample/PowerShell/HttpTrigger/function.json
@@ -1,0 +1,20 @@
+{
+  "disabled": false,
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/sample/PowerShell/HttpTrigger/run.ps1
+++ b/sample/PowerShell/HttpTrigger/run.ps1
@@ -1,0 +1,32 @@
+# Trigger the function by running Invoke-RestMethod:
+#    (via get method): Invoke-RestMethod -Uri http://localhost:7071/api/MyHttpTrigger?Name=Joe
+#   (via post method): Invoke-RestMethod `
+#                        -Uri http://localhost:7071/api/MyHttpTrigger `
+#                        -Method Post `
+#                        -Body (ConvertTo-Json @{ Name="Joe" }) `
+#                        -Headers @{'Content-Type' = 'application/json' }`
+
+# Input bindings are passed in via param block.
+param($req, $TriggerMetadata)
+
+# You can write to the Azure Functions log streams as you would in a normal PowerShell script.
+Write-Verbose "PowerShell HTTP trigger function processed a request." -Verbose
+
+# You can interact with query parameters, the body of the request, etc.
+$name = $req.Query.Name
+if (-not $name) { $name = $req.Body.Name }
+
+if($name) {
+    $status = 200
+    $body = "Hello " + $name
+}
+else {
+    $status = 400
+    $body = "Please pass a name on the query string or in the request body."
+}
+
+# You associate values to output bindings by calling 'Push-OutputBinding'.
+Push-OutputBinding -Name res -Value ([HttpResponseContext]@{
+    StatusCode = $status
+    Body = $body
+})

--- a/sample/PowerShell/host.json
+++ b/sample/PowerShell/host.json
@@ -1,0 +1,22 @@
+{
+    "version": "2.0",
+    "watchDirectories": [ "Shared", "Test" ],
+    "healthMonitor": {
+        "enabled": true,
+        "healthCheckInterval": "00:00:10",
+        "healthCheckWindow": "00:02:00",
+        "healthCheckThreshold": 6,
+        "counterThreshold": 0.80
+    },
+    "functionTimeout": "00:05:00",
+    "logging": {
+        "fileLoggingMode": "always"        
+    },
+    "extensions": {
+        "http": {
+            "routePrefix": "api",
+            "maxConcurrentRequests": 5,
+            "maxOutstandingRequests": 30
+        }
+    }
+}

--- a/src/WebJobs.Script/Rpc/LanguageWorkerConstants.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerConstants.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         public const string DotNetLanguageWorkerName = "dotnet";
         public const string NodeLanguageWorkerName = "node";
         public const string JavaLanguageWorkerName = "java";
+        public const string PowerShellLanguageWorkerName = "powershell";
         public const string WorkerConfigFileName = "worker.config.json";
         public const string DefaultWorkersDirectoryName = "workers";
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_PowerShell.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_PowerShell.cs
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Rpc;
+using Microsoft.WebJobs.Script.Tests;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
+{
+    [Trait(TestTraits.Category, TestTraits.EndToEnd)]
+    [Trait(TestTraits.Group, TestTraits.SamplesEndToEnd)]
+    public class SamplesEndToEndTests_PowerShell : IClassFixture<SamplesEndToEndTests_PowerShell.TestFixture>
+    {
+        private readonly ScriptSettingsManager _settingsManager;
+        private TestFixture _fixture;
+
+        public SamplesEndToEndTests_PowerShell(TestFixture fixture)
+        {
+            _fixture = fixture;
+            _settingsManager = ScriptSettingsManager.Instance;
+        }
+
+        [Fact]
+        public async Task HttpTrigger_PowerShell_Get_Succeeds()
+        {
+            await InvokeHttpTrigger("HttpTrigger");
+        }
+
+        private async Task InvokeHttpTrigger(string functionName)
+        {
+            string functionKey = await _fixture.Host.GetFunctionSecretAsync($"{functionName}");
+            string uri = $"api/{functionName}?code={functionKey}&name=Atlas";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/plain"));
+
+            var response = await _fixture.Host.HttpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        public class TestFixture : EndToEndTestFixture
+        {
+            static TestFixture()
+            {
+            }
+
+            public TestFixture()
+                : base(Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample\PowerShell"), "samples", LanguageWorkerConstants.PowerShellLanguageWorkerName)
+            {
+            }
+
+            public override void ConfigureJobHost(IWebJobsBuilder webJobsBuilder)
+            {
+                base.ConfigureJobHost(webJobsBuilder);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This replicates the java worker's e2e httptrigger test

Unfortunately, due to the snow, I can't test on Windows at the moment (and the tests/build don't seem to work on macOS) so I'm going to have CI test this.

resolves https://github.com/Azure/azure-functions-host/issues/4047