### PR TITLE
[ExtensionsMetadataGenerator] allowing for direct references to newer versions

### DIFF
--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.props
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.props
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <_ExtensionsMetadataGeneratorPropsImported>true</_ExtensionsMetadataGeneratorPropsImported>
   </PropertyGroup>
   
 </Project>

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets
@@ -4,27 +4,40 @@
     <_FunctionsExtensionsTaskFramework Condition=" '$(MSBuildRuntimeType)' == 'Core'">netstandard2.0</_FunctionsExtensionsTaskFramework>
     <_FunctionsExtensionsTaskFramework Condition=" '$(_FunctionsExtensionsTaskFramework)' == ''">net46</_FunctionsExtensionsTaskFramework>
     <_FunctionsExtensionsTasksDir Condition=" '$(_FunctionsExtensionsTasksDir)'=='' ">$(MSBuildThisFileDirectory)..\tools\$(_FunctionsExtensionsTaskFramework)</_FunctionsExtensionsTasksDir>
-    <_FunctionsExtensionsTaskAssemblyFullPath Condition=" '$(_FunctionsExtensionsTaskAssemblyFullPath)'=='' ">$(_FunctionsExtensionsTasksDir)\Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.dll</_FunctionsExtensionsTaskAssemblyFullPath>
-    <IsPackable>false</IsPackable>
-    <_IsFunctionsSdkBuild Condition="$(_FunctionsTaskFramework) != ''">true</_IsFunctionsSdkBuild>
+    <_FunctionsExtensionsTaskAssemblyFullPath Condition=" '$(_FunctionsExtensionsTaskAssemblyFullPath)'=='' ">$(_FunctionsExtensionsTasksDir)\Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.dll</_FunctionsExtensionsTaskAssemblyFullPath>    
     <_FunctionsExtensionsDir>$(TargetDir)</_FunctionsExtensionsDir>
-    <_FunctionsExtensionsDir Condition="$(_IsFunctionsSdkBuild) == 'true'">$(_FunctionsExtensionsDir)bin</_FunctionsExtensionsDir>
+    <_ExtensionsMetadataGeneratorTargetsImported>true</_ExtensionsMetadataGeneratorTargetsImported>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
+  
+  <!--
+    These properties must be overwritten in a Target because they depend on the
+    Microsoft.NET.Sdk.Functions.targets properties being evaluated first. This cannot
+    be guaranteed if a direct reference is added to the ExtensionsMetadataGenerator
+    package. Running this after _InitializeFunctionsSdk (which exists in the Microsoft.Net.Sdk.Functions
+    package) ensures that properties from that file are already evaluated.
+  -->
+  <Target Name="_InitializeExtensionMetadataGeneratorProps" AfterTargets="_InitializeFunctionsSdk">
+    <PropertyGroup>
+      <_IsFunctionsSdkBuild Condition="$(_FunctionsTaskFramework) != ''">true</_IsFunctionsSdkBuild>
+      <_FunctionsExtensionsDir Condition="$(_IsFunctionsSdkBuild) == 'true'">$(_FunctionsExtensionsDir)bin</_FunctionsExtensionsDir>
+    </PropertyGroup>
+  </Target>
 
   <UsingTask TaskName="GenerateFunctionsExtensionsMetadata"
              AssemblyFile="$(_FunctionsExtensionsTaskAssemblyFullPath)"/>
 
   <Target Name="_GenerateFunctionsExtensionsMetadataPostBuild"
           AfterTargets="Build">
-    
+
     <GenerateFunctionsExtensionsMetadata
       SourcePath="$(_FunctionsExtensionsDir)"
       OutputPath="$(_FunctionsExtensionsDir)"/>
-    
-    <Move Condition="$(_IsFunctionsSdkBuild) == 'true' AND Exists('$(TargetDir)extensions.json')" 
+
+    <Move Condition="$(_IsFunctionsSdkBuild) == 'true' AND Exists('$(TargetDir)extensions.json')"
           SourceFiles="$(TargetDir)extensions.json"
           DestinationFiles="$(TargetDir)bin\extensions.json"
-          OverwriteReadOnlyFiles="true" 
+          OverwriteReadOnlyFiles="true"
           ContinueOnError="true"/>
   </Target>
 


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-vs-build-sdk/issues/277.

In conjunction with https://github.com/Azure/azure-functions-vs-build-sdk/pull/310.

Allows for direct references to a newer version of this package:
- Properties in the props/targets files allow us to detect if we've already imported these files. If so, we can skip.
- Moving the property evaluation to a Target allows for the ordering to work as expected. MSBuild/Nuget will automatically import the targets file *before* the Sdk's targets file, which means some things weren't evaluating correctly. With it inside the Targets, we know that all of those properties have already been evaluated.