### PR TITLE
Start Context Cache support

### DIFF
--- a/WebJobs.Script.sln
+++ b/WebJobs.Script.sln
@@ -297,6 +297,17 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HttpTrigger", "HttpTrigger"
 		sample\PowerShell\HttpTrigger\run.ps1 = sample\PowerShell\HttpTrigger\run.ps1
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Python", "Python", "{0AE3CE25-4CD9-4769-AE58-399FC59CF70F}"
+	ProjectSection(SolutionItems) = preProject
+		sample\Python\host.json = sample\Python\host.json
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HttpTrigger", "HttpTrigger", "{BA45A727-34B7-484F-9B93-B1755AF09A2A}"
+	ProjectSection(SolutionItems) = preProject
+		sample\Python\HttpTrigger\__init__.py = sample\Python\HttpTrigger\__init__.py
+		sample\Python\HttpTrigger\function.json = sample\Python\HttpTrigger\function.json
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		test\WebJobs.Script.Tests.Shared\WebJobs.Script.Tests.Shared.projitems*{35c9ccb7-d8b6-4161-bb0d-bcfa7c6dcffb}*SharedItemsImports = 13
@@ -386,6 +397,8 @@ Global
 		{120DC6B3-B4B0-4CA6-A1B6-13177EAE325B} = {908055D8-096D-49BA-850D-C96F676C1561}
 		{FA3EB27D-D1C1-4AE0-A928-CF3882D929CD} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
 		{EA8288BA-CB4D-4B9C-ADF8-F4B7C41466EF} = {FA3EB27D-D1C1-4AE0-A928-CF3882D929CD}
+		{0AE3CE25-4CD9-4769-AE58-399FC59CF70F} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
+		{BA45A727-34B7-484F-9B93-B1755AF09A2A} = {0AE3CE25-4CD9-4769-AE58-399FC59CF70F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {85400884-5FFD-4C27-A571-58CB3C8CAAC5}

--- a/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerInitializationHostService.cs
+++ b/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerInitializationHostService.cs
@@ -19,13 +19,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
         private readonly IEnvironment _environment;
         private readonly IInstanceManager _instanceManager;
         private readonly ILogger _logger;
+        private readonly StartupContextProvider _startupContextProvider;
         private CancellationToken _cancellationToken;
 
-        public LinuxContainerInitializationHostService(IEnvironment environment, IInstanceManager instanceManager, ILogger<LinuxContainerInitializationHostService> logger)
+        public LinuxContainerInitializationHostService(IEnvironment environment, IInstanceManager instanceManager, ILogger<LinuxContainerInitializationHostService> logger, StartupContextProvider startupContextProvider)
         {
             _environment = environment;
             _instanceManager = instanceManager;
             _logger = logger;
+            _startupContextProvider = startupContextProvider;
         }
 
         public async Task StartAsync(CancellationToken cancellationToken)
@@ -33,14 +35,34 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
             _logger.LogInformation("Initializing LinuxContainerInitializationService.");
             _cancellationToken = cancellationToken;
 
-            // The service should be registered in IsLinuxContainerEnvironment only. But do additional check here.
+            // The service should be registered in Linux Consumption only, but do additional check here.
             if (_environment.IsLinuxConsumption())
             {
-                await ApplyContextIfPresent();
+                await ApplyStartContextIfPresent();
             }
         }
 
-        private async Task ApplyContextIfPresent()
+        private async Task ApplyStartContextIfPresent()
+        {
+            var startContext = await GetStartContextOrNullAsync();
+
+            if (!string.IsNullOrEmpty(startContext))
+            {
+                _logger.LogInformation("Applying host context");
+
+                var encryptedAssignmentContext = JsonConvert.DeserializeObject<EncryptedHostAssignmentContext>(startContext);
+                var assignmentContext = _startupContextProvider.SetContext(encryptedAssignmentContext);
+
+                bool success = _instanceManager.StartAssignment(assignmentContext, false);
+                _logger.LogInformation($"StartAssignment invoked (Success={success})");
+            }
+            else
+            {
+                _logger.LogInformation("No host context specified. Waiting for host assignment");
+            }
+        }
+
+        private async Task<string> GetStartContextOrNullAsync()
         {
             var startContext = _environment.GetEnvironmentVariable(EnvironmentSettingNames.ContainerStartContext);
 
@@ -61,26 +83,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
                 _logger.LogInformation("Host context specified via CONTAINER_START_CONTEXT");
             }
 
-            if (!string.IsNullOrEmpty(startContext))
-            {
-                _logger.LogInformation("Applying host context");
-
-                var encryptedAssignmentContext = JsonConvert.DeserializeObject<EncryptedHostAssignmentContext>(startContext);
-                var containerKey = _environment.GetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey);
-                var assignmentContext = encryptedAssignmentContext.Decrypt(containerKey);
-                if (_instanceManager.StartAssignment(assignmentContext, false))
-                {
-                    _logger.LogInformation("Start assign HostAssignmentContext success");
-                }
-                else
-                {
-                    _logger.LogError("Start assign HostAssignmentContext failed");
-                }
-            }
-            else
-            {
-                _logger.LogInformation("No host context specified. Waiting for host assignment");
-            }
+            return startContext;
         }
 
         private async Task<string> GetAssignmentContextFromSasUri(string sasUri)

--- a/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
@@ -22,12 +22,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         private readonly IEnvironment _environment;
         private readonly IInstanceManager _instanceManager;
         private readonly ILogger _logger;
+        private readonly StartupContextProvider _startupContextProvider;
 
-        public InstanceController(IEnvironment environment, IInstanceManager instanceManager, ILoggerFactory loggerFactory)
+        public InstanceController(IEnvironment environment, IInstanceManager instanceManager, ILoggerFactory loggerFactory, StartupContextProvider startupContextProvider)
         {
             _environment = environment;
             _instanceManager = instanceManager;
             _logger = loggerFactory.CreateLogger<InstanceController>();
+            _startupContextProvider = startupContextProvider;
         }
 
         [HttpPost]
@@ -36,30 +38,36 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         public async Task<IActionResult> Assign([FromBody] EncryptedHostAssignmentContext encryptedAssignmentContext)
         {
             _logger.LogDebug($"Starting container assignment for host : {Request?.Host}. ContextLength is: {encryptedAssignmentContext.EncryptedContext?.Length}");
-            var containerKey = _environment.GetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey);
-            var assignmentContext = encryptedAssignmentContext.IsWarmup
-                ? null
-                : encryptedAssignmentContext.Decrypt(containerKey);
 
-            // before starting the assignment we want to perform as much
-            // up front validation on the context as possible
-            string error = await _instanceManager.ValidateContext(assignmentContext, encryptedAssignmentContext.IsWarmup);
-            if (error != null)
+            bool succeeded = false;
+            if (!encryptedAssignmentContext.IsWarmup)
             {
-                return StatusCode(StatusCodes.Status400BadRequest, error);
+                var assignmentContext = _startupContextProvider.SetContext(encryptedAssignmentContext);
+
+                // before starting the assignment we want to perform as much
+                // up front validation on the context as possible
+                string error = await _instanceManager.ValidateContext(assignmentContext, encryptedAssignmentContext.IsWarmup);
+                if (error != null)
+                {
+                    return StatusCode(StatusCodes.Status400BadRequest, error);
+                }
+
+                // Wait for Sidecar specialization to complete before returning ok.
+                // This shouldn't take too long so ok to do this sequentially.
+                error = await _instanceManager.SpecializeMSISidecar(assignmentContext, encryptedAssignmentContext.IsWarmup);
+                if (error != null)
+                {
+                    return StatusCode(StatusCodes.Status500InternalServerError, error);
+                }
+
+                succeeded = _instanceManager.StartAssignment(assignmentContext, encryptedAssignmentContext.IsWarmup);
+            }
+            else
+            {
+                succeeded = true;
             }
 
-            // Wait for Sidecar specialization to complete before returning ok.
-            // This shouldn't take too long so ok to do this sequentially.
-            error = await _instanceManager.SpecializeMSISidecar(assignmentContext, encryptedAssignmentContext.IsWarmup);
-            if (error != null)
-            {
-                return StatusCode(StatusCodes.Status500InternalServerError, error);
-            }
-
-            var result = _instanceManager.StartAssignment(assignmentContext, encryptedAssignmentContext.IsWarmup);
-
-            return result || encryptedAssignmentContext.IsWarmup
+            return succeeded
                 ? Accepted()
                 : StatusCode(StatusCodes.Status409Conflict, "Instance already assigned");
         }

--- a/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             {
                 return null;
             }
+
             _logger.LogInformation($"Validating host assignment context (SiteId: {assignmentContext.SiteId}, SiteName: '{assignmentContext.SiteName}')");
             RunFromPackageContext pkgContext = assignmentContext.GetRunFromPkgContext();
             _logger.LogInformation($"Will be using {pkgContext.EnvironmentVariableName} app setting as zip url");

