### PR TITLE
Add LanguageWorkerProcessFactory  and LanguageWorkerChannelFactory 

### DIFF
--- a/src/WebJobs.Script/Rpc/Capabilities.cs
+++ b/src/WebJobs.Script/Rpc/Capabilities.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using Google.Protobuf.Collections;
 using Microsoft.Extensions.Logging;
@@ -14,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         public Capabilities(ILogger logger)
         {
-            _logger = logger;
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public string GetCapabilityState(string capability)

--- a/src/WebJobs.Script/Rpc/ILanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/ILanguageWorkerChannel.cs
@@ -17,8 +17,6 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         LanguageWorkerChannelState State { get; }
 
-        WorkerConfig Config { get; }
-
         void SetupFunctionInvocationBuffers(IEnumerable<FunctionMetadata> functions);
 
         void SendFunctionLoadRequests();

--- a/src/WebJobs.Script/Rpc/ILanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/ILanguageWorkerChannelManager.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.ManagedDependencies;
 using Microsoft.Extensions.Options;
-using FunctionMetadata = Microsoft.Azure.WebJobs.Script.Description.FunctionMetadata;
 
 namespace Microsoft.Azure.WebJobs.Script.Rpc
 {
@@ -21,8 +20,6 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         bool ShutdownChannelIfExists(string language, string workerId);
 
         void ShutdownChannels();
-
-        void ShutdownProcessRegistry();
 
         ILanguageWorkerChannel CreateLanguageWorkerChannel(string workerId, string scriptRootPath, string language, IMetricsLogger metricsLogger, int attemptCount, bool isWebhostChannel = false, IOptions<ManagedDependencyOptions> managedDependencyOptions = null);
     }

--- a/src/WebJobs.Script/Rpc/ILanguageWorkerProcess.cs
+++ b/src/WebJobs.Script/Rpc/ILanguageWorkerProcess.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.Azure.WebJobs.Script.Rpc
+{
+    public interface ILanguageWorkerProcess : IDisposable
+    {
+        int Id { get; }
+
+        Process StartProcess();
+    }
+}

--- a/src/WebJobs.Script/Rpc/ILanguageWorkerProcessManager.cs
+++ b/src/WebJobs.Script/Rpc/ILanguageWorkerProcessManager.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Script.Rpc
+{
+    public interface ILanguageWorkerProcessManager : IDisposable
+    {
+        ILanguageWorkerProcess CreateLanguageWorkerProcess(string workerId, string runtime, string scriptRootPath);
+    }
+}

--- a/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
@@ -1,0 +1,221 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Azure.WebJobs.Script.Abstractions;
+using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.Rpc
+{
+    internal class LanguageWorkerProcess : ILanguageWorkerProcess
+    {
+        private readonly IWorkerProcessFactory _processFactory;
+        private readonly IProcessRegistry _processRegistry;
+        private readonly ILogger _workerProcessLogger;
+        private readonly ILanguageWorkerConsoleLogSource _consoleLogSource;
+        private readonly IScriptEventManager _eventManager;
+
+        private Process _process;
+        private string _runtime;
+        private string _workerId;
+        private bool _disposing;
+        private Queue<string> _processStdErrDataQueue = new Queue<string>(3);
+
+        internal LanguageWorkerProcess()
+        {
+            // To help with unit tests
+        }
+
+        internal LanguageWorkerProcess(string runtime,
+                                       string workerId,
+                                       string rootScriptPath,
+                                       Uri serverUri,
+                                       WorkerProcessArguments workerProcessArguments,
+                                       IScriptEventManager eventManager,
+                                       IWorkerProcessFactory processFactory,
+                                       IProcessRegistry processRegistry,
+                                       ILoggerFactory loggerFactory,
+                                       ILanguageWorkerConsoleLogSource consoleLogSource)
+        {
+            _runtime = runtime;
+            _workerId = workerId;
+            _processFactory = processFactory;
+            _processRegistry = processRegistry;
+            _workerProcessLogger = loggerFactory.CreateLogger($"LanguageWorkerProcess.{runtime}.{workerId}");
+            _consoleLogSource = consoleLogSource;
+            _eventManager = eventManager;
+
+            var workerContext = new WorkerContext()
+            {
+                RequestId = Guid.NewGuid().ToString(),
+                MaxMessageLength = LanguageWorkerConstants.DefaultMaxMessageLengthBytes,
+                WorkerId = _workerId,
+                Arguments = workerProcessArguments,
+                WorkingDirectory = rootScriptPath,
+                ServerUri = serverUri,
+            };
+            _process = _processFactory.CreateWorkerProcess(workerContext);
+        }
+
+        public int Id => _process.Id;
+
+        internal Queue<string> ProcessStdErrDataQueue => _processStdErrDataQueue;
+
+        public Process StartProcess()
+        {
+            try
+            {
+                _process.ErrorDataReceived += (sender, e) => OnErrorDataReceived(sender, e);
+                _process.OutputDataReceived += (sender, e) => OnOutputDataReceived(sender, e);
+                _process.Exited += (sender, e) => OnProcessExited(sender, e);
+                _process.EnableRaisingEvents = true;
+
+                _workerProcessLogger?.LogInformation($"Starting language worker process:{_process.StartInfo.FileName} {_process.StartInfo.Arguments}");
+                _process.Start();
+                _workerProcessLogger?.LogInformation($"{_process.StartInfo.FileName} process with Id={_process.Id} started");
+
+                _process.BeginErrorReadLine();
+                _process.BeginOutputReadLine();
+
+                // Register process only after it starts
+                _processRegistry?.Register(_process);
+            }
+            catch (Exception ex)
+            {
+                throw new HostInitializationException($"Failed to start Language Worker Channel for language :{_runtime}", ex);
+            }
+
+            return _process;
+        }
+
+        private void OnErrorDataReceived(object sender, DataReceivedEventArgs e)
+        {
+            // TODO: per language stdout/err parser?
+            if (e.Data != null)
+            {
+                string msg = e.Data;
+                if (msg.IndexOf("warn", StringComparison.OrdinalIgnoreCase) > -1)
+                {
+                    if (LanguageWorkerChannelUtilities.IsLanguageWorkerConsoleLog(msg))
+                    {
+                        msg = LanguageWorkerChannelUtilities.RemoveLogPrefix(msg);
+                        _workerProcessLogger?.LogWarning(msg);
+                    }
+                    else
+                    {
+                        _consoleLogSource?.Log(msg);
+                    }
+                }
+                else if ((msg.IndexOf("error", StringComparison.OrdinalIgnoreCase) > -1) ||
+                          (msg.IndexOf("fail", StringComparison.OrdinalIgnoreCase) > -1) ||
+                          (msg.IndexOf("severe", StringComparison.OrdinalIgnoreCase) > -1))
+                {
+                    if (LanguageWorkerChannelUtilities.IsLanguageWorkerConsoleLog(msg))
+                    {
+                        msg = LanguageWorkerChannelUtilities.RemoveLogPrefix(msg);
+                        _workerProcessLogger?.LogError(msg);
+                    }
+                    else
+                    {
+                        _consoleLogSource?.Log(msg);
+                    }
+                    _processStdErrDataQueue = LanguageWorkerChannelUtilities.AddStdErrMessage(_processStdErrDataQueue, Sanitizer.Sanitize(msg));
+                }
+                else
+                {
+                    if (LanguageWorkerChannelUtilities.IsLanguageWorkerConsoleLog(msg))
+                    {
+                        msg = LanguageWorkerChannelUtilities.RemoveLogPrefix(msg);
+                        _workerProcessLogger?.LogInformation(msg);
+                    }
+                    else
+                    {
+                        _consoleLogSource?.Log(msg);
+                    }
+                }
+            }
+        }
+
+        private void OnProcessExited(object sender, EventArgs e)
+        {
+            if (_disposing)
+            {
+                // No action needed
+                return;
+            }
+            string exceptionMessage = string.Join(",", _processStdErrDataQueue.Where(s => !string.IsNullOrEmpty(s)));
+            try
+            {
+                if (_process.ExitCode != 0)
+                {
+                    var processExitEx = new LanguageWorkerProcessExitException($"{_process.StartInfo.FileName} exited with code {_process.ExitCode}\n {exceptionMessage}");
+                    processExitEx.ExitCode = _process.ExitCode;
+                    HandleWorkerProcessExitError(processExitEx);
+                }
+                else
+                {
+                    _process.WaitForExit();
+                    _process.Close();
+                }
+            }
+            catch (Exception)
+            {
+                // ignore process is already disposed
+            }
+        }
+
+        private void OnOutputDataReceived(object sender, DataReceivedEventArgs e)
+        {
+            if (e.Data != null)
+            {
+                string msg = e.Data;
+                if (LanguageWorkerChannelUtilities.IsLanguageWorkerConsoleLog(msg))
+                {
+                    msg = LanguageWorkerChannelUtilities.RemoveLogPrefix(msg);
+                    _workerProcessLogger?.LogInformation(msg);
+                }
+                else
+                {
+                    _consoleLogSource?.Log(msg);
+                }
+            }
+        }
+
+        internal void HandleWorkerProcessExitError(LanguageWorkerProcessExitException langExc)
+        {
+            // The subscriber of WorkerErrorEvent is expected to Dispose() the errored channel
+            if (langExc != null && langExc.ExitCode != -1)
+            {
+                _workerProcessLogger.LogDebug(langExc, $"Language Worker Process exited.", _process.StartInfo.FileName);
+                _eventManager.Publish(new WorkerErrorEvent(_runtime, _workerId, langExc));
+            }
+        }
+
+        public void Dispose()
+        {
+            _disposing = true;
+            // best effort process disposal
+            try
+            {
+                if (_process != null)
+                {
+                    if (!_process.HasExited)
+                    {
+                        _process.Kill();
+                        _process.WaitForExit();
+                    }
+                    _process.Dispose();
+                }
+            }
+            catch (Exception)
+            {
+                //ignore
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script/Rpc/LanguageWorkerProcessManager.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerProcessManager.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Azure.WebJobs.Script.Abstractions;
+using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebJobs.Script.Rpc
+{
+    public class LanguageWorkerProcessManager : ILanguageWorkerProcessManager
+    {
+        private readonly IWorkerProcessFactory _processFactory;
+        private readonly IEnumerable<WorkerConfig> _workerConfigs = null;
+        private readonly IProcessRegistry _processRegistry;
+        private readonly ILogger _logger = null;
+        private readonly ILoggerFactory _loggerFactory = null;
+        private readonly IScriptEventManager _eventManager = null;
+        private readonly IRpcServer _rpcServer = null;
+        private readonly ILanguageWorkerConsoleLogSource _consoleLogSource;
+
+        public LanguageWorkerProcessManager(IRpcServer rpcServer,
+                                       IOptions<LanguageWorkerOptions> languageWorkerOptions,
+                                       IScriptEventManager eventManager,
+                                       ILoggerFactory loggerFactory,
+                                       ILanguageWorkerConsoleLogSource consoleLogSource)
+        {
+            _loggerFactory = loggerFactory;
+            _eventManager = eventManager;
+            _rpcServer = rpcServer;
+            _workerConfigs = languageWorkerOptions.Value.WorkerConfigs;
+            _consoleLogSource = consoleLogSource;
+
+            _processFactory = new DefaultWorkerProcessFactory();
+            try
+            {
+                _processRegistry = ProcessRegistryFactory.Create();
+            }
+            catch (Exception e)
+            {
+                _logger.LogWarning(e, "Unable to create process registry");
+            }
+        }
+
+        public ILanguageWorkerProcess CreateLanguageWorkerProcess(string workerId, string runtime, string scriptRootPath)
+        {
+            WorkerConfig workerConfig = _workerConfigs.Where(c => c.Language.Equals(runtime, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+            return new LanguageWorkerProcess(runtime, workerId, scriptRootPath, _rpcServer.Uri, workerConfig.Arguments, _eventManager, _processFactory, _processRegistry, _loggerFactory, _consoleLogSource);
+        }
+
+        public void Dispose()
+        {
+            (_processRegistry as IDisposable)?.Dispose();
+        }
+    }
+}

--- a/src/WebJobs.Script/Rpc/RpcInitializationService.cs
+++ b/src/WebJobs.Script/Rpc/RpcInitializationService.cs
@@ -66,7 +66,6 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         {
             _logger.LogInformation("Shuttingdown Rpc Channels Manager");
             _languageWorkerChannelManager.ShutdownChannels();
-            _languageWorkerChannelManager.ShutdownProcessRegistry();
             await _rpcServer.KillAsync();
         }
 

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -188,6 +188,7 @@ namespace Microsoft.Azure.WebJobs.Script
             services.AddSingleton<FunctionRpc.FunctionRpcBase, FunctionRpcService>();
             services.AddSingleton<IRpcServer, GrpcServer>();
             services.TryAddSingleton<ILanguageWorkerConsoleLogSource, LanguageWorkerConsoleLogSource>();
+            services.AddSingleton<ILanguageWorkerProcessManager, LanguageWorkerProcessManager>();
             services.TryAddSingleton<ILanguageWorkerChannelManager, LanguageWorkerChannelManager>();
             services.TryAddSingleton<IDebugManager, DebugManager>();
             services.TryAddSingleton<IDebugStateProvider, DebugStateProvider>();

--- a/test/WebJobs.Script.Tests/Rpc/LanguageWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/LanguageWorkerChannelManagerTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using Microsoft.Azure.WebJobs.Script.Abstractions;
 using Microsoft.Azure.WebJobs.Script.Eventing;
@@ -11,6 +10,7 @@ using Microsoft.Azure.WebJobs.Script.Rpc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
+using Moq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         private TestLoggerProvider _loggerProvider;
         private ILoggerFactory _loggerFactory;
         private LanguageWorkerOptions _languageWorkerOptions;
+        private Mock<ILanguageWorkerProcessManager> _languageWorkerProcessManager;
         private IOptionsMonitor<ScriptApplicationHostOptions> _optionsMonitor;
 
         private string _scriptRootPath = @"c:\testing\FUNCTIONS-TEST";
@@ -50,16 +51,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
                 ScriptPath = @"c:\testing\FUNCTIONS-TEST\test$#"
             };
             _optionsMonitor = TestHelpers.CreateOptionsMonitor(applicationHostOptions);
+            _languageWorkerProcessManager = new Mock<ILanguageWorkerProcessManager>();
+            _languageWorkerProcessManager.Setup(m => m.CreateLanguageWorkerProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(new LanguageWorkerProcess());
         }
 
         [Fact]
         public void CreateChannels_Succeeds()
         {
-            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, null);
+            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, _languageWorkerProcessManager.Object);
+
             string workerId = Guid.NewGuid().ToString();
             string language = LanguageWorkerConstants.JavaLanguageWorkerName;
-
             ILanguageWorkerChannel javaWorkerChannel = CreateTestChannel(workerId, language);
+
             var initializedChannel = _languageWorkerChannelManager.GetChannel(language);
             string javaWorkerId2 = Guid.NewGuid().ToString();
             ILanguageWorkerChannel javaWorkerChannel2 = CreateTestChannel(javaWorkerId2, LanguageWorkerConstants.JavaLanguageWorkerName);
@@ -73,7 +77,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         public void ShutdownStandByChannels_Succeeds()
         {
             _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName, LanguageWorkerConstants.JavaLanguageWorkerName);
-            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, null);
+            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, _languageWorkerProcessManager.Object);
 
             string javaWorkerId = Guid.NewGuid().ToString();
             ILanguageWorkerChannel javaWorkerChannel = CreateTestChannel(javaWorkerId, LanguageWorkerConstants.JavaLanguageWorkerName);
@@ -94,7 +98,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         public void ShutdownStandByChannels_WorkerRuntinmeDotNet_Succeeds()
         {
             _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName, LanguageWorkerConstants.DotNetLanguageWorkerName);
-            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, null);
+            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, _languageWorkerProcessManager.Object);
 
             string javaWorkerId = Guid.NewGuid().ToString();
             ILanguageWorkerChannel javaWorkerChannel = CreateTestChannel(javaWorkerId, LanguageWorkerConstants.JavaLanguageWorkerName);
@@ -112,7 +116,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         [Fact]
         public void ShutdownChannels_Succeeds()
         {
-            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, null);
+            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, _languageWorkerProcessManager.Object);
 
             string javaWorkerId = Guid.NewGuid().ToString();
             ILanguageWorkerChannel javaWorkerChannel = CreateTestChannel(javaWorkerId, LanguageWorkerConstants.JavaLanguageWorkerName);
