### PR TITLE
Enable Node Placeholder Pools for RFZ / readonly

### DIFF
--- a/src/WebJobs.Script/Rpc/LanguageWorkerConstants.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerConstants.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         public const int ProcessStartTimeoutSeconds = 60;
         public const string FunctionWorkerRuntimeSettingName = "FUNCTIONS_WORKER_RUNTIME";
         public const string FunctionsWorkerProcessCountSettingName = "FUNCTIONS_WORKER_PROCESS_COUNT";
-        public const string FunctionsNodeVersionSetting = "WEBSITE_NODE_DEFAULT_VERSION";
         public const string DotNetLanguageWorkerName = "dotnet";
         public const string NodeLanguageWorkerName = "node";
         public const string JavaLanguageWorkerName = "java";

--- a/src/WebJobs.Script/Rpc/LanguageWorkerConstants.cs
+++ b/src/WebJobs.Script/Rpc/LanguageWorkerConstants.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         public const int ProcessStartTimeoutSeconds = 60;
         public const string FunctionWorkerRuntimeSettingName = "FUNCTIONS_WORKER_RUNTIME";
         public const string FunctionsWorkerProcessCountSettingName = "FUNCTIONS_WORKER_PROCESS_COUNT";
+        public const string FunctionsNodeVersionSetting = "WEBSITE_NODE_DEFAULT_VERSION";
         public const string DotNetLanguageWorkerName = "dotnet";
         public const string NodeLanguageWorkerName = "node";
         public const string JavaLanguageWorkerName = "java";

