### PR TITLE
Handle language worker process crash during placeholder mode

### DIFF
--- a/src/WebJobs.Script/Description/Rpc/WorkerLanguageInvoker.cs
+++ b/src/WebJobs.Script/Description/Rpc/WorkerLanguageInvoker.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
             ScriptInvocationResult result;
             _logger.LogDebug($"Sending invocation id:{invocationId}");
-            await _functionDispatcher.InvokeAsync(invocationContext);
+            _functionDispatcher.Invoke(invocationContext);
             result = await invocationContext.ResultSource.Task;
 
             await BindOutputsAsync(triggerValue, context.Binder, result);

--- a/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
+++ b/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
@@ -334,6 +334,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         {
             if (!_disposed && disposing)
             {
+                _logger.LogDebug("Disposing FunctionDispatcher");
                 _workerErrorSubscription.Dispose();
                 _workerRestartSubscription.Dispose();
                 _processStartCancellationToken.Cancel();

--- a/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
+++ b/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             _logger.LogDebug("Adding jobhost language worker channel for runtime: {language}. workerId:{id}", _workerRuntime, languageWorkerChannel.Id);
             // Not awaiting
             languageWorkerChannel.StartWorkerProcess();
-            languageWorkerChannel.SendFunctionLoadRequests().ContinueWith(functionLoadTask =>
+            languageWorkerChannel.LoadFunctionsAsync().ContinueWith(functionLoadTask =>
                 {
                     if (functionLoadTask.IsCompleted)
                     {
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             _logger.LogDebug("Creating new webhost language worker channel for runtime:{workerRuntime}.", _workerRuntime);
             ILanguageWorkerChannel workerChannel = _webHostLanguageWorkerChannelManager.CreateChannel(_workerRuntime);
             workerChannel.SetupFunctionInvocationBuffers(_functions);
-            await workerChannel.SendFunctionLoadRequests();
+            await workerChannel.LoadFunctionsAsync();
         }
 
         internal void ShutdownWebhostLanguageWorkerChannels()
@@ -198,7 +198,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                     {
                         _logger.LogDebug("Found initialized language worker channel for runtime: {workerRuntime} workerId:{workerId}", _workerRuntime, initializedChannel.Id);
                         initializedChannel.SetupFunctionInvocationBuffers(_functions);
-                        await initializedChannel.SendFunctionLoadRequests();
+                        await initializedChannel.LoadFunctionsAsync();
                     }
                     StartWorkerProcesses(initializedChannels.Count(), InitializeWebhostLanguageWorkerChannel);
                     State = FunctionDispatcherState.Initialized;

--- a/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
+++ b/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             _jobHostLanguageWorkerChannelManager.AddChannel(languageWorkerChannel);
             _logger.LogDebug("Adding jobhost language worker channel for runtime: {language}. workerId:{id}", _workerRuntime, languageWorkerChannel.Id);
             // Not awaiting
-            languageWorkerChannel.StartWorkerProcessAsync();
+            languageWorkerChannel.StartWorkerProcess();
             languageWorkerChannel.SendFunctionLoadRequests().ContinueWith(functionLoadTask =>
                 {
                     if (functionLoadTask.IsCompleted)
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         internal async void InitializeWebhostLanguageWorkerChannel()
         {
             _logger.LogDebug("Creating new webhost language worker channel for runtime:{workerRuntime}.", _workerRuntime);
-            ILanguageWorkerChannel workerChannel = await _webHostLanguageWorkerChannelManager.InitializeChannelAsync(_workerRuntime);
+            ILanguageWorkerChannel workerChannel = _webHostLanguageWorkerChannelManager.CreateChannel(_workerRuntime);
             workerChannel.SetupFunctionInvocationBuffers(_functions);
             await workerChannel.SendFunctionLoadRequests();
         }

--- a/src/WebJobs.Script/Rpc/FunctionRegistration/IFunctionDispatcher.cs
+++ b/src/WebJobs.Script/Rpc/FunctionRegistration/IFunctionDispatcher.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         // Tests if the function metadata is supported by a known language worker
         bool IsSupported(FunctionMetadata metadata, string language);
 
-        Task InvokeAsync(ScriptInvocationContext invocationContext);
+        void Invoke(ScriptInvocationContext invocationContext);
 
         Task InitializeAsync(IEnumerable<FunctionMetadata> functions);
     }

--- a/src/WebJobs.Script/Rpc/ILanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/ILanguageWorkerChannel.cs
@@ -19,9 +19,9 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         void SetupFunctionInvocationBuffers(IEnumerable<FunctionMetadata> functions);
 
-        Task SendFunctionLoadRequests();
+        Task LoadFunctionsAsync();
 
-        Task<bool> SendFunctionEnvironmentReloadRequest();
+        Task<bool> ReloadEnvironmentAsync();
 
         void StartWorkerProcess();
     }

--- a/src/WebJobs.Script/Rpc/ILanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/ILanguageWorkerChannel.cs
@@ -23,6 +23,6 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         Task<bool> SendFunctionEnvironmentReloadRequest();
 
-        Task StartWorkerProcessAsync();
+        void StartWorkerProcess();
     }
 }

--- a/src/WebJobs.Script/Rpc/ILanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/ILanguageWorkerChannel.cs
@@ -19,9 +19,9 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         void SetupFunctionInvocationBuffers(IEnumerable<FunctionMetadata> functions);
 
-        void SendFunctionLoadRequests();
+        Task SendFunctionLoadRequests();
 
-        Task SendFunctionEnvironmentReloadRequest();
+        Task<bool> SendFunctionEnvironmentReloadRequest();
 
         Task StartWorkerProcessAsync();
     }

--- a/src/WebJobs.Script/Rpc/IWebHostLanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/IWebHostLanguageWorkerChannelManager.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 {
     public interface IWebHostLanguageWorkerChannelManager
     {
-        Task<ILanguageWorkerChannel> InitializeChannelAsync(string language);
+        ILanguageWorkerChannel CreateChannel(string language);
 
         IEnumerable<ILanguageWorkerChannel> GetChannels(string language);
 

--- a/src/WebJobs.Script/Rpc/IWebHostLanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/IWebHostLanguageWorkerChannelManager.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
     {
         Task<ILanguageWorkerChannel> InitializeChannelAsync(string language);
 
-        Dictionary<string, TaskCompletionSource<ILanguageWorkerChannel>> GetChannels(string language);
+        IEnumerable<ILanguageWorkerChannel> GetChannels(string language);
 
         Task SpecializeAsync();
 
-        Task<bool> ShutdownChannelIfExistsAsync(string language, string workerId);
+        bool ShutdownChannelIfExists(string language, string workerId);
 
-        Task ShutdownChannelsAsync();
+        void ShutdownChannels();
     }
 }

--- a/src/WebJobs.Script/Rpc/JobHostLanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/JobHostLanguageWorkerChannelManager.cs
@@ -4,12 +4,19 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.Rpc
 {
     internal class JobHostLanguageWorkerChannelManager : IJobHostLanguageWorkerChannelManager
     {
+        private readonly ILogger _logger;
         private ConcurrentDictionary<string, ILanguageWorkerChannel> _channels = new ConcurrentDictionary<string, ILanguageWorkerChannel>();
+
+        public JobHostLanguageWorkerChannelManager(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<JobHostLanguageWorkerChannelManager>();
+        }
 
         public void AddChannel(ILanguageWorkerChannel channel)
         {
@@ -20,6 +27,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         {
             if (_channels.TryRemove(channel.Id, out ILanguageWorkerChannel removedChannel))
             {
+                _logger.LogDebug("Disposing language worker channel with id:{workerId}", removedChannel.Id);
                 (removedChannel as IDisposable)?.Dispose();
             }
         }
@@ -30,6 +38,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             {
                 if (_channels.TryRemove(channelId, out ILanguageWorkerChannel removedChannel))
                 {
+                    _logger.LogDebug("Disposing language worker channel with id:{workerId}", removedChannel.Id);
                     (removedChannel as IDisposable)?.Dispose();
                 }
             }

--- a/src/WebJobs.Script/Rpc/JobHostLanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/JobHostLanguageWorkerChannelManager.cs
@@ -4,19 +4,12 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.Rpc
 {
     internal class JobHostLanguageWorkerChannelManager : IJobHostLanguageWorkerChannelManager
     {
-        private readonly ILogger _logger;
         private ConcurrentDictionary<string, ILanguageWorkerChannel> _channels = new ConcurrentDictionary<string, ILanguageWorkerChannel>();
-
-        public JobHostLanguageWorkerChannelManager(ILoggerFactory loggerFactory)
-        {
-            _logger = loggerFactory.CreateLogger<JobHostLanguageWorkerChannelManager>();
-        }
 
         public void AddChannel(ILanguageWorkerChannel channel)
         {
@@ -27,7 +20,6 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         {
             if (_channels.TryRemove(channel.Id, out ILanguageWorkerChannel removedChannel))
             {
-                _logger.LogDebug("Disposing language worker channel with id:{workerId}", removedChannel.Id);
                 (removedChannel as IDisposable)?.Dispose();
             }
         }
@@ -38,7 +30,6 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             {
                 if (_channels.TryRemove(channelId, out ILanguageWorkerChannel removedChannel))
                 {
-                    _logger.LogDebug("Disposing language worker channel with id:{workerId}", removedChannel.Id);
                     (removedChannel as IDisposable)?.Dispose();
                 }
             }

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             }
         }
 
-        public async Task SendFunctionLoadRequests()
+        public async Task LoadFunctionsAsync()
         {
             // Wait for worker to be initialized before sending any function load requests
             var initialized = await _workerInitTask.Task;
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             }
         }
 
-        public async Task<bool> SendFunctionEnvironmentReloadRequest()
+        public async Task<bool> ReloadEnvironmentAsync()
         {
             // Wait for worker to be initialized before sending environment variables
             var initialized = await _workerInitTask.Task;

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
@@ -180,6 +180,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         public async Task SendFunctionLoadRequests()
         {
+            // Wait for worker to be initialized before sending any function load requests
             var initialized = await _workerInitTask.Task;
 
             if (_functions != null && initialized)

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannelFactory.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannelFactory.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         private readonly ILanguageWorkerProcessFactory _languageWorkerProcessManager = null;
         private readonly IScriptEventManager _eventManager = null;
         private readonly IEnumerable<WorkerConfig> _workerConfigs = null;
+        private readonly IEnvironment _environment;
 
         public LanguageWorkerChannelFactory(IScriptEventManager eventManager, IEnvironment environment, IRpcServer rpcServer, ILoggerFactory loggerFactory, IOptions<LanguageWorkerOptions> languageWorkerOptions,
             IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, ILanguageWorkerProcessFactory languageWorkerProcessManager)
@@ -28,6 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             _loggerFactory = loggerFactory;
             _workerConfigs = languageWorkerOptions.Value.WorkerConfigs;
             _languageWorkerProcessManager = languageWorkerProcessManager;
+            _environment = environment ?? throw new ArgumentNullException(nameof(environment));
         }
 
         public ILanguageWorkerChannel CreateLanguageWorkerChannel(string scriptRootPath, string runtime, IMetricsLogger metricsLogger, int attemptCount, IOptions<ManagedDependencyOptions> managedDependencyOptions = null)
@@ -49,6 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                          workerLogger,
                          metricsLogger,
                          attemptCount,
+                         _environment,
                          managedDependencyOptions);
         }
     }

--- a/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerProcess.cs
@@ -82,6 +82,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             }
             catch (Exception ex)
             {
+                _workerProcessLogger.LogError("Failed to start Language Worker Channel for language :{runtime}. {ex}", _runtime, ex);
                 throw new HostInitializationException($"Failed to start Language Worker Channel for language :{_runtime}", ex);
             }
         }

--- a/src/WebJobs.Script/Rpc/RpcInitializationService.cs
+++ b/src/WebJobs.Script/Rpc/RpcInitializationService.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             }
             _logger.LogDebug("Starting Rpc Initialization Service.");
             await InitializeRpcServerAsync();
-            await InitializeChannelsAsync();
+            InitializeChannels();
             _logger.LogDebug("Rpc Initialization Service started.");
         }
 
