### PR TITLE
Updating PowerShellWorker to version "0.1.97-preview"

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.8100001-0126c21e" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.3.1-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.95-preview" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.97-preview" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.7" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2" />


### PR DESCRIPTION
The feature for this release is to support the dependency download to happen on a background thread spawned by the FunctionLoad request and if the dependency download is still in progress and the function execution is invoked from the azure portal then the user will get the message on the azure portal log window that the dependency download is in progress and the function execution will continue when the download is done.

Release link:
https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v0.1.97-preview
