### PR TITLE
preventing races during specialization

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
@@ -12,115 +12,127 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
 
         private static readonly Action<ILogger, Exception> _scriptHostServiceInitCanceledByRuntime =
             LoggerMessage.Define(
-            LogLevel.Information,
-            new EventId(500, nameof(ScriptHostServiceInitCanceledByRuntime)),
-            "Initialization cancellation requested by runtime.");
+                LogLevel.Information,
+                new EventId(500, nameof(ScriptHostServiceInitCanceledByRuntime)),
+                "Initialization cancellation requested by runtime.");
 
         private static readonly Action<ILogger, int, TimeSpan, Exception> _unehealthyCountExceeded =
             LoggerMessage.Define<int, TimeSpan>(
-            LogLevel.Error,
-            new EventId(501, nameof(UnhealthyCountExceeded)),
-            "Host unhealthy count exceeds the threshold of {healthCheckThreshold} for time window {healthCheckWindow}. Initiating shutdown.");
+                LogLevel.Error,
+                new EventId(501, nameof(UnhealthyCountExceeded)),
+                "Host unhealthy count exceeds the threshold of {healthCheckThreshold} for time window {healthCheckWindow}. Initiating shutdown.");
 
         private static readonly Action<ILogger, Exception> _offline =
             LoggerMessage.Define(
-            LogLevel.Information,
-            new EventId(502, nameof(Offline)),
-            "Host is offline.");
+                LogLevel.Information,
+                new EventId(502, nameof(Offline)),
+                "Host is offline.");
 
         private static readonly Action<ILogger, Exception> _initializing =
             LoggerMessage.Define(
-            LogLevel.Information,
-            new EventId(503, nameof(Initializing)),
-            "Initializing Host.");
+                LogLevel.Information,
+                new EventId(503, nameof(Initializing)),
+                "Initializing Host.");
 
         private static readonly Action<ILogger, int, int, Exception> _initialization =
             LoggerMessage.Define<int, int>(
-            LogLevel.Information,
-            new EventId(504, nameof(Initialization)),
-            "Host initialization: ConsecutiveErrors={attemptCount}, StartupCount={startCount}");
+                LogLevel.Information,
+                new EventId(504, nameof(Initialization)),
+                "Host initialization: ConsecutiveErrors={attemptCount}, StartupCount={startCount}");
 
         private static readonly Action<ILogger, Exception> _inStandByMode =
             LoggerMessage.Define(
-            LogLevel.Information,
-            new EventId(505, nameof(InStandByMode)),
-            "Host is in standby mode");
+                LogLevel.Information,
+                new EventId(505, nameof(InStandByMode)),
+                "Host is in standby mode");
 
         private static readonly Action<ILogger, Exception> _unhealthyRestart =
             LoggerMessage.Define(
-            LogLevel.Error,
-            new EventId(506, nameof(UnhealthyRestart)),
-            "Host is unhealthy. Initiating a restart.");
+                LogLevel.Error,
+                new EventId(506, nameof(UnhealthyRestart)),
+                "Host is unhealthy. Initiating a restart.");
 
         private static readonly Action<ILogger, Exception> _stopping =
             LoggerMessage.Define(
-            LogLevel.Information,
-            new EventId(507, nameof(Stopping)),
-            "Stopping host...");
+                LogLevel.Information,
+                new EventId(507, nameof(Stopping)),
+                "Stopping host...");
 
         private static readonly Action<ILogger, Exception> _didNotShutDown =
             LoggerMessage.Define(
-            LogLevel.Warning,
-            new EventId(508, nameof(DidNotShutDown)),
-            "Host did not shutdown within its allotted time.");
+                LogLevel.Warning,
+                new EventId(508, nameof(DidNotShutDown)),
+                "Host did not shutdown within its allotted time.");
 
