### PR TITLE
Add functions worker runtime version log

### DIFF
--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -248,6 +248,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             {
                 version = description.DefaultRuntimeVersion;
             }
+            _logger.LogDebug($"{RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName} for language {description.Language}: {version}");
 
             description.ValidateWorkerPath(description.DefaultWorkerPath, os, architecture, version);
 

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -248,7 +248,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             {
                 version = description.DefaultRuntimeVersion;
             }
-            _logger.LogDebug($"{RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName} for language {description.Language}: {version}");
+            _logger.LogDebug($"EnvironmentVariable {RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName}: {version}");
 
             description.ValidateWorkerPath(description.DefaultWorkerPath, os, architecture, version);
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             Assert.Equal(expectedPath, configFactory.GetHydratedWorkerPath(workerDescription));
             Assert.Collection(testLogger.GetLogMessages(),
-                p => Assert.Equal("FUNCTIONS_WORKER_RUNTIME_VERSION for language python: 3.7", p.FormattedMessage));
+                p => Assert.Equal("EnvironmentVariable FUNCTIONS_WORKER_RUNTIME_VERSION: 3.7", p.FormattedMessage));
         }
 
         [Theory]
@@ -302,7 +302,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             Assert.Equal(expectedPath, configFactory.GetHydratedWorkerPath(workerDescription));
             Assert.Collection(testLogger.GetLogMessages(),
-                p => Assert.Equal("FUNCTIONS_WORKER_RUNTIME_VERSION for language python: 3.6", p.FormattedMessage));
+                p => Assert.Equal("EnvironmentVariable FUNCTIONS_WORKER_RUNTIME_VERSION: 3.6", p.FormattedMessage));
         }
 
         [Theory]

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
@@ -259,6 +259,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger());
 
             Assert.Equal(expectedPath, configFactory.GetHydratedWorkerPath(workerDescription));
+            Assert.Collection(testLogger.GetLogMessages(),
+                p => Assert.Equal("FUNCTIONS_WORKER_RUNTIME_VERSION for language python: 3.7", p.FormattedMessage));
         }
 
         [Theory]
@@ -299,6 +301,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger());
 
             Assert.Equal(expectedPath, configFactory.GetHydratedWorkerPath(workerDescription));
+            Assert.Collection(testLogger.GetLogMessages(),
+                p => Assert.Equal("FUNCTIONS_WORKER_RUNTIME_VERSION for language python: 3.6", p.FormattedMessage));
         }
 
         [Theory]


### PR DESCRIPTION
To disambiguate languages that support multiple worker runtime versions. 