### PR TITLE
[ExtensionsMetadataGenerator] ensuring correct ordering of targets

### DIFF
--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets
@@ -39,7 +39,7 @@
              AssemblyFile="$(_FunctionsExtensionsTaskAssemblyFullPath)"/>
 
   <Target Name="_GenerateFunctionsExtensionsMetadataPostBuild"
-          AfterTargets="Build">
+          AfterTargets="_GenerateFunctionsPostBuild">
 
     <GenerateFunctionsExtensionsMetadata
       SourcePath="$(_FunctionsExtensionsDir)"


### PR DESCRIPTION
Another fix for #5747 (this one builds on #5748).

Because we had both `_GenerateFunctionsPostBuild` and `_GenerateFunctionsExtensionsMetadataPostBuild` using `AfterTargets="Build"`, the ordering of these could change whether or not you were directly referencing ExtensionsMetadataGenerator.

This change ensures that the ordering will go `Build -> _GenerateFunctionsPostBuild -> _GenerateFunctionsExtensionsMetadataPostBuild -> _FunctionsBuildCleanOutput`, no matter what.

Note that our publish targets already had this guaranteed ordering as they didn't have multiple targets depending on `Build`.