### PR TITLE
Enable SyncTriggers cache; Support Disable Config

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -25,12 +25,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 {
     public sealed class FunctionsSyncManager : IFunctionsSyncManager, IDisposable
     {
-        // Until ANT 82 is fully released, the default value is disabled and we continue
-        // to return just the trigger data.
-        // After ANT 82, we will change the default to enabled.
-        // Note that this app setting is honored by both GeoMaster and Runtime.
-        public const string AzureWebsiteArmCacheEnabledDefaultValue = "0";
-
         private const string HubName = "HubName";
         private const string TaskHubName = "taskHubName";
         private const string Connection = "connection";
@@ -66,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         {
             get
             {
-                return _settings.GetSettingOrDefault(EnvironmentSettingNames.AzureWebsiteArmCacheEnabled, AzureWebsiteArmCacheEnabledDefaultValue) == "1";
+                return _settings.GetSettingOrDefault(EnvironmentSettingNames.AzureWebsiteArmCacheEnabled, "1") == "1";
             }
         }
 

--- a/src/WebJobs.Script/Config/ScriptSettingsManager.cs
+++ b/src/WebJobs.Script/Config/ScriptSettingsManager.cs
@@ -99,5 +99,18 @@ namespace Microsoft.Azure.WebJobs.Script.Config
 
             Environment.SetEnvironmentVariable(settingKey, settingValue);
         }
+
+        public bool SettingIsEnabled(string settingKey)
+        {
+            string value = GetSetting(settingKey);
+            if (!string.IsNullOrEmpty(value) &&
+                (string.Compare(value, "1", StringComparison.OrdinalIgnoreCase) == 0 ||
+                 string.Compare(value, "true", StringComparison.OrdinalIgnoreCase) == 0))
+            {
+                return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -1053,8 +1053,10 @@ namespace Microsoft.Azure.WebJobs.Script
                 }
             }
 
-            // A function can be disabled at the trigger or function level
-            if (IsDisabled(triggerDisabledValue, settingsManager) ||
+            // A function can be disabled at the trigger or function level, or via an
+            // app level per function setting
+            if (settingsManager.SettingIsEnabled($"AzureWebJobs.{functionName}.Disabled") ||
+                IsDisabled(triggerDisabledValue, settingsManager) ||
                 IsDisabled((JValue)configMetadata["disabled"], settingsManager))
             {
                 functionMetadata.IsDisabled = true;
@@ -1980,10 +1982,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 else
                 {
                     string settingName = (string)isDisabledValue;
-                    string value = settingsManager.GetSetting(settingName);
-                    if (!string.IsNullOrEmpty(value) &&
-                        (string.Compare(value, "1", StringComparison.OrdinalIgnoreCase) == 0 ||
-                         string.Compare(value, "true", StringComparison.OrdinalIgnoreCase) == 0))
+                    if (settingsManager.SettingIsEnabled(settingName))
                     {
                         return true;
                     }

--- a/test/WebJobs.Script.Tests/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Management/FunctionsSyncManagerTests.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         public void ArmCacheEnabled_VerifyDefault()
         {
             _scriptSettingsManagerMock.Setup(p => p.GetSetting(EnvironmentSettingNames.AzureWebsiteArmCacheEnabled)).Returns((string)null);
-            Assert.False(_functionsSyncManager.ArmCacheEnabled);
+            Assert.True(_functionsSyncManager.ArmCacheEnabled);
         }
 
         [Theory]


### PR DESCRIPTION
Corresponding v1 change for https://github.com/Azure/azure-functions-host/pull/4495.

Also in this PR I'm adding support for the v2 style app level Disable flag. This is needed for the new Functions ARM Enable/Disable API I'm working on. For the ARM API to work consistently across v1/v2 it needs to be able to disable a function via config only. In v2 it's possible already via the AzureFunctions.{name}.Disabled app setting, but in v1 currently function.json changes are required.

Also addressing https://github.com/Azure/azure-functions-host/issues/4483.