### PR TITLE
Implement a KubernetesSecretsRepository

### DIFF
--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/DefaultSecretManagerProvider.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/DefaultSecretManagerProvider.cs
@@ -66,6 +66,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 string azureWebJobsSecretStorageKeyVaultConnectionString = Environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsSecretStorageKeyVaultConnectionString);
                 return new KeyVaultSecretsRepository(Path.Combine(_options.CurrentValue.SecretsPath, "Sentinels"), azureWebJobsSecretStorageKeyVaultName, azureWebJobsSecretStorageKeyVaultConnectionString);
             }
+            else if (secretStorageType != null && secretStorageType.Equals("kubernetes", StringComparison.OrdinalIgnoreCase))
+            {
+                return new KubernetesSecretsRepository(_environment, new SimpleKubernetesClient(_environment));
+            }
             else if (storageString == null)
             {
                 throw new InvalidOperationException($"Secret initialization from Blob storage failed due to a missing Azure Storage connection string. If you intend to use files for secrets, add an App Setting key '{EnvironmentSettingNames.AzureWebJobsSecretStorageType}' with value '{FileStorage}'.");

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/IKubernetesClient.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/IKubernetesClient.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost
+{
+    public interface IKubernetesClient
+    {
+        bool IsWritable { get; }
+
+        Task<IDictionary<string, string>> GetSecrets();
+
+        Task UpdateSecrets(IDictionary<string, string> data);
+
+        void OnSecretChange(Action callback);
+    }
+}

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/KubernetesSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/KubernetesSecretsRepository.cs
@@ -1,0 +1,216 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Security;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.KeyVault;
+using Microsoft.Azure.KeyVault.Models;
+using Microsoft.Azure.Services.AppAuthentication;
+using Microsoft.Azure.WebJobs.Script.IO;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.Rest.Azure;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost
+{
+    /// <summary>
+    /// An <see cref="ISecretsRepository"/> implementation that uses the key vault as the backing store.
+    /// </summary>
+    public class KubernetesSecretsRepository : ISecretsRepository, IDisposable
+    {
+        // host.master = value
+        private const string MasterKey = "host.master";
+        // host.function.{keyName} = value
+        private const string HostFunctionKeyPrefix = "host.function.";
+        // host.systemKey.{keyName} = value
+        private const string SystemKeyPrefix = "host.systemKey.";
+        // functions.{functionName}.{keyName} = value
+        private const string FunctionKeyPrefix = "functions.";
+        private readonly IEnvironment _environment;
+        private readonly IKubernetesClient _kubernetesClient;
+        private bool _disposed;
+
+        public KubernetesSecretsRepository(IEnvironment environment, IKubernetesClient kubernetesClient)
+        {
+            _environment = environment;
+            _kubernetesClient = kubernetesClient;
+            _kubernetesClient.OnSecretChange(() =>
+            {
+                SecretsChanged?.Invoke(this, new SecretsChangedEventArgs { SecretsType = ScriptSecretsType.Host });
+                SecretsChanged?.Invoke(this, new SecretsChangedEventArgs { SecretsType = ScriptSecretsType.Function });
+            });
+        }
+
+        public event EventHandler<SecretsChangedEventArgs> SecretsChanged;
+
+        public bool IsEncryptionSupported => false;
+
+        public async Task<ScriptSecrets> ReadAsync(ScriptSecretsType type, string functionName)
+        {
+            return type == ScriptSecretsType.Host ? await ReadHostSecrets() : await ReadFunctionSecrets(functionName);
+        }
+
+        public async Task WriteAsync(ScriptSecretsType type, string functionName, ScriptSecrets secrets)
+        {
+            if (!_kubernetesClient.IsWritable)
+            {
+                throw new InvalidOperationException($"{nameof(KubernetesSecretsRepository)} is readonly when no {EnvironmentSettingNames.AzureWebJobsKubernetesSecretName} is specified.");
+            }
+
+            var newKeys = await Mergekeys(type, functionName, secrets);
+            await _kubernetesClient.UpdateSecrets(newKeys);
+        }
+
+        private async Task<IDictionary<string, string>> Mergekeys(ScriptSecretsType type, string functionName, ScriptSecrets secrets)
+        {
+            var currentKeys = await _kubernetesClient.GetSecrets();
+            var newKeys = new SortedDictionary<string, string>();
+
+            if (type == ScriptSecretsType.Host)
+            {
+                // A host key is changing. Add all existing function keys as is
+                foreach (var key in currentKeys.Where(k => k.Key.StartsWith(FunctionKeyPrefix)))
+                {
+                    newKeys.Add(key.Key, key.Value);
+                }
+
+                var hostSecret = secrets as HostSecrets;
+
+                if (hostSecret?.MasterKey != null)
+                {
+                    newKeys[MasterKey] = hostSecret.MasterKey.Value;
+                }
+
+                if (hostSecret?.FunctionKeys != null)
+                {
+                    foreach (var key in hostSecret.FunctionKeys)
+                    {
+                        newKeys[$"{HostFunctionKeyPrefix}{key.Name}"] = key.Value;
+                    }
+                }
+
+                if (hostSecret?.SystemKeys != null)
+                {
+                    foreach (var key in hostSecret.SystemKeys)
+                    {
+                        newKeys[$"{SystemKeyPrefix}{key.Name}"] = key.Value;
+                    }
+                }
+            }
+            else
+            {
+                // A function key is changing. Add all host and other functions keys
+                foreach (var key in currentKeys.Where(k => !k.Key.StartsWith($"{FunctionKeyPrefix}.{functionName}")))
+                {
+                    newKeys.Add(key.Key, key.Value);
+                }
+
+                var functionSecret = secrets as FunctionSecrets;
+                if (functionSecret?.Keys != null)
+                {
+                    foreach (var key in functionSecret.Keys)
+                    {
+                        newKeys[$"{FunctionKeyPrefix}{functionName}.{key.Name}"] = key.Value;
+                    }
+                }
+            }
+            return newKeys;
+        }
+
+        /// <summary>
+        /// no-op - allow stale secrets to remain
+        /// </summary>
+        public async Task PurgeOldSecretsAsync(IList<string> currentFunctions, ILogger logger)
+            => await Task.Yield();
+
+        /// <summary>
+        /// Runtime is not responsible for encryption so this code will never be executed.
+        /// </summary>
+        public Task WriteSnapshotAsync(ScriptSecretsType type, string functionName, ScriptSecrets secrets)
+            => throw new NotSupportedException();
+
+        /// <summary>
+        /// Runtime is not responsible for encryption so this code will never be executed.
+        /// </summary>
+        public Task<string[]> GetSecretSnapshots(ScriptSecretsType type, string functionName)
+            => throw new NotSupportedException();
+
+        private async Task<ScriptSecrets> ReadHostSecrets()
+        {
+            IDictionary<string, string> secrets = await _kubernetesClient.GetSecrets();
+
+            HostSecrets hostSecrets = new HostSecrets()
+            {
+                FunctionKeys = new List<Key>(),
+                SystemKeys = new List<Key>()
+            };
+
+            foreach (var pair in secrets)
+            {
+                if (pair.Key.StartsWith(MasterKey))
+                {
+                    hostSecrets.MasterKey = new Key("master", pair.Value);
+                }
+                else if (pair.Key.StartsWith(HostFunctionKeyPrefix))
+                {
+                    hostSecrets.FunctionKeys.Add(ParseKeyWithPrefix(HostFunctionKeyPrefix, pair.Key, pair.Value));
+                }
+                else if (pair.Key.StartsWith(SystemKeyPrefix))
+                {
+                    hostSecrets.SystemKeys.Add(ParseKeyWithPrefix(SystemKeyPrefix, pair.Key, pair.Value));
+                }
+            }
+
+            return hostSecrets?.MasterKey == null ? null : hostSecrets;
+        }
+
+        private async Task<ScriptSecrets> ReadFunctionSecrets(string functionName)
+        {
+            IDictionary<string, string> secrets = await _kubernetesClient.GetSecrets();
+            var prefix = $"{FunctionKeyPrefix}{functionName}.";
+
+            var functionSecrets = new FunctionSecrets()
+            {
+                Keys = secrets
+                    .Where(p => p.Key.StartsWith(prefix))
+                    .Select(p => ParseKeyWithPrefix(prefix, p.Key, p.Value))
+                    .ToList()
+            };
+
+            return functionSecrets.Keys.Count == 0 ? null : functionSecrets;
+        }
+
+        private Key ParseKeyWithPrefix(string prefix, string key, string value)
+            => new Key(key.Substring(prefix.Length), value);
+
+        private void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing && _kubernetesClient is IDisposable tmp)
+                {
+                    tmp.Dispose();
+                }
+
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
@@ -530,8 +530,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
             else
             {
-                Dictionary<string, string> secrets;
-                _secretsMap.TryRemove(e.Name, out secrets);
+                if (string.IsNullOrEmpty(e.Name))
+                {
+                    _secretsMap.Clear();
+                }
+                else
+                {
+                    _secretsMap.TryRemove(e.Name, out _);
+                }
             }
         }
 

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SimpleKubernetesClient.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SimpleKubernetesClient.cs
@@ -1,0 +1,315 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.IO;
+using Microsoft.Net.Http.Headers;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost
+{
+    public class SimpleKubernetesClient : IKubernetesClient, IDisposable
+    {
+        private const string NamespaceFile = "/run/secrets/kubernetes.io/serviceaccount/namespace";
+        private const string TokenFile = "/run/secrets/kubernetes.io/serviceaccount/token";
+        private const string CaFile = "/run/secrets/kubernetes.io/serviceaccount/ca.crt";
+        private const string KubernetesSecretsDir = "/run/secrets/functions-keys";
+        private readonly HttpClient _httpClient;
+        private readonly IEnvironment _environment;
+        private Action _watchCallback;
+        private bool _disposed;
+        private AutoRecoveringFileSystemWatcher _fileWatcher;
+
+        public SimpleKubernetesClient(IEnvironment environment) : this(environment, CreateHttpClient())
+        { }
+
+        // for testing
+        internal SimpleKubernetesClient(IEnvironment environment, HttpClient client)
+        {
+            _httpClient = client;
+            _environment = environment;
+            Task.Run(() => RunWatcher());
+        }
+
+        private string KubernetesObjectName => _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsKubernetesSecretName);
+
+        public bool IsWritable => !string.IsNullOrEmpty(KubernetesObjectName);
+
+        public async Task<IDictionary<string, string>> GetSecrets()
+        {
+            if (string.IsNullOrEmpty(KubernetesObjectName) && FileUtility.DirectoryExists(KubernetesSecretsDir))
+            {
+                return await GetFromFiles(KubernetesSecretsDir);
+            }
+            else if (!string.IsNullOrEmpty(KubernetesObjectName))
+            {
+                return await GetFromApiServer(KubernetesObjectName);
+            }
+            else
+            {
+                throw new InvalidOperationException($"{nameof(KubernetesSecretsRepository)} requires setting {EnvironmentSettingNames.AzureWebJobsKubernetesSecretName} or mounting secrets to {KubernetesSecretsDir}");
+            }
+        }
+
+        public async Task UpdateSecrets(IDictionary<string, string> data)
+        {
+            (var url, var isSecret) = await GetObjectUrl(KubernetesObjectName);
+            await CreateIfDoesntExist(url, isSecret);
+
+            data = isSecret
+                ? data.ToDictionary(k => k.Key, v => Convert.ToBase64String(Encoding.UTF8.GetBytes(v.Value)))
+                : data;
+
+            using (var request = await GetRequest(HttpMethod.Patch, url, new[] { new { op = "replace", path = "/data", value = data } }, "application/json-patch+json"))
+            {
+                var response = await _httpClient.SendAsync(request);
+                response.EnsureSuccessStatusCode();
+            }
+        }
+
+        public void OnSecretChange(Action callback)
+        {
+            _watchCallback = callback;
+        }
+
+        private async Task RunWatcher()
+        {
+            if (string.IsNullOrEmpty(KubernetesObjectName) && FileUtility.DirectoryExists(KubernetesSecretsDir))
+            {
+                _fileWatcher = new AutoRecoveringFileSystemWatcher(KubernetesSecretsDir);
+                _fileWatcher.Changed += (object sender, FileSystemEventArgs e)
+                    => _watchCallback?.Invoke();
+            }
+            else if (!string.IsNullOrEmpty(KubernetesObjectName))
+            {
+                (var url, _) = await GetObjectUrl(KubernetesObjectName, watchUrl: true);
+                using (var noTimeoutClient = CreateHttpClient())
+                using (var request = await GetRequest(HttpMethod.Get, url))
+                {
+                    while (!_disposed)
+                    {
+                        noTimeoutClient.Timeout = TimeSpan.FromMilliseconds(Timeout.Infinite);
+                        using (var response = await noTimeoutClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead))
+                        using (var reader = new StreamReader(await response.Content.ReadAsStreamAsync()))
+                        {
+                            while (!reader.EndOfStream && !_disposed)
+                            {
+                                reader.ReadLine(); // Read the line-json update
+                                _watchCallback?.Invoke();
+                            }
+                        }
+                        await Task.Delay(TimeSpan.FromSeconds(1));
+                    }
+                }
+            }
+        }
+
+        private async Task<IDictionary<string, string>> GetFromApiServer(string objectName)
+        {
+            (var url, var decode) = await GetObjectUrl(objectName);
+            using (var request = await GetRequest(HttpMethod.Get, url))
+            {
+                var response = await _httpClient.SendAsync(request);
+                if (response.IsSuccessStatusCode)
+                {
+                    var obj = await response.Content.ReadAsAsync<JObject>();
+                    return obj["data"]
+                        ?.ToObject<IDictionary<string, string>>()
+                        ?.ToDictionary(
+                            k => k.Key,
+                            v => decode
+                                ? Encoding.UTF8.GetString(Convert.FromBase64String(v.Value))
+                                : v.Value);
+                }
+                else if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    // If the collection is not there, return an empty list
+                    return new Dictionary<string, string>();
+                }
+                else
+                {
+                    throw new HttpRequestException($"Error calling GET {url}, Status: {response.StatusCode}, Content: {await response.Content.ReadAsStringAsync()}");
+                }
+            }
+        }
+
+        private async Task CreateIfDoesntExist(string url, bool isSecret)
+        {
+            using (var request = await GetRequest(HttpMethod.Get, url))
+            {
+                var response = await _httpClient.SendAsync(request);
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    var name = url.Split("/").Last();
+                    url = url.Substring(0, url.LastIndexOf("/"));
+                    var payload = new
+                    {
+                        kind = isSecret ? "Secret" : "ConfigMap",
+                        apiVersion = "v1",
+                        metadata = new
+                        {
+                            name = name
+                        }
+                    };
+                    using (var createRequest = await GetRequest(HttpMethod.Post, url, payload))
+                    {
+                        var createResponse = await _httpClient.SendAsync(createRequest);
+                        createResponse.EnsureSuccessStatusCode();
+                    }
+                }
+            }
+        }
+
+        private async Task<(string, bool)> GetObjectUrl(string objectName, bool watchUrl = false)
+        {
+            var isSecret = true;
+            if (!objectName.StartsWith("secrets/") && !objectName.StartsWith("configmaps/"))
+            {
+                // assume a secret if no type is specified.
+                objectName = $"secrets/{objectName}";
+            }
+            else if (objectName.StartsWith("configmaps/"))
+            {
+                // This allows the users to manage their keys in configMaps instead of secret.
+                // There is no difference currently in kubernetes between the 2 other than secrets
+                // requiring base64 encoding. If it's a configMap, then we don't need to decode it.
+                isSecret = false;
+            }
+
+            string @namespace = await FileUtility.ReadAsync(NamespaceFile);
+            var url = $"{_environment.GetKubernetesApiServerUrl()}/api/v1/";
+            if (watchUrl)
+            {
+                url += "watch/";
+            }
+            url += $"namespaces/{@namespace}/{objectName}";
+            return (url, isSecret);
+        }
+
+        private async Task<HttpRequestMessage> GetRequest(HttpMethod method, string url, object payload = null, string contentType = null, bool closeConnection = true)
+        {
+            string token = await FileUtility.ReadAsync(TokenFile);
+            const string jsonContentType = "application/json";
+            contentType = contentType ?? jsonContentType;
+
+            var request = new HttpRequestMessage(method, url);
+            request.Headers.Add(HeaderNames.Authorization, $"Bearer {token}");
+            request.Headers.Add(HeaderNames.Accept, jsonContentType);
+
+            if (closeConnection)
+            {
+                request.Headers.Add(HeaderNames.Connection, "close");
+            }
+
+            if (payload != null)
+            {
+                var jsonPayload = JsonConvert.SerializeObject(payload);
+                request.Content = new StringContent(jsonPayload, Encoding.UTF8, contentType);
+            }
+
+            return request;
+        }
+
+        private static async Task<IDictionary<string, string>> GetFromFiles(string path)
+        {
+            string[] files = await FileUtility.GetFilesAsync(path, "*");
+            var secrets = new Dictionary<string, string>(files.Length);
+            foreach (var file in files)
+            {
+                secrets.Add(Path.GetFileName(file), await FileUtility.ReadAsync(file));
+            }
+            return secrets;
+        }
+
+        private static HttpClient CreateHttpClient()
+        {
+            var client = new HttpClient(new HttpClientHandler
+            {
+                ServerCertificateCustomValidationCallback = ServerCertificateValidationCallback
+            });
+
+            client.DefaultRequestHeaders.Add(HeaderNames.UserAgent, ScriptConstants.HostUserAgent);
+            return client;
+        }
+
+        private static bool ServerCertificateValidationCallback(
+            HttpRequestMessage request,
+            X509Certificate2 certificate,
+            X509Chain certChain,
+            SslPolicyErrors sslPolicyErrors)
+        {
+            if (sslPolicyErrors == SslPolicyErrors.None)
+            {
+                // certificate is already valid
+                return true;
+            }
+            else if (sslPolicyErrors == SslPolicyErrors.RemoteCertificateNameMismatch ||
+                sslPolicyErrors == SslPolicyErrors.RemoteCertificateNotAvailable)
+            {
+                // api-server cert must exist and have the right subject
+                return false;
+            }
+            else if (sslPolicyErrors == SslPolicyErrors.RemoteCertificateChainErrors)
+            {
+                // only remaining error state is RemoteCertificateChainErrors
+                // check custom CA
+                var privateChain = new X509Chain();
+                privateChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+
+                var caCert = new X509Certificate2(CaFile);
+                // https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509chainpolicy?view=netcore-2.2
+                // Add CA cert to the chain store to include it in the chain check.
+                privateChain.ChainPolicy.ExtraStore.Add(caCert);
+                // Build the chain for `certificate` which should be the self-signed kubernetes api-server cert.
+                privateChain.Build(certificate);
+
+                foreach (X509ChainStatus chainStatus in privateChain.ChainStatus)
+                {
+                    if (chainStatus.Status != X509ChainStatusFlags.NoError &&
+                        // root CA cert is not always trusted.
+                        chainStatus.Status != X509ChainStatusFlags.UntrustedRoot)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+            else
+            {
+                // Unknown sslPolicyErrors
+                return false;
+            }
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _httpClient.Dispose();
+                    _fileWatcher?.Dispose();
+                }
+
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+    }
+}

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -182,5 +182,18 @@ namespace Microsoft.Azure.WebJobs.Script
             var mountEnabled = environment.GetEnvironmentVariable(MountEnabled);
             return !string.IsNullOrEmpty(mountEnabled) && string.Equals(mountEnabled, "1");
         }
