### PR TITLE
Use managedDependencyOptions only in JobHost scope

### DIFF
--- a/WebJobs.Script.sln
+++ b/WebJobs.Script.sln
@@ -288,6 +288,17 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HttpTrigger", "HttpTrigger"
 		sample\HttpWorker\HttpTrigger\function.json = sample\HttpWorker\HttpTrigger\function.json
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "powershell", "powershell", "{FA3EB27D-D1C1-4AE0-A928-CF3882D929CD}"
+	ProjectSection(SolutionItems) = preProject
+		sample\PowerShell\host.json = sample\PowerShell\host.json
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HttpTrigger", "HttpTrigger", "{EA8288BA-CB4D-4B9C-ADF8-F4B7C41466EF}"
+	ProjectSection(SolutionItems) = preProject
+		sample\PowerShell\HttpTrigger\function.json = sample\PowerShell\HttpTrigger\function.json
+		sample\PowerShell\HttpTrigger\run.ps1 = sample\PowerShell\HttpTrigger\run.ps1
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		test\WebJobs.Script.Tests.Shared\WebJobs.Script.Tests.Shared.projitems*{35c9ccb7-d8b6-4161-bb0d-bcfa7c6dcffb}*SharedItemsImports = 13
@@ -380,6 +391,8 @@ Global
 		{DCBE49B4-CE2C-4D44-8DD9-2B771343E1C6} = {34506711-9D66-41EF-BBA1-9A9DC1140209}
 		{908055D8-096D-49BA-850D-C96F676C1561} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
 		{120DC6B3-B4B0-4CA6-A1B6-13177EAE325B} = {908055D8-096D-49BA-850D-C96F676C1561}
