### PR TITLE
Update PowerShell Worker to v3.0.216

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.11020001-fabe022e" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.5.2-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.0.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker" Version="1.0.201" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.216" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.15" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.5" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.6" />


### PR DESCRIPTION
Changes in this release:

- Upgraded to PowerShell [6.2.4](https://github.com/PowerShell/PowerShell/releases/tag/v6.2.4).
- Minor internal improvements.

For more information, please see https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.216.