### PR TITLE
Revert "Use single instance of WebhostMetricsLogger"

### DIFF
--- a/src/WebJobs.Script.WebHost/DependencyInjection/DependencyValidator/DependencyValidator.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/DependencyValidator/DependencyValidator.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
             expected.ExpectNone<IEventGenerator>();
 
             expected.Expect<ILoggerFactory, ScriptLoggerFactory>();
-            expected.ExpectInstance<IMetricsLogger, WebHostMetricsLogger>();
+            expected.Expect<IMetricsLogger, WebHostMetricsLogger>();
 
             expected.Expect<IWebJobsExceptionHandler, WebScriptHostExceptionHandler>();
 

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -109,6 +109,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddTransient<VirtualFileSystem>();
             services.AddTransient<VirtualFileSystemMiddleware>();
 
+            // Logging and diagnostics
+            services.AddSingleton<IMetricsLogger, WebHostMetricsLogger>();
+
             // Secret management
             services.TryAddSingleton<ISecretManagerProvider, DefaultSecretManagerProvider>();
 

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -91,13 +91,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     }
 
                     // Logging and diagnostics
-                    // Get WebHostMetricsLogger registered at webhost
-                    IMetricsLogger metricsLogger = rootServiceProvider.GetService<IMetricsLogger>();
-                    if (metricsLogger != null)
-                    {
-                        services.AddSingleton(metricsLogger);
-                    }
-
+                    services.AddSingleton<IMetricsLogger, WebHostMetricsLogger>();
                     services.AddSingleton<IEventCollectorProvider, FunctionInstanceLogCollectorProvider>();
 
                     // Hosted services

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -133,10 +133,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 services.AddSingleton<ITypeLocator, ScriptTypeLocator>();
                 services.AddSingleton<ScriptSettingsManager>();
                 services.AddTransient<IExtensionsManager, ExtensionsManager>();
-
-                // Fallback option if webhost is not present.
                 services.TryAddSingleton<IMetricsLogger, MetricsLogger>();
-
                 services.TryAddSingleton<IScriptJobHostEnvironment, ConsoleScriptJobHostEnvironment>();
                 services.AddTransient<IExtensionBundleContentProvider, ExtensionBundleContentProvider>();
 

--- a/test/WebJobs.Script.Tests/Description/DotNet/DotNetFunctionInvokerTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/DotNetFunctionInvokerTests.cs
@@ -434,6 +434,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             compilationServiceFactory.Setup(f => f.CreateService(DotNetScriptTypes.CSharp, It.IsAny<IFunctionMetadataResolver>()))
                 .Returns(compilationService.Object);
 
+            var metricsLogger = new MetricsLogger();
+
             var hostBuilder = new HostBuilder()
                 .ConfigureDefaultTestWebScriptHost(o =>
                 {
@@ -459,7 +461,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 CompilationServiceFactory = compilationServiceFactory,
                 LoggerProvider = loggerProvider,
                 LoggerFactory = loggerFactory,
-                MetricsLogger = new TestMetricsLogger(),
+                MetricsLogger = metricsLogger
             };
         }
 
@@ -493,7 +495,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             public ILoggerFactory LoggerFactory { get; set; }
 
-            public IMetricsLogger MetricsLogger { get; set; }
+            public MetricsLogger MetricsLogger { get; set; }
         }
     }
 }


### PR DESCRIPTION
This reverts commit e9d2df354f4f19c35158d77f3964e01717e9256c.

Noticed after testing on private stamp that metrics from specialization and possibly other paths were missing. Need to do more investigation on why and possibly come up with an alternate solution.