### PR TITLE
[pack] Fixing the service registration for IJobHostMiddlewarePipeline and updating the location for http configuration

### DIFF
--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -77,8 +77,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     services.AddSingleton<DefaultScriptWebHookProvider>();
                     services.TryAddSingleton<IScriptWebHookProvider>(p => p.GetService<DefaultScriptWebHookProvider>());
                     services.TryAddSingleton<IWebHookProvider>(p => p.GetService<DefaultScriptWebHookProvider>());
-                    services.TryAddSingleton<IJobHostMiddlewarePipeline, DefaultMiddlewarePipeline>();
-                    services.TryAddSingleton<IJobHostHttpMiddleware, CustomHttpHeadersMiddleware>();
+                    services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobHostMiddlewarePipeline, DefaultMiddlewarePipeline>());
+                    services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobHostHttpMiddleware, CustomHttpHeadersMiddleware>());
                     services.TryAddSingleton<IJobHostHttpMiddleware, HstsConfigurationMiddleware>();
 
                     // Make sure the registered IHostIdProvider is used

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -77,9 +77,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     services.AddSingleton<DefaultScriptWebHookProvider>();
                     services.TryAddSingleton<IScriptWebHookProvider>(p => p.GetService<DefaultScriptWebHookProvider>());
                     services.TryAddSingleton<IWebHookProvider>(p => p.GetService<DefaultScriptWebHookProvider>());
-                    services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobHostMiddlewarePipeline, DefaultMiddlewarePipeline>());
+                    services.TryAddSingleton<IJobHostMiddlewarePipeline, DefaultMiddlewarePipeline>();
                     services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobHostHttpMiddleware, CustomHttpHeadersMiddleware>());
-                    services.TryAddSingleton<IJobHostHttpMiddleware, HstsConfigurationMiddleware>();
+                    services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobHostHttpMiddleware, HstsConfigurationMiddleware>());
 
                     // Make sure the registered IHostIdProvider is used
                     IHostIdProvider provider = rootServiceProvider.GetService<IHostIdProvider>();

--- a/src/WebJobs.Script/Config/ConfigurationSectionNames.cs
+++ b/src/WebJobs.Script/Config/ConfigurationSectionNames.cs
@@ -13,7 +13,8 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
         public const string HostIdPath = WebHost + ":hostid";
         public const string ExtensionBundle = "extensionBundle";
         public const string ManagedDependency = "managedDependency";
-        public const string Http = "http";
+        public const string Extensions = "extensions";
+        public const string Http = Extensions + ":http";
         public const string Hsts = Http + ":hsts";
         public const string CustomHttpHeaders = Http + ":customHeaders";
     }

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CustomHeadersMiddleware/CSharp/host.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CustomHeadersMiddleware/CSharp/host.json
@@ -1,13 +1,13 @@
 {
-  "version": "2.0",
-  "http": {
-    "customHeaders": {
-      "X-Content-Type-Options": "nosniff"
+    "version": "2.0",
+    "extensions": {
+        "durableTask": {
+            "hubName": "CustomHeadersMiddlewareCSharpTestHub"
+        },
+        "http": {
+            "customHeaders": {
+                "X-Content-Type-Options": "nosniff"
+            }
+        }
     }
-  },
-  "extensions": {
-    "durableTask": {
-      "hubName": "CustomHeadersMiddlewareCSharpTestHub"
-    }
-  }
 }

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CustomHeadersMiddleware/Node/host.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CustomHeadersMiddleware/Node/host.json
@@ -1,13 +1,13 @@
 ﻿{
-  "version": "2.0",
-  "http": {
-    "customHeaders": {
-      "X-Content-Type-Options": "nosniff"
+    "version": "2.0",
+    "extensions": {
+        "durableTask": {
+            "hubName": "CustomHeadersMiddlewareNodeTestHub"
+        },
+        "http": {
+            "customHeaders": {
+                "X-Content-Type-Options": "nosniff"
+            }
+        }
     }
-  },
-  "extensions": {
-    "durableTask": {
-      "hubName": "CustomHeadersMiddlewareNodeTestHub"
-    }
-  }
 }

--- a/test/WebJobs.Script.Tests/Configuration/CustomHttpHeadersOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/CustomHttpHeadersOptionsSetupTests.cs
@@ -50,9 +50,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                     }")]
         [InlineData(@"{
                     'version': '2.0',
-                    'http': {
-                        'customHeaders': {
-                            'X-Content-Type-Options': 'nosniff'
+                    'extensions': {
+                            'http': {
+                                'customHeaders': {
+                                    'X-Content-Type-Options': 'nosniff'
+                                }
                             }
                         }
                     }")]
@@ -71,13 +73,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         public void ValidCustomHttpHeadersConfig_BindsToOptions()
         {
             string hostJsonContent = @"{
-                                         'version': '2.0',
-                                         'http': {
-                                             'customHeaders': {
-                                                 'X-Content-Type-Options': 'nosniff'
-                                             }
-                                         }
-                                     }";
+                                        'version': '2.0',
+                                        'extensions': {
+                                                'http': {
+                                                    'customHeaders': {
+                                                        'X-Content-Type-Options': 'nosniff'
+                                                    }
+                                                }
+                                            }
+                                        }";
             File.WriteAllText(_hostJsonFile, hostJsonContent);
             var configuration = BuildHostJsonConfiguration();
 

--- a/test/WebJobs.Script.Tests/Configuration/HostHstsOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/HostHstsOptionsSetupTests.cs
@@ -55,10 +55,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                     'version': '2.0',
                     }")]
         [InlineData(@"{
-                    'version': '2.0',
-                    'http' : {
-                        'hsts' : {
-                            'isEnabled' : true
+                        'version': '2.0',
+                        'extensions': {
+                            'http': {
+                                'hsts': {
+                                    'isEnabled': true,
+                                    'maxAge': '10'
+                                }
                             }
                         }
                     }")]
@@ -77,14 +80,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         public void ValidHstsConfig_BindsToOptions()
         {
             string hostJsonContent = @"{
-                                         'version': '2.0',
-                                         'http': {
-                                             'hsts': {
-                                                 'isEnabled': true,
-                                                 'maxAge': '10'
-                                             }
-                                         }
-                                     }";
+                                        'version': '2.0',
+                                        'extensions': {
+                                            'http': {
+                                                'hsts': {
+                                                    'isEnabled': true,
+                                                    'maxAge': '10'
+                                                }
+                                            }
+                                        }
+                                    }";
             File.WriteAllText(_hostJsonFile, hostJsonContent);
             var configuration = BuildHostJsonConfiguration();
 


### PR DESCRIPTION
- There was a regression in the `IJobHostMiddlewarePipeline` flow. The registration of the hsts and customhttpheader middleware was done via `TryAddSingleton`. Because of this only the service that was registered first would actually get registered and the anything after that service was rejected.
- Since neither of the features were documented and are not being used because of the regression. I have also fixed the location of the configuration so that there is only one `http section (under extensions)` in the `host.json`