### PR TITLE
Delay non-essential startup tasks to improve performance

### DIFF
--- a/src/WebJobs.Script/Host/DebugManager.cs
+++ b/src/WebJobs.Script/Host/DebugManager.cs
@@ -39,9 +39,11 @@ namespace Microsoft.Azure.WebJobs.Script
             {
                 // create or update the debug sentinel file to trigger a
                 // debug timeout update across all instances
-                string debugSentinelFileName = Path.Combine(_scriptOptions.CurrentValue.LogPath, "Host", ScriptConstants.DebugSentinelFileName);
+                string debugSentinelDirectory = Path.Combine(_scriptOptions.CurrentValue.LogPath, "Host");
+                string debugSentinelFileName = Path.Combine(debugSentinelDirectory, ScriptConstants.DebugSentinelFileName);
                 if (!File.Exists(debugSentinelFileName))
                 {
+                    FileUtility.EnsureDirectoryExists(debugSentinelDirectory);
                     File.WriteAllText(debugSentinelFileName, "This is a system managed marker file used to control runtime debug mode behavior.");
                 }
                 else

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -681,6 +681,17 @@ namespace Microsoft.Azure.WebJobs.Script
             return false;
         }
 
+        public static void ExecuteAfterDelay(Action targetAction, TimeSpan delay, CancellationToken cancellationToken = default)
+        {
+            Task.Delay(delay, cancellationToken).ContinueWith(_ =>
+            {
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    targetAction();
+                }
+            }, TaskContinuationOptions.OnlyOnRanToCompletion);
+        }
+
         public static bool TryCleanUrl(string url, out string cleaned)
         {
             cleaned = null;


### PR DESCRIPTION
Fixes #5134 - We need to try to avoid any filesystem calls that are not in wwwroot, as part of cold start. This PR delays such calls where possible.

Delaying some of the file system calls opens up slight potential for race condition when dealing with "debug" and "diagnostic" mode. In a nutshell, users would have to wait a little once the host starts up to use debug or diagnostic mode. I am not sure if the impact is big for this. I would imagine that this is acceptable.

One way, we can prevent such scenario is if a call comes in from Portal where we toggle diagnostic mode, we first make sure the FileWatchers are setup. Then we let the toggle work.
However, I don't think it's worth the design if the impact is super small.  This still leaves the race where Watchers haven't started up and user manually placed the sentinels.