### PR TITLE
Add Disable instance api for Linux consumption (https://github.com/Azure/azure-functions-host/issues/5032)

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
@@ -71,5 +71,17 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         {
             return Ok(_instanceManager.GetInstanceInfo());
         }
+
+        [HttpPost]
+        [Route("admin/instance/disable")]
+        [Authorize(Policy = PolicyNames.AdminAuthLevel)]
+        public async Task<IActionResult> Disable([FromServices] IScriptHostManager hostManager)
+        {
+            _logger.LogDebug("Disabling container");
+            // Mark the container disabled. We check for this on host restart
+            await Utility.MarkContainerDisabled(_logger);
+            var tIgnore = Task.Run(() => hostManager.RestartHostAsync());
+            return Ok();
+        }
     }
 }

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     State = ScriptHostState.Default;
                 }
 
-                bool isOffline = Utility.CheckAppOffline(_applicationHostOptions.CurrentValue.ScriptPath);
+                bool isOffline = Utility.CheckAppOffline(_environment, _applicationHostOptions.CurrentValue.ScriptPath);
                 State = isOffline ? ScriptHostState.Offline : State;
                 bool hasNonTransientErrors = startupMode.HasFlag(JobHostStartupMode.HandlingNonTransientError);
 

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -157,6 +157,16 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
+        /// Gets a value indicating whether this specific linux consumption container instance is in offline mode.
+        /// </summary>
+        /// <param name="environment">The environment to verify</param>
+        /// <returns><see cref="true"/> if running in a Linux Consumption App Service app and the container is in draining mode; otherwise, false.</returns>
+        public static bool IsLinuxConsumptionContainerDisabled(this IEnvironment environment)
+        {
+            return environment.IsLinuxConsumption() && Utility.IsContainerDisabled();
+        }
+
+        /// <summary>
         /// Gets a value indicating whether the application is running in a Linux App Service
         /// environment (Dedicated Linux).
         /// </summary>

--- a/src/WebJobs.Script/OutOfProc/Rpc/RpcInitializationService.cs
+++ b/src/WebJobs.Script/OutOfProc/Rpc/RpcInitializationService.cs
@@ -65,8 +65,9 @@ namespace Microsoft.Azure.WebJobs.Script.Rpc
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            if (Utility.CheckAppOffline(_applicationHostOptions.CurrentValue.ScriptPath))
+            if (Utility.CheckAppOffline(_environment, _applicationHostOptions.CurrentValue.ScriptPath))
             {
+                _logger.LogDebug("App is offline. RpcInitializationService will not be started");
                 return;
             }
             _logger.LogDebug("Starting Rpc Initialization Service.");

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string ProxyMetadataFileName = "proxies.json";
         public const string ExtensionsMetadataFileName = "extensions.json";
         public const string AppOfflineFileName = "app_offline.htm";
+        public const string DisableContainerFileName = "container_offline";
         public const string ResourcePath = "Microsoft.Azure.WebJobs.Script.WebHost.Resources";
 
         public const string DefaultMasterKeyName = "master";

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
@@ -3,8 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -79,6 +82,51 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             Assert.Equal(objectResult.StatusCode, 500);
             Assert.Equal(objectResult.Value, "Specialize MSI sidecar call failed. StatusCode=BadRequest");
+        }
+
+        [Fact]
+        public async Task Disable_Writes_To_DisableContainerFile_Restarts_ScriptHost()
+        {
+            var environment = new TestEnvironment();
+            var loggerFactory = new LoggerFactory();
+            var loggerProvider = new TestLoggerProvider();
+            loggerFactory.AddProvider(loggerProvider);
+
+            var instanceController = new InstanceController(environment, null, loggerFactory);
+
+            var scriptHostManager = new Mock<IScriptHostManager>();
+
+            var fileSystem = new Mock<IFileSystem>();
+            var fileBase = new Mock<FileBase>();
+            fileBase.Setup(
+                    f => f.Exists(It.Is<string>(path => path.EndsWith(ScriptConstants.DisableContainerFileName))))
+                .Returns(false);
+            fileSystem.SetupGet(fs => fs.File).Returns(fileBase.Object);
+
+            var memoryStream = new MemoryStream();
+            fileSystem.Setup(s =>
+                    s.File.Open(It.Is<string>(path => path.EndsWith(ScriptConstants.DisableContainerFileName)), FileMode.Create, FileAccess.Write, FileShare.Read))
+                .Returns(memoryStream);
+
+            FileUtility.Instance = fileSystem.Object;
+
+            scriptHostManager.Setup(s => s.RestartHostAsync(It.IsAny<CancellationToken>()));
+
+            var actionResult = await instanceController.Disable(scriptHostManager.Object);
+
+            FileUtility.Instance = null;
+
+            scriptHostManager.Verify(s => s.RestartHostAsync(It.IsAny<CancellationToken>()), Times.Once);
+
+            // Remove BOM
+            var memoryStreamContents = Encoding.UTF8.GetString(memoryStream.ToArray()).Trim(new char[] { '\uFEFF' });
+
+            Assert.Equal("This container instance is offline", memoryStreamContents);
+
+            var okResult = actionResult as OkResult;
+
+            Assert.NotNull(okResult);
+            Assert.Equal(200, okResult.StatusCode);
         }
     }
 }


### PR DESCRIPTION
This will be used to put the container offline before it is killed to reduce the time containers marked for deletion are processing events.