### PR TITLE
Update powershell worker to 0.1.69-preview

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.6830001-df202c6c" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.3.1-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.63-preview" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.69-preview" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.5" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2" />


### PR DESCRIPTION
Update powershell worker to 0.1.69-preview

this handles all gRPC messages and moves to PowerShell SDK 6.2.0-rc.1