### PR TITLE
Sanitize FUNCTIONS_WORKER_RUNTIME_VERSION value

### DIFF
--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
@@ -50,8 +50,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         /// <summary>
         /// Gets or sets the regex used for sanitizing the runtime version string.
         /// </summary>
-        [JsonProperty(PropertyName = "sanitizeRuntimeVersion")]
-        public string SanitizeRuntimeVersion { get; set; }
+        [JsonProperty(PropertyName = "sanitizeRuntimeVersionRegex")]
+        public string SanitizeRuntimeVersionRegex { get; set; }
 
         /// <summary>
         /// Gets or sets the supported file extension type. Functions are registered with workers based on extension.
@@ -217,15 +217,15 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         private string GetSanitizedRuntimeVersion(string version)
         {
-            if (string.IsNullOrEmpty(SanitizeRuntimeVersion))
+            if (string.IsNullOrEmpty(SanitizeRuntimeVersionRegex))
             {
                 return version;
             }
 
-            var match = new Regex(SanitizeRuntimeVersion).Match(version);
+            var match = new Regex(SanitizeRuntimeVersionRegex).Match(version);
             if (!match.Success)
             {
-                throw new NotSupportedException($"Version {version} for language {Language} does not match the regular expression '{SanitizeRuntimeVersion}'");
+                throw new NotSupportedException($"Version {version} for language {Language} does not match the regular expression '{SanitizeRuntimeVersionRegex}'");
             }
 
             return match.Value;

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
@@ -376,7 +376,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 DefaultExecutablePath = "python",
                 DefaultWorkerPath = defaultWorkerPath,
                 DefaultRuntimeVersion = "3.6",
-                SanitizeRuntimeVersion = sanitizeRuntimeVersionRegex,
+                SanitizeRuntimeVersionRegex = sanitizeRuntimeVersionRegex,
                 SupportedArchitectures = new List<string>() { Architecture.X64.ToString(), Architecture.X86.ToString() },
                 SupportedRuntimeVersions = new List<string>() { "3.6", "3.7" },
                 SupportedOperatingSystems = new List<string>()
@@ -443,7 +443,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 Extensions = new List<string>() { ".py" },
                 Language = "python",
                 DefaultRuntimeVersion = "3.6",
-                SanitizeRuntimeVersion = sanitizeRuntimeVersionRegex
+                SanitizeRuntimeVersionRegex = sanitizeRuntimeVersionRegex
             };
             var configBuilder = ScriptSettingsManager.CreateDefaultConfigurationBuilder()
                   .AddInMemoryCollection(new Dictionary<string, string>
@@ -577,7 +577,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 Arguments = new List<string>(),
                 DefaultExecutablePath = "python",
                 SupportedRuntimeVersions = new List<string>() { "3.6", "3.7" },
-                SanitizeRuntimeVersion = sanitizeRuntimeVersionRegex,
+                SanitizeRuntimeVersionRegex = sanitizeRuntimeVersionRegex,
                 DefaultWorkerPath = $"{RpcWorkerConstants.RuntimeVersionPlaceholder}/worker.py",
                 WorkerDirectory = string.Empty,
                 Extensions = new List<string>() { ".py" },

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
@@ -357,12 +357,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Theory]
-        [InlineData("%FUNCTIONS_WORKER_RUNTIME_VERSION%/{os}/{architecture}", "3.7/LINUX/X64")]
-        [InlineData("%FUNCTIONS_WORKER_RUNTIME_VERSION%/{architecture}", "3.7/X64")]
-        [InlineData("%FUNCTIONS_WORKER_RUNTIME_VERSION%/{os}", "3.7/LINUX")]
-        public void LanguageWorker_FormatWorkerPath_EnvironmentVersionSet(string defaultWorkerPath, string expectedPath)
+        [InlineData("%FUNCTIONS_WORKER_RUNTIME_VERSION%/{os}/{architecture}", "3.7", null, "3.7/LINUX/X64")]
+        [InlineData("%FUNCTIONS_WORKER_RUNTIME_VERSION%/{architecture}", "3.7", null, "3.7/X64")]
+        [InlineData("%FUNCTIONS_WORKER_RUNTIME_VERSION%/{os}", "3.7", null, "3.7/LINUX")]
+        [InlineData("%FUNCTIONS_WORKER_RUNTIME_VERSION%", "~3.7", "[\\d\\.]+", "3.7")]
+        [InlineData("%FUNCTIONS_WORKER_RUNTIME_VERSION%", " 3.7 ", "[\\d\\.]+", "3.7")]
+        public void LanguageWorker_FormatWorkerPath_EnvironmentVersionSet(
+            string defaultWorkerPath,
+            string environmentRuntimeVersion,
+            string sanitizeRuntimeVersionRegex,
+            string expectedPath)
         {
-            _testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName, "3.7");
+            _testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName, environmentRuntimeVersion);
 
             RpcWorkerDescription workerDescription = new RpcWorkerDescription()
             {
@@ -370,6 +376,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 DefaultExecutablePath = "python",
                 DefaultWorkerPath = defaultWorkerPath,
                 DefaultRuntimeVersion = "3.6",
+                SanitizeRuntimeVersion = sanitizeRuntimeVersionRegex,
                 SupportedArchitectures = new List<string>() { Architecture.X64.ToString(), Architecture.X86.ToString() },
                 SupportedRuntimeVersions = new List<string>() { "3.6", "3.7" },
                 SupportedOperatingSystems = new List<string>()
@@ -400,8 +407,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             };
 
             Assert.Equal(expectedPath, workerDescription.DefaultWorkerPath);
