### PR TITLE
[pack] moving ExtensionsMetadataGenerator to use Mono.Cecil

### DIFF
--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/ExtensionsMetadataGenerator.Console.csproj
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/ExtensionsMetadataGenerator.Console.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Mono.Cecil" Version="0.11.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
   </ItemGroup>
 </Project>

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/ExtensionsMetadataGenerator.cs
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/ExtensionsMetadataGenerator.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using Mono.Cecil;
 #if !NET46
 #endif
 
@@ -43,21 +44,13 @@ namespace ExtensionsMetadataGenerator
                     {
                         try
                         {
-                            Assembly assembly = Assembly.LoadFrom(path);
-                            var currExtensionReferences = GenerateExtensionReferences(assembly);
+                            var currExtensionReferences = GenerateExtensionReferences(path, logger);
                             extensionReferences.AddRange(currExtensionReferences);
 
                             foreach (var foundRef in currExtensionReferences)
                             {
                                 logger.LogMessage($"Found extension: {foundRef.TypeName}");
                             }
-                        }
-                        catch (FileNotFoundException ex)
-                        {
-                            // Don't log this as an error. This will almost always happen due to some publishing artifacts (i.e. Razor) existing
-                            // in the functions bin folder without all of their dependencies present. These will almost never have Functions extensions,
-                            // so we don't want to write out errors every time there is a build. This message can be seen with detailed logging enabled.
-                            logger.LogMessage($"Could not evaluate '{Path.GetFileName(path)}' for extension metadata. If this assembly contains a Functions extension, ensure that all dependent assemblies exist in '{sourcePath}'. If this assembly does not contain any Functions extensions, this message can be ignored. Exception message: {ex.Message}");
                         }
                         catch (Exception ex)
                         {
@@ -81,44 +74,97 @@ namespace ExtensionsMetadataGenerator
             return json;
         }
 
-        public static bool IsWebJobsStartupAttributeType(Type attributeType)
+        public static bool IsWebJobsStartupAttributeType(TypeReference attributeType, ConsoleLogger logger)
         {
-            Type currentType = attributeType;
+            TypeReference currentAttributeType = attributeType;
 
-            while (currentType != null)
+            while (currentAttributeType != null)
             {
-                if (string.Equals(currentType.FullName, WebJobsStartupAttributeType, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(currentAttributeType.FullName, WebJobsStartupAttributeType, StringComparison.OrdinalIgnoreCase))
                 {
                     return true;
                 }
 
-                currentType = currentType.BaseType;
+                try
+                {
+                    currentAttributeType = currentAttributeType.Resolve()?.BaseType;
+                }
+                catch (FileNotFoundException ex)
+                {
+                    // Don't log this as an error. This will almost always happen due to some publishing artifacts (i.e. Razor) existing
+                    // in the functions bin folder without all of their dependencies present. These will almost never have Functions extensions,
+                    // so we don't want to write out errors every time there is a build. This message can be seen with detailed logging enabled.
+                    string attributeTypeName = GetReflectionFullName(attributeType);
+                    string fileName = Path.GetFileName(attributeType.Module.FileName);
+                    logger.LogMessage($"Could not determine whether the attribute type '{attributeTypeName}' used in the assembly '{fileName}' derives from '{WebJobsStartupAttributeType}' because the assembly defining its base type could not be found. Exception message: {ex.Message}");
+                    return false;
+                }
             }
 
             return false;
         }
 
-        public static IEnumerable<ExtensionReference> GenerateExtensionReferences(Assembly assembly)
+        public static IEnumerable<ExtensionReference> GenerateExtensionReferences(string fileName, ConsoleLogger logger)
         {
-            var startupAttributes = assembly.GetCustomAttributes()
-                .Where(a => IsWebJobsStartupAttributeType(a.GetType()));
+            BaseAssemblyResolver resolver = new DefaultAssemblyResolver();
+            resolver.AddSearchDirectory(Path.GetDirectoryName(fileName));
+
+            ReaderParameters readerParams = new ReaderParameters { AssemblyResolver = resolver };
+
+            AssemblyDefinition assembly = AssemblyDefinition.ReadAssembly(fileName, readerParams);
+
+            var startupAttributes = assembly.Modules.SelectMany(p => p.GetCustomAttributes())
+                .Where(a => IsWebJobsStartupAttributeType(a.AttributeType, logger));
 
             List<ExtensionReference> extensionReferences = new List<ExtensionReference>();
             foreach (var attribute in startupAttributes)
             {
-                var nameProperty = attribute.GetType().GetProperty("Name");
-                var typeProperty = attribute.GetType().GetProperty("WebJobsStartupType");
+                var typeProperty = attribute.ConstructorArguments.ElementAtOrDefault(0);
+                var nameProperty = attribute.ConstructorArguments.ElementAtOrDefault(1);
+
+                TypeDefinition typeDef = (TypeDefinition)typeProperty.Value;
+                string assemblyQualifiedName = Assembly.CreateQualifiedName(typeDef.Module.Assembly.FullName, GetReflectionFullName(typeDef));
+
+                string name = GetName((string)nameProperty.Value, typeDef);
 
                 var extensionReference = new ExtensionReference
                 {
-                    Name = (string)nameProperty.GetValue(attribute),
-                    TypeName = ((Type)typeProperty.GetValue(attribute)).AssemblyQualifiedName
+                    Name = name,
+                    TypeName = assemblyQualifiedName
                 };
 
                 extensionReferences.Add(extensionReference);
             }
 
             return extensionReferences;
+        }
+
+        // Because we're now using static analysis we can't rely on the constructor running. Copying the constructor logic from:
+        // https://github.com/Azure/azure-webjobs-sdk/blob/dev/src/Microsoft.Azure.WebJobs.Host/Hosting/WebJobsStartupAttribute.cs#L33-L47.
+        private static string GetName(string name, TypeDefinition startupTypeDef)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                // for a startup class named 'CustomConfigWebJobsStartup' or 'CustomConfigStartup',
+                // default to a name 'CustomConfig'
+                name = startupTypeDef.Name;
+                int idx = name.IndexOf("WebJobsStartup");
+                if (idx < 0)
+                {
+                    idx = name.IndexOf("Startup");
+                }
+                if (idx > 0)
+                {
+                    name = name.Substring(0, idx);
+                }
+            }
+
+            return name;
+        }
+
+        public static string GetReflectionFullName(TypeReference typeRef)
+        {
+            return typeRef.FullName.Replace("/", "+");
         }
     }
 }

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/Program.cs
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/Program.cs
@@ -2,17 +2,11 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.IO;
-using System.Reflection;
-using System.Runtime.Loader;
-using System.Threading;
 
 namespace ExtensionsMetadataGenerator.Console
 {
     public class Program
     {
-        private static readonly Assembly _thisAssembly = typeof(Program).Assembly;
-
         public static void Main(string[] args)
         {
             if (args.Length < 2)
@@ -28,72 +22,12 @@ namespace ExtensionsMetadataGenerator.Console
 
             try
             {
-                AssemblyLoader.Initialize(sourcePath, logger);
                 ExtensionsMetadataGenerator.Generate(sourcePath, args[1], logger);
             }
             catch (Exception ex)
             {
                 logger.LogError("Error generating extension metadata: " + ex.ToString());
                 throw;
-            }
-        }
-
-        private class AssemblyLoader
-        {
-            private static int _initialized;
-
-            public static void Initialize(string basePath, ConsoleLogger logger)
-            {
-                if (Interlocked.CompareExchange(ref _initialized, 1, 0) == 0)
-                {
-                    AppDomain.CurrentDomain.AssemblyResolve += (sender, args) =>
-                    {
-                        logger.LogMessage($"Resolving assembly: '{args.Name}'");
-
-                        try
-                        {
-                            string assemblyName = new AssemblyName(args.Name).Name;
-                            string assemblyPath = Path.Combine(basePath, assemblyName + ".dll");
-
-                            // This indicates a recursive lookup. Abort here to prevent stack overflow.
-                            if (args.RequestingAssembly == _thisAssembly)
-                            {
-                                logger.LogMessage($"Cannot load '{assemblyName}'. Aborting assembly resolution.");
-                                return null;
-                            }
-
-                            if (File.Exists(assemblyPath))
-                            {
-                                Assembly assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
-                                logger.LogMessage($"Assembly '{assemblyName}' loaded from '{assemblyPath}'.");
-                                return assembly;
-                            }
-
-                            try
-                            {
-                                // If the assembly file is not found, it may be a runtime assembly for a different
-                                // runtime version (i.e. the Function app assembly targets .NET Core 2.2, yet this
-                                // process is running 2.0). In that case, just try to return the currently-loaded assembly,
-                                // even if it's the wrong version; we won't be running it, just reflecting.
-                                Assembly assembly = Assembly.Load(assemblyName);
-                                logger.LogMessage($"Assembly '{assemblyName}' loaded.");
-                                return assembly;
-                            }
-                            catch (Exception ex)
-                            {
-                                // We'll already log an error if this happens; this gives a little more details if debug is enabled.
-                                logger.LogMessage($"Unable to find fallback for assembly '{assemblyName}'. {ex}");
-                            }
-
-                            return null;
-                        }
-                        catch (Exception ex)
-                        {
-                            logger.LogError($"Error resolving assembly '{args.Name}': {ex}");
-                            throw;
-                        }
-                    };
-                }
             }
         }
     }

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.csproj
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\metadatagenerator.props" />
   <PropertyGroup>
-    <Version>1.1.2</Version>
+    <Version>1.2.0</Version>
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <AssemblyName>Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator</AssemblyName>

--- a/tools/ExtensionsMetadataGenerator/test/TestProject_Razor/Startup.cs
+++ b/tools/ExtensionsMetadataGenerator/test/TestProject_Razor/Startup.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Hosting;
+using TestProject_Razor;
+
+[assembly: WebJobsStartup(typeof(Startup))]
+
+namespace TestProject_Razor
+{
+    public class Startup : IWebJobsStartup
+    {
+        public void Configure(IWebJobsBuilder builder)
+        {
+        }
+    }
+}

--- a/tools/ExtensionsMetadataGenerator/test/TestProject_Razor/TestProject_Razor.csproj
+++ b/tools/ExtensionsMetadataGenerator/test/TestProject_Razor/TestProject_Razor.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Moves us away from using Reflection completely in the EMG, which helps in a number of scenarios where dependent assemblies do not exist in the bin folder.

This is needed for v3 but it should apply to v1 and v2 as well. Getting it out for discussion.