### PR TITLE
Update PowerShell worker to 0.1.90-preview.

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.8100001-0126c21e" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.3.1-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.81-preview" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.90-preview" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.6" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2" />


### PR DESCRIPTION
Changes in this release:
* Revved version of PowerShell SDK to 6.2.0
* Made binding info dictionary case-insensitive to support case-insensitive binding names
* Updated logic to clean up jobs started during the function execution
* System logging improvements to reflect the correct worker pool size when the environment variable is not set

For more information, please see https://github.com/Azure/azure-functions-powershell-worker/releases/tag/0.1.90