### PR TITLE
[pack] absorbing new shoebox event name

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/AzureMonitorDiagnosticLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/AzureMonitorDiagnosticLogger.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 {
     public class AzureMonitorDiagnosticLogger : ILogger
     {
-        internal const string AzureMonitorCategoryName = "FunctionExecutionLogs";
-        internal const string AzureMonitorOperationName = "Microsoft.Web/sites/functions/execution";
+        internal const string AzureMonitorCategoryName = "FunctionAppLogs";
+        internal const string AzureMonitorOperationName = "Microsoft.Web/sites/functions/log";
 
         private readonly string _hostVersion = ScriptHost.Version;
         private readonly string _regionName;


### PR DESCRIPTION
For public preview, we're changing the name to "FunctionAppLogs". I deployed and tested this -- logs are showing up in my storage account with the new category as expected.