### PR TITLE
[ExtensionsMetadataGenerator] fixing build target for extensions.json

### DIFF
--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.csproj
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\metadatagenerator.props" />
   <PropertyGroup>
-    <Version>1.1.4</Version>
+    <Version>1.1.5</Version>
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <AssemblyName>Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator</AssemblyName>

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets
@@ -27,7 +27,7 @@
   <UsingTask TaskName="RemoveRuntimeDependencies"
              AssemblyFile="$(_FunctionsExtensionsTaskAssemblyFullPath)"/>
   
-  <Target Name="_FunctionsBuildCleanOutput" AfterTargets="_GenerateFunctionsPostBuild" Condition="$(_FunctionsSkipCleanOutput) != 'true'" >
+  <Target Name="_FunctionsBuildCleanOutput" AfterTargets="_GenerateFunctionsExtensionsMetadataPostBuild" Condition="$(_FunctionsSkipCleanOutput) != 'true'" >
     <RemoveRuntimeDependencies OutputPath="$(TargetDir)bin"/>
   </Target>
 


### PR DESCRIPTION
Fixes #5747

During builds we were trimming the output before we'd generate extensions, which caused them to fail to load dependent assemblies. This moves the trimming to occur after this happens. Publish was already behaving this way; Build was not.