### PR TITLE
Added global HTTP response headers configuration. Resolves #3788.

### DIFF
--- a/src/WebJobs.Script.WebHost/Configuration/CustomHttpHeadersOptions.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/CustomHttpHeadersOptions.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
+{
+    /// <summary>
+    /// Gets or sets the list of headers to add to every HTTP response.
+    /// </summary>
+    public class CustomHttpHeadersOptions : Dictionary<string, string>
+    {
+    }
+}

--- a/src/WebJobs.Script.WebHost/Configuration/CustomHttpHeadersOptionsSetup.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/CustomHttpHeadersOptionsSetup.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Script.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
+{
+    internal class CustomHttpHeadersOptionsSetup : IConfigureOptions<CustomHttpHeadersOptions>
+    {
+        private readonly IConfiguration _configuration;
+
+        public CustomHttpHeadersOptionsSetup(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public void Configure(CustomHttpHeadersOptions options)
+        {
+            IConfigurationSection jobHostSection = _configuration.GetSection(ConfigurationSectionNames.JobHost);
+            var httpGlobalSection = jobHostSection.GetSection(ConfigurationSectionNames.CustomHttpHeaders);
+            httpGlobalSection.Bind(options);
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Middleware/CustomHttpHeadersMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/CustomHttpHeadersMiddleware.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Script.Middleware;
+using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
+{
+    public class CustomHttpHeadersMiddleware : IJobHostHttpMiddleware
+    {
+        private readonly CustomHttpHeadersOptions _hostOptions;
+
+        public CustomHttpHeadersMiddleware(IOptions<CustomHttpHeadersOptions> hostOptions)
+        {
+            _hostOptions = hostOptions.Value;
+        }
+
+        public async Task Invoke(HttpContext context, RequestDelegate next)
+        {
+            await next(context);
+
+            foreach (var header in _hostOptions)
+            {
+                context.Response.Headers.TryAdd(header.Key, header.Value);
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -12,6 +12,7 @@ using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
 using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
+using Microsoft.Azure.WebJobs.Script.WebHost.Middleware;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -33,6 +34,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     // register default configuration
                     // must happen before the script host is added below
                     services.ConfigureOptions<HttpOptionsSetup>();
+                    services.ConfigureOptions<CustomHttpHeadersOptionsSetup>();
                     services.ConfigureOptions<HostHstsOptionsSetup>();
                 })
                 .AddScriptHost(webHostOptions, configLoggerFactory, webJobsBuilder =>
@@ -76,6 +78,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     services.TryAddSingleton<IScriptWebHookProvider>(p => p.GetService<DefaultScriptWebHookProvider>());
                     services.TryAddSingleton<IWebHookProvider>(p => p.GetService<DefaultScriptWebHookProvider>());
                     services.TryAddSingleton<IJobHostMiddlewarePipeline, DefaultMiddlewarePipeline>();
+                    services.TryAddSingleton<IJobHostHttpMiddleware, CustomHttpHeadersMiddleware>();
                     services.TryAddSingleton<IJobHostHttpMiddleware, HstsConfigurationMiddleware>();
 
                     // Make sure the registered IHostIdProvider is used

--- a/src/WebJobs.Script/Config/ConfigurationSectionNames.cs
+++ b/src/WebJobs.Script/Config/ConfigurationSectionNames.cs
@@ -15,5 +15,6 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
         public const string ManagedDependency = "managedDependency";
         public const string Http = "http";
         public const string Hsts = Http + ":hsts";
+        public const string CustomHttpHeaders = Http + ":customHeaders";
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/Middleware/CustomHeadersMiddlewareCSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Middleware/CustomHeadersMiddlewareCSharpEndToEndTests.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Rpc;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
+{
+    public class CustomHeadersMiddlewareCSharpEndToEndTests :
+        CustomHeadersMiddlewareEndToEndTestsBase<CustomHeadersMiddlewareCSharpEndToEndTests.TestFixture>
+    {
+        public CustomHeadersMiddlewareCSharpEndToEndTests(TestFixture fixture) : base(fixture)
+        {
+        }
+
+        [Fact]
+        public Task CustomHeadersMiddlewareRootUrl()
+        {
+            return CustomHeadersMiddlewareRootUrlTest();
+        }
+
+        [Fact]
+        public Task CustomHeadersMiddlewareAdminUrl()
+        {
+            return CustomHeadersMiddlewareAdminUrlTest();
+        }
+
+        [Fact]
+        public Task CustomHeadersMiddlewareHttpTriggerUrl()
+        {
+            return CustomHeadersMiddlewareHttpTriggerUrlTest();
+        }
+
+        [Fact]
+        public Task CustomHeadersMiddlewareExtensionWebhookUrl()
+        {
+            return CustomHeadersMiddlewareExtensionWebhookUrlTest();
+        }
+
+        public class TestFixture : CustomHeadersMiddlewareTestFixture
+        {
+            private const string ScriptRoot = @"TestScripts\CustomHeadersMiddleware\CSharp";
+
+            public TestFixture() : base(ScriptRoot, "csharp", LanguageWorkerConstants.DotNetLanguageWorkerName)
+            {
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/Middleware/CustomHeadersMiddlewareEndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/Middleware/CustomHeadersMiddlewareEndToEndTestsBase.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Models;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
+{
+    public abstract class CustomHeadersMiddlewareEndToEndTestsBase<TTestFixture> :
+        EndToEndTestsBase<TTestFixture> where TTestFixture : CustomHeadersMiddlewareTestFixture, new()
+    {
+        public CustomHeadersMiddlewareEndToEndTestsBase(TTestFixture fixture) : base(fixture)
+        {
+        }
+
+        protected async Task CustomHeadersMiddlewareRootUrlTest()
+        {
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, string.Empty);
+
+            HttpResponseMessage response = await Fixture.Host.HttpClient.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            IEnumerable<string> values;
+            Assert.True(response.Headers.TryGetValues("X-Content-Type-Options", out values));
+            Assert.Equal("nosniff", values.FirstOrDefault());
+        }
+
+        protected async Task CustomHeadersMiddlewareAdminUrlTest()
+        {
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "admin/host/ping");
+
+            HttpResponseMessage response = await Fixture.Host.HttpClient.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            IEnumerable<string> values;
+            Assert.True(response.Headers.TryGetValues("X-Content-Type-Options", out values));
+            Assert.Equal("nosniff", values.FirstOrDefault());
+        }
+
+        protected async Task CustomHeadersMiddlewareHttpTriggerUrlTest()
+        {
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "api/HttpTrigger");
+
+            HttpResponseMessage response = await Fixture.Host.HttpClient.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            IEnumerable<string> values;
+            Assert.True(response.Headers.TryGetValues("X-Content-Type-Options", out values));
+            Assert.Equal("nosniff", values.FirstOrDefault());
+        }
+
+        protected async Task CustomHeadersMiddlewareExtensionWebhookUrlTest()
+        {
+            var secrets = await Fixture.Host.SecretManager.GetHostSecretsAsync();
+            var url = $"/runtime/webhooks/durableTask/instances?taskHub=MiddlewareTestHub&code={secrets.MasterKey}";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, url);
+
+            HttpResponseMessage response = await Fixture.Host.HttpClient.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            IEnumerable<string> values;
+            Assert.True(response.Headers.TryGetValues("X-Content-Type-Options", out values));
+            Assert.Equal("nosniff", values.FirstOrDefault());
+        }
+    }
+
+    public abstract class CustomHeadersMiddlewareTestFixture: EndToEndTestFixture
+    {
+        protected override ExtensionPackageReference[] GetExtensionsToInstall()
+        {
+            return new ExtensionPackageReference[]
+            {
+                new ExtensionPackageReference
+                {
+                    Id = "Microsoft.Azure.WebJobs.Extensions.DurableTask",
+                    Version = "1.8.2"
+                }
+            };
+        }
+
+        protected CustomHeadersMiddlewareTestFixture(string rootPath, string testId, string language) :
+            base(rootPath, testId, language)
+        {
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/Middleware/CustomHeadersMiddlewareNodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Middleware/CustomHeadersMiddlewareNodeEndToEndTests.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Rpc;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
+{
+    public class CustomHeadersMiddlewareNodeEndToEndTests :
+        CustomHeadersMiddlewareEndToEndTestsBase<CustomHeadersMiddlewareNodeEndToEndTests.TestFixture>
+    {
+        public CustomHeadersMiddlewareNodeEndToEndTests(TestFixture fixture) : base(fixture)
+        {
+        }
+
+        [Fact]
+        public Task CustomHeadersMiddlewareRootUrl()
+        {
+            return CustomHeadersMiddlewareRootUrlTest();
+        }
+
+        [Fact]
+        public Task CustomHeadersMiddlewareAdminUrl()
+        {
+            return CustomHeadersMiddlewareAdminUrlTest();
+        }
+
+        [Fact]
+        public Task CustomHeadersMiddlewareHttpTriggerUrl()
+        {
+            return CustomHeadersMiddlewareHttpTriggerUrlTest();
+        }
+
+        [Fact]
+        public Task CustomHeadersMiddlewareExtensionWebhookUrl()
+        {
+            return CustomHeadersMiddlewareExtensionWebhookUrlTest();
+        }
+
+        public class TestFixture : CustomHeadersMiddlewareTestFixture
+        {
+            private const string ScriptRoot = @"TestScripts\CustomHeadersMiddleware\Node";
+
+            public TestFixture() : base(ScriptRoot, "node", LanguageWorkerConstants.NodeLanguageWorkerName)
+            {
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CustomHeadersMiddleware/CSharp/HttpTrigger/function.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CustomHeadersMiddleware/CSharp/HttpTrigger/function.json
@@ -1,0 +1,16 @@
+{
+  "bindings": [
+    {
+      "type": "httpTrigger",
+      "name": "req",
+      "direction": "in",
+      "methods": [ "get" ],
+      "authLevel": "anonymous"
+    },
+    {
+      "type": "http",
+      "name": "$return",
+      "direction": "out"
+    }
+  ]
+}

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CustomHeadersMiddleware/CSharp/HttpTrigger/run.csx
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CustomHeadersMiddleware/CSharp/HttpTrigger/run.csx
@@ -1,0 +1,10 @@
+﻿using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
+
+public static IActionResult Run(HttpRequest req, TraceWriter log)
+{
+    log.Info("C# HTTP trigger function processed a request.");
+
+    return new OkObjectResult("Success");
+}

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CustomHeadersMiddleware/CSharp/host.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CustomHeadersMiddleware/CSharp/host.json
@@ -1,0 +1,13 @@
+{
+  "version": "2.0",
+  "http": {
+    "customHeaders": {
+      "X-Content-Type-Options": "nosniff"
+    }
+  },
+  "extensions": {
+    "durableTask": {
+      "hubName": "CustomHeadersMiddlewareCSharpTestHub"
+    }
+  }
+}

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CustomHeadersMiddleware/Node/HttpTrigger/function.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CustomHeadersMiddleware/Node/HttpTrigger/function.json
@@ -1,0 +1,16 @@
+﻿{
+  "bindings": [
+    {
+      "type": "httpTrigger",
+      "name": "req",
+      "direction": "in",
+      "methods": [ "get" ],
+      "authLevel": "anonymous"
+    },
+    {
+      "type": "http",
+      "name": "$return",
+      "direction": "out"
+    }
+  ]
+}

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CustomHeadersMiddleware/Node/HttpTrigger/index.js
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CustomHeadersMiddleware/Node/HttpTrigger/index.js
@@ -1,0 +1,9 @@
+﻿module.exports = function (context, req) {
+    context.log('Node.js HTTP trigger function processed a request.');
+
+    const res = {
+        status: 200,
+    };
+
+    context.done(null, res);
+};

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CustomHeadersMiddleware/Node/host.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CustomHeadersMiddleware/Node/host.json
@@ -1,0 +1,13 @@
+﻿{
+  "version": "2.0",
+  "http": {
+    "customHeaders": {
+      "X-Content-Type-Options": "nosniff"
+    }
+  },
+  "extensions": {
+    "durableTask": {
+      "hubName": "CustomHeadersMiddlewareNodeTestHub"
+    }
+  }
+}

--- a/test/WebJobs.Script.Tests/Configuration/CustomHttpHeadersOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/CustomHttpHeadersOptionsSetupTests.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Azure.WebJobs.Script.Configuration;
+using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.WebJobs.Script.Tests;
+using Xunit;
+using static Microsoft.Azure.WebJobs.Script.EnvironmentSettingNames;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
+{
+    public class CustomHttpHeadersOptionsSetupTests
+    {
+        private readonly TestEnvironment _environment = new TestEnvironment();
+        private readonly TestLoggerProvider _loggerProvider = new TestLoggerProvider();
+        private readonly string _hostJsonFile;
+        private readonly string _rootPath;
+        private readonly ScriptApplicationHostOptions _options;
+
+        public CustomHttpHeadersOptionsSetupTests()
+        {
+            _rootPath = Path.Combine(Environment.CurrentDirectory, "ScriptHostTests");
+            Environment.SetEnvironmentVariable(AzureWebJobsScriptRoot, _rootPath);
+
+            if (!Directory.Exists(_rootPath))
+            {
+                Directory.CreateDirectory(_rootPath);
+            }
+
+            _options = new ScriptApplicationHostOptions
+            {
+                ScriptPath = _rootPath
+            };
+
+            _hostJsonFile = Path.Combine(_rootPath, "host.json");
+            if (File.Exists(_hostJsonFile))
+            {
+                File.Delete(_hostJsonFile);
+            }
+        }
+
+        [Theory]
+        [InlineData(@"{
+                    'version': '2.0',
+                    }")]
+        [InlineData(@"{
+                    'version': '2.0',
+                    'http': {
+                        'customHeaders': {
+                            'X-Content-Type-Options': 'nosniff'
+                            }
+                        }
+                    }")]
+        public void MissingOrValidCustomHttpHeadersConfig_DoesNotThrowException(string hostJsonContent)
+        {
+            File.WriteAllText(_hostJsonFile, hostJsonContent);
+            var configuration = BuildHostJsonConfiguration();
+
+            CustomHttpHeadersOptionsSetup setup = new CustomHttpHeadersOptionsSetup(configuration);
+            CustomHttpHeadersOptions options = new CustomHttpHeadersOptions();
+            var ex = Record.Exception(() => setup.Configure(options));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void ValidCustomHttpHeadersConfig_BindsToOptions()
+        {
+            string hostJsonContent = @"{
+                                         'version': '2.0',
+                                         'http': {
+                                             'customHeaders': {
+                                                 'X-Content-Type-Options': 'nosniff'
+                                             }
+                                         }
+                                     }";
+            File.WriteAllText(_hostJsonFile, hostJsonContent);
+            var configuration = BuildHostJsonConfiguration();
+
+            CustomHttpHeadersOptionsSetup setup = new CustomHttpHeadersOptionsSetup(configuration);
+            CustomHttpHeadersOptions options = new CustomHttpHeadersOptions();
+            setup.Configure(options);
+            Assert.Equal(new Dictionary<string, string>() { { "X-Content-Type-Options", "nosniff" } }, options);
+        }
+
+        private IConfiguration BuildHostJsonConfiguration(IEnvironment environment = null)
+        {
+            environment = environment ?? new TestEnvironment();
+
+            var loggerFactory = new LoggerFactory();
+            loggerFactory.AddProvider(_loggerProvider);
+
+            var configSource = new HostJsonFileConfigurationSource(_options, environment, loggerFactory);
+
+            var configurationBuilder = new ConfigurationBuilder()
+                .Add(configSource);
+
+            return configurationBuilder.Build();
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Middleware/CustomHttpHeadersMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Middleware/CustomHttpHeadersMiddlewareTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
+using Microsoft.Azure.WebJobs.Script.WebHost.Middleware;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
+{
+    public class CustomHttpHeadersMiddlewareTests
+    {
+        [Fact]
+        public async Task Invoke_hasCustomHeaders_AddsResponseHeaders()
+        {
+            var headers = new CustomHttpHeadersOptions
+            {
+                { "X-Content-Type-Options", "nosniff" },
+                { "Feature-Policy", "camera 'none'; geolocation 'none'" }
+            };
+            var headerOptions = new OptionsWrapper<CustomHttpHeadersOptions>(headers);
+
+            bool nextInvoked = false;
+            RequestDelegate next = (context) =>
+            {
+                nextInvoked = true;
+                context.Response.StatusCode = (int)HttpStatusCode.Accepted;
+                return Task.CompletedTask;
+            };
+
+            var middleware = new CustomHttpHeadersMiddleware(headerOptions);
+
+            var httpContext = new DefaultHttpContext();
+            await middleware.Invoke(httpContext, next);
+            Assert.True(nextInvoked);
+            Assert.Equal(httpContext.Response.Headers["X-Content-Type-Options"].ToString(), "nosniff");
+            Assert.Equal(httpContext.Response.Headers["Feature-Policy"].ToString(), "camera 'none'; geolocation 'none'");
+        }
+
+        [Fact]
+        public async Task Invoke_noCustomHeaders_DoesNotAddResponseHeader()
+        {
+            var headerOptions = new OptionsWrapper<CustomHttpHeadersOptions>(new CustomHttpHeadersOptions());
+
+            bool nextInvoked = false;
+            RequestDelegate next = (context) =>
+            {
+                nextInvoked = true;
+                context.Response.StatusCode = (int)HttpStatusCode.Accepted;
+                return Task.CompletedTask;
+            };
+
+            var middleware = new CustomHttpHeadersMiddleware(headerOptions);
+
+            var httpContext = new DefaultHttpContext();
+            await middleware.Invoke(httpContext, next);
+            Assert.True(nextInvoked);
+            Assert.Equal(httpContext.Response.Headers.Count, 0);
+        }
+    }
+}


### PR DESCRIPTION
Resolves #3788 

Global HTTP headers are configured at the root host.json level, ex.:

```json
{
  "version": "2.0",
  "customHeaders":
  {
    "X-Content-Type-Options": "nosniff"
  }
}
```

I chose the name `customHeaders` for its familiarity to ASP.NET Core developers, being used for the same purpose in web.config.