### PR TITLE
Applying timeout handling for specialization

### DIFF
--- a/src/WebJobs.Script.WebHost/Standby/StandbyManager.cs
+++ b/src/WebJobs.Script.WebHost/Standby/StandbyManager.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Azure.WebJobs.Script.Rpc;
 using Microsoft.Azure.WebJobs.Script.WebHost.Properties;
 using Microsoft.Extensions.Configuration;
@@ -32,6 +33,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         private readonly HostNameProvider _hostNameProvider;
         private readonly IDisposable _changeTokenCallbackSubscription;
         private readonly TimeSpan _specializationTimerInterval;
+        private readonly IApplicationLifetime _applicationLifetime;
 
         private Timer _specializationTimer;
         private static CancellationTokenSource _standbyCancellationTokenSource = new CancellationTokenSource();
@@ -39,13 +41,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         private static SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
 
         public StandbyManager(IScriptHostManager scriptHostManager, IWebHostLanguageWorkerChannelManager languageWorkerChannelManager, IConfiguration configuration, IScriptWebHostEnvironment webHostEnvironment,
-            IEnvironment environment, IOptionsMonitor<ScriptApplicationHostOptions> options, ILogger<StandbyManager> logger, HostNameProvider hostNameProvider)
-            : this(scriptHostManager, languageWorkerChannelManager, configuration, webHostEnvironment, environment, options, logger, hostNameProvider, TimeSpan.FromMilliseconds(500))
+            IEnvironment environment, IOptionsMonitor<ScriptApplicationHostOptions> options, ILogger<StandbyManager> logger, HostNameProvider hostNameProvider, IApplicationLifetime applicationLifetime)
+            : this(scriptHostManager, languageWorkerChannelManager, configuration, webHostEnvironment, environment, options, logger, hostNameProvider, applicationLifetime, TimeSpan.FromMilliseconds(500))
         {
         }
 
         public StandbyManager(IScriptHostManager scriptHostManager, IWebHostLanguageWorkerChannelManager languageWorkerChannelManager, IConfiguration configuration, IScriptWebHostEnvironment webHostEnvironment,
-            IEnvironment environment, IOptionsMonitor<ScriptApplicationHostOptions> options, ILogger<StandbyManager> logger, HostNameProvider hostNameProvider, TimeSpan specializationTimerInterval)
+            IEnvironment environment, IOptionsMonitor<ScriptApplicationHostOptions> options, ILogger<StandbyManager> logger, HostNameProvider hostNameProvider, IApplicationLifetime applicationLifetime, TimeSpan specializationTimerInterval)
         {
             _scriptHostManager = scriptHostManager ?? throw new ArgumentNullException(nameof(scriptHostManager));
             _options = options ?? throw new ArgumentNullException(nameof(options));
@@ -58,13 +60,23 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             _hostNameProvider = hostNameProvider ?? throw new ArgumentNullException(nameof(hostNameProvider));
             _changeTokenCallbackSubscription = ChangeToken.RegisterChangeCallback(_ => _logger.LogDebug($"{nameof(StandbyManager)}.{nameof(ChangeToken)} callback has fired."), null);
             _specializationTimerInterval = specializationTimerInterval;
+            _applicationLifetime = applicationLifetime;
         }
 
         public static IChangeToken ChangeToken => _standbyChangeToken;
 
         public Task SpecializeHostAsync()
         {
-            return _specializationTask.Value;
+            return _specializationTask.Value.ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                {
+                    // if we fail during specialization for whatever reason
+                    // this is fatal, so we shutdown
+                    _logger.LogError(t.Exception, $"Specialization failed. Shutting down.");
+                    _applicationLifetime.StopApplication();
+                }
+            });
         }
 
         public async Task SpecializeHostCoreAsync()
@@ -85,10 +97,26 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
             _hostNameProvider.Reset();
 
