### PR TITLE
Update PowerShell Worker to v2.0.215

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.8100001-0126c21e" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.5.2-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="1.0.197" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="2.0.215" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.15-11684" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.5" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.6" />


### PR DESCRIPTION
Changes in this release:

- Upgraded to PowerShell [6.2.4](https://github.com/PowerShell/PowerShell/releases/tag/v6.2.4).
- Minor internal improvements.

For more information, please see https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v2.0.215.