### PR TITLE
protecting against Exceptions when flushing FileWriter

### DIFF
--- a/src/WebJobs.Script/Diagnostics/DefaultFileWriterFactory.cs
+++ b/src/WebJobs.Script/Diagnostics/DefaultFileWriterFactory.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script
+{
+    internal class DefaultFileWriterFactory : IFileWriterFactory
+    {
+        /// <summary>
+        /// Creates an IFileWriter. The caller is responsible for disposing of the IFileWriter.
+        /// </summary>
+        /// <param name="filePath">The file path.</param>
+        /// <returns>An IFileWriter.</returns>
+        public IFileWriter Create(string filePath) => new FileWriter(filePath);
+    }
+}

--- a/src/WebJobs.Script/Diagnostics/FileWriter.cs
+++ b/src/WebJobs.Script/Diagnostics/FileWriter.cs
@@ -13,7 +13,7 @@ using Microsoft.Azure.WebJobs.Script.Config;
 
 namespace Microsoft.Azure.WebJobs.Script
 {
-    internal class FileWriter : IDisposable
+    internal class FileWriter : IFileWriter, IDisposable
     {
         internal const int LastModifiedCutoffDays = 1;
         internal const long MaxLogFileSizeBytes = 5 * 1024 * 1024;

--- a/src/WebJobs.Script/Diagnostics/IFileWriter.cs
+++ b/src/WebJobs.Script/Diagnostics/IFileWriter.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script
+{
+    internal interface IFileWriter
+    {
+        void AppendLine(string line);
+
+        void Flush();
+    }
+}

--- a/src/WebJobs.Script/Diagnostics/IFileWriterFactory.cs
+++ b/src/WebJobs.Script/Diagnostics/IFileWriterFactory.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script
+{
+    internal interface IFileWriterFactory
+    {
+        IFileWriter Create(string filePath);
+    }
+}

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -71,6 +71,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 string loggingPath = ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "Logging");
                 loggingBuilder.AddConfiguration(context.Configuration.GetSection(loggingPath));
 
+                loggingBuilder.Services.AddSingleton<IFileWriterFactory, DefaultFileWriterFactory>();
                 loggingBuilder.Services.AddSingleton<ILoggerProvider, HostFileLoggerProvider>();
                 loggingBuilder.Services.AddSingleton<ILoggerProvider, FunctionFileLoggerProvider>();
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/DiagnosticsEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/DiagnosticsEndToEndTests.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
+{
+    public class DiagnosticsEndToEndTests
+    {
+        private const string _scriptRoot = @"TestScripts\CSharp";
+        private readonly string _testLogPath = Path.Combine(TestHelpers.FunctionsTestDirectory, "Logs", Guid.NewGuid().ToString(), @"Functions");
+
+        private TestEventGenerator _eventGenerator = new TestEventGenerator();
+
+        [Fact]
+        public async Task FileLogger_IOExceptionDuringInvocation_Recovers()
+        {
+            var fileWriterFactory = new TestFileWriterFactory(onAppendLine: null,
+                onFlush: () =>
+                {
+                    // The below function will fail, causing an immediate flush. This exception
+                    // simulates the disk being full. ExecutionEvents should be logged as expected
+                    // and the "Finished" event should get logged.
+                    throw new IOException();
+                });
+
+            using (var host = new TestFunctionHost(_scriptRoot, _testLogPath,
+                configureWebHostServices: s =>
+                {
+                    s.AddSingleton<IEventGenerator>(_ => _eventGenerator);
+                },
+                configureScriptHostServices: s =>
+                {
+                    s.AddSingleton<IFileWriterFactory>(_ => fileWriterFactory);
+
+                    s.PostConfigure<ScriptJobHostOptions>(o =>
+                    {
+                        o.FileLoggingMode = FileLoggingMode.Always;
+                        o.Functions = new[] { "HttpTrigger-Scenarios" };
+                    });
+                }))
+            {
+                // Issue an invalid request that fails.
+                var content = new StringContent(JsonConvert.SerializeObject(new { scenario = "invalid" }));
+                var response = await host.HttpClient.PostAsync("/api/HttpTrigger-Scenarios", content);
+                Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+
+                await TestHelpers.Await(() =>
+                {
+                    var executionEvents = _eventGenerator.GetFunctionExecutionEvents();
+                    return executionEvents.SingleOrDefault(p => p.ExecutionStage == ExecutionStage.Finished) != null;
+                });
+            }
+        }
+
+        private class TestFileWriterFactory : IFileWriterFactory
+        {
+            private readonly Action<string> _onAppendLine;
+            private readonly Action _onFlush;
+
+            public TestFileWriterFactory(Action<string> onAppendLine, Action onFlush)
+            {
+                _onAppendLine = onAppendLine;
+                _onFlush = onFlush;
+            }
+
+            public IFileWriter Create(string filePath) => new TestFileWriter(_onAppendLine, _onFlush);
+        }
+
+        private class TestFileWriter : IFileWriter
+        {
+            private readonly Action<string> _onAppendLine;
+            private readonly Action _onFlush;
+
+            public TestFileWriter(Action<string> onAppendLine, Action onFlush)
+            {
+                _onAppendLine = onAppendLine;
+                _onFlush = onFlush;
+            }
+
+            public void AppendLine(string line)
+            {
+                _onAppendLine?.Invoke(line);
+            }
+
+            public void Flush()
+            {
+                _onFlush();
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     // request for triggering specialization.
                     s.AddSingleton<IStandbyManager, InfiniteTimerStandbyManager>();
 
-                    s.AddSingleton<IScriptHostBuilder, PausingScriptHostBuilder>();
+                    s.AddSingleton<IScriptHostBuilder, PausingScriptHostBuilder>(); 
                 })
                 .ConfigureScriptHostServices(s =>
                 {

--- a/test/WebJobs.Script.Tests.Shared/FunctionExecutionEvent.cs
+++ b/test/WebJobs.Script.Tests.Shared/FunctionExecutionEvent.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public class FunctionExecutionEvent
+    {
+        public string ExecutionId { get; set; }
+
+        public string SiteName { get; set; }
+
+        public int Concurrency { get; set; }
+
+        public string FunctionName { get; set; }
+
+        public string InvocationId { get; set; }
+
+        public ExecutionStage ExecutionStage { get; set; }
+
+        public bool Success { get; set; }
+
+        public long ExecutionTimeSpan { get; set; }
+
+        public DateTimeOffset Timestamp { get; set; }
+    }
+}

--- a/test/WebJobs.Script.Tests.Shared/TestEventGenerator.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestEventGenerator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
@@ -12,6 +13,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
     public class TestEventGenerator : IEventGenerator
     {
         private List<FunctionTraceEvent> _functionTraceEvents = new List<FunctionTraceEvent>();
+        private List<FunctionExecutionEvent> _functionExecutionEvents = new List<FunctionExecutionEvent>();
+
         private object _syncLock = new object();
 
         public IEnumerable<FunctionTraceEvent> GetFunctionTraceEvents()
@@ -19,6 +22,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             lock (_syncLock)
             {
                 return _functionTraceEvents.ToList();
+            }
+        }
+
+        public IEnumerable<FunctionExecutionEvent> GetFunctionExecutionEvents()
+        {
+            lock (_syncLock)
+            {
+                return _functionExecutionEvents.ToList();
             }
         }
 
@@ -44,6 +55,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public void LogFunctionExecutionEvent(string executionId, string siteName, int concurrency, string functionName, string invocationId, string executionStage, long executionTimeSpan, bool success)
         {
+            FunctionExecutionEvent executionEvent = new FunctionExecutionEvent
+            {
+                Timestamp = DateTimeOffset.UtcNow,
+                ExecutionId = executionId,
+                SiteName = siteName,
+                Concurrency = concurrency,
+                FunctionName = functionName,
+                InvocationId = invocationId,
+                ExecutionStage = (ExecutionStage)Enum.Parse(typeof(ExecutionStage), executionStage),
+                ExecutionTimeSpan = executionTimeSpan,
+                Success = success
+            };
+
+            lock (_syncLock)
+            {
+                _functionExecutionEvents.Add(executionEvent);
+            }
         }
 
         public void LogFunctionMetricEvent(string subscriptionId, string appName, string functionName, string eventName, long average, long minimum, long maximum, long count, DateTime eventTimestamp, string data, string runtimeSiteName, string slotName)

--- a/test/WebJobs.Script.Tests.Shared/WebJobs.Script.Tests.Shared.projitems
+++ b/test/WebJobs.Script.Tests.Shared/WebJobs.Script.Tests.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)DelegatedConfigureBuilder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FunctionExecutionEvent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpTestHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FunctionTraceEvent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TempDirectory.cs" />

--- a/test/WebJobs.Script.Tests/Diagnostics/FileLoggerProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/FileLoggerProviderTests.cs
@@ -32,8 +32,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             };
             var fileStatus = new Mock<IFileLoggingStatusManager>();
             var primaryStatus = new Mock<IPrimaryHostStateProvider>();
+            var fileWriterFactory = new DefaultFileWriterFactory();
 
-            using (var provider = new FunctionFileLoggerProvider(new OptionsWrapper<ScriptJobHostOptions>(options), fileStatus.Object, primaryStatus.Object))
+            using (var provider = new FunctionFileLoggerProvider(new OptionsWrapper<ScriptJobHostOptions>(options), fileStatus.Object, primaryStatus.Object, fileWriterFactory))
             {
                 provider.SetScopeProvider(new LoggerExternalScopeProvider());
 


### PR DESCRIPTION
Fixes #5853 

If the disk was full during a `Flush()` , we could throw an exception from the logger, which would abort some of the other monitoring we were doing. Targeted fix to prevent this -- will create a separate Issue to improve a few other things here (such as logging this exception directly to SystemLogger) as a separate work item.

The fix here is very targeted; everything else is to enable me to write a test that failed before the fix was implemented.