### PR TITLE
[pack]Update check for InStanbyMode.

### DIFF
--- a/src/WebJobs.Script.WebHost/App_Start/WebHostResolver.cs
+++ b/src/WebJobs.Script.WebHost/App_Start/WebHostResolver.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 // Determine whether we should do normal or standby initialization
                 if (!WebScriptHostManager.InStandbyMode)
                 {
-                    EncureInitializedNonStandbyMode(settings);
+                    EnsureInitializedNonStandbyMode(settings);
                 }
                 else
                 {
@@ -170,7 +170,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
         }
 
-        private void EncureInitializedNonStandbyMode(WebHostSettings settings)
+        private void EnsureInitializedNonStandbyMode(WebHostSettings settings)
         {
             try
             {

--- a/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostManager.cs
@@ -148,7 +148,18 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 {
                     return true;
                 }
-
+                if (ScriptSettingsManager.Instance.GetSetting(EnvironmentSettingNames.AzureWebsitePlaceholderMode) != null)
+                {
+                    // These environment variables are set by DWAS at during specialization.
+                    // Note: All three varaibles might not get set at the same time.
+                    // Each of these gets set during different phases of specialization
+                    if (!(ScriptSettingsManager.Instance.GetSetting(EnvironmentSettingNames.AzureWebsitePlaceholderMode) == "0"
+                        && ScriptSettingsManager.Instance.GetSetting(EnvironmentSettingNames.AzureWebsiteContainerReady) == "1"
+                        && ScriptSettingsManager.Instance.GetSetting(EnvironmentSettingNames.AzureWebsiteConfigurationReady) == "1"))
+                    {
+                        return true;
+                    }
+                }
                 // no longer standby mode
                 _standbyMode = false;
 

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyModeTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyModeTests.cs
@@ -46,6 +46,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Assert.Equal(true, WebScriptHostManager.InStandbyMode);
 
                 _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+                Assert.Equal(true, WebScriptHostManager.InStandbyMode);
+
+                _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
+                Assert.Equal(true, WebScriptHostManager.InStandbyMode);
+
+                _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsiteConfigurationReady, "1");
                 Assert.Equal(false, WebScriptHostManager.InStandbyMode);
 
                 // test only set one way

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyModeTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyModeTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-        public void InStandbyMode_ReturnsExpectedValue()
+        public void InStandbyMode_ReturnsExpectedValue_AzureWebsitePlaceholderMode_Set()
         {
             using (new TestEnvironment())
             {
@@ -44,13 +44,33 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
                 Assert.Equal(true, WebScriptHostManager.InStandbyMode);
+            }
+        }
 
+        [Fact]
+        public void InStandbyMode_ReturnsExpectedValue_AzureWebsiteContainerReady_Set()
+        {
+            using (new TestEnvironment())
+            {
                 _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
-                Assert.Equal(true, WebScriptHostManager.InStandbyMode);
-
                 _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
                 Assert.Equal(true, WebScriptHostManager.InStandbyMode);
+            }
+        }
 
+        [Fact]
+        public void InStandbyMode_ReturnsExpectedValue()
+        {
+            using (new TestEnvironment())
+            {
+                // initially false
+                Assert.Equal(false, WebScriptHostManager.InStandbyMode);
+            }
+
+            using (new TestEnvironment())
+            {
+                _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+                _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
                 _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsiteConfigurationReady, "1");
                 Assert.Equal(false, WebScriptHostManager.InStandbyMode);
 
@@ -99,6 +119,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
                 var settings = GetWebHostSettings();
                 _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+                _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsiteConfigurationReady, "1");
+                _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
+
                 Assert.False(WebScriptHostManager.InStandbyMode);
                 _webHostResolver.EnsureInitialized(settings);
 
@@ -200,6 +223,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             private string _home;
             private string _prevHome;
             private string _prevPlaceholderMode;
+            private string _prevConfigurationReady;
+            private string _prevContainerReady;
             private string _prevInstanceId;
 
             public TestEnvironment()
@@ -207,6 +232,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 _settingsManager = ScriptSettingsManager.Instance;
                 _prevHome = _settingsManager.GetSetting(EnvironmentSettingNames.AzureWebsiteHomePath);
                 _prevPlaceholderMode = _settingsManager.GetSetting(EnvironmentSettingNames.AzureWebsitePlaceholderMode);
+                _prevConfigurationReady = _settingsManager.GetSetting(EnvironmentSettingNames.AzureWebsiteConfigurationReady);
+                _prevContainerReady = _settingsManager.GetSetting(EnvironmentSettingNames.AzureWebsiteContainerReady);
                 _prevInstanceId = _settingsManager.GetSetting(EnvironmentSettingNames.AzureWebsiteInstanceId);
 
                 _home = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -223,6 +250,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsiteHomePath, _prevHome);
                 _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsiteInstanceId, _prevInstanceId);
                 _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsitePlaceholderMode, _prevPlaceholderMode);
+                _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsiteConfigurationReady, _prevConfigurationReady);
+                _settingsManager.SetSetting(EnvironmentSettingNames.AzureWebsiteContainerReady, _prevContainerReady);
+
                 try
                 {
                     Directory.Delete(_home, recursive: true);


### PR DESCRIPTION
Fixes #5265

When detecting standby mode or not, should check for all the three environment variables responsible for specialization:
- WEBSITE_PLACEHOLDER_MODE should be set to `0` . This can happen as soon as the specialization starts
- WEBSITE_CONTAINER_READY should be set to '1'. This is set after user conten is downloaded
- WEBSITE_CONFIGURATION_READY should be set to '1'. This is set after users AppSettings are injected via HttpRequest module. **Note this V1 only setting.**

Not waiting for all the three environment variables results in incorrect initialization of the customer app