### PR TITLE
ensuring GrpcServer is only shut down once

### DIFF
--- a/src/WebJobs.Script.Grpc/Server/GrpcServer.cs
+++ b/src/WebJobs.Script.Grpc/Server/GrpcServer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
 using Microsoft.Azure.WebJobs.Script.Abstractions;
@@ -12,6 +13,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 {
     public class GrpcServer : IRpcServer, IDisposable
     {
+        private int _shutdown = 0;
         private Server _server;
         private bool _disposed = false;
         public const int MaxMessageLengthBytes = 128 * 1024 * 1024;
@@ -36,7 +38,16 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             return Task.CompletedTask;
         }
 
-        public Task ShutdownAsync() => _server.ShutdownAsync();
+        public Task ShutdownAsync()
+        {
+            // The Grpc server will throw if it is shutdown multiple times.
+            if (Interlocked.CompareExchange(ref _shutdown, 1, 0) == 0)
+            {
+                return _server.ShutdownAsync();
+            }
+
+            return Task.CompletedTask;
+        }
 
         public Task KillAsync() => _server.KillAsync();
 
@@ -46,7 +57,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             {
                 if (disposing)
                 {
-                    _server.ShutdownAsync();
+                    ShutdownAsync();
                 }
                 _disposed = true;
             }

--- a/test/WebJobs.Script.Tests.Integration/Scale/TableStorageScaleMetricsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Scale/TableStorageScaleMetricsRepositoryTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Scale
             loggerFactory.AddProvider(_loggerProvider);
 
             // Allow for up to 30 seconds of creation retries for tests due to slow table deletes
-            _repository = new TableStorageScaleMetricsRepository(configuration, _hostIdProviderMock.Object, new OptionsWrapper<ScaleOptions>(_scaleOptions), loggerFactory, 30);
+            _repository = new TableStorageScaleMetricsRepository(configuration, _hostIdProviderMock.Object, new OptionsWrapper<ScaleOptions>(_scaleOptions), loggerFactory, 60);
 
             EmptyMetricsTableAsync().GetAwaiter().GetResult();
         }


### PR DESCRIPTION
Now that we dispose of the WebHost, this was causing the GrpcServer to call shutdown twice. The second time it would throw an exception, which would crash the test host in devops. This makes sure we only call it once.