--- a/src/WebJobs.Script.WebHost/Middleware/FunctionInvocationMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/FunctionInvocationMiddleware.cs
@@ -38,15 +38,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
 
         public async Task Invoke(HttpContext context)
         {
-            // TODO: DI Need to make sure downstream services are getting what they need
-            // that includes proxies.
-            //if (scriptHost != null)
-            //{
-            //    // flow required context through the request pipeline
-            //    // downstream middleware and filters rely on this
-            //    context.Items[ScriptConstants.AzureFunctionsHostKey] = scriptHost;
-            //}
-
             if (_next != null)
             {
                 await _next(context);

--- a/src/WebJobs.Script.WebHost/Models/EncryptedHostAssignmentContext.cs
+++ b/src/WebJobs.Script.WebHost/Models/EncryptedHostAssignmentContext.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Azure.WebJobs.Script.WebHost.Security;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
@@ -14,20 +13,5 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
 
         [JsonProperty("isWarmup")]
         public bool IsWarmup { get; set; }
-
-        public static EncryptedHostAssignmentContext Create(HostAssignmentContext context, string key)
-        {
-            string json = JsonConvert.SerializeObject(context);
-            var encryptionKey = Convert.FromBase64String(key);
-            string encrypted = SimpleWebTokenHelper.Encrypt(json, encryptionKey);
-
-            return new EncryptedHostAssignmentContext { EncryptedContext = encrypted };
-        }
-
-        public HostAssignmentContext Decrypt(string key)
-        {
-            var decrypted = SimpleWebTokenHelper.Decrypt(key.ToKeyBytes(), EncryptedContext);
-            return JsonConvert.DeserializeObject<HostAssignmentContext>(decrypted);
-        }
     }
 }

