### PR TITLE
disposing of hosts created in config tests

### DIFF
--- a/test/WebJobs.Script.Tests/Configuration/LoggingConfigurationTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/LoggingConfigurationTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         [Fact]
         public void Logging_Binds_AppInsightsOptions()
         {
-            IHost host = new HostBuilder()
+            var hostBuilder = new HostBuilder()
                 .ConfigureAppConfiguration(c =>
                 {
                     c.AddInMemoryCollection(new Dictionary<string, string>
@@ -36,14 +36,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                         { ConfigurationPath.Combine(_loggingPath, "ApplicationInsights", "SnapshotConfiguration", "IsEnabled"), "false" }
                     });
                 })
-                .ConfigureDefaultTestWebScriptHost()
-                .Build();
+                .ConfigureDefaultTestWebScriptHost();
 
-            ApplicationInsightsLoggerOptions appInsightsOptions = host.Services.GetService<IOptions<ApplicationInsightsLoggerOptions>>().Value;
+            using (IHost host = hostBuilder.Build())
+            {
+                ApplicationInsightsLoggerOptions appInsightsOptions = host.Services.GetService<IOptions<ApplicationInsightsLoggerOptions>>().Value;
 
-            Assert.Equal("some_key", appInsightsOptions.InstrumentationKey);
-            Assert.Null(appInsightsOptions.SamplingSettings);
-            Assert.False(appInsightsOptions.SnapshotConfiguration.IsEnabled);
+                Assert.Equal("some_key", appInsightsOptions.InstrumentationKey);
+                Assert.Null(appInsightsOptions.SamplingSettings);
+                Assert.False(appInsightsOptions.SnapshotConfiguration.IsEnabled);
+            }
         }
 
         [Fact]
@@ -53,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             // All of the filtering details are handled by the built-in logging infrastructure, so here we
             // simply want to make sure that we're populating the LoggerFilterOptions from our config.
 
-            IHost host = new HostBuilder()
+            var hostBuilder = new HostBuilder()
                 .ConfigureAppConfiguration(c =>
                 {
                     c.AddInMemoryCollection(new Dictionary<string, string>
@@ -63,78 +65,82 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                         { ConfigurationPath.Combine(_loggingPath, "Console", "LogLevel", "Default"), "Trace" }
                     });
                 })
-                .ConfigureDefaultTestWebScriptHost()
-                .Build();
+                .ConfigureDefaultTestWebScriptHost();
 
