### PR TITLE
Add changes for log analytics / azure monitoring for Linux Dedicated

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
@@ -9,13 +9,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
     internal class LinuxAppServiceEventGenerator : LinuxEventGenerator
     {
         private readonly LinuxAppServiceFileLoggerFactory _loggerFactory;
+        private readonly HostNameProvider _hostNameProvider;
 
-        public LinuxAppServiceEventGenerator(LinuxAppServiceFileLoggerFactory loggerFactory)
+        public LinuxAppServiceEventGenerator(LinuxAppServiceFileLoggerFactory loggerFactory, HostNameProvider hostNameProvider)
         {
             _loggerFactory = loggerFactory;
+            _hostNameProvider = hostNameProvider ?? throw new ArgumentNullException(nameof(hostNameProvider));
         }
 
-        public static string TraceEventRegex { get; } = $"(?<Level>[0-6]),(?<SubscriptionId>[^,]*),(?<AppName>[^,]*),(?<FunctionName>[^,]*),(?<EventName>[^,]*),(?<Source>[^,]*),\"(?<Details>.*)\",\"(?<Summary>.*)\",(?<HostVersion>[^,]*),(?<EventTimestamp>[^,]+),(?<ExceptionType>[^,]*),\"(?<ExceptionMessage>.*)\",(?<FunctionInvocationId>[^,]*),(?<HostInstanceId>[^,]*),(?<ActivityId>[^,\"]*)";
+        public static string TraceEventRegex { get; } = $"(?<Level>[0-6]),(?<SubscriptionId>[^,]*),(?<HostName>[^,]*),(?<AppName>[^,]*),(?<FunctionName>[^,]*),(?<EventName>[^,]*),(?<Source>[^,]*),\"(?<Details>.*)\",\"(?<Summary>.*)\",(?<HostVersion>[^,]*),(?<EventTimestamp>[^,]+),(?<ExceptionType>[^,]*),\"(?<ExceptionMessage>.*)\",(?<FunctionInvocationId>[^,]*),(?<HostInstanceId>[^,]*),(?<ActivityId>[^,\"]*)";
 
         public static string MetricEventRegex { get; } = $"(?<SubscriptionId>[^,]*),(?<AppName>[^,]*),(?<FunctionName>[^,]*),(?<EventName>[^,]*),(?<Average>\\d*),(?<Min>\\d*),(?<Max>\\d*),(?<Count>\\d*),(?<HostVersion>[^,]*),(?<EventTimestamp>[^,]+),(?<Details>[^,\"]*)";
 
@@ -27,10 +29,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         {
             var eventTimestamp = DateTime.UtcNow.ToString(EventTimestampFormat);
             var hostVersion = ScriptHost.Version;
+            var hostName = _hostNameProvider.Value;
             FunctionsSystemLogsEventSource.Instance.SetActivityId(activityId);
 
             var logger = _loggerFactory.GetOrCreate(FunctionsLogsCategory);
-            WriteEvent(logger, $"{(int)ToEventLevel(level)},{subscriptionId},{appName},{functionName},{eventName},{source},{NormalizeString(details)},{NormalizeString(summary)},{hostVersion},{eventTimestamp},{exceptionType},{NormalizeString(exceptionMessage)},{functionInvocationId},{hostInstanceId},{activityId}");
+            WriteEvent(logger, $"{(int)ToEventLevel(level)},{subscriptionId},{hostName},{appName},{functionName},{eventName},{source},{NormalizeString(details)},{NormalizeString(summary)},{hostVersion},{eventTimestamp},{exceptionType},{NormalizeString(exceptionMessage)},{functionInvocationId},{hostInstanceId},{activityId}");
         }
 
         public override void LogFunctionMetricEvent(string subscriptionId, string appName, string functionName, string eventName, long average,

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxEventGenerator.cs
@@ -12,15 +12,22 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         public static readonly string EventTimestampFormat = "MM/dd/yyyy hh:mm:ss.fff tt";
 
         // These names should match the source file names for fluentd
-        public static readonly string FunctionsLogsCategory = "functionslogs";
+        public static readonly string FunctionsLogsCategory = "functionslogsv2";
         public static readonly string FunctionsMetricsCategory = "functionsmetrics";
         public static readonly string FunctionsDetailsCategory = "functionsdetails";
         public static readonly string FunctionsExecutionEventsCategory = "functionexecutionevents";
 
         internal static string NormalizeString(string value)
         {
-            // need to remove newlines for csv output
+            // Need to remove newlines for csv output
             value = value.Replace(Environment.NewLine, " ");
+
+            // Need to replace double quotes with single quotes as
+            // our regex query looks at double quotes as delimeter for
+            // individual column
+            // TODO: Once the regex takes into account for quotes, we can
+            // safely remove this
+            value = value.Replace("\"", "'");
 
             // Wrap string literals in enclosing quotes
             // For string columns that may contain quotes and/or

--- a/src/WebJobs.Script.WebHost/HostNameProvider.cs
+++ b/src/WebJobs.Script.WebHost/HostNameProvider.cs
@@ -21,13 +21,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
     public class HostNameProvider
     {
         private readonly IEnvironment _environment;
-        private readonly ILogger _logger;
         private string _hostName;
 
-        public HostNameProvider(IEnvironment environment, ILogger<HostNameProvider> logger)
+        public HostNameProvider(IEnvironment environment)
         {
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
-            _logger = logger;
         }
 
         public virtual string Value
@@ -52,17 +50,17 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
         }
 
-        public virtual void Synchronize(HttpRequest request)
+        public virtual void Synchronize(HttpRequest request, ILogger logger)
         {
             string hostNameHeaderValue = request.Headers[ScriptConstants.AntaresDefaultHostNameHeader];
             if (!string.IsNullOrEmpty(hostNameHeaderValue) &&
                 string.Compare(Value, hostNameHeaderValue) != 0)
             {
-                    if (string.Compare(Value, hostNameHeaderValue) != 0)
-                    {
-                        _logger.LogInformation("HostName updated from '{0}' to '{1}'", Value, hostNameHeaderValue);
-                        _hostName = hostNameHeaderValue;
-                    }
+                if (string.Compare(Value, hostNameHeaderValue) != 0)
+                {
+                    logger.LogInformation("HostName updated from '{0}' to '{1}'", Value, hostNameHeaderValue);
+                    _hostName = hostNameHeaderValue;
+                }
             }
         }
 

--- a/src/WebJobs.Script.WebHost/Middleware/HostnameFixupMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/HostnameFixupMiddleware.cs
@@ -3,6 +3,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
 {
@@ -10,17 +11,18 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
     {
         private readonly RequestDelegate _next;
         private readonly HostNameProvider _hostNameProvider;
+        private readonly ILogger _logger;
 
-        public HostnameFixupMiddleware(RequestDelegate next, HostNameProvider hostNameProvider)
+        public HostnameFixupMiddleware(RequestDelegate next, HostNameProvider hostNameProvider, ILogger<HostnameFixupMiddleware> logger)
         {
             _next = next;
             _hostNameProvider = hostNameProvider;
+            _logger = logger;
         }
 
         public async Task Invoke(HttpContext context)
         {
-            _hostNameProvider.Synchronize(context.Request);
-
+            _hostNameProvider.Synchronize(context.Request, _logger);
             await _next.Invoke(context);
         }
     }

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -91,7 +91,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 }
                 else if (SystemEnvironment.Instance.IsLinuxAppService())
                 {
-                    return new LinuxAppServiceEventGenerator(new LinuxAppServiceFileLoggerFactory());
+                    var hostNameProvider = p.GetService<HostNameProvider>();
+                    return new LinuxAppServiceEventGenerator(new LinuxAppServiceFileLoggerFactory(), hostNameProvider);
                 }
                 else
                 {

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName)).Returns(testHostName);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.SkipSslValidation)).Returns((string)null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsSecretStorageType)).Returns("blob");
-            _hostNameProvider = new HostNameProvider(_mockEnvironment.Object, loggerFactory.CreateLogger<HostNameProvider>());
+            _hostNameProvider = new HostNameProvider(_mockEnvironment.Object);
 
             var functionMetadataProvider = new FunctionMetadataProvider(optionsMonitor, new OptionsWrapper<LanguageWorkerOptions>(CreateLanguageWorkerConfigSettings()), NullLogger<FunctionMetadataProvider>.Instance, new TestMetricsLogger());
             _functionsSyncManager = new FunctionsSyncManager(configuration, hostIdProviderMock.Object, optionsMonitor, loggerFactory.CreateLogger<FunctionsSyncManager>(), httpClient, secretManagerProviderMock.Object, _mockWebHostEnvironment.Object, _mockEnvironment.Object, _hostNameProvider, functionMetadataProvider);