--- a/src/WebJobs.Script/Rpc/RpcInitializationService.cs
+++ b/src/WebJobs.Script/Rpc/RpcInitializationService.cs
@@ -28,7 +28,11 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         {
             {
                 OSPlatform.Windows,
-                new List<string>() { LanguageWorkerConstants.JavaLanguageWorkerName }
+                new List<string>()
+                {
+                    LanguageWorkerConstants.JavaLanguageWorkerName,
+                    LanguageWorkerConstants.NodeLanguageWorkerName
+                }
             },
             {
                 OSPlatform.Linux,
@@ -46,6 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             LanguageWorkerConstants.JavaLanguageWorkerName
         };
 
+        // TODO: This will not be needed when we resolve placeholder workers without run from zip: https://github.com/Azure/azure-functions-host/issues/4534
         private List<string> _placeholderPoolWhitelistedRuntimes = new List<string>()
         {
             LanguageWorkerConstants.JavaLanguageWorkerName,

--- a/src/WebJobs.Script/Rpc/RpcInitializationService.cs
+++ b/src/WebJobs.Script/Rpc/RpcInitializationService.cs
@@ -122,18 +122,17 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         internal Task InitializeChannelsAsync()
         {
-            if (StartAsPlaceholderPool())
+            // TODO: Remove special casing when resolving https://github.com/Azure/azure-functions-host/issues/4534
+            if (ShouldStartAsPlaceholderPool())
             {
                 return _webHostlanguageWorkerChannelManager.InitializeChannelAsync(_workerRuntime);
             }
-            else if (ShouldStartInPlaceholderMode())
+            else if (ShouldStartStandbyPlaceholderChannels())
             {
                 return InitializePlaceholderChannelsAsync();
             }
-            else
-            {
-                return InitializeWebHostRuntimeChannelsAsync();
-            }
+
+            return InitializeWebHostRuntimeChannelsAsync();
         }
 
         private Task InitializePlaceholderChannelsAsync()
@@ -162,7 +161,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             return Task.CompletedTask;
         }
 
-        internal bool ShouldStartInPlaceholderMode()
+        internal bool ShouldStartStandbyPlaceholderChannels()
         {
             if (string.IsNullOrEmpty(_workerRuntime) && _environment.IsPlaceholderModeEnabled())
             {
@@ -176,7 +175,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             return false;
         }
 
-        internal bool StartAsPlaceholderPool()
+        internal bool ShouldStartAsPlaceholderPool()
         {
             // We are in placeholder mode but a worker runtime IS set
             return _environment.IsPlaceholderModeEnabled()

--- a/src/WebJobs.Script/Rpc/RpcInitializationService.cs
+++ b/src/WebJobs.Script/Rpc/RpcInitializationService.cs
@@ -184,7 +184,9 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         internal bool StartAsPlaceholderPool()
         {
             // We are in placeholder mode but a worker runtime IS set
-            return _environment.IsPlaceholderModeEnabled() && _placeholderPoolWhitelistedRuntimes.Contains(_workerRuntime);
+            return _environment.IsPlaceholderModeEnabled()
+                && !string.IsNullOrEmpty(_workerRuntime)
+                && _placeholderPoolWhitelistedRuntimes.Contains(_workerRuntime);
         }
 
         // To help with unit tests

--- a/src/WebJobs.Script/Rpc/RpcInitializationService.cs
+++ b/src/WebJobs.Script/Rpc/RpcInitializationService.cs
@@ -184,9 +184,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         internal bool StartAsPlaceholderPool()
         {
             // We are in placeholder mode but a worker runtime IS set
-            return _environment.IsPlaceholderModeEnabled()
-                && !string.IsNullOrEmpty(_workerRuntime)
-                && _placeholderPoolWhitelistedRuntimes.Contains(_workerRuntime);
+            return _environment.IsPlaceholderModeEnabled() && _placeholderPoolWhitelistedRuntimes.Contains(_workerRuntime);
         }
 
         // To help with unit tests

--- a/src/WebJobs.Script/Rpc/RpcInitializationService.cs
+++ b/src/WebJobs.Script/Rpc/RpcInitializationService.cs
@@ -28,11 +28,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         {
             {
                 OSPlatform.Windows,
-                new List<string>()
-                {
-                    LanguageWorkerConstants.JavaLanguageWorkerName,
-                    LanguageWorkerConstants.NodeLanguageWorkerName
-                }
+                new List<string>() { LanguageWorkerConstants.JavaLanguageWorkerName }
             },
             {
                 OSPlatform.Linux,
@@ -50,7 +46,6 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             LanguageWorkerConstants.JavaLanguageWorkerName
         };
 
-        // TODO: This will not be needed when we resolve placeholder workers without run from zip: https://github.com/Azure/azure-functions-host/issues/4534
         private List<string> _placeholderPoolWhitelistedRuntimes = new List<string>()
         {
             LanguageWorkerConstants.JavaLanguageWorkerName,

--- a/src/WebJobs.Script/Rpc/RpcInitializationService.cs
+++ b/src/WebJobs.Script/Rpc/RpcInitializationService.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         internal Task InitializeChannelsAsync()
         {
-            if (ShouldStartAsPlaceholderPool())
+            if (StartAsPlaceholderPool())
             {
                 return _webHostlanguageWorkerChannelManager.InitializeChannelAsync(_workerRuntime);
             }
@@ -176,10 +176,12 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             return false;
         }
 
-        internal bool ShouldStartAsPlaceholderPool()
+        internal bool StartAsPlaceholderPool()
         {
             // We are in placeholder mode but a worker runtime IS set
-            return _environment.IsPlaceholderModeEnabled() && _placeholderPoolWhitelistedRuntimes.Contains(_workerRuntime);
+            return _environment.IsPlaceholderModeEnabled()
+                && !string.IsNullOrEmpty(_workerRuntime)
+                && _placeholderPoolWhitelistedRuntimes.Contains(_workerRuntime);
         }
 
         // To help with unit tests

--- a/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             _logger.LogDebug("Completed language worker channel specialization");
         }
 
-        internal bool UsePlaceholderChannel(string workerRuntime)
+        private bool UsePlaceholderChannel(string workerRuntime)
         {
             if (!string.IsNullOrEmpty(workerRuntime))
             {

--- a/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             ILanguageWorkerChannel languageWorkerChannel = await GetChannelAsync(_workerRuntime);
             if (_workerRuntime != null && languageWorkerChannel != null)
             {
-                // TODO: remove this if/else once RFZ is supported. Only support sending function environment reload requests
+                // TODO: https://github.com/Azure/azure-functions-host/issues/4534 Don't kill non read-only processes once linked issue is resolved
                 if (_environment.FileSystemIsReadOnly())
                 {
                     _logger.LogInformation("Loading environment variables for runtime: {runtime}", _workerRuntime);

--- a/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
@@ -116,7 +116,6 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 {
                     _logger.LogDebug("Shutting down placeholder worker. Worker is not compatible for runtime: {runtime}", _workerRuntime);
                     // If we need to allow file edits, we should shutdown the webhost channel on specialization.
-                    _workerChannels.TryRemove(_workerRuntime, out _);
                     await ShutdownChannelIfExistsAsync(_workerRuntime, languageWorkerChannel.Id);
                 }
             }

--- a/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
@@ -129,7 +129,11 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             {
                 // Special case: node apps must be read-only to use the placeholder mode channel
                 // TODO: Remove special casing when resolving https://github.com/Azure/azure-functions-host/issues/4534
-                return !string.Equals(_workerRuntime, LanguageWorkerConstants.NodeLanguageWorkerName) || _environment.FileSystemIsReadOnly();
+                if (string.Equals(workerRuntime, LanguageWorkerConstants.NodeLanguageWorkerName))
+                {
+                    return _environment.FileSystemIsReadOnly();
+                }
+                return true;
             }
             return false;
         }

--- a/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
@@ -109,13 +109,14 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
                 // TODO: https://github.com/Azure/azure-functions-host/issues/4534 Don't kill non read-only processes once linked issue is resolved
                 if (_environment.FileSystemIsReadOnly())
                 {
-                    _logger.LogInformation("Loading environment variables for runtime: {runtime}", _workerRuntime);
+                    _logger.LogDebug("Loading environment variables for runtime: {runtime}", _workerRuntime);
                     await languageWorkerChannel.SendFunctionEnvironmentReloadRequest();
                 }
                 else
                 {
+                    _logger.LogDebug("Shutting down placeholder worker. Worker is not compatible for runtime: {runtime}", _workerRuntime);
                     // If we need to allow file edits, we should shutdown the webhost channel on specialization.
-                    _workerChannels.TryRemove(_workerRuntime, out Dictionary<string, TaskCompletionSource<ILanguageWorkerChannel>> languageWorkerChannels);
+                    _workerChannels.TryRemove(_workerRuntime, out _);
                     await ShutdownChannelIfExistsAsync(_workerRuntime, languageWorkerChannel.Id);
                 }
             }

--- a/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
         private Action _shutdownStandbyWorkerChannels;
 
         private ConcurrentDictionary<string, Dictionary<string, TaskCompletionSource<ILanguageWorkerChannel>>> _workerChannels = new ConcurrentDictionary<string, Dictionary<string, TaskCompletionSource<ILanguageWorkerChannel>>>();
+        // Keeps environment config from placeholder mode that must be consistent for placeholders to run correctly
+        private Dictionary<string, Dictionary<string, string>> _initialEnvironmentConfig = new Dictionary<string, Dictionary<string, string>>();
 
         public WebHostLanguageWorkerChannelManager(IScriptEventManager eventManager, IEnvironment environment, ILoggerFactory loggerFactory, ILanguageWorkerChannelFactory languageWorkerChannelFactory, IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions)
         {
@@ -39,6 +41,11 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
             _shutdownStandbyWorkerChannels = ScheduleShutdownStandbyChannels;
             _shutdownStandbyWorkerChannels = _shutdownStandbyWorkerChannels.Debounce(milliseconds: 5000);
+
+            _initialEnvironmentConfig.Add(LanguageWorkerConstants.NodeLanguageWorkerName, new Dictionary<string, string>
+                    {
+                        { LanguageWorkerConstants.FunctionsNodeVersionSetting, _environment.GetEnvironmentVariable(LanguageWorkerConstants.FunctionsNodeVersionSetting) }
+                    });
         }
 
         public Task<ILanguageWorkerChannel> InitializeChannelAsync(string runtime)
@@ -106,21 +113,48 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             ILanguageWorkerChannel languageWorkerChannel = await GetChannelAsync(_workerRuntime);
             if (_workerRuntime != null && languageWorkerChannel != null)
             {
-                // TODO: https://github.com/Azure/azure-functions-host/issues/4534 Don't kill non read-only processes once linked issue is resolved
-                if (_environment.FileSystemIsReadOnly())
+                // Don't use placeholder process if app is not read-only or important environment config has changed
+                // TODO: Allow non read-only apps to use placeholder process - https://github.com/Azure/azure-functions-host/issues/4534
+                if (UsePlaceholderProcess(_workerRuntime))
                 {
                     _logger.LogInformation("Loading environment variables for runtime: {runtime}", _workerRuntime);
                     await languageWorkerChannel.SendFunctionEnvironmentReloadRequest();
                 }
                 else
                 {
-                    // If we need to allow file edits, we should shutdown the webhost channel on specialization.
+                    // The process spun up in placeholder mode is incompatible and we should shut it down
                     _workerChannels.TryRemove(_workerRuntime, out Dictionary<string, TaskCompletionSource<ILanguageWorkerChannel>> languageWorkerChannels);
                     await ShutdownChannelIfExistsAsync(_workerRuntime, languageWorkerChannel.Id);
                 }
             }
             _shutdownStandbyWorkerChannels();
             _logger.LogDebug("Completed language worker channel specialization");
+        }
+
+        internal bool UsePlaceholderProcess(string selectedRuntime)
+        {
+            // App must be readonly
+            if (!_environment.FileSystemIsReadOnly())
+            {
+                return false;
+            }
+
+            // App must have specific environment configurations match
+            if (_initialEnvironmentConfig.TryGetValue(selectedRuntime, out Dictionary<string, string> environmentConfig))
+            {
+                foreach (string settingKey in environmentConfig.Keys)
+                {
+                    var currentValue = _environment.GetEnvironmentVariable(settingKey);
+                    environmentConfig.TryGetValue(settingKey, out string cachedValue);
+                    if (!string.Equals(currentValue, cachedValue, StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        // We found an environment setting that does not match the initial environment.
+                        return false;
+                    }
+                }
+            }
+            // App is readonly with matching environment
+            return true;
         }
 
         public Task<bool> ShutdownChannelIfExistsAsync(string language, string workerId)

--- a/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             _workerRuntime = _environment.GetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName);
 
             ILanguageWorkerChannel languageWorkerChannel = await GetChannelAsync(_workerRuntime);
-            if (languageWorkerChannel != null)
+            if (_workerRuntime != null && languageWorkerChannel != null)
             {
                 if (UsePlaceholderChannel(_workerRuntime))
                 {

--- a/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Rpc/WebHostLanguageWorkerChannelManager.cs
@@ -104,25 +104,28 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
             _workerRuntime = _environment.GetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName);
 
             ILanguageWorkerChannel languageWorkerChannel = await GetChannelAsync(_workerRuntime);
-            if (UsePlaceholderChannel(_workerRuntime, languageWorkerChannel != null))
+            if (languageWorkerChannel != null)
             {
-                _logger.LogDebug("Loading environment variables for runtime: {runtime}", _workerRuntime);
-                await languageWorkerChannel.SendFunctionEnvironmentReloadRequest();
-            }
-            else
-            {
-                _logger.LogDebug("Shutting down placeholder worker. Worker is not compatible for runtime: {runtime}", _workerRuntime);
-                // If we need to allow file edits, we should shutdown the webhost channel on specialization.
-                await ShutdownChannelIfExistsAsync(_workerRuntime, languageWorkerChannel.Id);
+                if (UsePlaceholderChannel(_workerRuntime))
+                {
+                    _logger.LogDebug("Loading environment variables for runtime: {runtime}", _workerRuntime);
+                    await languageWorkerChannel.SendFunctionEnvironmentReloadRequest();
+                }
+                else
+                {
+                    _logger.LogDebug("Shutting down placeholder worker. Worker is not compatible for runtime: {runtime}", _workerRuntime);
+                    // If we need to allow file edits, we should shutdown the webhost channel on specialization.
+                    await ShutdownChannelIfExistsAsync(_workerRuntime, languageWorkerChannel.Id);
+                }
             }
 
             _shutdownStandbyWorkerChannels();
             _logger.LogDebug("Completed language worker channel specialization");
         }
 
-        internal bool UsePlaceholderChannel(string workerRuntime, bool channelExists)
+        internal bool UsePlaceholderChannel(string workerRuntime)
         {
-            if (!string.IsNullOrEmpty(workerRuntime) && channelExists)
+            if (!string.IsNullOrEmpty(workerRuntime))
             {
                 // Special case: node apps must be read-only to use the placeholder mode channel
                 // TODO: Remove special casing when resolving https://github.com/Azure/azure-functions-host/issues/4534

--- a/test/WebJobs.Script.Tests/Rpc/RpcInitializationServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/RpcInitializationServiceTests.cs
@@ -294,7 +294,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         [InlineData("0", "functionsPlaceholderTemplateSite", "1234", false)]
         [InlineData("1", "functionsPlaceholderTemplateSitejava", "1234", false)]
         [InlineData("1", "functionsPlaceholderTemplateSite", "", true)]
-        public void ShouldStartInPlaceholderMode_Returns_ExpectedValue(string placeholderMode, string siteName, string siteInstanaceId, bool expectedResult)
+        public void ShouldStartStandbyPlaceholderChannels_Returns_ExpectedValue(string placeholderMode, string siteName, string siteInstanaceId, bool expectedResult)
         {
             Mock<IRpcServer> testRpcServer = new Mock<IRpcServer>();
             var mockEnvironment = new Mock<IEnvironment>();
@@ -302,7 +302,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)).Returns(siteName);
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId)).Returns(siteInstanaceId);
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer.Object, _mockLanguageWorkerChannelManager.Object, _logger);
-            Assert.Equal(expectedResult, _rpcInitializationService.ShouldStartInPlaceholderMode());
+            Assert.Equal(expectedResult, _rpcInitializationService.ShouldStartStandbyPlaceholderChannels());
         }
 
         [Theory]
@@ -323,7 +323,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName)).Returns(workerRuntime);
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId)).Returns(siteInstanaceId);
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer.Object, _mockLanguageWorkerChannelManager.Object, _logger);
-            Assert.Equal(expectedResult, _rpcInitializationService.StartAsPlaceholderPool());
+            Assert.Equal(expectedResult, _rpcInitializationService.ShouldStartAsPlaceholderPool());
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Rpc/RpcInitializationServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/RpcInitializationServiceTests.cs
@@ -302,7 +302,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)).Returns(siteName);
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId)).Returns(siteInstanaceId);
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer.Object, _mockLanguageWorkerChannelManager.Object, _logger);
-            Assert.Equal(_rpcInitializationService.ShouldStartInPlaceholderMode(), expectedResult);
+            Assert.Equal(expectedResult, _rpcInitializationService.ShouldStartInPlaceholderMode());
         }
 
         [Theory]
