### PR TITLE
[pack] fix non-signing builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,6 +70,5 @@ for:
       
       if (-not $bypassPackaging) {
         & .\tools\PollSigningResults.ps1
-        if (-not $?) { exit 1 }
-        Get-ChildItem buildoutput\signed\*.nupkg | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name -DeploymentName "Binaries" }
+        if (-not $?) { exit 1 }        
       }

--- a/tools/PollSigningResults.ps1
+++ b/tools/PollSigningResults.ps1
@@ -28,8 +28,7 @@ if (-not $bypassPackaging -and $env:SkipAssemblySigning -ne "true") {
 
   Expand-Archive "$directoryPath/../buildoutput/signed.zip" "$directoryPath/../buildoutput/signed"
 
-  Get-ChildItem "$directoryPath/../buildoutput/signed" | % {
-    Push-AppveyorArtifact $_.FullName
-  }
+  Get-ChildItem buildoutput\signed\*.nupkg | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name -DeploymentName "Binaries" }
+
   if (-not $?) { exit 1 }
 }

--- a/tools/RunSigningJob.ps1
+++ b/tools/RunSigningJob.ps1
@@ -2,15 +2,15 @@ $bypassPackaging = $env:APPVEYOR_PULL_REQUEST_NUMBER -and -not $env:APPVEYOR_PUL
 $directoryPath = Split-Path $MyInvocation.MyCommand.Path -Parent
 
 if (-not $bypassPackaging) {
-  # Only sign the ExtensionsMetadataGenerator
-  New-Item -ItemType Directory -Force -Path "$directoryPath\..\buildoutput\signing"
-  Compress-Archive $directoryPath\..\buildoutput\Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator*.nupkg $directoryPath\..\buildoutput\signing\tosign.zip  
-  Remove-Item $directoryPath\..\buildoutput\Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator*.nupkg
-
   if ($env:SkipAssemblySigning -eq "true") {
     "Signing disabled. Skipping signing process."
     exit 0;
   }
+
+  # Only sign the ExtensionsMetadataGenerator
+  New-Item -ItemType Directory -Force -Path "$directoryPath\..\buildoutput\signing"
+  Compress-Archive $directoryPath\..\buildoutput\Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator*.nupkg $directoryPath\..\buildoutput\signing\tosign.zip  
+  Remove-Item $directoryPath\..\buildoutput\Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator*.nupkg
 
   $ctx = New-AzureStorageContext $env:FILES_ACCOUNT_NAME $env:FILES_ACCOUNT_KEY
   Set-AzureStorageBlobContent "$directoryPath/../buildoutput/signing/tosign.zip" "azure-functions-host" -Blob "$env:APPVEYOR_BUILD_VERSION.zip" -Context $ctx


### PR DESCRIPTION
Our nightly builds set SkipAssemblySigning to 1, but the AppVeyor build still had a step that assumed there were packages to upload in the "signed" folder. This should make the "SkipAssemblySigning" flow work nicer.