### PR TITLE
Allow language worker restart without counting this as an error

### DIFF
--- a/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
+++ b/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
@@ -246,7 +246,16 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             if (!_disposing)
             {
                 _logger.LogDebug("Handling WorkerErrorEvent for runtime:{runtime}, workerId:{workerId}", workerError.Language, workerError.WorkerId);
-                _languageWorkerErrors.Add(workerError.Exception);
+
+                if (workerError.Exception == null)
+                {
+                    _logger.LogDebug("No exception in WorkerErrorEvent for runtime:{runtime}, workerId:{workerId}", workerError.Language, workerError.WorkerId);
+                }
+                else
+                {
+                    _languageWorkerErrors.Add(workerError.Exception);
+                }
+
                 bool isPreInitializedChannel = _webHostLanguageWorkerChannelManager.ShutdownChannelIfExists(workerError.Language, workerError.WorkerId);
                 if (!isPreInitializedChannel)
                 {

--- a/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
@@ -184,8 +184,9 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             // The subscriber of WorkerErrorEvent is expected to Dispose() the errored channel
             if (langExc != null && langExc.ExitCode != -1)
             {
-                _workerProcessLogger.LogDebug(langExc, $"Language Worker Process exited.", _process.StartInfo.FileName);
-                _eventManager.Publish(new WorkerErrorEvent(_runtime, _workerId, langExc));
+                _workerProcessLogger.LogDebug(langExc, $"Language Worker Process exited (exit code: {langExc.ExitCode}).", _process.StartInfo.FileName);
+                var isIntentionalExit = langExc.ExitCode == 200;
+                _eventManager.Publish(new WorkerErrorEvent(_runtime, _workerId, isIntentionalExit ? null : langExc));
             }
         }
 

--- a/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
@@ -14,6 +14,12 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 {
     internal class LanguageWorkerProcess : ILanguageWorkerProcess, IDisposable
     {
+        // When a language worker process exits with this code, this indicates
+        // that the worker decided to exit intentionally and not because of any error.
+        // For example, this is how the worker can express the desire to be restarted
+        // in order to pick up updated dependencies.
+        private const int NonErrorExitCode = 200;
+
         private readonly IWorkerProcessFactory _processFactory;
         private readonly IProcessRegistry _processRegistry;
         private readonly ILogger _workerProcessLogger;
@@ -185,7 +191,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             if (langExc != null && langExc.ExitCode != -1)
             {
                 _workerProcessLogger.LogDebug(langExc, $"Language Worker Process exited (exit code: {langExc.ExitCode}).", _process.StartInfo.FileName);
-                var isIntentionalExit = langExc.ExitCode == 200;
+                var isIntentionalExit = langExc.ExitCode == NonErrorExitCode;
                 _eventManager.Publish(new WorkerErrorEvent(_runtime, _workerId, isIntentionalExit ? null : langExc));
             }
         }

--- a/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannel.cs
+++ b/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannel.cs
@@ -73,10 +73,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             _state = LanguageWorkerChannelState.Initialized;
         }
 
-        public void RaiseWorkerError()
+        public void RaiseWorkerErrorWithException()
         {
             Exception testEx = new Exception("Test Worker Error");
-            _eventManager.Publish(new WorkerErrorEvent(_runtime, Id, testEx));
+            RaiseWorkerError(testEx);
+        }
+
+        public void RaiseWorkerErrorWithoutException()
+        {
+            RaiseWorkerError(null);
+        }
+
+        private void RaiseWorkerError(Exception exception)
+        {
+            _eventManager.Publish(new WorkerErrorEvent(_runtime, Id, exception));
         }
     }
 }


### PR DESCRIPTION
Making it possible for a language worker to signal to the host that it want to be restarted without counting this as an error. We need this now for the PowerShell worker: it will need to be restarted on a regular basis, and we don't want the app to stop