+
+        public static string GetKubernetesApiServerUrl(this IEnvironment environment)
+        {
+            string host = environment.GetEnvironmentVariable(KubernetesServiceHost);
+            string port = environment.GetEnvironmentVariable(KubernetesServiceHttpsPort);
+
+            if (string.IsNullOrEmpty(host) || string.IsNullOrEmpty(port))
+            {
+                throw new InvalidOperationException($"Both {KubernetesServiceHost} and {KubernetesServiceHttpsPort} are required for {nameof(GetKubernetesApiServerUrl)}.");
+            }
+
+            return $"https://{host}:{port}";
+        }
     }
 }

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -61,5 +61,9 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string RunningInContainer = "DOTNET_RUNNING_IN_CONTAINER";
 
         public const string ExtensionBundleSourceUri = "FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI";
+        public const string AzureWebJobsKubernetesSecretName = "AzureWebJobsKubernetesSecretName";
+
+        public const string KubernetesServiceHost = "KUBERNETES_SERVICE_HOST";
+        public const string KubernetesServiceHttpsPort = "KUBERNETES_SERVICE_PORT_HTTPS";
     }
 }

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -136,5 +136,6 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public static readonly ImmutableArray<string> HttpMethods = ImmutableArray.Create("get", "post", "delete", "head", "patch", "put", "options");
         public static readonly ImmutableArray<string> AssemblyFileTypes = ImmutableArray.Create(".dll", ".exe");