-            await _languageWorkerChannelManager.SpecializeAsync();
+            await SpecializeLanguageWorkerChannelsAsync();
+
             NotifyChange();
             await _scriptHostManager.RestartHostAsync();
             await _scriptHostManager.DelayUntilHostReady();
+        }
+
+        private async Task SpecializeLanguageWorkerChannelsAsync()
+        {
+            var specializationTimeout = TimeSpan.FromSeconds(30);
+            var value = _environment.GetEnvironmentVariable(EnvironmentSettingNames.SpecializationTimeout);
+            if (!string.IsNullOrEmpty(value) && TimeSpan.TryParse(value, out TimeSpan parsedTimeout))
+            {
+                specializationTimeout = parsedTimeout;
+            }
+
+            await Utility.RunWithTimeoutAsync(async () =>
+            {
+                await _languageWorkerChannelManager.SpecializeAsync();
+            }, specializationTimeout);
         }
 
         public void NotifyChange()
@@ -165,15 +193,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             _logger.LogInformation($"StandbyMode placeholder function directory created");
         }
 
-        private void OnSpecializationTimerTick(object state)
+        private async void OnSpecializationTimerTick(object state)
         {
             if (!_webHostEnvironment.InStandbyMode && _environment.IsContainerReady())
             {
                 _specializationTimer?.Dispose();
                 _specializationTimer = null;
 
-                SpecializeHostAsync().ContinueWith(t => _logger.LogError(t.Exception, "Error specializing host."),
-                    TaskContinuationOptions.OnlyOnFaulted);
+                await SpecializeHostAsync();
             }
         }
 

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string MsiEndpoint = "MSI_ENDPOINT";
         public const string MsiSecret = "MSI_SECRET";
         public const string DotnetSkipFirstTimeExperience = "DOTNET_SKIP_FIRST_TIME_EXPERIENCE";
+        public const string SpecializationTimeout = "SPECIALIZATION_TIMEOUT";
 
         /// <summary>
         /// Environment variable dynamically set by the platform when it is safe to

--- a/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
@@ -185,12 +185,14 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         internal void HandleWorkerProcessExitError(LanguageWorkerProcessExitException langExc)
         {
-            // The subscriber of WorkerErrorEvent is expected to Dispose() the errored channel
-            if (langExc != null && langExc.ExitCode != -1)
+            if (langExc == null)
             {
-                _workerProcessLogger.LogDebug(langExc, $"Language Worker Process exited.", _process.StartInfo.FileName);
-                _eventManager.Publish(new WorkerErrorEvent(_runtime, _workerId, langExc));
+                throw new ArgumentNullException(nameof(langExc));
             }
+
+            // The subscriber of WorkerErrorEvent is expected to Dispose() the errored channel
+            _workerProcessLogger.LogDebug(langExc, $"Language Worker Process exited.", _process.StartInfo.FileName);
+            _eventManager.Publish(new WorkerErrorEvent(_runtime, _workerId, langExc));
         }
 
         internal void HandleWorkerProcessRestart()

--- a/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
@@ -90,6 +90,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         public async Task SpecializeAsync()
         {
             _logger.LogInformation("Starting language worker channel specialization");
+
             _workerRuntime = _environment.GetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName);
             ILanguageWorkerChannel languageWorkerChannel = await GetChannelAsync(_workerRuntime);
             if (_workerRuntime != null && languageWorkerChannel != null)
@@ -98,6 +99,8 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 await languageWorkerChannel.SendFunctionEnvironmentReloadRequest();
             }
             _shutdownStandbyWorkerChannels();
+
+            _logger.LogInformation("Language worker channel specialization complete");
         }
 
         public async Task<bool> ShutdownChannelIfExistsAsync(string language, string workerId)

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -36,6 +36,18 @@ namespace Microsoft.Azure.WebJobs.Script
         private static readonly FilteredExpandoObjectConverter _filteredExpandoObjectConverter = new FilteredExpandoObjectConverter();
         private static List<string> dotNetLanguages = new List<string>() { DotNetScriptTypes.CSharp, DotNetScriptTypes.DotNetAssembly };
 
