### PR TITLE
[Do not merge]Decouple LanguageWorkerChannel and LanguageWorkerProcess

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -228,19 +228,15 @@ namespace Microsoft.Azure.WebJobs.Script
             await base.CallAsync(method, arguments, cancellationToken);
         }
 
-        internal static void AddLanguageWorkerChannelErrors(IFunctionDispatcher functionDispatcher, IDictionary<string, ICollection<string>> functionErrors)
+        internal static void AddLanguageWorkerChannelErrors(IFunctionDispatcher functionDispatcher, IDictionary<string, ICollection<string>> functionErrors, string workerRuntime)
         {
-            foreach (KeyValuePair<string, LanguageWorkerState> kvp in functionDispatcher.LanguageWorkerChannelStates)
-            {
-                string language = kvp.Key;
-                LanguageWorkerState workerState = kvp.Value;
+                LanguageWorkerState workerState = functionDispatcher.LanguageWorkerChannelState;
                 foreach (var functionRegistrationContext in workerState.GetRegistrations())
                 {
-                    var exMessage = $"Failed to start language worker process for: {language}";
+                    var exMessage = $"Failed to start language worker process for: {workerRuntime}";
                     var languageWorkerChannelException = workerState.Errors != null && workerState.Errors.Count > 0 ? new LanguageWorkerChannelException(exMessage, workerState.Errors[workerState.Errors.Count - 1]) : new LanguageWorkerChannelException(exMessage);
                     Utility.AddFunctionError(functionErrors, functionRegistrationContext.Metadata.Name, Utility.FlattenException(languageWorkerChannelException, includeSource: false));
                 }
-            }
         }
 
         protected override async Task StartAsyncCore(CancellationToken cancellationToken)
