### PR TITLE
Add logging for worker bundle is detected

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
@@ -169,6 +169,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                     ZipFile.ExtractToDirectory(filePath, options.ScriptPath, overwriteFiles: true);
                     _logger.LogInformation($"Zip extraction complete");
                 }
+
+                string bundlePath = Path.Combine(options.ScriptPath, "worker-bundle");
+                if (Directory.Exists(bundlePath))
+                {
+                    _logger.LogInformation($"Python worker bundle detected");
+                }
             }
         }
 


### PR DESCRIPTION
Adding logging so we can track how worker bundle usage changes over time. 