### PR TITLE
Max length check/handling for SyncTriggers

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -97,8 +97,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                     return result;
                 }
 
-                var payload = await GetSyncTriggersPayload();
-                string json = JsonConvert.SerializeObject(payload);
+                string json = await GetSyncTriggersPayload();
 
                 bool shouldSyncTriggers = true;
                 string newHash = null;
@@ -245,7 +244,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             return _hashBlob;
         }
 
-        public async Task<JToken> GetSyncTriggersPayload()
+        public async Task<string> GetSyncTriggersPayload()
         {
             var hostOptions = _applicationHostOptions.CurrentValue.ToHostOptions();
             var functionsMetadata = WebFunctionsManager.GetFunctionsMetadata(hostOptions, _workerConfigs, _logger);
@@ -257,7 +256,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             if (!ArmCacheEnabled)
             {
                 // extended format is disabled - just return triggers
-                return triggersArray;
+                return JsonConvert.SerializeObject(triggersArray);
             }
 
             // Add triggers to the payload
@@ -310,7 +309,17 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 // like KeyVault when the feature comes online
             }
 
-            return result;
+            string json = JsonConvert.SerializeObject(result);
+            if (json.Length > ScriptConstants.MaxTriggersStringLength)
+            {
+                // The settriggers call to the FE enforces a max request size
+                // limit. If we're over limit, revert to the minimal triggers
+                // format.
+                _logger.LogWarning($"SyncTriggers payload of length '{json.Length}' exceeds max length of '{ScriptConstants.MaxTriggersStringLength}'. Reverting to minimal format.");
+                return JsonConvert.SerializeObject(triggersArray);
+            }
+
+            return json;
         }
 
         internal async Task<IEnumerable<JObject>> GetFunctionTriggers(IEnumerable<FunctionMetadata> functionsMetadata, ScriptJobHostOptions hostOptions)
@@ -420,9 +429,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             if (ArmCacheEnabled)
             {
                 // sanitize the content before logging
-                var sanitizedContent = JObject.Parse(content);
-                sanitizedContent.Remove("secrets");
-                sanitizedContentString = sanitizedContent.ToString();
+                var sanitizedContent = JToken.Parse(content);
+                if (sanitizedContent.Type == JTokenType.Object)
+                {
+                    ((JObject)sanitizedContent).Remove("secrets");
+                    sanitizedContentString = sanitizedContent.ToString();
+                }
             }
 
             using (var request = BuildSetTriggersRequest())

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -107,6 +107,12 @@ namespace Microsoft.Azure.WebJobs.Script
         public const int MaximumHostIdLength = 32;
         public const int DynamicSkuConnectionLimit = 50;
 
+        /// <summary>
+        /// This constant is also defined in Antares, where the limit is ultimately enforced
+        /// for settriggers calls. If we raise that limit there, we should raise here as well.
+        /// </summary>
+        public const int MaxTriggersStringLength = 102400;
+
         public const string ExtensionsProjectFileName = "extensions.csproj";
         public const string MetadataGeneratorPackageId = "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator";
         public const string MetadataGeneratorPackageVersion = "1.1.*";


### PR DESCRIPTION
The Front End enforces a max sync triggers payload size. When exceeded it returns 400 BadRequest. We should perform this check ourselves before sending the request, and if we're over size, don't send the extended format.