### PR TITLE
Allow language worker restart without counting this as an error

### DIFF
--- a/src/WebJobs.Script/Eventing/Rpc/WorkerRestartEvent.cs
+++ b/src/WebJobs.Script/Eventing/Rpc/WorkerRestartEvent.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script.Eventing
+{
+    public class WorkerRestartEvent : RpcChannelEvent
+    {
+        internal WorkerRestartEvent(string language, string workerId)
+            : base(workerId)
+        {
+            Language = language;
+        }
+
+        internal string Language { get; }
+    }
+}

--- a/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
+++ b/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
@@ -246,7 +246,16 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             if (!_disposing)
             {
                 _logger.LogDebug("Handling WorkerErrorEvent for runtime:{runtime}, workerId:{workerId}", workerError.Language, workerError.WorkerId);
-                _languageWorkerErrors.Add(workerError.Exception);
+
+                if (workerError.Exception == null)
+                {
+                    _logger.LogDebug("No exception in WorkerErrorEvent for runtime:{runtime}, workerId:{workerId}", workerError.Language, workerError.WorkerId);
+                }
+                else
+                {
+                    _languageWorkerErrors.Add(workerError.Exception);
+                }
+
                 bool isPreInitializedChannel = _webHostLanguageWorkerChannelManager.ShutdownChannelIfExists(workerError.Language, workerError.WorkerId);
                 if (!isPreInitializedChannel)
                 {

--- a/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
+++ b/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
@@ -268,11 +268,11 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             bool isPreInitializedChannel = _webHostLanguageWorkerChannelManager.ShutdownChannelIfExists(runtime, workerId);
             if (!isPreInitializedChannel)
             {
-                _logger.LogDebug("Disposing errored channel for workerId: {channelId}, for runtime:{language}", workerId, runtime);
-                var erroredChannel = _jobHostLanguageWorkerChannelManager.GetChannels().Where(ch => ch.Id == workerId).FirstOrDefault();
-                if (erroredChannel != null)
+                _logger.LogDebug("Disposing channel for workerId: {channelId}, for runtime:{language}", workerId, runtime);
+                var channel = _jobHostLanguageWorkerChannelManager.GetChannels().Where(ch => ch.Id == workerId).FirstOrDefault();
+                if (channel != null)
                 {
-                    _jobHostLanguageWorkerChannelManager.DisposeAndRemoveChannel(erroredChannel);
+                    _jobHostLanguageWorkerChannelManager.DisposeAndRemoveChannel(channel);
                 }
             }
 

--- a/src/WebJobs.Script/Rpc/LanguageWorkerConstants.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerConstants.cs
@@ -52,5 +52,9 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         public const string RawHttpBodyBytes = "RawHttpBodyBytes";
         public const string TypedDataCollection = "TypedDataCollection";
         public const string RpcHttpBodyOnly = "RpcHttpBodyOnly";
+
+        // Language Worker process exit codes
+        public const int SuccessExitCode = 0;
+        public const int IntentionalRestartExitCode = 200;
     }
 }

--- a/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
@@ -14,12 +14,6 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 {
     internal class LanguageWorkerProcess : ILanguageWorkerProcess, IDisposable
     {
-        // When a language worker process exits with this code, this indicates
-        // that the worker decided to exit intentionally and not because of any error.
-        // For example, this is how the worker can express the desire to be restarted
-        // in order to pick up updated dependencies.
-        private const int NonErrorExitCode = 200;
-
         private readonly IWorkerProcessFactory _processFactory;
         private readonly IProcessRegistry _processRegistry;
         private readonly ILogger _workerProcessLogger;
@@ -150,16 +144,20 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             string exceptionMessage = string.Join(",", _processStdErrDataQueue.Where(s => !string.IsNullOrEmpty(s)));
             try
             {
-                if (_process.ExitCode != 0)
+                if (_process.ExitCode == LanguageWorkerConstants.SuccessExitCode)
+                {
+                    _process.WaitForExit();
+                    _process.Close();
+                }
+                else if (_process.ExitCode == LanguageWorkerConstants.IntentionalRestartExitCode)
+                {
+                    HandleWorkerProcessRestart();
+                }
+                else
                 {
                     var processExitEx = new LanguageWorkerProcessExitException($"{_process.StartInfo.FileName} exited with code {_process.ExitCode}\n {exceptionMessage}");
                     processExitEx.ExitCode = _process.ExitCode;
                     HandleWorkerProcessExitError(processExitEx);
-                }
-                else
-                {
-                    _process.WaitForExit();
-                    _process.Close();
                 }
             }
             catch (Exception)
@@ -190,10 +188,15 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             // The subscriber of WorkerErrorEvent is expected to Dispose() the errored channel
             if (langExc != null && langExc.ExitCode != -1)
             {
-                _workerProcessLogger.LogDebug(langExc, $"Language Worker Process exited (exit code: {langExc.ExitCode}).", _process.StartInfo.FileName);
-                var isIntentionalExit = langExc.ExitCode == NonErrorExitCode;
-                _eventManager.Publish(new WorkerErrorEvent(_runtime, _workerId, isIntentionalExit ? null : langExc));
+                _workerProcessLogger.LogDebug(langExc, $"Language Worker Process exited.", _process.StartInfo.FileName);
+                _eventManager.Publish(new WorkerErrorEvent(_runtime, _workerId, langExc));
             }
+        }
+
+        internal void HandleWorkerProcessRestart()
+        {
+            _workerProcessLogger?.LogInformation("Language Worker Process exited and needs to be restarted.");
+            _eventManager.Publish(new WorkerRestartEvent(_runtime, _workerId));
         }
 
         public void Dispose()

--- a/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
@@ -184,8 +184,9 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             // The subscriber of WorkerErrorEvent is expected to Dispose() the errored channel
             if (langExc != null && langExc.ExitCode != -1)
             {
-                _workerProcessLogger.LogDebug(langExc, $"Language Worker Process exited.", _process.StartInfo.FileName);
-                _eventManager.Publish(new WorkerErrorEvent(_runtime, _workerId, langExc));
+                _workerProcessLogger.LogDebug(langExc, $"Language Worker Process exited (exit code: {langExc.ExitCode}).", _process.StartInfo.FileName);
+                var isIntentionalExit = langExc.ExitCode == 200;
+                _eventManager.Publish(new WorkerErrorEvent(_runtime, _workerId, isIntentionalExit ? null : langExc));
             }
         }
 

