### PR TITLE
Disable script compilation in omnisharp

### DIFF
--- a/omnisharp.json
+++ b/omnisharp.json
@@ -1,0 +1,5 @@
+{
+    "script": {
+        "enabled": false
+    }
+}


### PR DESCRIPTION
Omnisharp throws a lot of errors for all the csx files in the sample folder. I don't think it needs to compile those while the project is open in vscode 