### PR TITLE
Fixing InvokeUrlTemplate formatting

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/ProxyEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/ProxyEndToEndTests.cs
@@ -46,13 +46,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             Assert.Equal(22, metadata.Length);
             var function = metadata.Single(p => p.Name == "PingRoute");
-            Assert.Equal("https://localhost/myroute/mysubroute", function.InvokeUrlTemplate.AbsoluteUri);
+            Assert.Equal("https://localhost/api/myroute/mysubroute", function.InvokeUrlTemplate.AbsoluteUri);
 
             function = metadata.Single(p => p.Name == "Ping");
             Assert.Equal("https://localhost/api/ping", function.InvokeUrlTemplate.AbsoluteUri);
 
             function = metadata.Single(p => p.Name == "LocalFunctionCall");
-            Assert.Equal("https://localhost/myhttptrigger", function.InvokeUrlTemplate.AbsoluteUri);
+            Assert.Equal("https://localhost/api/myhttptrigger", function.InvokeUrlTemplate.AbsoluteUri);
 
             // get functions omitting proxies
             uri = "admin/functions";

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
@@ -344,7 +344,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 
             Assert.Equal(16, metadata.Length);
             var function = metadata.Single(p => p.Name == "HttpTrigger-CustomRoute");
-            Assert.Equal("https://localhost/csharp/products/{category:alpha?}/{id:int?}/{extra?}", function.InvokeUrlTemplate.ToString());
+            Assert.Equal("https://localhost/api/csharp/products/{category:alpha?}/{id:int?}/{extra?}", function.InvokeUrlTemplate.ToString());
 
             function = metadata.Single(p => p.Name == "HttpTrigger");
             Assert.Equal("https://localhost/api/httptrigger", function.InvokeUrlTemplate.ToString());

--- a/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
@@ -14,10 +14,12 @@ using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Rpc;
 using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Extensions;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Moq;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
@@ -101,6 +103,39 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             string prefix = await WebFunctionsManager.GetRoutePrefix(_testRootScriptPath);
             Assert.Equal(expected, prefix);
+        }
+
+        [Fact]
+        public void GetFunctionInvokeUrlTemplate_ReturnsExpectedResult()
+        {
+            string baseUrl = "https://localhost";
+            var functionMetadata = new FunctionMetadata
+            {
+                Name = "TestFunction"
+            };
+            var httpTriggerBinding = new BindingMetadata
+            {
+                Name = "req",
+                Type = "httpTrigger",
+                Direction = BindingDirection.In,
+                Raw = new JObject()
+            };
+            functionMetadata.Bindings.Add(httpTriggerBinding);
+            var uri = FunctionMetadataExtensions.GetFunctionInvokeUrlTemplate(baseUrl, functionMetadata, "api");
+            Assert.Equal("https://localhost/api/testfunction", uri.ToString());
+
+            // with empty route prefix
+            uri = FunctionMetadataExtensions.GetFunctionInvokeUrlTemplate(baseUrl, functionMetadata, string.Empty);
+            Assert.Equal("https://localhost/testfunction", uri.ToString());
+
+            // with a custom route
+            httpTriggerBinding.Raw.Add("route", "catalog/products/{category:alpha?}/{id:int?}");
+            uri = FunctionMetadataExtensions.GetFunctionInvokeUrlTemplate(baseUrl, functionMetadata, "api");
+            Assert.Equal("https://localhost/api/catalog/products/{category:alpha?}/{id:int?}", uri.ToString());
+
+            // with empty route prefix
+            uri = FunctionMetadataExtensions.GetFunctionInvokeUrlTemplate(baseUrl, functionMetadata, string.Empty);
+            Assert.Equal("https://localhost/catalog/products/{category:alpha?}/{id:int?}", uri.ToString());
         }
 
         private static HttpClient CreateHttpClient(StringBuilder writeContent)


### PR DESCRIPTION
If a custom route was being used, it is currently being appended directly to the base route, w/o including the route prefix. You'll notice that the URI we show in the portal is correct because the portal is forming the URI itself and isn't using the value returned from these APIs. I want to get this in because we're releasing some new ARM APIs and people will be consuming the URI returned from ListFunction(s).

E.g. currently for host route prefix `api` (the default) and http trigger function with custom route `catalog/products/{category:alpha?}/{id:int?}` we'll return:

    https://<host>/catalog/products/{category:alpha?}/{id:int?}

instead of the correct value:

    https://<host>/api/catalog/products/{category:alpha?}/{id:int?}

@ahmelsayed - you have a PR https://github.com/Azure/azure-functions-host/pull/3954 out now that fixes a problem in this area but doesn't address all the issues. So I think this PR subsumes yours? I also added a test for your scenario.