### PR TITLE
Add Host Offline logs to all admin requests

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -24,6 +24,7 @@ using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using HttpHandler = Microsoft.Azure.WebJobs.IAsyncConverter<System.Net.Http.HttpRequestMessage, System.Net.Http.HttpResponseMessage>;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
@@ -93,8 +94,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         [HttpPost]
         [Route("admin/host/ping")]
         [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
-        public IActionResult Ping()
+        public IActionResult Ping([FromServices] IScriptHostManager scriptHostManager)
         {
+            var pingStatus = new JObject
+            {
+                { "hostState", scriptHostManager.State.ToString() }
+            };
+
+            string message = $"Ping Status: {pingStatus.ToString()}";
+            _logger.Log(LogLevel.Debug, new EventId(0, "PingStatus"), message);
+
             return Ok();
         }
 


### PR DESCRIPTION
Should help with https://github.com/Azure/azure-functions-host/issues/4514

~~The PR adds `"Host is Offline"` warning log to add `/admin` requests. With this, all `/admin/host/ping` requests with add this information, if the host is offline.~~ This will help us surface the information using a detector to the users.

Update: The PR adds a JSON log on every `/admin/host/ping` request with the host state. Example - 
```
Ping Status: {
  "hostState": "Offline"
}
```