### PR TITLE
extending retries for scale metric table creation

### DIFF
--- a/src/WebJobs.Script.WebHost/Scale/TableStorageScaleMetricsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Scale/TableStorageScaleMetricsRepository.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
         }
 
-        internal async Task CreateIfNotExistsAsync(CloudTable table, int retryCount = 3, int retryDelayMS = 1000)
+        internal async Task CreateIfNotExistsAsync(CloudTable table, int retryCount = 20, int retryDelayMS = 1000)
         {
             int attempt = 0;
             do
@@ -222,7 +222,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     // though these should only happen in tests not production, because we only ever
                     // delete OLD tables and we'll never be attempting to recreate a table we just
                     // deleted outside of tests.
-                    if (e.RequestInformation.HttpStatusCode == (int)HttpStatusCode.Conflict)
+                    if (e.RequestInformation.HttpStatusCode == (int)HttpStatusCode.Conflict &&
+                        attempt < retryCount)
                     {
                         // wait a bit and try again
                         await Task.Delay(retryDelayMS);

--- a/test/WebJobs.Script.Tests.Integration/Scale/TableStorageScaleMetricsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Scale/TableStorageScaleMetricsRepositoryTests.cs
@@ -41,7 +41,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Scale
             _loggerProvider = new TestLoggerProvider();
             ILoggerFactory loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(_loggerProvider);
-            _repository = new TableStorageScaleMetricsRepository(configuration, _hostIdProviderMock.Object, new OptionsWrapper<ScaleOptions>(_scaleOptions), loggerFactory);
+
+            // Allow for up to 30 seconds of creation retries for tests due to slow table deletes
+            _repository = new TableStorageScaleMetricsRepository(configuration, _hostIdProviderMock.Object, new OptionsWrapper<ScaleOptions>(_scaleOptions), loggerFactory, 30);
 
             EmptyMetricsTableAsync().GetAwaiter().GetResult();
         }
@@ -163,7 +165,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Scale
             }
 
             await _repository.ExecuteBatchSafeAsync(batch);
-            
+
             var result = await _repository.ReadMetricsAsync(monitors);
 
             var resultMetrics = result[monitor1].Cast<TestScaleMetrics1>().ToArray();
@@ -327,7 +329,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Scale
         public async Task LogStorageException_LogsDetails()
         {
             StorageException ex = null;
-            var table =_repository.TableClient.GetTableReference("dne");
+            var table = _repository.TableClient.GetTableReference("dne");
             var continuationToken = new TableContinuationToken();
             try
             {


### PR DESCRIPTION
@mathewc I think this is your area. I'm seeing the `WriteAsync_RollsToNewTable` test fail every-other-time I run it locally b/c tables are still being deleted by the time it tries to create new ones. It's also failing in DevOps (I assume b/c tests are running in a different order than in AppVeyor now).

The docs say that you can [get Conflicts for up to 40 seconds after a Delete](https://docs.microsoft.com/en-us/rest/api/storageservices/Delete-Table?redirectedfrom=MSDN#remarks) so I don't think it's crazy to retry for a while if we see 409s.

I'll defer to you the best way to do this -- I can also bump that retry variable up to a constructor param so that we can explicitly extend it just for the tests (you mention that this scnenario isn't really in play for prod). Or have an internal prop I can set to tweak it for tests...