### PR TITLE
Fixing broken logging

### DIFF
--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -108,6 +108,6 @@ namespace Microsoft.Azure.WebJobs.Script
         /// This constant is also defined in Antares, where the limit is ultimately enforced
         /// for settriggers calls. If we raise that limit there, we should raise here as well.
         /// </summary>
-        public const int MaxTriggersStringLength = 102400;
+        public const int MaxTriggersStringLength = 204800;
     }
 }


### PR DESCRIPTION
In a recent investigation, I noticed that we're not emitting system logs from FunctionsSyncManager. This is likely because the code originated in v2, and when ported to v1, I didn't remember the fact that we have to double log to TraceWriter to get system logs. These missing logs are making SyncTriggers investigations difficult/misleading. Unfortunately this will make code merges more complicated for this file in the future :(

E.g. if you run a query in prod for logs with Source="Microsoft.Azure.WebJobs.Script.WebHost.Management.FunctionsSyncManager" for v2 apps you'll find them, but none for v1.