### PR TITLE
Removing unification rules for asssemblies that are no longer runtime deployed

### DIFF
--- a/src/WebJobs.Script/runtimeassemblies-relaxed.json
+++ b/src/WebJobs.Script/runtimeassemblies-relaxed.json
@@ -440,14 +440,6 @@
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
-      "name": "Microsoft.Data.Edm",
-      "resolutionPolicy": "minorMatchOrLower"
-    },
-    {
-      "name": "Microsoft.Data.OData",
-      "resolutionPolicy": "minorMatchOrLower"
-    },
-    {
       "name": "Microsoft.DiaSymReader",
       "resolutionPolicy": "minorMatchOrLower"
     },
@@ -1289,10 +1281,6 @@
     },
     {
       "name": "System.ServiceProcess",
-      "resolutionPolicy": "minorMatchOrLower"
-    },
-    {
-      "name": "System.Spatial",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {

--- a/src/WebJobs.Script/runtimeassemblies.json
+++ b/src/WebJobs.Script/runtimeassemblies.json
@@ -455,14 +455,6 @@
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
-      "name": "Microsoft.Data.Edm",
-      "resolutionPolicy": "minorMatchOrLower"
-    },
-    {
-      "name": "Microsoft.Data.OData",
-      "resolutionPolicy": "minorMatchOrLower"
-    },
-    {
       "name": "Microsoft.DiaSymReader",
       "resolutionPolicy": "minorMatchOrLower"
     },
@@ -1316,10 +1308,6 @@
     },
     {
       "name": "System.ServiceProcess",
-      "resolutionPolicy": "minorMatchOrLower"
-    },
-    {
-      "name": "System.Spatial",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {


### PR DESCRIPTION
Resolves #5908 