@@ -793,7 +789,7 @@ namespace Microsoft.Azure.WebJobs.Script
             }
             else if (exception is LanguageWorkerChannelException)
             {
-                AddLanguageWorkerChannelErrors(_functionDispatcher, FunctionErrors);
+                AddLanguageWorkerChannelErrors(_functionDispatcher, FunctionErrors, _workerRuntime);
             }
             else
             {

--- a/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
+++ b/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                     _channelFactory = (language, registrations, attemptCount) =>
                     {
                         string workerId = Guid.NewGuid().ToString();
-                        var languageWorkerChannel = _languageWorkerChannelManager.CreateLanguageWorkerChannel(workerId, _scriptOptions.RootScriptPath, language, registrations, _metricsLogger, attemptCount, false);
+                        var languageWorkerChannel = _languageWorkerChannelManager.CreateLanguageWorkerChannel(workerId, _scriptOptions.RootScriptPath, language, registrations, _metricsLogger, attemptCount);
                         var languageWorkerProcess = _languageWorkerChannelManager.StartWorkerProcess(workerId, language, _scriptOptions.RootScriptPath);
                         return Tuple.Create(languageWorkerChannel, languageWorkerProcess);
                     };

--- a/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
+++ b/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
@@ -64,9 +64,10 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 {
                     _channelFactory = (language, registrations, attemptCount) =>
                     {
-                        var languageWorkerChannel = _languageWorkerChannelManager.CreateLanguageWorkerChannel(Guid.NewGuid().ToString(), _scriptOptions.RootScriptPath, language, registrations, _metricsLogger, attemptCount, false);
-                        languageWorkerChannel.StartWorkerProcess();
-                        return languageWorkerChannel;
+                        string workerId = Guid.NewGuid().ToString();
+                        var languageWorkerChannel = _languageWorkerChannelManager.CreateLanguageWorkerChannel(workerId, _scriptOptions.RootScriptPath, language, registrations, _metricsLogger, attemptCount, false);
+                        var languageWorkerProcess = _languageWorkerChannelManager.StartWorkerProcess(workerId, language, _scriptOptions.RootScriptPath);
+                        return Tuple.Create(languageWorkerChannel, languageWorkerProcess);
                     };
                 }
                 return _channelFactory;
@@ -118,8 +119,9 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         {
             _workerState = new LanguageWorkerState();
             WorkerConfig config = _workerConfigs.Where(c => c.Language.Equals(runtime, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
-            _workerState.Channel = ChannelFactory(runtime, _workerState.Functions, 0);
-            return _workerState;
+            Tuple<ILanguageWorkerChannel, ILanguageWorkerProcess> workerChannelAndProcess = ChannelFactory(runtime, state.Functions, 0);
+            state.Channel = workerChannelAndProcess.Item1;
+            state.WorkerProcess = workerChannelAndProcess.Item2;
         }
 
         public void Register(FunctionRegistrationContext context)
@@ -134,8 +136,9 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             bool isPreInitializedChannel = _languageWorkerChannelManager.ShutdownChannelIfExists(workerError.Language);
             if (!isPreInitializedChannel)
             {
-                _logger.LogDebug("Disposing errored channel for workerId: {channelId}, for runtime:{language}", _workerState.Channel.Id, workerError.Language);
+                    _logger.LogDebug("Disposing errored channel for workerId: {channelId}, for runtime:{language}", erroredWorkerState.Channel.WorkerId, workerError.Language);
                 _workerState.Channel.Dispose();
+                    erroredWorkerState.WorkerProcess.Dispose();
             }
             _logger.LogDebug("Restarting worker channel for runtime:{runtime}", workerError.Language);
             RestartWorkerChannel(workerError.Language);
@@ -145,7 +148,9 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         {
             if (_workerState.Errors.Count < 3)
             {
-                _workerState.Channel = CreateNewChannelWithExistingWorkerState(runtime);
+                var newWorkerChannelAndProcess = CreateNewChannelWithExistingWorkerState(runtime, erroredWorkerState);
+                erroredWorkerState.Channel = newWorkerChannelAndProcess.Item1;
+                erroredWorkerState.WorkerProcess = newWorkerChannelAndProcess.Item2;
             }
             else
             {
@@ -167,15 +172,13 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 _workerState.AddRegistration(reg);
                 reg.InputBuffer.LinkTo(errorBlock);
             }));
-            _eventManager.Publish(new WorkerProcessErrorEvent(_workerState.Channel.Id, runtime, languageWorkerChannelException));
+            _eventManager.Publish(new WorkerProcessErrorEvent(erroredWorkerState.Channel.WorkerId, runtime, languageWorkerChannelException));
         }
 
-        private ILanguageWorkerChannel CreateNewChannelWithExistingWorkerState(string language)
+        private Tuple<ILanguageWorkerChannel, ILanguageWorkerProcess> CreateNewChannelWithExistingWorkerState(string language, LanguageWorkerState erroredWorkerState)
         {
             WorkerConfig config = _workerConfigs.Where(c => c.Language.Equals(language, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
-            var newWorkerChannel = ChannelFactory(language, _workerState.Functions, _workerState.Errors.Count);
-            newWorkerChannel.RegisterFunctions(_workerState.Functions);
-            return newWorkerChannel;
+            return ChannelFactory(language, erroredWorkerState.Functions, erroredWorkerState.Errors.Count);
         }
 
         protected virtual void Dispose(bool disposing)
@@ -189,13 +192,9 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                     {
                         subscription.Dispose();
                     }
-                    // WebhostLanguageWorkerChannels life time is managed by LanguageWorkerChannelManager
-                    if (!_workerState.Channel.IsWebhostChannel)
-                    {
-                            pair.Value.Channel.ShutdownWorkerProcess();
-                    }
                         // TODO #3296 - send WorkerTerminate message to shut down language worker process gracefully (instead of just a killing)
                         pair.Value.Channel.Dispose();
+                        pair.Value.WorkerProcess.Dispose();
                 }
                 disposedValue = true;
             }

--- a/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
+++ b/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
@@ -189,13 +189,13 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                     {
                         subscription.Dispose();
                     }
-                    // TODO #3296 - send WorkerTerminate message to shut down language worker process gracefully (instead of just a killing)
                     // WebhostLanguageWorkerChannels life time is managed by LanguageWorkerChannelManager
                     if (!_workerState.Channel.IsWebhostChannel)
                     {
-                        _workerState.Channel.Dispose();
+                            pair.Value.Channel.ShutdownWorkerProcess();
                     }
-                    _workerState.Functions.Dispose();
+                        // TODO #3296 - send WorkerTerminate message to shut down language worker process gracefully (instead of just a killing)
+                        pair.Value.Channel.Dispose();
                 }
                 disposedValue = true;
             }