@@ -138,7 +142,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             _testEnvironment = new TestEnvironment();
             _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName, LanguageWorkerConstants.NodeLanguageWorkerName);
 
-            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, null);
+            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, _languageWorkerProcessManager.Object);
             string javaWorkerId = Guid.NewGuid().ToString();
             ILanguageWorkerChannel javaWorkerChannel = CreateTestChannel(javaWorkerId, LanguageWorkerConstants.JavaLanguageWorkerName);
 
@@ -153,7 +157,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         {
             _testEnvironment = new TestEnvironment();
 
-            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, null);
+            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, _languageWorkerProcessManager.Object);
             string javaWorkerId = Guid.NewGuid().ToString();
             ILanguageWorkerChannel javaWorkerChannel = CreateTestChannel(javaWorkerId, LanguageWorkerConstants.JavaLanguageWorkerName);
 
@@ -167,7 +171,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         public void ShutdownChannelsIfExist_Succeeds()
         {
             _testEnvironment = new TestEnvironment();
-            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, null);
+            _languageWorkerChannelManager = new LanguageWorkerChannelManager(_eventManager, _testEnvironment, _rpcServer, _loggerFactory, new OptionsWrapper<LanguageWorkerOptions>(_languageWorkerOptions), _optionsMonitor, _languageWorkerProcessManager.Object);
             string javaWorkerId1 = Guid.NewGuid().ToString();
             ILanguageWorkerChannel javaWorkerChannel1 = CreateTestChannel(javaWorkerId1, LanguageWorkerConstants.JavaLanguageWorkerName);
 

