### PR TITLE
setting MaxConnectionsPerServer for CloudTableClient usage in Windows Consumption

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/FunctionInstanceLogCollectorProvider.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/FunctionInstanceLogCollectorProvider.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.WebHost.Storage;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -17,20 +18,22 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         private readonly IHostIdProvider _hostIdProvider;
         private readonly IConfiguration _configuration;
         private readonly ILoggerFactory _loggerFactory;
+        private readonly IDelegatingHandlerProvider _delegatingHandlerProvider;
 
-        public FunctionInstanceLogCollectorProvider(IFunctionMetadataManager metadataManager,
-            IMetricsLogger metrics, IHostIdProvider hostIdProvider, IConfiguration configuration, ILoggerFactory loggerFactory)
+        public FunctionInstanceLogCollectorProvider(IFunctionMetadataManager metadataManager, IMetricsLogger metrics,
+            IHostIdProvider hostIdProvider, IConfiguration configuration, ILoggerFactory loggerFactory, IDelegatingHandlerProvider delegatingHandlerProvider)
         {
             _metadataManager = metadataManager ?? throw new ArgumentNullException(nameof(metadataManager));
             _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
             _hostIdProvider = hostIdProvider ?? throw new ArgumentNullException(nameof(hostIdProvider));
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+            _delegatingHandlerProvider = delegatingHandlerProvider ?? throw new ArgumentNullException(nameof(delegatingHandlerProvider));
         }
 
         public IAsyncCollector<FunctionInstanceLogEntry> Create()
         {
-            return new FunctionInstanceLogger(_metadataManager, _metrics, _hostIdProvider, _configuration, _loggerFactory);
+            return new FunctionInstanceLogger(_metadataManager, _metrics, _hostIdProvider, _configuration, _loggerFactory, _delegatingHandlerProvider);
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Storage/DefaultDelegatingHandlerProvider.cs
+++ b/src/WebJobs.Script.WebHost/Storage/DefaultDelegatingHandlerProvider.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Storage
+{
+    internal class DefaultDelegatingHandlerProvider : IDelegatingHandlerProvider
+    {
+        private readonly IEnvironment _environment;
+
+        public DefaultDelegatingHandlerProvider(IEnvironment environment)
+        {
+            _environment = environment ?? throw new ArgumentNullException(nameof(environment));
+        }
+
+        public DelegatingHandler Create()
+        {
+            // The DelegatingHandler only applies to the Antares Sandbox where connections are limited.
+            return _environment.IsWindowsConsumption() ? new WebJobsStorageDelegatingHandler() : null;
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Storage/IDelegatingHandlerProvider.cs
+++ b/src/WebJobs.Script.WebHost/Storage/IDelegatingHandlerProvider.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net.Http;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Storage
+{
+    /// <summary>
+    /// Represents a type used to create a <see cref="DelegatingHandler"/> to be used by the WebJobs Azure Storage clients.
+    /// </summary>
+    public interface IDelegatingHandlerProvider
+    {
+        /// <summary>
+        /// Creates a new <see cref="DelegatingHandler"/>.
+        /// </summary>
+        /// <returns>The <see cref="DelegatingHandler"/>.</returns>
+        DelegatingHandler Create();
+    }
+}

--- a/src/WebJobs.Script.WebHost/Storage/WebJobsStorageDelegatingHandler.cs
+++ b/src/WebJobs.Script.WebHost/Storage/WebJobsStorageDelegatingHandler.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Storage
+{
+    internal class WebJobsStorageDelegatingHandler : DelegatingHandler
+    {
+        private const int MaxConnectionsPerServer = 50;
+        private bool _isInnerHandlerConfigured = false;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (!_isInnerHandlerConfigured)
+            {
+                InitializeInnerHandler();
+
+                _isInnerHandlerConfigured = true;
+            }
+
+            return base.SendAsync(request, cancellationToken);
+        }
+
+        private void InitializeInnerHandler()
+        {
+            try
+            {
+                // Storage ensures that the inner handler is an HttpClientHandler
+                if (!(InnerHandler is HttpClientHandler innerHandler))
+                {
+                    throw new InvalidOperationException("The inner handler has not been initialized by the Storage SDK.");
+                }
+
+                innerHandler.MaxConnectionsPerServer = MaxConnectionsPerServer;
+            }
+            catch (InvalidOperationException)
+            {
+                // This exception is thrown if there's a race and this was set by another thread.
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -16,6 +16,7 @@ using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
 using Microsoft.Azure.WebJobs.Script.WebHost.Middleware;
+using Microsoft.Azure.WebJobs.Script.WebHost.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -108,6 +109,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     {
                         services.AddSingleton<IHostIdProvider>(provider);
                     }
+
+                    services.AddSingleton<IDelegatingHandlerProvider, DefaultDelegatingHandlerProvider>();
 
                     // Logging and diagnostics
                     services.AddSingleton<IMetricsLogger>(a => new NonDisposableMetricsLogger(metricsLogger));

--- a/test/WebJobs.Script.Tests.Integration/Scale/TableStorageScaleMetricsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Scale/TableStorageScaleMetricsRepositoryTests.cs
@@ -6,14 +6,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos.Table;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Storage;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
-using Microsoft.Azure.Cosmos.Table;
 using Moq;
 using Xunit;
 
@@ -42,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Scale
             loggerFactory.AddProvider(_loggerProvider);
 
             // Allow for up to 30 seconds of creation retries for tests due to slow table deletes
-            _repository = new TableStorageScaleMetricsRepository(configuration, _hostIdProviderMock.Object, new OptionsWrapper<ScaleOptions>(_scaleOptions), loggerFactory, 60);
+            _repository = new TableStorageScaleMetricsRepository(configuration, _hostIdProviderMock.Object, new OptionsWrapper<ScaleOptions>(_scaleOptions), loggerFactory, 60, new DefaultDelegatingHandlerProvider(new TestEnvironment()));
 
             EmptyMetricsTableAsync().GetAwaiter().GetResult();
         }
@@ -56,7 +57,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Scale
             var options = new ScaleOptions();
             ILoggerFactory loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(_loggerProvider);
-            var localRepository = new TableStorageScaleMetricsRepository(configuration, _hostIdProviderMock.Object, new OptionsWrapper<ScaleOptions>(options), loggerFactory);
+            var localRepository = new TableStorageScaleMetricsRepository(configuration, _hostIdProviderMock.Object, new OptionsWrapper<ScaleOptions>(options), loggerFactory, new TestEnvironment());
 
             var monitor1 = new TestScaleMonitor1();
             var monitor2 = new TestScaleMonitor2();


### PR DESCRIPTION
Pulling this change from the SDK: https://github.com/Azure/azure-webjobs-sdk/pull/2484

Previously, our [MaxConnectionsHelper](https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/MaxConnectionHelper.cs) would globally control this via reflection. But now that we're on the latest Storage SDK, this no longer works and the proper way to do it is to use a delegating handler. The old way needs to stick around for any customers using our v3 storage extension, but it no longer applies to our usage in the host.