### PR TITLE
Update PowerShell worker to v0.1.111-preview.

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.8100001-0126c21e" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.4.1" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.3" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.102-preview" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.111-preview" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.10" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2" />


### PR DESCRIPTION
The major changes for this release are:
* Proxies fix
* Updated proto files used by PowerShell worker
* Set response Content-Type to 'application/json' when an object is provided to Body
* Managed Dependencies (MDs) enhancements:
    -    Added retry logic for module installation with a maximum of 3 retries
    -    If unable to reach the PSGallery during installation:
         * If this is the first time we are installing MDs, we error out and stop execution
         * If there is a previous installation of MDs, log that we could not connect to the PSGallery and continue with the function app execution
* Enhancements to throughput performance

Release details: https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v0.1.111-preview