### PR TITLE
rev powershell version to 0.1.102-preview

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.8100001-0126c21e" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.4.1" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.97-preview" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.102-preview" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.8" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2" />


### PR DESCRIPTION
The major changes for this release are:

* Fix regression that made local debugging stop working. This was because a runspace was not created at startup.
* Rev gRPC library versions
* Fix regression where Rpc.RawBody was getting passed in as a hashtable instead of a string