### PR TITLE
V2 SyncTriggers Improvements

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         [Authorize(Policy = PolicyNames.AdminAuthLevel)]
         public async Task<IActionResult> List(bool includeProxies = false)
         {
-            var result = await _functionsManager.GetFunctionsMetadata(Request, includeProxies);
+            var result = await _functionsManager.GetFunctionsMetadata(includeProxies);
             return Ok(result);
         }
 
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
             {
                 // if we don't have any errors registered, make sure the function exists
                 // before returning empty errors
-                var result = await _functionsManager.GetFunctionsMetadata(Request, includeProxies: true);
+                var result = await _functionsManager.GetFunctionsMetadata(includeProxies: true);
                 var function = result.FirstOrDefault(p => p.Name.ToLowerInvariant() == name.ToLowerInvariant());
                 if (function == null)
                 {

--- a/src/WebJobs.Script.WebHost/Extensions/FunctionMetadataExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Extensions/FunctionMetadataExtensions.cs
@@ -5,8 +5,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Management.Models;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;

--- a/src/WebJobs.Script.WebHost/Management/IWebFunctionsManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/IWebFunctionsManager.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 {
     public interface IWebFunctionsManager
     {
-        Task<IEnumerable<FunctionMetadataResponse>> GetFunctionsMetadata(HttpRequest request, bool includeProxies);
+        Task<IEnumerable<FunctionMetadataResponse>> GetFunctionsMetadata(bool includeProxies);
 
         Task<(bool, FunctionMetadataResponse)> TryGetFunction(string name, HttpRequest request);
 

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -13,6 +13,11 @@ namespace Microsoft.Azure.WebJobs.Script
         // For testing
         internal static string BaseDirectory { get; set; }
 
+        public static string GetEnvironmentVariableOrDefault(this IEnvironment environment, string name, string defaultValue)
+        {
+            return environment.GetEnvironmentVariable(name) ?? defaultValue;
+        }
+
         public static bool IsAppServiceEnvironment(this IEnvironment environment)
         {
             return !string.IsNullOrEmpty(environment.GetEnvironmentVariable(AzureWebsiteInstanceId));

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string EasyAuthEnabled = "WEBSITE_AUTH_ENABLED";
         public const string AzureWebJobsSecretStorageKeyVaultName = "AzureWebJobsSecretStorageKeyVaultName";
         public const string AzureWebJobsSecretStorageKeyVaultConnectionString = "AzureWebJobsSecretStorageKeyVaultConnectionString";
+        public const string AzureWebsiteArmCacheEnabled = "WEBSITE_FUNCTIONS_ARMCACHE_ENABLED";
 
         /// <summary>
         /// Environment variable dynamically set by the platform when it is safe to


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-functions-host/issues/3949. See corresponding v1 PR: https://github.com/Azure/azure-functions-host/pull/4325.

Because the extended sync triggers payload format is behind a feature flag (WEBSITE_FUNCTIONS_ARMCACHE_ENABLED) these changes can be released before ANT 82. We'll just enable the extended format post ANT 82 by flipping the default in a new runtime release.