### PR TITLE
Rpc http cookie behavior on V3

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -38,6 +38,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.7.0" />
     <PackageReference Include="Grpc.Core" Version="1.20.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.10120001-f33e57bd" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.5.2-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.0.0" />

--- a/src/WebJobs.Script/Workers/Rpc/MessageExtensions/RpcMessageExtensionUtilities.cs
+++ b/src/WebJobs.Script/Workers/Rpc/MessageExtensions/RpcMessageExtensionUtilities.cs
@@ -57,10 +57,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 cookieOptions.Secure = cookie.Secure.Value;
             }
 
-            if (TryGetRpcSameSiteEnumConverter(cookie.SameSite, out SameSiteMode sameSiteMode))
-            {
-                cookieOptions.SameSite = sameSiteMode;
-            }
+            cookieOptions.SameSite = RpcSameSiteEnumConverter(cookie.SameSite);
 
             if (cookie.HttpOnly != null)
             {
@@ -80,21 +77,18 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             return new Tuple<string, string, CookieOptions>(cookie.Name, cookie.Value, cookieOptions);
         }
 
-        private static bool TryGetRpcSameSiteEnumConverter(RpcHttpCookie.Types.SameSite sameSite, out SameSiteMode sameSiteMode)
+        private static SameSiteMode RpcSameSiteEnumConverter(RpcHttpCookie.Types.SameSite sameSite)
         {
-            sameSiteMode = SameSiteMode.None;
             switch (sameSite)
             {
                 case RpcHttpCookie.Types.SameSite.Strict:
-                    sameSiteMode = SameSiteMode.Strict;
-                    return true;
+                    return SameSiteMode.Strict;
                 case RpcHttpCookie.Types.SameSite.Lax:
-                    sameSiteMode = SameSiteMode.Lax;
-                    return true;
+                    return SameSiteMode.Lax;
                 case RpcHttpCookie.Types.SameSite.None:
-                    return false;
+                    return (SameSiteMode)(-1);
                 default:
-                    return false;
+                    return (SameSiteMode)(-1);
             }
         }
     }

--- a/src/WebJobs.Script/Workers/Rpc/MessageExtensions/RpcMessageExtensionUtilities.cs
+++ b/src/WebJobs.Script/Workers/Rpc/MessageExtensions/RpcMessageExtensionUtilities.cs
@@ -86,9 +86,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 case RpcHttpCookie.Types.SameSite.Lax:
                     return SameSiteMode.Lax;
                 case RpcHttpCookie.Types.SameSite.None:
-                    return SameSiteMode.None;
+                    return SameSiteMode.Unspecified;
                 default:
-                    return SameSiteMode.None;
+                    return SameSiteMode.Unspecified;
             }
         }
     }

--- a/src/WebJobs.Script/Workers/Rpc/MessageExtensions/RpcMessageExtensionUtilities.cs
+++ b/src/WebJobs.Script/Workers/Rpc/MessageExtensions/RpcMessageExtensionUtilities.cs
@@ -86,9 +86,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 case RpcHttpCookie.Types.SameSite.Lax:
                     return SameSiteMode.Lax;
                 case RpcHttpCookie.Types.SameSite.None:
-                    return (SameSiteMode)(-1);
+                    return SameSiteMode.Unspecified;
                 default:
-                    return (SameSiteMode)(-1);
+                    return SameSiteMode.Unspecified;
             }
         }
     }

--- a/src/WebJobs.Script/Workers/Rpc/MessageExtensions/RpcMessageExtensionUtilities.cs
+++ b/src/WebJobs.Script/Workers/Rpc/MessageExtensions/RpcMessageExtensionUtilities.cs
@@ -57,7 +57,10 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 cookieOptions.Secure = cookie.Secure.Value;
             }
 
-            cookieOptions.SameSite = RpcSameSiteEnumConverter(cookie.SameSite);
+            if (TryGetRpcSameSiteEnumConverter(cookie.SameSite, out SameSiteMode sameSiteMode))
+            {
+                cookieOptions.SameSite = sameSiteMode;
+            }
 
             if (cookie.HttpOnly != null)
             {
@@ -77,18 +80,21 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             return new Tuple<string, string, CookieOptions>(cookie.Name, cookie.Value, cookieOptions);
         }
 
-        private static SameSiteMode RpcSameSiteEnumConverter(RpcHttpCookie.Types.SameSite sameSite)
+        private static bool TryGetRpcSameSiteEnumConverter(RpcHttpCookie.Types.SameSite sameSite, out SameSiteMode sameSiteMode)
         {
+            sameSiteMode = SameSiteMode.None;
             switch (sameSite)
             {
                 case RpcHttpCookie.Types.SameSite.Strict:
-                    return SameSiteMode.Strict;
+                    sameSiteMode = SameSiteMode.Strict;
+                    return true;
                 case RpcHttpCookie.Types.SameSite.Lax:
-                    return SameSiteMode.Lax;
+                    sameSiteMode = SameSiteMode.Lax;
+                    return true;
                 case RpcHttpCookie.Types.SameSite.None:
-                    return SameSiteMode.Unspecified;
+                    return false;
                 default:
-                    return SameSiteMode.Unspecified;
+                    return false;
             }
         }
     }

--- a/test/WebJobs.Script.Tests/Binding/ActionResults/RawScriptResultTests.cs
+++ b/test/WebJobs.Script.Tests/Binding/ActionResults/RawScriptResultTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Binding.ActionResults
                         Path = "/",
                         HttpOnly = true,
                         MaxAge = TimeSpan.FromSeconds(20),
-                        SameSite = (SameSiteMode)(-1)
+                        SameSite = SameSiteMode.Unspecified
                     })
                 }
             };

--- a/test/WebJobs.Script.Tests/Binding/ActionResults/RawScriptResultTests.cs
+++ b/test/WebJobs.Script.Tests/Binding/ActionResults/RawScriptResultTests.cs
@@ -61,13 +61,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Binding.ActionResults
                 {
                     new Tuple<string, string, CookieOptions>("firstCookie", "cookieValue", new CookieOptions()
                     {
-                        SameSite = SameSiteMode.None
+                        SameSite = SameSiteMode.Lax
                     }),
                     new Tuple<string, string, CookieOptions>("secondCookie", "cookieValue2", new CookieOptions()
                     {
                         Path = "/",
                         HttpOnly = true,
-                        MaxAge = TimeSpan.FromSeconds(20)
+                        MaxAge = TimeSpan.FromSeconds(20),
+                        SameSite = (SameSiteMode)(-1)
                     })
                 }
             };
@@ -78,7 +79,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Binding.ActionResults
             context.HttpContext.Response.Headers.TryGetValue("Set-Cookie", out StringValues cookies);
 
             Assert.Equal(2, cookies.Count);
-            Assert.Equal("firstCookie=cookieValue; path=/; samesite=none", cookies[0]);
+            Assert.Equal("firstCookie=cookieValue; path=/; samesite=lax", cookies[0]);
             // TODO: https://github.com/Azure/azure-functions-host/issues/4890
             Assert.Equal("secondCookie=cookieValue2; max-age=20; path=/; httponly", cookies[1]);
         }


### PR DESCRIPTION
Prevents break but doesn't take full advantage of "samesite=none"

Complete fix here:
https://github.com/Azure/azure-functions-nodejs-worker/pull/270

Addresses:
https://github.com/Azure/azure-functions-host/issues/4890