@@ -323,7 +323,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName)).Returns(workerRuntime);
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId)).Returns(siteInstanaceId);
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer.Object, _mockLanguageWorkerChannelManager.Object, _logger);
-            Assert.Equal(_rpcInitializationService.ShouldStartInPlaceholderMode(), expectedResult);
+            Assert.Equal(expectedResult, _rpcInitializationService.StartAsPlaceholderPool());
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Rpc/RpcInitializationServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/RpcInitializationServiceTests.cs
@@ -304,5 +304,26 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer.Object, _mockLanguageWorkerChannelManager.Object, _logger);
             Assert.Equal(_rpcInitializationService.ShouldStartInPlaceholderMode(), expectedResult);
         }
+
+        [Theory]
+        [InlineData("1", "node", "1234", true)]
+        [InlineData("0", "node", "1234", false)]
+        [InlineData("1", "node", "", true)]
+        [InlineData("1", "java", "1234", true)]
+        [InlineData("0", "java", "1234", false)]
+        [InlineData("1", "java", "", true)]
+        [InlineData("1", "", "1234", false)]
+        [InlineData("1", "dotnet", "1234", false)]
+        [InlineData("1", "python", "1234", false)]
+        public void ShouldStartAsPlaceholderPool_Returns_ExpectedValue(string placeholderMode, string workerRuntime, string siteInstanaceId, bool expectedResult)
+        {
+            Mock<IRpcServer> testRpcServer = new Mock<IRpcServer>();
+            var mockEnvironment = new Mock<IEnvironment>();
+            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode)).Returns(placeholderMode);
+            mockEnvironment.Setup(p => p.GetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName)).Returns(workerRuntime);
+            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId)).Returns(siteInstanaceId);
+            _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer.Object, _mockLanguageWorkerChannelManager.Object, _logger);
+            Assert.Equal(_rpcInitializationService.ShouldStartInPlaceholderMode(), expectedResult);
+        }
     }
 }