--- a/test/WebJobs.Script.Tests.Integration/Security/SecretManagerProviderTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Security/SecretManagerProviderTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             var loggerProvider = new TestLoggerProvider();
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(loggerProvider);
-            var hostNameProvider = new HostNameProvider(environment, loggerFactory.CreateLogger<HostNameProvider>());
+            var hostNameProvider = new HostNameProvider(environment);
 
             _provider = new DefaultSecretManagerProvider(optionsMonitor, mockIdProvider.Object, config,
                 new TestEnvironment(), NullLoggerFactory.Instance, new TestMetricsLogger(), hostNameProvider);

--- a/test/WebJobs.Script.Tests/DefaultScriptWebHookProviderTests.cs
+++ b/test/WebJobs.Script.Tests/DefaultScriptWebHookProviderTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             loggerFactory.AddProvider(loggerProvider);
             var testEnvironment = new TestEnvironment();
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName, TestHostName);
-            var hostNameProvider = new HostNameProvider(testEnvironment, loggerFactory.CreateLogger<HostNameProvider>());
+            var hostNameProvider = new HostNameProvider(testEnvironment);
             _webHookProvider = new DefaultScriptWebHookProvider(mockSecretManagerProvider.Object, hostNameProvider);
         }
 

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxAppServiceEventGeneratorTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxAppServiceEventGeneratorTests.cs
@@ -67,12 +67,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
                 p => Assert.Equal(functionName, p),
                 p => Assert.Equal(eventName, p),
                 p => Assert.Equal(source, p),
