### PR TITLE
[pack] allow host restarts to be cancelled; improving logging

### DIFF
--- a/src/WebJobs.Script.WebHost/ScriptHostStartupOperation.cs
+++ b/src/WebJobs.Script.WebHost/ScriptHostStartupOperation.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost
+{
+    /// <summary>
+    /// Used to track all outstanding startup operations.
+    /// </summary>
+    internal class ScriptHostStartupOperation : IDisposable
+    {
+        // Use a dictionary here as we need the concurrency support, but also need to be able to remove
+        // specific items from the collection.
+        private static readonly ConcurrentDictionary<ScriptHostStartupOperation, object> _startupOperations = new ConcurrentDictionary<ScriptHostStartupOperation, object>();
+        private readonly ILogger _logger;
+
+        private bool _disposed = false;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScriptHostStartupOperation"/> class.
+        /// </summary>
+        /// <param name="cancellationToken">A CancellationToken that will be linked and exposed via the <see cref="CancellationTokenSource"/> property.</param>
+        /// <param name="parentId">The parent operation Id, if applicable.</param>
+        private ScriptHostStartupOperation(CancellationToken cancellationToken, ILogger logger, Guid? parentId = null)
+        {
+            Id = Guid.NewGuid();
+            CancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            ParentId = parentId;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Gets the list of currently active operations.
+        /// </summary>
+        public static ICollection<ScriptHostStartupOperation> ActiveOperations => _startupOperations.Keys;
+
+        /// <summary>
+        /// Gets the Id of the operation, used for tracking through logs.
+        /// </summary>
+        public Guid Id { get; }
+
+        /// <summary>
+        /// Gets the parent operation that started this one. Used when restarting during exceptions.
+        /// </summary>
+        public Guid? ParentId { get; }
+
+        /// <summary>
+        /// Gets the CancellationTokenSource used to cancel this operation. This is CancellationTokenSource is linked to the
+        /// CancellationToken passed via the <see cref="Create(CancellationToken, ILogger, Guid?)"/> method.
+        /// </summary>
+        public CancellationTokenSource CancellationTokenSource { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="ScriptHostStartupOperation"/> and adds it to the <see cref="ActiveOperations"/> collection.
+        /// </summary>
+        /// <param name="cancellationToken">A CancellationToken to be linked to <see cref="CancellationTokenSource"/>.</param>
+        /// <param name="logger">A logger.</param>
+        /// <param name="parentId">Ther parent operation id, if needed.</param>
+        /// <returns>A new instance.</returns>
+        public static ScriptHostStartupOperation Create(CancellationToken cancellationToken, ILogger logger, Guid? parentId = null)
+        {
+            var operation = new ScriptHostStartupOperation(cancellationToken, logger, parentId);
+            _startupOperations.AddOrUpdate(operation, addValue: null, (k, v) => null);
+            Log.StartupOperationCreated(logger, operation.Id, operation.ParentId);
+            return operation;
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _startupOperations.TryRemove(this, out object _);
+                CancellationTokenSource?.Dispose();
+                Log.StartupOperationCompleted(_logger, Id);
+                _disposed = true;
+            }
+        }
+
+        private static class Log
+        {
+            private static readonly Action<ILogger, Guid, Guid?, Exception> _startupOperationCreated =
+                LoggerMessage.Define<Guid, Guid?>(
+                    LogLevel.Debug,
+                    new EventId(524, nameof(StartupOperationCreated)),
+                    "Startup operation '{operationId}' with parent id '{parentOperationId}' created.");
+
+            private static readonly Action<ILogger, Guid, Exception> _startupOperationCompleted =
+                LoggerMessage.Define<Guid>(
+                    LogLevel.Debug,
+                    new EventId(523, nameof(StartupOperationCompleted)),
+                    "Startup operation '{operationId}' completed.");
+
+            public static void StartupOperationCreated(ILogger logger, Guid operationId, Guid? parentOperationId)
+            {
+                _startupOperationCreated(logger, operationId, parentOperationId, null);
+            }
+
+            public static void StartupOperationCompleted(ILogger logger, Guid operationId)
+            {
+                _startupOperationCompleted(logger, operationId, null);
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
@@ -144,8 +146,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
         }
 
-        private async Task StartHostAsync(CancellationToken cancellationToken, int attemptCount = 0, JobHostStartupMode startupMode = JobHostStartupMode.Normal)
+        private async Task StartHostAsync(CancellationToken cancellationToken, int attemptCount = 0,
+            JobHostStartupMode startupMode = JobHostStartupMode.Normal, Guid? parentOperationId = null)
         {
+            // Add this to the list of trackable startup operations. Restarts can use this to cancel any ongoing or pending operations.
+            var activeOperation = ScriptHostStartupOperation.Create(cancellationToken, _logger, parentOperationId);
+
             using (_metricsLogger.LatencyEvent(MetricEventNames.ScriptHostManagerStartService))
             {
                 try
@@ -157,10 +163,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     // the IHostedService has ever started.
                     _hostStartedSource.TrySetResult(true);
 
-                    await UnsynchronizedStartHostAsync(cancellationToken, attemptCount, startupMode);
+                    await UnsynchronizedStartHostAsync(activeOperation, attemptCount, startupMode);
                 }
                 finally
                 {
+                    activeOperation.Dispose();
                     _hostStartSemaphore.Release();
                 }
             }
@@ -171,13 +178,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         /// before calling this method. Host starts and restarts must be synchronous to prevent orphaned
         /// hosts or an incorrect ActiveHost.
         /// </summary>
-        private async Task UnsynchronizedStartHostAsync(CancellationToken cancellationToken, int attemptCount = 0, JobHostStartupMode startupMode = JobHostStartupMode.Normal)
+        private async Task UnsynchronizedStartHostAsync(ScriptHostStartupOperation activeOperation, int attemptCount = 0, JobHostStartupMode startupMode = JobHostStartupMode.Normal)
         {
             IHost localHost = null;
+            var currentCancellationToken = activeOperation.CancellationTokenSource.Token;
+            _logger.StartupOperationStarting(activeOperation.Id);
 
             try
             {
-                cancellationToken.ThrowIfCancellationRequested();
+                currentCancellationToken.ThrowIfCancellationRequested();
 
                 // if we were in an error state retain that,
                 // otherwise move to default
@@ -192,10 +201,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                 // If we're in a non-transient error state or offline, skip host initialization
                 bool skipJobHostStartup = isOffline || hasNonTransientErrors;
+                bool skipHostJsonConfiguration = startupMode == JobHostStartupMode.HandlingConfigurationParsingError;
+                _logger.Building(skipJobHostStartup, skipHostJsonConfiguration, activeOperation.Id);
 
                 using (_metricsLogger.LatencyEvent(MetricEventNames.ScriptHostManagerBuildScriptHost))
                 {
-                    localHost = BuildHost(skipJobHostStartup, skipHostJsonConfiguration: startupMode == JobHostStartupMode.HandlingConfigurationParsingError);
+                    localHost = BuildHost(skipJobHostStartup, skipHostJsonConfiguration);
                 }
 
                 ActiveHost = localHost;
@@ -207,7 +218,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     scriptHost.HostInitialized += OnHostInitialized;
                 }
 
-                LogInitialization(localHost, isOffline, attemptCount, ++_hostStartCount);
+                LogInitialization(localHost, isOffline, attemptCount, ++_hostStartCount, activeOperation.Id);
 
                 if (!_scriptWebHostEnvironment.InStandbyMode)
                 {
@@ -216,11 +227,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     DisposeRequestTrackingModule();
                 }
 
-                cancellationToken.ThrowIfCancellationRequested();
+                currentCancellationToken.ThrowIfCancellationRequested();
+
+                var hostInstanceId = GetHostInstanceId(localHost);
+                _logger.StartupOperationStartingHost(activeOperation.Id, hostInstanceId);
 
                 using (_metricsLogger.LatencyEvent(MetricEventNames.ScriptHostManagerStartScriptHost))
                 {
-                    await ActiveHost.StartAsync(cancellationToken);
+                    await localHost.StartAsync(currentCancellationToken);
                 }
 
                 if (!startupMode.HasFlag(JobHostStartupMode.HandlingError))
@@ -235,7 +249,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
             catch (OperationCanceledException)
             {
-                GetHostLogger(localHost).StartupWasCanceled();
+                GetHostLogger(localHost).StartupOperationWasCanceled(activeOperation.Id);
                 throw;
             }
             catch (Exception exc)
@@ -247,14 +261,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 {
                     LastError = exc;
                     State = ScriptHostState.Error;
-                    logger.ErrorOccured(exc);
+                    logger.ErrorOccuredDuringStartupOperation(activeOperation.Id, exc);
                 }
                 else
                 {
                     // Another host has been created before this host
                     // threw its startup exception. We want to make sure it
                     // doesn't control the state of the service.
-                    logger.ErrorOccuredInactive(exc);
+                    logger.ErrorOccuredInactive(activeOperation.Id, exc);
                 }
 
                 attemptCount++;
@@ -284,10 +298,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 // logger will be disposed.
                 logger = _logger;
 
-                if (cancellationToken.IsCancellationRequested)
+                if (currentCancellationToken.IsCancellationRequested)
                 {
-                    logger.CancellationRequested();
-                    cancellationToken.ThrowIfCancellationRequested();
+                    logger.CancellationRequested(activeOperation.Id);
+                    currentCancellationToken.ThrowIfCancellationRequested();
                 }
 
                 var nextStartupAttemptMode = JobHostStartupMode.Normal;
@@ -305,23 +319,23 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                 if (nextStartupAttemptMode != JobHostStartupMode.Normal)
                 {
-                    logger.LogDebug($"Starting new host with '{nextStartupAttemptMode}'.");
-                    Task ignore = StartHostAsync(cancellationToken, attemptCount, nextStartupAttemptMode);
+                    logger.LogDebug($"Starting new host with '{nextStartupAttemptMode}' and parent operation id '{activeOperation.Id}'.");
+                    Task ignore = StartHostAsync(currentCancellationToken, attemptCount, nextStartupAttemptMode, activeOperation.Id);
                 }
                 else
                 {
                     logger.LogDebug($"Will start a new host after delay.");
-                    await Utility.DelayWithBackoffAsync(attemptCount, cancellationToken, min: TimeSpan.FromSeconds(1), max: TimeSpan.FromMinutes(2), logger: logger)
+                    await Utility.DelayWithBackoffAsync(attemptCount, currentCancellationToken, min: TimeSpan.FromSeconds(1), max: TimeSpan.FromMinutes(2), logger: logger)
                         .ContinueWith(t =>
                         {
-                            if (cancellationToken.IsCancellationRequested)
+                            if (currentCancellationToken.IsCancellationRequested)
                             {
-                                logger.LogDebug("Cancellation requested during delay. A new host will not be started.");
-                                cancellationToken.ThrowIfCancellationRequested();
+                                logger.LogDebug($"Cancellation for operation '{activeOperation.Id}' requested during delay. A new host will not be started.");
+                                currentCancellationToken.ThrowIfCancellationRequested();
                             }
 
                             logger.LogDebug("Starting new host after delay.");
-                            return StartHostAsync(cancellationToken, attemptCount);
+                            return StartHostAsync(currentCancellationToken, attemptCount, parentOperationId: activeOperation.Id);
                         });
                 }
             }
@@ -376,6 +390,18 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                 // If anything is mid-startup, cancel it.
                 _startupLoopTokenSource?.Cancel();
+                foreach (var startupOperation in ScriptHostStartupOperation.ActiveOperations)
+                {
+                    _logger.CancelingStartupOperationForRestart(startupOperation.Id);
+                    try
+                    {
+                        startupOperation.CancellationTokenSource.Cancel();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // This can be disposed at any time.
+                    }
+                }
 
                 try
                 {
@@ -392,12 +418,27 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                     var previousHost = ActiveHost;
                     ActiveHost = null;
-                    Task startTask = UnsynchronizedStartHostAsync(cancellationToken);
-                    Task stopTask = Orphan(previousHost, cancellationToken);
 
-                    await startTask;
+                    using (var activeOperation = ScriptHostStartupOperation.Create(cancellationToken, _logger))
+                    {
+                        Task startTask = UnsynchronizedStartHostAsync(activeOperation);
+                        Task stopTask = Orphan(previousHost, cancellationToken);
+
+                        await startTask;
+                    }
 
                     _logger.Restarted();
+                }
+                catch (OperationCanceledException)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        _logger.ScriptHostServiceRestartCanceledByRuntime();
+                        throw;
+                    }
+
+                    // If the exception was triggered by our startup operation cancellation token, just ignore as
+                    // it doesn't indicate an issue.
                 }
                 finally
                 {
@@ -424,7 +465,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         private IHost BuildHost(bool skipHostStartup, bool skipHostJsonConfiguration)
         {
-            _logger.Building(skipHostStartup.ToString(), skipHostJsonConfiguration.ToString());
             return _scriptHostBuilder.BuildHost(skipHostStartup, skipHostJsonConfiguration);
         }
 
@@ -449,7 +489,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             ILoggerFactory hostLoggerFactory = null;
             try
             {
-                hostLoggerFactory = host?.Services.GetService<ILoggerFactory>();
+                hostLoggerFactory = host?.Services?.GetService<ILoggerFactory>();
             }
             catch (ObjectDisposedException)
             {
@@ -461,24 +501,24 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             return hostLoggerFactory?.CreateLogger(LogCategories.Startup) ?? _logger;
         }
 
-        private void LogInitialization(IHost host, bool isOffline, int attemptCount, int startCount)
+        private void LogInitialization(IHost host, bool isOffline, int attemptCount, int startCount, Guid operationId)
         {
             var logger = GetHostLogger(host);
 
             if (isOffline)
             {
-                logger.Offline();
+                logger.Offline(operationId);
             }
             else
             {
-                logger.Initializing();
+                logger.Initializing(operationId);
             }
-            logger.Initialization(attemptCount, startCount);
+            logger.Initialization(attemptCount, startCount, operationId);
 
             if (_scriptWebHostEnvironment.InStandbyMode)
             {
                 // Reading the string from resources to make sure resource loading code path is warmed up during placeholder as well.
-                logger.InStandByMode();
+                logger.InStandByMode(operationId);
             }
         }
 

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -115,6 +115,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public IServiceProvider JobHostServices => _hostService.Services;
 
+        public IServiceProvider WebHostServices => _testServer.Host.Services;
+
         public ScriptJobHostOptions ScriptOptions => JobHostServices.GetService<IOptions<ScriptJobHostOptions>>().Value;
 
         public ISecretManager SecretManager => _testServer.Host.Services.GetService<ISecretManagerProvider>().Current;
@@ -197,7 +199,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         /// <returns>The messages from the WebHost LoggerProvider</returns>
         public IList<LogMessage> GetWebHostLogMessages() => _webHostLoggerProvider.GetAllLogMessages();
 
-        public string GetLog() => string.Join(Environment.NewLine, GetScriptHostLogMessages());
+        public string GetLog() => string.Join(Environment.NewLine, GetScriptHostLogMessages().Concat(GetWebHostLogMessages()).OrderBy(m => m.Timestamp));
 
         public void ClearLogMessages() => _scriptHostLoggerProvider.ClearAllLogMessages();
 

--- a/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
@@ -278,7 +278,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.True(AreRequiredMetricsGenerated(metricsLogger));
 
             // Make sure the error was logged to the correct logger
-            Assert.Contains(hostALogger.GetAllLogMessages(), m => m.FormattedMessage != null && m.FormattedMessage.Contains("Host startup was canceled."));
+            Assert.Contains(hostALogger.GetAllLogMessages(), m => m.FormattedMessage != null && m.FormattedMessage.StartsWith("Host startup operation '") && m.FormattedMessage.EndsWith("' was canceled."));
 
             // Make sure we orphaned the correct host
             hostA.Verify(m => m.StopAsync(It.IsAny<CancellationToken>()), Times.Exactly(1));


### PR DESCRIPTION
Fixes #5020  

Introduces a new class, `ScriptHostStartupOperation`, which is used to track details about a startup in `WebJobsScriptHostService`. It also allows us to track any pending or active startup operations, which means that we can have calls to `RestartAsync` to cancel all of these. Previously, restarts couldn't be cancelled by other restarts as we only had a single `CancellationToken` to break out of the startup loop (and that token is cancelled upon the first restart, and therefore not useful after that). In rare cases this could lead to an infinite loop of failing restarts (see the issue for details).