### PR TITLE
Support for IMDS MSI implementation

### DIFF
--- a/src/WebJobs.Script.WebHost/Models/ManagedServiceIdentity.cs
+++ b/src/WebJobs.Script.WebHost/Models/ManagedServiceIdentity.cs
@@ -18,5 +18,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
         public string ResourceId { get; set; }
 
         public string Certificate { get; set; }
+
+        public string PrincipalId { get; set; }
     }
 }


### PR DESCRIPTION
The property will be used by TokenService to choose the ManagedServiceIdentity to use when retrieving tokens.