### PR TITLE
[HttpWorker]Parse JSON response for HttpTrigger

### DIFF
--- a/src/WebJobs.Script/Binding/Http/HttpBinding.cs
+++ b/src/WebJobs.Script/Binding/Http/HttpBinding.cs
@@ -17,7 +17,7 @@ using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.WebApiCompatShim;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
-using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Azure.WebJobs.Script.Workers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -115,12 +115,12 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
             // Sniff the object to see if it looks like a response object
             // by convention
             object bodyValue = null;
-            if (responseObject.TryGetValue(RpcWorkerConstants.RpcHttpBody, out bodyValue, ignoreCase: true))
+            if (responseObject.TryGetValue(WorkerConstants.HttpBody, out bodyValue, ignoreCase: true))
             {
                 // the response content becomes the specified body value
                 content = bodyValue;
 
-                if (responseObject.TryGetValue(RpcWorkerConstants.RpcHttpHeaders, out IDictionary<string, object> headersValue, ignoreCase: true))
+                if (responseObject.TryGetValue(WorkerConstants.HttpHeaders, out IDictionary<string, object> headersValue, ignoreCase: true))
                 {
                     headers = headersValue;
                 }
@@ -130,12 +130,12 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
                     statusCode = responseStatusCode.Value;
                 }
 
-                if (responseObject.TryGetValue<bool>(RpcWorkerConstants.RpcHttpEnableContentNegotiation, out bool enableContentNegotiationValue, ignoreCase: true))
+                if (responseObject.TryGetValue<bool>(WorkerConstants.HttpEnableContentNegotiation, out bool enableContentNegotiationValue, ignoreCase: true))
                 {
                     enableContentNegotiation = enableContentNegotiationValue;
                 }
 
-                if (responseObject.TryGetValue(RpcWorkerConstants.RpcHttpCookies, out List<Tuple<string, string, CookieOptions>> cookiesValue, ignoreCase: true))
+                if (responseObject.TryGetValue(WorkerConstants.HttpCookies, out List<Tuple<string, string, CookieOptions>> cookiesValue, ignoreCase: true))
                 {
                     cookies = cookiesValue;
                 }
@@ -146,8 +146,8 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
         {
             statusCode = StatusCodes.Status200OK;
 
-            if (!responseObject.TryGetValue(RpcWorkerConstants.RpcHttpStatusCode, out object statusValue, ignoreCase: true) &&
-                !responseObject.TryGetValue(RpcWorkerConstants.RpcHttpStatus, out statusValue, ignoreCase: true))
+            if (!responseObject.TryGetValue(WorkerConstants.HttpStatusCode, out object statusValue, ignoreCase: true) &&
+                !responseObject.TryGetValue(WorkerConstants.HttpStatus, out statusValue, ignoreCase: true))
             {
                 return false;
             }

--- a/src/WebJobs.Script/Workers/Http/HttpOutputBindingResponse.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpOutputBindingResponse.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Script.Workers.Http
+{
+    internal class HttpOutputBindingResponse
+    {
+        public string StatusCode { get; set; }
+
+        public string Status { get; set; }
+
+        public object Body { get; set; }
+
+        public IDictionary<string, object> Headers { get; set; }
+    }
+}

--- a/src/WebJobs.Script/Workers/Http/HttpScriptInvocationResultExtensions.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpScriptInvocationResultExtensions.cs
@@ -23,7 +23,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
 
             foreach (var outputBindingMetadata in scriptInvocationContext.FunctionMetadata.OutputBindings)
             {
-                scriptInvocationResult.Outputs[outputBindingMetadata.Name] = GetOutputValue(outputBindingMetadata.Name, outputBindingMetadata.Type, outputBindingMetadata.DataType, httpScriptInvocationResult.Outputs);
+                object outputValue = GetOutputValue(outputBindingMetadata.Name, outputBindingMetadata.Type, outputBindingMetadata.DataType, httpScriptInvocationResult.Outputs);
+                if (outputValue != null)
+                {
+                    scriptInvocationResult.Outputs[outputBindingMetadata.Name] = outputValue;
+                }
             }
 
             if (httpScriptInvocationResult.ReturnValue != null)

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
@@ -30,14 +30,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         // Rpc message length
         public const int DefaultMaxMessageLengthBytes = 128 * 1024 * 1024;
 
-        // Rpc Http Constants
-        public const string RpcHttpBody = "body";
-        public const string RpcHttpHeaders = "headers";
-        public const string RpcHttpEnableContentNegotiation = "enableContentNegotiation";
-        public const string RpcHttpCookies = "cookies";
-        public const string RpcHttpStatusCode = "statusCode";
-        public const string RpcHttpStatus = "status";
-
         // Capabilites
         public const string RawHttpBodyBytes = "RawHttpBodyBytes";
         public const string TypedDataCollection = "TypedDataCollection";

--- a/src/WebJobs.Script/Workers/WorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/WorkerConstants.cs
@@ -40,5 +40,13 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         // Language Worker process exit codes
         public const int SuccessExitCode = 0;
         public const int IntentionalRestartExitCode = 200;
+
+        // Http Constants
+        public const string HttpBody = "body";
+        public const string HttpHeaders = "headers";
+        public const string HttpEnableContentNegotiation = "enableContentNegotiation";
+        public const string HttpCookies = "cookies";
+        public const string HttpStatusCode = "statusCode";
+        public const string HttpStatus = "status";
     }
 }

--- a/test/WebJobs.Script.Tests/HttpWorker/HttpScriptInvocationResultExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/HttpWorker/HttpScriptInvocationResultExtensionsTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Azure.WebJobs.Script.Workers.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
+{
+    public class HttpScriptInvocationResultExtensionsTests
+    {
+        [Theory]
+        [InlineData("{\"statusCode\": \"204\"}", "{\"StatusCode\":\"204\",\"Status\":null,\"Body\":null,\"Headers\":null}")]
+        [InlineData("{\"body\": \"hello\"}", "{\"StatusCode\":null,\"Status\":null,\"Body\":\"hello\",\"Headers\":null}")]
+        [InlineData("{\"body\": \"hello\", \"statusCode\":\"300\"}", "{\"StatusCode\":\"300\",\"Status\":null,\"Body\":\"hello\",\"Headers\":null}")]
+        [InlineData("{\"body\":\"foobar\",\"statusCode\":\"301\",\"headers\":{\"header1\":\"header1Value\",\"header2\":\"header2Value\"}}", "{\"StatusCode\":\"301\",\"Status\":null,\"Body\":\"foobar\",\"Headers\":{\"header1\":\"header1Value\",\"header2\":\"header2Value\"}}")]
+        public void GetHttpOutputBindingResponse_ReturnsExpected(string inputString, string expectedOutput)
+        {
+            Dictionary<string, object> outputsFromWorker = new Dictionary<string, object>();
+            outputsFromWorker["httpOutput1"] = inputString;
+            var actualResult = HttpScriptInvocationResultExtensions.GetHttpOutputBindingResponse("httpOutput1", outputsFromWorker);
+            Assert.Equal(expectedOutput, actualResult);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5542

When using HttpWorker with HttpTrigger and other output bindings, we need a way to differentiate between HttpTrigger reponse vs response from the HttpWorker for function invocation.

This PR adds ability to set HttpTrigger response to JSON. If JSON response has following properties:
- StatusCode
- Body
- Headers
Response for HttpTrigger will include details provided in JSON response. If explicit response is not set, default 200 OK will be returned. This follows same format as language workers making the experience consistent for all out-of-proc workers.

Please see PR https://github.com/pragnagopa/functions-http-worker/pull/5 for an E2E example