--- a/test/WebJobs.Script.Tests/Rpc/WebHostLanguageWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/WebHostLanguageWorkerChannelManagerTests.cs
@@ -163,25 +163,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         }
 
         [Fact]
-        public async Task SpecializeAsync_Node_DifferentVersion_KillsProcess()
-        {
-            _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName, LanguageWorkerConstants.NodeLanguageWorkerName);
-            _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionsNodeVersionSetting, "8.11.1");
-            _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteZipDeployment, "1");
-
-            _languageWorkerChannelManager = new WebHostLanguageWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _languageWorkerChannelFactory, _optionsMonitor);
-
-            ILanguageWorkerChannel nodeWorkerChannel = CreateTestChannel(LanguageWorkerConstants.NodeLanguageWorkerName);
-            // Change version of node just before specialization and after initialization
-            _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionsNodeVersionSetting, "10.15.2");
-
-            await _languageWorkerChannelManager.SpecializeAsync();
-
-            var initializedChannel = await _languageWorkerChannelManager.GetChannelAsync(LanguageWorkerConstants.NodeLanguageWorkerName);
-            Assert.Null(initializedChannel);
-        }
-
-        [Fact]
         public async Task SpecializeAsync_Node_NotReadOnly_KillsProcess()
         {
             _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName, LanguageWorkerConstants.NodeLanguageWorkerName);
