### PR TITLE
Cold start Improvements for Functions

### DIFF
--- a/src/WebJobs.Script.WebHost/DependencyInjection/DryIoc/Container.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/DryIoc/Container.cs
@@ -2045,7 +2045,9 @@ namespace DryIoc
 #if FEC_EXPRESSION_INFO
             return lambdaExpr.ToLambdaExpression().Compile();
 #else
-            return lambdaExpr.Compile();
+            // Passing preferInterpretation: true as the default value of False uses JIT compile which has a huge impact on Functions cold start time
+            // This optimization is needed for Functions Host only and is not part of the DryIoc codebase which it was copied from.
+            return lambdaExpr.Compile(preferInterpretation: true);
 #endif
         }
 


### PR DESCRIPTION
This change will improve cold starts by ~30% across the board for all languages.

Here are the numbers:


  | percentile_Time_taken_50 | percentile_Time_taken_80 | percentile_Time_taken_90 | percentile_Time_taken_95 | percentile_Time_taken_99 | avg_Time_taken | count_
-- | -- | -- | -- | -- | -- | -- | --
Current cold start with   placeholders | **2032** | 2250 | 2359 | 2609 | 3422 | 2111.71276595745 | 94
Updated cold start with   placeholders and optimization | **1454** | 1579 | 1734 | 1906 | 2328 | 1483.76470588235 | 119
Current cold start without   placeholders | **9500** | 10469 | 11062 | 11453 | 12406 | 9789.04 | 50
Updated cold start   without placeholders and optimization | **6985** | 7859 | 8734 | 8922 | 9765 | 7208.12 | 50