+        internal static async Task RunWithTimeoutAsync(Func<Task> action, TimeSpan timeout)
+        {
+            Task timeoutTask = Task.Delay(timeout);
+            Task actionTask = action();
+            Task completedTask = await Task.WhenAny(actionTask, timeoutTask);
+
+            if (completedTask == timeoutTask)
+            {
+                throw new Exception($"Task did not complete within timeout interval {timeout}.");
+            }
+        }
+
         internal static async Task InvokeWithRetriesAsync(Action action, int maxRetries, TimeSpan retryInterval)
         {
             await InvokeWithRetriesAsync(() =>

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
@@ -302,7 +302,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             await AwaitHostStateAsync(ScriptHostState.Offline);
 
             // verify function status returns 503 immediately
-            await TestHelpers.RunWithTimeoutAsync(async () =>
+            await Utility.RunWithTimeoutAsync(async () =>
             {
                 response = await GetFunctionStatusAsync(functionName);
             }, TimeSpan.FromSeconds(1));

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -266,9 +266,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             public InfiniteTimerStandbyManager(IScriptHostManager scriptHostManager, IWebHostLanguageWorkerChannelManager languageWorkerChannelManager,
                 IConfiguration configuration, IScriptWebHostEnvironment webHostEnvironment, IEnvironment environment,
-                IOptionsMonitor<ScriptApplicationHostOptions> options, ILogger<StandbyManager> logger, HostNameProvider hostNameProvider)
+                IOptionsMonitor<ScriptApplicationHostOptions> options, ILogger<StandbyManager> logger, HostNameProvider hostNameProvider, Microsoft.AspNetCore.Hosting.IApplicationLifetime applicationLifetime)
                 : base(scriptHostManager, languageWorkerChannelManager, configuration, webHostEnvironment, environment, options,
-                      logger, hostNameProvider, TimeSpan.FromMilliseconds(-1))
+                      logger, hostNameProvider, applicationLifetime, TimeSpan.FromMilliseconds(-1))
             {
             }
         }

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -39,18 +39,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
         }
 
