### PR TITLE
Update PowerShell worker to 0.1.152-preview

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.8100001-0126c21e" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.5.10246" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.3" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.120-preview" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.152-preview" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.11" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.3" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.4" />


### PR DESCRIPTION
Changes in this release:

- Major Managed Dependencies update:
  - Allowed specifying any (not just `Az`) module from PowerShell Gallery in `requirements.psd1` (up to 10 entries).
  - Allowed specifying exact module versions in `requirements.psd1` (as opposed to just `<MajorVersion>.*` 
 pattern), including pre-release versions.
  - More reliable implementation of module upgrades (fixing [#247](https://github.com/Azure/azure-functions-powershell-worker/issues/247), [#248](https://github.com/Azure/azure-functions-powershell-worker/issues/248), [#252](https://github.com/Azure/azure-functions-powershell-worker/issues/252), and other intermittent issues).
  - Improved cold start performance.
  - Added a warning when `managedDependencies` is enabled in `host.json` but no dependencies are specified in `requirements.psd1`.
- Fixed issue [#281](https://github.com/Azure/azure-functions-powershell-worker/issues/281) (Clear pushed output binding values on exceptions).
- System logging fixes and improvements.

For more information, please see https://github.com/Azure/azure-functions-powershell-worker/releases