### PR TITLE
[pack]Keep 'win-x64' and 'win10-x64' runtimes for PowerShell worker

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -242,7 +242,7 @@ function cleanExtension([string] $bitness) {
         }
     }
 
-    $keepRuntimes = @('win', 'win-x86', 'win10-x86')
+    $keepRuntimes = @('win', 'win-x86', 'win10-x86', 'win-x64', 'win10-x64')
     Get-ChildItem "$privateSiteExtensionPath\$bitness\workers\powershell\runtimes" -Exclude $keepRuntimes -ErrorAction SilentlyContinue |
         Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
 }


### PR DESCRIPTION
Keep 'win-x64' and 'win10-x64' runtimes for PowerShell worker