### PR TITLE
Add global exception logger for linux consumption

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxContainerEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxContainerEventGenerator.cs
@@ -106,5 +106,17 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         {
 //            _writeEvent($"{ScriptConstants.LinuxAzureMonitorEventStreamName} {(int)ToEventLevel(level)},{resourceId},{operationName},{category},{regionName},{NormalizeString(properties)},{_containerName},{TenantId},{DateTime.UtcNow.ToString()}");
         }
+
+        public static void LogUnhandledException(Exception e)
+        {
+            var linuxContainerEventGenerator = new LinuxContainerEventGenerator(SystemEnvironment.Instance);
+            linuxContainerEventGenerator.LogFunctionTraceEvent(LogLevel.Error,
+                SystemEnvironment.Instance.GetSubscriptionId() ?? string.Empty,
+                SystemEnvironment.Instance.GetAzureWebsiteUniqueSlotName() ?? string.Empty, string.Empty, string.Empty,
+                nameof(LogUnhandledException), e?.ToString(), string.Empty, e?.GetType().ToString() ?? string.Empty,
+                e?.ToString(), string.Empty, string.Empty, string.Empty,
+                SystemEnvironment.Instance.GetRuntimeSiteName() ?? string.Empty,
+                SystemEnvironment.Instance.GetSlotName() ?? string.Empty);
+        }
     }
 }

--- a/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
@@ -261,11 +261,20 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
 
         private void OnProcessMonitorTimer(object state)
         {
-            _process.Refresh();
-            var commitSizeBytes = _process.WorkingSet64;
-            if (commitSizeBytes != 0)
+            try
             {
-                AddMemoryActivity(DateTime.UtcNow, commitSizeBytes);
+                _process.Refresh();
+                var commitSizeBytes = _process.WorkingSet64;
+                if (commitSizeBytes != 0)
+                {
+                    AddMemoryActivity(DateTime.UtcNow, commitSizeBytes);
+                }
+            }
+            catch (Exception e)
+            {
+                // throwing this exception will mask other underlying exceptions.
+                // Log and let other interesting exceptions bubble up.
+                _logger.LogError(e, nameof(OnProcessMonitorTimer));
             }
         }
 

--- a/src/WebJobs.Script.WebHost/Program.cs
+++ b/src/WebJobs.Script.WebHost/Program.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Configuration.EnvironmentVariables;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
-using DataProtectionCostants = Microsoft.Azure.Web.DataProtection.Constants;
+using DataProtectionConstants = Microsoft.Azure.Web.DataProtection.Constants;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
 {
@@ -84,17 +84,26 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             {
                 // Linux containers always start out in placeholder mode
                 SystemEnvironment.Instance.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
+                AppDomain.CurrentDomain.UnhandledException += CurrentDomainOnUnhandledException;
             }
 
             // Some environments only set the auth key. Ensure that is used as the encryption key if that is not set
             string authEncryptionKey = SystemEnvironment.Instance.GetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey);
             if (authEncryptionKey != null &&
-                SystemEnvironment.Instance.GetEnvironmentVariable(DataProtectionCostants.AzureWebsiteEnvironmentMachineKey) == null)
+                SystemEnvironment.Instance.GetEnvironmentVariable(DataProtectionConstants.AzureWebsiteEnvironmentMachineKey) == null)
             {
-                SystemEnvironment.Instance.SetEnvironmentVariable(DataProtectionCostants.AzureWebsiteEnvironmentMachineKey, authEncryptionKey);
+                SystemEnvironment.Instance.SetEnvironmentVariable(DataProtectionConstants.AzureWebsiteEnvironmentMachineKey, authEncryptionKey);
             }
 
             ConfigureMinimumThreads(SystemEnvironment.Instance.IsWindowsConsumption());
+        }
+
+        private static void CurrentDomainOnUnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            // Fallback console logs in case kusto logging fails.
+            Console.WriteLine($"{nameof(CurrentDomainOnUnhandledException)}: {e.ExceptionObject}");
+
+            LinuxContainerEventGenerator.LogUnhandledException((Exception)e.ExceptionObject);
         }
 
         private static void ConfigureMinimumThreads(bool isDynamicSku)


### PR DESCRIPTION
On windows these errors get logged in eventviewer. On Linux we need an explicit handler for capturing these logs.