### PR TITLE
Update java worker release to 1.6.0

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -43,7 +43,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.11020001-fabe022e" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.5.2-SNAPSHOT" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.6.0" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.0.2" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.235" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.237" />

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.0.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.0-dev637091944077950638" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.5.2-SNAPSHOT" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.6.0" />
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />


### PR DESCRIPTION
- Need to set these values to int.MaxValue and ignore host settings. Related issue #5650
- Add the support for WorkerStatus.
- Add initial support for java 11 runtie.

v2 https://github.com/Azure/azure-functions-host/pull/5938

https://github.com/Azure/azure-functions-java-worker/releases/tag/1.6.0