### PR TITLE
Fail executions when the worker goes down

### DIFF
--- a/src/WebJobs.Script/Workers/Rpc/IJobHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/IJobHostRpcWorkerChannelManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -10,7 +11,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
     {
         void AddChannel(IRpcWorkerChannel channel);
 
-        Task<bool> ShutdownChannelIfExistsAsync(string channelId);
+        Task<bool> ShutdownChannelIfExistsAsync(string channelId, Exception workerException);
 
         void ShutdownChannels();
 

--- a/src/WebJobs.Script/Workers/Rpc/IRpcWorkerChannel.cs
+++ b/src/WebJobs.Script/Workers/Rpc/IRpcWorkerChannel.cs
@@ -29,5 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         Task DrainInvocationsAsync();
 
         bool IsExecutingInvocation(string invocationId);
+
+        bool TryFailExecutions(Exception workerException);
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/IWebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/IWebHostRpcWorkerChannelManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -14,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         Task SpecializeAsync();
 
-        Task<bool> ShutdownChannelIfExistsAsync(string language, string workerId);
+        Task<bool> ShutdownChannelIfExistsAsync(string language, string workerId, Exception workerException);
 
         Task ShutdownChannelsAsync();
     }

--- a/src/WebJobs.Script/Workers/Rpc/JobHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/JobHostRpcWorkerChannelManager.cs
@@ -24,11 +24,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             _channels.TryAdd(channel.Id, channel);
         }
 
-        public Task<bool> ShutdownChannelIfExistsAsync(string channelId)
+        public Task<bool> ShutdownChannelIfExistsAsync(string channelId, Exception workerException)
         {
             if (_channels.TryRemove(channelId, out IRpcWorkerChannel removedChannel))
             {
                 _logger.LogDebug("Disposing JobHost language worker channel with id:{workerId}", removedChannel.Id);
+                removedChannel.TryFailExecutions(workerException);
                 (removedChannel as IDisposable)?.Dispose();
                 return Task.FromResult(true);
             }

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerChannel.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerChannel.cs
@@ -520,5 +520,22 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         {
             return _executingInvocations.ContainsKey(invocationId);
         }
+
+        public bool TryFailExecutions(Exception workerException)
+        {
+            if (workerException == null)
+            {
+                return false;
+            }
+
+            foreach (ScriptInvocationContext currContext in _executingInvocations?.Values)
+            {
+                string invocationId = currContext?.ExecutionContext?.InvocationId.ToString();
+                _workerChannelLogger.LogDebug("Worker '{workerId}' encountered a fatal error. Failing invocation id: {Id}", _workerId, invocationId);
+                currContext?.ResultSource?.TrySetException(workerException);
+                _executingInvocations.TryRemove(invocationId, out ScriptInvocationContext _);
+            }
+            return true;
+        }
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             return false;
         }
 
-        public Task<bool> ShutdownChannelIfExistsAsync(string language, string workerId)
+        public Task<bool> ShutdownChannelIfExistsAsync(string language, string workerId, Exception workerException = null)
         {
             if (string.IsNullOrEmpty(language))
             {
@@ -170,6 +170,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                             if (workerChannel != null)
                             {
                                 _logger.LogDebug("Disposing WebHost channel for workerId: {channelId}, for runtime:{language}", workerId, language);
+                                workerChannel.TryFailExecutions(workerException);
                                 (channelTask.Result as IDisposable)?.Dispose();
                             }
                         }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
@@ -506,7 +506,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 WorkerConfigs = TestHelpers.GetTestWorkerConfigs()
             };
             IRpcWorkerChannelFactory testLanguageWorkerChannelFactory = new TestRpcWorkerChannelFactory(eventManager, _testLogger, scriptOptions.Value.RootScriptPath, throwOnProcessStartUp);
