### PR TITLE
improving SlidingWindow test

### DIFF
--- a/test/WebJobs.Script.Tests/SlidingWindowTests.cs
+++ b/test/WebJobs.Script.Tests/SlidingWindowTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -63,8 +64,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             for (int i = 0; i < 5; i++)
             {
                 window.AddEvent(new MyItem { Data = i });
-                log.AppendLine($"{DateTime.UtcNow}: Added item: {i}");
-                await Task.Delay(100);
+                log.AppendLine($"{DateTime.UtcNow.ToString("HH:mm:ss.FFFZ")}: Added item: {i}");
+                Thread.Sleep(50);
             }
 
             var eventsField = window.GetType().GetField("_events", BindingFlags.Instance | BindingFlags.NonPublic);


### PR DESCRIPTION
This test was failing quite often and I think it's b/c we can get "stuck" in between calls to add, which means one item falls out of the window. The last failure, for example, logged this (they all should be 100ms apart, and these are more than 1 second, which is the window):

```
5/15/2019 8:49:49 PM | Expected 5. Actual 4.
5/15/2019 8:49:47 PM: Added item: 0
5/15/2019 8:49:48 PM: Added item: 1
5/15/2019 8:49:49 PM: Added item: 2
5/15/2019 8:49:49 PM: Added item: 3
5/15/2019 8:49:49 PM: Added item: 4
```