### PR TITLE
adding mocked SystemLogger and MetricsLogger tests

### DIFF
--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -101,6 +101,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     // Hosted services
                     services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, HttpInitializationService>());
                     services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, FileMonitoringService>());
+
+                    ConfigureRegisteredBuilders(services, rootServiceProvider);
                 });
 
             var debugStateProvider = rootServiceProvider.GetService<IDebugStateProvider>();

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
@@ -13,6 +13,8 @@ using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -78,16 +80,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
                 }
             }
 
-            // TODO: Re-enable this when we can override IMetricsLogger
             // App Insights logs first, so wait until this metric appears
-            // string metricKey = MetricsEventManager.GetAggregateKey(MetricEventNames.FunctionUserLog, functionName);
-            // IEnumerable<string> GetMetrics() => _fixture.MetricsLogger.LoggedEvents.Where(p => p == metricKey);
+            string metricKey = MetricsEventManager.GetAggregateKey(MetricEventNames.FunctionUserLog, functionName);
+            IEnumerable<string> GetMetrics() => _fixture.MetricsLogger.LoggedEvents.Where(p => p == metricKey);
 
             // TODO: Remove this check when metrics are supported in Node:
             // https://github.com/Azure/azure-functions-host/issues/2189
-            // int expectedCount = this is ApplicationInsightsCSharpEndToEndTests ? 10 : 5;
-            // await TestHelpers.Await(() => GetMetrics().Count() == expectedCount,
-            //    timeout: 15000, userMessageCallback: () => string.Join(Environment.NewLine, GetMetrics().Select(p => p.ToString())));
+            int expectedCount = this is ApplicationInsightsCSharpEndToEndTests ? 10 : 5;
+            await TestHelpers.Await(() => GetMetrics().Count() == expectedCount,
+                timeout: 15000, userMessageCallback: () => string.Join(Environment.NewLine, GetMetrics().Select(p => p.ToString())));
         }
 
         [Fact(Skip = "HTTP logging not currently supported")]

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
@@ -31,11 +31,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
             };
 
             TestHost = new TestFunctionHost(scriptPath, logPath,
-                jobHostBuilder =>
+                configureJobHost: jobHostBuilder =>
                 {
                     jobHostBuilder.Services.AddSingleton<ITelemetryChannel>(_ => Channel);
-                    jobHostBuilder.Services.AddSingleton<IMetricsLogger>(_ => MetricsLogger);
-
                     jobHostBuilder.Services.Configure<ScriptJobHostOptions>(o =>
                     {
                         o.Functions = new[]
@@ -45,7 +43,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
                         };
                     });
                 },