--- a/test/WebJobs.Script.Tests/Rpc/LanguageWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/LanguageWorkerChannelTests.cs
@@ -1,65 +1,151 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.Eventing.Rpc;
+using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Microsoft.Azure.WebJobs.Script.Rpc;
+using Microsoft.Extensions.Logging;
+using Moq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
 {
     public class LanguageWorkerChannelTests
     {
-        [Fact]
-        public void ErrorMessageQueue_Empty()
+        private static string _expectedLogMsg = "Outbound event subscribe event handler invoked";
+
+        private Mock<ILanguageWorkerProcess> _mockLanguageWorkerProcess = new Mock<ILanguageWorkerProcess>();
+        private string _workerId = "testWorkerId";
+        private string _scriptRootPath = "c:\testdir";
+        private IScriptEventManager _eventManager = new ScriptEventManager();
+        private Mock<IMetricsLogger> _mockMetricsLogger = new Mock<IMetricsLogger>();
+        private Mock<ILanguageWorkerConsoleLogSource> _mockConsoleLogger = new Mock<ILanguageWorkerConsoleLogSource>();
+        private Mock<FunctionRpc.FunctionRpcBase> _mockFunctionRpcService = new Mock<FunctionRpc.FunctionRpcBase>();
+        private TestRpcServer _testRpcServer = new TestRpcServer();
+        private ILoggerFactory _loggerFactory = MockNullLoggerFactory.CreateLoggerFactory();
+        private TestFunctionRpcService _testFunctionRpcService;
+        private TestLogger _logger;
+        private LanguageWorkerChannel _workerChannel;
+        private IEnumerable<FunctionMetadata> _functions = new List<FunctionMetadata>();
+
+        public LanguageWorkerChannelTests()
         {
-            LanguageWorkerChannel languageWorkerChannel = new LanguageWorkerChannel();
-            Assert.Empty(languageWorkerChannel.ProcessStdErrDataQueue);
+            _logger = new TestLogger("FunctionDispatcherTests");
+            _testFunctionRpcService = new TestFunctionRpcService(_eventManager, _workerId, _logger, _expectedLogMsg);
+            var testWorkerConfig = TestHelpers.GetTestWorkerConfigs().FirstOrDefault();
+            _mockLanguageWorkerProcess.Setup(m => m.StartProcess());
+
+            _workerChannel = new LanguageWorkerChannel(
+               _workerId,
+               _scriptRootPath,
+               _eventManager,
+               testWorkerConfig,
+               _mockLanguageWorkerProcess.Object,
+               _loggerFactory,
+               _mockMetricsLogger.Object,
+               0);
+            _workerChannel.WorkerChannelLogger = _logger;
         }
 
         [Fact]
-        public void ErrorMessageQueue_Enqueue_Success()
+        public async Task StartWorkerProcessAsync_Invoked()
         {
-            LanguageWorkerChannel languageWorkerChannel = new LanguageWorkerChannel();
-            LanguageWorkerChannelUtilities.AddStdErrMessage(languageWorkerChannel.ProcessStdErrDataQueue, "Error1");
-            LanguageWorkerChannelUtilities.AddStdErrMessage(languageWorkerChannel.ProcessStdErrDataQueue, "Error2");
-
-            Assert.True(languageWorkerChannel.ProcessStdErrDataQueue.Count == 2);
-            string exceptionMessage = string.Join(",", languageWorkerChannel.ProcessStdErrDataQueue.Where(s => !string.IsNullOrEmpty(s)));
-            Assert.Equal("Error1,Error2", exceptionMessage);
+            await _workerChannel.StartWorkerProcessAsync();
+            _mockLanguageWorkerProcess.Verify(m => m.StartProcess(), Times.Once);
         }
 
         [Fact]
-        public void ErrorMessageQueue_Full_Enqueue_Success()
+        public void SendWorkerInitRequest_PublishesOutboundEvent()
         {
-            LanguageWorkerChannel languageWorkerChannel = new LanguageWorkerChannel();
-            LanguageWorkerChannelUtilities.AddStdErrMessage(languageWorkerChannel.ProcessStdErrDataQueue, "Error1");
-            LanguageWorkerChannelUtilities.AddStdErrMessage(languageWorkerChannel.ProcessStdErrDataQueue, "Error2");
-            LanguageWorkerChannelUtilities.AddStdErrMessage(languageWorkerChannel.ProcessStdErrDataQueue, "Error3");
-            LanguageWorkerChannelUtilities.AddStdErrMessage(languageWorkerChannel.ProcessStdErrDataQueue, "Error4");
-            Assert.True(languageWorkerChannel.ProcessStdErrDataQueue.Count == 3);
-            string exceptionMessage = string.Join(",", languageWorkerChannel.ProcessStdErrDataQueue.Where(s => !string.IsNullOrEmpty(s)));
-            Assert.Equal("Error2,Error3,Error4", exceptionMessage);
+            StartStream startStream = new StartStream()
+            {
+                WorkerId = _workerId
+            };
+            StreamingMessage startStreamMessage = new StreamingMessage()
+            {
+                StartStream = startStream
+            };
+            RpcEvent rpcEvent = new RpcEvent(_workerId, startStreamMessage);
+            _workerChannel.SendWorkerInitRequest(rpcEvent);
+            var traces = _logger.GetLogMessages();
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, _expectedLogMsg)));
         }
 
