### PR TITLE
[pack] handling RestartAsync() being called before StartAsync() in WebJobsScriptHostService

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
@@ -130,6 +130,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
                 new EventId(519, nameof(EnteringRestart)),
                 "Restart requested. Cancelling any active host startup.");
 
+        private static readonly Action<ILogger, Exception> _restartBeforeStart =
+            LoggerMessage.Define(
+                LogLevel.Debug,
+                new EventId(520, nameof(RestartBeforeStart)),
+                "RestartAsync was called before StartAsync. Delaying restart until StartAsync has been called.");
+
         public static void ScriptHostServiceInitCanceledByRuntime(this ILogger logger)
         {
             _scriptHostServiceInitCanceledByRuntime(logger, null);
@@ -228,6 +234,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
         public static void EnteringRestart(this ILogger logger)
         {
             _enteringRestart(logger, null);
+        }
+
+        public static void RestartBeforeStart(this ILogger logger)
+        {
+            _restartBeforeStart(logger, null);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
@@ -327,6 +327,41 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             await startTask;
         }
 
+        [Fact]
+        public async Task HostRestart_BeforeStart_WaitsForStartToContinue()
+        {
+            _host = CreateMockHost();
+
+            var hostBuilder = new Mock<IScriptHostBuilder>();
+            hostBuilder.SetupSequence(b => b.BuildHost(It.IsAny<bool>(), It.IsAny<bool>()))
+                .Returns(_host.Object)
+                .Returns(_host.Object);
+
+            _webHostLoggerProvider = new TestLoggerProvider();
+            _loggerFactory = new LoggerFactory();
+            _loggerFactory.AddProvider(_webHostLoggerProvider);
+
+            _hostService = new WebJobsScriptHostService(
+               _monitor, hostBuilder.Object, _loggerFactory, _mockRootServiceProvider.Object, _mockRootScopeFactory.Object,
+               _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object, _hostPerformanceManager, _healthMonitorOptions);
+
+            // Simulate a call to specialize coming from the PlaceholderSpecializationMiddleware. This
+            // can happen before we ever start the service, which could create invalid state.
+            Task restartTask = _hostService.RestartHostAsync(CancellationToken.None);
+
+            await _hostService.StartAsync(CancellationToken.None);
+            await restartTask;
+
+            var messages = _webHostLoggerProvider.GetAllLogMessages();
+
+            // The CancellationToken is canceled quick enough that we never build the initial host, so the
+            // only one we start is the restarted/specialized one.
+            Assert.NotNull(messages.Single(p => p.EventId.Id == 513)); // "Building" message
+            Assert.NotNull(messages.Single(p => p.EventId.Id == 514)); // "StartupWasCanceled" message
+            Assert.NotNull(messages.Single(p => p.EventId.Id == 520)); // "RestartBeforeStart" message
+            _host.Verify(p => p.StartAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
         public void RestartHost()
         {
             _hostService.RestartHostAsync(CancellationToken.None).Wait();


### PR DESCRIPTION
Fixes #4845 

This fix ensures that a call to `RestartAsync()` does not continue until `StartAsync()` is called once.