-            LoggerFilterOptions filterOptions = host.Services.GetService<IOptions<LoggerFilterOptions>>().Value;
+            using (IHost host = hostBuilder.Build())
+            {
+                LoggerFilterOptions filterOptions = host.Services.GetService<IOptions<LoggerFilterOptions>>().Value;
 
-            Assert.Equal(6, filterOptions.Rules.Count);
+                Assert.Equal(6, filterOptions.Rules.Count);
 
-            var rules = filterOptions.Rules.ToArray();
+                var rules = filterOptions.Rules.ToArray();
 
-            var rule = rules[0];
-            Assert.Null(rule.ProviderName);
-            Assert.Null(rule.CategoryName);
-            Assert.Null(rule.LogLevel);
-            Assert.NotNull(rule.Filter); // The broad "allowed category" filter.
+                var rule = rules[0];
+                Assert.Null(rule.ProviderName);
+                Assert.Null(rule.CategoryName);
+                Assert.Null(rule.LogLevel);
+                Assert.NotNull(rule.Filter); // The broad "allowed category" filter.
 
-            rule = rules[1];
-            Assert.Equal(LogLevel.Trace, rule.LogLevel);
-            Assert.Equal("Console", rule.ProviderName);
+                rule = rules[1];
+                Assert.Equal(LogLevel.Trace, rule.LogLevel);
+                Assert.Equal("Console", rule.ProviderName);
 
-            rule = rules[2];
-            Assert.Equal(LogLevel.Trace, rule.LogLevel);
-            Assert.Null(rule.ProviderName);
-            Assert.Equal("Some.Custom.Category", rule.CategoryName);
+                rule = rules[2];
+                Assert.Equal(LogLevel.Trace, rule.LogLevel);
+                Assert.Null(rule.ProviderName);
+                Assert.Equal("Some.Custom.Category", rule.CategoryName);
 
-            rule = rules[3];
-            Assert.Equal(LogLevel.Error, rule.LogLevel);
-            Assert.Null(rule.ProviderName);
+                rule = rules[3];
+                Assert.Equal(LogLevel.Error, rule.LogLevel);
+                Assert.Null(rule.ProviderName);
 
-            rule = rules[4];
-            Assert.Equal(typeof(SystemLoggerProvider).FullName, rule.ProviderName);
-            Assert.Null(rule.CategoryName);
-            Assert.Equal(LogLevel.None, rule.LogLevel);
-            Assert.Null(rule.Filter);
+                rule = rules[4];
+                Assert.Equal(typeof(SystemLoggerProvider).FullName, rule.ProviderName);
+                Assert.Null(rule.CategoryName);
+                Assert.Equal(LogLevel.None, rule.LogLevel);
+                Assert.Null(rule.Filter);
 
-            rule = rules[5];
-            Assert.Equal(typeof(SystemLoggerProvider).FullName, rule.ProviderName);
-            Assert.Null(rule.CategoryName);
-            Assert.Null(rule.LogLevel);
-            Assert.NotNull(rule.Filter); // The system-specific "allowed category" filter
+                rule = rules[5];
+                Assert.Equal(typeof(SystemLoggerProvider).FullName, rule.ProviderName);
+                Assert.Null(rule.CategoryName);
+                Assert.Null(rule.LogLevel);
+                Assert.NotNull(rule.Filter); // The system-specific "allowed category" filter
+            }
         }
 
         [Fact]
         public void Logging_DefaultsToInformation()
         {
-            IHost host = new HostBuilder()
-                .ConfigureDefaultTestWebScriptHost()
-                .Build();
+            var hostBuilder = new HostBuilder()
+                .ConfigureDefaultTestWebScriptHost();
 
-            LoggerFilterOptions filterOptions = host.Services.GetService<IOptions<LoggerFilterOptions>>().Value;
+            using (IHost host = hostBuilder.Build())
+            {
+                LoggerFilterOptions filterOptions = host.Services.GetService<IOptions<LoggerFilterOptions>>().Value;
 
-            Assert.Equal(LogLevel.None, filterOptions.MinLevel);
+                Assert.Equal(LogLevel.None, filterOptions.MinLevel);
 
-            var rules = filterOptions.Rules.ToArray();
-            Assert.Equal(3, rules.Length);
+                var rules = filterOptions.Rules.ToArray();
+                Assert.Equal(3, rules.Length);
 
-            var rule = rules[0];
-            Assert.Null(rule.ProviderName);
-            Assert.Null(rule.CategoryName);
-            Assert.Null(rule.LogLevel);
-            Assert.NotNull(rule.Filter); // The broad "allowed category" filter.
+                var rule = rules[0];
+                Assert.Null(rule.ProviderName);
+                Assert.Null(rule.CategoryName);
+                Assert.Null(rule.LogLevel);
+                Assert.NotNull(rule.Filter); // The broad "allowed category" filter.
 
-            rule = rules[1];
-            Assert.Equal(typeof(SystemLoggerProvider).FullName, rule.ProviderName);
-            Assert.Null(rule.CategoryName);
-            Assert.Equal(LogLevel.None, rule.LogLevel);
-            Assert.Null(rule.Filter);
+                rule = rules[1];
+                Assert.Equal(typeof(SystemLoggerProvider).FullName, rule.ProviderName);
+                Assert.Null(rule.CategoryName);
+                Assert.Equal(LogLevel.None, rule.LogLevel);
+                Assert.Null(rule.Filter);
 
-            rule = rules[2];
-            Assert.Equal(typeof(SystemLoggerProvider).FullName, rule.ProviderName);
-            Assert.Null(rule.CategoryName);
-            Assert.Null(rule.LogLevel);
-            Assert.NotNull(rule.Filter); // The system-specific "allowed category" filter
+                rule = rules[2];
+                Assert.Equal(typeof(SystemLoggerProvider).FullName, rule.ProviderName);
+                Assert.Null(rule.CategoryName);
+                Assert.Null(rule.LogLevel);
+                Assert.NotNull(rule.Filter); // The system-specific "allowed category" filter
+            }
         }
 
         [Fact]
