### PR TITLE
fixing backoff overflow exceptions

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
@@ -325,18 +323,17 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 else
                 {
                     logger.LogDebug($"Will start a new host after delay.");
-                    await Utility.DelayWithBackoffAsync(attemptCount, currentCancellationToken, min: TimeSpan.FromSeconds(1), max: TimeSpan.FromMinutes(2), logger: logger)
-                        .ContinueWith(t =>
-                        {
-                            if (currentCancellationToken.IsCancellationRequested)
-                            {
-                                logger.LogDebug($"Cancellation for operation '{activeOperation.Id}' requested during delay. A new host will not be started.");
-                                currentCancellationToken.ThrowIfCancellationRequested();
-                            }
 
-                            logger.LogDebug("Starting new host after delay.");
-                            return StartHostAsync(currentCancellationToken, attemptCount, parentOperationId: activeOperation.Id);
-                        });
+                    await Utility.DelayWithBackoffAsync(attemptCount, currentCancellationToken, min: TimeSpan.FromSeconds(1), max: TimeSpan.FromMinutes(2), logger: logger);
+
+                    if (currentCancellationToken.IsCancellationRequested)
+                    {
+                        logger.LogDebug($"Cancellation for operation '{activeOperation.Id}' requested during delay. A new host will not be started.");
+                        currentCancellationToken.ThrowIfCancellationRequested();
+                    }
+
+                    logger.LogDebug("Starting new host after delay.");
+                    Task ignore = StartHostAsync(currentCancellationToken, attemptCount, parentOperationId: activeOperation.Id);
                 }
             }
         }

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -109,7 +109,17 @@ namespace Microsoft.Azure.WebJobs.Script
         public static async Task DelayWithBackoffAsync(int exponent, CancellationToken cancellationToken, TimeSpan? unit = null,
             TimeSpan? min = null, TimeSpan? max = null, ILogger logger = null)
         {
-            TimeSpan delay = ComputeBackoff(exponent, unit, min, max);
+            TimeSpan delay = TimeSpan.FromSeconds(5);
+
+            try
+            {
+                delay = ComputeBackoff(exponent, unit, min, max);
+            }
+            catch (Exception ex)
+            {
+                logger?.LogDebug(ex, $"Exception while calculating backoff. Using a default '{delay}' delay.");
+            }
+
             logger?.LogDebug($"Delay is '{delay}'.");
 
             if (delay.TotalMilliseconds > 0)
@@ -127,12 +137,27 @@ namespace Microsoft.Azure.WebJobs.Script
 
         internal static TimeSpan ComputeBackoff(int exponent, TimeSpan? unit = null, TimeSpan? min = null, TimeSpan? max = null)
         {
+            TimeSpan maxValue = max ?? TimeSpan.MaxValue;
+
+            // prevent an OverflowException
+            if (exponent >= 64)
+            {
+                return maxValue;
+            }
+
             // determine the exponential backoff factor
             long backoffFactor = Convert.ToInt64((Math.Pow(2, exponent) - 1) / 2);
 
             // compute the backoff delay
             unit = unit ?? TimeSpan.FromSeconds(1);
             long totalDelayTicks = backoffFactor * unit.Value.Ticks;
+
+            // If we've overflowed long, return max.
+            if (backoffFactor > 0 && totalDelayTicks <= 0)
+            {
+                return maxValue;
+            }
+
             TimeSpan delay = TimeSpan.FromTicks(totalDelayTicks);
 
             // apply minimum restriction
@@ -142,9 +167,9 @@ namespace Microsoft.Azure.WebJobs.Script
             }
 
             // apply maximum restriction
-            if (max.HasValue && delay > max)
+            if (delay > maxValue)
             {
-                delay = max.Value;
+                delay = maxValue;
             }
 
             return delay;

--- a/test/WebJobs.Script.Tests/UtilityTests.cs
+++ b/test/WebJobs.Script.Tests/UtilityTests.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Dynamic;
 using System.Globalization;
 using System.IO.Abstractions;
-using System.IO.Abstractions.TestingHelpers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -162,6 +161,29 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             TimeSpan result = Utility.ComputeBackoff(exponent, unit, min, max);
             TimeSpan expectedTimespan = TimeSpan.Parse(expected);
             Assert.Equal(expectedTimespan, result);
+        }
+
+        [Theory]
+        [InlineData("00:02:00", "00:02:00")]
+        [InlineData(null, "10675199.02:48:05.4775807")]
+        public void ComputeBackoff_Overflow(string maxValue, string expected)
+        {
+            TimeSpan? max = null;
+            if (maxValue != null)
+            {
+                max = TimeSpan.Parse(maxValue);
+            }
+
+            TimeSpan expectedValue = TimeSpan.Parse(expected);
+
+            // Catches two overflow bugs:
+            // 1. Computed ticks would fluctuate between positive and negative, resulting in min-and-max alternating.
+            // 2. At 64+ we'd throw an OverflowException.
+            for (int i = 60; i < 70; i++)
+            {
+                TimeSpan result = Utility.ComputeBackoff(i, min: TimeSpan.FromSeconds(1), max: max);
+                Assert.Equal(expectedValue, result);
+            }
         }
 
         [Theory]


### PR DESCRIPTION
Fixes #5166, #4699.

Fixing `ComputeBackoff`. Exponents can get big quick. After some number of retries, `TimeSpan.FromTicks()` starts alternating between positive and negative numbers, so the delay jumps back and forth from min-to-max. And then the calculation gets so large it throws. `System.OverflowException: 'Arithmetic operation resulted in an overflow.'` And because we’re using a `ContinueWith()` and not checking the previous task, we just ignore that exception and continue on. The log doesn’t get written, and the delay doesn’t occur.

I've fixed `ComputeBackoff()` to now behave as expected as the exponent gets larger -- and also removed the `ContinueWith()` so we can properly see any other exceptions (and if we find one, I apply a 5-second delay just to slow things down). That will give us better insight into whether there are other bugs lurking here.
