### PR TITLE
Do not raise events from language worker channel when disposing

### DIFF
--- a/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
+++ b/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         private readonly IDisposable _rpcChannelReadySubscriptions;
         private readonly int _debounceSeconds = 10;
         private readonly int _maxAllowedProcessCount = 10;
+        private readonly object _disposeLock = new object();
         private IScriptEventManager _eventManager;
         private IEnumerable<WorkerConfig> _workerConfigs;
         private ILanguageWorkerChannelManager _languageWorkerChannelManager;
@@ -263,15 +264,12 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!_disposed)
+            if (!_disposed && _disposing)
             {
-                if (disposing)
-                {
-                    _workerErrorSubscription.Dispose();
-                    _rpcChannelReadySubscriptions.Dispose();
-                    _workerState.DisposeAndRemoveChannels();
-                    _workerState.Functions.Dispose();
-                }
+                _workerErrorSubscription.Dispose();
+                _rpcChannelReadySubscriptions.Dispose();
+                _workerState.DisposeAndRemoveChannels();
+                _workerState.Functions.Dispose();
                 _disposed = true;
             }
         }

--- a/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
+++ b/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
@@ -28,7 +28,6 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         private readonly IDisposable _rpcChannelReadySubscriptions;
         private readonly int _debounceSeconds = 10;
         private readonly int _maxAllowedProcessCount = 10;
-        private readonly object _disposeLock = new object();
         private IScriptEventManager _eventManager;
         private IEnumerable<WorkerConfig> _workerConfigs;
         private ILanguageWorkerChannelManager _languageWorkerChannelManager;

--- a/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
+++ b/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
@@ -264,7 +264,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!_disposed && _disposing)
+            if (!_disposed && disposing)
             {
                 _workerErrorSubscription.Dispose();
                 _rpcChannelReadySubscriptions.Dispose();

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
@@ -284,6 +284,11 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         internal void PublishWorkerProcessReadyEvent(FunctionEnvironmentReloadResponse res)
         {
+            if (_disposing)
+            {
+                // do not publish ready events when disposing
+                return;
+            }
             WorkerProcessReadyEvent wpEvent = new WorkerProcessReadyEvent(_workerId, _workerConfig.Language);
             _eventManager.Publish(wpEvent);
         }

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
@@ -293,6 +293,11 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             _startLatencyMetric?.Dispose();
             _startLatencyMetric = null;
 
+            if (_disposing)
+            {
+                // do not publish ready events when disposing
+                return;
+            }
             _initMessage = initEvent.Message.WorkerInitResponse;
             if (_initMessage.Result.IsFailure(out Exception exc))
             {

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
@@ -504,6 +504,10 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         internal void HandleWorkerError(Exception exc)
         {
+            if (_disposing)
+            {
+                return;
+            }
             LanguageWorkerProcessExitException langExc = exc as LanguageWorkerProcessExitException;
             // The subscriber of WorkerErrorEvent is expected to Dispose() the errored channel
             if (langExc != null && langExc.ExitCode == -1)

--- a/src/WebJobs.Script/Rpc/LanguageWorkerState.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerState.cs
@@ -37,9 +37,11 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         {
             foreach (string channelId in _channels.Keys)
             {
-                _channels[channelId].Dispose();
+                if (_channels.TryRemove(channelId, out ILanguageWorkerChannel channel))
+                {
+                    channel?.Dispose();
+                }
             }
-            _channels.Clear();
         }
 
         internal IEnumerable<ILanguageWorkerChannel> GetChannels()


### PR DESCRIPTION
This is a potential fix for test run that was aborted: https://ci.appveyor.com/project/appsvc/azure-webjobs-sdk-script-y8o14/builds/24626094/job/6buj7f8iuf7yqx3v

```
dotnet.exe : The active test run was aborted. Reason: Unhandled Exception: System.ObjectDisposedException: Cannot access a disposed object.
At C:\azure-webjobs-sdk-script\run-tests.ps1:21 char:5
+     & dotnet $cmdargs | Out-Host
+     ~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (The active test...isposed object.:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
 
   at System.Reactive.Subjects.ReplaySubject`1.ReplayBase.CheckDisposed()
   at System.Reactive.Subjects.ReplaySubject`1.Replay
Base.Subscribe(IObserver`1 observer)
   at Microsoft.Azure.WebJobs.Script.Rpc.LanguageWorkerChannel.RegisterFunctions(IObservable`1 functionRegistrations) in C:\azure-webjobs-sdk-script\src\WebJobs.Script\Rpc\LanguageWorkerChannel.cs:line 322
   at Microsoft.Azure.WebJobs.Script.Rpc.FunctionDispatcher.AddOrUpdateWorkerChannels(RpcJobHostChannelReadyEvent rpcChannelReadyEvent) in 
C:\azure-webjobs-sdk-script\src\WebJobs.Script\Rpc\FunctionRegistration\FunctionDispatcher.cs:line 259
   at System.Reactive.AnonymousSafeObserver`1.OnNext(T value)
   at System.Reactive.ScheduledObserver`1.Dispatch(ICancelable cancel)
   at System.Threading.Thread.ThreadMain_ThreadStart()
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
```

This does not repro locally. Language worker channel raises events coming from a language worker process. This PR ensures that no events are raised after dispose is called.