### PR TITLE
[pack] registering correct ExceptionHandler

### DIFF
--- a/src/WebJobs.Script.WebHost/DependencyInjection/DependencyValidator/DependencyValidator.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/DependencyValidator/DependencyValidator.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using Microsoft.Azure.WebJobs.Host.Loggers;
+using Microsoft.Azure.WebJobs.Host.Timers;
 using Microsoft.Azure.WebJobs.Hosting;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
@@ -29,6 +30,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
             expected.Expect<ILoggerFactory, ScriptLoggerFactory>();
 
             expected.Expect<IMetricsLogger, WebHostMetricsLogger>();
+
+            expected.Expect<IWebJobsExceptionHandler, WebScriptHostExceptionHandler>();
 
             expected.Expect<IEventCollectorFactory>("Microsoft.Azure.WebJobs.Logging.EventCollectorFactory");
 

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                     services.AddSingleton<HttpRequestQueue>();
                     services.AddSingleton<IHostLifetime, JobHostHostLifetime>();
-                    services.TryAddSingleton<IWebJobsExceptionHandler, WebScriptHostExceptionHandler>();
+                    services.AddSingleton<IWebJobsExceptionHandler, WebScriptHostExceptionHandler>();
                     services.AddSingleton<IScriptJobHostEnvironment, WebScriptJobHostEnvironment>();
 
                     services.AddSingleton<DefaultScriptWebHookProvider>();

--- a/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/EndToEndTimeoutTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/EndToEndTimeoutTests.cs
@@ -125,8 +125,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                        o.FunctionTimeout = timeout;
                        o.Functions = new List<string> { functionName };
                    });
-
-                   b.Services.AddSingleton<IWebJobsExceptionHandler, MockExceptionHandler>();
                },
                options =>
                {
@@ -135,6 +133,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                .ConfigureLogging(b =>
                {
                    b.AddProvider(_loggerProvider);
+               })
+               .ConfigureServices(s =>
+               {
+                   s.AddSingleton<IWebJobsExceptionHandler, MockExceptionHandler>();
                });
 
             return builder;


### PR DESCRIPTION
We've never actually been running with the correct ExceptionHandler in v2. Another victim of `TryAdd` :-( We're always using the default one from WebJobs, which throws an exception on a background thread in order to force a process crash. Our intent was always to perform a graceful shutdown if we see a timeout... and now we'll finally be doing that.

I also added a validation of this in the DependencyValidator to ensure we keep loading the correct one.