### PR TITLE
Remove x-ms-site-restricted-token generation endpoint

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -22,7 +22,6 @@ using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
 using Microsoft.Azure.WebJobs.Script.WebHost.Filters;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
-using Microsoft.Azure.WebJobs.Script.WebHost.Security;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies;
 using Microsoft.Extensions.DependencyInjection;
@@ -266,28 +265,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
             }
 
             return Accepted();
-        }
-
-        /// <summary>
-        /// This endpoint generates a temporary x-ms-site-restricted-token for core tool
-        /// to access KuduLite zipdeploy endpoint in Linux Consumption
-        /// </summary>
-        /// <returns>
-        /// 200 on token generated
-        /// 400 on non-Linux container environment
-        /// </returns>
-        [HttpGet]
-        [Route("admin/host/token")]
-        [Authorize(Policy = PolicyNames.AdminAuthLevel)]
-        public IActionResult GetAdminToken()
-        {
-            if (!_environment.IsLinuxConsumption())
-            {
-                return BadRequest("Endpoint is only available when running in Linux Container");
-            }
-
-            string requestHeaderToken = SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddMinutes(5));
-            return Ok(requestHeaderToken);
         }
 
         [HttpGet]

--- a/test/WebJobs.Script.Tests/Controllers/Admin/HostControllerTests.cs
+++ b/test/WebJobs.Script.Tests/Controllers/Admin/HostControllerTests.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs.Host.Scale;
@@ -17,7 +16,6 @@ using Microsoft.Azure.WebJobs.Script.ExtensionBundle;
 using Microsoft.Azure.WebJobs.Script.Scale;
 using Microsoft.Azure.WebJobs.Script.WebHost.Controllers;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
-using Microsoft.Azure.WebJobs.Script.WebHost.Security;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
@@ -100,46 +98,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 // verify file does not exist
                 Assert.False(fileExists);
-            }
-        }
-
-        [Fact]
-        public void GetAdminToken_Succeeds()
-        {
-            // Arrange
-            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(It.Is<string>(k => k == EnvironmentSettingNames.ContainerName))).Returns<string>(v => v = "ContainerName");
-
-            var key = TestHelpers.GenerateKeyBytes();
-            var stringKey = TestHelpers.GenerateKeyHexString(key);
-            using (new TestScopedEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, stringKey))
-            {
-                // Act
-                ObjectResult result = (ObjectResult)_hostController.GetAdminToken();
-                HttpStatusCode resultStatus = (HttpStatusCode)result.StatusCode;
-                string token = (string)result.Value;
-
-                // Assert
-                Assert.Equal(HttpStatusCode.OK, resultStatus);
-                Assert.True(SimpleWebTokenHelper.ValidateToken(token, new SystemClock()));
-            }
-        }
-
-        [Fact]
-        public void GetAdminToken_Fails_NotLinuxContainer()
-        {
-            // Arrange
-            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(It.Is<string>(k => k == EnvironmentSettingNames.ContainerName))).Returns<string>(v => v = null);
-
-            var key = TestHelpers.GenerateKeyBytes();
-            var stringKey = TestHelpers.GenerateKeyHexString(key);
-            using (new TestScopedEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, stringKey))
-            {
-                // Act
-                ObjectResult result = (ObjectResult)_hostController.GetAdminToken();
-                HttpStatusCode resultStatus = (HttpStatusCode)result.StatusCode;
-
-                // Assert
-                Assert.Equal(HttpStatusCode.BadRequest, resultStatus);
             }
         }
 


### PR DESCRIPTION
It is a revert of https://github.com/Azure/azure-functions-host/pull/4585.

Since x-ms-site-restricted-token is embedded in web request in ANT85,
Toolings don't need to call **admin/host/token** endpoint to get the token for remote build anymore.
- VSCode: https://github.com/microsoft/vscode-azuretools/pull/600
- Core Tools: https://github.com/Azure/azure-functions-core-tools/pull/1561