### PR TITLE
Configure unbounded FunctionTimeout when user specifies -1

### DIFF
--- a/src/WebJobs.Script/Config/ScriptHostOptionsSetup.cs
+++ b/src/WebJobs.Script/Config/ScriptHostOptionsSetup.cs
@@ -70,13 +70,18 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
 
         private void ConfigureFunctionTimeout(ScriptJobHostOptions options)
         {
-            if (options.FunctionTimeout != null)
+            if (options.FunctionTimeout == null)
             {
-                ValidateTimeoutValue(options, options.FunctionTimeout);
+                options.FunctionTimeout = _environment.IsDynamic() ? DefaultFunctionTimeoutDynamic : DefaultFunctionTimeout;
+            }
+            else if (!_environment.IsDynamic() && TimeSpan.Compare(options.FunctionTimeout.Value, TimeSpan.FromDays(-1)) == 0)
+            {
+                // If a value of -1 is specified on a dedicated host, it should result in an infinite timeout
+                options.FunctionTimeout = null;
             }
             else
             {
-                options.FunctionTimeout = _environment.IsDynamic() ? DefaultFunctionTimeoutDynamic : DefaultFunctionTimeout;
+                ValidateTimeoutValue(options, options.FunctionTimeout);
             }
         }
 

--- a/test/WebJobs.Script.Tests/Configuration/ScriptHostOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ScriptHostOptionsSetupTests.cs
@@ -159,6 +159,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         }
 
         [Fact]
+        public void Configure_AppliesInfiniteTimeout_IfNotDynamic()
+        {
+            var settings = new Dictionary<string, string>
+            {
+                { ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "functionTimeout"), "-1" }
+            };
+
+            var options = GetConfiguredOptions(settings);
+            Assert.Equal(null, options.FunctionTimeout);
+        }
+
+        [Fact]
         public void Configure_AppliesTimeoutLimits_IfDynamic()
         {
             string configPath = ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "functionTimeout");
@@ -175,6 +187,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             Assert.Equal(expectedMessage, ex.Message);
 
             settings[configPath] = (ScriptHostOptionsSetup.MinFunctionTimeout - TimeSpan.FromSeconds(1)).ToString();
+            ex = Assert.Throws<ArgumentException>(() => GetConfiguredOptions(settings, environment));
+            Assert.Equal(expectedMessage, ex.Message);
+
+            settings[configPath] = "-1";
             ex = Assert.Throws<ArgumentException>(() => GetConfiguredOptions(settings, environment));
             Assert.Equal(expectedMessage, ex.Message);
         }


### PR DESCRIPTION
Resolves #4528 

This goes in conjunction with [this PR](https://github.com/Azure/Azure-Functions/pull/1251) to update the host.json schema