### PR TITLE
Resetting shared load context during specialization to ensure dependencies are properly resolved

### DIFF
--- a/src/WebJobs.Script.WebHost/Standby/IStandbyManager.cs
+++ b/src/WebJobs.Script.WebHost/Standby/IStandbyManager.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
 {

--- a/src/WebJobs.Script.WebHost/Standby/StandbyManager.cs
+++ b/src/WebJobs.Script.WebHost/Standby/StandbyManager.cs
@@ -7,6 +7,7 @@ using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Rpc;
 using Microsoft.Azure.WebJobs.Script.WebHost.Properties;
 using Microsoft.Extensions.Configuration;
@@ -97,9 +98,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
             _hostNameProvider.Reset();
 
+            // Reset the shared load context to ensure we're reloading
+            // user dependencies
+            FunctionAssemblyLoadContext.ResetSharedContext();
+
             await _languageWorkerChannelManager.SpecializeAsync();
 
             NotifyChange();
+
             await _scriptHostManager.RestartHostAsync();
             await _scriptHostManager.DelayUntilHostReady();
         }

--- a/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
+++ b/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
+using System.Threading;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Extensions.DependencyModel;
@@ -24,7 +25,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         private static readonly Lazy<Dictionary<string, ScriptRuntimeAssembly>> _runtimeAssemblies = new Lazy<Dictionary<string, ScriptRuntimeAssembly>>(DependencyHelper.GetRuntimeAssemblies);
         private static readonly Lazy<Dictionary<string, ResolutionPolicyEvaluator>> _resolutionPolicyEvaluators = new Lazy<Dictionary<string, ResolutionPolicyEvaluator>>(InitializeLoadPolicyEvaluators);
         private static readonly ConcurrentDictionary<string, object> _sharedContextAssembliesInFallbackLoad = new ConcurrentDictionary<string, object>();
-        private static readonly Lazy<FunctionAssemblyLoadContext> _defaultContext = new Lazy<FunctionAssemblyLoadContext>(CreateSharedContext, true);
+
+        private static Lazy<FunctionAssemblyLoadContext> _defaultContext = new Lazy<FunctionAssemblyLoadContext>(CreateSharedContext, true);
 
         private readonly List<string> _probingPaths = new List<string>();
         private readonly IDictionary<string, string> _depsAssemblies;
@@ -42,6 +44,11 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         }
 
         public static FunctionAssemblyLoadContext Shared => _defaultContext.Value;
+
+        internal static void ResetSharedContext()
+        {
+            _defaultContext = new Lazy<FunctionAssemblyLoadContext>(CreateSharedContext, true);
+        }
 
         internal static IDictionary<string, string> InitializeDeps(string basePath)
         {

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -204,7 +204,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public static IWebJobsBuilder UseScriptExternalStartup(this IWebJobsBuilder builder, string rootScriptPath, ILoggerFactory loggerFactory, IExtensionBundleManager extensionBundleManager)
         {
-            var logger = loggerFactory.CreateLogger<ScriptStartupTypeLocator>() ?? throw new ArgumentNullException(nameof(loggerFactory));
+            var logger = loggerFactory?.CreateLogger<ScriptStartupTypeLocator>() ?? throw new ArgumentNullException(nameof(loggerFactory));
+
             return builder.UseExternalStartup(new ScriptStartupTypeLocator(rootScriptPath, logger, extensionBundleManager));
         }
 


### PR DESCRIPTION
The changes in this PR are primarily to address an issue where users deploying a deps file with their function payload would not see the dependencies specified in the file loaded after specialization. The changes here also help ensure dependency resolution happens again with the updated environment (essentially having a load context dedicated to the specialized site)

Resolves #4850