+        public static readonly string HostUserAgent = $"azure-functions-host/{ScriptHost.Version}";
     }
 }


### PR DESCRIPTION
This adds a `KubernetesSecretsRepository` implementation of `ISecretsRepository`. I'm still working on adding some tests, but the functionality is done. I have few questions that I'll add as comments. 

With this PR the user can set `AzureWebJobsSecretStorageType=kubernetes`

Then optionally you can set `AzureWebJobsKubernetesSecretName` to a kubernetes secret name in the same namespace as the deployment. If you don't set that, then we expect a secret to be volumeMounted into `/run/secrets/functions-keys` 

**Note**: when using `volumeMount`, the secrets are readonly and can't be updated by the runtime APIs. When using a `AzureWebJobsKubernetesSecretName` with a kubernetes secret (or configMap), it's read/write.

**Note**: To use `AzureWebJobsKubernetesSecretName`, you need to allow the functions pod identity to be able to read and modify that secret. 

the secret in kubernetes 

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: function-keys
type: Opaque
data:
  host.master: <base64 of masterkey>
  function.HttpTrigger.default: <base64 of default key for HttpTrigger function>
```

if you set `AzureWebJobsKubernetesSecretName` to `configmaps/{name}` it'll use configmaps instead which doesn't require base64 enoding

![2019-05-16_22-01-38](https://user-images.githubusercontent.com/645740/57904400-7300ca00-7827-11e9-96e4-a587e9954b2a.gif)

If you don't want to create an identity for the function pod, you can mount the sam secret or configmap using this 

```yaml
    spec:
      containers:
      - name: app
        volumeMounts:
        - mountPath: /run/secrets/functions-keys
          name: functions-keys
          readOnly: true
      volumes:
      - name: functions-keys
        secret:
          secretName: func-keys
```

and don't set `AzureWebJobsKubernetesSecretName`.

/cc @jeffhollan  @paulbatum @mattchenderson 