### PR TITLE
[pack]In placeholder mode, skip check for functions with SpecifiedLanguage

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -640,7 +640,10 @@ namespace Microsoft.Azure.WebJobs.Script
             Collection<FunctionDescriptor> functionDescriptors = new Collection<FunctionDescriptor>();
             var httpFunctions = new Dictionary<string, HttpTriggerAttribute>();
 
-            Utility.VerifyFunctionsMatchSpecifiedLanguage(functions, _workerRuntime);
+            if (!_environment.IsPlaceholderModeEnabled())
+            {
+                Utility.VerifyFunctionsMatchSpecifiedLanguage(functions, _workerRuntime);
+            }
 
             foreach (FunctionMetadata metadata in functions)
             {


### PR DESCRIPTION
Placeholder pools use individual template sites with Worker runtime set. For the Java placeholder template, FUNCTIONS_WORKER_RUNTIME is set to java but app is loading placeholder content which has C# http trigger. This throws HostInitializationException.