### PR TITLE
Fixing the false positive case for bundle not present

### DIFF
--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -110,6 +110,10 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
                             _logger.LogInformation(Resources.ExtensionBundleFound, bundlePath);
                             break;
                         }
+                        else
+                        {
+                            bundlePath = null;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Found this to be a root cause of a number of cases, where 

`C:\Users\<user>\AppData\Local\Temp\Functions\ExtensionBundles\Microsoft.Azure.Functions.ExtensionBundle\1.0.0` would be present but empty. The runtime would think that the bundle is present over there and would not trigger a download.

related issue
https://github.com/Azure/azure-functions-powershell-worker/issues/212
