### PR TITLE
[pack] allowing ExtensionsMetadataGenerator to roll forward to .NET Core 3.0 if 2.0 is not found

### DIFF
--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/runtimeconfig.template.json
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+  "rollForward": "Major"
+}

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.csproj
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\metadatagenerator.props" />
   <PropertyGroup>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <AssemblyName>Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator</AssemblyName>


### PR DESCRIPTION
Fixes #5307

Using ["rollForward": "Major"](https://github.com/dotnet/designs/blob/master/accepted/runtime-binding.md#major-version-selection----opt-in-behavior-using-configuration-knobs) to allow dotnet to use the 3.0 shared framework if 2.0 is not found.