@@ -111,40 +111,38 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             }
         }
 
-        internal Task InitializeChannelsAsync()
+        internal void InitializeChannels()
         {
             if (ShouldStartInPlaceholderMode())
             {
-                return InitializePlaceholderChannelsAsync();
+                InitializePlaceholderChannels();
             }
 
-            return InitializeWebHostRuntimeChannelsAsync();
+            InitializeWebHostRuntimeChannels();
         }
 
-        private Task InitializePlaceholderChannelsAsync()
+        private void InitializePlaceholderChannels()
         {
             if (_environment.IsLinuxHostingEnvironment())
             {
-                return InitializePlaceholderChannelsAsync(OSPlatform.Linux);
+                InitializePlaceholderChannels(OSPlatform.Linux);
             }
 
-            return InitializePlaceholderChannelsAsync(OSPlatform.Windows);
+            InitializePlaceholderChannels(OSPlatform.Windows);
         }
 
-        private Task InitializePlaceholderChannelsAsync(OSPlatform os)
+        private void InitializePlaceholderChannels(OSPlatform os)
         {
-            return Task.WhenAll(_hostingOSToWhitelistedRuntimes[os].Select(runtime =>
-                _webHostlanguageWorkerChannelManager.InitializeChannelAsync(runtime)));
+            _hostingOSToWhitelistedRuntimes[os].Select(runtime =>
+                _webHostlanguageWorkerChannelManager.CreateChannel(runtime));
         }
 