--- a/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
@@ -14,6 +14,12 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 {
     internal class LanguageWorkerProcess : ILanguageWorkerProcess, IDisposable
     {
+        // When a language worker process exits with this code, this indicates
+        // that the worker decided to exit intentionally and not because of any error.
+        // For example, this is how the worker can express the desire to be restarted
+        // in order to pick up updated dependencies.
+        private const int NonErrorExitCode = 200;
+
         private readonly IWorkerProcessFactory _processFactory;
         private readonly IProcessRegistry _processRegistry;
         private readonly ILogger _workerProcessLogger;
@@ -185,7 +191,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             if (langExc != null && langExc.ExitCode != -1)
             {
                 _workerProcessLogger.LogDebug(langExc, $"Language Worker Process exited (exit code: {langExc.ExitCode}).", _process.StartInfo.FileName);
-                var isIntentionalExit = langExc.ExitCode == 200;
+                var isIntentionalExit = langExc.ExitCode == NonErrorExitCode;
                 _eventManager.Publish(new WorkerErrorEvent(_runtime, _workerId, isIntentionalExit ? null : langExc));
             }
         }

--- a/test/WebJobs.Script.Tests/Rpc/FunctionDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/FunctionDispatcherTests.cs
@@ -248,32 +248,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             }
         }
 
-        [Fact]
-        public async void FunctionDispatcher_Restart_ErroredChannels_OnMixOfWorkerRestartAndErrorEvents()
-        {
-            int expectedProcessCount = 1;
-            FunctionDispatcher functionDispatcher = (FunctionDispatcher)GetTestFunctionDispatcher(expectedProcessCount.ToString());
-            await functionDispatcher.InitializeAsync(GetTestFunctionsList(LanguageWorkerConstants.NodeLanguageWorkerName));
-
-            await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount);
-
-            // Don't exceed the error limit...
-            for (int errorCount = 0; errorCount < 2; errorCount++)
-            {
-                TestLanguageWorkerChannel testWorkerChannel = (TestLanguageWorkerChannel)functionDispatcher.JobHostLanguageWorkerChannelManager.GetChannels().FirstOrDefault();
-                testWorkerChannel.RaiseWorkerError();
-                await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount);
-            }
-
-            // ...but the number of *intentional* restarts is not limited
-            for (int restartCount = 0; restartCount < (expectedProcessCount * 3) + 1; restartCount++)
-            {
-                TestLanguageWorkerChannel testWorkerChannel = (TestLanguageWorkerChannel)functionDispatcher.JobHostLanguageWorkerChannelManager.GetChannels().FirstOrDefault();
-                testWorkerChannel.RaiseWorkerRestart();
-                await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount);
-            }
-        }
-
         private static FunctionDispatcher GetTestFunctionDispatcher(string maxProcessCountValue = null, bool addWebhostChannel = false, Mock<IWebHostLanguageWorkerChannelManager> mockwebHostLanguageWorkerChannelManager = null)
         {
             var eventManager = new ScriptEventManager();

--- a/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannel.cs
+++ b/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannel.cs
@@ -73,20 +73,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             _state = LanguageWorkerChannelState.Initialized;
         }
 
-        public void RaiseWorkerErrorWithException()
+        public void RaiseWorkerError()
         {
             Exception testEx = new Exception("Test Worker Error");
-            RaiseWorkerError(testEx);
+            _eventManager.Publish(new WorkerErrorEvent(_runtime, Id, testEx));
         }
 
-        public void RaiseWorkerErrorWithoutException()
+        public void RaiseWorkerRestart()
         {
-            RaiseWorkerError(null);
-        }
-
-        private void RaiseWorkerError(Exception exception)
-        {
-            _eventManager.Publish(new WorkerErrorEvent(_runtime, Id, exception));
+            _eventManager.Publish(new WorkerRestartEvent(_runtime, Id));
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannel.cs
+++ b/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannel.cs
@@ -73,10 +73,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             _state = LanguageWorkerChannelState.Initialized;
         }
 
-        public void RaiseWorkerError()
+        public void RaiseWorkerErrorWithException()
         {
             Exception testEx = new Exception("Test Worker Error");
-            _eventManager.Publish(new WorkerErrorEvent(_runtime, Id, testEx));
+            RaiseWorkerError(testEx);
+        }
+
+        public void RaiseWorkerErrorWithoutException()
+        {
+            RaiseWorkerError(null);
+        }
+
+        private void RaiseWorkerError(Exception exception)
+        {
+            _eventManager.Publish(new WorkerErrorEvent(_runtime, Id, exception));
         }
     }
 }


### PR DESCRIPTION
Making it possible for a language worker to signal to the host that it want to be restarted without counting this as an error. We need this now for the PowerShell worker: it will need to be restarted on a regular basis, and we don't want the host to stop because of that.