### PR TITLE
MSI support for Linux consumption

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
@@ -43,6 +43,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                 return StatusCode(StatusCodes.Status400BadRequest, error);
             }
 
+            // Wait for Sidecar specialization to complete before returning ok.
+            // This shouldn't take too long so ok to do this sequentially.
+            error = await _instanceManager.SpecializeMSISidecar(assignmentContext);
+            if (error != null)
+            {
+                return StatusCode(StatusCodes.Status500InternalServerError, error);
+            }
+
             var result = _instanceManager.StartAssignment(assignmentContext);
 
             return result

--- a/src/WebJobs.Script.WebHost/Management/IInstanceManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/IInstanceManager.cs
@@ -14,5 +14,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         Task<string> ValidateContext(HostAssignmentContext assignmentContext);
 
         bool StartAssignment(HostAssignmentContext assignmentContext);
+
+        Task<string> SpecializeMSISidecar(HostAssignmentContext assignmentContext);
     }
 }

--- a/src/WebJobs.Script.WebHost/Models/HostAssignmentContext.cs
+++ b/src/WebJobs.Script.WebHost/Models/HostAssignmentContext.cs
@@ -21,6 +21,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
         [JsonProperty("lastModifiedTime")]
         public DateTime LastModifiedTime { get; set; }
 
+        [JsonProperty("MSISpecializationPayload")]
+        public MSIContext MSIContext { get; set; }
+
         public string ZipUrl
         {
             get
@@ -42,6 +45,21 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
                     return string.Empty;
                 }
             }
+        }
+
+        public bool IsMSIEnabled(out string endpoint)
+        {
+            endpoint = null;
+            if (Environment.TryGetValue(EnvironmentSettingNames.MsiEndpoint, out endpoint))
+            {
+                string secret;
+                if (Environment.TryGetValue(EnvironmentSettingNames.MsiSecret, out secret))
+                {
+                    return !string.IsNullOrEmpty(endpoint) && !string.IsNullOrEmpty(secret);
+                }
+            }
+
+            return false;
         }
 
         public bool Equals(HostAssignmentContext other)

