### PR TITLE
Checking explicitly for managedDependencyOptions.Value.Enabled

### DIFF
--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
@@ -356,7 +356,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 }
             };
 
-            if (_managedDependencyOptions?.Value != null)
+            if (_managedDependencyOptions?.Value != null && _managedDependencyOptions.Value.Enabled)
             {
                 _workerChannelLogger?.LogInformation($"Adding dependency download request to {_workerConfig.Language} language worker");
                 request.ManagedDependencyEnabled = _managedDependencyOptions.Value.Enabled;

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
@@ -358,7 +358,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
             if (_managedDependencyOptions?.Value != null && _managedDependencyOptions.Value.Enabled)
             {
-                _workerChannelLogger?.LogInformation($"Adding dependency download request to {_workerConfig.Language} language worker");
+                _workerChannelLogger?.LogDebug($"Adding dependency download request to {_workerConfig.Language} language worker");
                 request.ManagedDependencyEnabled = _managedDependencyOptions.Value.Enabled;
             }
 


### PR DESCRIPTION
Checking explicitly for managedDependencyOptions.Value.Enabled as options set up have Value !=null even when managedDependency section is not present in the host.json

Git issue: https://github.com/Azure/azure-functions-host/issues/4331
