### PR TITLE
Log DefaultWorkerPath when FUNCTIONS_WORKER_RUNTIME_VERSION is empty

### DIFF
--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
@@ -183,18 +183,19 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             OSPlatform os = systemRuntimeInformation.GetOSPlatform();
             Architecture architecture = systemRuntimeInformation.GetOSArchitecture();
             string version = environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName);
+            logger.LogDebug($"EnvironmentVariable {RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName}: {version}");
 
             if (!string.IsNullOrEmpty(version))
             {
                 DefaultRuntimeVersion = version;
             }
-            logger.LogDebug($"EnvironmentVariable {RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName}: {DefaultRuntimeVersion}");
 
             ValidateDefaultWorkerPathFormatters(systemRuntimeInformation);
 
             DefaultWorkerPath = DefaultWorkerPath.Replace(RpcWorkerConstants.OSPlaceholder, os.ToString())
                              .Replace(RpcWorkerConstants.ArchitecturePlaceholder, architecture.ToString())
                              .Replace(RpcWorkerConstants.RuntimeVersionPlaceholder, DefaultRuntimeVersion);
+            logger.LogDebug($"DefaultWorkerPath: {DefaultWorkerPath}");
         }
 
         internal bool ShouldFormatWorkerPath(string workerPath)

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
@@ -183,12 +183,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             OSPlatform os = systemRuntimeInformation.GetOSPlatform();
             Architecture architecture = systemRuntimeInformation.GetOSArchitecture();
             string version = environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName);
-            logger.LogDebug($"EnvironmentVariable {RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName}: {version}");
 
             if (!string.IsNullOrEmpty(version))
             {
                 DefaultRuntimeVersion = version;
             }
+            logger.LogDebug($"EnvironmentVariable {RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName}: {DefaultRuntimeVersion}");
 
             ValidateDefaultWorkerPathFormatters(systemRuntimeInformation);
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
@@ -391,7 +391,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var testLogger = new TestLogger("test");
             workerDescription.FormatWorkerPathIfNeeded(_testSysRuntimeInfo, _testEnvironment, testLogger);
             Assert.Collection(testLogger.GetLogMessages(),
-                p => Assert.Equal("EnvironmentVariable FUNCTIONS_WORKER_RUNTIME_VERSION: 3.6", p.FormattedMessage));
+                p => Assert.Equal("EnvironmentVariable FUNCTIONS_WORKER_RUNTIME_VERSION: ", p.FormattedMessage),
+                p => Assert.Equal("DefaultWorkerPath: 3.6/LINUX/X64", p.FormattedMessage));
         }
 
         [Theory]
@@ -439,7 +440,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             Assert.Equal(expectedPath, workerDescription.DefaultWorkerPath);
             Assert.Collection(testLogger.GetLogMessages(),
-                p => Assert.Equal("EnvironmentVariable FUNCTIONS_WORKER_RUNTIME_VERSION: 3.7", p.FormattedMessage));
+                p => Assert.Equal("EnvironmentVariable FUNCTIONS_WORKER_RUNTIME_VERSION: 3.7", p.FormattedMessage),
+                p => Assert.Equal($"DefaultWorkerPath: {expectedPath}", p.FormattedMessage));
         }
 
         [Theory]


### PR DESCRIPTION
Some workers do not have FUNCTIONS_WORKER_RUNTIME_VERSION setting (e.g. powershell), we still want to report the DefaultWorker path to give us a general information on which worker file is being used.