### PR TITLE
Add Host Instance ID to AppInsights logs

### DIFF
--- a/src/WebJobs.Script/Config/ScriptTelemetryInitializer.cs
+++ b/src/WebJobs.Script/Config/ScriptTelemetryInitializer.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebJobs.Script.Config
+{
+    internal class ScriptTelemetryInitializer : ITelemetryInitializer
+    {
+        private readonly ScriptJobHostOptions _hostOptions;
+
+        public ScriptTelemetryInitializer(IOptions<ScriptJobHostOptions> hostOptions)
+        {
+            if (hostOptions == null)
+            {
+                throw new ArgumentNullException(nameof(hostOptions));
+            }
+
+            if (hostOptions.Value == null)
+            {
+                throw new ArgumentNullException(nameof(hostOptions.Value));
+            }
+
+            _hostOptions = hostOptions.Value;
+        }
+
+        public void Initialize(ITelemetry telemetry)
+        {
+            telemetry?.Context?.Properties?.Add(ScriptConstants.LogPropertyHostInstanceIdKey, _hostOptions.InstanceId);
+        }
+    }
+}

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -243,6 +243,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
                 builder.Services.AddSingleton<ISdkVersionProvider, FunctionsSdkVersionProvider>();
 
+                builder.Services.AddSingleton<ITelemetryInitializer, ScriptTelemetryInitializer>();
+
                 if (SystemEnvironment.Instance.IsPlaceholderModeEnabled())
                 {
                     for (int i = 0; i < builder.Services.Count; i++)

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
@@ -355,20 +355,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
                 // Every telemetry will have {originalFormat}, Category, Level, but we validate those elsewhere.
                 // We're only interested in the custom properties.
                 Assert.Equal("1", traces[0].Message);
-                Assert.Equal(5, traces[0].Properties.Count);
+                Assert.Equal(6, traces[0].Properties.Count);
                 Assert.Equal("customValue1", traces[0].Properties["prop__customKey1"]);
 
                 Assert.Equal("2", traces[1].Message);
-                Assert.Equal(6, traces[1].Properties.Count);
+                Assert.Equal(7, traces[1].Properties.Count);
                 Assert.Equal("customValue1", traces[1].Properties["prop__customKey1"]);
                 Assert.Equal("customValue2", traces[1].Properties["prop__customKey2"]);
 
                 Assert.Equal("3", traces[2].Message);
-                Assert.Equal(5, traces[2].Properties.Count);
+                Assert.Equal(6, traces[2].Properties.Count);
                 Assert.Equal("customValue1", traces[2].Properties["prop__customKey1"]);
 
                 Assert.Equal("4", traces[3].Message);
-                Assert.Equal(4, traces[3].Properties.Count);
+                Assert.Equal(5, traces[3].Properties.Count);
             }
         }
 

--- a/test/WebJobs.Script.Tests/Configuration/ScriptTelemetryInitializerTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ScriptTelemetryInitializerTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
+{
+    public class ScriptTelemetryInitializerTests
+    {
+        [Fact]
+        public void Add_Host_Instance_Id_Test()
+        {
+            var telemetry = new RequestTelemetry
+            {
+                Url = new Uri("https://localhost/api/function?name=World"),
+                ResponseCode = "200",
+                Name = "Function Request"
+            };
+
+            var jobHostOptions = new ScriptJobHostOptions();
+            var hostInstanceID = jobHostOptions.InstanceId;
+
+            var initializer = new ScriptTelemetryInitializer(new OptionsWrapper<ScriptJobHostOptions>(jobHostOptions));
+            initializer.Initialize(telemetry);
+
+            Assert.True(telemetry.Context.Properties.TryGetValue(ScriptConstants.LogPropertyHostInstanceIdKey, out string telemetryHostId));
+            Assert.Equal(hostInstanceID, telemetryHostId);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4202 
Adding Host Instance ID to all App Insights Logs. The ID can be viewed using `customDimensions.HostInstanceId` in App Insights.