@@ -232,28 +213,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             var languageWorkerChannel = await languageWorkerChannelManager.InitializeLanguageWorkerChannel("test", _scriptRootPath);
             var ex = await Assert.ThrowsAsync<AggregateException>(async () => await languageWorkerChannelManager.GetChannelAsync("test"));
             Assert.Contains("Process startup failed", ex.InnerException.Message);
-        }
-
-        [Theory]
-        [InlineData("1", "node", "10.15.2", true)]
-        [InlineData("0", "node", "10.15.2", false)]
-        [InlineData("1", "node", "8.11.1", false)]
-        [InlineData("1", "java", "10.15.2", true)]
-        [InlineData("0", "java", "10.15.2", false)]
-        [InlineData("1", "java", "8.11.1", true)]
-        [InlineData("1", "python", "8.11.1", true)]
-        [InlineData("0", "python", "8.11.1", false)]
-        public void UsePlaceholderProcess_Returns_ExpectedValue(string readOnly, string workerRuntime, string nodeVersion, bool expectedResult)
-        {
-            _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionsNodeVersionSetting, "10.15.2");
-            _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteRunFromPackage, readOnly);
-
-            _languageWorkerChannelManager = new WebHostLanguageWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _languageWorkerChannelFactory, _optionsMonitor);
-            // Change node version
-            _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionsNodeVersionSetting, nodeVersion);
-
-            var shouldUsePlaceholder = _languageWorkerChannelManager.UsePlaceholderProcess(workerRuntime);
-            Assert.Equal(expectedResult, shouldUsePlaceholder);
         }
 
         private ILanguageWorkerChannel CreateTestChannel(string language)

