### PR TITLE
Update PowerShellWorker versions to 3.0.235 (PS6) and 3.0.237 (PS7)

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -42,7 +42,8 @@
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.11020001-fabe022e" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.5.2-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.0.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.216" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.235" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.237" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.16" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="3.0.5" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.6" />


### PR DESCRIPTION
PowerShell worker release notes:
- https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.235
- https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.237