### PR TITLE
[pack][Hotfix][V2]Remove  duplicate worker directories from siteextension

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -226,7 +226,14 @@ function CreateZips([string] $runtimeSuffix) {
     Rename-Item "$privateSiteExtensionPath" "$siteExtensionPath\$extensionVersion"
     Copy-Item .\src\WebJobs.Script.WebHost\extension.xml "$siteExtensionPath"
     ZipContent $siteExtensionPath "$buildOutput\Functions.$extensionVersion$runtimeSuffix.zip"
+}
 
+function deleteDuplicateWorkers() {
+    Write-Host "Deleting workers directory: $privateSiteExtensionPath\32bit\workers" 
+    Remove-Item -Recurse -Force "$privateSiteExtensionPath\32bit\workers" -ErrorAction SilentlyContinue
+    Write-Host "Moving workers directory:$privateSiteExtensionPath\64bit\workers to" $privateSiteExtensionPath 
+    
+    Move-Item -Path "$privateSiteExtensionPath\64bit\workers"  -Destination "$privateSiteExtensionPath\workers" 
 }
 
 function cleanExtension([string] $bitness) {
@@ -245,6 +252,7 @@ function cleanExtension([string] $bitness) {
     $keepRuntimes = @('win', 'win-x86', 'win10-x86', 'win-x64', 'win10-x64')
     Get-ChildItem "$privateSiteExtensionPath\$bitness\workers\powershell\runtimes" -Exclude $keepRuntimes -ErrorAction SilentlyContinue |
         Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+    deleteDuplicateWorkers
 }
   
 dotnet --version

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             }
         }
 
-        internal string GetDefaultWorkersDirectory(Func<string, bool> directoryExists)
+        internal static string GetDefaultWorkersDirectory(Func<string, bool> directoryExists)
         {
             string assemblyLocalPath = Path.GetDirectoryName(new Uri(typeof(RpcWorkerConfigFactory).Assembly.CodeBase).LocalPath);
             string workersDirPath = Path.Combine(assemblyLocalPath, RpcWorkerConstants.DefaultWorkersDirectoryName);

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
-        public void DefaultLanguageWorkersDir_Set_To_CurrentDir()
+        public void DefaultLanguageWorkersDir()
         {
             var expectedWorkersDir = Path.Combine(Path.GetDirectoryName(new Uri(typeof(RpcWorkerConfigFactory).Assembly.CodeBase).LocalPath), RpcWorkerConstants.DefaultWorkersDirectoryName);
             var config = new ConfigurationBuilder().Build();
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
-        public void DefaultLanguageWorkersDir_Set_To_ParentDir()
+        public void GetDefaultWorkersDirectory_Returns_Expected()
         {
             string assemblyLocalPath = Path.GetDirectoryName(new Uri(typeof(RpcWorkerConfigFactory).Assembly.CodeBase).LocalPath);
             string defaultWorkersDirPath = Path.Combine(assemblyLocalPath, RpcWorkerConstants.DefaultWorkersDirectoryName);
@@ -48,11 +48,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             {
                 return false;
             };
-            var expectedWorkersDir = Path.Combine(Directory.GetParent(assemblyLocalPath).FullName, RpcWorkerConstants.DefaultWorkersDirectoryName);
+            var expectedWorkersDirIsCurrentDir = Path.Combine(assemblyLocalPath, RpcWorkerConstants.DefaultWorkersDirectoryName);
+            var expectedWorkersDirIsParentDir = Path.Combine(Directory.GetParent(assemblyLocalPath).FullName, RpcWorkerConstants.DefaultWorkersDirectoryName);
             var config = new ConfigurationBuilder().Build();
             var testLogger = new TestLogger("test");
-            var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger(), testDirectoryExists);
-            Assert.Equal(expectedWorkersDir, configFactory.WorkersDirPath);
+            var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger());
+
+            Assert.Equal(expectedWorkersDirIsCurrentDir, configFactory.GetDefaultWorkersDirectory(Directory.Exists));
+            Assert.Equal(expectedWorkersDirIsParentDir, configFactory.GetDefaultWorkersDirectory(testDirectoryExists));
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
@@ -30,12 +30,28 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
-        public void DefaultLanguageWorkersDir()
+        public void DefaultLanguageWorkersDir_Set_To_CurrentDir()
         {
             var expectedWorkersDir = Path.Combine(Path.GetDirectoryName(new Uri(typeof(RpcWorkerConfigFactory).Assembly.CodeBase).LocalPath), RpcWorkerConstants.DefaultWorkersDirectoryName);
             var config = new ConfigurationBuilder().Build();
             var testLogger = new TestLogger("test");
             var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger());
+            Assert.Equal(expectedWorkersDir, configFactory.WorkersDirPath);
+        }
+
+        [Fact]
+        public void DefaultLanguageWorkersDir_Set_To_ParentDir()
+        {
+            string assemblyLocalPath = Path.GetDirectoryName(new Uri(typeof(RpcWorkerConfigFactory).Assembly.CodeBase).LocalPath);
+            string defaultWorkersDirPath = Path.Combine(assemblyLocalPath, RpcWorkerConstants.DefaultWorkersDirectoryName);
+            Func<string, bool> testDirectoryExists = path =>
+            {
+                return false;
+            };
+            var expectedWorkersDir = Path.Combine(Directory.GetParent(assemblyLocalPath).FullName, RpcWorkerConstants.DefaultWorkersDirectoryName);
+            var config = new ConfigurationBuilder().Build();
+            var testLogger = new TestLogger("test");
+            var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger(), testDirectoryExists);
             Assert.Equal(expectedWorkersDir, configFactory.WorkersDirPath);
         }
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
@@ -52,10 +52,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var expectedWorkersDirIsParentDir = Path.Combine(Directory.GetParent(assemblyLocalPath).FullName, RpcWorkerConstants.DefaultWorkersDirectoryName);
             var config = new ConfigurationBuilder().Build();
             var testLogger = new TestLogger("test");
-            var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger());
 
-            Assert.Equal(expectedWorkersDirIsCurrentDir, configFactory.GetDefaultWorkersDirectory(Directory.Exists));
-            Assert.Equal(expectedWorkersDirIsParentDir, configFactory.GetDefaultWorkersDirectory(testDirectoryExists));
+            Assert.Equal(expectedWorkersDirIsCurrentDir, RpcWorkerConfigFactory.GetDefaultWorkersDirectory(Directory.Exists));
+            Assert.Equal(expectedWorkersDirIsParentDir, RpcWorkerConfigFactory.GetDefaultWorkersDirectory(testDirectoryExists));
         }
 
         [Fact]


### PR DESCRIPTION
Site Extension includes "Workers" directories in both 32 bit and 64Bit folders.  Workers that are shipped with functions host do not rely on host bitness to select worker binaries.

For Workers that do need architecture specific binaries, nuget packages produced should include folder structure per architecture. So far, only python worker needs platform specific binaries. Please see: https://github.com/Azure/azure-functions-python-worker/blob/dev/python/prodV2/worker.config.json for an example. SiteExtension does not include python worker as python is not supported on windows.

Fix is scoped to SiteExtension. No changes when running locally or via CLI. For V2, this reduces the site extension size by ~87MB