-        private Task InitializeWebHostRuntimeChannelsAsync()
+        private void InitializeWebHostRuntimeChannels()
         {
             if (_webHostLevelWhitelistedRuntimes.Contains(_workerRuntime))
             {
-                return _webHostlanguageWorkerChannelManager.InitializeChannelAsync(_workerRuntime);
+                _webHostlanguageWorkerChannelManager.CreateChannel(_workerRuntime);
             }
-
-            return Task.CompletedTask;
         }
 
         private bool ShouldStartInPlaceholderMode()

--- a/src/WebJobs.Script/Rpc/RpcInitializationService.cs
+++ b/src/WebJobs.Script/Rpc/RpcInitializationService.cs
@@ -65,10 +65,11 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             _logger.LogDebug("Rpc Initialization Service started.");
         }
 
-        public async Task StopAsync(CancellationToken cancellationToken)
+        public Task StopAsync(CancellationToken cancellationToken)
         {
             _logger.LogDebug("Shuttingdown Rpc Channels Manager");
-            await _webHostlanguageWorkerChannelManager.ShutdownChannelsAsync();
+            _webHostlanguageWorkerChannelManager.ShutdownChannels();
+            return Task.CompletedTask;
         }
 
         public async Task OuterStopAsync(CancellationToken cancellationToken)

