### PR TITLE
Fixing Host Keys race condition (#4661)

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -54,8 +54,8 @@
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.7" />
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.8100001-0126c21e" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="3.0.14-11656" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.14-11656" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="3.0.14-11660" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.14-11660" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.3" />
     <PackageReference Include="Microsoft.Azure.WebSites.DataProtection" Version="2.1.91-alpha" />
     <PackageReference Include="System.Net.Primitives" Version="4.3.0" />

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -192,6 +192,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 if (scriptHost != null)
                 {
                     scriptHost.HostInitializing += OnHostInitializing;
+                    scriptHost.HostInitialized += OnHostInitialized;
                 }
 
                 LogInitialization(localHost, isOffline, attemptCount, ++_hostStartCount);
@@ -391,6 +392,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             IsHostHealthy(throwWhenUnhealthy: true);
         }
 
+        /// <summary>
+        /// Called after the host has been fully initialized, but before it
+        /// has been started.
+        /// </summary>
+        private void OnHostInitialized(object sender, EventArgs e)
+        {
+            State = ScriptHostState.Initialized;
+        }
+
         private IHost BuildHost(bool skipHostStartup, bool skipHostJsonConfiguration)
         {
             _logger.Building(skipHostStartup.ToString(), skipHostJsonConfiguration.ToString());
@@ -517,6 +527,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 if (scriptHost != null)
                 {
                     scriptHost.HostInitializing -= OnHostInitializing;
+                    scriptHost.HostInitialized -= OnHostInitialized;
                 }
             }
             catch (ObjectDisposedException)

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.5.2-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.1.1" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.174-preview" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.14-11656" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.14-11660" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.3" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.4" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.14-11656" />

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.3.0" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.10-11656" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.10-11660" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.5.2-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.1.0" />

--- a/test/WebJobs.Script.Tests/Controllers/Admin/KeysControllerTests.cs
+++ b/test/WebJobs.Script.Tests/Controllers/Admin/KeysControllerTests.cs
@@ -64,7 +64,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             _functionsSyncManagerMock = new Mock<IFunctionsSyncManager>(MockBehavior.Strict);
             _functionsSyncManagerMock.Setup(p => p.TrySyncTriggersAsync(false)).ReturnsAsync(new SyncTriggersResult { Success = true });
-            _testController = new KeysController(new OptionsWrapper<ScriptApplicationHostOptions>(settings), new TestSecretManagerProvider(_secretsManagerMock.Object), new LoggerFactory(), fileSystem.Object, _functionsSyncManagerMock.Object);
+            var hostManagerMock = new Mock<IScriptHostManager>(MockBehavior.Strict);
+            hostManagerMock.SetupGet(p => p.State).Returns(ScriptHostState.Running);
+            _testController = new KeysController(new OptionsWrapper<ScriptApplicationHostOptions>(settings), new TestSecretManagerProvider(_secretsManagerMock.Object), new LoggerFactory(), fileSystem.Object, _functionsSyncManagerMock.Object, hostManagerMock.Object);
 
             var keys = new Dictionary<string, string>
             {

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.9.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.10-11656" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.10-11660" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="2.1.0.227">
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.0" />


### PR DESCRIPTION
Fix Host Keys race condition issue (#4661).

Also fixing ScriptHostState issue (#4095). This latter fix relies on two other PRs:
- Core SDK: https://github.com/Azure/azure-webjobs-sdk/pull/2266
- EventGrid Extension: https://github.com/Azure/azure-functions-eventgrid-extension/pull/75

We'll have to pull in the SDK fix in as part of this PR once it's in.

@paulbatum FYI