@@ -144,7 +150,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             // sure Information-level logs are filtered
 
             TestLoggerProvider loggerProvider = new TestLoggerProvider();
-            IHost host = new HostBuilder()
+            var hostBuilder = new HostBuilder()
                 .ConfigureAppConfiguration(c =>
                 {
                     c.AddInMemoryCollection(new Dictionary<string, string>
@@ -156,58 +162,64 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 .ConfigureLogging(l =>
                 {
                     l.AddProvider(loggerProvider);
-                })
-                .Build();
+                });
 
-            ILogger logger = host.Services.GetService<ILogger<LoggingConfigurationTests>>();
+            using (IHost host = hostBuilder.Build())
+            {
+                ILogger logger = host.Services.GetService<ILogger<LoggingConfigurationTests>>();
 
-            logger.LogInformation("Information");
-            logger.LogWarning("Warning");
+                logger.LogInformation("Information");
+                logger.LogWarning("Warning");
 
-            LogMessage messages = loggerProvider.GetAllLogMessages().Single();
-            Assert.Equal("Warning", messages.FormattedMessage);
+                LogMessage messages = loggerProvider.GetAllLogMessages().Single();
+                Assert.Equal("Warning", messages.FormattedMessage);
+            }
         }
 
         [Fact]
         public void LoggerProviders_Default()
         {
-            IHost host = new HostBuilder()
-                .ConfigureDefaultTestWebScriptHost()
-                .Build();
+            var hostBuilder = new HostBuilder()
+                .ConfigureDefaultTestWebScriptHost();
 
-            IEnumerable<ILoggerProvider> loggerProviders = host.Services.GetService<IEnumerable<ILoggerProvider>>();
+            using (IHost host = hostBuilder.Build())
+            {
+                IEnumerable<ILoggerProvider> loggerProviders = host.Services.GetService<IEnumerable<ILoggerProvider>>();
 
-            Assert.Equal(5, loggerProviders.Count());
-            loggerProviders.OfType<SystemLoggerProvider>().Single();
-            loggerProviders.OfType<HostFileLoggerProvider>().Single();
-            loggerProviders.OfType<FunctionFileLoggerProvider>().Single();
-            loggerProviders.OfType<UserLogMetricsLoggerProvider>().Single();
-            loggerProviders.OfType<AzureMonitorDiagnosticLoggerProvider>().Single();
+                Assert.Equal(5, loggerProviders.Count());
+                loggerProviders.OfType<SystemLoggerProvider>().Single();
+                loggerProviders.OfType<HostFileLoggerProvider>().Single();
+                loggerProviders.OfType<FunctionFileLoggerProvider>().Single();
+                loggerProviders.OfType<UserLogMetricsLoggerProvider>().Single();
+                loggerProviders.OfType<AzureMonitorDiagnosticLoggerProvider>().Single();
+            }
         }
 
         [Fact]
         public void LoggerProviders_ConsoleEnabled_IfDevelopmentEnvironment()
         {
-            IHost host = new HostBuilder()
-                .UseEnvironment(EnvironmentName.Development)
-                .ConfigureDefaultTestWebScriptHost()
-                .Build();
+            var hostBuilder = new HostBuilder()
+                 .UseEnvironment(EnvironmentName.Development)
+                 .ConfigureDefaultTestWebScriptHost();
 
-            IEnumerable<ILoggerProvider> loggerProviders = host.Services.GetService<IEnumerable<ILoggerProvider>>();
+            using (IHost host = hostBuilder.Build())
+            {
+                IEnumerable<ILoggerProvider> loggerProviders = host.Services.GetService<IEnumerable<ILoggerProvider>>();
 
-            Assert.Equal(6, loggerProviders.Count());
-            loggerProviders.OfType<SystemLoggerProvider>().Single();
-            loggerProviders.OfType<HostFileLoggerProvider>().Single();
-            loggerProviders.OfType<FunctionFileLoggerProvider>().Single();
-            loggerProviders.OfType<ConsoleLoggerProvider>().Single();
-            loggerProviders.OfType<UserLogMetricsLoggerProvider>().Single();
-            loggerProviders.OfType<AzureMonitorDiagnosticLoggerProvider>().Single();
+                Assert.Equal(6, loggerProviders.Count());
+                loggerProviders.OfType<SystemLoggerProvider>().Single();
+                loggerProviders.OfType<HostFileLoggerProvider>().Single();
+                loggerProviders.OfType<FunctionFileLoggerProvider>().Single();
+                loggerProviders.OfType<ConsoleLoggerProvider>().Single();
+                loggerProviders.OfType<UserLogMetricsLoggerProvider>().Single();
+                loggerProviders.OfType<AzureMonitorDiagnosticLoggerProvider>().Single();
+            }
         }
 
         [Fact]
         public void LoggerProviders_ConsoleEnabled_InConfiguration()
         {
-            IHost host = new HostBuilder()
+            var hostBuilder = new HostBuilder()
                  .ConfigureAppConfiguration(c =>
                  {
                      c.AddInMemoryCollection(new Dictionary<string, string>
@@ -215,24 +227,26 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                         { ConfigurationPath.Combine(_loggingPath, "Console", "IsEnabled"), "True" }
                     });
                  })