--- a/src/WebJobs.Script.WebHost/Models/MSIContext.cs
+++ b/src/WebJobs.Script.WebHost/Models/MSIContext.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
+{
+    public class MSIContext
+    {
+        public string MSISecret { get; set; }
+
+        public IEnumerable<ManagedServiceIdentity> Identities { get; set; }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Models/ManagedServiceIdentity.cs
+++ b/src/WebJobs.Script.WebHost/Models/ManagedServiceIdentity.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
+{
+    public class ManagedServiceIdentity
+    {
+        public ManagedServiceIdentityType Type { get; set; }
+
+        public string ClientId { get; set; }
+
+        public string TenantId { get; set; }
+
+        public string Thumbprint { get; set; }
+
+        public string SecretUrl { get; set; }
+
+        public string ResourceId { get; set; }
+
+        public string Certificate { get; set; }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Models/ManagedServiceIdentityType.cs
+++ b/src/WebJobs.Script.WebHost/Models/ManagedServiceIdentityType.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
+{
+    [Flags]
+    public enum ManagedServiceIdentityType
+    {
+        [EnumMember]
+        None = 0,
+        [EnumMember]
+        SystemAssigned = 1,
+        [EnumMember]
+        UserAssigned = 2
+    }
+}

--- a/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
@@ -44,5 +44,6 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
         public const string LinuxContainerSpecializationZipWrite = "linux.container.specialization.zip.write";
         public const string LinuxContainerSpecializationZipHead = "linux.container.specialization.zip.head";
         public const string LinuxContainerSpecializationFuseMount = "linux.container.specialization.zip.mount";
+        public const string LinuxContainerSpecializationMSIInit = "linux.container.specialization.msi.init";
     }
 }

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -36,6 +36,8 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AzureWebJobsSecretStorageKeyVaultConnectionString = "AzureWebJobsSecretStorageKeyVaultConnectionString";
         public const string AzureWebsiteArmCacheEnabled = "WEBSITE_FUNCTIONS_ARMCACHE_ENABLED";
         public const string MountEnabled = "WEBSITE_MOUNT_ENABLED";
+        public const string MsiEndpoint = "MSI_ENDPOINT";
+        public const string MsiSecret = "MSI_SECRET";
 
         /// <summary>
         /// Environment variable dynamically set by the platform when it is safe to

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -117,6 +117,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string LinuxLogEventStreamName = "MS_FUNCTION_LOGS";
         public const string LinuxMetricEventStreamName = "MS_FUNCTION_METRICS";
         public const string LinuxFunctionDetailsEventStreamName = "MS_FUNCTION_DETAILS";
+        public const string LinuxMSISpecializationStem = "/api/specialize?api-version=2017-09-01";
 
         public const string DurableTaskPropertyName = "durableTask";
         public const string DurableTaskHubName = "HubName";

--- a/test/WebJobs.Script.Tests.Integration/Management/HostAssignmentContextTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/HostAssignmentContextTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
+{
+    public class HostAssignmentContextTests
+    {
+        [Theory]
+        [InlineData(null, null, false)]
+        [InlineData("", "", false)]
+        [InlineData("secret", "", false)]
+        [InlineData("", "endpoint", false)]
+        [InlineData("secret", "endpoint", true)]
+        public void IsMSIEnabled_ReturnsMSIEndpointAndMSIStatus(string msiSecret, string msiEndpoint, bool expectedMsiEnabled)
+        {
+            var hostAssignmentContext = new HostAssignmentContext();
+            hostAssignmentContext.Environment = new Dictionary<string, string>();
+            hostAssignmentContext.Environment[EnvironmentSettingNames.MsiSecret] = msiSecret;
+            hostAssignmentContext.Environment[EnvironmentSettingNames.MsiEndpoint] = msiEndpoint;
+
+            string actualMsiEndpoint;
+            var actualMsiEnabled = hostAssignmentContext.IsMSIEnabled(out actualMsiEndpoint);
+            Assert.Equal(expectedMsiEnabled, actualMsiEnabled);
+            Assert.Equal(msiEndpoint, actualMsiEndpoint);
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Controllers;
+using Microsoft.Azure.WebJobs.Script.WebHost.Management;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security;
+using Microsoft.Extensions.Logging;
+using Microsoft.WebJobs.Script.Tests;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
+{
+    [Trait(TestTraits.Category, TestTraits.EndToEnd)]
+    [Trait(TestTraits.Group, TestTraits.ContainerInstanceTests)]
+    public class InstanceControllerTests
+    {
+        private readonly TestOptionsFactory<ScriptApplicationHostOptions> _optionsFactory = new TestOptionsFactory<ScriptApplicationHostOptions>(new ScriptApplicationHostOptions());
+
+        [Fact]
+        public async Task Assign_MSISpecializationFailure_ReturnsError()
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
+
+            var scriptWebEnvironment = new ScriptWebHostEnvironment(environment);
+
+            var loggerFactory = new LoggerFactory();
+            var loggerProvider = new TestLoggerProvider();
+            loggerFactory.AddProvider(loggerProvider);
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+            handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.BadRequest
+            });
+
+            var instanceManager = new InstanceManager(_optionsFactory, new HttpClient(handlerMock.Object), scriptWebEnvironment, environment, loggerFactory.CreateLogger<InstanceManager>(), new TestMetricsLogger());
+
+            InstanceManager.Reset();
+
+            var instanceController = new InstanceController(environment, instanceManager);
+
+            const string containerEncryptionKey = "/a/vXvWJ3Hzgx4PFxlDUJJhQm5QVyGiu0NNLFm/ZMMg=";
+            var hostAssignmentContext = new HostAssignmentContext
+            {
+                Environment = new Dictionary<string, string>()
+            };
+
+            hostAssignmentContext.Environment[EnvironmentSettingNames.MsiEndpoint] = "http://localhost:8081";
+            hostAssignmentContext.Environment[EnvironmentSettingNames.MsiSecret] = "secret";
+
+            var encryptedHostAssignmentValue = SimpleWebTokenHelper.Encrypt(JsonConvert.SerializeObject(hostAssignmentContext), containerEncryptionKey.ToKeyBytes());
+
+            var encryptedHostAssignmentContext = new EncryptedHostAssignmentContext()
+            {
+                EncryptedContext = encryptedHostAssignmentValue
+            };
+
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, containerEncryptionKey);
+
+            IActionResult result = await instanceController.Assign(encryptedHostAssignmentContext);
+
+            var objectResult = result as ObjectResult;
+
+            Assert.Equal(objectResult.StatusCode, 500);
+            Assert.Equal(objectResult.Value, "Specialize MSI sidecar call failed. StatusCode=BadRequest");
+        }
+    }
+}


### PR DESCRIPTION
 MSI Token service is implemented as a sidecar which gets specialized when the main container (Functions host) is specialized.
 If MSI is enabled for a site, the specialization payload will include MSI_ENDPOINT and MSI_SECRET which function apps can use to communicate with Token Service.