### PR TITLE
[pack] removing Azure Monitor app setting

### DIFF
--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -58,12 +58,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                         IEnvironment environment = services.GetService<IEnvironment>();
                         IScriptWebHostEnvironment hostEnvironment = services.GetService<IScriptWebHostEnvironment>();
 
-                        // Temporarily hide Azure Monitor support behind an app setting.
-                        string monitorSetting = environment.GetEnvironmentVariable("AZURE_MONITOR_ENABLED");
-                        bool.TryParse(monitorSetting, out bool monitorenabled);
-
-                        if (monitorenabled &&
-                            !hostEnvironment.InStandbyMode &&
+                        if (!hostEnvironment.InStandbyMode &&
                             !string.IsNullOrEmpty(environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName)))
                         {
                             IEventGenerator eventGenerator = services.GetService<IEventGenerator>();

--- a/test/WebJobs.Script.Tests/Configuration/LoggingConfigurationTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/LoggingConfigurationTests.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         }
 
         [Fact]
-        public void LoggerProviders_AzureMonitor_NoAppSetting()
+        public void LoggerProviders_AzureMonitor()
         {
             IHost host = new HostBuilder()
               .ConfigureDefaultTestWebScriptHost()
@@ -275,43 +275,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             loggerProviders.OfType<HostFileLoggerProvider>().Single();
             loggerProviders.OfType<FunctionFileLoggerProvider>().Single();
             loggerProviders.OfType<UserLogMetricsLoggerProvider>().Single();
-            loggerProviders.OfType<NullLoggerProvider>().Single();
-        }
-
-        [Theory]
-        [InlineData("1", false)] // only true/false are parsed
-        [InlineData("true", true)]
-        [InlineData("false", false)]
-        [InlineData("nonsense", false)]
-        public void LoggerProviders_AzureMonitor_AppSetting(string appSettingValue, bool expected)
-        {
-            IHost host = new HostBuilder()
-              .ConfigureDefaultTestWebScriptHost()
-              .ConfigureServices(s =>
-              {
-                  TestEnvironment environment = new TestEnvironment();
-                  environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName, "something.azurewebsites.net");
-                  environment.SetEnvironmentVariable("AZURE_MONITOR_ENABLED", appSettingValue);
-                  s.AddSingleton<IEnvironment>(environment);
-              })
-              .Build();
-
-            IEnumerable<ILoggerProvider> loggerProviders = host.Services.GetService<IEnumerable<ILoggerProvider>>();
-
-            Assert.Equal(5, loggerProviders.Count());
-            loggerProviders.OfType<SystemLoggerProvider>().Single();
-            loggerProviders.OfType<HostFileLoggerProvider>().Single();
-            loggerProviders.OfType<FunctionFileLoggerProvider>().Single();
-            loggerProviders.OfType<UserLogMetricsLoggerProvider>().Single();
-
-            if (expected)
-            {
-                loggerProviders.OfType<AzureMonitorDiagnosticLoggerProvider>().Single();
-            }
-            else
-            {
-                loggerProviders.OfType<NullLoggerProvider>().Single();
-            }
+            loggerProviders.OfType<AzureMonitorDiagnosticLoggerProvider>().Single();
         }
     }
 }


### PR DESCRIPTION
Now that Ant80 is rolled out, we no longer need this.