### PR TITLE
[ExtensionsMetadataGenerator] improving ordering of cleaning, whether Sdk is present or not

### DIFF
--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.csproj
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\metadatagenerator.props" />
   <PropertyGroup>
-    <Version>1.1.6</Version>
+    <Version>1.1.7</Version>
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <AssemblyName>Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator</AssemblyName>

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets
@@ -6,23 +6,16 @@
     <_FunctionsExtensionsTasksDir Condition=" '$(_FunctionsExtensionsTasksDir)'=='' ">$(MSBuildThisFileDirectory)..\tools\$(_FunctionsExtensionsTaskFramework)</_FunctionsExtensionsTasksDir>
     <_FunctionsExtensionsTaskAssemblyFullPath Condition=" '$(_FunctionsExtensionsTaskAssemblyFullPath)'=='' ">$(_FunctionsExtensionsTasksDir)\Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.dll</_FunctionsExtensionsTaskAssemblyFullPath>    
     <_FunctionsExtensionsDir>$(TargetDir)</_FunctionsExtensionsDir>
+    <_FunctionsExtensionsDir Condition="$(_IsFunctionsSdkBuild) == 'true'">$(_FunctionsExtensionsDir)bin</_FunctionsExtensionsDir>
     <_ExtensionsMetadataGeneratorTargetsImported>true</_ExtensionsMetadataGeneratorTargetsImported>
     <IsPackable>false</IsPackable>
-  </PropertyGroup>
-  
-  <!--
-    These properties must be overwritten in a Target because they depend on the
-    Microsoft.NET.Sdk.Functions.targets properties being evaluated first. This cannot
-    be guaranteed if a direct reference is added to the ExtensionsMetadataGenerator
-    package. Running this after _InitializeFunctionsSdk (which exists in the Microsoft.Net.Sdk.Functions
-    package) ensures that properties from that file are already evaluated.
-  -->
-  <Target Name="_InitializeExtensionMetadataGeneratorProps" AfterTargets="_InitializeFunctionsSdk">
-    <PropertyGroup>
-      <_IsFunctionsSdkBuild Condition="$(_FunctionsTaskFramework) != ''">true</_IsFunctionsSdkBuild>
-      <_FunctionsExtensionsDir Condition="$(_IsFunctionsSdkBuild) == 'true'">$(_FunctionsExtensionsDir)bin</_FunctionsExtensionsDir>
-    </PropertyGroup>
-  </Target>
+    
+    <!-- If the Sdk is present, we want to make sure that we generate extension metadata (extensions.json) and clean the output after
+           the function metdata (function.json) has been generated. If not, we may delete files that function generation needs.
+         If the Sdk is not present, we need this to run after Build, as there is no function metadata generation step. -->
+    <_GenerateFunctionsExtensionsMetadataPostBuildAfterTargets>Build</_GenerateFunctionsExtensionsMetadataPostBuildAfterTargets>
+    <_GenerateFunctionsExtensionsMetadataPostBuildAfterTargets Condition="$(_IsFunctionsSdkBuild) != ''">_GenerateFunctionsPostBuild</_GenerateFunctionsExtensionsMetadataPostBuildAfterTargets>
+  </PropertyGroup>  
 
   <UsingTask TaskName="RemoveRuntimeDependencies"
              AssemblyFile="$(_FunctionsExtensionsTaskAssemblyFullPath)"/>
@@ -39,7 +32,7 @@
              AssemblyFile="$(_FunctionsExtensionsTaskAssemblyFullPath)"/>
 
   <Target Name="_GenerateFunctionsExtensionsMetadataPostBuild"
-          AfterTargets="Build">
+          AfterTargets="$(_GenerateFunctionsExtensionsMetadataPostBuildAfterTargets)">
 
     <GenerateFunctionsExtensionsMetadata
       SourcePath="$(_FunctionsExtensionsDir)"


### PR DESCRIPTION
Fixes #5786

This builds on https://github.com/Azure/azure-functions-vs-build-sdk/pull/403 and https://github.com/Azure/azure-functions-vs-build-sdk/pull/402.

Now that `_IsFunctionsSdkBuild` is set in the props file, we're able to depend on it earlier, including for AfterTargets values.