--- a/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
@@ -55,8 +55,10 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             try
             {
                 languageWorkerChannel = _languageWorkerChannelFactory.CreateLanguageWorkerChannel(scriptRootPath, runtime, null, 0);
-                await languageWorkerChannel.StartWorkerProcessAsync();
+                // Keep track of language worker channel as soon as we might start it
+                // TODO: we should not make this something that we just need to do.
                 AddOrUpdateWorkerChannels(runtime, languageWorkerChannel);
+                await languageWorkerChannel.StartWorkerProcessAsync();
             }
             catch (Exception ex)
             {
@@ -157,19 +159,19 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             }
         }
 
-        internal void AddOrUpdateWorkerChannels(string initializedRuntime, ILanguageWorkerChannel initializedLanguageWorkerChannel)
+        internal void AddOrUpdateWorkerChannels(string initializedRuntime, ILanguageWorkerChannel newLanguageWorkerChannel)
         {
-            _logger.LogDebug("Adding webhost language worker channel for runtime: {language}. workerId:{id}", initializedRuntime, initializedLanguageWorkerChannel.Id);
+            _logger.LogDebug("Adding webhost language worker channel for runtime: {language}. workerId:{id}", initializedRuntime, newLanguageWorkerChannel.Id);
             _workerChannels.AddOrUpdate(initializedRuntime,
                     (runtime) =>
                     {
                         List<ILanguageWorkerChannel> newLanguageWorkerChannels = new List<ILanguageWorkerChannel>();
-                        newLanguageWorkerChannels.Add(initializedLanguageWorkerChannel);
+                        newLanguageWorkerChannels.Add(newLanguageWorkerChannel);
                         return newLanguageWorkerChannels;
                     },
                     (runtime, existingLanguageWorkerChannels) =>
                     {
-                        existingLanguageWorkerChannels.Add(initializedLanguageWorkerChannel);
+                        existingLanguageWorkerChannels.Add(newLanguageWorkerChannel);
                         return existingLanguageWorkerChannels;
                     });
         }

--- a/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
@@ -41,13 +41,13 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             _shutdownStandbyWorkerChannels = _shutdownStandbyWorkerChannels.Debounce(milliseconds: 5000);
         }
 
-        public Task<ILanguageWorkerChannel> InitializeChannelAsync(string runtime)
+        public ILanguageWorkerChannel CreateChannel(string runtime)
         {
             _logger?.LogDebug("Initializing language worker channel for runtime:{runtime}", runtime);
-            return InitializeLanguageWorkerChannel(runtime, _applicationHostOptions.CurrentValue.ScriptPath);
+            return CreateLanguageWorkerChannel(runtime, _applicationHostOptions.CurrentValue.ScriptPath);
         }
 
-        private async Task<ILanguageWorkerChannel> InitializeLanguageWorkerChannel(string runtime, string scriptRootPath)
+        private ILanguageWorkerChannel CreateLanguageWorkerChannel(string runtime, string scriptRootPath)
         {
             ILanguageWorkerChannel languageWorkerChannel = null;
             string workerId = Guid.NewGuid().ToString();
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 // Keep track of language worker channel as soon as we might start it
                 // TODO: we should not make this something that we just need to do.
                 AddOrUpdateWorkerChannels(runtime, languageWorkerChannel);
-                await languageWorkerChannel.StartWorkerProcessAsync();
+                languageWorkerChannel.StartWorkerProcess();
             }
             catch (Exception ex)
             {

--- a/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             if (_workerRuntime != null && languageWorkerChannel != null)
             {
                 _logger.LogInformation("Loading environment variables for runtime: {runtime}", _workerRuntime);
-                await languageWorkerChannel.SendFunctionEnvironmentReloadRequest();
+                await languageWorkerChannel.ReloadEnvironmentAsync();
             }
             _shutdownStandbyWorkerChannels();
         }

