### PR TITLE
[ExtensionsMetadataGenerator] ensuring ordering of publish targets

### DIFF
--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.csproj
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\metadatagenerator.props" />
   <PropertyGroup>
-    <Version>1.1.1</Version>
+    <Version>1.1.2</Version>
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <AssemblyName>Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator</AssemblyName>

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets
@@ -41,8 +41,14 @@
           ContinueOnError="true"/>
   </Target>
 
+  <!--
+    This target must run after the function assemblies are copied to the bin directory. Otherwise, 
+    extensions will be missed during Publish. This AfterTargets (which references a target in
+    Microsoft.NET.Sdk.Functions.Publish.targets) ensures that the ordering is correct, even if the
+    ExtensionsMetadataGenerator package is referenced directly in the project file.
+  -->
   <Target Name="_GenerateFunctionsExtensionsMetadataPostPublish"
-          AfterTargets="Publish">
+          AfterTargets="_GenerateFunctionsAndCopyContentFiles">
     <GenerateFunctionsExtensionsMetadata
           SourcePath="$(PublishDir)bin"
           OutputPath="$(PublishDir)bin"/>


### PR DESCRIPTION
Fixes #3386.

If you directly reference ExtensionsMetadataGenerator, the targets are imported ahead of the ones from Microsoft.NET.Sdk.Functions. We had two targets with `AfterTargets="Publish"`:
1. `_GenerateFunctionsAndCopyContentFiles` ([in Microsoft.Net.Sdk.Functions](https://github.com/Azure/azure-functions-vs-build-sdk/blob/master/src/Microsoft.NET.Sdk.Functions.MSBuild/Targets/netstandard1.0/Microsoft.NET.Sdk.Functions.Publish.targets#L134-L152)), which copies the function assemblies to the \bin directory
2. `_GenerateFunctionsExtensionsMetadataPostPublish`, which runs the ExtensionsMetadataGenerator over the \bin directory

If these run in the wrong order, you'll get an extensions.json without any extensions from the function assembly. This would work correctly from a build, but not a publish.

This requires that the Microsoft.NET.Sdk.Functions package is also referenced (as the AfterTargets wouldn't exist otherwise), but that will always be the case for Publish. When we use this package in the host for extension mangement, it only ever runs a Build.