### PR TITLE
fix: resolve issue #5786

### DIFF
--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets
@@ -39,7 +39,7 @@
              AssemblyFile="$(_FunctionsExtensionsTaskAssemblyFullPath)"/>
 
   <Target Name="_GenerateFunctionsExtensionsMetadataPostBuild"
-          AfterTargets="Build">
+          AfterTargets="_GenerateFunctionsPostBuild">
 
     <GenerateFunctionsExtensionsMetadata
       SourcePath="$(_FunctionsExtensionsDir)"


### PR DESCRIPTION
The function.json is not generated due to missed dependencies caused by the runtime cleanup targets. Delaying the clean up targets at the end of the process solves the issue #5786