-        public static async Task RunWithTimeoutAsync(Func<Task> action, TimeSpan timeout)
-        {
-            Task timeoutTask = Task.Delay(timeout);
-            Task actionTask = action();
-            Task completedTask = await Task.WhenAny(actionTask, timeoutTask);
-
-            if (completedTask == timeoutTask)
-            {
-                throw new Exception($"Task did not complete within timeout interval {timeout}.");
-            }
-        }
-
         public static byte[] GenerateKeyBytes()
         {
             using (var aes = new AesManaged())

--- a/test/WebJobs.Script.Tests/StandbyManagerTests.cs
+++ b/test/WebJobs.Script.Tests/StandbyManagerTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.Rpc;
 using Microsoft.Azure.WebJobs.Script.WebHost;
@@ -29,6 +30,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         private string _testSettingValue = "TestSettingValue";
         private ILoggerProvider _testLoggerProvider;
         private ILoggerFactory _testLoggerFactory;
+        private Mock<IApplicationLifetime> _mockApplicationLifetime;
 
         public StandbyManagerTests()
         {
@@ -39,6 +41,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _mockWebHostEnvironment = new Mock<IScriptWebHostEnvironment>();
             _mockLanguageWorkerChannelManager = new Mock<IWebHostLanguageWorkerChannelManager>();
             _testEnvironment = new TestEnvironment();
+            _mockApplicationLifetime = new Mock<IApplicationLifetime>(MockBehavior.Strict);
 
             _testLoggerProvider = new TestLoggerProvider();
             _testLoggerFactory = new LoggerFactory();
@@ -49,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public async Task Specialize_ResetsConfiguration()
         {
             var hostNameProvider = new HostNameProvider(_testEnvironment, _testLoggerFactory.CreateLogger<HostNameProvider>());
-            var manager = new StandbyManager(_mockHostManager.Object, _mockLanguageWorkerChannelManager.Object, _mockConfiguration.Object, _mockWebHostEnvironment.Object, _testEnvironment, _mockOptionsMonitor.Object, NullLogger<StandbyManager>.Instance, hostNameProvider);
+            var manager = new StandbyManager(_mockHostManager.Object, _mockLanguageWorkerChannelManager.Object, _mockConfiguration.Object, _mockWebHostEnvironment.Object, _testEnvironment, _mockOptionsMonitor.Object, NullLogger<StandbyManager>.Instance, hostNameProvider, _mockApplicationLifetime.Object);
 
             await manager.SpecializeHostAsync();
 
@@ -62,7 +65,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName, "placeholder.azurewebsites.net");
 
             var hostNameProvider = new HostNameProvider(_testEnvironment, _testLoggerFactory.CreateLogger<HostNameProvider>());
-            var manager = new StandbyManager(_mockHostManager.Object, _mockLanguageWorkerChannelManager.Object, _mockConfiguration.Object, _mockWebHostEnvironment.Object, _testEnvironment, _mockOptionsMonitor.Object, NullLogger<StandbyManager>.Instance, hostNameProvider);
+            var manager = new StandbyManager(_mockHostManager.Object, _mockLanguageWorkerChannelManager.Object, _mockConfiguration.Object, _mockWebHostEnvironment.Object, _testEnvironment, _mockOptionsMonitor.Object, NullLogger<StandbyManager>.Instance, hostNameProvider, _mockApplicationLifetime.Object);
 
             Assert.Equal("placeholder.azurewebsites.net", hostNameProvider.Value);
 
@@ -86,7 +89,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName, LanguageWorkerConstants.JavaLanguageWorkerName);
 
             var hostNameProvider = new HostNameProvider(_testEnvironment, _testLoggerFactory.CreateLogger<HostNameProvider>());
-            var manager = new StandbyManager(_mockHostManager.Object, _mockLanguageWorkerChannelManager.Object, _mockConfiguration.Object, _mockWebHostEnvironment.Object, _testEnvironment, _mockOptionsMonitor.Object, NullLogger<StandbyManager>.Instance, hostNameProvider);
+            var manager = new StandbyManager(_mockHostManager.Object, _mockLanguageWorkerChannelManager.Object, _mockConfiguration.Object, _mockWebHostEnvironment.Object, _testEnvironment, _mockOptionsMonitor.Object, NullLogger<StandbyManager>.Instance, hostNameProvider, _mockApplicationLifetime.Object);
             await manager.SpecializeHostAsync();
             Assert.Equal(_testSettingValue, _testEnvironment.GetEnvironmentVariable(_testSettingName));
         }

--- a/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
@@ -343,7 +343,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(loggerProvider);
             var hostNameProvider = new HostNameProvider(mockEnvironment.Object, loggerFactory.CreateLogger<HostNameProvider>());
-            var manager = new StandbyManager(_hostService, mockLanguageWorkerChannelManager.Object, mockConfiguration.Object, mockScriptWebHostEnvironment.Object, mockEnvironment.Object, _monitor, testLogger, hostNameProvider);
+            var mockApplicationLifetime = new Mock<Microsoft.AspNetCore.Hosting.IApplicationLifetime>(MockBehavior.Strict);
+            var manager = new StandbyManager(_hostService, mockLanguageWorkerChannelManager.Object, mockConfiguration.Object, mockScriptWebHostEnvironment.Object, mockEnvironment.Object, _monitor, testLogger, hostNameProvider, mockApplicationLifetime.Object);
             manager.SpecializeHostAsync().Wait();
         }
 


### PR DESCRIPTION
Until we identify the root cause for some hangs we're seeing in language worker specialization, apply a timeout to the task to bound it. In addition, if specialization fails for any reason, we're in an unknown state so we initiate a shutdown.