### PR TITLE
Explicitly SetupFunctionInvocationBuffers

### DIFF
--- a/src/WebJobs.Script/Rpc/ILanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/ILanguageWorkerChannel.cs
@@ -19,7 +19,9 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         WorkerConfig Config { get; }
 
-        void RegisterFunctions(IObservable<FunctionMetadata> functionRegistrations);
+        void SetupFunctionInvocationBuffers(IEnumerable<FunctionMetadata> functions);
+
+        void SendFunctionLoadRequests();
 
         void SendFunctionEnvironmentReloadRequest();
 

--- a/src/WebJobs.Script/Rpc/LanguageWorkerState.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerState.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         {
             if (_channels.TryRemove(channel.Id, out ILanguageWorkerChannel removedChannel))
             {
-                channel?.Dispose();
+                removedChannel?.Dispose();
             }
         }
 

--- a/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannel.cs
+++ b/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannel.cs
@@ -42,7 +42,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         {
         }
 
-        public void RegisterFunctions(IObservable<FunctionMetadata> functionRegistrations)
+        public void SetupFunctionInvocationBuffers(IEnumerable<FunctionMetadata> functions)
+        {
+            _testLogger.LogInformation("SetupFunctionInvocationBuffers called");
+        }
+
+        public void SendFunctionLoadRequests()
         {
             _testLogger.LogInformation("RegisterFunctions called");
         }


### PR DESCRIPTION
This PR eliminates any race conditions that might occur if function invocation request are received before functions are loaded by a language worker.