### PR TITLE
[ExtensionsMetadataGenerator] fixing infinite recursion bug; logging improvements

### DIFF
--- a/tools/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.sln
+++ b/tools/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.352
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExtensionsMetadataGenerator", "src\ExtensionsMetadataGenerator\ExtensionsMetadataGenerator.csproj", "{18D4920B-5C4B-4519-81A5-F4A3B17B81FB}"
 EndProject
@@ -18,6 +18,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{A829A3BC
 		build\metadatagenerator.props = build\metadatagenerator.props
 		..\..\build\package.props = ..\..\build\package.props
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestProject_Razor", "test\TestProject_Razor\TestProject_Razor.csproj", "{98D17B38-4716-4381-9DD3-91DA17EB427B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -45,6 +47,10 @@ Global
 		{A93B2389-BC00-4DC2-A37B-C8A9EA4C83DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A93B2389-BC00-4DC2-A37B-C8A9EA4C83DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A93B2389-BC00-4DC2-A37B-C8A9EA4C83DB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{98D17B38-4716-4381-9DD3-91DA17EB427B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{98D17B38-4716-4381-9DD3-91DA17EB427B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{98D17B38-4716-4381-9DD3-91DA17EB427B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{98D17B38-4716-4381-9DD3-91DA17EB427B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/ConsoleLogger.cs
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/ConsoleLogger.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace ExtensionsMetadataGenerator
+{
+    /// <summary>
+    ///  A simple logger.
+    /// </summary>
+    public class ConsoleLogger
+    {
+        private const int SpacesPerIndent = 2;
+        private int _indent = 0;
+
+        public IDisposable Indent()
+        {
+            return new IndentDisposable(this);
+        }
+
+        private void PushIndent()
+        {
+            _indent++;
+        }
+
+        private void PopIndent()
+        {
+            if (--_indent < 0)
+            {
+                _indent = 0;
+            }
+        }
+
+        public void LogMessage(string message)
+        {
+            System.Console.WriteLine(Indent(message));
+        }
+
+        public void LogError(string message)
+        {
+            System.Console.Error.WriteLine(Indent(message));
+        }
+
+        private string Indent(string message)
+        {
+            return message.PadLeft(message.Length + (_indent * SpacesPerIndent));
+        }
+
+        private class IndentDisposable : IDisposable
+        {
+            private readonly ConsoleLogger _logger;
+
+            public IndentDisposable(ConsoleLogger logger)
+            {
+                _logger = logger;
+                _logger.PushIndent();
+            }
+
+            public void Dispose()
+            {
+                _logger.PopIndent();
+            }
+        }
+    }
+}

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/ExtensionsMetadataGenerator.cs
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/ExtensionsMetadataGenerator.cs
@@ -52,9 +52,16 @@ namespace ExtensionsMetadataGenerator
                                 logger.LogMessage($"Found extension: {foundRef.TypeName}");
                             }
                         }
-                        catch (Exception exc)
+                        catch (FileNotFoundException ex)
                         {
-                            logger.LogError($"Could not evaluate '{Path.GetFileName(path)}' for extension metadata. If this assembly contains a Functions extension, ensure that all dependent assemblies exist in '{sourcePath}'. If this assembly does not contain any Functions extensions, this message can be ignored. Exception message: {exc.Message}");
+                            // Don't log this as an error. This will almost always happen due to some publishing artifacts (i.e. Razor) existing
+                            // in the functions bin folder without all of their dependencies present. These will almost never have Functions extensions,
+                            // so we don't want to write out errors every time there is a build. This message can be seen with detailed logging enabled.
+                            logger.LogMessage($"Could not evaluate '{Path.GetFileName(path)}' for extension metadata. If this assembly contains a Functions extension, ensure that all dependent assemblies exist in '{sourcePath}'. If this assembly does not contain any Functions extensions, this message can be ignored. Exception message: {ex.Message}");
+                        }
+                        catch (Exception ex)
+                        {
+                            logger.LogError($"Could not evaluate '{Path.GetFileName(path)}' for extension metadata. Exception message: {ex.Message}");
                         }
                     }
                 }

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/Program.cs
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/Program.cs
@@ -11,76 +11,85 @@ namespace ExtensionsMetadataGenerator.Console
 {
     public class Program
     {
+        private static readonly Assembly _thisAssembly = typeof(Program).Assembly;
+
         public static void Main(string[] args)
         {
+            if (args.Length < 2)
+            {
+                System.Console.WriteLine("Usage: ");
+                System.Console.WriteLine("metadatagen <sourcepath> <output>");
+
+                return;
+            }
+
+            ConsoleLogger logger = new ConsoleLogger();
+            string sourcePath = args[0];
+
             try
             {
-                if (args.Length < 2)
-                {
-                    System.Console.WriteLine("Usage: ");
-                    System.Console.WriteLine("metadatagen <sourcepath> <output>");
-
-                    return;
-                }
-
-                string sourcePath = args[0];
-                AssemblyLoader.Initialize(sourcePath, Log);
-                ExtensionsMetadataGenerator.Generate(sourcePath, args[1], Log);
+                AssemblyLoader.Initialize(sourcePath, logger);
+                ExtensionsMetadataGenerator.Generate(sourcePath, args[1], logger);
             }
             catch (Exception ex)
             {
-                Log("Error generating extension metadata: " + ex.ToString());
+                logger.LogError("Error generating extension metadata: " + ex.ToString());
                 throw;
             }
-        }
-
-        private static void Log(string message)
-        {
-            System.Console.Error.Write(message);
         }
 
         private class AssemblyLoader
         {
             private static int _initialized;
 
-            public static void Initialize(string basePath, Action<string> logger)
+            public static void Initialize(string basePath, ConsoleLogger logger)
             {
                 if (Interlocked.CompareExchange(ref _initialized, 1, 0) == 0)
                 {
                     AppDomain.CurrentDomain.AssemblyResolve += (sender, args) =>
                     {
+                        logger.LogMessage($"Resolving assembly: '{args.Name}'");
+
                         try
                         {
                             string assemblyName = new AssemblyName(args.Name).Name;
                             string assemblyPath = Path.Combine(basePath, assemblyName + ".dll");
 
+                            // This indicates a recursive lookup. Abort here to prevent stack overflow.
+                            if (args.RequestingAssembly == _thisAssembly)
+                            {
+                                logger.LogMessage($"Cannot load '{assemblyName}'. Aborting assembly resolution.");
+                                return null;
+                            }
+
                             if (File.Exists(assemblyPath))
                             {
-                                var assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
+                                Assembly assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
+                                logger.LogMessage($"Assembly '{assemblyName}' loaded from '{assemblyPath}'.");
                                 return assembly;
                             }
 
-                            // If the assembly file is not found, it may be a runtime assembly for a different
-                            // runtime version (i.e. the Function app assembly targets .NET Core 2.2, yet this
-                            // process is running 2.0). In that case, just try to return the currently-loaded assembly,
-                            // even if it's the wrong version; we won't be running it, just reflecting.
                             try
                             {
-                                var assembly = Assembly.Load(assemblyName);
+                                // If the assembly file is not found, it may be a runtime assembly for a different
+                                // runtime version (i.e. the Function app assembly targets .NET Core 2.2, yet this
+                                // process is running 2.0). In that case, just try to return the currently-loaded assembly,
+                                // even if it's the wrong version; we won't be running it, just reflecting.
+                                Assembly assembly = Assembly.Load(assemblyName);
+                                logger.LogMessage($"Assembly '{assemblyName}' loaded.");
                                 return assembly;
                             }
-                            catch (Exception exc)
+                            catch (Exception ex)
                             {
-                                // Log and continue. This will likely fail as the assembly won't be found, but we have a clear
-                                // message now that can help us diagnose.
-                                logger($"Unable to find fallback for assmebly `{assemblyName}`. {exc.GetType().Name} {exc.Message}");
+                                // We'll already log an error if this happens; this gives a little more details if debug is enabled.
+                                logger.LogMessage($"Unable to find fallback for assembly '{assemblyName}'. {ex}");
                             }
 
                             return null;
                         }
                         catch (Exception ex)
                         {
-                            logger($"Error resolving assembly '{args.Name}': {ex}");
+                            logger.LogError($"Error resolving assembly '{args.Name}': {ex}");
                             throw;
                         }
                     };

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/BuildTasks/GenerateFunctionsExtensionsMetadata.cs
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/BuildTasks/GenerateFunctionsExtensionsMetadata.cs
@@ -68,7 +68,9 @@ namespace ExtensionsMetadataGenerator.BuildTasks
                 {
                     if (e.Data != null)
                     {
-                        outputString.Append(e.Data);
+                        // These debug logs will only appear in builds with detailed or higher verbosity.
+                        Log.LogMessage(MessageImportance.Low, e.Data);
+                        outputString.AppendLine(e.Data);
                     }
                 };
 
@@ -79,7 +81,10 @@ namespace ExtensionsMetadataGenerator.BuildTasks
 
                 if (process.ExitCode != 0)
                 {
-                    Log.LogError($"Metadata generation failed. Exit code: '{process.ExitCode}' Output: '{outputString.ToString()}' Error: '{errorString.ToString()}'");
+                    // Dump any debug output if there is an error. This may have been hidden due to the msbuild verbosity level.
+                    Log.LogMessage(MessageImportance.High, "Debug output from extension.json generator:");
+                    Log.LogMessage(MessageImportance.High, outputString.ToString());
+                    Log.LogError($"Metadata generation failed. Exit code: '{process.ExitCode}' Error: '{errorString.ToString()}'");
                     return false;
                 }
 

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.csproj
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\metadatagenerator.props" />
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <AssemblyName>Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator</AssemblyName>

--- a/tools/ExtensionsMetadataGenerator/test/ExtensionsMetadataGeneratorTests/ExtensionsMetadataGeneratorTests.csproj
+++ b/tools/ExtensionsMetadataGenerator/test/ExtensionsMetadataGeneratorTests/ExtensionsMetadataGeneratorTests.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\..\src\ExtensionsMetadataGenerator.Console\ExtensionsMetadataGenerator.Console.csproj" />
     <ProjectReference Include="..\TestProject_Core21\TestProject_Core21.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" OutputItemType="Content" CopyToOutputDirectory="PreserveNewest" />
     <ProjectReference Include="..\TestProject_Core22\TestProject_Core22.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" OutputItemType="Content" CopyToOutputDirectory="PreserveNewest" />
+    <ProjectReference Include="..\TestProject_Razor\TestProject_Razor.csproj" ReferenceOutputAssembly="false" SkipGetTargetFrameworkProperties="true" OutputItemType="Content" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/ExtensionsMetadataGenerator/test/TestProject_Razor/AssemblyAttribute.cs
+++ b/tools/ExtensionsMetadataGenerator/test/TestProject_Razor/AssemblyAttribute.cs
@@ -1,0 +1,3 @@
+﻿// This attribute will not be resolve-able because the Razor.Runtime assembly will not be
+// present in the output directory. This is used by tests to ensure we don't crash.
+[assembly: Microsoft.AspNetCore.Razor.Hosting.RazorExtensionAssemblyName("something", "something")]

--- a/tools/ExtensionsMetadataGenerator/test/TestProject_Razor/TestProject_Razor.csproj
+++ b/tools/ExtensionsMetadataGenerator/test/TestProject_Razor/TestProject_Razor.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.2.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes #4055.

With the help of several customers, I found one scenario where we hit infinite recursion and end up with a StackOverflowException. I was able to repro this by creating an empty AspNetCore MVC app in my solution and publishing it with something like `dotnet publish ..\FunctionApp55.sln -o e:\publish`. This put the Web app assembly in the Function bin directory, which means we'd scan it. 

The culprit seems to be a dependency on `Microsoft.AspNetCore.Razor.Runtime`, which does not get deployed along with the Web application. When we can't find it, we attempt an `Assembly.Load(<assembly name without version>)` to hopefully find it already loaded (this works with some core assemblies that have version mismatches but are still load-able). In this case, that initiates a recursion where we keep trying to load that assembly forever. 

Now, if I see that a load request was initiated by the generator assembly itself, I abort the load and log a message that this assembly cannot be scanned for extensions (which I'm assuming 99+% of the time is perfectly fine).

I've also added a *ton* more logging here. This should help us diagnose issues in the future. In the normal build process you won't see it, but if you either hit a process crash or enable detailed+ msbuild verbosity, they'll show up and will make debugging things like this a ton easier.

As an example, here's some relevant details in my build output when I run against my repro:

`dotnet publish ..\FunctionApp55.sln -o e:\publish -v:d`

```
         Found 58 assemblies to evaluate in 'e:\publish\bin':
           FunctionApp55.dll
             Resolving assembly: 'Microsoft.Azure.WebJobs.Host, Version=3.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
             Assembly 'Microsoft.Azure.WebJobs.Host' loaded from 'e:\publish\bin\Microsoft.Azure.WebJobs.Host.dll'.
             Found extension: MyFunctionApp55.Startup, FunctionApp55, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
           Microsoft.ApplicationInsights.dll
           Microsoft.AspNetCore.Authentication.Abstractions.dll

           ...snip...

           Microsoft.Azure.WebJobs.Extensions.CosmosDB.dll
             Found extension: Microsoft.Azure.WebJobs.Extensions.CosmosDB.CosmosDBWebJobsStartup, Microsoft.Azure.WebJobs.Extensions.CosmosDB, Version=3.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35
           Microsoft.Azure.WebJobs.Host.dll

           ..snip..

           Newtonsoft.Json.dll
           WebApplication18.dll
             Resolving assembly: 'Microsoft.AspNetCore.Mvc.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'
             Assembly 'Microsoft.AspNetCore.Mvc.Core' loaded from 'e:\publish\bin\Microsoft.AspNetCore.Mvc.Core.dll'.
             Resolving assembly: 'Microsoft.AspNetCore.Razor.Runtime, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'
             Resolving assembly: 'Microsoft.AspNetCore.Razor.Runtime, Culture=neutral, PublicKeyToken=null'
             Cannot load 'Microsoft.AspNetCore.Razor.Runtime'. Aborting assembly resolution.
             Unable to find fallback for assembly 'Microsoft.AspNetCore.Razor.Runtime'. System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.AspNetCore.Razor.Runtime, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified.
         File name: 'Microsoft.AspNetCore.Razor.Runtime, Culture=neutral, PublicKeyToken=null'
            at System.Reflection.RuntimeAssembly.nLoad(AssemblyName fileName, String codeBase, RuntimeAssembly locationHint, StackCrawlMark& stackMark, IntPtr pPrivHostBinder, Boolean throwOnFileNotFound, IntPtr ptrLoadContextBinder)
            at System.Reflection.RuntimeAssembly.InternalLoadAssemblyName(AssemblyName assemblyRef, RuntimeAssembly reqAssembly, StackCrawlMark& stackMark, IntPtr pPrivHostBinder, Boolean throwOnFileNotFound, IntPtr ptrLoadContextBinder)
            at System.Reflection.RuntimeAssembly.InternalLoad(String assemblyString, StackCrawlMark& stackMark, IntPtr pPrivHostBinder)
            at System.Reflection.RuntimeAssembly.InternalLoad(String assemblyString, StackCrawlMark& stackMark)
            at System.Reflection.Assembly.Load(String assemblyString)
            at ExtensionsMetadataGenerator.Console.Program.AssemblyLoader.<>c__DisplayClass1_0.<Initialize>b__0(Object sender, ResolveEventArgs args) in C:\git\functions_v2\azure-functions-host\tools\ExtensionsMetadataGenerator\src\ExtensionsMetadataGenerator.Console\Program.cs:line 78

           WebApplication18.Views.dll
             Resolving assembly: 'Microsoft.AspNetCore.Razor.Runtime, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'
             Resolving assembly: 'Microsoft.AspNetCore.Razor.Runtime, Culture=neutral, PublicKeyToken=null'
             Cannot load 'Microsoft.AspNetCore.Razor.Runtime'. Aborting assembly resolution.
             Unable to find fallback for assembly 'Microsoft.AspNetCore.Razor.Runtime'. System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.AspNetCore.Razor.Runtime, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified.
         File name: 'Microsoft.AspNetCore.Razor.Runtime, Culture=neutral, PublicKeyToken=null'
            at System.Reflection.RuntimeAssembly.nLoad(AssemblyName fileName, String codeBase, RuntimeAssembly locationHint, StackCrawlMark& stackMark, IntPtr pPrivHostBinder, Boolean throwOnFileNotFound, IntPtr ptrLoadContextBinder)
            at System.Reflection.RuntimeAssembly.InternalLoadAssemblyName(AssemblyName assemblyRef, RuntimeAssembly reqAssembly, StackCrawlMark& stackMark, IntPtr pPrivHostBinder, Boolean throwOnFileNotFound, IntPtr ptrLoadContextBinder)
            at System.Reflection.RuntimeAssembly.InternalLoad(String assemblyString, StackCrawlMark& stackMark, IntPtr pPrivHostBinder)
            at System.Reflection.RuntimeAssembly.InternalLoad(String assemblyString, StackCrawlMark& stackMark)
            at System.Reflection.Assembly.Load(String assemblyString)
            at ExtensionsMetadataGenerator.Console.Program.AssemblyLoader.<>c__DisplayClass1_0.<Initialize>b__0(Object sender, ResolveEventArgs args) in C:\git\functions_v2\azure-functions-host\tools\ExtensionsMetadataGenerator\src\ExtensionsMetadataGenerator.Console\Program.cs:line 78

         'e:\publish\bin\extensions.json' successfully written.
```
