### PR TITLE
Adding function start time to metrics publisher

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
@@ -481,7 +481,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                         runningFunctionInfo.ExecutionStage.ToString(),
                         runningFunctionInfo.Success,
                         (long)executionTimespan,
-                        currentTime);
+                        _executionId,
+                        currentTime,
+                        runningFunctionInfo.StartTime);
                 }
             }
 

--- a/src/WebJobs.Script.WebHost/Metrics/IMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/IMetricsPublisher.cs
@@ -8,6 +8,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
 {
     public interface IMetricsPublisher
     {
-        void AddFunctionExecutionActivity(string functionName, string invocationId, int concurrency, string executionStage, bool success, long executionTimeSpan, DateTime utcNow);
+        void AddFunctionExecutionActivity(string functionName, string invocationId, int concurrency, string executionStage, bool success, long executionTimeSpan, string executionId, DateTime eventTimeStamp, DateTime functionStartTime);
     }
 }

--- a/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         internal async Task SendRequest<T>(ConcurrentQueue<T> activitiesToPublish, string publishPath)
         {
             var request = BuildRequest(HttpMethod.Post, publishPath, activitiesToPublish.ToArray());
-            _logger.LogDebug($"Publishing {activitiesToPublish.ToArray().Count()} activities to {publishPath}.");
+            _logger.LogDebug($"Publishing {activitiesToPublish.Count()} activities to {publishPath}.");
             HttpResponseMessage response = await _httpClient.SendAsync(request);
             response.EnsureSuccessStatusCode();
         }

--- a/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
@@ -95,17 +95,21 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             }
         }
 
