### PR TITLE
preventing 'old' startup exceptions from shutting down host

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -249,6 +249,10 @@ namespace Microsoft.Azure.WebJobs.Script
             var ignore = LogInitializationAsync();
 
             await InitializeAsync();
+
+            // Throw if cancellation occurred during initialization.
+            cancellationToken.ThrowIfCancellationRequested();
+
             await base.StartAsyncCore(cancellationToken);
 
             LogHostFunctionErrors();

--- a/test/WebJobs.Script.Tests.Shared/TestHostExtensions.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHostExtensions.cs
@@ -1,15 +1,16 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Linq;
 using System.Threading;
-using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.WebJobs.Script.Tests;
 
-namespace Microsoft.WebJobs.Script.Tests
+namespace Microsoft.Extensions.Hosting
 {
     public static class TestHostExtensions
     {
@@ -26,6 +27,11 @@ namespace Microsoft.WebJobs.Script.Tests
         public static string GetStorageConnectionString(this IHost host)
         {
             return host.Services.GetService<IConfiguration>().GetWebJobsConnectionString("Storage");
+        }
+
+        public static TestLoggerProvider GetTestLoggerProvider(this IHost host)
+        {
+            return host.Services.GetServices<ILoggerProvider>().SingleOrDefault(p => p is TestLoggerProvider) as TestLoggerProvider;
         }
     }
 }


### PR DESCRIPTION
Fixes #4089.

I've also:
- Added additional logging that would have made the investigation into this easier. It was really hard to follow due to the number of log-less code paths we can take.
- Added a `ThrowIfCancelationRequested()` at the point I was seeing this error. We already knew startup was canceled, so there's no need to try to start the host.