-                .ConfigureDefaultTestWebScriptHost()
-                .Build();
+                .ConfigureDefaultTestWebScriptHost();
 
-            IEnumerable<ILoggerProvider> loggerProviders = host.Services.GetService<IEnumerable<ILoggerProvider>>();
+            using (IHost host = hostBuilder.Build())
+            {
+                IEnumerable<ILoggerProvider> loggerProviders = host.Services.GetService<IEnumerable<ILoggerProvider>>();
 
-            Assert.Equal(6, loggerProviders.Count());
-            loggerProviders.OfType<SystemLoggerProvider>().Single();
-            loggerProviders.OfType<HostFileLoggerProvider>().Single();
-            loggerProviders.OfType<FunctionFileLoggerProvider>().Single();
-            loggerProviders.OfType<ConsoleLoggerProvider>().Single();
-            loggerProviders.OfType<UserLogMetricsLoggerProvider>().Single();
-            loggerProviders.OfType<AzureMonitorDiagnosticLoggerProvider>().Single();
+                Assert.Equal(6, loggerProviders.Count());
+                loggerProviders.OfType<SystemLoggerProvider>().Single();
+                loggerProviders.OfType<HostFileLoggerProvider>().Single();
+                loggerProviders.OfType<FunctionFileLoggerProvider>().Single();
+                loggerProviders.OfType<ConsoleLoggerProvider>().Single();
+                loggerProviders.OfType<UserLogMetricsLoggerProvider>().Single();
+                loggerProviders.OfType<AzureMonitorDiagnosticLoggerProvider>().Single();
+            }
         }
 
         [Fact]
         public void LoggerProviders_ApplicationInsights()
         {
-            IHost host = new HostBuilder()
+            var hostBuilder = new HostBuilder()
                .ConfigureAppConfiguration(c =>
                {
                    c.AddInMemoryCollection(new Dictionary<string, string>
@@ -240,41 +254,45 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                         { "APPINSIGHTS_INSTRUMENTATIONKEY", "some_key" }
                   });
                })
