### PR TITLE
fixing using in MaxConnectionHelper

### DIFF
--- a/WebJobs.Script.sln
+++ b/WebJobs.Script.sln
@@ -311,6 +311,8 @@ EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		test\WebJobs.Script.Tests.Shared\WebJobs.Script.Tests.Shared.projitems*{35c9ccb7-d8b6-4161-bb0d-bcfa7c6dcffb}*SharedItemsImports = 13
+		test\WebJobs.Script.Tests.Shared\WebJobs.Script.Tests.Shared.projitems*{3ba93614-3a4a-49b0-bfbc-7831e2c02bb7}*SharedItemsImports = 5
+		test\WebJobs.Script.Tests.Shared\WebJobs.Script.Tests.Shared.projitems*{edddaed1-0e37-4ed7-a595-63f686dee90a}*SharedItemsImports = 5
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/WebJobs.Script.WebHost/MaxConnectionHelper.cs
+++ b/src/WebJobs.Script.WebHost/MaxConnectionHelper.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Net.Http;
 using System.Reflection;
-using Microsoft.Azure.Storage;
 using Microsoft.Extensions.Logging;
+using Microsoft.WindowsAzure.Storage;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
 {


### PR DESCRIPTION
When we moved to the latest storage assemblies, this using was incorrectly updated to the new namespace. It needs to use the older namespace to continue setting this value for those using the older storage extension.