### PR TITLE
Add support for Excluded/Included types for App insights sampling

### DIFF
--- a/src/WebJobs.Script/Config/ApplicationInsightsLoggerOptionsSetup.cs
+++ b/src/WebJobs.Script/Config/ApplicationInsightsLoggerOptionsSetup.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             // IConfiguration will cause the SnapshotConfiguration to be created and the TelemetryProcessor to be applied.
             _configuration.Bind(options);
 
-            ApplySamplingIsEnabled(options);
+            ApplySamplingSettings(options);
 
             string quickPulseKey = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AppInsightsQuickPulseAuthApiKey);
             if (!string.IsNullOrEmpty(quickPulseKey))
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             }
         }
 
-        private void ApplySamplingIsEnabled(ApplicationInsightsLoggerOptions options)
+        private void ApplySamplingSettings(ApplicationInsightsLoggerOptions options)
         {
             // Sampling settings do not have a built-in "IsEnabled" value, so we are making our own.
             string samplingPath = nameof(ApplicationInsightsLoggerOptions.SamplingSettings);
@@ -51,7 +51,12 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             if (!samplingEnabled)
             {
                 options.SamplingSettings = null;
+                return;
             }
+
+            // Excluded/Included types must be moved from SamplingSettings to their respective properties in logger options
+            options.SamplingExcludedTypes = _configuration.GetSection(samplingPath).GetValue<string>("ExcludedTypes", null);
+            options.SamplingIncludedTypes = _configuration.GetSection(samplingPath).GetValue<string>("IncludedTypes", null);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Configuration/ApplicationInsightsLoggerOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ApplicationInsightsLoggerOptionsSetupTests.cs
@@ -52,6 +52,33 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             setup.Configure(options);
 
             Assert.Null(options.SamplingSettings);
+            Assert.Null(options.SamplingExcludedTypes);
+            Assert.Null(options.SamplingIncludedTypes);
+        }
+
+        [Fact]
+        public void Configure_SamplingExcludedIncludedTypes_AppliesSettings()
+        {
+            string excludedTypes = "Dependency;Event";
+            string includedTypes = "PageView;Trace";
+
+            IConfiguration config = new ConfigurationBuilder()
+               .AddInMemoryCollection(new Dictionary<string, string>
+               {
+                   { $"{SamplingSettings}:MaxTelemetryItemsPerSecond", "25" },
+                   { $"{SamplingSettings}:IsEnabled", "true" },
+                   { $"{SamplingSettings}:ExcludedTypes", excludedTypes },
+                   { $"{SamplingSettings}:IncludedTypes", includedTypes },
+               })
+               .Build();
+
+            ApplicationInsightsLoggerOptionsSetup setup = new ApplicationInsightsLoggerOptionsSetup(new MockLoggerConfiguration(config), _environment);
+
+            ApplicationInsightsLoggerOptions options = new ApplicationInsightsLoggerOptions();
+            setup.Configure(options);
+
+            Assert.Equal(excludedTypes, options.SamplingExcludedTypes);
+            Assert.Equal(includedTypes, options.SamplingIncludedTypes);
         }
 
         [Fact]


### PR DESCRIPTION
Re-creating #4843 because I'm unable to re-open that PR.

Resolves #4753

This depends on these changes to work: Azure/azure-webjobs-sdk#2303, which should be fully checked in and consumed by the host at this point.