### PR TITLE
[pack] ensuring that we look at the same InStandbyMode value during app initialization

### DIFF
--- a/src/WebJobs.Script.WebHost/Standby/StandbyChangeTokenSource.cs
+++ b/src/WebJobs.Script.WebHost/Standby/StandbyChangeTokenSource.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Standby
 {
-    public class StandbyChangeTokenSource : IOptionsChangeTokenSource<ScriptApplicationHostOptions>
+    public class StandbyChangeTokenSource : IOptionsChangeTokenSource<StandbyOptions>
     {
         public string Name { get; set; }
 

--- a/src/WebJobs.Script.WebHost/Standby/StandbyOptions.cs
+++ b/src/WebJobs.Script.WebHost/Standby/StandbyOptions.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost
+{
+    /// <summary>
+    /// Provides options values related to StandbyMode. If you need to check whether
+    /// the host is currently in standby mode, use an <see cref="IOptionsMonitor{StandbyOptions}"/>.
+    /// The options will only be reset after the host has started and the StandbyManager specializes
+    /// the host. Avoid checking Standby and Placeholder environment variables directly as they can
+    /// change at any time, even during initialization.
+    /// </summary>
+    public class StandbyOptions
+    {
+        public bool InStandbyMode { get; set; }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Standby/StandbyOptionsSetup.cs
+++ b/src/WebJobs.Script.WebHost/Standby/StandbyOptionsSetup.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost
+{
+    internal class StandbyOptionsSetup : IConfigureOptions<StandbyOptions>
+    {
+        private readonly IEnvironment _environment;
+
+        public StandbyOptionsSetup(IEnvironment environment)
+        {
+            _environment = environment ?? throw new ArgumentNullException(nameof(environment));
+        }
+
+        public void Configure(StandbyOptions options)
+        {
+            options.InStandbyMode = _environment.IsPlaceholderModeEnabled();
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -122,7 +122,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddSingleton<IHostedService>(s => s.GetRequiredService<WebJobsScriptHostService>());
 
             // Configuration
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IConfigureOptions<ScriptApplicationHostOptions>, ScriptApplicationHostOptionsSetup>());
+            services.ConfigureOptions<ScriptApplicationHostOptionsSetup>();
+            services.ConfigureOptions<StandbyOptionsSetup>();
             services.ConfigureOptions<LanguageWorkerOptionsSetup>();
 
             services.TryAddSingleton<IDependencyValidator, DependencyValidator>();
@@ -130,13 +131,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         private static void AddStandbyServices(this IServiceCollection services)
         {
-            services.AddSingleton<IOptionsChangeTokenSource<ScriptApplicationHostOptions>, StandbyChangeTokenSource>();
+            services.AddSingleton<IOptionsChangeTokenSource<StandbyOptions>, StandbyChangeTokenSource>();
 
             // Core script host service
             services.AddSingleton<IHostedService>(p =>
             {
-                var hostEnvironment = p.GetService<IScriptWebHostEnvironment>();
-                if (hostEnvironment.InStandbyMode)
+                var standbyOptions = p.GetService<IOptionsMonitor<StandbyOptions>>();
+                if (standbyOptions.CurrentValue.InStandbyMode)
                 {
                     var standbyManager = p.GetService<IStandbyManager>();
                     return new StandbyInitializationService(standbyManager);

--- a/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
@@ -9,6 +9,7 @@ using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Script.Extensions;
 using Microsoft.Azure.WebJobs.Script.WebHost.Middleware;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
 {
@@ -22,12 +23,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         public static IApplicationBuilder UseWebJobsScriptHost(this IApplicationBuilder builder, IApplicationLifetime applicationLifetime, Action<WebJobsRouteBuilder> routes)
         {
             IEnvironment environment = builder.ApplicationServices.GetService<IEnvironment>() ?? SystemEnvironment.Instance;
+            IOptionsMonitor<StandbyOptions> standbyOptions = builder.ApplicationServices.GetService<IOptionsMonitor<StandbyOptions>>();
 
             builder.UseMiddleware<SystemTraceMiddleware>();
             builder.UseMiddleware<HostnameFixupMiddleware>();
             builder.UseMiddleware<EnvironmentReadyCheckMiddleware>();
 
-            if (environment.IsPlaceholderModeEnabled())
+            if (standbyOptions.CurrentValue.InStandbyMode)
             {
                 builder.UseMiddleware<PlaceholderSpecializationMiddleware>();
             }

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyInitializationTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyInitializationTests.cs
@@ -1,0 +1,126 @@
+﻿//// Copyright (c) .NET Foundation. All rights reserved.
+//// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Azure.WebJobs.Script.Configuration;
+using Microsoft.Azure.WebJobs.Script.Rpc;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.WebJobs.Script.Tests;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public class StandbyInitializationTests
+    {
+        [Fact]
+        public async Task IsPlaceholderMode_ThroughoutInitialization_EvaluatesCorrectly()
+        {
+            StandbyManager.ResetChangeToken();
+
+            string standbyPath = Path.Combine(Path.GetTempPath(), "functions", "standby", "wwwroot");
+            string specializedScriptRoot = @"TestScripts\CSharp";
+            string scriptRootConfigPath = ConfigurationPath.Combine(ConfigurationSectionNames.WebHost, nameof(ScriptApplicationHostOptions.ScriptPath));
+
+            var settings = new Dictionary<string, string>()
+            {
+                { EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1" },
+                { EnvironmentSettingNames.AzureWebsiteContainerReady, null },
+             };
+
+            var environment = new TestEnvironment(settings);
+            var loggerProvider = new TestLoggerProvider();
+
+            var builder = Program.CreateWebHostBuilder()
+                .ConfigureLogging(b =>
+                {
+                    b.AddProvider(loggerProvider);
+                })
+                .ConfigureAppConfiguration(c =>
+                {
+                    c.AddInMemoryCollection(new Dictionary<string, string>
+                    {
+                        { scriptRootConfigPath, specializedScriptRoot }
+                    });
+                })
+                .ConfigureServices((bc, s) =>
+                {
+                    s.AddSingleton<IEnvironment>(environment);
+
+                    // Simulate the environment becoming specialized after these options have been 
+                    // initialized with standby paths.
+                    s.AddOptions<ScriptApplicationHostOptions>()
+                        .PostConfigure<IEnvironment>((o, e) =>
+                        {
+                            Specialize(e);
+                        });
+                })
+                .AddScriptHostBuilder(webJobsBuilder =>
+                {
+                    webJobsBuilder.Services.PostConfigure<ScriptJobHostOptions>(o =>
+                    {
+                        // Only load the function we care about, but not during standby
+                        if (o.RootScriptPath != standbyPath)
+                        {
+                            o.Functions = new[]
+                            {
+                                "HttpTrigger-Dynamic"
+                            };
+                        }
+                    });
+                });
+
+            var server = new TestServer(builder);
+            var client = server.CreateClient();
+
+            // Force the specialization middleware to run       
+            HttpResponseMessage response = await InvokeFunction(client);
+            response.EnsureSuccessStatusCode();
+
+            string log = loggerProvider.GetLog();
+            Assert.Contains("Creating StandbyMode placeholder function directory", log);
+            Assert.Contains("Starting host specialization", log);
+
+            // Make sure this was registered.
+            var hostedServices = server.Host.Services.GetServices<IHostedService>();
+            Assert.Contains(hostedServices, p => p is StandbyInitializationService);
+        }
+
+        private static void Specialize(IEnvironment environment)
+        {
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
+            environment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName, "dotnet");
+        }
+
+        private static async Task<HttpResponseMessage> InvokeFunction(HttpClient client)
+        {
+            var input = new JObject
+            {
+                { "name", "he" },
+                { "location", "here" }
+            };
+            HttpRequestMessage request = new HttpRequestMessage
+            {
+                RequestUri = new Uri("http://localhost/api/httptrigger-dynamic"),
+                Method = HttpMethod.Post,
+                Content = new StringContent(input.ToString())
+            };
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/plain"));
+            request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+            return await client.SendAsync(request);
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Configuration/ScriptApplicationHostOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ScriptApplicationHostOptionsSetupTests.cs
@@ -1,13 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -19,12 +16,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         [Fact]
         public void Configure_InStandbyMode_ReturnsExpectedConfiguration()
         {
-            var settings = new Dictionary<string, string>
-            {
-                { EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1" }
-            };
-
-            ScriptApplicationHostOptionsSetup setup = CreateSetupWithConfiguration(new TestEnvironment(settings));
+            ScriptApplicationHostOptionsSetup setup = CreateSetupWithConfiguration(true);
 
             var options = new ScriptApplicationHostOptions();
             setup.Configure(options);
@@ -35,14 +27,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             Assert.False(options.IsSelfHost);
         }
 
-        private ScriptApplicationHostOptionsSetup CreateSetupWithConfiguration(IEnvironment environment = null)
+        private ScriptApplicationHostOptionsSetup CreateSetupWithConfiguration(bool inStandbyMode)
         {
             var builder = new ConfigurationBuilder();
-            environment = environment ?? SystemEnvironment.Instance;
-
             var configuration = builder.Build();
 
-            return new ScriptApplicationHostOptionsSetup(configuration, environment);
+            var standbyOptions = new TestOptionsMonitor<StandbyOptions>(new StandbyOptions { InStandbyMode = inStandbyMode });
+            var mockCache = new Mock<IOptionsMonitorCache<ScriptApplicationHostOptions>>();
+
+            return new ScriptApplicationHostOptionsSetup(configuration, standbyOptions, mockCache.Object);
         }
     }
 }


### PR DESCRIPTION
Targeted fix for #4355.

Rather than reading from env vars everywhere, which can change during initialization, I've cached them in the options. This way all services will think they're in standby mode and we won't hit partial initialization. 