### PR TITLE
Update PowerShellWorker to 0.1.159-preview

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.8100001-0126c21e" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.5.10246" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.0.3" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.152-preview" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.159-preview" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.12" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.3" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.4" />


### PR DESCRIPTION
Changes in this release:

- Fixed cold start time regression when using Managed Dependencies.
- Fixed a problem with installing some modules from the PowerShell Gallery when using the `<MajorVersion>.*` pattern.

For more information, please see https://github.com/Azure/azure-functions-powershell-worker/releases