--- a/src/WebJobs.Script/Rpc/FunctionRegistration/IFunctionDispatcher.cs
+++ b/src/WebJobs.Script/Rpc/FunctionRegistration/IFunctionDispatcher.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 {
     public interface IFunctionDispatcher : IDisposable
     {
-        IDictionary<string, LanguageWorkerState> LanguageWorkerChannelStates { get; }
+        LanguageWorkerState LanguageWorkerChannelState { get; }
 
         // Tests if the function metadata is supported by a known language worker
         bool IsSupported(FunctionMetadata metadata, string language);

--- a/src/WebJobs.Script/Rpc/ILanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/ILanguageWorkerChannel.cs
@@ -5,22 +5,16 @@ using System;
 
 namespace Microsoft.Azure.WebJobs.Script.Rpc
 {
-    public delegate ILanguageWorkerChannel CreateChannel(string language, IObservable<FunctionRegistrationContext> registrations, int attemptCount);
+    public delegate Tuple<ILanguageWorkerChannel, ILanguageWorkerProcess> CreateChannel(string language, IObservable<FunctionRegistrationContext> registrations, int attemptCount);
 
     public interface ILanguageWorkerChannel : IDisposable
     {
-        string Id { get; }
+        string WorkerId { get; }
 
-        bool IsWebhostChannel { get; }
-
-        WorkerConfig Config { get; }
+        string Runtime { get; }
 
         void RegisterFunctions(IObservable<FunctionRegistrationContext> functionRegistrations);
 
         void SendFunctionEnvironmentReloadRequest();
-
-        void StartWorkerProcess();
-
-        void ShutdownWorkerProcess();
     }
 }

--- a/src/WebJobs.Script/Rpc/ILanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/ILanguageWorkerChannel.cs
@@ -20,5 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         void SendFunctionEnvironmentReloadRequest();
 
         void StartWorkerProcess();
+
+        void ShutdownWorkerProcess();
     }
 }

--- a/src/WebJobs.Script/Rpc/ILanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/ILanguageWorkerChannelManager.cs
@@ -27,6 +27,6 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         void ShutdownChannels();
 
-        ILanguageWorkerChannel CreateLanguageWorkerChannel(string workerId, string scriptRootPath, string language, IObservable<FunctionRegistrationContext> functionRegistrations, IMetricsLogger metricsLogger, int attemptCount, bool isWebhostChannel);
+        ILanguageWorkerChannel CreateLanguageWorkerChannel(string workerId, string scriptRootPath, string language, IObservable<FunctionRegistrationContext> functionRegistrations, IMetricsLogger metricsLogger, int attemptCount);
     }
 }

--- a/src/WebJobs.Script/Rpc/ILanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/ILanguageWorkerChannelManager.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         Task SpecializeAsync();
 
+        ILanguageWorkerProcess StartWorkerProcess(string workerId, string runtime, string rootScriptPath);
+
         bool ShutdownChannelIfExists(string language);
 
         void ShutdownStandbyChannels(IEnumerable<FunctionMetadata> functions);

--- a/src/WebJobs.Script/Rpc/ILanguageWorkerProcess.cs
+++ b/src/WebJobs.Script/Rpc/ILanguageWorkerProcess.cs
@@ -1,16 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 
 namespace Microsoft.Azure.WebJobs.Script.Rpc
 {
-    internal interface ILanguageWorkerProcess
+    public interface ILanguageWorkerProcess : IDisposable
     {
         Process WorkerProcess { get; }
 
-        void StartProcess();
-
-        void ShutdownProcess();
+        Process StartProcess();
     }
 }

--- a/src/WebJobs.Script/Rpc/ILanguageWorkerProcess.cs
+++ b/src/WebJobs.Script/Rpc/ILanguageWorkerProcess.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+
+namespace Microsoft.Azure.WebJobs.Script.Rpc
+{
+    internal interface ILanguageWorkerProcess
+    {
+        Process WorkerProcess { get; }
+
+        void StartProcess();
+
+        void ShutdownProcess();
+    }
+}

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
@@ -59,8 +59,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
            Uri serverUri,
            ILoggerFactory loggerFactory,
            IMetricsLogger metricsLogger,