-                p => Assert.Equal(details, p),
-                p => Assert.Equal(summary, p),
+                p => Assert.Equal(details, LinuxContainerEventGeneratorTests.UnNormalize(p)),
+                p => Assert.Equal(summary, LinuxContainerEventGeneratorTests.UnNormalize(p)),
                 p => Assert.Equal(ScriptHost.Version, p),
                 p => Assert.True(DateTime.TryParse(p, out dt)),
                 p => Assert.Equal(exceptionType, p),
-                p => Assert.Equal(exceptionMessage, p),
+                p => Assert.Equal(exceptionMessage, LinuxContainerEventGeneratorTests.UnNormalize(p)),
                 p => Assert.Equal(functionInvocationId, p),
                 p => Assert.Equal(hostInstanceId, p),
                 p => Assert.Equal(activityId, p));
@@ -126,8 +126,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             Assert.Collection(groupMatches,
                 p => Assert.Equal(siteName, p),
                 p => Assert.Equal(functionName, p),
-                p => Assert.Equal(inputBindings, p),
-                p => Assert.Equal(outputBindings, p),
+                p => Assert.Equal(inputBindings, LinuxContainerEventGeneratorTests.UnNormalize(p)),
+                p => Assert.Equal(outputBindings, LinuxContainerEventGeneratorTests.UnNormalize(p)),
                 p => Assert.Equal(scriptType, p),
                 p => Assert.Equal(isDisabled ? "1" : "0", p));
         }

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxAppServiceEventGeneratorTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxAppServiceEventGeneratorTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -14,6 +15,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 {
     public class LinuxAppServiceEventGeneratorTests
     {
+        private const string _hostNameDefault = "SimpleApp";
+
         private readonly LinuxAppServiceEventGenerator _generator;
         private readonly Dictionary<string, MockLinuxAppServiceFileLogger> _loggers;
 
@@ -32,7 +35,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             var loggerFactoryMock = new Mock<LinuxAppServiceFileLoggerFactory>(MockBehavior.Strict);
             loggerFactoryMock.Setup(f => f.GetOrCreate(It.IsAny<string>())).Returns<string>(s => _loggers[s]);
 
-            _generator = new LinuxAppServiceEventGenerator(loggerFactoryMock.Object);
+            var environmentMock = new Mock<IEnvironment>();
+            environmentMock.Setup(f => f.GetEnvironmentVariable(It.Is<string>(v => v == "WEBSITE_HOSTNAME")))
+                .Returns<string>(s => _hostNameDefault);
+
+            var hostNameProvider = new HostNameProvider(environmentMock.Object);
+            _generator = new LinuxAppServiceEventGenerator(loggerFactoryMock.Object, hostNameProvider);
         }
 
         [Theory]
@@ -47,13 +55,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             var match = regex.Match(evt);
 
             Assert.True(match.Success);
-            Assert.Equal(16, match.Groups.Count);
+            Assert.Equal(17, match.Groups.Count);
 
             DateTime dt;
             var groupMatches = match.Groups.Select(p => p.Value).Skip(1).ToArray();
             Assert.Collection(groupMatches,
                 p => Assert.Equal((int)LinuxEventGenerator.ToEventLevel(level), int.Parse(p)),
                 p => Assert.Equal(subscriptionId, p),
+                p => Assert.Equal(_hostNameDefault, p),
                 p => Assert.Equal(appName, p),
                 p => Assert.Equal(functionName, p),
                 p => Assert.Equal(eventName, p),

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxContainerEventGeneratorTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxContainerEventGeneratorTests.cs
@@ -72,12 +72,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
                 p => Assert.Equal(functionName, p),
                 p => Assert.Equal(eventName, p),
                 p => Assert.Equal(source, p),
-                p => Assert.Equal(details, JsonUnescape(p)),
-                p => Assert.Equal(summary, JsonUnescape(p)),
+                p => Assert.Equal(details, UnNormalize(JsonUnescape(p))),
+                p => Assert.Equal(summary, UnNormalize(JsonUnescape(p))),
                 p => Assert.Equal(ScriptHost.Version, p),
                 p => Assert.True(DateTime.TryParse(p, out dt)),
                 p => Assert.Equal(exceptionType, p),
-                p => Assert.Equal(exceptionMessage, JsonUnescape(p)),
+                p => Assert.Equal(exceptionMessage, UnNormalize(JsonUnescape(p))),
                 p => Assert.Equal(functionInvocationId, p),
                 p => Assert.Equal(hostInstanceId, p),
                 p => Assert.Equal(activityId, p),
@@ -91,6 +91,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             // Because the log data is being JSON serialized it ends up getting
             // escaped. This function reverses that escaping.
             return value.Replace("\\", string.Empty);
+        }
+
+        public static string UnNormalize(string normalized)
+        {
+            // We replace all double quotes to single before the writing the logs
+            // to avoid our logging agents parsing break
+            // TODO: we can remove this once platform is able to handle quotes in logs
+            return normalized.Replace("'", "\"");
         }
 
         private static string JsonSerializeEvent(string evt)
@@ -166,8 +174,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             Assert.Collection(groupMatches,
                 p => Assert.Equal(siteName, p),
                 p => Assert.Equal(functionName, p),
-                p => Assert.Equal(inputBindings, JsonUnescape(p)),
-                p => Assert.Equal(outputBindings, JsonUnescape(p)),
+                p => Assert.Equal(inputBindings, UnNormalize(JsonUnescape(p))),
+                p => Assert.Equal(outputBindings, UnNormalize(JsonUnescape(p))),
                 p => Assert.Equal(scriptType, p),
                 p => Assert.Equal(isDisabled ? "1" : "0", p));
         }