-                configurationBuilder =>
+                configureJobHostServices: s =>
+                {
+                    s.AddSingleton<IMetricsLogger>(_ => MetricsLogger);
+                },
+                configureAppConfiguration: configurationBuilder =>
                 {
                     configurationBuilder.AddInMemoryCollection(new Dictionary<string, string>
                     {

--- a/test/WebJobs.Script.Tests.Integration/Host/WebJobsScriptHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/WebJobsScriptHostServiceTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Host
                 .Returns(() => _underHighLoad);
 
             _testHost = new TestFunctionHost(testScriptPath, testLogPath,
-                configureServices: services =>
+                configureWebHostServices: services =>
                 {
                     services.AddSingleton<IOptions<HostHealthMonitorOptions>>(wrappedHealthMonitorOptions);
                     services.AddSingleton<IScriptJobHostEnvironment>(_mockJobHostEnvironment.Object);

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/Node/Scenarios/index.js
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/Node/Scenarios/index.js
@@ -44,6 +44,8 @@ module.exports = function (context, input) {
         console.log('console log');
 
         context.done();
+
+        context.log('after done');
     }
     else if (scenario === 'bindingData') {
         var bindingData = context.bindingData;

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpEndToEndTests.cs
@@ -108,11 +108,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 
             logs.Single(p => p.EndsWith($"From TraceWriter: {guid1}"));
             logs.Single(p => p.EndsWith($"From ILogger: {guid2}"));
-
-            // TODO: Re-enable once we can override the IMetricsLogger
+                        
             // Make sure we get a metric logged from both ILogger and TraceWriter
             var key = MetricsEventManager.GetAggregateKey(MetricEventNames.FunctionUserLog, "Scenarios");            
-            // Assert.Equal(2, Fixture.MetricsLogger.LoggedEvents.Where(p => p == key).Count());
+            Assert.Equal(2, Fixture.MetricsLogger.LoggedEvents.Where(p => p == key).Count());
 
             // Make sure we've gotten a log from the aggregator
             IEnumerable<LogMessage> getAggregatorLogs() => Fixture.Host.GetScriptHostLogMessages().Where(p => p.Category == LogCategories.Aggregator);
@@ -121,6 +120,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 
             var aggregatorLogs = getAggregatorLogs();
             Assert.Equal(1, aggregatorLogs.Count());
+
+            // Make sure that no user logs made it to the EventGenerator (which the SystemLogger writes to)
+            IEnumerable<FunctionTraceEvent> allLogs = Fixture.EventGenerator.GetFunctionTraceEvents();
+            Assert.False(allLogs.Any(l => l.Summary.Contains("From ")));
+            Assert.False(allLogs.Any(l => l.Source.EndsWith(".User")));
+            Assert.False(allLogs.Any(l => l.Source == LanguageWorkerConstants.FunctionConsoleLogCategoryName));
+            Assert.NotEmpty(allLogs);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,6 +9,7 @@ using Microsoft.Azure.WebJobs.Script.BindingExtensions;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Models;
 using Microsoft.Azure.WebJobs.Script.Rpc;
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -58,6 +58,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public TestMetricsLogger MetricsLogger { get; private set; } = new TestMetricsLogger();
 
+        public TestEventGenerator EventGenerator { get; private set; } = new TestEventGenerator();
+
         protected virtual ExtensionPackageReference[] GetExtensionsToInstall()
         {
             return null;
@@ -89,8 +91,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             Host = new TestFunctionHost(_copiedRootPath, logPath, webJobsBuilder =>
             {
-                webJobsBuilder.Services.AddSingleton<IMetricsLogger>(_ => MetricsLogger);
                 ConfigureJobHost(webJobsBuilder);
+            },
+            configureJobHostServices: s =>
+            {
+                s.AddSingleton<IMetricsLogger>(_ => MetricsLogger);
+            },
+            configureWebHostServices: s =>
+            {
+                s.AddSingleton<IEventGenerator>(_ => EventGenerator);
             });
 
             string connectionString = Host.JobHostServices.GetService<IConfiguration>().GetWebJobsConnectionString(ConnectionStringNames.Storage);

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/NodeEndToEndTests.cs
@@ -226,12 +226,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             // verify the console log
             Assert.Equal("console log", consoleLog);
 
-            // TODO: Re-enable once we can override IMetricsLogger
             // We only expect 9 user log metrics to be counted, since
             // verbose logs are filtered by default (the TestLogger explicitly
             // allows all levels for testing purposes)
             var key = MetricsEventManager.GetAggregateKey(MetricEventNames.FunctionUserLog, "Scenarios");
-            // Assert.Equal(9, Fixture.MetricsLogger.LoggedEvents.Where(p => p == key).Count());
+            Assert.Equal(9, Fixture.MetricsLogger.LoggedEvents.Where(p => p == key).Count());
+
+            // Make sure that no user logs made it to the EventGenerator (which the SystemLogger writes to)
+            IEnumerable<FunctionTraceEvent> allLogs = Fixture.EventGenerator.GetFunctionTraceEvents();
+            Assert.False(allLogs.Any(l => l.Summary.Contains("loglevel")));
+            Assert.False(allLogs.Any(l => l.Summary.Contains("after done")));
+            Assert.False(allLogs.Any(l => l.Source.EndsWith(".User")));
+            Assert.False(allLogs.Any(l => l.Source == LanguageWorkerConstants.FunctionConsoleLogCategoryName));
+            Assert.NotEmpty(allLogs);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests.Shared/FunctionTraceEvent.cs
+++ b/test/WebJobs.Script.Tests.Shared/FunctionTraceEvent.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public class FunctionTraceEvent
+    {
+        public DateTimeOffset Timestamp { get; set; }
+
+        public LogLevel Level { get; set; }
+
+        public string SubscriptionId { get; set; }
+
+        public string AppName { get; set; }
+
+        public string FunctionName { get; set; }
+
+        public string EventName { get; set; }
+
+        public string Source { get; set; }
+
+        public string Details { get; set; }
+
+        public string Summary { get; set; }
+
+        public string ExceptionType { get; set; }
+
+        public string ExceptionMessage { get; set; }
+
+        public string FunctionInvocationId { get; set; }
+
+        public string HostInstanceId { get; set; }
+
+        public string ActivityId { get; set; }
+
+        public override string ToString()
+        {
+            return $"[{Timestamp.ToString("HH:mm:ss.fff")}] [{Source}] {Summary}";
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Shared/TestEventGenerator.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestEventGenerator.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public class TestEventGenerator : IEventGenerator
+    {
+        private List<FunctionTraceEvent> _functionTraceEvents = new List<FunctionTraceEvent>();
+        private object _syncLock = new object();
+
+        public IEnumerable<FunctionTraceEvent> GetFunctionTraceEvents()
+        {
+            lock (_syncLock)
+            {
+                return _functionTraceEvents.ToList();
+            }
+        }
+
+        public void ClearEvents()
+        {
+            lock (_syncLock)
+            {
+                _functionTraceEvents.Clear();
+            }
+        }
+
+        public void LogAzureMonitorDiagnosticLogEvent(LogLevel level, string resourceId, string operationName, string category, string regionName, string properties)
+        {
+        }
+
+        public void LogFunctionDetailsEvent(string siteName, string functionName, string inputBindings, string outputBindings, string scriptType, bool isDisabled)
+        {
+        }
+
+        public void LogFunctionExecutionAggregateEvent(string siteName, string functionName, long executionTimeInMs, long functionStartedCount, long functionCompletedCount, long functionFailedCount)
+        {
+        }
+
+        public void LogFunctionExecutionEvent(string executionId, string siteName, int concurrency, string functionName, string invocationId, string executionStage, long executionTimeSpan, bool success)
+        {
+        }
+
+        public void LogFunctionMetricEvent(string subscriptionId, string appName, string functionName, string eventName, long average, long minimum, long maximum, long count, DateTime eventTimestamp)
+        {
+        }
+
+        public void LogFunctionTraceEvent(LogLevel level, string subscriptionId, string appName, string functionName, string eventName, string source, string details, string summary, string exceptionType, string exceptionMessage, string functionInvocationId, string hostInstanceId, string activityId)
+        {
+            FunctionTraceEvent traceEvent = new FunctionTraceEvent
+            {
+                Timestamp = DateTimeOffset.UtcNow,
+                Level = level,
+                SubscriptionId = subscriptionId,
+                AppName = appName,
+                FunctionName = functionName,
+                EventName = eventName,
+                Source = source,
+                Details = details,
+                Summary = summary,
+                ExceptionType = exceptionType,
+                ExceptionMessage = exceptionMessage,
+                FunctionInvocationId = functionInvocationId,
+                HostInstanceId = hostInstanceId,
+                ActivityId = activityId
+            };
+
+            lock (_syncLock)
+            {
+                _functionTraceEvents.Add(traceEvent);
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Shared/WebJobs.Script.Tests.Shared.projitems
+++ b/test/WebJobs.Script.Tests.Shared/WebJobs.Script.Tests.Shared.projitems
@@ -12,10 +12,12 @@
     <Compile Include="$(MSBuildThisFileDirectory)DelegatedConfigureBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpTestHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NullScriptHostEnvironment.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FunctionTraceEvent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TempDirectory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestChangeTokenSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestConfigurationBuilderExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestEnvironment.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestEventGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestHostBuilderExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestHostExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestMetricsLogger.cs" />


### PR DESCRIPTION
1. Adding a new `IConfigureBuilder` call that allows you to configure JobHost services last (and thus override services)
2. Added a `TestStartup` class that lets us modify services after the call to `Startup.ConfigureServices()`. Some WebHost-level services (like `IEventGenerator`) weren't able to be overridden due to this being the last thing that was called: https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Startup.cs#L26.

Re-enables the `IMetricsLogger` tests and adds a regression test for #4003. 