-        private static readonly Action<ILogger,  Exception> _shutDownCompleted =
+        private static readonly Action<ILogger, Exception> _shutDownCompleted =
             LoggerMessage.Define(
-            LogLevel.Information,
-            new EventId(509, nameof(ShutDownCompleted)),
-            "Host shutdown completed.");
+                LogLevel.Information,
+                new EventId(509, nameof(ShutDownCompleted)),
+                "Host shutdown completed.");
 
         private static readonly Action<ILogger, string, Exception> _skipRestart =
             LoggerMessage.Define<string>(
-            LogLevel.Debug,
-            new EventId(510, nameof(SkipRestart)),
-            "Host restart was requested, but current host state is '{state}'. Skipping restart.");
+                LogLevel.Debug,
+                new EventId(510, nameof(SkipRestart)),
+                "Host restart was requested, but current host state is '{state}'. Skipping restart.");
 
         private static readonly Action<ILogger, Exception> _restarting =
             LoggerMessage.Define(
-            LogLevel.Information,
-            new EventId(511, nameof(Restarting)),
-            "Restarting host.");
+                LogLevel.Information,
+                new EventId(511, nameof(Restarting)),
+                "Restarting host.");
 
         private static readonly Action<ILogger, Exception> _restarted =
             LoggerMessage.Define(
-            LogLevel.Information,
-            new EventId(512, nameof(Restarted)),
-            "Host restarted.");
+                LogLevel.Information,
+                new EventId(512, nameof(Restarted)),
+                "Host restarted.");
 
         private static readonly Action<ILogger, string, string, Exception> _building =
             LoggerMessage.Define<string, string>(
-            LogLevel.Information,
-            new EventId(513, nameof(Building)),
-            "Building host: startup suppressed:{skipHostStartup}, configuration suppressed: {skipHostJsonConfiguration}");
+                LogLevel.Information,
+                new EventId(513, nameof(Building)),
+                "Building host: startup suppressed:{skipHostStartup}, configuration suppressed: {skipHostJsonConfiguration}");
 
         private static readonly Action<ILogger, Exception> _startupWasCanceled =
             LoggerMessage.Define(
-            LogLevel.Debug,
-            new EventId(514, nameof(StartupWasCanceled)),
-            "Host startup was canceled.");
+                LogLevel.Debug,
+                new EventId(514, nameof(StartupWasCanceled)),
+                "Host startup was canceled.");
 
         private static readonly Action<ILogger, Exception> _errorOccured =
             LoggerMessage.Define(
-            LogLevel.Debug,
-            new EventId(515, nameof(ErrorOccured)),
-            "A host error has occurred");
+                LogLevel.Error,
+                new EventId(515, nameof(ErrorOccured)),
+                "A host error has occurred");
 
         private static readonly Action<ILogger, Exception> _errorOccuredInactive =
             LoggerMessage.Define(
-            LogLevel.Debug,
-            new EventId(516, nameof(ErrorOccuredInactive)),
-            "A host error has occurred on an inactive host");
+                LogLevel.Warning,
+                new EventId(516, nameof(ErrorOccuredInactive)),
+                "A host error has occurred on an inactive host");
 
         private static readonly Action<ILogger, Exception> _cancellationRequested =
             LoggerMessage.Define(
-            LogLevel.Debug,
-            new EventId(517, nameof(CancellationRequested)),
-            "Cancellation requested. A new host will not be started.");
+                LogLevel.Debug,
+                new EventId(517, nameof(CancellationRequested)),
+                "Cancellation requested. A new host will not be started.");
+
+        private static readonly Action<ILogger, string, string, Exception> _activeHostChanging =
+            LoggerMessage.Define<string, string>(
+                LogLevel.Debug,
+                new EventId(518, nameof(ActiveHostChanging)),
+                "Active host changing from '{oldHostInstanceId}' to '{newHostInstanceId}'.");
+
+        private static readonly Action<ILogger, Exception> _enteringRestart =
+            LoggerMessage.Define(
+                LogLevel.Debug,
+                new EventId(519, nameof(EnteringRestart)),
+                "Restart requested. Cancelling any active host startup.");
 
         public static void ScriptHostServiceInitCanceledByRuntime(this ILogger logger)
         {
-           _scriptHostServiceInitCanceledByRuntime(logger, null);
+            _scriptHostServiceInitCanceledByRuntime(logger, null);
         }
 
         public static void UnhealthyCountExceeded(this ILogger logger, int healthCheckThreshold, TimeSpan healthCheckWindow)
@@ -130,22 +142,22 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
 
         public static void Offline(this ILogger logger)
         {
-           _offline(logger, null);
+            _offline(logger, null);
         }
 
         public static void Initializing(this ILogger logger)
         {
-           _initializing(logger, null);
+            _initializing(logger, null);
         }
 
         public static void Initialization(this ILogger logger, int attemptCount, int startCount)
         {
-           _initialization(logger, attemptCount, startCount, null);
+            _initialization(logger, attemptCount, startCount, null);
         }
 
         public static void InStandByMode(this ILogger logger)
         {
-           _inStandByMode(logger, null);
+            _inStandByMode(logger, null);
         }
 
         public static void UnhealthyRestart(this ILogger logger)
@@ -155,7 +167,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
 
         public static void Stopping(this ILogger logger)
         {
-           _stopping(logger, null);
+            _stopping(logger, null);
         }
 
         public static void DidNotShutDown(this ILogger logger)
@@ -165,7 +177,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
 
         public static void ShutDownCompleted(this ILogger logger)
         {
-           _shutDownCompleted(logger, null);
+            _shutDownCompleted(logger, null);
         }
 
         public static void SkipRestart(this ILogger logger, string state)