-            IWebHostRpcWorkerChannelManager testWebHostLanguageWorkerChannelManager = new TesRpcWorkerChannelManager(eventManager, _testLogger, scriptOptions.Value.RootScriptPath, testLanguageWorkerChannelFactory);
+            IWebHostRpcWorkerChannelManager testWebHostLanguageWorkerChannelManager = new TestRpcWorkerChannelManager(eventManager, _testLogger, scriptOptions.Value.RootScriptPath, testLanguageWorkerChannelFactory);
             IJobHostRpcWorkerChannelManager jobHostLanguageWorkerChannelManager = new JobHostRpcWorkerChannelManager(loggerFactory);
             if (addWebhostChannel)
             {

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerChannelTests.cs
@@ -250,6 +250,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
+        public void InFlight_Functions_FailedWithException()
+        {
+            var resultSource = new TaskCompletionSource<ScriptInvocationResult>();
+            ScriptInvocationContext scriptInvocationContext = GetTestScriptInvocationContext(Guid.NewGuid(), resultSource);
+            _workerChannel.SendInvocationRequest(scriptInvocationContext);
+            Assert.True(_workerChannel.IsExecutingInvocation(scriptInvocationContext.ExecutionContext.InvocationId.ToString()));
+            Exception workerException = new Exception("worker failed");
+            _workerChannel.TryFailExecutions(workerException);
+            Assert.False(_workerChannel.IsExecutingInvocation(scriptInvocationContext.ExecutionContext.InvocationId.ToString()));
+            Assert.Equal(TaskStatus.Faulted, resultSource.Task.Status);
+            Assert.Equal(workerException, resultSource.Task.Exception.InnerException);
+        }
+
+        [Fact]
         public void SendLoadRequests_PublishesOutboundEvents()
         {
             _metricsLogger.ClearCollections();

--- a/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannel.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannel.cs
@@ -130,5 +130,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         {
             return _executingInvocations.Contains(invocationId);
         }
+
+        public bool TryFailExecutions(Exception exception)
+        {
+            // Executions are no longer executing
+            _executingInvocations = new HashSet<string>();
+            return true;
+        }
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannelManager.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannelManager.cs
@@ -15,7 +15,7 @@ using Moq;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 {
-    public class TesRpcWorkerChannelManager : IWebHostRpcWorkerChannelManager
+    public class TestRpcWorkerChannelManager : IWebHostRpcWorkerChannelManager
     {
         private IScriptEventManager _eventManager;
         private ILogger _testLogger;
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         private string _scriptRootPath;
         private IRpcWorkerChannelFactory _testLanguageWorkerChannelFactory;
 
-        public TesRpcWorkerChannelManager(IScriptEventManager eventManager, ILogger testLogger, string scriptRootPath, IRpcWorkerChannelFactory testLanguageWorkerChannelFactory)
+        public TestRpcWorkerChannelManager(IScriptEventManager eventManager, ILogger testLogger, string scriptRootPath, IRpcWorkerChannelFactory testLanguageWorkerChannelFactory)
         {
             _eventManager = eventManager;
             _testLogger = testLogger;
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         {
         }
 
-        public async Task<bool> ShutdownChannelIfExistsAsync(string language, string workerId)
+        public async Task<bool> ShutdownChannelIfExistsAsync(string language, string workerId, Exception workerException)
         {
             if (string.IsNullOrEmpty(language))
             {
@@ -97,6 +97,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                         IRpcWorkerChannel channel = await value?.Task;
                         if (channel != null)
                         {
+                            channel.TryFailExecutions(workerException);
                             (channel as IDisposable)?.Dispose();
                             rpcWorkerChannels.Remove(workerId);
                             return true;

--- a/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
@@ -332,13 +332,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             (javaWorkerChannel as TestRpcWorkerChannel).SendInvocationRequest(scriptInvocationContext);
             Assert.True(javaWorkerChannel.IsExecutingInvocation(invocationId.ToString()));
             Exception workerException = new Exception("Worker exception");
+            // Channel is removed immediately but is not failed immediately
             await _rpcWorkerChannelManager.ShutdownChannelIfExistsAsync(RpcWorkerConstants.JavaLanguageWorkerName, javaWorkerChannel.Id, workerException);
 
             Assert.Null(_rpcWorkerChannelManager.GetChannels(RpcWorkerConstants.JavaLanguageWorkerName));
 
             var initializedChannel = await _rpcWorkerChannelManager.GetChannelAsync(RpcWorkerConstants.JavaLanguageWorkerName);
             Assert.Null(initializedChannel);
-            // This should be canceled
+            // Execution will be terminated in the background - giving it 10 seconds
+            await TestHelpers.Await(() =>
+            {
+                return !javaWorkerChannel.IsExecutingInvocation(invocationId.ToString());
+            }, 10000);
             Assert.False(javaWorkerChannel.IsExecutingInvocation(invocationId.ToString()));
         }
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Abstractions;
+using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.Workers;
@@ -314,6 +315,31 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             var initializedChannel = await _rpcWorkerChannelManager.GetChannelAsync(RpcWorkerConstants.JavaLanguageWorkerName);
             Assert.Null(initializedChannel);
+        }
+
+        [Fact]
+        public async Task ShutdownChannelsIfExistsAsync_StopsWorkerInvocations()
+        {
+            IRpcWorkerChannel javaWorkerChannel = CreateTestChannel(RpcWorkerConstants.JavaLanguageWorkerName);
+            Guid invocationId = Guid.NewGuid();
+            ScriptInvocationContext scriptInvocationContext = new ScriptInvocationContext()
+            {
+                ExecutionContext = new ExecutionContext()
+                {
+                    InvocationId = invocationId
+                }
+            };
+            (javaWorkerChannel as TestRpcWorkerChannel).SendInvocationRequest(scriptInvocationContext);
+            Assert.True(javaWorkerChannel.IsExecutingInvocation(invocationId.ToString()));
+            Exception workerException = new Exception("Worker exception");
+            await _rpcWorkerChannelManager.ShutdownChannelIfExistsAsync(RpcWorkerConstants.JavaLanguageWorkerName, javaWorkerChannel.Id, workerException);
+
+            Assert.Null(_rpcWorkerChannelManager.GetChannels(RpcWorkerConstants.JavaLanguageWorkerName));
+
+            var initializedChannel = await _rpcWorkerChannelManager.GetChannelAsync(RpcWorkerConstants.JavaLanguageWorkerName);
+            Assert.Null(initializedChannel);
+            // This should be canceled
+            Assert.False(javaWorkerChannel.IsExecutingInvocation(invocationId.ToString()));
         }
 
         [Fact]


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-functions-host/issues/5385

> @amamounelsayed brought up that when a language worker process crashes (ex: uncaught exception), those requests that were outstanding never complete. Specifically, he tested an HTTP request that caused a worker process crash. Then, some time later, a function timeout exception was thrown bringing down the whole WebHost. If a language worker process crashes, we should mark those outstanding executions as failed.

V2 version: https://github.com/Azure/azure-functions-host/pull/5928