### PR TITLE
Additional storage e2e coverage

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/Storage/StorageEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Storage/StorageEndToEndTests.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Models;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.WindowsAzure.Storage.Queue;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Storage
+{
+    public class StorageEndToEndTests : IClassFixture<StorageEndToEndTests.StorageTestFixture>
+    {
+        private StorageTestFixture _fixture;
+
+        public StorageEndToEndTests(StorageTestFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task QueueTriggerToBlobRich()
+        {
+            var logs = _fixture.Host.GetScriptHostLogMessages();
+
+            string id = Guid.NewGuid().ToString();
+            string messageContent = string.Format("{{ \"id\": \"{0}\" }}", id);
+            CloudQueueMessage message = new CloudQueueMessage(messageContent);
+
+            await _fixture.TestQueue.AddMessageAsync(message);
+
+            var resultBlob = _fixture.TestOutputContainer.GetBlockBlobReference(id);
+            string result = await TestHelpers.WaitForBlobAndGetStringAsync(resultBlob);
+            Assert.Equal(TestHelpers.RemoveByteOrderMarkAndWhitespace(messageContent), TestHelpers.RemoveByteOrderMarkAndWhitespace(result));
+        }
+
+        public class StorageTestFixture : EndToEndTestFixture
+        {
+            public StorageTestFixture() : base(@"TestScripts\CSharp", "csharp", RpcWorkerConstants.DotNetLanguageWorkerName)
+            {
+            }
+
+            protected override ExtensionPackageReference[] GetExtensionsToInstall()
+            {
+                // This test fixture should use the most recent major version of the storage extension, so update this as required.
+                return new ExtensionPackageReference[]
+                {
+                    new ExtensionPackageReference
+                    {
+                        Id = "Microsoft.Azure.WebJobs.Extensions.Storage",
+                        Version = "3.0.10"
+                    }
+                };
+            }
+
+            public override void ConfigureScriptHost(IWebJobsBuilder webJobsBuilder)
+            {
+                webJobsBuilder.Services.Configure<ScriptJobHostOptions>(o =>
+                {
+                    o.Functions = new[]
+                    {
+                        "QueueTriggerToBlobRichTypes",
+                    };
+                });
+            }
+        }
+    }
+
+
+    public class StorageV9EndToEndTests : IClassFixture<StorageV9EndToEndTests.StorageReferenceTestFixture>
+    {
+        private EndToEndTestFixture _fixture;
+
+        public StorageV9EndToEndTests(StorageReferenceTestFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task CanUseStorageV9Types()
+        {
+            // The point of this test is to verify back compat behavior that a user can still #r and use storage v9 types in CSX, 
+            // regardless of whether the storage extension installed (and of what version)
+
+            string testData = Guid.NewGuid().ToString();
+
+            await _fixture.Host.BeginFunctionAsync("StorageReferenceV9", testData);
+
+            await TestHelpers.Await(() =>
+            {
+                // make sure the function executed successfully
+                var logs = _fixture.Host.GetScriptHostLogMessages();
+                return logs.Any(p => p.FormattedMessage != null && p.FormattedMessage.Contains(testData));
+            }, userMessageCallback: _fixture.Host.GetLog);
+        }
+
+        public class StorageReferenceTestFixture : EndToEndTestFixture
+        {
+            public StorageReferenceTestFixture() : base(@"TestScripts\CSharp", "csharp", RpcWorkerConstants.DotNetLanguageWorkerName)
+            {
+            }
+
+            protected override ExtensionPackageReference[] GetExtensionsToInstall()
+            {
+                // It is explicitly intended that this scenario has no package references
+                return new ExtensionPackageReference[]
+                {
+                };
+            }
+
+            public override void ConfigureScriptHost(IWebJobsBuilder webJobsBuilder)
+            {
+                webJobsBuilder.Services.Configure<ScriptJobHostOptions>(o =>
+                {
+                    o.Functions = new[]
+                    {
+                        "StorageReferenceV9",
+                    };
+                });
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/QueueTriggerToBlobRichTypes/function.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/QueueTriggerToBlobRichTypes/function.json
@@ -1,0 +1,16 @@
+﻿{
+  "bindings": [
+    {
+      "type": "queueTrigger",
+      "name": "input",
+      "queueName": "test-input-csharp",
+      "direction": "in"
+    },
+    {
+      "type": "blob",
+      "name": "output",
+      "direction": "inout",
+      "path": "test-output-csharp/{id}"
+    }
+  ]
+}

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/QueueTriggerToBlobRichTypes/run.csx
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/QueueTriggerToBlobRichTypes/run.csx
@@ -1,0 +1,16 @@
+﻿#r "Microsoft.WindowsAzure.Storage"
+using Microsoft.WindowsAzure.Storage.Blob;
+
+public static async Task Run(WorkItem input, CloudBlockBlob output, TraceWriter log)
+{
+    string json = string.Format("{{ \"id\": \"{0}\" }}", input.Id);
+
+    log.Info($"C# script processed queue message. Item={json}");
+    
+    await output.UploadTextAsync(json);
+}
+
+public class WorkItem
+{
+    public string Id { get; set; }
+}

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/StorageReferenceV9/function.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/StorageReferenceV9/function.json
@@ -1,0 +1,9 @@
+{
+  "bindings": [
+    {
+      "type": "manualTrigger",
+      "name": "input",
+      "direction": "in"
+    }
+  ]
+}

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/StorageReferenceV9/run.csx
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/StorageReferenceV9/run.csx
@@ -1,0 +1,10 @@
+﻿// Use storage v9
+#r "Microsoft.WindowsAzure.Storage"
+using Microsoft.WindowsAzure.Storage.Blob;
+
+public static void Run(string input, TraceWriter log)
+{
+    // it is enough to just reference the type - as long as compilation is successful, we're good
+    CloudBlockBlob blob;
+    log.Info(input);
+}


### PR DESCRIPTION
Adds some E2E test cases that will help with validating the storage upgrade (https://github.com/Azure/azure-functions-host/pull/5218)

- Test for csx #r storage v9 with no nuget reference (back compat)
- Test for storage rich type scenario