-        [Theory]
-        [InlineData("languageWorkerConsoleLog Connection established")]
-        [InlineData("LANGUAGEWORKERCONSOLELOG Connection established")]
-        [InlineData("LanguageWorkerConsoleLog Connection established")]
-        public void IsLanguageWorkerConsoleLog_Returns_True_RemovesLogPrefix(string msg)
+        [Fact]
+        public void SendInvocationRequest_PublishesOutboundEvent()
         {
-            LanguageWorkerChannel languageWorkerChannel = new LanguageWorkerChannel();
-            Assert.True(LanguageWorkerChannelUtilities.IsLanguageWorkerConsoleLog(msg));
-            Assert.Equal(" Connection established", LanguageWorkerChannelUtilities.RemoveLogPrefix(msg));
+            ScriptInvocationContext scriptInvocationContext = new ScriptInvocationContext()
+            {
+                FunctionMetadata = GetTestFunctionsList("node").FirstOrDefault(),
+                ExecutionContext = new ExecutionContext()
+                {
+                    InvocationId = Guid.NewGuid(),
+                    FunctionName = "js1",
+                    FunctionAppDirectory = _scriptRootPath,
+                    FunctionDirectory = _scriptRootPath
+                },
+                BindingData = new Dictionary<string, object>(),
+                Inputs = new List<(string name, DataType type, object val)>()
+            };
+            _workerChannel.SendInvocationRequest(scriptInvocationContext);
+            var traces = _logger.GetLogMessages();
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, _expectedLogMsg)));
         }
 
