### PR TITLE
Cap TestData max size in Function responses (#5647)

### DIFF
--- a/src/WebJobs.Script.WebHost/Extensions/FunctionMetadataExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Extensions/FunctionMetadataExtensions.cs
@@ -162,7 +162,18 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Extensions
                 await FileUtility.WriteAsync(testDataPath, string.Empty);
             }
 
-            return await FileUtility.ReadAsync(testDataPath);
+            string data = await FileUtility.ReadAsync(testDataPath);
+
+            // We avoid inlining test data beyond the specified length. We do this to
+            // provide back compat for the majority of cases. In all other cases, the caller
+            // is expected to follow TestDataHref to retrieve the data.
+            if (data.Length > ScriptConstants.MaxTestDataInlineStringLength &&
+                SystemEnvironment.Instance.GetEnvironmentVariableOrDefault(EnvironmentSettingNames.TestDataCapEnabled, "1") == "1")
+            {
+                return null;
+            }
+
+            return data;
         }
 
         private static Uri GetFunctionHref(string functionName, string baseUrl) =>

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string CloudName = "WEBSITE_CLOUD_NAME";
         public const string RoleInstanceId = "RoleInstanceId";
         public const string HealthPingEnabled = "WEBSITE_FUNCTIONS_HEALTH_PING_ENABLED";
+        public const string TestDataCapEnabled = "WEBSITE_FUNCTIONS_TESTDATA_CAP_ENABLED";
 
         /// <summary>
         /// Environment variable dynamically set by the platform when it is safe to

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -128,6 +128,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// for settriggers calls. If we raise that limit there, we should raise here as well.
         /// </summary>
         public const int MaxTriggersStringLength = 204800;
+        public const int MaxTestDataInlineStringLength = 4 * 1024;
 
         public const string ExtensionsProjectFileName = "extensions.csproj";
         public const string MetadataGeneratorPackageId = "Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator";

--- a/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
@@ -88,15 +88,41 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             _webFunctionsManager = new WebFunctionsManager(optionsMonitor, loggerFactory, httpClient, secretManagerProviderMock.Object, functionsSyncManager, hostNameProvider, functionMetadataManager);
         }
 
-        [Fact]
-        public async Task ReadFunctionsMetadataSucceeds()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ReadFunctionsMetadataSucceeds(bool testDataCapEnabled)
         {
-            IEnumerable<FunctionMetadataResponse> metadata = await _webFunctionsManager.GetFunctionsMetadata(includeProxies: false);
-            var jsFunctions = metadata.Where(funcMetadata => funcMetadata.Language == RpcWorkerConstants.NodeLanguageWorkerName).ToList();
-            var unknownFunctions = metadata.Where(funcMetadata => string.IsNullOrEmpty(funcMetadata.Language)).ToList();
+            var env = new Dictionary<string, string>();
+            if (!testDataCapEnabled)
+            {
+                env.Add(EnvironmentSettingNames.TestDataCapEnabled, "0");
+            }
+            var envScope = new TestScopedEnvironmentVariable(env);
+            using (envScope)
+            {
+                var metadata = (await _webFunctionsManager.GetFunctionsMetadata(includeProxies: false)).ToArray();
 
-            Assert.Equal(2, jsFunctions.Count());
-            Assert.Equal(1, unknownFunctions.Count());
+                Assert.Equal(2, metadata.Count(p => p.Language == RpcWorkerConstants.NodeLanguageWorkerName));
+                Assert.Equal(1, metadata.Count(p => string.IsNullOrEmpty(p.Language)));
+
+                Assert.Equal("https://test.azurewebsites.net/admin/vfs/function1.dat", metadata[0].TestDataHref.AbsoluteUri);
+                Assert.Equal("https://test.azurewebsites.net/admin/vfs/function2.dat", metadata[1].TestDataHref.AbsoluteUri);
+                Assert.Equal("https://test.azurewebsites.net/admin/vfs/function3.dat", metadata[2].TestDataHref.AbsoluteUri);
+
+                Assert.Equal("Test Data 1", metadata[0].TestData);
+                Assert.Equal("Test Data 2", metadata[1].TestData);
+
+                if (testDataCapEnabled)
+                {
+                    // TestData size is capped by default
+                    Assert.Null(metadata[2].TestData);
+                }
+                else
+                {
+                    Assert.Equal(ScriptConstants.MaxTestDataInlineStringLength + 1, metadata[2].TestData.Length);
+                }
+            }
         }
 
         [Fact]
@@ -263,6 +289,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
   ]
 }";
 
+            string testData1 = "Test Data 1";
+            string testData2 = "Test Data 2";
+            string testData3 = TestHelpers.NewRandomString(ScriptConstants.MaxTestDataInlineStringLength + 1);
+
             fileBase.Setup(f => f.Exists(Path.Combine(rootPath, @"function1\function.json"))).Returns(true);
             fileBase.Setup(f => f.Exists(Path.Combine(rootPath, @"function1\main.py"))).Returns(true);
             fileBase.Setup(f => f.ReadAllText(Path.Combine(rootPath, @"function1\function.json"))).Returns(function1);
@@ -272,7 +302,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             });
             fileBase.Setup(f => f.Open(Path.Combine(testDataPath, "function1.dat"), It.IsAny<FileMode>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>())).Returns(() =>
             {
-                return new MemoryStream(Encoding.UTF8.GetBytes(function1));
+                return new MemoryStream(Encoding.UTF8.GetBytes(testData1));
             });
 
             fileBase.Setup(f => f.Exists(Path.Combine(rootPath, @"function2\function.json"))).Returns(true);
@@ -284,7 +314,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             });
             fileBase.Setup(f => f.Open(Path.Combine(testDataPath, "function2.dat"), It.IsAny<FileMode>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>())).Returns(() =>
             {
-                return new MemoryStream(Encoding.UTF8.GetBytes(function1));
+                return new MemoryStream(Encoding.UTF8.GetBytes(testData2));
             });
 
             fileBase.Setup(f => f.Exists(Path.Combine(rootPath, @"function3\function.json"))).Returns(true);
@@ -296,7 +326,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             });
             fileBase.Setup(f => f.Open(Path.Combine(testDataPath, "function3.dat"), It.IsAny<FileMode>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>())).Returns(() =>
             {
-                return new MemoryStream(Encoding.UTF8.GetBytes(function1));
+                return new MemoryStream(Encoding.UTF8.GetBytes(testData3));
             });
 
             return fileSystem.Object;


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-functions-host/issues/5647. Both old and new portal are being updated to use TestDataHref rather than TestData.

I'll be merging this into v2/v1 as well.