-           int attemptCount,
-           bool isWebHostChannel = false)
+           int attemptCount)
         {
             _workerId = workerId;
             _functionRegistrations = functionRegistrations;

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             _startSubscription = _inboundWorkerEvents.Where(msg => msg.MessageType == MsgType.StartStream)
                 .Timeout(processStartTimeout)
                 .Take(1)
-                .Subscribe(SendWorkerInitRequest, HandleWorkerError);
+                .Subscribe(SendWorkerInitRequest, HandleWorkerChannelError);
 
             _eventSubscriptions.Add(_inboundWorkerEvents
                 .Where(msg => msg.MessageType == MsgType.RpcLog)
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             _inboundWorkerEvents.Where(msg => msg.MessageType == MsgType.WorkerInitResponse)
                 .Timeout(workerInitTimeout)
                 .Take(1)
-                .Subscribe(PublishWebhostRpcChannelReadyEvent, HandleWorkerError);
+                .Subscribe(PublishWebhostRpcChannelReadyEvent, HandleWorkerChannelError);
 
             SendStreamingMessage(new StreamingMessage
             {
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             _initMessage = initEvent.Message.WorkerInitResponse;
             if (_initMessage.Result.IsFailure(out Exception exc))
             {
-                HandleWorkerError(exc);
+                HandleWorkerChannelError(exc);
                 return;
             }
             if (_functionRegistrations == null)
@@ -311,7 +311,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             }
         }
 
-        internal void HandleWorkerError(Exception exc)
+        internal void HandleWorkerChannelError(Exception exc)
         {
             _eventManager.Publish(new WorkerErrorEvent(_runtime, WorkerId, exc));
         }

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         private IObservable<FunctionRegistrationContext> _functionRegistrations;
         private WorkerInitResponse _initMessage;
         private string _workerId;
-        private LanguageWorkerProcess _languageWorkerProcess;
+        private ILanguageWorkerProcess _languageWorkerProcess;
         private IDictionary<string, BufferBlock<ScriptInvocationContext>> _functionInputBuffers = new Dictionary<string, BufferBlock<ScriptInvocationContext>>();
         private IDictionary<string, Exception> _functionLoadErrors = new Dictionary<string, Exception>();
         private ConcurrentDictionary<string, ScriptInvocationContext> _executingInvocations = new ConcurrentDictionary<string, ScriptInvocationContext>();

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannelManager.cs
@@ -237,20 +237,14 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             foreach (string runtime in _workerChannels.Keys.ToList())
             {
                 _logger.LogInformation("Shutting down language worker channel for runtime:{runtime}", runtime);
-                if (_workerChannels[runtime] != null)
-                {
-                    _workerChannels[runtime].Dispose();
-                }
+                _workerChannels[runtime]?.Dispose();
             }
             _workerChannels.Clear();
 
             foreach (string runtime in _workerProcesses.Keys.ToList())
             {
                 _logger.LogInformation("Shutting down language worker process for runtime:{runtime}", runtime);
-                if (_workerProcesses[runtime] != null)
-                {
-                    _workerProcesses[runtime].Dispose();
-                }
+                _workerProcesses[runtime]?.Dispose();
             }
             _workerProcesses.Clear();
             (_processRegistry as IDisposable)?.Dispose();

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannelManager.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                .Subscribe(AddOrUpdateWorkerChannels);
         }
 
-        public ILanguageWorkerChannel CreateLanguageWorkerChannel(string workerId, string scriptRootPath, string language, IObservable<FunctionRegistrationContext> functionRegistrations, IMetricsLogger metricsLogger, int attemptCount, bool isWebhostChannel = false)
+        public ILanguageWorkerChannel CreateLanguageWorkerChannel(string workerId, string scriptRootPath, string language, IObservable<FunctionRegistrationContext> functionRegistrations, IMetricsLogger metricsLogger, int attemptCount)
         {
             WorkerConfig languageWorkerConfig = GetWorkerConfig(language);
             return new LanguageWorkerChannel(
@@ -78,8 +78,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                          _rpcServer.Uri,
                          _loggerFactory,
                          metricsLogger,
-                         attemptCount,
-                         isWebhostChannel);
+                         attemptCount);
         }
 
         private WorkerConfig GetWorkerConfig(string language)