--- a/test/WebJobs.Script.Tests.Integration/Rpc/LanguageWorkerChannelManagerEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Rpc/LanguageWorkerChannelManagerEndToEndTests.cs
@@ -20,10 +20,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public TestFixture Fixture { get; set; }
 
         [Fact]
-        public async Task InitializeAsync_DoNotInitialize_JavaWorker_ProxiesOnly()
+        public void InitializeAsync_DoNotInitialize_JavaWorker_ProxiesOnly()
         {
             var channelManager = _languageWorkerChannelManager as WebHostLanguageWorkerChannelManager;
-            var javaChannel = await channelManager.GetChannelAsync(LanguageWorkerConstants.JavaLanguageWorkerName);
+            var javaChannel = channelManager.GetChannel(LanguageWorkerConstants.JavaLanguageWorkerName);
             Assert.Null(javaChannel);
         }
 

--- a/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/NodeContentTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/NodeContentTests.cs
@@ -133,13 +133,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-        public async Task InitializeAsync_WorkerRuntime_Node_DoNotInitialize_JavaWorker()
+        public void InitializeAsync_WorkerRuntime_Node_DoNotInitialize_JavaWorker()
         {
             var channelManager = _languageWorkerChannelManager as WebHostLanguageWorkerChannelManager;
 
-            ILanguageWorkerChannel javaChannel = await channelManager.GetChannelAsync(LanguageWorkerConstants.JavaLanguageWorkerName);
+            var javaChannel = channelManager.GetChannel(LanguageWorkerConstants.JavaLanguageWorkerName);
             Assert.Null(javaChannel);
-            ILanguageWorkerChannel nodeChannel = await channelManager.GetChannelAsync(LanguageWorkerConstants.NodeLanguageWorkerName);
+            var nodeChannel = channelManager.GetChannel(LanguageWorkerConstants.NodeLanguageWorkerName);
             Assert.Null(nodeChannel);
         }
 

