### PR TITLE
[pack]Remove dup workers directories from site extension

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -226,7 +226,14 @@ function CreateZips([string] $runtimeSuffix) {
     Rename-Item "$privateSiteExtensionPath" "$siteExtensionPath\$extensionVersion"
     Copy-Item .\src\WebJobs.Script.WebHost\extension.xml "$siteExtensionPath"
     ZipContent $siteExtensionPath "$buildOutput\Functions.$extensionVersion$runtimeSuffix.zip"
+}
 
+function deleteDuplicateWorkers() {
+    Write-Host "Deleting workers directory: $privateSiteExtensionPath\32bit\workers" 
+    Remove-Item -Recurse -Force "$privateSiteExtensionPath\32bit\workers" -ErrorAction SilentlyContinue
+    Write-Host "Moving workers directory:$privateSiteExtensionPath\64bit\workers to" $privateSiteExtensionPath 
+    
+    Move-Item -Path "$privateSiteExtensionPath\64bit\workers"  -Destination "$privateSiteExtensionPath\workers" 
 }
 
 function cleanExtension([string] $bitness) {
@@ -245,6 +252,7 @@ function cleanExtension([string] $bitness) {
     $keepRuntimes = @('win', 'win-x86', 'win10-x86', 'win-x64', 'win10-x64')
     Get-ChildItem "$privateSiteExtensionPath\$bitness\workers\powershell\runtimes" -Exclude $keepRuntimes -ErrorAction SilentlyContinue |
         Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    deleteDuplicateWorkers
 }
   
 dotnet --version

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -33,6 +33,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
             _metricsLogger = metricsLogger;
             WorkersDirPath = Path.Combine(Path.GetDirectoryName(new Uri(typeof(RpcWorkerConfigFactory).Assembly.CodeBase).LocalPath), RpcWorkerConstants.DefaultWorkersDirectoryName);
+            if (!Directory.Exists(WorkersDirPath))
+            {
+                // Site Extension. Default to parent directory
+                WorkersDirPath = Path.Combine(Directory.GetParent(Path.GetDirectoryName(new Uri(typeof(RpcWorkerConfigFactory).Assembly.CodeBase).LocalPath)).FullName, RpcWorkerConstants.DefaultWorkersDirectoryName);
+            }
             var workersDirectorySection = _config.GetSection($"{RpcWorkerConstants.LanguageWorkersSectionName}:{WorkerConstants.WorkersDirectorySectionName}");
             if (!string.IsNullOrEmpty(workersDirectorySection.Value))
             {


### PR DESCRIPTION
Site Extension includes "Workers" directories in both 32 bit and 64Bit folders.  Workers that are shipped with functions host do not rely on host bitness to select worker binaries.

Fix is scoped to SiteExtension. No changes when running locally or via CLI. For V2, this reduces the site extension size by ~87MB