### PR TITLE
Add ability to set samesite=none in out of proc http cookies

### DIFF
--- a/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
+++ b/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
@@ -431,11 +431,12 @@ message RpcException {
 
 // Http cookie type. Note that only name and value are used for Http requests
 message RpcHttpCookie {
-  // Enum that lets servers require that a cookie shouoldn't be sent with cross-site requests
+  // Enum that lets servers require that a cookie shouldn't be sent with cross-site requests
   enum SameSite {
       None = 0;
       Lax = 1;
       Strict = 2;
+      ExplicitNone = 3;
   }
 
   // Cookie name

--- a/src/WebJobs.Script/Workers/Rpc/MessageExtensions/RpcMessageExtensionUtilities.cs
+++ b/src/WebJobs.Script/Workers/Rpc/MessageExtensions/RpcMessageExtensionUtilities.cs
@@ -87,6 +87,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     return SameSiteMode.Lax;
                 case RpcHttpCookie.Types.SameSite.None:
                     return (SameSiteMode)(-1);
+                case RpcHttpCookie.Types.SameSite.ExplicitNone:
+                    return SameSiteMode.None;
                 default:
                     return (SameSiteMode)(-1);
             }

--- a/test/WebJobs.Script.Tests/Binding/ActionResults/RawScriptResultTests.cs
+++ b/test/WebJobs.Script.Tests/Binding/ActionResults/RawScriptResultTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Binding.ActionResults
             await result.ExecuteResultAsync(context);
             context.HttpContext.Response.Headers.TryGetValue("Set-Cookie", out StringValues cookies);
 
-            Assert.Equal(2, cookies.Count);
+            Assert.Equal(3, cookies.Count);
             Assert.Equal("firstCookie=cookieValue; path=/; samesite=lax", cookies[0]);
             Assert.Equal("secondCookie=cookieValue2; max-age=20; path=/; httponly", cookies[1]);
             Assert.Equal("thirdCookie=cookieValue3; path=/; samesite=none", cookies[2]);

--- a/test/WebJobs.Script.Tests/Binding/ActionResults/RawScriptResultTests.cs
+++ b/test/WebJobs.Script.Tests/Binding/ActionResults/RawScriptResultTests.cs
@@ -70,6 +70,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Binding.ActionResults
                         HttpOnly = true,
                         MaxAge = TimeSpan.FromSeconds(20),
                         SameSite = (SameSiteMode)(-1)
+                    }),
+                    new Tuple<string, string, CookieOptions>("thirdCookie", "cookieValue3", new CookieOptions()
+                    {
+                        SameSite = SameSiteMode.None
                     })
                 }
             };
@@ -82,6 +86,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Binding.ActionResults
             Assert.Equal(2, cookies.Count);
             Assert.Equal("firstCookie=cookieValue; path=/; samesite=lax", cookies[0]);
             Assert.Equal("secondCookie=cookieValue2; max-age=20; path=/; httponly", cookies[1]);
+            Assert.Equal("thirdCookie=cookieValue3; path=/; samesite=none", cookies[2]);
         }
 
         [Fact]


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-functions-host/issues/4890

Adds ability for out-of-proc workers to explicitly set "SameSite=None" (details [here](https://blog.chromium.org/2019/10/developers-get-ready-for-new.html))

Because we already named our default "None" (which actually means "unspecified"), the new property is called "ExplicitNone"

Node.js worker PR here: https://github.com/Azure/azure-functions-nodejs-worker/pull/286