--- a/test/WebJobs.Script.Tests/Rpc/FunctionDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/FunctionDispatcherTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -17,6 +18,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
 {
     public class FunctionDispatcherTests
     {
+        private static TestLanguageWorkerChannel _javaTestChannel;
+        private static TestLogger _testLogger = new TestLogger("FunctionDispatcherTests");
+
         [Theory]
         [InlineData("node", "node")]
         [InlineData("java", "java")]
@@ -347,6 +351,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
                 testWebHostLanguageWorkerChannelManager = mockwebHostLanguageWorkerChannelManager.Object;
             }
             var mockFunctionDispatcherLoadBalancer = new Mock<IFunctionDispatcherLoadBalancer>();
+
+            _javaTestChannel = new TestLanguageWorkerChannel(Guid.NewGuid().ToString(), "java", eventManager, _testLogger, false);
+
             return new FunctionDispatcher(scriptOptions,
                 metricsLogger.Object,
                 testEnv,

--- a/test/WebJobs.Script.Tests/Rpc/FunctionDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/FunctionDispatcherTests.cs
@@ -9,7 +9,9 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.Rpc;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.WebJobs.Script.Tests;
 using Moq;
 using Xunit;
 using FunctionMetadata = Microsoft.Azure.WebJobs.Script.Description.FunctionMetadata;
@@ -339,12 +341,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             {
                 WorkerConfigs = TestHelpers.GetTestWorkerConfigs()
             };
+
+            var testLoggerProvider = new TestLoggerProvider();
+            var testLoggerFactory = new LoggerFactory();
+            testLoggerFactory.AddProvider(testLoggerProvider);
+
             IWebHostLanguageWorkerChannelManager testWebHostLanguageWorkerChannelManager = new TestLanguageWorkerChannelManager(eventManager, testLogger, scriptOptions.Value.RootScriptPath);
             ILanguageWorkerChannelFactory testLanguageWorkerChannelFactory = new TestLanguageWorkerChannelFactory(eventManager, testLogger, scriptOptions.Value.RootScriptPath);
-            IJobHostLanguageWorkerChannelManager jobHostLanguageWorkerChannelManager = new JobHostLanguageWorkerChannelManager();
+            IJobHostLanguageWorkerChannelManager jobHostLanguageWorkerChannelManager = new JobHostLanguageWorkerChannelManager(testLoggerFactory);
             if (addWebhostChannel)
             {
-                testWebHostLanguageWorkerChannelManager.InitializeChannelAsync("java");
+                testWebHostLanguageWorkerChannelManager.CreateChannel("java");
             }
             if (mockwebHostLanguageWorkerChannelManager != null)
             {

--- a/test/WebJobs.Script.Tests/Rpc/LanguageWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/LanguageWorkerChannelManagerTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
 {
-    public class WebHostLanguageWorkerChannelManagerTests
+    public class LanguageWorkerChannelManagerTests
     {
         private WebHostLanguageWorkerChannelManager _languageWorkerChannelManager;
         private IScriptEventManager _eventManager;
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
                 { "StandbyModeEnabled", "true" }
             };
 
-        public WebHostLanguageWorkerChannelManagerTests()
+        public LanguageWorkerChannelManagerTests()
         {
             _eventManager = new ScriptEventManager();
             _rpcServer = new TestRpcServer();

--- a/test/WebJobs.Script.Tests/Rpc/LanguageWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/LanguageWorkerChannelTests.cs
@@ -107,19 +107,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         public async Task SendLoadRequests_PublishesOutboundEvents()
         {
             _workerChannel.SetupFunctionInvocationBuffers(GetTestFunctionsList("node"));
-            await _workerChannel.SendFunctionLoadRequests();
+            await _workerChannel.LoadFunctionsAsync();
             var traces = _logger.GetLogMessages();
             var functionLoadLogs = traces.Where(m => string.Equals(m.FormattedMessage, _expectedLogMsg));
             Assert.True(functionLoadLogs.Count() == 2);
         }
 
         [Fact]
-        public async Task SendSendFunctionEnvironmentReloadRequest_PublishesOutboundEvents()
+        public async Task ReloadEnvironmentAsync_PublishesOutboundEvents()
         {
             Environment.SetEnvironmentVariable("TestNull", null);
             Environment.SetEnvironmentVariable("TestEmpty", string.Empty);
             Environment.SetEnvironmentVariable("TestValid", "TestValue");
-            await _workerChannel.SendFunctionEnvironmentReloadRequest();
+            await _workerChannel.ReloadEnvironmentAsync();
             _testFunctionRpcService.PublishFunctionEnvironmentReloadResponseEvent();
             var traces = _logger.GetLogMessages();
             var functionLoadLogs = traces.Where(m => string.Equals(m.FormattedMessage, "Sending FunctionEnvironmentReloadRequest"));
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         }
 
         [Fact]
-        public void SendSendFunctionEnvironmentReloadRequest_SanitizedEnvironmentVariables()
+        public void ReloadEnvironmentAsync_SanitizedEnvironmentVariables()
         {
             Environment.SetEnvironmentVariable("TestNull", null);
             Environment.SetEnvironmentVariable("TestEmpty", string.Empty);

--- a/test/WebJobs.Script.Tests/Rpc/RpcInitializationServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/RpcInitializationServiceTests.cs
@@ -35,8 +35,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             };
             _optionsMonitor = TestHelpers.CreateOptionsMonitor(applicationHostOptions);
             ILanguageWorkerChannel testLanguageWorkerChannel = new TestLanguageWorkerChannel(Guid.NewGuid().ToString(), LanguageWorkerConstants.NodeLanguageWorkerName);
-            _mockLanguageWorkerChannelManager.Setup(m => m.InitializeChannelAsync(It.IsAny<string>()))
-                                             .Returns(Task.FromResult<ILanguageWorkerChannel>(testLanguageWorkerChannel));
+            _mockLanguageWorkerChannelManager.Setup(m => m.CreateChannel(It.IsAny<string>()))
+                                             .Returns(testLanguageWorkerChannel);
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
                 offlineFilePath = TestHelpers.CreateOfflineFile();
                 _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
                 await _rpcInitializationService.StartAsync(CancellationToken.None);
-                _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(LanguageWorkerConstants.JavaLanguageWorkerName), Times.Never);
+                _mockLanguageWorkerChannelManager.Verify(m => m.CreateChannel(LanguageWorkerConstants.JavaLanguageWorkerName), Times.Never);
                 Assert.DoesNotContain("testserver", testRpcServer.Uri.ToString());
                 await testRpcServer.ShutdownAsync();
             }
@@ -70,8 +70,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
 
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
             await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(LanguageWorkerConstants.JavaLanguageWorkerName), Times.Once);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(LanguageWorkerConstants.PythonLanguageWorkerName), Times.Never);
+            _mockLanguageWorkerChannelManager.Verify(m => m.CreateChannel(LanguageWorkerConstants.JavaLanguageWorkerName), Times.Once);
+            _mockLanguageWorkerChannelManager.Verify(m => m.CreateChannel(LanguageWorkerConstants.PythonLanguageWorkerName), Times.Never);
             Assert.Contains("testserver", testRpcServer.Uri.ToString());
             await testRpcServer.ShutdownAsync();
         }
@@ -86,8 +86,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
 
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
             await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(LanguageWorkerConstants.JavaLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(LanguageWorkerConstants.PythonLanguageWorkerName), Times.Never);