-        [Theory]
-        [InlineData("grpc languageWorkerConsoleLog Connection established")]
-        [InlineData("My secret languageWorkerConsoleLog")]
-        [InlineData("Connection established")]
-        public void IsLanguageWorkerConsoleLog_Returns_False(string msg)
+        [Fact]
+        public void SendLoadRequests_PublishesOutboundEvents()
         {
-            LanguageWorkerChannel languageWorkerChannel = new LanguageWorkerChannel();
-            Assert.False(LanguageWorkerChannelUtilities.IsLanguageWorkerConsoleLog(msg));
+            _workerChannel.SetupFunctionInvocationBuffers(GetTestFunctionsList("node"));
+            _workerChannel.SendFunctionLoadRequests();
+            var traces = _logger.GetLogMessages();
+            var functionLoadLogs = traces.Where(m => string.Equals(m.FormattedMessage, _expectedLogMsg));
+            Assert.True(functionLoadLogs.Count() == 2);
+        }
+
+        [Fact]
+        public void ReceivesInboundEvent_InvocationResponse()
+        {
+            _testFunctionRpcService.PublishInvocationResponseEvent();
+            var traces = _logger.GetLogMessages();
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "InvocationResponse received for invocation id: TestInvocationId")));
+        }
+
+        [Fact]
+        public void ReceivesInboundEvent_FunctionLoadResponse()
+        {
+            _workerChannel.SetupFunctionInvocationBuffers(GetTestFunctionsList("node"));
+            _testFunctionRpcService.PublishFunctionLoadResponseEvent("TestFunctionId1");
+            var traces = _logger.GetLogMessages();
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Setting up FunctionInvocationBuffer for function:js1 with functionId:TestFunctionId1")));
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Setting up FunctionInvocationBuffer for function:js2 with functionId:TestFunctionId2")));
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Received FunctionLoadResponse for functionId:TestFunctionId1")));
+        }
+
+        private IEnumerable<FunctionMetadata> GetTestFunctionsList(string runtime)
+        {
+            return new List<FunctionMetadata>()
+            {
+                new FunctionMetadata()
+                {
+                     Language = runtime,
+                     Name = "js1",
+                     FunctionId = "TestFunctionId1"
+                },
+
+                new FunctionMetadata()
+                {
+                     Language = runtime,
+                     Name = "js2",
+                     FunctionId = "TestFunctionId2"
+                }
+            };
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Rpc/LanguageWorkerProcessTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/LanguageWorkerProcessTests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.Azure.WebJobs.Script.Rpc;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
+{
+    public class LanguageWorkerProcessTests
+    {
+        [Fact]
+        public void ErrorMessageQueue_Empty()
+        {
+            LanguageWorkerProcess languageWorkerProcess = new LanguageWorkerProcess();
+            Assert.Empty(languageWorkerProcess.ProcessStdErrDataQueue);
+        }
+
+        [Fact]
+        public void ErrorMessageQueue_Enqueue_Success()
+        {
+            LanguageWorkerProcess languageWorkerProcess = new LanguageWorkerProcess();
+            LanguageWorkerChannelUtilities.AddStdErrMessage(languageWorkerProcess.ProcessStdErrDataQueue, "Error1");
+            LanguageWorkerChannelUtilities.AddStdErrMessage(languageWorkerProcess.ProcessStdErrDataQueue, "Error2");
+
+            Assert.True(languageWorkerProcess.ProcessStdErrDataQueue.Count == 2);
+            string exceptionMessage = string.Join(",", languageWorkerProcess.ProcessStdErrDataQueue.Where(s => !string.IsNullOrEmpty(s)));
+            Assert.Equal("Error1,Error2", exceptionMessage);
+        }
+
+        [Fact]
+        public void ErrorMessageQueue_Full_Enqueue_Success()
+        {
+            LanguageWorkerProcess languageWorkerProcess = new LanguageWorkerProcess();
+            LanguageWorkerChannelUtilities.AddStdErrMessage(languageWorkerProcess.ProcessStdErrDataQueue, "Error1");
+            LanguageWorkerChannelUtilities.AddStdErrMessage(languageWorkerProcess.ProcessStdErrDataQueue, "Error2");
+            LanguageWorkerChannelUtilities.AddStdErrMessage(languageWorkerProcess.ProcessStdErrDataQueue, "Error3");
+            LanguageWorkerChannelUtilities.AddStdErrMessage(languageWorkerProcess.ProcessStdErrDataQueue, "Error4");
+            Assert.True(languageWorkerProcess.ProcessStdErrDataQueue.Count == 3);
+            string exceptionMessage = string.Join(",", languageWorkerProcess.ProcessStdErrDataQueue.Where(s => !string.IsNullOrEmpty(s)));
+            Assert.Equal("Error2,Error3,Error4", exceptionMessage);
+        }
+
+        [Theory]
+        [InlineData("languageWorkerConsoleLog Connection established")]
+        [InlineData("LANGUAGEWORKERCONSOLELOG Connection established")]
+        [InlineData("LanguageWorkerConsoleLog Connection established")]
+        public void IsLanguageWorkerConsoleLog_Returns_True_RemovesLogPrefix(string msg)
+        {
+            Assert.True(LanguageWorkerChannelUtilities.IsLanguageWorkerConsoleLog(msg));
+            Assert.Equal(" Connection established", LanguageWorkerChannelUtilities.RemoveLogPrefix(msg));
+        }
+
+        [Theory]
+        [InlineData("grpc languageWorkerConsoleLog Connection established")]
+        [InlineData("My secret languageWorkerConsoleLog")]
+        [InlineData("Connection established")]
+        public void IsLanguageWorkerConsoleLog_Returns_False(string msg)
+        {
+            Assert.False(LanguageWorkerChannelUtilities.IsLanguageWorkerConsoleLog(msg));
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Rpc/TestFunctionRpcService.cs
+++ b/test/WebJobs.Script.Tests/Rpc/TestFunctionRpcService.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.Eventing.Rpc;
+using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
+{
+    public class TestFunctionRpcService
+    {
+        private IScriptEventManager _eventManager;
+        private ILogger _logger;
+        private string _workerId;
+        private IDictionary<string, IDisposable> _outboundEventSubscriptions = new Dictionary<string, IDisposable>();
+
+        public TestFunctionRpcService(IScriptEventManager eventManager, string workerId, TestLogger logger, string expectedLogMsg = "")
+        {
+            _eventManager = eventManager;
+            _logger = logger;
+            _workerId = workerId;
+            _outboundEventSubscriptions.Add(workerId, _eventManager.OfType<OutboundEvent>()
+                        .Where(evt => evt.WorkerId == workerId)
+                        .Subscribe(evt =>
+                        {
+                            _logger.LogInformation(expectedLogMsg);
+                        }));
+        }
+
+        public void PublishFunctionLoadResponseEvent(string functionId)
+        {
+            StatusResult statusResult = new StatusResult()
+            {
+                Status = StatusResult.Types.Status.Success
+            };
+            FunctionLoadResponse functionLoadResponse = new FunctionLoadResponse()
+            {
+                FunctionId = functionId,
+                Result = statusResult
+            };
+            StreamingMessage responseMessage = new StreamingMessage()
+            {
+                FunctionLoadResponse = functionLoadResponse
+            };
+            _eventManager.Publish(new InboundEvent(_workerId, responseMessage));
+        }
+
+        public void PublishInvocationResponseEvent()
+        {
+            StatusResult statusResult = new StatusResult()
+            {
+                Status = StatusResult.Types.Status.Success
+            };
+            InvocationResponse invocationResponse = new InvocationResponse()
+            {
+                InvocationId = "TestInvocationId",
+                Result = statusResult
+            };
+            StreamingMessage responseMessage = new StreamingMessage()
+            {
+                InvocationResponse = invocationResponse
+            };
+            _eventManager.Publish(new InboundEvent(_workerId, responseMessage));
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannel.cs
+++ b/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannel.cs
@@ -32,8 +32,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
 
         public string Id => _workerId;
 
-        public WorkerConfig Config => throw new NotImplementedException();
-
         public IDictionary<string, BufferBlock<ScriptInvocationContext>> FunctionInputBuffers => throw new NotImplementedException();
 
         public LanguageWorkerChannelState State => _state;


### PR DESCRIPTION
- Added ILanguageWorkerProcess and LanguageWorkerProcess to handle operations related to process start up and shutdown
- Moved process helpers from LanguageWorkerChannel. 
  - This decouples worker process and worker channel
  -  Makes it easy to mock LanguageWorkerChannel as it is not attached to a process
- Added LanguageWorkerProcessFactory that creates LanguageWorkerProcess objects
- Added LanguageWorkerChannelFactory that creates LanguageWorkerChannel objects
- Added Unit tests for LangaugeWorkerChannel
- Added JobHostLanguageWorkerChannelManager - caches language worker channels that are created within the JobHost