### PR TITLE
Add support to load native libraries from the function.deps.json file.

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
+++ b/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         private readonly List<string> _probingPaths = new List<string>();
         private readonly IDictionary<string, string> _depsAssemblies;
+        private readonly IDictionary<string, string> _nativeLibraries;
 
         public FunctionAssemblyLoadContext(string basePath)
         {
@@ -38,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 throw new ArgumentNullException(nameof(basePath));
             }
 
-            _depsAssemblies = InitializeDeps(basePath);
+            (_depsAssemblies, _nativeLibraries) = InitializeDeps(basePath);
 
             _probingPaths.Add(basePath);
         }
@@ -50,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             _defaultContext = new Lazy<FunctionAssemblyLoadContext>(CreateSharedContext, true);
         }
 
-        internal static IDictionary<string, string> InitializeDeps(string basePath)
+        internal static (IDictionary<string, string> depsAssemblies, IDictionary<string, string> nativeLibraries) InitializeDeps(string basePath)
         {
             string depsFilePath = Path.Combine(basePath, DotNetConstants.FunctionsDepsFileName);
 
@@ -64,8 +65,14 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                     using (Stream file = File.OpenRead(depsFilePath))
                     {
                         var depsContext = reader.Read(file);
-                        return depsContext.RuntimeLibraries.SelectMany(l => SelectRuntimeAssemblyGroup(rids, l.RuntimeAssemblyGroups))
+                        var depsAssemblies = depsContext.RuntimeLibraries.SelectMany(l => SelectRuntimeAssemblyGroup(rids, l.RuntimeAssemblyGroups))
                             .ToDictionary(path => Path.GetFileNameWithoutExtension(path));
+
+                        // Note the difference here that nativeLibraries has the whole file name, including extension.
+                        var nativeLibraries = depsContext.RuntimeLibraries.SelectMany(l => SelectRuntimeAssemblyGroup(rids, l.NativeLibraryGroups))
+                            .ToDictionary(path => Path.GetFileName(path));
+
+                        return (depsAssemblies, nativeLibraries);
                     }
                 }
                 catch
@@ -73,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 }
             }
 
-            return null;
+            return (null, null);
         }
 
         private static IEnumerable<string> SelectRuntimeAssemblyGroup(List<string> rids, IReadOnlyList<RuntimeAssetGroup> runtimeAssemblyGroups)
@@ -289,7 +296,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
         {
             string fileName = GetUnmanagedLibraryFileName(unmanagedDllName);
-            string filePath = GetRuntimeNativeAssetPath(fileName, true);
+            string filePath = GetRuntimeNativeAssetPath(fileName);
 
             if (filePath != null)
             {
@@ -299,17 +306,31 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             return base.LoadUnmanagedDll(unmanagedDllName);
         }
 
-        private string GetRuntimeNativeAssetPath(string assetFileName, bool isNativeAsset)
+        private string GetRuntimeNativeAssetPath(string assetFileName)
         {
             string basePath = _probingPaths[0];
-            string ridSubFolder = isNativeAsset ? "native" : string.Empty;
+            const string ridSubFolder = "native";
             string runtimesPath = Path.Combine(basePath, "runtimes");
 
             List<string> rids = DependencyHelper.GetRuntimeFallbacks();
 
-            return rids.Select(r => Path.Combine(runtimesPath, r, ridSubFolder, assetFileName))
+            string result = rids.Select(r => Path.Combine(runtimesPath, r, ridSubFolder, assetFileName))
                 .Union(_probingPaths)
                 .FirstOrDefault(p => File.Exists(p));
+
+            if (result == null && _nativeLibraries != null)
+            {
+                if (_nativeLibraries.TryGetValue(assetFileName, out string relativePath))
+                {
+                    string nativeLibraryFullPath = Path.Combine(basePath, relativePath);
+                    if (File.Exists(nativeLibraryFullPath))
+                    {
+                        result = nativeLibraryFullPath;
+                    }
+                }
+            }
+
+            return result;
         }
 
         internal string GetUnmanagedLibraryFileName(string unmanagedLibraryName)

--- a/test/WebJobs.Script.Tests/Description/DotNet/TestFiles/DepsFiles/function.deps.json
+++ b/test/WebJobs.Script.Tests/Description/DotNet/TestFiles/DepsFiles/function.deps.json
@@ -8,6 +8,7 @@
     ".NETCoreApp,Version=v2.1": {
       "FunctionApp66/1.0.0": {
         "dependencies": {
+          "Microsoft.ML.CpuMath": "1.4.0",
           "Microsoft.NET.Sdk.Functions": "1.0.23",
           "System.ServiceModel.Http": "4.5.3"
         },
@@ -682,6 +683,39 @@
           "lib/netstandard2.0/Microsoft.Extensions.Primitives.dll": {
             "assemblyVersion": "2.1.0.0",
             "fileVersion": "2.1.0.18136"
+          }
+        }
+      },
+      "Microsoft.ML.CpuMath/1.4.0": {
+        "dependencies": {
+          "System.Memory": "4.5.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.ML.CpuMath.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.4.28230.4"
+          }
+        },
+        "runtimeTargets": {
+          "runtimes/linux-x64/nativeassets/netstandard2.0/libCpuMathNative.so": {
+            "rid": "linux-x64",
+            "assetType": "native",
+            "fileVersion": "0.0.0.0"
+          },
+          "runtimes/osx-x64/nativeassets/netstandard2.0/libCpuMathNative.dylib": {
+            "rid": "osx-x64",
+            "assetType": "native",
+            "fileVersion": "0.0.0.0"
+          },
+          "runtimes/win-x64/nativeassets/netstandard2.0/CpuMathNative.dll": {
+            "rid": "win-x64",
+            "assetType": "native",
+            "fileVersion": "1.4.28230.4"
+          },
+          "runtimes/win-x86/nativeassets/netstandard2.0/CpuMathNative.dll": {
+            "rid": "win-x86",
+            "assetType": "native",
+            "fileVersion": "1.4.28230.4"
           }
         }
       },
@@ -1712,6 +1746,13 @@
       "sha512": "sha512-U+TqiIAwTQQVlX/+270Z1pv+4aVOl7/Dd39znQcdDpK8nzbdaEt0qahI0e6ZPb8b/1YvQ/iUeWpuYq91NWjaTg==",
       "path": "microsoft.extensions.primitives/2.1.0",
       "hashPath": "microsoft.extensions.primitives.2.1.0.nupkg.sha512"
+    },
+    "Microsoft.ML.CpuMath/1.4.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-eRDY1KMcDc4iT075MOWlQL4RBrvI9GYl0wD/LiCR4h49hej61qHk88FW3ij3kBRrxSG9ssG8jJJJCNaQeGUaZg==",
+      "path": "microsoft.ml.cpumath/1.4.0",
+      "hashPath": "microsoft.ml.cpumath.1.4.0.nupkg.sha512"
     },
     "Microsoft.Net.Http.Headers/2.1.0": {
       "type": "package",


### PR DESCRIPTION
This allows for probing of more locations for native libraries instead of just the "runtimes\{rid}\native" folder. For example, native assets can also live in a "runtimes\{rid}\nativeassets\{tfm}" folder.

Fix #5187

cc @fabiocav 