### PR TITLE
Host.json tracing for "durableTask"

### DIFF
--- a/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
@@ -49,7 +49,8 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             private static readonly string[] WellKnownHostJsonProperties = new[]
             {
                 "version", "functionTimeout", "functions", "http", "watchDirectories", "queues", "serviceBus",
-                "eventHub", "singleton", "logging", "aggregator", "healthMonitor", "extensionBundle", "managedDependencies"
+                "eventHub", "singleton", "logging", "aggregator", "healthMonitor", "extensionBundle", "managedDependencies",
+                "durableTask",
             };
 
             private readonly HostJsonFileConfigurationSource _configurationSource;


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-functions-host/issues/5422

The [durableTask section of host.json](https://docs.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-bindings#durable-functions-2-0-host-json) has a large number of settings that users can configure. We want these user-configured settings traced as-is to simplify debugging/supportability.

No secrets or PII are ever expected to be in this section, so it should be safe for tracing.