### PR TITLE
Allow Internal Auth for SyncTriggers

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
         [HttpPost]
         [Route("admin/host/synctriggers")]
-        [Authorize(Policy = PolicyNames.AdminAuthLevel)]
+        [Authorize(Policy = PolicyNames.AdminAuthLevelOrInternal)]
         public async Task<IActionResult> SyncTriggers()
         {
             var result = await _functionsSyncManager.TrySyncTriggersAsync();

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
@@ -99,6 +99,37 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         }
 
         [Fact]
+        public async Task SyncTriggers_InternalAuth_Succeeds()
+        {
+            using (new TestScopedSettings(_settingsManager, EnvironmentSettingNames.AzureWebsiteInstanceId, "testinstance"))
+            {
+                string uri = "admin/host/synctriggers";
+                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
+                HttpResponseMessage response = await _fixture.Host.HttpClient.SendAsync(request);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            }
+        }
+
+        [Fact]
+        public async Task SyncTriggers_ExternalUnauthorized_ReturnsUnauthorized()
+        {
+            string uri = "admin/host/synctriggers";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
+            HttpResponseMessage response = await _fixture.Host.HttpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task SyncTriggers_AdminLevel_Succeeds()
+        {
+            string uri = "admin/host/synctriggers";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
+            request.Headers.Add(AuthenticationLevelHandler.FunctionsKeyHeaderName, await _fixture.Host.GetMasterKeyAsync());
+            HttpResponseMessage response = await _fixture.Host.HttpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
         public async Task HostLog_Anonymous_Fails()
         {
             var request = new HttpRequestMessage(HttpMethod.Post, "admin/host/log");

--- a/test/WebJobs.Script.Tests/Controllers/Admin/FunctionsControllerTests.cs
+++ b/test/WebJobs.Script.Tests/Controllers/Admin/FunctionsControllerTests.cs
@@ -27,7 +27,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
-    public class AdminControllerTests : IDisposable
+    public class FunctionsControllerTests : IDisposable
     {
         private readonly TempDirectory _secretsDirectory = new TempDirectory();
 


### PR DESCRIPTION
For slot swaps, the Antares Controller will do a SyncTriggers. It will use Antares internal auth, just like we use for other endpoints hit by Antares infr (e.g. the /logs endpoint hit by ScaleController)