@@ -175,17 +187,17 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
 
         public static void Restarting(this ILogger logger)
         {
-           _restarting(logger, null);
+            _restarting(logger, null);
         }
 
         public static void Restarted(this ILogger logger)
         {
-           _restarted(logger, null);
+            _restarted(logger, null);
         }
 
         public static void Building(this ILogger logger, string skipHostStartup, string skipHostJsonConfiguration)
         {
-           _building(logger, skipHostStartup, skipHostJsonConfiguration, null);
+            _building(logger, skipHostStartup, skipHostJsonConfiguration, null);
         }
 
         public static void StartupWasCanceled(this ILogger logger)
@@ -206,6 +218,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
         public static void CancellationRequested(this ILogger logger)
         {
             _cancellationRequested(logger, null);
+        }
+
+        public static void ActiveHostChanging(this ILogger logger, string oldHostInstanceId, string newHostInstanceId)
+        {
+            _activeHostChanging(logger, oldHostInstanceId, newHostInstanceId, null);
+        }
+
+        public static void EnteringRestart(this ILogger logger)
+        {
+            _enteringRestart(logger, null);
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETestBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETestBase.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         protected readonly object _originalTimeZoneInfoCache = GetCachedTimeZoneInfo();
         protected TestMetricsLogger _metricsLogger;
 
-    public StandbyManagerE2ETestBase()
+        public StandbyManagerE2ETestBase()
         {
             _testRootPath = Path.Combine(Path.GetTempPath(), "StandbyManagerTests");
             CleanupTestDirectory();
@@ -92,8 +92,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     });
 
                     c.AddSingleton<IEnvironment>(_ => environment);
-                    c.AddSingleton<IConfigureBuilder<ILoggingBuilder>>(new DelegatedConfigureBuilder<ILoggingBuilder>(b => b.AddProvider(_loggerProvider)));
                     c.AddSingleton<IMetricsLogger>(_ => _metricsLogger);
+                })
+                .ConfigureScriptHostLogging(b =>
+                {
+                    b.AddProvider(_loggerProvider);
                 });
 
             _httpServer = new TestServer(webHostBuilder);
@@ -121,7 +124,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             // issue warmup request and verify
             var request = new HttpRequestMessage(HttpMethod.Get, uri);
             var response = await _httpClient.SendAsync(request);
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.True(response.StatusCode == HttpStatusCode.OK, $"Expected 'OK'. Actual '{response.StatusCode}'. {_loggerProvider.GetLog()}");
             string responseBody = await response.Content.ReadAsStringAsync();
             Assert.Equal("WarmUp complete.", responseBody);
         }

--- a/test/WebJobs.Script.Tests.Shared/TestLoggerProvider.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestLoggerProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.WebJobs.Script.Tests
         /// <returns>The log message.</returns>
         public string GetLog()
         {
-            return string.Join(Environment.NewLine, GetAllLogMessages().Select(p => p.FormattedMessage));
+            return string.Join(Environment.NewLine, GetAllLogMessages());
         }
 
         public void ClearAllLogMessages()

--- a/test/WebJobs.Script.Tests.Shared/TestWebHostBuilderExtensions.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestWebHostBuilderExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Tests;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Hosting
 {
@@ -17,5 +18,8 @@ namespace Microsoft.AspNetCore.Hosting
 
         public static IWebHostBuilder ConfigureScriptHostAppConfiguration(this IWebHostBuilder webHostBuilder, Action<IConfigurationBuilder> builder) =>
             webHostBuilder.ConfigureServices(s => s.AddSingleton<IConfigureBuilder<IConfigurationBuilder>>(_ => new DelegatedConfigureBuilder<IConfigurationBuilder>(builder)));
+
+        public static IWebHostBuilder ConfigureScriptHostLogging(this IWebHostBuilder webHostBuilder, Action<ILoggingBuilder> builder) =>
+            webHostBuilder.ConfigureServices(s => s.AddSingleton<IConfigureBuilder<ILoggingBuilder>>(_ => new DelegatedConfigureBuilder<ILoggingBuilder>(builder)));
     }
 }


### PR DESCRIPTION
Fixes #4629.

This is especially apparent when Antares is rolling out a new version. During host reboots we'll be at lower capacity which means specialization occurs very quickly after the process starts up. In some cases, the standby host is still starting and waiting to serve the warmup request. If we specialize right then (which issues a call to `RestartHostAsync()`), we're off to the races. In one incident, the specialized host actually finished first, which means when the standby host completed it's initialization, it set itself back to being active, leaving the customer with a permanent standby host.

And looking at the code, it's possible we'd end up with un-disposed hosts as well. If we issue the restart while the active host is still null (standby is still building), we'll skip any call to Orphan. So that host could stick around and not be properly disposed as we expect.

I'm trying to remove this class of error completely by requiring that any host start or restart needs a lock in order to start. We already take a semaphore when restarting, but calls directly to `StartAsync()` were not a part of this. This will prevent the race I listed above and also mean that during a restart we'll know the previous call had completed everything it was intending to do.