### PR TITLE
Update PowerShell worker to 0.1.174-preview

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.8100001-0126c21e" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.5.10246" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.159-preview" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.174-preview" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.3" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.4" />


### PR DESCRIPTION
Changes in this release:

- Upgraded to PowerShell [6.2.3](https://github.com/PowerShell/PowerShell/releases/tag/v6.2.3).
- **Breaking change**: HTTP request body is not automatically deserialized from JSON unless the request contains `application/json` in the `Content-Type` header (fixed issue #241).
- Management Dependencies upgrade forces PowerShell worker restarts when new module versions are detected.
- Improved error and exception logging for function code.
- Added a warning when a function invocation is blocked because of concurrency limit.
- Other logging improvements.

For more information, please see https://github.com/Azure/azure-functions-powershell-worker/releases.