--- a/src/WebJobs.Script.WebHost/Models/FunctionAppSecrets.cs
+++ b/src/WebJobs.Script.WebHost/Models/FunctionAppSecrets.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Script.WebHost.Management;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
+{
+    /// <summary>
+    /// Secrets cache format used by both <see cref="FunctionsSyncManager"/> and <see cref="StartupContextProvider"/>.
+    /// </summary>
+    public class FunctionAppSecrets
+    {
+        [JsonProperty("host")]
+        public HostSecrets Host { get; set; }
+
+        [JsonProperty("function")]
+        public FunctionSecrets[] Function { get; set; }
+
+        public class FunctionSecrets
+        {
+            [JsonProperty("name")]
+            public string Name { get; set; }
+
+            [JsonProperty("secrets")]
+            public IDictionary<string, string> Secrets { get; set; }
+        }
+
+        public class HostSecrets
+        {
+            [JsonProperty("master")]
+            public string Master { get; set; }
+
+            [JsonProperty("function")]
+            public IDictionary<string, string> Function { get; set; }
+
+            [JsonProperty("system")]
+            public IDictionary<string, string> System { get; set; }
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Models/HostAssignmentContext.cs
+++ b/src/WebJobs.Script.WebHost/Models/HostAssignmentContext.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
 {
@@ -30,6 +31,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
 
         [JsonProperty("EasyAuthSpecializationPayload")]
         public EasyAuthSettings EasyAuthSettings { get; set; }
+
+        [JsonProperty("Secrets")]
+        public FunctionAppSecrets Secrets { get; set; }
 
         public long? PackageContentLength { get; set; }
 

--- a/src/WebJobs.Script.WebHost/Security/Authentication/Keys/AuthenticationLevelHandler.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Keys/AuthenticationLevelHandler.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Authentication
             }
         }
 
-        internal static async Task<(string, AuthorizationLevel)> GetAuthorizationKeyInfoAsync(HttpRequest request, ISecretManagerProvider secretManagerProvider)
+        internal static Task<(string, AuthorizationLevel)> GetAuthorizationKeyInfoAsync(HttpRequest request, ISecretManagerProvider secretManagerProvider)
         {
             // first see if a key value is specified via headers or query string (header takes precedence)
             string keyValue = null;
@@ -97,53 +97,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Authentication
             if (!string.IsNullOrEmpty(keyValue))
             {
                 ISecretManager secretManager = secretManagerProvider.Current;
-
-                // see if the key specified is the master key
-                HostSecretsInfo hostSecrets = await secretManager.GetHostSecretsAsync().ConfigureAwait(false);
-                if (!string.IsNullOrEmpty(hostSecrets.MasterKey) &&
-                    Key.SecretValueEquals(keyValue, hostSecrets.MasterKey))
-                {
-                    return (ScriptConstants.DefaultMasterKeyName, AuthorizationLevel.Admin);
-                }
-
-                if (HasMatchingKey(hostSecrets.SystemKeys, keyValue, out string keyName))
-                {
-                    return (keyName, AuthorizationLevel.System);
-                }
-
-                // see if the key specified matches the host function key
-                if (HasMatchingKey(hostSecrets.FunctionKeys, keyValue, out keyName))
-                {
-                    return (keyName, AuthorizationLevel.Function);
-                }
-
-                // If there is a function specific key specified try to match against that
-                IFunctionExecutionFeature executionFeature = request.HttpContext.Features.Get<IFunctionExecutionFeature>();
-                if (executionFeature != null)
-                {
-                    IDictionary<string, string> functionSecrets = await secretManager.GetFunctionSecretsAsync(executionFeature.Descriptor.Name);
-                    if (HasMatchingKey(functionSecrets, keyValue, out keyName))
-                    {
-                        return (keyName, AuthorizationLevel.Function);
-                    }
-                }
+                var functionName = request.HttpContext.Features.Get<IFunctionExecutionFeature>()?.Descriptor.Name;
+                return secretManager.GetAuthorizationLevelOrNullAsync(keyValue, functionName);
             }
 
-            return (null, AuthorizationLevel.Anonymous);
-        }
-
-        private static bool HasMatchingKey(IDictionary<string, string> secrets, string keyValue, out string matchedKeyName)
-        {
-            matchedKeyName = null;
-            if (secrets == null)
-            {
-                return false;
-            }
-
-            string matchedValue;
-            (matchedKeyName, matchedValue) = secrets.FirstOrDefault(s => Key.SecretValueEquals(s.Value, keyValue));
-
-            return matchedValue != null;
+            return Task.FromResult<(string, AuthorizationLevel)>((null, AuthorizationLevel.Anonymous));
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/DefaultSecretManagerProvider.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/DefaultSecretManagerProvider.cs
@@ -22,10 +22,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         private readonly IConfiguration _configuration;
         private readonly IEnvironment _environment;
         private readonly HostNameProvider _hostNameProvider;
+        private readonly StartupContextProvider _startupContextProvider;
         private Lazy<ISecretManager> _secretManagerLazy;
 
         public DefaultSecretManagerProvider(IOptionsMonitor<ScriptApplicationHostOptions> options, IHostIdProvider hostIdProvider,
-            IConfiguration configuration, IEnvironment environment, ILoggerFactory loggerFactory, IMetricsLogger metricsLogger, HostNameProvider hostNameProvider)
+            IConfiguration configuration, IEnvironment environment, ILoggerFactory loggerFactory, IMetricsLogger metricsLogger, HostNameProvider hostNameProvider, StartupContextProvider startupContextProvider)
         {
             if (loggerFactory == null)
             {
@@ -37,6 +38,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
             _hostNameProvider = hostNameProvider ?? throw new ArgumentNullException(nameof(hostNameProvider));
+            _startupContextProvider = startupContextProvider ?? throw new ArgumentNullException(nameof(startupContextProvider));
 
             _loggerFactory = loggerFactory;
             _metricsLogger = metricsLogger ?? throw new ArgumentNullException(nameof(metricsLogger));
@@ -50,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         private void ResetSecretManager() => Interlocked.Exchange(ref _secretManagerLazy, new Lazy<ISecretManager>(Create));
 
-        private ISecretManager Create() => new SecretManager(CreateSecretsRepository(), _loggerFactory.CreateLogger<SecretManager>(), _metricsLogger, _hostNameProvider);
+        private ISecretManager Create() => new SecretManager(CreateSecretsRepository(), _loggerFactory.CreateLogger<SecretManager>(), _metricsLogger, _hostNameProvider, _startupContextProvider);
 
         internal ISecretsRepository CreateSecretsRepository()
         {

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/ISecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/ISecretManager.cs
@@ -3,12 +3,21 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
 {
     public interface ISecretManager
     {
+        /// <summary>
+        /// Deterine the <see cref="AuthorizationLevel"/> for the specified key.
+        /// </summary>
+        /// <param name="key">The key to check.</param>
+        /// <param name="functionName">Optional function name, if we're authorizing a specific function.</param>
+        /// <returns>A key name, auth level pair.</returns>
+        Task<(string, AuthorizationLevel)> GetAuthorizationLevelOrNullAsync(string key, string functionName = null);
+
         /// <summary>
         /// Deletes a function secret.
         /// </summary>

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
@@ -12,7 +12,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.KeyVault.Models;
-using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Properties;
 using Microsoft.Extensions.Logging;
@@ -22,41 +22,41 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 {
     public class SecretManager : IDisposable, ISecretManager
     {
-        private readonly ConcurrentDictionary<string, Dictionary<string, string>> _secretsMap = new ConcurrentDictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
         private readonly IKeyValueConverterFactory _keyValueConverterFactory;
         private readonly ILogger _logger;
         private readonly ISecretsRepository _repository;
         private readonly HostNameProvider _hostNameProvider;
+        private readonly StartupContextProvider _startupContextProvider;
+        private ConcurrentDictionary<string, IDictionary<string, string>> _functionSecrets;
         private HostSecretsInfo _hostSecrets;
         private SemaphoreSlim _hostSecretsLock = new SemaphoreSlim(1, 1);
         private IMetricsLogger _metricsLogger;
         private string _repositoryClassName;
+        private DateTime _lastCacheResetTime;
 
         // for testing
         public SecretManager()
         {
         }
 
-        public SecretManager(ISecretsRepository repository, ILogger logger, IMetricsLogger metricsLogger, HostNameProvider hostNameProvider, bool createHostSecretsIfMissing = false)
-            : this(repository, new DefaultKeyValueConverterFactory(repository.IsEncryptionSupported), logger, metricsLogger, hostNameProvider, createHostSecretsIfMissing)
+        public SecretManager(ISecretsRepository repository, ILogger logger, IMetricsLogger metricsLogger, HostNameProvider hostNameProvider, StartupContextProvider startupContextProvider)
+            : this(repository, new DefaultKeyValueConverterFactory(repository.IsEncryptionSupported), logger, metricsLogger, hostNameProvider, startupContextProvider)
         {
         }
 
-        public SecretManager(ISecretsRepository repository, IKeyValueConverterFactory keyValueConverterFactory, ILogger logger, IMetricsLogger metricsLogger, HostNameProvider hostNameProvider, bool createHostSecretsIfMissing = false)
+        public SecretManager(ISecretsRepository repository, IKeyValueConverterFactory keyValueConverterFactory, ILogger logger, IMetricsLogger metricsLogger, HostNameProvider hostNameProvider, StartupContextProvider startupContextProvider)
         {
-            _repository = repository;
-            _keyValueConverterFactory = keyValueConverterFactory;
-            _repository.SecretsChanged += OnSecretsChanged;
-            _logger = logger;
+            _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+            _keyValueConverterFactory = keyValueConverterFactory ?? throw new ArgumentNullException(nameof(keyValueConverterFactory));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _metricsLogger = metricsLogger ?? throw new ArgumentNullException(nameof(metricsLogger));
-            _repositoryClassName = _repository.GetType().Name.ToLower();
-            _hostNameProvider = hostNameProvider;
+            _hostNameProvider = hostNameProvider ?? throw new ArgumentNullException(nameof(hostNameProvider));
+            _startupContextProvider = startupContextProvider ?? throw new ArgumentNullException(nameof(startupContextProvider));
 
-            if (createHostSecretsIfMissing)
-            {
-                // GetHostSecrets will create host secrets if not present
-                GetHostSecretsAsync().GetAwaiter().GetResult();
-            }
+            _repositoryClassName = _repository.GetType().Name.ToLower();
+            _repository.SecretsChanged += OnSecretsChanged;
+
+            InitializeCache();
         }
 
         public void Dispose()
@@ -80,13 +80,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             {
                 if (_hostSecrets == null)
                 {
-                    HostSecrets hostSecrets;
-                    // Allow only one thread to modify the secrets
                     await _hostSecretsLock.WaitAsync();
+
+                    HostSecrets hostSecrets;
                     try
                     {
-                        hostSecrets = await LoadSecretsAsync<HostSecrets>();
+                        _logger.LogDebug($"Loading host secrets");
 
+                        hostSecrets = await LoadSecretsAsync<HostSecrets>();
                         if (hostSecrets == null)
                         {
                             // host secrets do not yet exist so generate them
@@ -104,7 +105,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                         catch (CryptographicException ex)
                         {
                             string message = string.Format(Resources.TraceNonDecryptedHostSecretRefresh, ex);
-                            _logger?.LogDebug(message);
+                            _logger.LogDebug(message);
                             await PersistSecretsAsync(hostSecrets, null, true);
                             hostSecrets = GenerateHostSecrets(hostSecrets);
                             await RefreshSecretsAsync(hostSecrets);
@@ -145,11 +146,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 }
 
                 functionName = functionName.ToLowerInvariant();
-                Dictionary<string, string> functionSecrets;
-                _secretsMap.TryGetValue(functionName, out functionSecrets);
 
-                if (functionSecrets == null)
+                if (!_functionSecrets.TryGetValue(functionName, out IDictionary<string, string> functionSecrets))
                 {
+                    _logger.LogDebug($"Loading secrets for function '{functionName}'");
+
                     FunctionSecrets secrets = await LoadFunctionSecretsAsync(functionName);
                     if (secrets == null)
                     {
@@ -169,7 +170,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     catch (CryptographicException ex)
                     {
                         string message = string.Format(Resources.TraceNonDecryptedFunctionSecretRefresh, functionName, ex);
-                        _logger?.LogDebug(message);
+                        _logger.LogDebug(message);
                         await PersistSecretsAsync(secrets, functionName, true);
                         secrets = GenerateFunctionSecrets(secrets);
                         await RefreshSecretsAsync(secrets, functionName);
@@ -181,19 +182,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                         await RefreshSecretsAsync(secrets, functionName);
                     }
 
-                    Dictionary<string, string> result = secrets.Keys.ToDictionary(s => s.Name, s => s.Value);
-
-                    functionSecrets = _secretsMap.AddOrUpdate(functionName, result, (n, r) => result);
+                    var result = secrets.Keys.ToDictionary(s => s.Name, s => s.Value);
+                    functionSecrets = _functionSecrets.AddOrUpdate(functionName, result, (n, r) => result);
                 }
 
                 if (merged)
                 {
                     // If merged is true, we combine function specific keys with host level function keys,
                     // prioritizing function specific keys
-                    HostSecretsInfo hostSecrets = await GetHostSecretsAsync();
-                    Dictionary<string, string> hostFunctionSecrets = hostSecrets.FunctionKeys;
-
-                    functionSecrets = functionSecrets.Union(hostFunctionSecrets.Where(s => !functionSecrets.ContainsKey(s.Key)))
+                    var hostSecrets = await GetHostSecretsAsync();
+                    functionSecrets = functionSecrets.Union(hostSecrets.FunctionKeys.Where(s => !functionSecrets.ContainsKey(s.Key)))
                         .ToDictionary(kv => kv.Key, kv => kv.Value);
                 }
 
@@ -380,7 +378,89 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         private async Task<ScriptSecrets> LoadSecretsAsync(ScriptSecretsType type, string keyScope)
         {
-            return await _repository.ReadAsync(type, keyScope).ConfigureAwait(false);
+            return await _repository.ReadAsync(type, keyScope);
+        }
+
+        public async Task<(string, AuthorizationLevel)> GetAuthorizationLevelOrNullAsync(string keyValue, string functionName = null)
+        {
+            if (keyValue != null)
+            {
+                // Before authorizing, check the cache load state. Do this first because checking the auth level will
+                // cause the secrets to be loaded into cache - we want to know if they were cached BEFORE this check.
+                bool secretsCached = _hostSecrets != null || _functionSecrets.Any();
+
+                var result = await GetAuthorizationLevelAsync(this, keyValue, functionName);
+                if (result.Item2 != AuthorizationLevel.Anonymous)
+                {
+                    // key match
+                    return result;
+                }
+                else
+                {
+                    // A key was presented but there wasn't a match. If we used cached key values,
+                    // reset cache and try once more.
+                    // We throttle resets, to ensure invalid requests can't force us to slam storage.
+                    if (secretsCached && ((DateTime.UtcNow - _lastCacheResetTime) > TimeSpan.FromMinutes(1)))
+                    {
+                        _hostSecrets = null;
+                        _functionSecrets.Clear();
+                        _lastCacheResetTime = DateTime.UtcNow;
+
+                        return await GetAuthorizationLevelAsync(this, keyValue, functionName);
+                    }
+                }
+            }
+
+            // no key match
+            return (null, AuthorizationLevel.Anonymous);
+        }
+
+        internal static async Task<(string, AuthorizationLevel)> GetAuthorizationLevelAsync(ISecretManager secretManager, string keyValue, string functionName = null)
+        {
+            // see if the key specified is the master key
+            HostSecretsInfo hostSecrets = await secretManager.GetHostSecretsAsync();
+            if (!string.IsNullOrEmpty(hostSecrets.MasterKey) &&
+                Key.SecretValueEquals(keyValue, hostSecrets.MasterKey))
+            {
+                return (ScriptConstants.DefaultMasterKeyName, AuthorizationLevel.Admin);
+            }
+
+            if (HasMatchingKey(hostSecrets.SystemKeys, keyValue, out string keyName))
+            {
+                return (keyName, AuthorizationLevel.System);
+            }
+
+            // see if the key specified matches the host function key
+            if (HasMatchingKey(hostSecrets.FunctionKeys, keyValue, out keyName))
+            {
+                return (keyName, AuthorizationLevel.Function);
+            }
+
+            // If there is a function specific key specified try to match against that
+            if (functionName != null)
+            {
+                IDictionary<string, string> functionSecrets = await secretManager.GetFunctionSecretsAsync(functionName);
+                if (HasMatchingKey(functionSecrets, keyValue, out keyName))
+                {
+                    return (keyName, AuthorizationLevel.Function);
+                }
+            }
+
+            return (null, AuthorizationLevel.Anonymous);
+        }
+
+        private static bool HasMatchingKey(IDictionary<string, string> secrets, string keyValue, out string matchedKeyName)
+        {
+            matchedKeyName = null;
+            if (secrets == null)
+            {
+                return false;
+            }
+
+            string matchedValue;
+            (matchedKeyName, matchedValue) = secrets.FirstOrDefault(s => Key.SecretValueEquals(s.Value, keyValue));
+
+            return matchedValue != null;
         }
 
         private static ScriptSecretsType GetSecretsType<T>() where T : ScriptSecrets
@@ -531,23 +611,22 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         {
             // clear the cached secrets if they exist
             // they'll be reloaded on demand next time
-            if (secretsType == ScriptSecretsType.Host &&
-                _hostSecrets != null)
+            if (secretsType == ScriptSecretsType.Host && _hostSecrets != null)
             {
                 _logger.LogInformation("Host keys change detected. Clearing cache.");
                 _hostSecrets = null;
             }
             else
             {
-                if (!string.IsNullOrEmpty(functionName) && _secretsMap.ContainsKey(functionName))
+                if (!string.IsNullOrEmpty(functionName) && _functionSecrets.ContainsKey(functionName))
                 {
                     _logger.LogInformation($"Function keys change detected. Clearing cache for function '{functionName}'.");
-                    _secretsMap.TryRemove(functionName, out _);
+                    _functionSecrets.TryRemove(functionName, out _);
                 }
-                else if (_secretsMap.Any())
+                else if (_functionSecrets.Any())
                 {
                     _logger.LogInformation("Function keys change detected. Clearing all cached function keys.");
-                    _secretsMap.Clear();
+                    _functionSecrets.Clear();
                 }
             }
         }
@@ -604,6 +683,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         private string GetFunctionName(string keyScope, ScriptSecretsType secretsType)
         {
             return (secretsType == ScriptSecretsType.Function) ? keyScope : null;
+        }
+
+        private void InitializeCache()
+        {
+            var cachedFunctionSecrets = _startupContextProvider.GetFunctionSecretsOrNull();
+            _functionSecrets = cachedFunctionSecrets != null ?
+                new ConcurrentDictionary<string, IDictionary<string, string>>(cachedFunctionSecrets, StringComparer.OrdinalIgnoreCase) :
+                new ConcurrentDictionary<string, IDictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
+
+            _hostSecrets = _startupContextProvider.GetHostSecretsOrNull();
         }
 
         private string GetEncryptionKeysHashes()

--- a/src/WebJobs.Script.WebHost/StartupContextProvider.cs
+++ b/src/WebJobs.Script.WebHost/StartupContextProvider.cs
@@ -1,0 +1,159 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost
+{
+    /// <summary>
+    /// Class used for startup optimization, to provide access to values required at startup from
+    /// efficient cache, rather than requiring external fetch operations.
+    /// </summary>
+    public class StartupContextProvider
+    {
+        private readonly IEnvironment _environment;
+        private readonly ILogger _logger;
+        private readonly object _syncLock = new object();
+        private bool _loaded = false;
+        private StartupContext _startupContext;
+
+        public StartupContextProvider(IEnvironment environment, ILogger<StartupContextProvider> logger)
+        {
+            _environment = environment ?? throw new ArgumentNullException(nameof(environment));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        internal StartupContext Context
+        {
+            get
+            {
+                // context is only loaded once on startup
+                if (!_loaded)
+                {
+                    lock (_syncLock)
+                    {
+                        if (!_loaded)
+                        {
+                            _startupContext = GetStartupContextOrNull();
+                            _loaded = true;
+                        }
+                    }
+                }
+                return _startupContext;
+            }
+
+            set
+            {
+                lock (_syncLock)
+                {
+                    _startupContext = value;
+                    _loaded = true;
+                }
+            }
+        }
+
+        public virtual HostSecretsInfo GetHostSecretsOrNull()
+        {
+            if (Context?.Secrets?.Host != null)
+            {
+                var hostSecrets = Context.Secrets.Host;
+                var secretsInfo = new HostSecretsInfo
+                {
+                    MasterKey = hostSecrets.Master,
+                    FunctionKeys = new Dictionary<string, string>(hostSecrets.Function, StringComparer.OrdinalIgnoreCase),
+                    SystemKeys = new Dictionary<string, string>(hostSecrets.System, StringComparer.OrdinalIgnoreCase)
+                };
+                _logger.LogDebug("Loaded host keys from startup context");
+
+                return secretsInfo;
+            }
+
+            return null;
+        }
+
+        public virtual IDictionary<string, IDictionary<string, string>> GetFunctionSecretsOrNull()
+        {
+            if (Context?.Secrets?.Function != null)
+            {
+                var functionKeys = Context.Secrets.Function.ToDictionary(p => p.Name, p => p.Secrets);
+
+                _logger.LogDebug($"Loaded keys for {functionKeys.Keys.Count} functions from startup context");
+
+                return functionKeys;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Load context from local file system if specified.
+        /// </summary>
+        /// <returns>The context.</returns>
+        private StartupContext GetStartupContextOrNull()
+        {
+            var contextPath = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteStartupContextCache);
+            if (!string.IsNullOrEmpty(contextPath))
+            {
+                try
+                {
+                    _logger.LogDebug($"Loading startup context from {contextPath}");
+                    string content = File.ReadAllText(contextPath);
+
+                    // Context files are onetime use. We delete after reading to ensure
+                    // that we don't use a stale file in the future if the app recycles, etc.
+                    // Dont' want to block on this file operation, so we kick it off in the background.
+                    Task.Run(() => File.Delete(contextPath));
+
+                    string decryptedContent = SimpleWebTokenHelper.Decrypt(content, environment: _environment);
+                    var context = JsonConvert.DeserializeObject<StartupContext>(decryptedContent);
+
+                    return context;
+                }
+                catch (Exception ex)
+                {
+                    // best effort
+                    _logger.LogError(ex, "Failed to load startup context");
+                    return null;
+                }
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Decrypt and deserialize the specified context, and apply values from it to the
+        /// startup cache context.
+        /// </summary>
+        /// <param name="encryptedContext">The encrypted assignment context.</param>
+        /// <returns>The decrypted assignment context</returns>
+        public virtual HostAssignmentContext SetContext(EncryptedHostAssignmentContext encryptedContext)
+        {
+            string decryptedContext = SimpleWebTokenHelper.Decrypt(encryptedContext.EncryptedContext, environment: _environment);
+            var hostAssignmentContext = JsonConvert.DeserializeObject<HostAssignmentContext>(decryptedContext);
+
+            // apply values from the context to our cached context
+            Context = new StartupContext
+            {
+                Secrets = hostAssignmentContext.Secrets
+            };
+
+            return hostAssignmentContext;
+        }
+
+        public class StartupContext
+        {
+            [JsonProperty("secrets")]
+            public FunctionAppSecrets Secrets { get; set; }
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -110,6 +110,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddSingleton<IWebFunctionsManager, WebFunctionsManager>();
             services.AddSingleton<IInstanceManager, InstanceManager>();
             services.AddSingleton(_ => new HttpClient());
+            services.AddSingleton<StartupContextProvider>();
             services.AddSingleton<HostNameProvider>();
             services.AddSingleton<IFileSystem>(_ => FileUtility.Instance);
             services.AddTransient<VirtualFileSystem>();
@@ -171,7 +172,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 {
                     var instanceManager = s.GetService<IInstanceManager>();
                     var logger = s.GetService<ILogger<LinuxContainerInitializationHostService>>();
-                    return new LinuxContainerInitializationHostService(environment, instanceManager, logger);
+                    var startupContextProvider = s.GetService<StartupContextProvider>();
+                    return new LinuxContainerInitializationHostService(environment, instanceManager, logger, startupContextProvider);
                 }
 
                 return NullHostedService.Instance;

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AzureFilesContentShare = "WEBSITE_CONTENTSHARE";
         public const string AzureWebsiteRuntimeSiteName = "WEBSITE_DEPLOYMENT_ID";
         public const string FunctionsRuntimeScaleMonitoringEnabled = "FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED";
+        public const string AzureWebsiteStartupContextCache = "WEBSITE_FUNCTIONS_STARTUPCONTEXT_CACHE";
 
         /// <summary>
         /// Environment variable dynamically set by the platform when it is safe to

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
@@ -53,10 +53,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 });
 
             var instanceManager = new InstanceManager(_optionsFactory, new HttpClient(handlerMock.Object), scriptWebEnvironment, environment, loggerFactory.CreateLogger<InstanceManager>(), new TestMetricsLogger(), null);
+            var startupContextProvider = new StartupContextProvider(environment, loggerFactory.CreateLogger<StartupContextProvider>());
 
             InstanceManager.Reset();
 
-            var instanceController = new InstanceController(environment, instanceManager, loggerFactory);
+            var instanceController = new InstanceController(environment, instanceManager, loggerFactory, startupContextProvider);
 
             const string containerEncryptionKey = "/a/vXvWJ3Hzgx4PFxlDUJJhQm5QVyGiu0NNLFm/ZMMg=";
             var hostAssignmentContext = new HostAssignmentContext
@@ -92,8 +93,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             var loggerProvider = new TestLoggerProvider();
             loggerFactory.AddProvider(loggerProvider);
 
-            var instanceController = new InstanceController(environment, null, loggerFactory);
-
+            var startupContextProvider = new StartupContextProvider(environment, loggerFactory.CreateLogger<StartupContextProvider>());
+            var instanceController = new InstanceController(environment, null, loggerFactory, startupContextProvider);
             var scriptHostManager = new Mock<IScriptHostManager>();
 
             var fileSystem = new Mock<IFileSystem>();

--- a/test/WebJobs.Script.Tests.Integration/Security/SecretManagerProviderTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Security/SecretManagerProviderTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             var hostNameProvider = new HostNameProvider(environment);
 
             _provider = new DefaultSecretManagerProvider(optionsMonitor, mockIdProvider.Object, config,
-                new TestEnvironment(), NullLoggerFactory.Instance, new TestMetricsLogger(), hostNameProvider);
+                new TestEnvironment(), NullLoggerFactory.Instance, new TestMetricsLogger(), hostNameProvider, new StartupContextProvider(environment, loggerFactory.CreateLogger<StartupContextProvider>()));
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests.Shared/TestSecretManager.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestSecretManager.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Extensions.Logging;
 
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public virtual Task PurgeOldSecretsAsync(string rootScriptPath, ILogger logger)
         {
-            throw new NotImplementedException();
+            return Task.CompletedTask;
         }
 
         public virtual Task<bool> DeleteSecretAsync(string secretName, string keyScope, ScriptSecretsType secretsType)
@@ -31,8 +31,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             return Task.FromResult(true);
         }
 
-        public virtual Task<IDictionary<string, string>> GetFunctionSecretsAsync(string functionName, bool merged)
+        public virtual Task<IDictionary<string, string>> GetFunctionSecretsAsync(string functionName, bool merged = false)
         {
+            // for testing, any time we're asked for function keys, we return a static set
             return Task.FromResult<IDictionary<string, string>>(new Dictionary<string, string>
             {
                 { "Key1", $"{functionName}1".ToLowerInvariant() },
@@ -76,17 +77,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public void Reset()
         {
             _hostFunctionKeys = new Dictionary<string, string>
-                {
-                    { "HostKey1", "HostValue1" },
-                    { "HostKey2", "HostValue2" },
-                };
+            {
+                { "HostKey1", "HostValue1" },
+                { "HostKey2", "HostValue2" },
+            };
 
             _hostSystemKeys = new Dictionary<string, string>
-                {
-                    { "SystemKey1", "SystemValue1" },
-                    { "SystemKey2", "SystemValue2" },
-                    { "Test_Extension", "SystemValue3" },
-                };
+            {
+                { "SystemKey1", "SystemValue1" },
+                { "SystemKey2", "SystemValue2" },
+                { "Test_Extension", "SystemValue3" },
+            };
+        }
+
+        public async Task<(string, AuthorizationLevel)> GetAuthorizationLevelOrNullAsync(string key, string functionName = null)
+        {
+            return await SecretManager.GetAuthorizationLevelAsync(this, key, functionName);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
@@ -8,15 +8,16 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Logging;
-using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 using Microsoft.Azure.WebJobs.Script.WebHost.Properties;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.WebJobs.Script.Tests;
 using Moq;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using WebJobs.Script.Tests;
 using Xunit;
 
@@ -24,10 +25,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
 {
     public class SecretManagerTests
     {
+        private const string TestEncryptionKey = "/a/vXvWJ3Hzgx4PFxlDUJJhQm5QVyGiu0NNLFm/ZMMg=";
         private readonly HostNameProvider _hostNameProvider;
         private readonly TestEnvironment _testEnvironment;
         private readonly TestLoggerProvider _loggerProvider;
         private readonly ILogger _logger;
+        private readonly StartupContextProvider _startupContextProvider;
 
         public SecretManagerTests()
         {
@@ -38,7 +41,101 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(_loggerProvider);
             _logger = _loggerProvider.CreateLogger(LogCategories.CreateFunctionCategory("test"));
+
             _hostNameProvider = new HostNameProvider(_testEnvironment);
+            _startupContextProvider = new StartupContextProvider(_testEnvironment, loggerFactory.CreateLogger<StartupContextProvider>());
+        }
+
+        [Fact]
+        public async Task CachedSecrets_UsedWhenPresent()
+        {
+            using (var directory = new TempDirectory())
+            {
+                string startupContextPath = Path.Combine(directory.Path, Guid.NewGuid().ToString());
+                _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteStartupContextCache, startupContextPath);
+                _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestEncryptionKey);
+
+                WriteStartContextCache(startupContextPath);
+
+                using (var secretManager = CreateSecretManager(directory.Path))
+                {
+                    var functionSecrets = await secretManager.GetFunctionSecretsAsync("function1", true);
+
+                    Assert.Equal(4, functionSecrets.Count);
+                    Assert.Equal("function1value", functionSecrets["test-function-1"]);
+                    Assert.Equal("function2value", functionSecrets["test-function-2"]);
+                    Assert.Equal("hostfunction1value", functionSecrets["test-host-function-1"]);
+                    Assert.Equal("hostfunction2value", functionSecrets["test-host-function-2"]);
+
+                    var hostSecrets = await secretManager.GetHostSecretsAsync();
+
+                    Assert.Equal("test-master-key", hostSecrets.MasterKey);
+                    Assert.Equal(2, hostSecrets.FunctionKeys.Count);
+                    Assert.Equal("hostfunction1value", hostSecrets.FunctionKeys["test-host-function-1"]);
+                    Assert.Equal("hostfunction2value", hostSecrets.FunctionKeys["test-host-function-2"]);
+                    Assert.Equal(2, hostSecrets.SystemKeys.Count);
+                    Assert.Equal("system1value", hostSecrets.SystemKeys["test-system-1"]);
+                    Assert.Equal("system2value", hostSecrets.SystemKeys["test-system-2"]);
+                }
+
+                var logs = _loggerProvider.GetAllLogMessages();
+                Assert.Equal($"Loading startup context from {startupContextPath}", logs[0].FormattedMessage);
+                Assert.Equal($"Loaded keys for 2 functions from startup context", logs[1].FormattedMessage);
+                Assert.Equal($"Loaded host keys from startup context", logs[2].FormattedMessage);
+            }
+        }
+
+        private FunctionAppSecrets WriteStartContextCache(string path)
+        {
+            var secrets = new FunctionAppSecrets();
+            secrets.Host = new FunctionAppSecrets.HostSecrets
+            {
+                Master = "test-master-key"
+            };
+            secrets.Host.Function = new Dictionary<string, string>
+            {
+                { "test-host-function-1", "hostfunction1value" },
+                { "test-host-function-2", "hostfunction2value" }
+            };
+            secrets.Host.System = new Dictionary<string, string>
+            {
+                { "test-system-1", "system1value" },
+                { "test-system-2", "system2value" }
+            };
+            secrets.Function = new FunctionAppSecrets.FunctionSecrets[]
+            {
+                new FunctionAppSecrets.FunctionSecrets
+                {
+                    Name = "function1",
+                    Secrets = new Dictionary<string, string>
+                    {
+                        { "test-function-1", "function1value" },
+                        { "test-function-2", "function2value" }
+                    }
+                },
+                new FunctionAppSecrets.FunctionSecrets
+                {
+                    Name = "function2",
+                    Secrets = new Dictionary<string, string>
+                    {
+                        { "test-function-1", "function1value" },
+                        { "test-function-2", "function2value" }
+                    }
+                }
+            };
+
+            var context = new JObject
+            {
+                { "secrets", JObject.FromObject(secrets) }
+            };
+
+            string json = JsonConvert.SerializeObject(context);
+            var encryptionKey = Convert.FromBase64String(TestEncryptionKey);
+            string encryptedJson = SimpleWebTokenHelper.Encrypt(json, encryptionKey);
+
+            File.WriteAllText(path, encryptedJson);
+
+            return secrets;
         }
 
         [Fact]
@@ -85,8 +182,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                 File.WriteAllText(Path.Combine(directory.Path, "testfunction.json"), functionSecrets);
 
                 IDictionary<string, string> result;
-                ISecretsRepository repository = new FileSystemSecretsRepository(directory.Path);
-                using (var secretManager = new SecretManager(repository, _logger, new TestMetricsLogger(), _hostNameProvider))
+                using (var secretManager = CreateSecretManager(directory.Path))
                 {
                     result = await secretManager.GetFunctionSecretsAsync("testfunction", true);
                 }
@@ -124,11 +220,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
 }";
                 File.WriteAllText(Path.Combine(directory.Path, functionName + ".json"), functionSecretsJson);
 
-                Mock<IKeyValueConverterFactory> mockValueConverterFactory = GetConverterFactoryMock();
-
                 IDictionary<string, string> functionSecrets;
-                ISecretsRepository repository = new FileSystemSecretsRepository(directory.Path);
-                using (var secretManager = new SecretManager(repository, mockValueConverterFactory.Object, _logger, new TestMetricsLogger(), _hostNameProvider))
+                using (var secretManager = CreateSecretManager(directory.Path))
                 {
                     functionSecrets = await secretManager.GetFunctionSecretsAsync(functionName);
                 }
@@ -182,11 +275,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
 }";
                 File.WriteAllText(Path.Combine(directory.Path, ScriptConstants.HostMetadataFileName), hostSecretsJson);
 
-                Mock<IKeyValueConverterFactory> mockValueConverterFactory = GetConverterFactoryMock();
-
                 HostSecretsInfo hostSecrets;
-                ISecretsRepository repository = new FileSystemSecretsRepository(directory.Path);
-                using (var secretManager = new SecretManager(repository, mockValueConverterFactory.Object, _logger, new TestMetricsLogger(), _hostNameProvider))
+                using (var secretManager = CreateSecretManager(directory.Path))
                 {
                     hostSecrets = await secretManager.GetHostSecretsAsync();
                 }
@@ -210,11 +300,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             using (var directory = new TempDirectory())
             {
                 string expectedTraceMessage = Resources.TraceHostSecretGeneration;
-                Mock<IKeyValueConverterFactory> mockValueConverterFactory = GetConverterFactoryMock(false, false);
-
                 HostSecretsInfo hostSecrets;
-                ISecretsRepository repository = new FileSystemSecretsRepository(directory.Path);
-                using (var secretManager = new SecretManager(repository, mockValueConverterFactory.Object, _logger, new TestMetricsLogger(), _hostNameProvider))
+
+                using (var secretManager = CreateSecretManager(directory.Path, simulateWriteConversion: false, setStaleValue: false))
                 {
                     hostSecrets = await secretManager.GetHostSecretsAsync();
                 }
@@ -241,11 +329,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                 string functionName = "TestFunction";
                 string expectedTraceMessage = string.Format(Resources.TraceFunctionSecretGeneration, functionName);
 
-                Mock<IKeyValueConverterFactory> mockValueConverterFactory = GetConverterFactoryMock(false, false);
-
                 IDictionary<string, string> functionSecrets;
-                ISecretsRepository repository = new FileSystemSecretsRepository(directory.Path);
-                using (var secretManager = new SecretManager(repository, mockValueConverterFactory.Object, _logger, new TestMetricsLogger(), _hostNameProvider))
+                using (var secretManager = CreateSecretManager(directory.Path, simulateWriteConversion: false, setStaleValue: false))
                 {
                     functionSecrets = await secretManager.GetFunctionSecretsAsync(functionName);
                 }
@@ -268,11 +353,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                 string functionName = "TestFunction";
                 string expectedTraceMessage = string.Format(Resources.TraceAddOrUpdateFunctionSecret, "Function", secretName, functionName, "Created");
 
-                Mock<IKeyValueConverterFactory> mockValueConverterFactory = GetConverterFactoryMock(false);
-
                 KeyOperationResult result;
-                ISecretsRepository repository = new FileSystemSecretsRepository(directory.Path);
-                using (var secretManager = new SecretManager(repository, mockValueConverterFactory.Object, _logger, new TestMetricsLogger(), _hostNameProvider))
+                using (var secretManager = CreateSecretManager(directory.Path, simulateWriteConversion: false))
                 {
                     result = await secretManager.AddOrUpdateFunctionSecretAsync(secretName, null, functionName, ScriptSecretsType.Function);
                 }
@@ -295,10 +377,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             {
                 CreateTestSecrets(directory.Path);
 
-                Mock<IKeyValueConverterFactory> mockValueConverterFactory = GetConverterFactoryMock(false);
                 KeyOperationResult result;
-                ISecretsRepository repository = new FileSystemSecretsRepository(directory.Path);
-                using (var secretManager = new SecretManager(repository, mockValueConverterFactory.Object, _logger, new TestMetricsLogger(), _hostNameProvider))
+                using (var secretManager = CreateSecretManager(directory.Path, simulateWriteConversion: false))
                 {
                     var keys = await secretManager.GetFunctionSecretsAsync("testfunction");
                     Assert.Equal(2, keys.Count);
@@ -326,10 +406,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             {
                 CreateTestSecrets(directory.Path);
 
-                Mock<IKeyValueConverterFactory> mockValueConverterFactory = GetConverterFactoryMock(false);
                 KeyOperationResult result;
-                ISecretsRepository repository = new FileSystemSecretsRepository(directory.Path);
-                using (var secretManager = new SecretManager(repository, mockValueConverterFactory.Object, _logger, new TestMetricsLogger(), _hostNameProvider))
+                using (var secretManager = CreateSecretManager(directory.Path, simulateWriteConversion: false))
                 {
                     var hostKeys = await secretManager.GetHostSecretsAsync();
                     Assert.Equal(2, hostKeys.FunctionKeys.Count);
@@ -357,10 +435,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             {
                 CreateTestSecrets(directory.Path);
 
-                Mock<IKeyValueConverterFactory> mockValueConverterFactory = GetConverterFactoryMock(false);
                 KeyOperationResult result;
-                ISecretsRepository repository = new FileSystemSecretsRepository(directory.Path);
-                using (var secretManager = new SecretManager(repository, mockValueConverterFactory.Object, _logger, new TestMetricsLogger(), _hostNameProvider))
+                using (var secretManager = CreateSecretManager(directory.Path, simulateWriteConversion: false))
                 {
                     var hostKeys = await secretManager.GetHostSecretsAsync();
                     Assert.Equal(2, hostKeys.SystemKeys.Count);
@@ -381,59 +457,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             }
         }
 
-        private void CreateTestSecrets(string path)
-        {
-            string hostSecrets =
-                    @"{
-    'masterKey': {
-        'name': 'master',
-        'value': '1234',
-        'encrypted': false
-    },
-    'functionKeys': [
-        {
-            'name': 'function-host-1',
-            'value': '456',
-            'encrypted': false
-        },
-        {
-            'name': 'function-host-2',
-            'value': '789',
-            'encrypted': false
-        }
-    ],
-    'systemKeys': [
-        {
-            'name': 'host-system-1',
-            'value': '654',
-            'encrypted': false
-        },
-        {
-            'name': 'host-system-2',
-            'value': '321',
-            'encrypted': false
-        }
-    ]
-}";
-            string functionSecrets =
-                @"{
-    'keys': [
-        {
-            'name': 'function-key-1',
-            'value': '1234',
-            'encrypted': false
-        },
-        {
-            'name': 'function-key-2',
-            'value': '5678',
-            'encrypted': false
-        }
-    ]
-}";
-            File.WriteAllText(Path.Combine(path, ScriptConstants.HostMetadataFileName), hostSecrets);
-            File.WriteAllText(Path.Combine(path, "testfunction.json"), functionSecrets);
-        }
-
         [Fact]
         public async Task AddOrUpdateFunctionSecrets_WithFunctionNameAndNoSecret_EncryptsSecretAndPersistsFile()
         {
@@ -443,11 +466,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                 string functionName = "TestFunction";
                 string expectedTraceMessage = string.Format(Resources.TraceAddOrUpdateFunctionSecret, "Function", secretName, functionName, "Created");
 
-                Mock<IKeyValueConverterFactory> mockValueConverterFactory = GetConverterFactoryMock(true);
-
                 KeyOperationResult result;
-                ISecretsRepository repository = new FileSystemSecretsRepository(directory.Path);
-                using (var secretManager = new SecretManager(repository, mockValueConverterFactory.Object, _logger, new TestMetricsLogger(), _hostNameProvider))
+                using (var secretManager = CreateSecretManager(directory.Path))
                 {
                     result = await secretManager.AddOrUpdateFunctionSecretAsync(secretName, null, functionName, ScriptSecretsType.Function);
                 }
@@ -473,11 +493,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                 string functionName = "TestFunction";
                 string expectedTraceMessage = string.Format(Resources.TraceAddOrUpdateFunctionSecret, "Function", secretName, functionName, "Created");
 
-                Mock<IKeyValueConverterFactory> mockValueConverterFactory = GetConverterFactoryMock(false);
-
                 KeyOperationResult result;
-                ISecretsRepository repository = new FileSystemSecretsRepository(directory.Path);
-                using (var secretManager = new SecretManager(repository, mockValueConverterFactory.Object, _logger, new TestMetricsLogger(), _hostNameProvider))
+                using (var secretManager = CreateSecretManager(directory.Path, simulateWriteConversion: false))
                 {
                     result = await secretManager.AddOrUpdateFunctionSecretAsync(secretName, "TestSecretValue", functionName, ScriptSecretsType.Function);
                 }
@@ -533,11 +550,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             string secretName = "TestSecret";
             string expectedTraceMessage = string.Format(Resources.TraceAddOrUpdateFunctionSecret, "Host", secretName, scope, "Created");
 
-            Mock<IKeyValueConverterFactory> mockValueConverterFactory = GetConverterFactoryMock(false);
-
             KeyOperationResult result;
-            ISecretsRepository repository = new FileSystemSecretsRepository(directory.Path);
-            using (var secretManager = new SecretManager(repository, mockValueConverterFactory.Object, _logger, new TestMetricsLogger(), _hostNameProvider))
+            using (var secretManager = CreateSecretManager(directory.Path, simulateWriteConversion: false))
             {
                 result = await secretManager.AddOrUpdateFunctionSecretAsync(secretName, "TestSecretValue", scope, ScriptSecretsType.Host);
             }
@@ -561,11 +575,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             string testSecret = "abcde0123456789abcde0123456789abcde0123456789";
             using (var directory = new TempDirectory())
             {
-                Mock<IKeyValueConverterFactory> mockValueConverterFactory = GetConverterFactoryMock(false);
-
                 KeyOperationResult result;
-                ISecretsRepository repository = new FileSystemSecretsRepository(directory.Path);
-                using (var secretManager = new SecretManager(repository, mockValueConverterFactory.Object, _logger, new TestMetricsLogger(), _hostNameProvider))
+                using (var secretManager = CreateSecretManager(directory.Path, simulateWriteConversion: false))
                 {
                     result = await secretManager.SetMasterKeyAsync(testSecret);
                 }
@@ -587,11 +598,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
         {
             using (var directory = new TempDirectory())
             {
-                Mock<IKeyValueConverterFactory> mockValueConverterFactory = GetConverterFactoryMock(false);
-
                 KeyOperationResult result;
-                ISecretsRepository repository = new FileSystemSecretsRepository(directory.Path);
-                using (var secretManager = new SecretManager(repository, mockValueConverterFactory.Object, _logger, new TestMetricsLogger(), _hostNameProvider))
+                using (var secretManager = CreateSecretManager(directory.Path, simulateWriteConversion: false))
                 {
                     result = await secretManager.SetMasterKeyAsync();
                 }
@@ -617,11 +625,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             {
                 string expectedTraceMessage = Resources.TraceHostSecretGeneration;
                 bool preExistingFile = File.Exists(hostSecretPath);
-
-                Mock<IKeyValueConverterFactory> mockValueConverterFactory = GetConverterFactoryMock(false, false);
-
-                ISecretsRepository repository = new FileSystemSecretsRepository(secretsPath);
-                var secretManager = new SecretManager(repository, mockValueConverterFactory.Object, _logger, new TestMetricsLogger(), _hostNameProvider, true);
+                var secretManager = CreateSecretManager(secretsPath, createHostSecretsIfMissing: true, simulateWriteConversion: false, setStaleValue: false);
                 bool fileCreated = File.Exists(hostSecretPath);
 
                 Assert.False(preExistingFile);
@@ -650,11 +654,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
     'systemKeys': []
 }";
                 File.WriteAllText(Path.Combine(directory.Path, ScriptConstants.HostMetadataFileName), hostSecretsJson);
-                Mock<IKeyValueConverterFactory> mockValueConverterFactory = GetConverterFactoryMock(true, false);
                 HostSecretsInfo hostSecrets;
-                ISecretsRepository repository = new FileSystemSecretsRepository(directory.Path);
-
-                using (var secretManager = new SecretManager(repository, mockValueConverterFactory.Object, _logger, new TestMetricsLogger(), _hostNameProvider))
+                using (var secretManager = CreateSecretManager(directory.Path, simulateWriteConversion: true, setStaleValue: false))
                 {
                     hostSecrets = await secretManager.GetHostSecretsAsync();
                 }
@@ -693,11 +694,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
     ]
 }";
                     File.WriteAllText(Path.Combine(directory.Path, functionName + ".json"), functionSecretsJson);
-                    Mock<IKeyValueConverterFactory> mockValueConverterFactory = GetConverterFactoryMock(true, false);
                     IDictionary<string, string> functionSecrets;
-                    ISecretsRepository repository = new FileSystemSecretsRepository(directory.Path);
-
-                    using (var secretManager = new SecretManager(repository, mockValueConverterFactory.Object, _logger, new TestMetricsLogger(), _hostNameProvider))
+                    using (var secretManager = CreateSecretManager(directory.Path, simulateWriteConversion: true, setStaleValue: false))
                     {
                             functionSecrets = await secretManager.GetFunctionSecretsAsync(functionName);
                     }
@@ -729,7 +727,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
     'keys': [
         {
             'name': 'Key1',
-            'value': 'FunctionValue1',
+            'value': 'cryptoError',
             'encrypted': true
         },
         {
@@ -740,9 +738,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
     ]
 }";
                 IDictionary<string, string> functionSecrets;
-                ISecretsRepository repository = new FileSystemSecretsRepository(directory.Path);
-
-                using (var secretManager = new SecretManager(repository, _logger, new TestMetricsLogger(), _hostNameProvider))
+                using (var secretManager = CreateSecretManager(directory.Path))
                 {
                     InvalidOperationException ioe = null;
                     try
@@ -771,6 +767,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                     }
                 }
 
+                int backupCount = Directory.GetFiles(directory.Path, $"{functionName}.{ScriptConstants.Snapshot}*").Length;
+                Assert.True(backupCount >= ScriptConstants.MaximumSecretBackupCount);
+
                 Assert.True(Directory.GetFiles(directory.Path, $"{functionName}.{ScriptConstants.Snapshot}*").Length >= ScriptConstants.MaximumSecretBackupCount);
                 Assert.True(_loggerProvider.GetAllLogMessages().Any(
                     t => t.Level == LogLevel.Debug && t.FormattedMessage.IndexOf(expectedTraceMessage, StringComparison.OrdinalIgnoreCase) > -1),
@@ -796,9 +795,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                 File.WriteAllText(filePath, hostSecretsJson);
 
                 HostSecretsInfo hostSecrets = null;
-                ISecretsRepository repository = new FileSystemSecretsRepository(directory.Path);
-
-                using (var secretManager = new SecretManager(repository, _logger, new TestMetricsLogger(), _hostNameProvider))
+                using (var secretManager = CreateSecretManager(directory.Path))
                 {
                     await Task.WhenAll(
                         Task.Run(async () =>
@@ -818,7 +815,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                     Assert.Equal(hostSecrets.MasterKey, "1234");
                 }
 
-                using (var secretManager = new SecretManager(repository, null, new TestMetricsLogger(), _hostNameProvider))
+                using (var secretManager = CreateSecretManager(directory.Path))
                 {
                     await Assert.ThrowsAsync<IOException>(async () =>
                     {
@@ -866,8 +863,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                 File.WriteAllText(filePath, functionSecretsJson);
 
                 IDictionary<string, string> functionSecrets = null;
-                ISecretsRepository repository = new FileSystemSecretsRepository(directory.Path);
-                using (var secretManager = new SecretManager(repository, _logger, new TestMetricsLogger(), _hostNameProvider))
+                using (var secretManager = CreateSecretManager(directory.Path))
                 {
                     await Task.WhenAll(
                         Task.Run(async () =>
@@ -887,7 +883,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                     Assert.Equal(functionSecrets["Key1"], "FunctionValue1");
                 }
 
-                using (var secretManager = new SecretManager(repository, _logger, new TestMetricsLogger(), _hostNameProvider))
+                using (var secretManager = CreateSecretManager(directory.Path))
                 {
                     await Assert.ThrowsAsync<IOException>(async () =>
                     {
@@ -927,17 +923,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
     'systemKeys': []
 }";
                 File.WriteAllText(Path.Combine(directory.Path, ScriptConstants.HostMetadataFileName), hostSecretsJson);
-                Mock<IKeyValueConverterFactory> mockValueConverterFactory = GetConverterFactoryMock(true, false);
                 HostSecretsInfo hostSecrets;
-                ISecretsRepository repository = new FileSystemSecretsRepository(directory.Path);
                 TestMetricsLogger metricsLogger = new TestMetricsLogger();
 
-                using (var secretManager = new SecretManager(repository, mockValueConverterFactory.Object, _logger, metricsLogger, _hostNameProvider))
+                using (var secretManager = CreateSecretManager(directory.Path, metricsLogger: metricsLogger, simulateWriteConversion: true, setStaleValue: false))
                 {
                     hostSecrets = await secretManager.GetHostSecretsAsync();
                 }
 
-                string eventName = string.Format(MetricEventNames.SecretManagerGetHostSecrets, repository.GetType().Name.ToLower());
+                string eventName = string.Format(MetricEventNames.SecretManagerGetHostSecrets, typeof(FileSystemSecretsRepository).Name.ToLower());
                 metricsLogger.EventsBegan.Single(e => string.Equals(e, eventName));
                 metricsLogger.EventsEnded.Single(e => string.Equals(e.ToString(), eventName));
             }
@@ -965,17 +959,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
     ]
 }";
                 File.WriteAllText(Path.Combine(directory.Path, functionName + ".json"), functionSecretsJson);
-                Mock<IKeyValueConverterFactory> mockValueConverterFactory = GetConverterFactoryMock(true, false);
                 IDictionary<string, string> functionSecrets;
-                ISecretsRepository repository = new FileSystemSecretsRepository(directory.Path);
                 TestMetricsLogger metricsLogger = new TestMetricsLogger();
 
-                using (var secretManager = new SecretManager(repository, mockValueConverterFactory.Object, null, metricsLogger, _hostNameProvider))
+                using (var secretManager = CreateSecretManager(directory.Path, metricsLogger: metricsLogger, simulateWriteConversion: true, setStaleValue: false))
                 {
                     functionSecrets = await secretManager.GetFunctionSecretsAsync(functionName);
                 }
 
-                string eventName = string.Format(MetricEventNames.SecretManagerGetFunctionSecrets, repository.GetType().Name.ToLower());
+                string eventName = string.Format(MetricEventNames.SecretManagerGetFunctionSecrets, typeof(FileSystemSecretsRepository).Name.ToLower());
                 metricsLogger.EventsBegan.Single(e => e.StartsWith(eventName));
                 metricsLogger.EventsBegan.Single(e => e.Contains("testfunction"));
                 metricsLogger.EventsEnded.Single(e => e.ToString().StartsWith(eventName));
@@ -1010,6 +1002,81 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                 .Returns(mockValueWriter.Object);
 
             return mockValueConverterFactory;
+        }
+
+        private SecretManager CreateSecretManager(string secretsPath, ILogger logger = null, IMetricsLogger metricsLogger = null, IKeyValueConverterFactory keyConverterFactory = null, bool createHostSecretsIfMissing = false, bool simulateWriteConversion = true, bool setStaleValue = true)
+        {
+            logger = logger ?? _logger;
+            metricsLogger = metricsLogger ?? new TestMetricsLogger();
+
+            if (keyConverterFactory == null)
+            {
+                Mock<IKeyValueConverterFactory> mockValueConverterFactory = GetConverterFactoryMock(simulateWriteConversion, setStaleValue);
+                keyConverterFactory = mockValueConverterFactory.Object;
+            }
+
+            ISecretsRepository repository = new FileSystemSecretsRepository(secretsPath);
+            var secretManager = new SecretManager(repository, keyConverterFactory, logger, metricsLogger, _hostNameProvider, _startupContextProvider);
+
+            if (createHostSecretsIfMissing)
+            {
+                secretManager.GetHostSecretsAsync().GetAwaiter().GetResult();
+            }
+
+            return secretManager;
+        }
+
+        private void CreateTestSecrets(string path)
+        {
+            string hostSecrets =
+                    @"{
+    'masterKey': {
+        'name': 'master',
+        'value': '1234',
+        'encrypted': false
+    },
+    'functionKeys': [
+        {
+            'name': 'function-host-1',
+            'value': '456',
+            'encrypted': false
+        },
+        {
+            'name': 'function-host-2',
+            'value': '789',
+            'encrypted': false
+        }
+    ],
+    'systemKeys': [
+        {
+            'name': 'host-system-1',
+            'value': '654',
+            'encrypted': false
+        },
+        {
+            'name': 'host-system-2',
+            'value': '321',
+            'encrypted': false
+        }
+    ]
+}";
+            string functionSecrets =
+                @"{
+    'keys': [
+        {
+            'name': 'function-key-1',
+            'value': '1234',
+            'encrypted': false
+        },
+        {
+            'name': 'function-key-2',
+            'value': '5678',
+            'encrypted': false
+        }
+    ]
+}";
+            File.WriteAllText(Path.Combine(path, ScriptConstants.HostMetadataFileName), hostSecrets);
+            File.WriteAllText(Path.Combine(path, "testfunction.json"), functionSecrets);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/StartupContextProviderTests.cs
+++ b/test/WebJobs.Script.Tests/StartupContextProviderTests.cs
@@ -1,0 +1,227 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security;
+using Microsoft.Extensions.Logging;
+using Microsoft.WebJobs.Script.Tests;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public class StartupContextProviderTests
+    {
+        private const string TestEncryptionKey = "/a/vXvWJ3Hzgx4PFxlDUJJhQm5QVyGiu0NNLFm/ZMMg=";
+
+        private readonly FunctionAppSecrets _secrets;
+        private readonly StartupContextProvider _startupContextProvider;
+        private readonly TestEnvironment _environment;
+        private readonly TestLoggerProvider _loggerProvider;
+
+        public StartupContextProviderTests()
+        {
+            _secrets = new FunctionAppSecrets();
+            _secrets.Host = new FunctionAppSecrets.HostSecrets
+            {
+                Master = "test-master-key"
+            };
+            _secrets.Host.Function = new Dictionary<string, string>
+            {
+                { "test-host-function-1", "hostfunction1value" },
+                { "test-host-function-2", "hostfunction2value" }
+            };
+            _secrets.Host.System = new Dictionary<string, string>
+            {
+                { "test-system-1", "system1value" },
+                { "test-system-2", "system2value" }
+            };
+            _secrets.Function = new FunctionAppSecrets.FunctionSecrets[]
+            {
+                new FunctionAppSecrets.FunctionSecrets
+                {
+                    Name = "function1",
+                    Secrets = new Dictionary<string, string>
+                    {
+                        { "test-function-1", "function1value" },
+                        { "test-function-2", "function2value" }
+                    }
+                },
+                new FunctionAppSecrets.FunctionSecrets
+                {
+                    Name = "function2",
+                    Secrets = new Dictionary<string, string>
+                    {
+                        { "test-function-1", "function1value" },
+                        { "test-function-2", "function2value" }
+                    }
+                }
+            };
+
+            _environment = new TestEnvironment();
+            var loggerFactory = new LoggerFactory();
+            _loggerProvider = new TestLoggerProvider();
+            loggerFactory.AddProvider(_loggerProvider);
+
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestEncryptionKey);
+
+            _startupContextProvider = new StartupContextProvider(_environment, loggerFactory.CreateLogger<StartupContextProvider>());
+        }
+
+        [Fact]
+        public async Task GetHostSecretsOrNull_ReturnsExpectedSecrets()
+        {
+            var path = WriteStartupContext();
+
+            var secrets = _startupContextProvider.GetHostSecretsOrNull();
+
+            Assert.Equal(_secrets.Host.Master, secrets.MasterKey);
+            Assert.Equal(_secrets.Host.Function, secrets.FunctionKeys);
+            Assert.Equal(_secrets.Host.System, secrets.SystemKeys);
+
+            var logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
+            Assert.True(logs.Contains($"Loading startup context from {path}"));
+            Assert.True(logs.Contains("Loaded host keys from startup context"));
+
+            // verify the context file is deleted after it's consumed
+            await TestHelpers.Await(() =>
+            {
+                return !File.Exists(path);
+            }, timeout: 1000);
+        }
+
+        [Fact]
+        public void GetFunctionSecretsOrNull_ReturnsExpectedSecrets()
+        {
+            var path = WriteStartupContext();
+
+            var secrets = _startupContextProvider.GetFunctionSecretsOrNull();
+
+            foreach (var function in _secrets.Function)
+            {
+                Assert.Equal(function.Secrets, secrets[function.Name]);
+            }
+
+            var logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
+            Assert.True(logs.Contains($"Loading startup context from {path}"));
+            Assert.True(logs.Contains($"Loaded keys for {_secrets.Function.Length} functions from startup context"));
+        }
+
+        [Fact]
+        public void GetHostSecretsOrNull_NoStartupContext_ReturnsNull()
+        {
+            var secrets = _startupContextProvider.GetHostSecretsOrNull();
+            Assert.Null(secrets);
+        }
+
+        [Fact]
+        public void GetContext_InvalidJson_ReturnsNull()
+        {
+            WriteStartupContext("sdlkflk");
+            Assert.Null(_startupContextProvider.Context);
+
+            VerifyLastLog(LogLevel.Error, "Failed to load startup context");
+        }
+
+        [Fact]
+        public void GetContext_InvalidPath_ReturnsNull()
+        {
+            var path = Path.Combine(Path.GetTempPath(), "dne.txt");
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteStartupContextCache, path);
+
+            Assert.Null(_startupContextProvider.Context);
+
+            VerifyLastLog(LogLevel.Error, "Failed to load startup context");
+        }
+
+        [Fact]
+        public void GetContext_EnvVarNotSet_ReturnsNull()
+        {
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteStartupContextCache, null);
+
+            Assert.Null(_startupContextProvider.Context);
+        }
+
+        [Fact]
+        public void GetFunctionSecretsOrNull_NoStartupContext_ReturnsNull()
+        {
+            var secrets = _startupContextProvider.GetFunctionSecretsOrNull();
+            Assert.Null(secrets);
+        }
+
+        [Fact]
+        public void GetFunctionSecretsOrNull_InvalidDecryptionKey_ReturnsNull()
+        {
+            WriteStartupContext();
+
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, "invalid");
+
+            var secrets = _startupContextProvider.GetFunctionSecretsOrNull();
+            Assert.Null(secrets);
+
+            var log = VerifyLastLog(LogLevel.Error, "Failed to load startup context");
+            Assert.Equal(typeof(FormatException), log.Exception.GetType());
+        }
+
+        [Fact]
+        public void SetContext_AppliesHostAssignmentContext()
+        {
+            var context = new HostAssignmentContext
+            {
+                Environment = new Dictionary<string, string>(),
+                SiteName = "TestSite",
+                Secrets = _secrets
+            };
+            string json = JsonConvert.SerializeObject(context);
+            string encrypted = SimpleWebTokenHelper.Encrypt(json, environment: _environment);
+            var encryptedContext = new EncryptedHostAssignmentContext { EncryptedContext = encrypted };
+
+            var result = _startupContextProvider.SetContext(encryptedContext);
+            Assert.Equal(context.SiteName, result.SiteName);
+            Assert.Equal(_secrets.Host.Master, result.Secrets.Host.Master);
+
+            var secrets = _startupContextProvider.GetHostSecretsOrNull();
+            Assert.Equal(_secrets.Host.Master, secrets.MasterKey);
+            Assert.Equal(_secrets.Host.Function, secrets.FunctionKeys);
+            Assert.Equal(_secrets.Host.System, secrets.SystemKeys);
+        }
+
+        private string WriteStartupContext(string context = null)
+        {
+            var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.txt");
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteStartupContextCache, path);
+
+            if (context == null)
+            {
+                var content = new JObject
+                {
+                    { "secrets", JObject.FromObject(_secrets) }
+                };
+                context = JsonConvert.SerializeObject(content);
+            }
+
+            var encrypted = SimpleWebTokenHelper.Encrypt(context, environment: _environment);
+
+            File.WriteAllText(path, encrypted);
+
+            return path;
+        }
+
+        private LogMessage VerifyLastLog(LogLevel level, string message)
+        {
+            var logs = _loggerProvider.GetAllLogMessages();
+            var log = logs.Last();
+            Assert.Equal(level, log.Level);
+            Assert.Equal("Failed to load startup context", log.FormattedMessage);
+
+            return log;
+        }
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-functions-host/issues/5371.

To improve cold-start, I'm introducing a generalized mechanism for passing startup context to the host. On App Service / Windows, DWAS will pass this context to us via local files, which can be efficiently read (not Azure Files). Initially this information will be keys - allowing us to save 2 storage calls on startup. Tests have shown this to be a 250ms savings on cold start. I've generalized the approach so it'll work for Linux Consumption as well.

As part of this work, I also added logic for dealing with stale cache/keys. When we get a key mismatch and keys are currently cached, we'll force a reload. Not only will this handle situations where we may have started with an already stale startup cache (shouldn't happen), but it will also help in general for issues we've seen in the past. E.g. if file system notifications fail for whatever reason, some workers may not pick up key changes. Now they'll reload. Also, in Linux Consumption where there is no shared file system. If keys are cached then updated, unless the app is restarted, old cached keys will continue to be used. This will allow the app to reload keys.


