### PR TITLE
Fix unhandled exception when log file is locked by another process

### DIFF
--- a/src/WebJobs.Script/Diagnostics/FileWriter.cs
+++ b/src/WebJobs.Script/Diagnostics/FileWriter.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Azure.WebJobs.Script
                     // we include a sequence number in case a log file is created within a second of the
                     // last one (could happen if a log file becomes locked by another process).
                     var timestamp = DateTime.UtcNow.ToString("yyyy-MM-ddTHH-mm-ssK");
-                    string filePath = Path.Combine(_logFilePath, $"{timestamp}-{_instanceId}-{_currentLogFileSequence++}.log");
+                    string filePath = Path.Combine(_logFilePath, $"{timestamp}-{_currentLogFileSequence++}-{_instanceId}.log");
                     _currentLogFileInfo = new FileInfo(filePath);
                     _currentLogFileInfo.Create().Close();
                     newLogFileCreated = true;


### PR DESCRIPTION
Resolves #3745 

Overview: IOException is crashing the host when log file is unable to be opened. This means the log file is unusable for an unknown amount of time, so we need to create a new log file so we don't lose logs.

Questions to be answered: Would changing the format of log file names be a breaking change?