### PR TITLE
Add process uptime to host status api

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -75,7 +75,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                 State = scriptHostManager.State.ToString(),
                 Version = ScriptHost.Version,
                 VersionDetails = Utility.GetInformationalVersion(typeof(ScriptHost)),
-                Id = await hostIdProvider.GetHostIdAsync(CancellationToken.None)
+                Id = await hostIdProvider.GetHostIdAsync(CancellationToken.None),
+                ProcessUptime = (long)(DateTime.UtcNow - Process.GetCurrentProcess().StartTime).TotalMilliseconds
             };
 
             var lastError = scriptHostManager.LastError;

--- a/src/WebJobs.Script.WebHost/Models/HostStatus.cs
+++ b/src/WebJobs.Script.WebHost/Models/HostStatus.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.ObjectModel;
 using Newtonsoft.Json;
 
@@ -37,5 +38,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
         /// </summary>
         [JsonProperty(PropertyName = "errors", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public Collection<string> Errors { get; set; }
+
+        /// <summary>
+        /// Gets or sets the uptime of the process
+        /// </summary>
+        [JsonProperty(PropertyName = "processUptime", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public long ProcessUptime { get; set; }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             string content = await response.Content.ReadAsStringAsync();
             JObject jsonContent = JObject.Parse(content);
 
-            Assert.Equal(4, jsonContent.Properties().Count());
+            Assert.Equal(5, jsonContent.Properties().Count());
             AssemblyFileVersionAttribute fileVersionAttr = typeof(HostStatus).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>();
             Assert.True(((string)jsonContent["id"]).Length > 0);
             string expectedVersion = fileVersionAttr.Version;
@@ -637,7 +637,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                 Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
             }
         }
-        
+
         [Fact]
         public async Task HttpTriggerWithObject_Post_Succeeds()
         {


### PR DESCRIPTION
This is needed in the tooling to be able to tell when the application restarted as a result of deployment. It can take minutes on dedicated linux. 

/cc @ankitkumarr 