### PR TITLE
StartupContextProvider should expand path environment variable

### DIFF
--- a/src/WebJobs.Script.WebHost/StartupContextProvider.cs
+++ b/src/WebJobs.Script.WebHost/StartupContextProvider.cs
@@ -104,6 +104,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             {
                 try
                 {
+                    contextPath = Environment.ExpandEnvironmentVariables(contextPath);
                     _logger.LogDebug($"Loading startup context from {contextPath}");
                     string content = File.ReadAllText(contextPath);
 

--- a/test/WebJobs.Script.Tests/StartupContextProviderTests.cs
+++ b/test/WebJobs.Script.Tests/StartupContextProviderTests.cs
@@ -142,6 +142,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public void GetContext_ExpandsEnvironmentVariables()
+        {
+            string path = Path.Combine("%TEMP%", $"{Guid.NewGuid()}.txt");
+            WriteStartupContext(path: path);
+
+            Assert.NotNull(_startupContextProvider.Context);
+        }
+
+        [Fact]
         public void GetContext_EnvVarNotSet_ReturnsNull()
         {
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteStartupContextCache, null);
@@ -193,9 +202,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(_secrets.Host.System, secrets.SystemKeys);
         }
 
-        private string WriteStartupContext(string context = null)
+        private string WriteStartupContext(string context = null, string path = null)
         {
-            var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.txt");
+            path = path ?? Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.txt");
+            path = Environment.ExpandEnvironmentVariables(path);
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteStartupContextCache, path);
 
             if (context == null)


### PR DESCRIPTION
Hamid found this bug in his cold-start testing. It seems that after Kranthi and I did the E2E DWAS / runtime testing, the code checked into ANT 87 uses an un-expanded path variable for the context path (e.g. `%System%\local\xxx`)