+		{FA3EB27D-D1C1-4AE0-A928-CF3882D929CD} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
+		{EA8288BA-CB4D-4B9C-ADF8-F4B7C41466EF} = {FA3EB27D-D1C1-4AE0-A928-CF3882D929CD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {85400884-5FFD-4C27-A571-58CB3C8CAAC5}

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         internal Task InitializeJobhostLanguageWorkerChannelAsync(int attemptCount)
         {
-            var rpcWorkerChannel = _rpcWorkerChannelFactory.Create(_scriptOptions.RootScriptPath, _workerRuntime, _metricsLogger, attemptCount, _managedDependencyOptions);
+            var rpcWorkerChannel = _rpcWorkerChannelFactory.Create(_scriptOptions.RootScriptPath, _workerRuntime, _metricsLogger, attemptCount);
             rpcWorkerChannel.SetupFunctionInvocationBuffers(_functions);
             _jobHostLanguageWorkerChannelManager.AddChannel(rpcWorkerChannel);
             rpcWorkerChannel.StartWorkerProcessAsync().ContinueWith(workerInitTask =>
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                      if (workerInitTask.IsCompleted)
                      {
                          _logger.LogDebug("Adding jobhost language worker channel for runtime: {language}. workerId:{id}", _workerRuntime, rpcWorkerChannel.Id);
-                         rpcWorkerChannel.SendFunctionLoadRequests();
+                         rpcWorkerChannel.SendFunctionLoadRequests(_managedDependencyOptions.Value);
                          State = FunctionInvocationDispatcherState.Initialized;
                      }
                      else
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             _logger.LogDebug("Creating new webhost language worker channel for runtime:{workerRuntime}.", _workerRuntime);
             IRpcWorkerChannel workerChannel = await _webHostLanguageWorkerChannelManager.InitializeChannelAsync(_workerRuntime);
             workerChannel.SetupFunctionInvocationBuffers(_functions);
-            workerChannel.SendFunctionLoadRequests();
+            workerChannel.SendFunctionLoadRequests(_managedDependencyOptions.Value);
         }
 
         internal async void ShutdownWebhostLanguageWorkerChannels()
@@ -190,7 +190,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                             {
                                 IRpcWorkerChannel initializedLanguageWorkerChannel = await initializedLanguageWorkerChannelTask.Task;
                                 initializedLanguageWorkerChannel.SetupFunctionInvocationBuffers(_functions);
-                                initializedLanguageWorkerChannel.SendFunctionLoadRequests();
+                                initializedLanguageWorkerChannel.SendFunctionLoadRequests(_managedDependencyOptions.Value);
                             }
                             catch (Exception ex)
                             {

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             _jobHostLanguageWorkerChannelManager = jobHostLanguageWorkerChannelManager;
             _eventManager = eventManager;
             _workerConfigs = languageWorkerOptions.Value.WorkerConfigs;
-            _managedDependencyOptions = managedDependencyOptions;
+            _managedDependencyOptions = managedDependencyOptions ?? throw new ArgumentNullException(nameof(managedDependencyOptions));
             _logger = loggerFactory.CreateLogger<RpcFunctionInvocationDispatcher>();
             _rpcWorkerChannelFactory = rpcWorkerChannelFactory;
             _workerRuntime = _environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName);

--- a/src/WebJobs.Script/Workers/Rpc/IRpcWorkerChannel.cs
+++ b/src/WebJobs.Script/Workers/Rpc/IRpcWorkerChannel.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.ManagedDependencies;
 
 namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 {
@@ -19,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         void SetupFunctionInvocationBuffers(IEnumerable<FunctionMetadata> functions);
 
-        void SendFunctionLoadRequests();
+        void SendFunctionLoadRequests(ManagedDependencyOptions managedDependencyOptions);
 
         Task SendFunctionEnvironmentReloadRequest();
 

--- a/src/WebJobs.Script/Workers/Rpc/IRpcWorkerChannelFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/IRpcWorkerChannelFactory.cs
@@ -2,13 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
-using Microsoft.Azure.WebJobs.Script.ManagedDependencies;
-using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 {
     public interface IRpcWorkerChannelFactory
     {
-        IRpcWorkerChannel Create(string scriptRootPath, string language, IMetricsLogger metricsLogger, int attemptCount, IOptions<ManagedDependencyOptions> managedDependencyOptions = null);
+        IRpcWorkerChannel Create(string scriptRootPath, string language, IMetricsLogger metricsLogger, int attemptCount);
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerChannelFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerChannelFactory.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             _applicationHostOptions = applicationHostOptions;
         }
 
-        public IRpcWorkerChannel Create(string scriptRootPath, string runtime, IMetricsLogger metricsLogger, int attemptCount, IOptions<ManagedDependencyOptions> managedDependencyOptions = null)
+        public IRpcWorkerChannel Create(string scriptRootPath, string runtime, IMetricsLogger metricsLogger, int attemptCount)
         {
             var languageWorkerConfig = _workerConfigs.Where(c => c.Description.Language.Equals(runtime, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
             if (languageWorkerConfig == null)
@@ -50,8 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                          workerLogger,
                          metricsLogger,
                          attemptCount,
-                         _applicationHostOptions,
-                         managedDependencyOptions);
+                         _applicationHostOptions);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.ManagedDependencies;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.Options;
@@ -391,7 +392,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 new OptionsWrapper<LanguageWorkerOptions>(workerConfigOptions),
                 testWebHostLanguageWorkerChannelManager,
                 jobHostLanguageWorkerChannelManager,
-                null,
+                new OptionsWrapper<ManagedDependencyOptions>(new ManagedDependencyOptions()),
                 mockFunctionDispatcherLoadBalancer.Object);
         }
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerChannelTests.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         {
             _metricsLogger.ClearCollections();
             _workerChannel.SetupFunctionInvocationBuffers(GetTestFunctionsList("node"));
-            _workerChannel.SendFunctionLoadRequests();
+            _workerChannel.SendFunctionLoadRequests(null);
             var traces = _logger.GetLogMessages();
             var functionLoadLogs = traces.Where(m => string.Equals(m.FormattedMessage, _expectedLogMsg));
             AreExpectedMetricsGenerated();
@@ -212,7 +212,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.True(functions.First().Name == funcName);
 
             _workerChannel.SetupFunctionInvocationBuffers(functions);
-            _workerChannel.SendFunctionLoadRequests();
+            _workerChannel.SendFunctionLoadRequests(null);
             var traces = _logger.GetLogMessages();
             var functionLoadLogs = traces.Where(m => m.FormattedMessage?.Contains(_expectedLoadMsgPartial) ?? false);
             var t = functionLoadLogs.Last<LogMessage>().FormattedMessage;
@@ -301,7 +301,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 Name = "js1",
                 FunctionId = "TestFunctionId1"
             };
-            var functionLoadRequest = _workerChannel.GetFunctionLoadRequest(metadata);
+            var functionLoadRequest = _workerChannel.GetFunctionLoadRequest(metadata, null);
             Assert.False(functionLoadRequest.Metadata.IsProxy);
             FunctionMetadata proxyMetadata = new FunctionMetadata()
             {
@@ -310,7 +310,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 FunctionId = "TestFunctionId1",
                 IsProxy = true
             };
-            var proxyFunctionLoadRequest = _workerChannel.GetFunctionLoadRequest(proxyMetadata);
+            var proxyFunctionLoadRequest = _workerChannel.GetFunctionLoadRequest(proxyMetadata, null);
             Assert.True(proxyFunctionLoadRequest.Metadata.IsProxy);
         }
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannel.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannel.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.ManagedDependencies;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.Logging;
 
@@ -51,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _testLogger.LogInformation("SetupFunctionInvocationBuffers called");
         }
 
-        public void SendFunctionLoadRequests()
+        public void SendFunctionLoadRequests(ManagedDependencyOptions managedDependencies)
         {
             _testLogger.LogInformation("RegisterFunctions called");
         }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannelFactory.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannelFactory.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _throwOnProcessStartUp = throwOnProcessStartUp;
     }
 
-        public IRpcWorkerChannel Create(string scriptRootPath, string language, IMetricsLogger metricsLogger, int attemptCount, IOptions<ManagedDependencyOptions> managedDependencyOptions = null)
+        public IRpcWorkerChannel Create(string scriptRootPath, string language, IMetricsLogger metricsLogger, int attemptCount)
         {
             return new TestRpcWorkerChannel(Guid.NewGuid().ToString(), language, _eventManager, _testLogger, throwOnProcessStartUp: _throwOnProcessStartUp);
         }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
@@ -319,7 +319,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
         private IRpcWorkerChannel CreateTestChannel(string language)
         {
-            var testChannel = _rpcWorkerChannelFactory.Create(_scriptRootPath, language, null, 0, null);
+            var testChannel = _rpcWorkerChannelFactory.Create(_scriptRootPath, language, null, 0);
             _rpcWorkerChannelManager.AddOrUpdateWorkerChannels(language, testChannel);
             _rpcWorkerChannelManager.SetInitializedWorkerChannel(language, testChannel);
             return testChannel;


### PR DESCRIPTION
This change is need to enable Powershell language worker in placeholder mode. Powershell language worker channel needs to be created without ManagedDependencyOptions at application level.