--- a/test/WebJobs.Script.Tests/Rpc/WebHostLanguageWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/WebHostLanguageWorkerChannelManagerTests.cs
@@ -163,6 +163,25 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         }
 
         [Fact]
+        public async Task SpecializeAsync_Node_DifferentVersion_KillsProcess()
+        {
+            _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName, LanguageWorkerConstants.NodeLanguageWorkerName);
+            _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionsNodeVersionSetting, "8.11.1");
+            _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteZipDeployment, "1");
+
+            _languageWorkerChannelManager = new WebHostLanguageWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _languageWorkerChannelFactory, _optionsMonitor);
+
+            ILanguageWorkerChannel nodeWorkerChannel = CreateTestChannel(LanguageWorkerConstants.NodeLanguageWorkerName);
+            // Change version of node just before specialization and after initialization
+            _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionsNodeVersionSetting, "10.15.2");
+
+            await _languageWorkerChannelManager.SpecializeAsync();
+
+            var initializedChannel = await _languageWorkerChannelManager.GetChannelAsync(LanguageWorkerConstants.NodeLanguageWorkerName);
+            Assert.Null(initializedChannel);
+        }
+
+        [Fact]
         public async Task SpecializeAsync_Node_NotReadOnly_KillsProcess()
         {
             _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName, LanguageWorkerConstants.NodeLanguageWorkerName);