-        public void AddFunctionExecutionActivity(string functionName, string invocationId, int concurrency, string executionStage, bool success, long executionTimeSpan, DateTime eventTimeStamp)
+        public void AddFunctionExecutionActivity(string functionName, string invocationId, int concurrency, string executionStage, bool success, long executionTimeSpan, string executionId, DateTime eventTimeStamp, DateTime functionStartTime)
         {
+            Enum.TryParse(executionStage, out FunctionExecutionStage functionExecutionStage);
+
             FunctionActivity activity = new FunctionActivity
             {
                 FunctionName = functionName,
                 InvocationId = invocationId,
                 Concurrency = concurrency,
-                ExecutionStage = executionStage,
+                ExecutionStage = functionExecutionStage,
+                ExecutionId = executionId,
                 IsSucceeded = success,
                 ExecutionTimeSpanInMs = executionTimeSpan,
                 EventTimeStamp = eventTimeStamp,
+                StartTime = functionStartTime,
                 Tenant = _tenant
             };
 
@@ -166,7 +170,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             catch (Exception ex) when (!ex.IsFatal())
             {
                 _errorCount++;
-                _logger.LogError(ex, "Error publishing activites");
 
                 if (_errorCount < _maxErrorLimit)
                 {
@@ -174,7 +177,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
                 }
                 else
                 {
-                    _logger.LogError(string.Format("LinuxContainerMetricsPublisher : Max error limit reached. Draining current activities for {0}", _containerName));
+                    _logger.LogError(ex, string.Format("LinuxContainerMetricsPublisher : Max error limit reached. Draining current activities for {0} for publish path: {1}", _containerName, publishPath));
                     DrainActivities(currentActivities, activitiesToProcess);
                     _errorCount = 0;
                 }
@@ -184,6 +187,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         internal async Task SendRequest<T>(ConcurrentQueue<T> activitiesToPublish, string publishPath)
         {
             var request = BuildRequest(HttpMethod.Post, publishPath, activitiesToPublish.ToArray());
+            _logger.LogDebug($"Publishing {activitiesToPublish.ToArray().Count()} activities to {publishPath}.");
             HttpResponseMessage response = await _httpClient.SendAsync(request);
             response.EnsureSuccessStatusCode();
         }
@@ -201,7 +205,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             _processMonitorTimer = new Timer(OnProcessMonitorTimer, null, TimeSpan.Zero, _memorySnapshotInterval);
             _metricsPublisherTimer = new Timer(OnFunctionMetricsPublishTimer, null, TimeSpan.Zero, _metricPublishInterval);
 
-            _logger.LogInformation(string.Format("Starting metrics publisher for container : {0}", _containerName));
+            _logger.LogInformation(string.Format("Starting metrics publisher for container : {0}. Publishing endpoint is {1}", _containerName, _requestUri));
         }
 
         private void OnProcessMonitorTimer(object state)

--- a/src/WebJobs.Script.WebHost/Models/ActivityBase.cs
+++ b/src/WebJobs.Script.WebHost/Models/ActivityBase.cs
@@ -2,9 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
 {

--- a/src/WebJobs.Script.WebHost/Models/FunctionActivity.cs
+++ b/src/WebJobs.Script.WebHost/Models/FunctionActivity.cs
@@ -2,9 +2,25 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.Serialization;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
 {
+    public enum FunctionExecutionStage
+    {
+        /// <summary>
+        /// The function is currently executing.
+        /// </summary>
+        [EnumMember]
+        InProgress,
+
+        /// <summary>
+        /// The function has finished executing.
+        /// </summary>
+        [EnumMember]
+        Finished
+    }
+
     public class FunctionActivity : ActivityBase
     {
         public string FunctionName { get; set; }
@@ -15,10 +31,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
 
         public string ExecutionId { get; set; }
 
-        public string ExecutionStage { get; set; }
+        public FunctionExecutionStage ExecutionStage { get; set; }
 
         public bool IsSucceeded { get; set; }
 
         public long ExecutionTimeSpanInMs { get; set; }
+
+        public DateTime StartTime { get; set; }
     }
 }

--- a/src/WebJobs.Script.WebHost/NullMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/NullMetricsPublisher.cs
@@ -17,9 +17,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             _logger.LogDebug("Initializing null metrics publisher");
         }
 
-        public void AddFunctionExecutionActivity(string functionName, string invocationId, int concurrency, string executionStage, bool success, long executionTimeSpan, DateTime utcNow)
+        public void AddFunctionExecutionActivity(string functionName, string invocationId, int concurrency, string executionStage, bool success, long executionTimeSpan, string executionId, DateTime eventTimeStamp, DateTime functionStartTime)
         {
-            _logger.LogDebug("Ignoring function activity metric: {functionName} {invocationId} {concurrency} {executionStage} {success} {executionTimeSpan}", functionName, invocationId, concurrency, executionStage, success, executionTimeSpan);
+            _logger.LogDebug("Ignoring function activity metric: {functionName} {invocationId} {concurrency} {executionStage} {success} {executionTimeSpan} {executionId} {eventTimeStamp} {functionStartTime}",
+                functionName, invocationId, concurrency, executionStage, success, executionTimeSpan, executionId, eventTimeStamp, functionStartTime);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Metrics/LinuxContainerMetricsPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/LinuxContainerMetricsPublisherTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             FunctionName = string.Empty,
             InvocationId = string.Empty,
             Concurrency = 1,
-            ExecutionStage = string.Empty,
+            ExecutionStage = FunctionExecutionStage.InProgress,
             IsSucceeded = true,
             ExecutionTimeSpanInMs = 1,
             EventTimeStamp = DateTime.UtcNow,
@@ -133,10 +133,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
                 _testFunctionActivity.FunctionName,
                 _testFunctionActivity.InvocationId,
                 _testFunctionActivity.Concurrency,
-                _testFunctionActivity.ExecutionStage,
+                _testFunctionActivity.ExecutionStage.ToString(),
                 _testFunctionActivity.IsSucceeded,
                 _testFunctionActivity.ExecutionTimeSpanInMs,
-                _testFunctionActivity.EventTimeStamp);
+                _testFunctionActivity.ExecutionId,
+                _testFunctionActivity.EventTimeStamp,
+                _testFunctionActivity.StartTime);
 
             Assert.Matches("Added function activity", _testLoggerProvider.GetAllLogMessages().Single().FormattedMessage);
             Assert.Equal(LogLevel.Debug, _testLoggerProvider.GetAllLogMessages().Single().Level);
@@ -145,7 +147,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
 
             _metricsPublisher.OnFunctionMetricsPublishTimer(null);
             _metricsPublisher.OnFunctionMetricsPublishTimer(null);
-            Assert.Empty(_testLoggerProvider.GetAllLogMessages());
+            Assert.Matches("Publishing", _testLoggerProvider.GetAllLogMessages().Single().FormattedMessage);
         }
 
         [Fact]
@@ -158,7 +160,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
 
             _metricsPublisher.OnFunctionMetricsPublishTimer(null);
             _metricsPublisher.OnFunctionMetricsPublishTimer(null);
-            Assert.Empty(_testLoggerProvider.GetLog());
+            Assert.Matches("Publishing", _testLoggerProvider.GetAllLogMessages().Single().FormattedMessage);
         }
 
         [Fact]


### PR DESCRIPTION
Populating function start time from the host so that our memory snapshots start time- end time intervals are correct.