### PR TITLE
Parse JToken correctly for empty and null string in host.json

### DIFF
--- a/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
                     case JTokenType.Bytes:
                     case JTokenType.TimeSpan:
                         string key = ConfigurationSectionNames.JobHost + ConfigurationPath.KeyDelimiter + ConfigurationPath.Combine(_path.Reverse());
-                        Data[key] = token.Value<string>().ToString(CultureInfo.InvariantCulture);
+                        Data[key] = token.Value<string>()?.ToString(CultureInfo.InvariantCulture);
                         break;
                     default:
                         break;

--- a/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
                     case JTokenType.Bytes:
                     case JTokenType.TimeSpan:
                         string key = ConfigurationSectionNames.JobHost + ConfigurationPath.KeyDelimiter + ConfigurationPath.Combine(_path.Reverse());
-                        Data[key] = token.Value<JValue>().ToString(CultureInfo.InvariantCulture);
+                        Data[key] = token.Value<string>().ToString(CultureInfo.InvariantCulture);
                         break;
                     default:
                         break;

--- a/test/WebJobs.Script.Tests/Configuration/HostJsonFileConfigurationSourceTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/HostJsonFileConfigurationSourceTests.cs
@@ -146,6 +146,35 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             Assert.Equal($"Host configuration file read:{Environment.NewLine}{hostJson}", logMessage);
         }
 
+        [Fact]
+        public void Parse_Json_Token_For_NullOrEmptyString()
+        {
+            //  Invalid empty string as value
+            string hostJsonContent = @"
+            {
+                'version': '2.0',
+                'functionTimeout': ''
+            }";
+
+            File.WriteAllText(_hostJsonFile, hostJsonContent);
+            Assert.True(File.Exists(_hostJsonFile));
+
+            var config = BuildHostJsonConfiguration();
+            Assert.Equal(config["AzureFunctionsJobHost:functionTimeout"], string.Empty);
+
+            // Valid null as value
+            hostJsonContent = @"
+            {
+                'version': '2.0',
+                'functionTimeout': null
+            }";
+
+            File.WriteAllText(_hostJsonFile, hostJsonContent);
+            Assert.True(File.Exists(_hostJsonFile));
+            config = BuildHostJsonConfiguration();
+            Assert.Equal(config["AzureFunctionsJobHost:functionTimeout"], null);
+        }
+
         private IConfiguration BuildHostJsonConfiguration(IEnvironment environment = null)
         {
             environment = environment ?? new TestEnvironment();


### PR DESCRIPTION
When host.json has setting as "functionTimeout": null, it is translated to empty string as value. Fixing this.
Fixes #4332