### PR TITLE
[AppInsights] [v1] bumping MaxTelemetryItemsPerSecond default to 20

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -1756,7 +1756,11 @@ namespace Microsoft.Azure.WebJobs.Script
 
         internal static void ApplyApplicationInsightsConfig(JObject configJson, ScriptHostConfiguration scriptConfig)
         {
-            scriptConfig.ApplicationInsightsSamplingSettings = new SamplingPercentageEstimatorSettings();
+            scriptConfig.ApplicationInsightsSamplingSettings = new SamplingPercentageEstimatorSettings
+            {
+                MaxTelemetryItemsPerSecond = 20
+            };
+
             JObject configSection = (JObject)configJson["applicationInsights"];
             JToken value;
             if (configSection != null)

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -1023,7 +1023,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             ScriptHost.ApplyApplicationInsightsConfig(config, scriptConfig);
 
             Assert.NotNull(scriptConfig.ApplicationInsightsSamplingSettings);
-            Assert.Equal(5, scriptConfig.ApplicationInsightsSamplingSettings.MaxTelemetryItemsPerSecond);
+            Assert.Equal(20, scriptConfig.ApplicationInsightsSamplingSettings.MaxTelemetryItemsPerSecond);
         }
 
         [Fact]
@@ -1101,7 +1101,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             ScriptHost.ApplyApplicationInsightsConfig(config, scriptConfig);
 
             Assert.NotNull(scriptConfig.ApplicationInsightsSamplingSettings);
-            Assert.Equal(5, scriptConfig.ApplicationInsightsSamplingSettings.MaxTelemetryItemsPerSecond);
+            Assert.Equal(20, scriptConfig.ApplicationInsightsSamplingSettings.MaxTelemetryItemsPerSecond);
         }
 
         [Fact]


### PR DESCRIPTION
`v1.x` version of #4219, which fixes #3806. 