### PR TITLE
[pack] [AppInsights] changing initializer to not use Add()

### DIFF
--- a/src/WebJobs.Script/Config/ScriptTelemetryInitializer.cs
+++ b/src/WebJobs.Script/Config/ScriptTelemetryInitializer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Options;
@@ -29,7 +30,14 @@ namespace Microsoft.Azure.WebJobs.Script.Config
 
         public void Initialize(ITelemetry telemetry)
         {
-            telemetry?.Context?.Properties?.Add(ScriptConstants.LogPropertyHostInstanceIdKey, _hostOptions.InstanceId);
+            IDictionary<string, string> telemetryProps = telemetry?.Context?.Properties;
+
+            if (telemetryProps == null)
+            {
+                return;
+            }
+
+            telemetryProps[ScriptConstants.LogPropertyHostInstanceIdKey] = _hostOptions.InstanceId;
         }
     }
 }


### PR DESCRIPTION
TelemetryInitializers can be called more than once with the same telemetry, so we need to be prepared for that. App Insights handles these but logs them as traces -- I happened to notice this while validating in UD0 that we had a bunch of trace messages being emitted. This would be happening a *ton* for every customer, so we need to fix this and re-release.

```	
AI (Internal): [Microsoft-ApplicationInsights-Core] [msg=Log Error];[msg=Exception while initializing Microsoft.Azure.WebJobs.Script.Config.ScriptTelemetryInitializer, exception message - System.ArgumentException: The key already existed in the dictionary.
   at System.Collections.Concurrent.ConcurrentDictionary`2.System.Collections.Generic.IDictionary<TKey,TValue>.Add(TKey key, TValue value)
   at Microsoft.Azure.WebJobs.Script.Config.ScriptTelemetryInitializer.Initialize(ITelemetry telemetry) in C:\azure-webjobs-sdk-script\src\WebJobs.Script\Config\ScriptTelemetryInitializer.cs:line 33
   at Microsoft.ApplicationInsights.TelemetryClient.Initialize(ITelemetry telemetry)]
```