### PR TITLE
Delay invocations until worker ready on restart due to error (hotfix commit)

### DIFF
--- a/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs
@@ -102,6 +102,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
             if (!ready)
             {
+                _logger.LogDebug($"functionDispatcher state: {_functionDispatcher.State}");
                 bool result = await Utility.DelayAsync((_functionDispatcher.ErrorEventsThreshold + 1) * WorkerConstants.ProcessStartTimeoutSeconds, WorkerConstants.WorkerReadyCheckPollingIntervalMilliseconds, () =>
                 {
                     return _functionDispatcher.State != FunctionInvocationDispatcherState.Initialized;

--- a/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs
@@ -90,19 +90,26 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         private async Task DelayUntilFunctionDispatcherInitializedOrShutdown()
         {
-            if (_functionDispatcher != null && _functionDispatcher.State != FunctionInvocationDispatcherState.Initialized)
+            // Don't delay if functionDispatcher is already initialized OR is skipping initialization for one of
+            // these reasons: started in placeholder, has no functions, functions do not match set language.
+            if (_functionDispatcher == null
+                || _functionDispatcher.State == FunctionInvocationDispatcherState.Initialized
+                || _functionDispatcher.State == FunctionInvocationDispatcherState.Default)
             {
-                _logger.LogDebug($"functionDispatcher state: {_functionDispatcher.State}");
-                bool result = await Utility.DelayAsync((_functionDispatcher.ErrorEventsThreshold + 1) * WorkerConstants.ProcessStartTimeoutSeconds, WorkerConstants.WorkerReadyCheckPollingIntervalMilliseconds, () =>
-                {
-                    return _functionDispatcher.State != FunctionInvocationDispatcherState.Initialized;
-                });
+                return;
+            }
 
-                if (result)
-                {
-                    _logger.LogError($"Final functionDispatcher state: {_functionDispatcher.State}. Initialization timed out and host is shutting down");
-                    _applicationLifetime.StopApplication();
-                }
+            // Delay until functionDispatcher state is "Initialized"
+            _logger.LogDebug($"functionDispatcher state: {_functionDispatcher.State}");
+            bool result = await Utility.DelayAsync((_functionDispatcher.ErrorEventsThreshold + 1) * WorkerConstants.ProcessStartTimeoutSeconds, WorkerConstants.WorkerReadyCheckPollingIntervalMilliseconds, () =>
+            {
+                return _functionDispatcher.State != FunctionInvocationDispatcherState.Initialized;
+            });
+
+            if (result)
+            {
+                _logger.LogError($"Final functionDispatcher state: {_functionDispatcher.State}. Initialization timed out and host is shutting down");
+                _applicationLifetime.StopApplication();
             }
         }
 

--- a/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         private async Task DelayUntilFunctionDispatcherInitializedOrShutdown()
         {
-            if (_functionDispatcher != null && _functionDispatcher.State == FunctionInvocationDispatcherState.Initializing)
+            if (_functionDispatcher != null && _functionDispatcher.State != FunctionInvocationDispatcherState.Initialized)
             {
                 _logger.LogDebug($"functionDispatcher state: {_functionDispatcher.State}");
                 bool result = await Utility.DelayAsync((_functionDispatcher.ErrorEventsThreshold + 1) * WorkerConstants.ProcessStartTimeoutSeconds, WorkerConstants.WorkerReadyCheckPollingIntervalMilliseconds, () =>

--- a/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
             // Don't delay if functionDispatcher is already initialized OR is skipping initialization for one of
             // these reasons: started in placeholder, has no functions, functions do not match set language.
-            var ready = _functionDispatcher.State == FunctionInvocationDispatcherState.Initialized || _functionDispatcher.State == FunctionInvocationDispatcherState.Default;
+            bool ready = _functionDispatcher.State == FunctionInvocationDispatcherState.Initialized || _functionDispatcher.State == FunctionInvocationDispatcherState.Default;
 
             if (!ready)
             {

--- a/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs
@@ -90,12 +90,6 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         private async Task DelayUntilFunctionDispatcherInitializedOrShutdown()
         {
-            // TODO: remove this. Keeping for targeted fix
-            if (_functionDispatcher == null)
-            {
-                return;
-            }
-
             // Don't delay if functionDispatcher is already initialized OR is skipping initialization for one of
             // these reasons: started in placeholder, has no functions, functions do not match set language.
             bool ready = _functionDispatcher.State == FunctionInvocationDispatcherState.Initialized || _functionDispatcher.State == FunctionInvocationDispatcherState.Default;

--- a/src/WebJobs.Script/Workers/FunctionInvocationDispatcherState.cs
+++ b/src/WebJobs.Script/Workers/FunctionInvocationDispatcherState.cs
@@ -20,6 +20,16 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         /// invocations. All functions have been indexed. Listeners may not yet
         /// be not yet running.
         /// </summary>
-        Initialized
+        Initialized,
+
+        /// <summary>
+        /// The FunctionDispatcherState was fully initialized but has enconutered an error and is restarting
+        /// </summary>
+        Recovering,
+
+        /// <summary>
+        /// The FunctionDispatcherState is disposing
+        /// </summary>
+        Disposing
     }
 }

--- a/src/WebJobs.Script/Workers/FunctionInvocationDispatcherState.cs
+++ b/src/WebJobs.Script/Workers/FunctionInvocationDispatcherState.cs
@@ -11,24 +11,25 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         Default,
 
         /// <summary>
-        /// The FunctionDispatcherState is starting.
+        /// The FunctionDispatcher is starting.
         /// </summary>
         Initializing,
 
         /// <summary>
-        /// The FunctionDispatcherState has been fully initialized and can accept direct function
+        /// The FunctionDispatcher has been fully initialized and can accept direct function
         /// invocations. All functions have been indexed. Listeners may not yet
         /// be not yet running.
         /// </summary>
         Initialized,
 
         /// <summary>
-        /// The FunctionDispatcherState was fully initialized but has enconutered an error and is restarting
+        /// The FunctionDispatcher was previously "Initialized" but no longer has any initialized
+        /// worker processes to handle function invocations.
         /// </summary>
-        Recovering,
+        WorkerProcessRestarting,
 
         /// <summary>
-        /// The FunctionDispatcherState is disposing
+        /// The FunctionDispatcher is disposing
         /// </summary>
         Disposing
     }

--- a/src/WebJobs.Script/Workers/FunctionInvocationDispatcherState.cs
+++ b/src/WebJobs.Script/Workers/FunctionInvocationDispatcherState.cs
@@ -31,6 +31,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         /// <summary>
         /// The FunctionDispatcher is disposing
         /// </summary>
-        Disposing
+        Disposing,
+
+        /// <summary>
+        /// The FunctionDispatcher is disposed
+        /// </summary>
+        Disposed
     }
 }

--- a/src/WebJobs.Script/Workers/FunctionInvocationDispatcherState.cs
+++ b/src/WebJobs.Script/Workers/FunctionInvocationDispatcherState.cs
@@ -16,9 +16,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         Initializing,
 
         /// <summary>
-        /// The FunctionDispatcher has been fully initialized and can accept direct function
-        /// invocations. All functions have been indexed. Listeners may not yet
-        /// be not yet running.
+        /// The FunctionDispatcher has been fully initialized and can accept function
+        /// invocations. All functions have been indexed. At least one worker process is initialized.
         /// </summary>
         Initialized,
 

--- a/src/WebJobs.Script/Workers/Http/HttpFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpFunctionInvocationDispatcher.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         {
             if (!_disposing)
             {
-                _logger.LogDebug("Handling WorkerErrorEvent for workerId:{workerId}", workerError.WorkerId);
+                _logger.LogDebug("Handling WorkerErrorEvent for workerId:{workerId}. Failed with: {exception}", workerError.WorkerId, workerError.Exception);
                 AddOrUpdateErrorBucket(workerError);
                 await DisposeAndRestartWorkerChannel(workerError.WorkerId);
             }

--- a/src/WebJobs.Script/Workers/Http/HttpFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpFunctionInvocationDispatcher.cs
@@ -123,9 +123,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             // Since we only have one HTTP worker process, as soon as we dispose it, InvokeAsync will fail. Set state to
             // indicate we are not ready to receive new requests.
             State = FunctionInvocationDispatcherState.WorkerProcessRestarting;
-
             _logger.LogDebug("Disposing channel for workerId: {channelId}", workerId);
-            State = FunctionInvocationDispatcherState.WorkerProcessRestarting;
             if (_httpWorkerChannel != null)
             {
                 (_httpWorkerChannel as IDisposable)?.Dispose();

--- a/src/WebJobs.Script/Workers/Http/HttpFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpFunctionInvocationDispatcher.cs
@@ -169,6 +169,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
                 _workerErrorSubscription.Dispose();
                 _workerRestartSubscription.Dispose();
                 (_httpWorkerChannel as IDisposable)?.Dispose();
+                State = FunctionInvocationDispatcherState.Disposed;
                 _disposed = true;
             }
         }

--- a/src/WebJobs.Script/Workers/Http/HttpFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpFunctionInvocationDispatcher.cs
@@ -120,7 +120,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
 
         private async Task DisposeAndRestartWorkerChannel(string workerId)
         {
+            // Since we only have one HTTP worker process, as soon as we dispose it, InvokeAsync will fail. Set state to
+            // indicate we are not ready to receive new requests.
+            State = FunctionInvocationDispatcherState.WorkerProcessRestarting;
+
             _logger.LogDebug("Disposing channel for workerId: {channelId}", workerId);
+            State = FunctionInvocationDispatcherState.WorkerProcessRestarting;
             if (_httpWorkerChannel != null)
             {
                 (_httpWorkerChannel as IDisposable)?.Dispose();
@@ -173,6 +178,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         public void Dispose()
         {
             _disposing = true;
+            State = FunctionInvocationDispatcherState.Disposing;
             Dispose(true);
         }
 

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -335,7 +335,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 // Set state to "Recovering" if there are no other workers to handle work
                 if ((await GetInitializedWorkerChannelsAsync()).Count() == 0)
                 {
-                    State = FunctionInvocationDispatcherState.Recovering;
+                    State = FunctionInvocationDispatcherState.WorkerProcessRestarting;
                     _logger.LogDebug("No initialized worker channels for runtime '{runtime}'. Delaying future invocations", runtime);
                 }
                 // Restart worker channel

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -394,6 +394,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 _processStartCancellationToken.Cancel();
                 _processStartCancellationToken.Dispose();
                 _jobHostLanguageWorkerChannelManager.DisposeAndRemoveChannels();
+                State = FunctionInvocationDispatcherState.Disposed;
                 _disposed = true;
             }
         }

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -341,8 +341,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 // Restart worker channel
                 _logger.LogDebug("Restarting worker channel for runtime:{runtime}", runtime);
                 await RestartWorkerChannel(runtime, workerId);
-                State = FunctionInvocationDispatcherState.Initialized;
-                _logger.LogDebug("Restarted worker channel for runtime:{runtime}", runtime);
+                // State is set back to "Initialized" when worker channel is up again
             }
             else
             {

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -332,7 +332,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
             if (ShouldRestartWorkerChannel(runtime, isWebHostChannel, isJobHostChannel))
             {
-                // Set state to "Recovering" if there are no other workers to handle work
+                // Set state to "WorkerProcessRestarting" if there are no other workers to handle work
                 if ((await GetInitializedWorkerChannelsAsync()).Count() == 0)
                 {
                     State = FunctionInvocationDispatcherState.WorkerProcessRestarting;

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             {
                 if (string.Equals(_workerRuntime, workerError.Language))
                 {
-                    _logger.LogDebug("Handling WorkerErrorEvent for runtime:{runtime}, workerId:{workerId}", workerError.Language, workerError.WorkerId);
+                    _logger.LogDebug("Handling WorkerErrorEvent for runtime:{runtime}, workerId:{workerId}. Failed with: {exception}", workerError.Language, _workerRuntime, workerError.Exception);
                     AddOrUpdateErrorBucket(workerError);
                     await DisposeAndRestartWorkerChannel(workerError.Language, workerError.WorkerId);
                 }

--- a/test/WebJobs.Script.Tests/Description/Worker/WorkerFunctionInvokerTests.cs
+++ b/test/WebJobs.Script.Tests/Description/Worker/WorkerFunctionInvokerTests.cs
@@ -56,20 +56,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _applicationLifetime.Verify(a => a.StopApplication(), Times.Once);
         }
 
-        [Fact]
-        public async Task FunctionDispatcher_WorkerProcessRestarting_DelaysInvoke()
-        {
-            _mockFunctionInvocationDispatcher.Setup(a => a.State).Returns(FunctionInvocationDispatcherState.WorkerProcessRestarting);
-            var timeoutTask = Task.Delay(TimeSpan.FromSeconds(5));
-            var result = await Task.WhenAny(_testFunctionInvoker.InvokeCore(new object[] { }, null), timeoutTask);
-            Assert.Equal(timeoutTask, result);
-
-            _mockFunctionInvocationDispatcher.Setup(a => a.State).Returns(FunctionInvocationDispatcherState.Initialized);
-            var invokeCoreTask = _testFunctionInvoker.InvokeCore(new object[] { }, null);
-            result = await Task.WhenAny(invokeCoreTask, Task.Delay(TimeSpan.FromSeconds(5)));
-            Assert.Equal(invokeCoreTask, result);
-        }
-
         [Theory]
         [InlineData(FunctionInvocationDispatcherState.Default, false)]
         [InlineData(FunctionInvocationDispatcherState.Initializing, true)]

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
@@ -200,8 +200,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 func1
             };
             await functionDispatcher.InitializeAsync(functions);
-            Assert.True(functionDispatcher.State == FunctionInvocationDispatcherState.Initializing || functionDispatcher.State == FunctionInvocationDispatcherState.Initialized);
+            Assert.Equal(FunctionInvocationDispatcherState.Initializing, functionDispatcher.State);
             await WaitForFunctionDispactherStateInitialized(functionDispatcher);
+            Assert.Equal(FunctionInvocationDispatcherState.Initialized, functionDispatcher.State);
         }
 
         [Fact]
@@ -260,8 +261,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             testWorkerChannel.RaiseWorkerRestart();
             await TestHelpers.Await(() =>
             {
-                return functionDispatcher.State == FunctionInvocationDispatcherState.WorkerProcessRestarting
-                || functionDispatcher.State == FunctionInvocationDispatcherState.Initialized;
+                return functionDispatcher.State == FunctionInvocationDispatcherState.WorkerProcessRestarting;
             }, 3000);
             await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount);
             Assert.True(functionDispatcher.State == FunctionInvocationDispatcherState.Initialized);

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
@@ -220,8 +220,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 func1
             };
             await functionDispatcher.InitializeAsync(functions);
-            Assert.True(functionDispatcher.State == FunctionInvocationDispatcherState.Initializing || functionDispatcher.State == FunctionInvocationDispatcherState.Initialized);
+            Assert.Equal(FunctionInvocationDispatcherState.Initializing, functionDispatcher.State);
             await WaitForFunctionDispactherStateInitialized(functionDispatcher);
+            Assert.Equal(FunctionInvocationDispatcherState.Initialized, functionDispatcher.State);
             functionDispatcher.Dispose();
             Assert.True(functionDispatcher == null || functionDispatcher.State == FunctionInvocationDispatcherState.Disposing || functionDispatcher.State == FunctionInvocationDispatcherState.Disposed);
         }
@@ -264,7 +265,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 return functionDispatcher.State == FunctionInvocationDispatcherState.WorkerProcessRestarting;
             }, 3000);
             await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount);
-            Assert.True(functionDispatcher.State == FunctionInvocationDispatcherState.Initialized);
+            Assert.Equal(FunctionInvocationDispatcherState.Initialized, functionDispatcher.State);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannel.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannel.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         public async Task StartWorkerProcessAsync()
         {
             // To verify FunctionDispatcher transistions
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            await Task.Delay(TimeSpan.FromMilliseconds(500));
 
             if (_throwOnProcessStartUp)
             {


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-functions-host/issues/5629, https://github.com/Azure/azure-functions-host/issues/5624