### PR TITLE
Fixing DurableTask SyncTriggers config parsing

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -358,20 +358,19 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             var config = new Dictionary<string, string>();
             if (FileUtility.FileExists(hostJsonPath))
             {
-                var hostJson = JObject.Parse(await FileUtility.ReadAsync(hostJsonPath));
-                JToken durableTaskValue;
+                var json = JObject.Parse(await FileUtility.ReadAsync(hostJsonPath));
+
+                // get the DurableTask extension config section
+                JToken extensionsValue;
+                if (json.TryGetValue("extensions", StringComparison.OrdinalIgnoreCase, out extensionsValue) && extensionsValue != null)
+                {
+                    json = (JObject)extensionsValue;
+                }
 
                 // we will allow case insensitivity given it is likely user hand edited
                 // see https://github.com/Azure/azure-functions-durable-extension/issues/111
-                //
-                // We're looking for {VALUE}
-                // {
-                //     "durableTask": {
-                //         "hubName": "{VALUE}",
-                //         "azureStorageConnectionStringName": "{VALUE}"
-                //     }
-                // }
-                if (hostJson.TryGetValue(DurableTask, StringComparison.OrdinalIgnoreCase, out durableTaskValue) && durableTaskValue != null)
+                JToken durableTaskValue;
+                if (json.TryGetValue(DurableTask, StringComparison.OrdinalIgnoreCase, out durableTaskValue) && durableTaskValue != null)
                 {
                     try
                     {

--- a/test/WebJobs.Script.Tests/Managment/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Managment/FunctionsSyncManagerTests.cs
@@ -384,7 +384,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             fileSystem.SetupGet(f => f.File).Returns(fileBase.Object);
             fileBase.Setup(f => f.Exists(Path.Combine(rootPath, "host.json"))).Returns(true);
 
-            hostJsonContent = hostJsonContent ?? @"{ ""durableTask"": { ""HubName"": ""TestHubValue"", ""azureStorageConnectionStringName"": ""DurableStorage"" }}";
+            var durableConfig = new JObject
+            {
+                { "HubName", "TestHubValue" },
+                { "azureStorageConnectionStringName", "DurableStorage" }
+            };
+            var extensionsConfig = new JObject
+            {
+                { "durableTask", durableConfig }
+            };
+            var defaultHostConfig = new JObject
+            {
+                { "extensions", extensionsConfig }
+            };
+            hostJsonContent = hostJsonContent ?? defaultHostConfig.ToString();
             var testHostJsonStream = new MemoryStream(Encoding.UTF8.GetBytes(hostJsonContent));
             testHostJsonStream.Position = 0;
             fileBase.Setup(f => f.Open(Path.Combine(rootPath, @"host.json"), It.IsAny<FileMode>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>())).Returns(testHostJsonStream);


### PR DESCRIPTION
The Kudu update [here](https://github.com/projectkudu/kudu/commit/7a8e2a21a753c6a1578e9775ff953b4f761866a8#diff-abf2dbc20b1bcf04681110fb0bf9824f) was never ported to runtime it seems.

The v1 logic should be good as is, since it's reading the old v1 config format (code [here](https://github.com/Azure/azure-functions-host/blob/edbfc8e4b8096a75bca0be0d2e72acb15687694c/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs#L337)).