### PR TITLE
Fix compilation of WebJobs.Script.Grpc on macOS 10.15

### DIFF
--- a/src/WebJobs.Script.Grpc/generate_protos.sh
+++ b/src/WebJobs.Script.Grpc/generate_protos.sh
@@ -33,9 +33,14 @@
 
 # enter Script.Rpc directory
 
-echo "OS: $OSTYPE"
+ARCH=$(uname -m)
+echo "OS: $OSTYPE $ARCH"
 if [[ $OSTYPE == "darwin"* ]]; then
-     PLATFORM="macosx_x86"
+    if [[ $ARCH == "x86_64" ]]; then
+        PLATFORM="macosx_x64"
+    else
+        PLATFORM="macosx_x86"
+    fi
 elif [[ $OSTYPE == "linux"* ]];then
      PLATFORM="linux_x64"
 else


### PR DESCRIPTION
Support for 32-bit executables was dropped on macOS 10.15 (Catalina) so the 64-bit version of protoc must be used when running on a 64-bits machine.