### PR TITLE
Adding managedDependency only when the file system is not read only

### DIFF
--- a/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
@@ -193,7 +193,8 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             private JObject GetDefaultHostConfigObject()
             {
                 var hostJsonJObj = JObject.Parse("{'version': '2.0'}");
-                if (string.Equals(_configurationSource.Environment.GetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName), "powershell", StringComparison.InvariantCultureIgnoreCase))
+                if (string.Equals(_configurationSource.Environment.GetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName), "powershell", StringComparison.InvariantCultureIgnoreCase)
+                    && !_configurationSource.Environment.FileSystemIsReadOnly())
                 {
                     hostJsonJObj.Add("managedDependency", JToken.Parse("{'Enabled': true}"));
                 }


### PR DESCRIPTION
Adding condition to add managedDependency enabled to true when the file system is not read-only
