### PR TITLE
Make LanguageWorkerChannel enforce rpc message order

### DIFF
--- a/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
+++ b/src/WebJobs.Script/Rpc/FunctionRegistration/FunctionDispatcher.cs
@@ -109,6 +109,10 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         internal Task InitializeJobhostLanguageWorkerChannelAsync(int attemptCount)
         {
             var languageWorkerChannel = _languageWorkerChannelFactory.CreateLanguageWorkerChannel(_scriptOptions.RootScriptPath, _workerRuntime, _metricsLogger, attemptCount, _managedDependencyOptions);
+            languageWorkerChannel.SetupFunctionInvocationBuffers(_functions);
+            _jobHostLanguageWorkerChannelManager.AddChannel(languageWorkerChannel);
+            languageWorkerChannel.LoadFunctionsAsync();
+
             // Start worker process without awaiting
             languageWorkerChannel.StartWorkerProcessAsync().ContinueWith(workerInitTask =>
                 {
@@ -123,8 +127,6 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                     }
                 });
             // Call LoadFunctionsAsync, which will guarantee ordering internally
-            languageWorkerChannel.LoadFunctionsAsync(_functions);
-            _jobHostLanguageWorkerChannelManager.AddChannel(languageWorkerChannel);
             return Task.CompletedTask;
         }
 

--- a/src/WebJobs.Script/Rpc/ILanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/ILanguageWorkerChannel.cs
@@ -17,7 +17,9 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         LanguageWorkerChannelState State { get; }
 
-        Task LoadFunctionsAsync(IEnumerable<FunctionMetadata> functions);
+        void SetupFunctionInvocationBuffers(IEnumerable<FunctionMetadata> functions);
+
+        Task LoadFunctionsAsync(IEnumerable<FunctionMetadata> functions = null);
 
         Task ReloadEnvironmentAsync();
 

--- a/src/WebJobs.Script/Rpc/ILanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/ILanguageWorkerChannel.cs
@@ -17,11 +17,9 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         LanguageWorkerChannelState State { get; }
 
-        void SetupFunctionInvocationBuffers(IEnumerable<FunctionMetadata> functions);
+        Task LoadFunctionsAsync(IEnumerable<FunctionMetadata> functions);
 
-        void SendFunctionLoadRequests();
-
-        Task SendFunctionEnvironmentReloadRequest();
+        Task ReloadEnvironmentAsync();
 
         Task StartWorkerProcessAsync();
     }

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             _workerInitTask.SetResult(true);
         }
 
-        internal void SetupFunctionInvocationBuffers(IEnumerable<FunctionMetadata> functions)
+        public void SetupFunctionInvocationBuffers(IEnumerable<FunctionMetadata> functions)
         {
             _functions = functions;
             foreach (FunctionMetadata metadata in functions)
@@ -179,9 +179,12 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             }
         }
 
-        public async Task LoadFunctionsAsync(IEnumerable<FunctionMetadata> functions)
+        public async Task LoadFunctionsAsync(IEnumerable<FunctionMetadata> functions = null)
         {
-            SetupFunctionInvocationBuffers(functions);
+            if (functions != null)
+            {
+                SetupFunctionInvocationBuffers(functions);
+            }
 
             // Wait for worker to be initialized before sending environment variables
             var initialized = await _workerInitTask.Task;

--- a/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerChannel.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         private ILogger _workerChannelLogger;
         private ILanguageWorkerProcess _languageWorkerProcess;
         private TaskCompletionSource<bool> _environmentReloadTask;
-        private TaskCompletionSource<bool> _workerInitTask = new TaskCompletionSource<bool>();
+        private TaskCompletionSource<bool> _workerInitTask;
 
         internal LanguageWorkerChannel(
            string workerId,
@@ -111,6 +111,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         public async Task StartWorkerProcessAsync()
         {
+            _workerInitTask = new TaskCompletionSource<bool>();
             _startSubscription = _inboundWorkerEvents.Where(msg => msg.MessageType == MsgType.StartStream)
                 .Timeout(TimeSpan.FromSeconds(LanguageWorkerConstants.ProcessStartTimeoutSeconds))
                 .Take(1)

--- a/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
@@ -106,7 +106,8 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             if (_workerRuntime != null && languageWorkerChannel != null)
             {
                 _logger.LogInformation("Loading environment variables for runtime: {runtime}", _workerRuntime);
-                await languageWorkerChannel.SendFunctionEnvironmentReloadRequest();
+                // Send environment reload
+                await languageWorkerChannel.ReloadEnvironmentAsync();
             }
             _shutdownStandbyWorkerChannels();
             _logger.LogDebug("Completed language worker channel specialization");

--- a/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannel.cs
+++ b/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannel.cs
@@ -42,17 +42,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         {
         }
 
-        public void SetupFunctionInvocationBuffers(IEnumerable<FunctionMetadata> functions)
+        public Task LoadFunctionsAsync(IEnumerable<FunctionMetadata> functions)
         {
             _testLogger.LogInformation("SetupFunctionInvocationBuffers called");
-        }
-
-        public void SendFunctionLoadRequests()
-        {
             _testLogger.LogInformation("RegisterFunctions called");
+            return Task.CompletedTask;
         }
 
-        public Task SendFunctionEnvironmentReloadRequest()
+        public Task ReloadEnvironmentAsync()
         {
             _testLogger.LogInformation("SendFunctionEnvironmentReloadRequest called");
             return Task.CompletedTask;

--- a/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannel.cs
+++ b/test/WebJobs.Script.Tests/Rpc/TestLanguageWorkerChannel.cs
@@ -42,9 +42,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         {
         }
 
-        public Task LoadFunctionsAsync(IEnumerable<FunctionMetadata> functions)
+        public void SetupFunctionInvocationBuffers(IEnumerable<FunctionMetadata> functions)
         {
             _testLogger.LogInformation("SetupFunctionInvocationBuffers called");
+        }
+
+        public Task LoadFunctionsAsync(IEnumerable<FunctionMetadata> functions = null)
+        {
+            if (functions != null)
+            {
+                SetupFunctionInvocationBuffers(functions);
+            }
             _testLogger.LogInformation("RegisterFunctions called");
             return Task.CompletedTask;
         }


### PR DESCRIPTION
This is part 1 of changes to contain async ordering of messages to prevent race conditions and other bugs/complexity. Currently, callers of methods on LanguageWorkerChannel have to be aware of the precise ordering that is required for RPC messages, and they have to call those methods in the correct order.

In a next iteration of changes, we can remove the TaskCompletionSource's in WebHostLanguageWorkerChannelManager to decrease chances of deadlock and change logic in InvokeAsync to make sure that we never get the error message `Did not find any initialized language workers`, which can happen if invocation happens during worker initialization.

Related to: https://github.com/Azure/azure-functions-host/issues/4882