-            Assert.Collection(testLogger.GetLogMessages(),
-                p => Assert.Equal("EnvironmentVariable FUNCTIONS_WORKER_RUNTIME_VERSION: 3.7", p.FormattedMessage));
+
+            var expectedLogMessage = string.Format($"EnvironmentVariable FUNCTIONS_WORKER_RUNTIME_VERSION: {environmentRuntimeVersion}");
+            Assert.Collection(testLogger.GetLogMessages(), p => Assert.Equal(expectedLogMessage, p.FormattedMessage));
         }
 
         [Theory]
@@ -547,8 +555,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.Equal(ex.Message, $"Version {workerDescription.DefaultRuntimeVersion} is not supported for language {workerDescription.Language}");
         }
 
-        [Fact]
-        public void LanguageWorker_FormatWorkerPath_UnsupportedEnvironmentRuntimeVersion()
+        [Theory]
+        [InlineData(null, "Version 3.4 is not supported for language python")]
+        [InlineData("[\\d\\.]+", "Version 3.4 is not supported for language python")]
+        [InlineData("[\\d]+", "Version 3 is not supported for language python")]
+        [InlineData("[A-Z]+", "Version 3.4 for language python does not match the regular expression '[A-Z]+'")]
+        public void LanguageWorker_FormatWorkerPath_UnsupportedEnvironmentRuntimeVersion(
+            string sanitizeRuntimeVersionRegex,
+            string expectedExceptionMessage)
         {
             _testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName, "3.4");
 
@@ -557,6 +571,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 Arguments = new List<string>(),
                 DefaultExecutablePath = "python",
                 SupportedRuntimeVersions = new List<string>() { "3.6", "3.7" },
+                SanitizeRuntimeVersion = sanitizeRuntimeVersionRegex,
                 DefaultWorkerPath = $"{RpcWorkerConstants.RuntimeVersionPlaceholder}/worker.py",
                 WorkerDirectory = string.Empty,
                 Extensions = new List<string>() { ".py" },
@@ -573,7 +588,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var testLogger = new TestLogger("test");
 
             var ex = Assert.Throws<NotSupportedException>(() => workerDescription.FormatWorkerPathIfNeeded(_testSysRuntimeInfo, _testEnvironment, testLogger));
-            Assert.Equal(ex.Message, $"Version 3.4 is not supported for language {workerDescription.Language}");
+            Assert.Equal(ex.Message, expectedExceptionMessage);
         }
 
         private IEnumerable<RpcWorkerConfig> TestReadWorkerProviderFromConfig(IEnumerable<TestRpcWorkerConfig> configs, ILogger testLogger, TestMetricsLogger testMetricsLogger, string language = null, Dictionary<string, string> keyValuePairs = null, bool appSvcEnv = false)

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
@@ -413,10 +413,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Theory]
-        [InlineData("%FUNCTIONS_WORKER_RUNTIME_VERSION%/{os}/{architecture}", "3.6/LINUX/X64")]
-        [InlineData("%FUNCTIONS_WORKER_RUNTIME_VERSION%/{architecture}", "3.6/X64")]
-        [InlineData("%FUNCTIONS_WORKER_RUNTIME_VERSION%/{os}", "3.6/LINUX")]
-        public void LanguageWorker_FormatWorkerPath_EnvironmentVersionNotSet(string defaultWorkerPath, string expectedPath)
+        [InlineData("%FUNCTIONS_WORKER_RUNTIME_VERSION%/{os}/{architecture}", null, "3.6/LINUX/X64")]
+        [InlineData("%FUNCTIONS_WORKER_RUNTIME_VERSION%/{architecture}", null, "3.6/X64")]
+        [InlineData("%FUNCTIONS_WORKER_RUNTIME_VERSION%/{os}", null, "3.6/LINUX")]
+        [InlineData("%FUNCTIONS_WORKER_RUNTIME_VERSION%/{os}", "", "3.6/LINUX")]
+        [InlineData("%FUNCTIONS_WORKER_RUNTIME_VERSION%/{os}", "[\\d\\.]+", "3.6/LINUX")]
+        public void LanguageWorker_FormatWorkerPath_EnvironmentVersionNotSet(
+            string defaultWorkerPath,
+            string sanitizeRuntimeVersionRegex,
+            string expectedPath)
         {
             // We fall back to the default version when this is not set
             // Environment.SetEnvironmentVariable(LanguageWorkerConstants.FunctionWorkerRuntimeVersionSettingName, "3.7");
@@ -437,7 +442,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 WorkerDirectory = string.Empty,
                 Extensions = new List<string>() { ".py" },
                 Language = "python",
-                DefaultRuntimeVersion = "3.6"
+                DefaultRuntimeVersion = "3.6",
+                SanitizeRuntimeVersion = sanitizeRuntimeVersionRegex
             };
             var configBuilder = ScriptSettingsManager.CreateDefaultConfigurationBuilder()
                   .AddInMemoryCollection(new Dictionary<string, string>


### PR DESCRIPTION
We need this for PowerShell worker now. We expect the FUNCTIONS_WORKER_RUNTIME_VERSION values coming from Antares to look like `~6` or `~7`. We want to map this value to the worker path, but we want to avoid the `~` character in folder names.

After this change, worker authors will be able to specify transformation rules in the worker config file by providing a regular expression in the optional **sanitizeRuntimeVersion** property, like this:

``` json
{
    "description":{
        "language":"powershell",
        "defaultWorkerPath":"%FUNCTIONS_WORKER_RUNTIME_VERSION%/PowerShellWorker.dll",
        "supportedRuntimeVersions":["6", "7"],
        "defaultRuntimeVersion":"6",
        "sanitizeRuntimeVersion":"\\d+"
    }
}
```

As a result, the first match of this regular expression in FUNCTIONS_WORKER_RUNTIME_VERSION will be used instead of the original FUNCTIONS_WORKER_RUNTIME_VERSION.