@@ -213,6 +232,28 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             var languageWorkerChannel = await languageWorkerChannelManager.InitializeLanguageWorkerChannel("test", _scriptRootPath);
             var ex = await Assert.ThrowsAsync<AggregateException>(async () => await languageWorkerChannelManager.GetChannelAsync("test"));
             Assert.Contains("Process startup failed", ex.InnerException.Message);
+        }
+
+        [Theory]
+        [InlineData("1", "node", "10.15.2", true)]
+        [InlineData("0", "node", "10.15.2", false)]
+        [InlineData("1", "node", "8.11.1", false)]
+        [InlineData("1", "java", "10.15.2", true)]
+        [InlineData("0", "java", "10.15.2", false)]
+        [InlineData("1", "java", "8.11.1", true)]
+        [InlineData("1", "python", "8.11.1", true)]
+        [InlineData("0", "python", "8.11.1", false)]
+        public void UsePlaceholderProcess_Returns_ExpectedValue(string readOnly, string workerRuntime, string nodeVersion, bool expectedResult)
+        {
+            _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionsNodeVersionSetting, "10.15.2");
+            _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteRunFromPackage, readOnly);
+
+            _languageWorkerChannelManager = new WebHostLanguageWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _languageWorkerChannelFactory, _optionsMonitor);
+            // Change node version
+            _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionsNodeVersionSetting, nodeVersion);
+
+            var shouldUsePlaceholder = _languageWorkerChannelManager.UsePlaceholderProcess(workerRuntime);
+            Assert.Equal(expectedResult, shouldUsePlaceholder);
         }
 
         private ILanguageWorkerChannel CreateTestChannel(string language)

--- a/test/WebJobs.Script.Tests/Rpc/WebHostLanguageWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/WebHostLanguageWorkerChannelManagerTests.cs
@@ -215,17 +215,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         }
 
         [Theory]