-              .ConfigureDefaultTestWebScriptHost()
-              .Build();
+              .ConfigureDefaultTestWebScriptHost();
 
-            IEnumerable<ILoggerProvider> loggerProviders = host.Services.GetService<IEnumerable<ILoggerProvider>>();
+            using (IHost host = hostBuilder.Build())
+            {
+                IEnumerable<ILoggerProvider> loggerProviders = host.Services.GetService<IEnumerable<ILoggerProvider>>();
 
-            Assert.Equal(6, loggerProviders.Count());
-            loggerProviders.OfType<SystemLoggerProvider>().Single();
-            loggerProviders.OfType<HostFileLoggerProvider>().Single();
-            loggerProviders.OfType<FunctionFileLoggerProvider>().Single();
-            loggerProviders.OfType<ApplicationInsightsLoggerProvider>().Single();
-            loggerProviders.OfType<UserLogMetricsLoggerProvider>().Single();
-            loggerProviders.OfType<AzureMonitorDiagnosticLoggerProvider>().Single();
+                Assert.Equal(6, loggerProviders.Count());
+                loggerProviders.OfType<SystemLoggerProvider>().Single();
+                loggerProviders.OfType<HostFileLoggerProvider>().Single();
+                loggerProviders.OfType<FunctionFileLoggerProvider>().Single();
+                loggerProviders.OfType<ApplicationInsightsLoggerProvider>().Single();
+                loggerProviders.OfType<UserLogMetricsLoggerProvider>().Single();
+                loggerProviders.OfType<AzureMonitorDiagnosticLoggerProvider>().Single();
+            }
         }
 
         [Fact]
         public void LoggerProviders_AzureMonitor()
         {
-            IHost host = new HostBuilder()
+            var hostBuilder = new HostBuilder()
               .ConfigureDefaultTestWebScriptHost()
               .ConfigureServices(s =>
               {
                   TestEnvironment environment = new TestEnvironment();
                   environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName, "something.azurewebsites.net");
                   s.AddSingleton<IEnvironment>(environment);
-              })
-              .Build();
+              });
 
-            IEnumerable<ILoggerProvider> loggerProviders = host.Services.GetService<IEnumerable<ILoggerProvider>>();
+            using (IHost host = hostBuilder.Build())
+            {
+                IEnumerable<ILoggerProvider> loggerProviders = host.Services.GetService<IEnumerable<ILoggerProvider>>();
 
-            Assert.Equal(5, loggerProviders.Count());
-            loggerProviders.OfType<SystemLoggerProvider>().Single();
-            loggerProviders.OfType<HostFileLoggerProvider>().Single();
-            loggerProviders.OfType<FunctionFileLoggerProvider>().Single();
-            loggerProviders.OfType<UserLogMetricsLoggerProvider>().Single();
-            loggerProviders.OfType<AzureMonitorDiagnosticLoggerProvider>().Single();
+                Assert.Equal(5, loggerProviders.Count());
+                loggerProviders.OfType<SystemLoggerProvider>().Single();
+                loggerProviders.OfType<HostFileLoggerProvider>().Single();
+                loggerProviders.OfType<FunctionFileLoggerProvider>().Single();
+                loggerProviders.OfType<UserLogMetricsLoggerProvider>().Single();
+                loggerProviders.OfType<AzureMonitorDiagnosticLoggerProvider>().Single();
+            }
         }
     }
 }


### PR DESCRIPTION
We had a set of tests that were creating hosts, building them, validating, then moving on, without disposing. This hasn't hit us in v2, but some of the v3 tests needed to change a little bit and this was causing sporadic failures. 

The reason -- when we requests an `ApplicationInsightsLoggerProvider` in these tests, that instantiates a `TelemetryClient`, which also instantiates a global request tracking module. So any requests made (even to a `TestServer`) will be auto-tracked. In v3 some of the http pipeline tests now hit a `TestServer`, so this was causing some unexpected headers that I had to track back to these tests.

It's good to have this in v2 as well, so cherry-picking that change here.
