### PR TITLE
Fixing gRPC script to work w/ paths containing spaces

### DIFF
--- a/src/WebJobs.Script.Grpc/generate_protos.bat
+++ b/src/WebJobs.Script.Grpc/generate_protos.bat
@@ -34,7 +34,7 @@ setlocal
 @rem enter Script.Rpc directory
 cd /d %~dp0
 
-set NUGET_PATH=%UserProfile%\.nuget\packages
+set NUGET_PATH="%UserProfile%\.nuget\packages"
 set GRPC_TOOLS_PATH=%NUGET_PATH%\grpc.tools\1.20.1\tools\windows_x86
 set PROTO_PATH=.\azure-functions-language-worker-protobuf\src\proto
 set PROTO=.\azure-functions-language-worker-protobuf\src\proto\FunctionRpc.proto


### PR DESCRIPTION
`generate_protos.bat` doesn't work if there are spaces in the path.