### PR TITLE
Fix linux consumption runtime stack metric logging

### DIFF
--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AppInsightsConnectionString = "APPLICATIONINSIGHTS_CONNECTION_STRING";
         public const string AppInsightsQuickPulseAuthApiKey = "APPINSIGHTS_QUICKPULSEAUTHAPIKEY";
         public const string FunctionsExtensionVersion = "FUNCTIONS_EXTENSION_VERSION";
+        public const string WebsiteNodeDefaultVersion = "WEBSITE_NODE_DEFAULT_VERSION";
         public const string ContainerName = "CONTAINER_NAME";
         public const string WebSiteHomeStampName = "WEBSITE_HOME_STAMPNAME";
         public const string WebSiteStampDeploymentId = "WEBSITE_STAMP_DEPLOYMENT_ID";

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -274,17 +274,9 @@ namespace Microsoft.Azure.WebJobs.Script
 
                 if (!_environment.IsPlaceholderModeEnabled())
                 {
-                    string runtimeStack = _workerRuntime;
-
-                    // Appending the runtime version is currently only enabled for linux consumption. This will be eventually enabled for
-                    // Windows Consumption as well.
-                    string runtimeVersion = _environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName);
-
-                    if (!string.IsNullOrEmpty(runtimeVersion))
-                    {
-                        runtimeStack = string.Concat(runtimeStack, "-", runtimeVersion);
-                    }
-
+                    // Appending the runtime version is currently only enabled for linux consumption.
+                    // This will be eventually enabled for Windows Consumption as well.
+                    string runtimeStack = GetPreciseRuntimeStack(_workerRuntime);
                     _metricsLogger.LogEvent(string.Format(MetricEventNames.HostStartupRuntimeLanguage, runtimeStack));
                 }
 
@@ -298,6 +290,35 @@ namespace Microsoft.Azure.WebJobs.Script
 
                 CleanupFileSystem();
             }
+        }
+
+        /// <summary>
+        /// Appends specific functions worker runtime version after runtime stack
+        /// </summary>
+        /// <returns>A string contains specific runtime stack (e.g. python-3.6, dotnet-~2) or single stack</returns>
+        private string GetPreciseRuntimeStack(string runtime)
+        {
+            string runtimeStack = runtime?.ToLower() ?? string.Empty;
+            string preciseRuntime = string.Empty;
+            switch (runtimeStack)
+            {
+                case "dotnet":
+                    // Get Dotnet version from FUNCTIONS_EXTENSION_VERSION
+                    preciseRuntime = $"dotnet-{_environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsExtensionVersion)}";
+                    break;
+                case "node":
+                    // Get Node version from WEBSITE_NODE_DEFAULT_VERSION
+                    preciseRuntime = $"node-{_environment.GetEnvironmentVariable(EnvironmentSettingNames.WebsiteNodeDefaultVersion)}";
+                    break;
+                case "python":
+                    preciseRuntime = $"python-{_environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName)}";
+                    break;
+                default:
+                    // PowerShell, Java only has single version
+                    preciseRuntime = runtimeStack;
+                    break;
+            }
+            return preciseRuntime.TrimEnd('-');
         }
 
         private async Task LogInitializationAsync()

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.Configuration;
@@ -396,6 +397,71 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     var scriptHost = host.GetScriptHost();
                     await scriptHost.InitializeAsync();
                     Assert.Single(loggerProvider.GetAllLogMessages(), m => m.Level == LogLevel.Warning && m.FormattedMessage.StartsWith("Site extension version currently set to 'latest'."));
+                }
+            }
+            finally
+            {
+                EnvironmentExtensions.BaseDirectory = null;
+            }
+        }
+
+        [Theory]
+        [InlineData("dotnet", "", "", "", "dotnet")]
+        [InlineData("dotnet", "~2", "", "", "dotnet-~2")]
+        [InlineData("python", "~2", "", "", "python")]
+        [InlineData("python", "~2", "", "3.6", "python-3.6")]
+        [InlineData("python", "~3", "~8", "3.7", "python-3.7")]
+        [InlineData("node", "~3", "", "3.6", "node")]
+        [InlineData("node", "~2", "~8", "3.6", "node-~8")]
+        [InlineData("powershell", "~2", "", "", "powershell")]
+        [InlineData("powershell", "~2", "~10", "3.6", "powershell")]
+        [InlineData("java", "~3", "", "", "java")]
+        [InlineData("java", "~3", "~8", "3.6", "java")]
+        public async Task Initialize_WithRuntimeAndWorkerVersion_ReportRuntimeToMetricsTable(
+            string functionsWorkerRuntime,
+            string functionsExtensionVersion,
+            string websiteNodeDefaultVersion,
+            string functionsWorkerRuntimeVersion,
+            string expectedRuntimeStack)
+        {
+            try
+            {
+                using (var tempDirectory = new TempDirectory())
+                {
+                    string rootPath = Path.Combine(tempDirectory.Path, Guid.NewGuid().ToString());
+                    Directory.CreateDirectory(rootPath);
+                    var metricsLogger = new TestMetricsLogger();
+                    var environment = new TestEnvironment();
+
+                    environment.SetEnvironmentVariable(
+                        RpcWorkerConstants.FunctionWorkerRuntimeSettingName, functionsWorkerRuntime);
+                    environment.SetEnvironmentVariable(
+                        EnvironmentSettingNames.FunctionsExtensionVersion, functionsExtensionVersion);
+                    environment.SetEnvironmentVariable(
+                        EnvironmentSettingNames.WebsiteNodeDefaultVersion, websiteNodeDefaultVersion);
+                    environment.SetEnvironmentVariable(
+                        RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName, functionsWorkerRuntimeVersion);
+
+                    IHost host = new HostBuilder()
+                        .ConfigureServices(s =>
+                        {
+                            s.AddSingleton<IEnvironment>(environment);
+                        })
+                        .ConfigureDefaultTestWebScriptHost(
+                        null,
+                        o =>
+                        {
+                            o.ScriptPath = rootPath;
+                        },
+                        false,
+                        s =>
+                        {
+                            s.AddSingleton<IMetricsLogger>(metricsLogger);
+                        })
+                        .Build();
+                    var scriptHost = host.GetScriptHost();
+                    await scriptHost.InitializeAsync();
+                    Assert.Single(metricsLogger.LoggedEvents, e => e.Equals($"host.startup.runtime.language.{expectedRuntimeStack}"));
                 }
             }
             finally


### PR DESCRIPTION
Resolves: https://github.com/Azure/azure-functions-host/issues/5621

We should derive worker runtime version from
- dotnet: FUNCTIONS_EXTENSION_VERSION
- node: WEBSITE_NODE_DEFAULT_VERSION
- python: FUNCTIONS_WORKER_RUNTIME_VERSION
- powershell, java only have single version

@brettsam : I want to write unittest for metric logger, could you point me an example? Thanks.