--- a/test/WebJobs.Script.Tests/Eventing/DiagnosticLoggerTests.cs
+++ b/test/WebJobs.Script.Tests/Eventing/DiagnosticLoggerTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
             var loggerProvider = new TestLoggerProvider();
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(loggerProvider);
-            _hostNameProvider = new HostNameProvider(_environment, loggerFactory.CreateLogger<HostNameProvider>());
+            _hostNameProvider = new HostNameProvider(_environment);
             _logger = new AzureMonitorDiagnosticLogger(_category, _hostInstanceId, _mockEventGenerator.Object, _environment, new LoggerExternalScopeProvider(), _hostNameProvider);
         }
 

--- a/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady)).Returns("1");
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.CoreToolsEnvironment)).Returns((string)null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName)).Returns(TestHostName);
-            var hostNameProvider = new HostNameProvider(_mockEnvironment.Object, loggerFactory.CreateLogger<HostNameProvider>());
+            var hostNameProvider = new HostNameProvider(_mockEnvironment.Object);
 
             var workerOptions = new LanguageWorkerOptions();
             FileUtility.Instance = fileSystem;

--- a/test/WebJobs.Script.Tests/Metrics/LinuxContainerMetricsPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/LinuxContainerMetricsPublisherTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             loggerFactory.AddProvider(_testLoggerProvider);
 
             ILogger<LinuxContainerMetricsPublisher> logger = loggerFactory.CreateLogger<LinuxContainerMetricsPublisher>();
