### PR TITLE
Updated Linux container end to end test

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 p => Assert.EndsWith(" bytes written", p),
                 p => Assert.StartsWith("Running: ", p),
                 p => Assert.StartsWith("Output:", p),
-                p => Assert.True(p.StartsWith("bash:") || p.StartsWith("usr/bin/bash:")),
+                p => Assert.True(p.StartsWith("bash:") || p.StartsWith("/usr/bin/bash:")),
                 p => Assert.StartsWith("exitCode:", p),
                 p => Assert.StartsWith("Triggering specialization", p));
         }

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 p => Assert.EndsWith(" bytes written", p),
                 p => Assert.StartsWith("Running: ", p),
                 p => Assert.StartsWith("Output:", p),
-                p => Assert.StartsWith("bash:", p),
+                p => Assert.True(p.StartsWith("bash:") || p.StartsWith("usr/bin/bash:")),
                 p => Assert.StartsWith("exitCode:", p),
                 p => Assert.StartsWith("Triggering specialization", p));
         }


### PR DESCRIPTION
While moving the build to devops, it was found that "bash" command was resolving to "/usr/bin/bash". Updated test to accommodate the same