### PR TITLE
Warn when SCM_RUN_FROM_PACKAGE points to an empty location

### DIFF
--- a/src/WebJobs.Script.WebHost/Models/RunFromPackageContext.cs
+++ b/src/WebJobs.Script.WebHost/Models/RunFromPackageContext.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
 
             if (!exists)
             {
-                logger.LogWarning($"{EnvironmentSettingNames.ScmRunFromPackage} points to an empty location. Function app has no content.");
+                logger.LogWarning($"{EnvironmentVariableName} points to an empty location. Function app has no content.");
             }
 
             return exists;

--- a/src/WebJobs.Script.WebHost/Models/RunFromPackageContext.cs
+++ b/src/WebJobs.Script.WebHost/Models/RunFromPackageContext.cs
@@ -46,6 +46,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
                 }
             }, maxRetries: 2, retryInterval: TimeSpan.FromSeconds(0.3));
 
+            if (!exists)
+            {
+                logger.LogWarning($"{EnvironmentSettingNames.ScmRunFromPackage} points to an empty location. Function app has no content.");
+            }
+
             return exists;
         }
     }

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
@@ -222,6 +222,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             var logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
             Assert.Collection(logs,
+                p => Assert.StartsWith($"{EnvironmentSettingNames.ScmRunFromPackage} points to an empty location. Function app has no content.", p),
                 p => Assert.StartsWith("Starting Assignment", p),
                 p => Assert.StartsWith("Applying 1 app setting(s)", p),
                 p => Assert.StartsWith("Triggering specialization", p));

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
@@ -222,9 +222,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             var logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
             Assert.Collection(logs,
-                p => Assert.StartsWith($"{EnvironmentSettingNames.ScmRunFromPackage} points to an empty location. Function app has no content.", p),
                 p => Assert.StartsWith("Starting Assignment", p),
                 p => Assert.StartsWith("Applying 1 app setting(s)", p),
+                p => Assert.StartsWith($"{EnvironmentSettingNames.ScmRunFromPackage} points to an empty location. Function app has no content.", p),
                 p => Assert.StartsWith("Triggering specialization", p));
         }
 


### PR DESCRIPTION
SCM_RUN_FROM_PACKAGE is used by Linux Consumption for linking a function app blob URL.

We have an incident where a customer manually removes their Linux Consumption function app content from their storage account. We want to log this scenario.