@@ -105,7 +104,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             {
                 string workerId = Guid.NewGuid().ToString();
                 _logger.LogInformation("Creating language worker channel for runtime:{runtime}", language);
-                ILanguageWorkerChannel languageWorkerChannel = CreateLanguageWorkerChannel(workerId, scriptRootPath, language, null, null, 0, true);
+                ILanguageWorkerChannel languageWorkerChannel = CreateLanguageWorkerChannel(workerId, scriptRootPath, language, null, null, 0);
 
                 var languageWorkerProcess = StartWorkerProcess(workerId, language, scriptRootPath);
                 _workerProcesses.Add(language, languageWorkerProcess);

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannelManager.cs
@@ -166,6 +166,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 for (int i = 0; i < standbyChannels.Count(); i++)
                 {
                     _logger.LogInformation("Disposing standby channel for runtime:{language}", standbyChannels.ElementAt(i).Key);
+                    standbyChannels.ElementAt(i).Value.ShutdownWorkerProcess();
                     standbyChannels.ElementAt(i).Value.Dispose();
                     _workerChannels.Remove(standbyChannels.ElementAt(i).Key);
                 }
@@ -196,7 +197,11 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             foreach (string runtime in _workerChannels.Keys.ToList())
             {
                 _logger.LogInformation("Shutting down language worker channel for runtime:{runtime}", runtime);
-                _workerChannels[runtime]?.Dispose();
+                if (_workerChannels[runtime] != null)
+                {
+                    _workerChannels[runtime].ShutdownWorkerProcess();
+                    _workerChannels[runtime].Dispose();
+                }
             }
             _workerChannels.Clear();
             (_processRegistry as IDisposable)?.Dispose();

--- a/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.Rpc
 {
-    internal class LanguageWorkerProcess
+    internal class LanguageWorkerProcess : ILanguageWorkerProcess
     {
         private readonly IWorkerProcessFactory _processFactory;
         private readonly IProcessRegistry _processRegistry;
@@ -49,11 +49,11 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             _process = _processFactory.CreateWorkerProcess(workerContext);
         }
 
-        internal Process WorkerProcess => _process;
+        public Process WorkerProcess => _process;
 
         internal Queue<string> ProcessStdErrDataQueue => _processStdErrDataQueue;
 
-        internal void StartProcess()
+        public void StartProcess()
         {
             try
             {
@@ -181,7 +181,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             }
         }
 
-        internal void ShutdownProcess()
+        public void ShutdownProcess()
         {
             _disposing = true;
             // best effort process disposal

--- a/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
@@ -36,14 +36,14 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                                        IScriptEventManager eventManager,
                                        IWorkerProcessFactory processFactory,
                                        IProcessRegistry processRegistry,
-                                       ILogger workerChannelLogger,
+                                       ILoggerFactory loggerFactory,
                                        ILanguageWorkerConsoleLogSource consoleLogSource)
         {
             _runtime = runtime;
             _workerId = workerId;
             _processFactory = processFactory;
             _processRegistry = processRegistry;
-            _workerChannelLogger = workerChannelLogger;
+            _workerChannelLogger = loggerFactory.CreateLogger($"LanguageWorkerProcess.{runtime}.{workerId}");
             _consoleLogSource = consoleLogSource;
             _eventManager = eventManager;
             _process = _processFactory.CreateWorkerProcess(workerContext);
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         internal Queue<string> ProcessStdErrDataQueue => _processStdErrDataQueue;
 
-        public void StartProcess()
+        public Process StartProcess()
         {
             try
             {
@@ -76,6 +76,8 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             {
                 throw new HostInitializationException($"Failed to start Language Worker Channel for language :{_runtime}", ex);
             }
+
+            return _process;
         }
 
         private void OnErrorDataReceived(object sender, DataReceivedEventArgs e)
@@ -181,7 +183,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             }
         }
 
-        public void ShutdownProcess()
+        public void Dispose()
         {
             _disposing = true;
             // best effort process disposal

--- a/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
@@ -1,0 +1,206 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.Rpc
+{
+    internal class LanguageWorkerProcess
+    {
+        private readonly IWorkerProcessFactory _processFactory;
+        private readonly IProcessRegistry _processRegistry;
+        private readonly ILogger _workerChannelLogger;
+        private readonly ILanguageWorkerConsoleLogSource _consoleLogSource;
+        private readonly IScriptEventManager _eventManager;
+
+        private Process _process;
+        private string _runtime;
+        private string _workerId;
+        private bool _disposing;
+        private Queue<string> _processStdErrDataQueue = new Queue<string>(3);
+
+        internal LanguageWorkerProcess()
+        {
+            // To help with unit tests
+        }
+
+        internal LanguageWorkerProcess(string runtime,
+                                       string workerId,
+                                       WorkerContext workerContext,
+                                       IScriptEventManager eventManager,
+                                       IWorkerProcessFactory processFactory,
+                                       IProcessRegistry processRegistry,
+                                       ILogger workerChannelLogger,
+                                       ILanguageWorkerConsoleLogSource consoleLogSource)
+        {
+            _runtime = runtime;
+            _workerId = workerId;
+            _processFactory = processFactory;
+            _processRegistry = processRegistry;
+            _workerChannelLogger = workerChannelLogger;
+            _consoleLogSource = consoleLogSource;
+            _eventManager = eventManager;
+            _process = _processFactory.CreateWorkerProcess(workerContext);
+        }
+
+        internal Process WorkerProcess => _process;
+
+        internal Queue<string> ProcessStdErrDataQueue => _processStdErrDataQueue;
+
+        internal void StartProcess()
+        {
+            try
+            {
+                _process.ErrorDataReceived += (sender, e) => OnErrorDataReceived(sender, e);
+                _process.OutputDataReceived += (sender, e) => OnOutputDataReceived(sender, e);
+                _process.Exited += (sender, e) => OnProcessExited(sender, e);
+                _process.EnableRaisingEvents = true;
+
+                _workerChannelLogger?.LogInformation($"Starting language worker process:{_process.StartInfo.FileName} {_process.StartInfo.Arguments}");
+                _process.Start();
+                _workerChannelLogger?.LogInformation($"{_process.StartInfo.FileName} process with Id={_process.Id} started");
+
+                _process.BeginErrorReadLine();
+                _process.BeginOutputReadLine();
+
+                // Register process only after it starts
+                _processRegistry?.Register(_process);
+            }
+            catch (Exception ex)
+            {
+                throw new HostInitializationException($"Failed to start Language Worker Channel for language :{_runtime}", ex);
+            }
+        }
+
+        private void OnErrorDataReceived(object sender, DataReceivedEventArgs e)
+        {
+            // TODO: per language stdout/err parser?
+            if (e.Data != null)
+            {
+                string msg = e.Data;
+                if (msg.IndexOf("warn", StringComparison.OrdinalIgnoreCase) > -1)
+                {
+                    if (LanguageWorkerChannelUtilities.IsLanguageWorkerConsoleLog(msg))
+                    {
+                        msg = LanguageWorkerChannelUtilities.RemoveLogPrefix(msg);
+                        _workerChannelLogger?.LogWarning(msg);
+                    }
+                    else
+                    {
+                        _consoleLogSource?.Log(msg);
+                    }
+                }
+                else if ((msg.IndexOf("error", StringComparison.OrdinalIgnoreCase) > -1) ||
+                          (msg.IndexOf("fail", StringComparison.OrdinalIgnoreCase) > -1) ||
+                          (msg.IndexOf("severe", StringComparison.OrdinalIgnoreCase) > -1))
+                {
+                    if (LanguageWorkerChannelUtilities.IsLanguageWorkerConsoleLog(msg))
+                    {
+                        msg = LanguageWorkerChannelUtilities.RemoveLogPrefix(msg);
+                        _workerChannelLogger?.LogError(msg);
+                    }
+                    else
+                    {
+                        _consoleLogSource?.Log(msg);
+                    }
+                    _processStdErrDataQueue = LanguageWorkerChannelUtilities.AddStdErrMessage(_processStdErrDataQueue, Sanitizer.Sanitize(msg));
+                }
+                else
+                {
+                    if (LanguageWorkerChannelUtilities.IsLanguageWorkerConsoleLog(msg))
+                    {
+                        msg = LanguageWorkerChannelUtilities.RemoveLogPrefix(msg);
+                        _workerChannelLogger?.LogInformation(msg);
+                    }
+                    else
+                    {
+                        _consoleLogSource?.Log(msg);
+                    }
+                }
+            }
+        }
+
+        private void OnProcessExited(object sender, EventArgs e)
+        {
+            if (_disposing)
+            {
+                // No action needed
+                return;
+            }
+            string exceptionMessage = string.Join(",", _processStdErrDataQueue.Where(s => !string.IsNullOrEmpty(s)));
+            try
+            {
+                if (_process.ExitCode != 0)
+                {
+                    var processExitEx = new LanguageWorkerProcessExitException($"{_process.StartInfo.FileName} exited with code {_process.ExitCode}\n {exceptionMessage}");
+                    processExitEx.ExitCode = _process.ExitCode;
+                    HandleWorkerPorcessExitError(processExitEx);
+                }
+                else
+                {
+                    _process.WaitForExit();
+                    _process.Close();
+                }
+            }
+            catch (Exception)
+            {
+                // ignore process is already disposed
+            }
+        }
+
+        private void OnOutputDataReceived(object sender, DataReceivedEventArgs e)
+        {
+            if (e.Data != null)
+            {
+                string msg = e.Data;
+                if (LanguageWorkerChannelUtilities.IsLanguageWorkerConsoleLog(msg))
+                {
+                    msg = LanguageWorkerChannelUtilities.RemoveLogPrefix(msg);
+                    _workerChannelLogger?.LogInformation(msg);
+                }
+                else
+                {
+                    _consoleLogSource?.Log(msg);
+                }
+            }
+        }
+
+        internal void HandleWorkerPorcessExitError(LanguageWorkerProcessExitException langExc)
+        {
+            // The subscriber of WorkerErrorEvent is expected to Dispose() the errored channel
+            if (langExc != null && langExc.ExitCode != -1)
+            {
+                _workerChannelLogger.LogDebug(langExc, $"Language Worker Process exited.", _process.StartInfo.FileName);
+                _eventManager.Publish(new WorkerErrorEvent(_runtime, _workerId, langExc));
+            }
+        }
+
+        internal void ShutdownProcess()
+        {
+            _disposing = true;
+            // best effort process disposal
+            try
+            {
+                if (_process != null)
+                {
+                    if (!_process.HasExited)
+                    {
+                        _process.Kill();
+                        _process.WaitForExit();
+                    }
+                    _process.Dispose();
+                }
+            }
+            catch (Exception e)
+            {
+                _workerChannelLogger.LogDebug(e, "LanguageWorkerChannel Dispose failure");
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script/Rpc/LanguageWorkerState.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerState.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         internal ILanguageWorkerChannel Channel { get; set; }
 
+        internal ILanguageWorkerProcess WorkerProcess { get; set; }
+
         internal List<Exception> Errors { get; set; } = new List<Exception>();
 
         // Registered list of functions which can be replayed if the worker fails to start / errors

--- a/test/WebJobs.Script.Tests.Integration/Rpc/FunctionDispatcherEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Rpc/FunctionDispatcherEndToEndTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -47,9 +48,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             await TestHelpers.Await(() =>
             {
                 return GetCurrentWorkerChannel().WorkerId != _nodeWorkerChannel.WorkerId
-                       || FunctionErrorsAdded();
+                         || FunctionErrorsAdded();
+
             }, pollingInterval: 4 * 1000, timeout: 60 * 1000);
             _nodeWorkerChannel = GetCurrentWorkerChannel();
+            _nodeWorkerProcess = GetCurrentWorkerProcess();
         }
 
         private static void KillProcess(int oldProcId)

--- a/test/WebJobs.Script.Tests.Integration/Rpc/FunctionDispatcherEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Rpc/FunctionDispatcherEndToEndTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
     public class FunctionDispatcherEndToEndTests : IClassFixture<FunctionDispatcherEndToEndTests.TestFixture>
     {
         private LanguageWorkerState _channelState;
-        private LanguageWorkerChannel _nodeWorkerChannel;
+        private ILanguageWorkerChannel _nodeWorkerChannel;
         private ILanguageWorkerProcess _nodeWorkerProcess;
         private string _functionName = "HttpTrigger";
 
@@ -66,15 +66,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             process.Start();
         }
 
-        private LanguageWorkerChannel GetCurrentWorkerChannel()
+        private ILanguageWorkerChannel GetCurrentWorkerChannel()
         {
-            return (LanguageWorkerChannel)_channelState.Channel;
+            return _channelState.Channel;
         }
 
         private ILanguageWorkerProcess GetCurrentWorkerProcess()
         {
-            var nodeChannelStates = _channelStates.Where(w => w.Key.Equals(LanguageWorkerConstants.NodeLanguageWorkerName));
-            return (ILanguageWorkerProcess)nodeChannelStates.FirstOrDefault().Value.WorkerProcess;
+            return (ILanguageWorkerProcess)_channelState.WorkerProcess;
         }
 
         private bool FunctionErrorsAdded()

--- a/test/WebJobs.Script.Tests.Integration/Rpc/FunctionDispatcherEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Rpc/FunctionDispatcherEndToEndTests.cs
@@ -12,14 +12,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class FunctionDispatcherEndToEndTests : IClassFixture<FunctionDispatcherEndToEndTests.TestFixture>
     {
-        private IDictionary<string, LanguageWorkerState> _channelStates;
+        private LanguageWorkerState _channelState;
         private LanguageWorkerChannel _nodeWorkerChannel;
         private string _functionName = "HttpTrigger";
 
         public FunctionDispatcherEndToEndTests(TestFixture fixture)
         {
             Fixture = fixture;
-            _channelStates = Fixture.JobHost.FunctionDispatcher.LanguageWorkerChannelStates;
+            _channelState = Fixture.JobHost.FunctionDispatcher.LanguageWorkerChannelState;
             _nodeWorkerChannel = GetCurrentWorkerChannel();
         }
 
@@ -63,8 +63,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         private LanguageWorkerChannel GetCurrentWorkerChannel()
         {
-            var nodeWorkerChannels = _channelStates.Where(w => w.Key.Equals(LanguageWorkerConstants.NodeLanguageWorkerName));
-            return (LanguageWorkerChannel)nodeWorkerChannels.FirstOrDefault().Value.Channel;
+            return (LanguageWorkerChannel)_channelState.Channel;
         }
 
         private bool FunctionErrorsAdded()

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node.cs
@@ -23,6 +23,7 @@ using Microsoft.WindowsAzure.Storage.Blob;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 {
@@ -438,15 +439,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             IEnumerable<int> nodeProcessesAfter = Process.GetProcessesByName("node").Select(p => p.Id);
             // Verify number of node processes before and after restart are the same.
             Assert.Equal(nodeProcessesBefore.Count(), nodeProcessesAfter.Count());
+
             // Verify node process is different after host restart
-            var result = nodeProcessesBefore.Where(pId1 => !nodeProcessesAfter.Any(pId2 => pId2 == pId1));
+            var result = nodeProcessesAfter.Where(pId1 => !nodeProcessesBefore.Any(pId2 => pId2 == pId1));
             Assert.Equal(1, result.Count());
         }
 
         [Fact]
         public async Task HttpTrigger_Disabled_SucceedsWithAdminKey()
         {
-
             // first try with function key only - expect 404
             string functionKey = await _fixture.Host.GetFunctionSecretAsync("HttpTrigger-Disabled");
             string uri = $"api/httptrigger-disabled?code={functionKey}";

--- a/test/WebJobs.Script.Tests/Rpc/LanguageWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/LanguageWorkerChannelManagerTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             ILanguageWorkerChannel javaWorkerChannel = CreateTestChannel(workerId, language);
             var initializedChannel = _languageWorkerChannelManager.GetChannel(language);
             Assert.NotNull(initializedChannel);
-            Assert.Equal(workerId, initializedChannel.Id);
+            Assert.Equal(workerId, initializedChannel.WorkerId);
         }
 
         [Fact]
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             Assert.Null(initializedChannel);
             initializedChannel = _languageWorkerChannelManager.GetChannel(LanguageWorkerConstants.JavaLanguageWorkerName);
             Assert.NotNull(initializedChannel);
-            Assert.Equal(javaWorkerId, initializedChannel.Id);
+            Assert.Equal(javaWorkerId, initializedChannel.WorkerId);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Rpc/LanguageWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/LanguageWorkerChannelTests.cs
@@ -12,14 +12,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         [Fact]
         public void ErrorMessageQueue_Empty()
         {
-            LanguageWorkerChannel languageWorkerChannel = new LanguageWorkerChannel();
+            LanguageWorkerProcess languageWorkerChannel = new LanguageWorkerProcess();
             Assert.Empty(languageWorkerChannel.ProcessStdErrDataQueue);
         }
 
         [Fact]
         public void ErrorMessageQueue_Enqueue_Success()
         {
-            LanguageWorkerChannel languageWorkerChannel = new LanguageWorkerChannel();
+            LanguageWorkerProcess languageWorkerChannel = new LanguageWorkerProcess();
             LanguageWorkerChannelUtilities.AddStdErrMessage(languageWorkerChannel.ProcessStdErrDataQueue, "Error1");
             LanguageWorkerChannelUtilities.AddStdErrMessage(languageWorkerChannel.ProcessStdErrDataQueue, "Error2");
 
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         [Fact]
         public void ErrorMessageQueue_Full_Enqueue_Success()
         {
-            LanguageWorkerChannel languageWorkerChannel = new LanguageWorkerChannel();
+            LanguageWorkerProcess languageWorkerChannel = new LanguageWorkerProcess();
             LanguageWorkerChannelUtilities.AddStdErrMessage(languageWorkerChannel.ProcessStdErrDataQueue, "Error1");
             LanguageWorkerChannelUtilities.AddStdErrMessage(languageWorkerChannel.ProcessStdErrDataQueue, "Error2");
             LanguageWorkerChannelUtilities.AddStdErrMessage(languageWorkerChannel.ProcessStdErrDataQueue, "Error3");
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         [InlineData("LanguageWorkerConsoleLog Connection established")]
         public void IsLanguageWorkerConsoleLog_Returns_True_RemovesLogPrefix(string msg)
         {
-            LanguageWorkerChannel languageWorkerChannel = new LanguageWorkerChannel();
+            LanguageWorkerProcess languageWorkerChannel = new LanguageWorkerProcess();
             Assert.True(LanguageWorkerChannelUtilities.IsLanguageWorkerConsoleLog(msg));
             Assert.Equal(" Connection established", LanguageWorkerChannelUtilities.RemoveLogPrefix(msg));
         }
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         [InlineData("Connection established")]
         public void IsLanguageWorkerConsoleLog_Returns_False(string msg)
         {
-            LanguageWorkerChannel languageWorkerChannel = new LanguageWorkerChannel();
+            LanguageWorkerProcess languageWorkerChannel = new LanguageWorkerProcess();
             Assert.False(LanguageWorkerChannelUtilities.IsLanguageWorkerConsoleLog(msg));
         }
     }


### PR DESCRIPTION
- Added ILanguageWorkerProcess and LanguageWorkerProcess to handle operations related to process start up and shutdown
- Moved process helpers from LanguageWorkerChannel. 
  - This decouples worker process and worker channel
  -  Makes it easy to mock LanguageWorkerChannel as it is not attached to a process

Note: We have existing tests that verify processes start and dispose properly.