### PR TITLE
Do not pass cmd params when starting HttpWorker

### DIFF
--- a/src/WebJobs.Script/Workers/Http/HttpWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpWorkerConstants.cs
@@ -12,5 +12,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
 
         // Child Process Env vars
         public const string PortEnvVarName = "FUNCTIONS_HTTPWORKER_PORT";
+        public const string WorkerIdEnvVarName = "FUNCTIONS_HTTPWORKER_ID";
     }
 }

--- a/src/WebJobs.Script/Workers/Http/HttpWorkerContext.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpWorkerContext.cs
@@ -12,7 +12,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
 
         public override string GetFormattedArguments()
         {
-           return $" --workerId {WorkerId} --port {Port}";
+            // Ensure parsing cmd args is not required by httpworker
+            return string.Empty;
         }
     }
 }

--- a/src/WebJobs.Script/Workers/Http/HttpWorkerProcess.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpWorkerProcess.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
                 Port = _httpWorkerOptions.Port
             };
             workerContext.EnvironmentVariables.Add(HttpWorkerConstants.PortEnvVarName, _httpWorkerOptions.Port.ToString());
+            workerContext.EnvironmentVariables.Add(HttpWorkerConstants.WorkerIdEnvVarName, _workerId);
             return _processFactory.CreateWorkerProcess(workerContext);
         }
 

--- a/test/WebJobs.Script.Tests/Workers/Http/HttpWorkerProcessTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Http/HttpWorkerProcessTests.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
                 Process childProcess = httpWorkerProcess.CreateWorkerProcess();
                 Assert.NotNull(childProcess.StartInfo.EnvironmentVariables);
                 Assert.Equal(childProcess.StartInfo.EnvironmentVariables[HttpWorkerConstants.PortEnvVarName], _workerPort.ToString());
+                Assert.Equal(childProcess.StartInfo.EnvironmentVariables[HttpWorkerConstants.WorkerIdEnvVarName], _testWorkerId);
                 childProcess.Dispose();
             }
         }


### PR DESCRIPTION
Fixes #5541 

Starting HttpWorker with command line params requires users of few runtimes  to parse cmd args even though values are not needed. Passing any values as environment variables is a better approach