### PR TITLE
preventing disposed host from returning its services to requests

### DIFF
--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -94,10 +94,13 @@ namespace Microsoft.Azure.WebJobs.Script
         /// of 2, 4, 8, 16, etc. seconds.</param>
         /// <param name="min">The minimum delay.</param>
         /// <param name="max">The maximum delay.</param>
+        /// <param name="logger">An optional logger that will emit the delay.</param>
         /// <returns>A <see cref="Task"/> representing the computed backoff interval.</returns>
-        public static async Task DelayWithBackoffAsync(int exponent, CancellationToken cancellationToken, TimeSpan? unit = null, TimeSpan? min = null, TimeSpan? max = null)
+        public static async Task DelayWithBackoffAsync(int exponent, CancellationToken cancellationToken, TimeSpan? unit = null,
+            TimeSpan? min = null, TimeSpan? max = null, ILogger logger = null)
         {
             TimeSpan delay = ComputeBackoff(exponent, unit, min, max);
+            logger?.LogDebug($"Delay is '{delay}'.");
 
             if (delay.TotalMilliseconds > 0)
             {


### PR DESCRIPTION
Fixes #4406.

This bug has been around forever; timing may be exposing it now more than before. In short, if a JobHost threw an exception during `StartAsync()`, we start a task to dispose it, then start a task to create a new host. If that second task takes a while to occur (due to backoff or some CPU scheduling on the machine), there's a period of time where we could return a disposed set of Services to any request that asked for them. 

I've updated this to now set `_host` to null before we call Orphan in two places. Also added logging to hopefully help catch more timing issues like this in the future.