### PR TITLE
Allow secrets and log paths to be configurable

### DIFF
--- a/src/WebJobs.Script.WebHost/Configuration/WebScriptHostConfigurationSource.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/WebScriptHostConfigurationSource.cs
@@ -55,10 +55,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
                 else
                 {
                     // Local hosting or Linux container scenarios
-                    Data[WebHostScriptPathProperty] = GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsScriptRoot);
-                    Data[LogPathProperty] = Path.Combine(Path.GetTempPath(), @"Functions");
-                    Data[SecretsPathProperty] = Path.Combine(AppContext.BaseDirectory, "Secrets");
-                    Data[TestDataPathProperty] = Path.Combine(Path.GetTempPath(), @"FunctionsData");
+                    Data[WebHostScriptPathProperty] = GetOrDefault(EnvironmentSettingNames.AzureWebJobsScriptRoot, Environment.CurrentDirectory);
+                    Data[LogPathProperty] = GetOrDefault(EnvironmentSettingNames.FunctionsLogPath, Path.Combine(Path.GetTempPath(), @"Functions"));
+                    Data[SecretsPathProperty] = GetOrDefault(EnvironmentSettingNames.FunctionsSecretsPath, Path.Combine(AppContext.BaseDirectory, "Secrets"));
+                    Data[TestDataPathProperty] = GetOrDefault(EnvironmentSettingNames.FunctionsTestDataPath, Path.Combine(Path.GetTempPath(), @"FunctionsData"));
+                }
+
+                string GetOrDefault(string variableName, string @default)
+                {
+                    var result = GetEnvironmentVariable(variableName);
+                    return string.IsNullOrEmpty(result) ? @default : result;
                 }
             }
         }

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -74,5 +74,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public const string KubernetesServiceHost = "KUBERNETES_SERVICE_HOST";
         public const string KubernetesServiceHttpsPort = "KUBERNETES_SERVICE_PORT_HTTPS";
+        public const string FunctionsLogPath = "FUNCTIONS_LOG_PATH";
+        public const string FunctionsSecretsPath = "FUNCTIONS_SECRETS_PATH";
+        public const string FunctionsTestDataPath = "FUNCTIONS_TEST_DATA_PATH";
     }
 }


### PR DESCRIPTION
This is for:
    - Container scenarios where the secrets folder can be injected from
    the environment
    - For the CLI to be able to provide a secrets and logging folder.