+            _mockLanguageWorkerChannelManager.Verify(m => m.CreateChannel(LanguageWorkerConstants.JavaLanguageWorkerName), Times.Never);
+            _mockLanguageWorkerChannelManager.Verify(m => m.CreateChannel(LanguageWorkerConstants.PythonLanguageWorkerName), Times.Never);
             Assert.Contains("testserver", testRpcServer.Uri.ToString());
             await testRpcServer.ShutdownAsync();
         }
@@ -103,8 +103,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
 
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
             await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(LanguageWorkerConstants.PythonLanguageWorkerName), Times.Once);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(LanguageWorkerConstants.JavaLanguageWorkerName), Times.Never);
+            _mockLanguageWorkerChannelManager.Verify(m => m.CreateChannel(LanguageWorkerConstants.PythonLanguageWorkerName), Times.Once);
+            _mockLanguageWorkerChannelManager.Verify(m => m.CreateChannel(LanguageWorkerConstants.JavaLanguageWorkerName), Times.Never);
             Assert.Contains("testserver", testRpcServer.Uri.ToString());
             await testRpcServer.ShutdownAsync();
         }
@@ -120,8 +120,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
 
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
             await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(LanguageWorkerConstants.PythonLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(LanguageWorkerConstants.JavaLanguageWorkerName), Times.Never);
+            _mockLanguageWorkerChannelManager.Verify(m => m.CreateChannel(LanguageWorkerConstants.PythonLanguageWorkerName), Times.Never);
+            _mockLanguageWorkerChannelManager.Verify(m => m.CreateChannel(LanguageWorkerConstants.JavaLanguageWorkerName), Times.Never);
             Assert.Contains("testserver", testRpcServer.Uri.ToString());
             await testRpcServer.ShutdownAsync();
         }
@@ -138,8 +138,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
 
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
             await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(LanguageWorkerConstants.PythonLanguageWorkerName), Times.Once);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(LanguageWorkerConstants.JavaLanguageWorkerName), Times.Never);
+            _mockLanguageWorkerChannelManager.Verify(m => m.CreateChannel(LanguageWorkerConstants.PythonLanguageWorkerName), Times.Once);
+            _mockLanguageWorkerChannelManager.Verify(m => m.CreateChannel(LanguageWorkerConstants.JavaLanguageWorkerName), Times.Never);
             Assert.Contains("testserver", testRpcServer.Uri.ToString());
             await testRpcServer.ShutdownAsync();
         }
@@ -156,8 +156,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
 
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
             await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(LanguageWorkerConstants.PythonLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(LanguageWorkerConstants.JavaLanguageWorkerName), Times.Never);
+            _mockLanguageWorkerChannelManager.Verify(m => m.CreateChannel(LanguageWorkerConstants.PythonLanguageWorkerName), Times.Never);
+            _mockLanguageWorkerChannelManager.Verify(m => m.CreateChannel(LanguageWorkerConstants.JavaLanguageWorkerName), Times.Never);
             Assert.Contains("testserver", testRpcServer.Uri.ToString());
             await testRpcServer.ShutdownAsync();
         }
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
             _rpcInitializationService.AddSupportedWebHostLevelRuntime(LanguageWorkerConstants.NodeLanguageWorkerName);
             await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(LanguageWorkerConstants.NodeLanguageWorkerName), Times.Once);
+            _mockLanguageWorkerChannelManager.Verify(m => m.CreateChannel(LanguageWorkerConstants.NodeLanguageWorkerName), Times.Once);
             Assert.Contains("testserver", testRpcServer.Uri.ToString());
             await testRpcServer.ShutdownAsync();
         }
@@ -189,7 +189,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             _rpcInitializationService.AddSupportedWebHostLevelRuntime(LanguageWorkerConstants.NodeLanguageWorkerName);
 
             await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(LanguageWorkerConstants.NodeLanguageWorkerName), Times.Once);
+            _mockLanguageWorkerChannelManager.Verify(m => m.CreateChannel(LanguageWorkerConstants.NodeLanguageWorkerName), Times.Once);
             Assert.Contains("testserver", testRpcServer.Uri.ToString());
             await testRpcServer.ShutdownAsync();
         }
@@ -203,8 +203,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
 
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
             await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(LanguageWorkerConstants.NodeLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(LanguageWorkerConstants.JavaLanguageWorkerName), Times.Never);
+            _mockLanguageWorkerChannelManager.Verify(m => m.CreateChannel(LanguageWorkerConstants.NodeLanguageWorkerName), Times.Never);
+            _mockLanguageWorkerChannelManager.Verify(m => m.CreateChannel(LanguageWorkerConstants.JavaLanguageWorkerName), Times.Never);
             Assert.Contains("testserver", testRpcServer.Uri.ToString());
             await testRpcServer.ShutdownAsync();
         }
