### PR TITLE
Fall back to relying on PATH when the dotnet executable is not found at the expected location

### DIFF
--- a/src/WebJobs.Script/Workers/Http/Configuration/HttpWorkerOptionsSetup.cs
+++ b/src/WebJobs.Script/Workers/Http/Configuration/HttpWorkerOptionsSetup.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
                 {
                     throw new HostConfigurationException($"Missing WorkerDescription for HttpWorker");
                 }
-                httpWorkerDescription.ApplyDefaultsAndValidate(_scriptJobHostOptions.RootScriptPath);
+                httpWorkerDescription.ApplyDefaultsAndValidate(_scriptJobHostOptions.RootScriptPath, _logger);
                 options.Arguments = new WorkerProcessArguments()
                 {
                     ExecutablePath = options.Description.DefaultExecutablePath,

--- a/src/WebJobs.Script/Workers/Http/HttpWorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpWorkerDescription.cs
@@ -5,12 +5,13 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.IO;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.Workers.Http
 {
     public class HttpWorkerDescription : WorkerDescription
     {
-        public override void ApplyDefaultsAndValidate(string workerDirectory)
+        public override void ApplyDefaultsAndValidate(string workerDirectory, ILogger logger)
         {
             if (workerDirectory == null)
             {

--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerDescription.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.Workers
 {
@@ -27,6 +28,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         /// </summary>
         public List<string> Arguments { get; set; }
 
-        public abstract void ApplyDefaultsAndValidate(string workerDirectory);
+        public abstract void ApplyDefaultsAndValidate(string workerDirectory, ILogger logger);
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     {
                         workerDescription.DefaultWorkerPath = GetHydratedWorkerPath(workerDescription);
                     }
-                    workerDescription.ApplyDefaultsAndValidate(Directory.GetCurrentDirectory());
+                    workerDescription.ApplyDefaultsAndValidate(Directory.GetCurrentDirectory(), _logger);
                     _workerDescripionDictionary[workerDescription.Language] = workerDescription;
                 }
                 catch (Exception ex)

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
@@ -150,14 +150,21 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     || DefaultExecutablePath.Equals(RpcWorkerConstants.DotNetExecutableNameWithExtension, StringComparison.OrdinalIgnoreCase)))
             {
                 var programFilesFolder = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
-                var fullPath = Path.Combine(programFilesFolder, RpcWorkerConstants.DotNetFolderName, DefaultExecutablePath);
+
+                var fullPath = Path.Combine(
+                                    programFilesFolder,
+                                    RpcWorkerConstants.DotNetFolderName,
+                                    RpcWorkerConstants.DotNetExecutableNameWithExtension);
+
                 if (FileExists(fullPath))
                 {
                     DefaultExecutablePath = fullPath;
                 }
                 else
                 {
-                    logger.Log(LogLevel.Warning, $"File '{fullPath}' is not found, '{RpcWorkerConstants.DotNetExecutableName}' invocation will rely on the PATH environment variable.");
+                    logger.Log(
+                        LogLevel.Warning,
+                        $"File '{fullPath}' is not found, '{DefaultExecutablePath}' invocation will rely on the PATH environment variable.");
                 }
             }
         }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
@@ -278,7 +278,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             var expectedExecutablePath =
                 RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                    ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet", defaultExecutablePath)
+                    ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet", "dotnet.exe")
                     : defaultExecutablePath;
 
             var workerDescription = new RpcWorkerDescription
@@ -286,7 +286,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 Language = testLanguage,
                 Extensions = new List<string>(),
                 DefaultExecutablePath = defaultExecutablePath,
-                FileExists = path => true
+                FileExists = path =>
+                                {
+                                    Assert.Equal(expectedExecutablePath, path);
+                                    return true;
+                                }
             };
 
             workerDescription.ApplyDefaultsAndValidate(Directory.GetCurrentDirectory(), testLogger);
@@ -305,7 +309,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             var expectedExecutablePath =
                 RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                    ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet", defaultExecutablePath)
+                    ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet", "dotnet.exe")
                     : defaultExecutablePath;
 
             var workerDescription = new RpcWorkerDescription
@@ -313,7 +317,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 Language = testLanguage,
                 Extensions = new List<string>(),
                 DefaultExecutablePath = defaultExecutablePath,
-                FileExists = path => false
+                FileExists = path =>
+                                {
+                                    Assert.Equal(expectedExecutablePath, path);
+                                    return false;
+                                }
             };
 
             workerDescription.ApplyDefaultsAndValidate(Directory.GetCurrentDirectory(), testLogger);
@@ -324,15 +332,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Theory]
-        // It does not matter whether the file exists or not
-        [InlineData(@"D:\CustomExecutableFolder\dotnet", true)]
-        [InlineData(@"D:\CustomExecutableFolder\dotnet", false)]
-        [InlineData(@"/CustomExecutableFolder/dotnet", true)]
-        [InlineData(@"/CustomExecutableFolder/dotnet", false)]
-        [InlineData("AnythingElse", true)]
-        [InlineData("AnythingElse", false)]
+        [InlineData(@"D:\CustomExecutableFolder\dotnet")]
+        [InlineData(@"/CustomExecutableFolder/dotnet")]
+        [InlineData("AnythingElse")]
         public void ValidateWorkerDescription_DoesNotModifyDefaultWorkerExecutablePath_WhenDoesNotStrictlyMatchDotNet(
-            string defaultExecutablePath, bool fileExists)
+            string defaultExecutablePath)
         {
             var testLogger = new TestLogger(testLanguage);
 
@@ -341,7 +345,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 Language = testLanguage,
                 Extensions = new List<string>(),
                 DefaultExecutablePath = defaultExecutablePath,
-                FileExists = path => fileExists
+                FileExists = path =>
+                                {
+                                    Assert.True(false, "FileExists should not be called");
+                                    return false;
+                                }
             };
 
             workerDescription.ApplyDefaultsAndValidate(Directory.GetCurrentDirectory(), testLogger);


### PR DESCRIPTION
Fall back to relying on PATH when the dotnet executable is not found at the expected location.

See https://github.com/Azure/azure-functions-core-tools/pull/1626#issuecomment-546558691 for more details.