### PR TITLE
Add support for Access-Control-Allow-Methods header in CORS middleware

### DIFF
--- a/src/WebJobs.Script.WebHost/Configuration/CorsOptionsSetup.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/CorsOptionsSetup.cs
@@ -33,6 +33,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
                     policyBuilder = policyBuilder.AllowCredentials();
                 }
 
+                policyBuilder.AllowAnyHeader();
+                policyBuilder.AllowAnyMethod();
+
                 var policy = policyBuilder.Build();
                 options.AddDefaultPolicy(policy);
             }


### PR DESCRIPTION
This matches the behaviour of AppService CORS middleware used in windows function apps.