@@ -219,8 +219,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             _rpcInitializationService.AddSupportedWebHostLevelRuntime(LanguageWorkerConstants.NodeLanguageWorkerName);
 
             await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(LanguageWorkerConstants.JavaLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(LanguageWorkerConstants.NodeLanguageWorkerName), Times.Never);
+            _mockLanguageWorkerChannelManager.Verify(m => m.CreateChannel(LanguageWorkerConstants.JavaLanguageWorkerName), Times.Never);
+            _mockLanguageWorkerChannelManager.Verify(m => m.CreateChannel(LanguageWorkerConstants.NodeLanguageWorkerName), Times.Never);
             Assert.Contains("testserver", testRpcServer.Uri.ToString());
             await testRpcServer.ShutdownAsync();
         }
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
 
             await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(LanguageWorkerConstants.PythonLanguageWorkerName), Times.Never);
+            _mockLanguageWorkerChannelManager.Verify(m => m.CreateChannel(LanguageWorkerConstants.PythonLanguageWorkerName), Times.Never);
             Assert.Contains("testserver", testRpcServer.Uri.ToString());
             await testRpcServer.ShutdownAsync();
         }

--- a/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannel.cs
+++ b/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannel.cs
@@ -45,15 +45,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             _testLogger.LogInformation("SetupFunctionInvocationBuffers called");
         }
 
-        public Task SendFunctionLoadRequests()
+        public Task LoadFunctionsAsync()
         {
             _testLogger.LogInformation("RegisterFunctions called");
             return Task.CompletedTask;
         }
 
-        public Task<bool> SendFunctionEnvironmentReloadRequest()
+        public Task<bool> ReloadEnvironmentAsync()
         {
-            _testLogger.LogInformation("SendFunctionEnvironmentReloadRequest called");
+            _testLogger.LogInformation("Sending FunctionEnvironmentReloadRequest");
             return Task.FromResult(true);
         }
 

--- a/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannel.cs
+++ b/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannel.cs
@@ -62,10 +62,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             _testLogger.LogInformation("SendInvocationRequest called");
         }
 
-        public async Task StartWorkerProcessAsync()
+        public void StartWorkerProcess()
         {
             // To verify FunctionDispatcher transistions
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
             string workerVersion = Guid.NewGuid().ToString();
             IDictionary<string, string> workerCapabilities = new Dictionary<string, string>()
             {

--- a/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannel.cs
+++ b/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannel.cs
@@ -45,15 +45,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             _testLogger.LogInformation("SetupFunctionInvocationBuffers called");
         }
 
-        public void SendFunctionLoadRequests()
+        public Task SendFunctionLoadRequests()
         {
             _testLogger.LogInformation("RegisterFunctions called");
+            return Task.CompletedTask;
         }
 
-        public Task SendFunctionEnvironmentReloadRequest()
+        public Task<bool> SendFunctionEnvironmentReloadRequest()
         {
             _testLogger.LogInformation("SendFunctionEnvironmentReloadRequest called");
-            return Task.CompletedTask;
+            return Task.FromResult(true);
         }
 
         public void SendInvocationRequest(ScriptInvocationContext context)

--- a/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannelManager.cs
+++ b/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannelManager.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             return null;
         }
 
-        public Task<ILanguageWorkerChannel> InitializeChannelAsync(string language)
+        public ILanguageWorkerChannel CreateChannel(string language)
         {
             ILanguageWorkerChannel workerChannel = new TestLanguageWorkerChannel(Guid.NewGuid().ToString(), language, _eventManager, _testLogger, true);
             if (_workerChannels.TryGetValue(language, out List<ILanguageWorkerChannel> workerChannels))
@@ -53,8 +53,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
                 _workerChannels.TryAdd(language, new List<ILanguageWorkerChannel>());
                 _workerChannels[language].Add(workerChannel);
             }
-            workerChannel.StartWorkerProcessAsync();
-            return Task.FromResult(workerChannel);
+            workerChannel.StartWorkerProcess();
+            return workerChannel;
         }
 
         public void ShutdownChannels()


### PR DESCRIPTION
Reverts: https://github.com/Azure/azure-functions-host/commit/b9807ebab1b8084dd0aae8b8d20953c6f2bf6972

Re-applies fix to: https://github.com/Azure/azure-functions-host/issues/4792 and https://github.com/Azure/azure-functions-host/issues/4796

Fixes deadlock when language worker process fails to start in placeholder mode

TODO: make sure all error paths are covered and exceptions being handled as appropriate.
TODO: make sure there are enough logs

cc: @mathewc @pragnagopa 