### PR TITLE
[pack] Adding the function missing function name in the metrics table

### DIFF
--- a/src/WebJobs.Script/Diagnostics/FunctionStartedEvent.cs
+++ b/src/WebJobs.Script/Diagnostics/FunctionStartedEvent.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
             InvocationId = invocationId;
             FunctionMetadata = functionMetadata;
             Success = true;
+            FunctionName = functionMetadata?.Name;
         }
 
         public FunctionMetadata FunctionMetadata { get; private set; }

--- a/test/WebJobs.Script.Tests/Description/FunctionInvokerBaseTests.cs
+++ b/test/WebJobs.Script.Tests/Description/FunctionInvokerBaseTests.cs
@@ -189,9 +189,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var completedStartEvent = (FunctionStartedEvent)_metricsLogger.MetricEventsEnded.ElementAt(0);
             Assert.Same(startedEvent, completedStartEvent);
             Assert.False(completedStartEvent.Success);
+            Assert.Equal(startedEvent.FunctionName, "TestFunction");
 
             // verify invoke failed event
-            Assert.False(string.IsNullOrEmpty(_metricsLogger.LoggedEvents.FirstOrDefault(e => e == MetricEventNames.FunctionInvokeFailed)));
+
+            Assert.False(string.IsNullOrEmpty(_metricsLogger.LoggedEvents.FirstOrDefault(e => e == $"{MetricEventNames.FunctionInvokeFailed}_testfunction")));
 
             // verify latency event
             var startLatencyEvent = _metricsLogger.EventsBegan.ElementAt(0);

--- a/test/WebJobs.Script.Tests/Description/FunctionInvokerBaseTests.cs
+++ b/test/WebJobs.Script.Tests/Description/FunctionInvokerBaseTests.cs
@@ -131,9 +131,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var completedStartEvent = (FunctionStartedEvent)_metricsLogger.MetricEventsEnded.ElementAt(0);
             Assert.Same(startedEvent, completedStartEvent);
             Assert.True(completedStartEvent.Success);
+            Assert.Equal(startedEvent.FunctionName, "TestFunction");
 
             // verify invoke failed event
-            Assert.False(string.IsNullOrEmpty(_metricsLogger.LoggedEvents.FirstOrDefault(e => e == MetricEventNames.FunctionInvokeSucceeded)));
+            Assert.False(string.IsNullOrEmpty(_metricsLogger.LoggedEvents.FirstOrDefault(e => e == $"{MetricEventNames.FunctionInvokeSucceeded}_testfunction")));
 
             // verify latency event
             var startLatencyEvent = _metricsLogger.EventsBegan.ElementAt(0);


### PR DESCRIPTION
closes #4745 