-            var hostNameProvider = new HostNameProvider(mockEnvironment.Object, new Mock<ILogger<HostNameProvider>>().Object);
+            var hostNameProvider = new HostNameProvider(mockEnvironment.Object);
             var standbyOptions = new TestOptionsMonitor<StandbyOptions>(new StandbyOptions { InStandbyMode = true });
             _metricsPublisher = new LinuxContainerMetricsPublisher(mockEnvironment.Object, standbyOptions, logger, hostNameProvider, _httpClient);
             _testLoggerProvider.ClearAllLogMessages();

--- a/test/WebJobs.Script.Tests/Middleware/HostnameFixupMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Middleware/HostnameFixupMiddlewareTests.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
             var mockEnvironment = new Mock<IEnvironment>(MockBehavior.Strict);
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName)).Returns(TestHostName);
 
-            _hostNameProvider = new HostNameProvider(mockEnvironment.Object, loggerFactory.CreateLogger<HostNameProvider>());
-            _middleware = new HostnameFixupMiddleware(requestDelegate, _hostNameProvider);
+            _hostNameProvider = new HostNameProvider(mockEnvironment.Object);
+            _middleware = new HostnameFixupMiddleware(requestDelegate, _hostNameProvider, loggerFactory.CreateLogger<HostnameFixupMiddleware>());
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
 
             // validate hostname sync trace
             var log = logs[0];
-            Assert.Equal("Microsoft.Azure.WebJobs.Script.WebHost.HostNameProvider", log.Category);
+            Assert.Equal("Microsoft.Azure.WebJobs.Script.WebHost.Middleware.HostnameFixupMiddleware", log.Category);
             Assert.Equal(LogLevel.Information, log.Level);
             Assert.Equal("HostName updated from 'test.azurewebsites.net' to 'test2.azurewebsites.net'", log.FormattedMessage);
 

--- a/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             var loggerProvider = new TestLoggerProvider();
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(loggerProvider);
-            _hostNameProvider = new HostNameProvider(_testEnvironment, loggerFactory.CreateLogger<HostNameProvider>());
+            _hostNameProvider = new HostNameProvider(_testEnvironment);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/StandbyManagerTests.cs
+++ b/test/WebJobs.Script.Tests/StandbyManagerTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public async Task Specialize_ResetsConfiguration()
         {
             TestMetricsLogger metricsLogger = new TestMetricsLogger();
-            var hostNameProvider = new HostNameProvider(_testEnvironment, _testLoggerFactory.CreateLogger<HostNameProvider>());
+            var hostNameProvider = new HostNameProvider(_testEnvironment);
             var manager = new StandbyManager(_mockHostManager.Object, _mockLanguageWorkerChannelManager.Object, _mockConfiguration.Object, _mockWebHostEnvironment.Object, _testEnvironment, _mockOptionsMonitor.Object, NullLogger<StandbyManager>.Instance, hostNameProvider, _mockApplicationLifetime.Object, metricsLogger);
 
             await manager.SpecializeHostAsync();
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             TestMetricsLogger metricsLogger = new TestMetricsLogger();
             _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName, "placeholder.azurewebsites.net");
 
