### PR TITLE
Updated Binding Redirects for FSharp.Core

### DIFF
--- a/src/WebJobs.Script.Host/App.config
+++ b/src/WebJobs.Script.Host/App.config
@@ -28,7 +28,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.WebJobs.Host" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/src/WebJobs.Script/app.config
+++ b/src/WebJobs.Script/app.config
@@ -28,7 +28,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.WebJobs.Host" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/test/WebJobs.Script.Tests.Integration/App.config
+++ b/test/WebJobs.Script.Tests.Integration/App.config
@@ -71,7 +71,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />

--- a/test/WebJobs.Script.Tests/app.config
+++ b/test/WebJobs.Script.Tests/app.config
@@ -28,7 +28,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.6.2.0" newVersion="4.6.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Azure.WebJobs.Host" publicKeyToken="31bf3856ad364e35" culture="neutral" />


### PR DESCRIPTION
#4005
I see that you seem to have a lot on your plate but I have taken the liberty of updating the FSharp.Core references to the newest version that is available currently. 