### PR TITLE
Add admin/host/token endpoint

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -248,7 +248,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                 return BadRequest("Endpoint is only available when running in Linux Container");
             }
 
-            string requestHeaderToken = SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddHours(2));
+            string requestHeaderToken = SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddMinutes(5));
             return Ok(requestHeaderToken);
         }
 

--- a/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
@@ -69,9 +69,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         }
 
         [HttpGet]
-        [Route("admin/gettoken")]
+        [Route("admin/getsitetoken")]
         [Authorize(Policy = PolicyNames.AdminAuthLevel)]
-        public IActionResult GetRequestHeaderToken()
+        public IActionResult GetSiteToken()
         {
             // This endpoint is used by getting a temporary x-ms-site-restricted-token to for KuduLite request in Linux Consumption
             string websiteEncryptionKey = _environment.GetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey);

--- a/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
@@ -68,12 +68,25 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
             return Ok(_instanceManager.GetInstanceInfo());
         }
 
+        /// <summary>
+        /// This endpoint generates a temporary x-ms-site-restricted-token for core tool
+        /// to access KuduLite zipdeploy endpoint in Linux Consumption
+        /// </summary>
+        /// <returns>
+        /// 200 on token generated
+        /// 400 on non-Linux container environment
+        /// 404 on WEBSITE_AUTH_ENCRYPTION_KEY is not set
+        /// </returns>
         [HttpGet]
         [Route("admin/getsitetoken")]
         [Authorize(Policy = PolicyNames.AdminAuthLevel)]
         public IActionResult GetSiteToken()
         {
-            // This endpoint is used by getting a temporary x-ms-site-restricted-token to for KuduLite request in Linux Consumption
+            if (!_environment.IsLinuxContainerEnvironment())
+            {
+                return BadRequest("Endpoint is only available when running in Linux Container");
+            }
+
             string websiteEncryptionKey = _environment.GetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey);
             if (string.IsNullOrEmpty(websiteEncryptionKey))
             {

--- a/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
-using Microsoft.Azure.WebJobs.Script.WebHost.Security;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
@@ -66,35 +64,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         public IActionResult GetInstanceInfo()
         {
             return Ok(_instanceManager.GetInstanceInfo());
-        }
-
-        /// <summary>
-        /// This endpoint generates a temporary x-ms-site-restricted-token for core tool
-        /// to access KuduLite zipdeploy endpoint in Linux Consumption
-        /// </summary>
-        /// <returns>
-        /// 200 on token generated
-        /// 400 on non-Linux container environment
-        /// 404 on WEBSITE_AUTH_ENCRYPTION_KEY is not set
-        /// </returns>
-        [HttpGet]
-        [Route("admin/getsitetoken")]
-        [Authorize(Policy = PolicyNames.AdminAuthLevel)]
-        public IActionResult GetSiteToken()
-        {
-            if (!_environment.IsLinuxContainerEnvironment())
-            {
-                return BadRequest("Endpoint is only available when running in Linux Container");
-            }
-
-            string websiteEncryptionKey = _environment.GetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey);
-            if (string.IsNullOrEmpty(websiteEncryptionKey))
-            {
-                return NotFound("WEBSITE_AUTH_ENCRYPTION_KEY is not set.");
-            }
-
-            string requestHeaderToken = SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddHours(2), websiteEncryptionKey.ToKeyBytes());
-            return Ok(requestHeaderToken);
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                 return NotFound("WEBSITE_AUTH_ENCRYPTION_KEY is not set.");
             }
 
-            string requestHeaderToken = SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddMinutes(30), websiteEncryptionKey.ToKeyBytes());
+            string requestHeaderToken = SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddHours(2), websiteEncryptionKey.ToKeyBytes());
             return Ok(requestHeaderToken);
         }
     }

--- a/test/WebJobs.Script.Tests/Controllers/Admin/HostControllerTests.cs
+++ b/test/WebJobs.Script.Tests/Controllers/Admin/HostControllerTests.cs
@@ -4,10 +4,12 @@
 using System.IO;
 using System.Net;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs.Script.WebHost.Controllers;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
@@ -104,9 +106,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 // Act
                 ObjectResult result = (ObjectResult)_hostController.GetAdminToken();
                 HttpStatusCode resultStatus = (HttpStatusCode)result.StatusCode;
+                string token = (string)result.Value;
 
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, resultStatus);
+                Assert.True(SimpleWebTokenHelper.ValidateToken(token, new SystemClock()));
             }
         }
 

--- a/test/WebJobs.Script.Tests/Controllers/Admin/HostControllerTests.cs
+++ b/test/WebJobs.Script.Tests/Controllers/Admin/HostControllerTests.cs
@@ -90,5 +90,43 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Assert.False(fileExists);
             }
         }
+
+        [Fact]
+        public void GetAdminToken_Succeeds()
+        {
+            // Arrange
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(It.Is<string>(k => k == EnvironmentSettingNames.ContainerName))).Returns<string>(v => v = "ContainerName");
+
+            var key = TestHelpers.GenerateKeyBytes();
+            var stringKey = TestHelpers.GenerateKeyHexString(key);
+            using (new TestScopedEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, stringKey))
+            {
+                // Act
+                ObjectResult result = (ObjectResult)_hostController.GetAdminToken();
+                HttpStatusCode resultStatus = (HttpStatusCode)result.StatusCode;
+
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, resultStatus);
+            }
+        }
+
+        [Fact]
+        public void GetAdminToken_Fails_NotLinuxContainer()
+        {
+            // Arrange
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(It.Is<string>(k => k == EnvironmentSettingNames.ContainerName))).Returns<string>(v => v = null);
+
+            var key = TestHelpers.GenerateKeyBytes();
+            var stringKey = TestHelpers.GenerateKeyHexString(key);
+            using (new TestScopedEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, stringKey))
+            {
+                // Act
+                ObjectResult result = (ObjectResult)_hostController.GetAdminToken();
+                HttpStatusCode resultStatus = (HttpStatusCode)result.StatusCode;
+
+                // Assert
+                Assert.Equal(HttpStatusCode.BadRequest, resultStatus);
+            }
+        }
     }
 }


### PR DESCRIPTION
Add an `admin/host/token` endpoint in function host for providing a temporary x-ms-site-restricted-token.
This endpoint is used by function core tool when calling /api/zipdeploy endpoint in KuduLite (Linux Consumption).
1. The function core tool will make a call to `ARM api/sites/{name}/hostRuntimeApiName/{*extensionApiMethod}`.
2. After receiving the temporary x-ms-site-restricted-token, attaches it to Kudulite's /api/zipdeploy request header.
3. The KuduLite will check the authentication according to the token, and decide whether it should proceed the build.

We want to add this mechanism because in Service Fabric Mesh, we allow user to access our container with IP address, which mean they can bypass the frontend authentication.
Such mechanism will secure the endpoints even when a user is calling api/zipdeploy endpoint using IP address.

@balag0 