-            var hostNameProvider = new HostNameProvider(_testEnvironment, _testLoggerFactory.CreateLogger<HostNameProvider>());
+            var hostNameProvider = new HostNameProvider(_testEnvironment);
             var manager = new StandbyManager(_mockHostManager.Object, _mockLanguageWorkerChannelManager.Object, _mockConfiguration.Object, _mockWebHostEnvironment.Object, _testEnvironment, _mockOptionsMonitor.Object, NullLogger<StandbyManager>.Instance, hostNameProvider, _mockApplicationLifetime.Object, metricsLogger);
 
             Assert.Equal("placeholder.azurewebsites.net", hostNameProvider.Value);
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             });
             _testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, RpcWorkerConstants.JavaLanguageWorkerName);
 
-            var hostNameProvider = new HostNameProvider(_testEnvironment, _testLoggerFactory.CreateLogger<HostNameProvider>());
+            var hostNameProvider = new HostNameProvider(_testEnvironment);
             var manager = new StandbyManager(_mockHostManager.Object, _mockLanguageWorkerChannelManager.Object, _mockConfiguration.Object, _mockWebHostEnvironment.Object, _testEnvironment, _mockOptionsMonitor.Object, NullLogger<StandbyManager>.Instance, hostNameProvider, _mockApplicationLifetime.Object, metricsLogger);
             await manager.SpecializeHostAsync();
 
@@ -112,7 +112,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             TestMetricsLogger metricsLogger = new TestMetricsLogger();
             _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName, "placeholder.azurewebsites.net");
 
-            var hostNameProvider = new HostNameProvider(_testEnvironment, _testLoggerFactory.CreateLogger<HostNameProvider>());
+            var hostNameProvider = new HostNameProvider(_testEnvironment);
             var manager = new StandbyManager(_mockHostManager.Object, _mockLanguageWorkerChannelManager.Object, _mockConfiguration.Object, _mockWebHostEnvironment.Object, _testEnvironment, _mockOptionsMonitor.Object, NullLogger<StandbyManager>.Instance, hostNameProvider, _mockApplicationLifetime.Object, metricsLogger);
             await manager.InitializeAsync().ContinueWith(t => { }); // Ignore errors.
 

--- a/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
@@ -396,7 +396,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var loggerProvider = new TestLoggerProvider();
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(loggerProvider);
-            var hostNameProvider = new HostNameProvider(mockEnvironment.Object, loggerFactory.CreateLogger<HostNameProvider>());
+            var hostNameProvider = new HostNameProvider(mockEnvironment.Object);
             var mockApplicationLifetime = new Mock<Microsoft.AspNetCore.Hosting.IApplicationLifetime>(MockBehavior.Strict);
             var manager = new StandbyManager(_hostService, mockLanguageWorkerChannelManager.Object, mockConfiguration.Object, mockScriptWebHostEnvironment.Object, mockEnvironment.Object, _monitor, testLogger, hostNameProvider, mockApplicationLifetime.Object, new TestMetricsLogger());
             manager.SpecializeHostAsync().Wait();


### PR DESCRIPTION
Closes #4945 

We decided to rename the file to `functionslogsv2` as this now has a new schema and we want to avoid potential incompatibility between platform and host versions. Such as if Functions runtime is writing in a different format while the platform expects it in a different format.

ANT86 has the change to parse `functionslogsv2` accurately, and also knows to parse `functionslogs` for backwards compatibility. 

**Note** - We can't merge this until **ANT 86** is complete in our platform.