-        [InlineData("node", "1", true, true)]
-        [InlineData("node", "0", true, false)]
-        [InlineData("node", "1", false, false)]
-        [InlineData("java", "1", true, true)]
-        [InlineData("java", "0", true, true)]
-        [InlineData("java", "1", false, false)]
-        public void TryParseStatusCode_ReturnsExpectedResult(string workerRuntime, string runFromZip, bool channelExists, bool expectedReturn)
+        [InlineData("node", "1", true)]
+        [InlineData("node", "0", false)]
+        [InlineData("java", "1", true)]
+        [InlineData("java", "0", true)]
+        public void TryParseStatusCode_ReturnsExpectedResult(string workerRuntime, string runFromZip, bool expectedReturn)
         {
             _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteZipDeployment, runFromZip);
             _languageWorkerChannelManager = new WebHostLanguageWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _languageWorkerChannelFactory, _optionsMonitor);
-            Assert.Equal(_languageWorkerChannelManager.UsePlaceholderChannel(workerRuntime, channelExists), expectedReturn);
+            Assert.Equal(_languageWorkerChannelManager.UsePlaceholderChannel(workerRuntime), expectedReturn);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Rpc/WebHostLanguageWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Rpc/WebHostLanguageWorkerChannelManagerTests.cs
@@ -193,6 +193,28 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
         }
 
         [Fact]
+        public async Task SpecializeAsync_Java_ReadOnly_KeepsProcessAlive()
+        {
+            _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName, LanguageWorkerConstants.JavaLanguageWorkerName);
+            _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteZipDeployment, "1");
+
+            _languageWorkerChannelManager = new WebHostLanguageWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _languageWorkerChannelFactory, _optionsMonitor);
+
+            ILanguageWorkerChannel javaWorkerChannel = CreateTestChannel(LanguageWorkerConstants.JavaLanguageWorkerName);
+
+            await _languageWorkerChannelManager.SpecializeAsync();
+
+            // Verify logs
+            var traces = _testLogger.GetLogMessages();
+            var functionLoadLogs = traces.Where(m => string.Equals(m.FormattedMessage, "SendFunctionEnvironmentReloadRequest called"));
+            Assert.True(functionLoadLogs.Count() == 1);
+
+            // Verify channel
+            var initializedChannel = await _languageWorkerChannelManager.GetChannelAsync(LanguageWorkerConstants.JavaLanguageWorkerName);
+            Assert.Equal(javaWorkerChannel, initializedChannel);
+        }
+
+        [Fact]
         public async Task SpecializeAsync_Node_NotReadOnly_KillsProcess()
         {
             _testEnvironment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeSettingName, LanguageWorkerConstants.NodeLanguageWorkerName);
@@ -212,18 +234,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Rpc
             // Verify channel
             var initializedChannel = await _languageWorkerChannelManager.GetChannelAsync(LanguageWorkerConstants.NodeLanguageWorkerName);
             Assert.Null(initializedChannel);
-        }
-
-        [Theory]
-        [InlineData("node", "1", true)]
-        [InlineData("node", "0", false)]
-        [InlineData("java", "1", true)]
-        [InlineData("java", "0", true)]
-        public void TryParseStatusCode_ReturnsExpectedResult(string workerRuntime, string runFromZip, bool expectedReturn)
-        {
-            _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteZipDeployment, runFromZip);
-            _languageWorkerChannelManager = new WebHostLanguageWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _languageWorkerChannelFactory, _optionsMonitor);
-            Assert.Equal(_languageWorkerChannelManager.UsePlaceholderChannel(workerRuntime), expectedReturn);
         }
 
         [Fact]


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-functions-host/issues/4713

One part of this change whitelists node for placeholder pool scenarios (in RpcInitializationService).

Another part of this change makes sure to only use the placeholder pool channel on read-only apps (in WebHostLanguageWorkerChannelManager). Adding the notion of a "placeholder pool" temporarily until the one LanguageWorkerChannelManager at the webhost level has a notion of a file restart.

~~Another part of this change is to whitelist node for placeholder mode in windows. This is done so that if we turn off pools (say, if we find a bug), we won't see a significant regression in performance after having improved it.~~

~~In order to do the change above, we are checking to make sure that the major version of node.exe started in placeholder mode matches that requested by the user.~~