### PR TITLE
Deflect GitHub bug reports with "Diagnose and solve problems"

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -4,6 +4,9 @@ about: Create a report to help us improve
 
 ---
 
+#### Check for a solution in the Azure portal
+For issues in production, please check for a solution to common issues in the Azure portal before opening a bug. In the Azure portal, navigate to your function app => `Platform features` => `Diagnose and solve problems` and the relevant dashboards before opening your issue.
+
 <!-- 
 Please provide a succinct description of the issue. Please make an effort to fill in the all the sections below or we may close your issue for being low quality. 
 -->


### PR DESCRIPTION
I've worked on a few bug reports that could have been solved with the "Diagnose and solve problems" blade. It would be great to make it easy to deflect GitHub issues that are easily solved!

Would love help on the wording / formatting

@paulbatum @fabiocav @mattchenderson @alexkarcher-msft 