### PR TITLE
Update PowerShell worker to 1.0.188

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.8100001-0126c21e" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.5.2-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="0.1.174-preview" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="1.0.188" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.14-11660" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.3" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.4" />


### PR DESCRIPTION
Changes in this release:
- The blob size limit for PowerShell functions triggered by blob is determined by the Functions host now, which effectively raised the limit from 4 MB to 120 MB (fixed issue https://github.com/Azure/azure-functions-powershell-worker/pull/346).
- Introduced TraceContext parameter (see issue https://github.com/Azure/azure-functions-host/issues/3747).
- Improved system log messages.


For more information, please see https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v1.0.188.