### PR TITLE
Add support for customHandler section in host.json

### DIFF
--- a/src/WebJobs.Script/Config/ConfigurationSectionNames.cs
+++ b/src/WebJobs.Script/Config/ConfigurationSectionNames.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
         public const string ManagedDependency = "managedDependency";
         public const string Extensions = "extensions";
         public const string HttpWorker = "httpWorker";
+        public const string CustomHandler = "customHandler";
         public const string Http = Extensions + ":http";
         public const string Hsts = Http + ":hsts";
         public const string CustomHttpHeaders = Http + ":customHeaders";

--- a/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             {
                 "version", "functionTimeout", "functions", "http", "watchDirectories", "queues", "serviceBus",
                 "eventHub", "singleton", "logging", "aggregator", "healthMonitor", "extensionBundle", "managedDependencies",
-                "customHandler"
+                "customHandler", "httpWorker"
             };
 
             private readonly HostJsonFileConfigurationSource _configurationSource;

--- a/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             {
                 "version", "functionTimeout", "functions", "http", "watchDirectories", "queues", "serviceBus",
                 "eventHub", "singleton", "logging", "aggregator", "healthMonitor", "extensionBundle", "managedDependencies",
-                "httpWorker"
+                "customHandler"
             };
 
             private readonly HostJsonFileConfigurationSource _configurationSource;

--- a/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
         public const string FunctionInvokeFailed = "function.invoke.failed";
 
         // Http worker events
-        public const string HttpWorker = "hostjsonfileconfigurationsource.httpworker";
+        public const string CustomHandlerConfiguration = "hostjsonfileconfigurationsource.customhandler";
         public const string DelayUntilWorkerIsInitialized = "httpworkerchannel.delayuntilworkerisinitialized";
 
         // Out of proc process events

--- a/src/WebJobs.Script/Workers/Http/Configuration/HttpWorkerOptions.cs
+++ b/src/WebJobs.Script/Workers/Http/Configuration/HttpWorkerOptions.cs
@@ -5,10 +5,14 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
 {
     public class HttpWorkerOptions
     {
+        public string Type { get; set; } = "http";
+
         public HttpWorkerDescription Description { get; set; }
 
         public WorkerProcessArguments Arguments { get; set; }
 
         public int Port { get; set; }
+
+        public bool EnableForwardingHttpRequest { get; set; }
     }
 }

--- a/src/WebJobs.Script/Workers/Http/Configuration/HttpWorkerOptionsSetup.cs
+++ b/src/WebJobs.Script/Workers/Http/Configuration/HttpWorkerOptionsSetup.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using Microsoft.Azure.WebJobs.Script.Configuration;
@@ -8,6 +10,8 @@ using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Script.Workers.Http
 {
@@ -17,6 +21,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
         private ILogger _logger;
         private IMetricsLogger _metricsLogger;
         private ScriptJobHostOptions _scriptJobHostOptions;
+        private string argumentsSectionName = $"{WorkerConstants.WorkerDescription}:arguments";
+        private string workerArgumentsSectionName = $"{WorkerConstants.WorkerDescription}:workerArguments";
 
         public HttpWorkerOptionsSetup(IOptions<ScriptJobHostOptions> scriptJobHostOptions, IConfiguration configuration, ILoggerFactory loggerFactory, IMetricsLogger metricsLogger)
         {
@@ -30,27 +36,92 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
         {
             IConfigurationSection jobHostSection = _configuration.GetSection(ConfigurationSectionNames.JobHost);
             var httpWorkerSection = jobHostSection.GetSection(ConfigurationSectionNames.HttpWorker);
+            var customHandlerSection = jobHostSection.GetSection(ConfigurationSectionNames.CustomHandler);
+
+            if (httpWorkerSection.Exists() && customHandlerSection.Exists())
+            {
+                _logger.LogWarning($"Both {ConfigurationSectionNames.HttpWorker} and {ConfigurationSectionNames.CustomHandler} sections are spefified in {ScriptConstants.HostMetadataFileName} file. {ConfigurationSectionNames.CustomHandler} takes precedence.");
+            }
+
+            if (customHandlerSection.Exists())
+            {
+                ConfigureWorkerDescription(options, customHandlerSection);
+                return;
+            }
+
             if (httpWorkerSection.Exists())
             {
+                // TODO: Add aka.ms/link to new docs
                 _metricsLogger.LogEvent(MetricEventNames.HttpWorker);
-                httpWorkerSection.Bind(options);
-                HttpWorkerDescription httpWorkerDescription = options.Description;
-
-                if (httpWorkerDescription == null)
-                {
-                    throw new HostConfigurationException($"Missing WorkerDescription for HttpWorker");
-                }
-                httpWorkerDescription.ApplyDefaultsAndValidate(_scriptJobHostOptions.RootScriptPath, _logger);
-                options.Arguments = new WorkerProcessArguments()
-                {
-                    ExecutablePath = options.Description.DefaultExecutablePath,
-                    WorkerPath = options.Description.DefaultWorkerPath
-                };
-
-                options.Arguments.ExecutableArguments.AddRange(options.Description.Arguments);
-                options.Port = GetUnusedTcpPort();
-                _logger.LogDebug("Configured httpWorker with {DefaultExecutablePath}: {exepath} with arguments {args}", nameof(options.Description.DefaultExecutablePath), options.Description.DefaultExecutablePath, options.Arguments);
+                _logger.LogWarning($"Section {ConfigurationSectionNames.HttpWorker} will be deprecated. Please use {ConfigurationSectionNames.CustomHandler} section.");
+                ConfigureWorkerDescription(options, httpWorkerSection);
+                // Explicity set this empty to differentiate between customHandler and httpWorker options.
+                options.Type = string.Empty;
             }
+        }
+
+        private void ConfigureWorkerDescription(HttpWorkerOptions options, IConfigurationSection workerSection)
+        {
+            workerSection.Bind(options);
+            HttpWorkerDescription httpWorkerDescription = options.Description;
+
+            if (httpWorkerDescription == null)
+            {
+                throw new HostConfigurationException($"Missing worker Description.");
+            }
+
+            var argumentsList = GetArgumentList(workerSection, argumentsSectionName);
+            if (argumentsList != null)
+            {
+                httpWorkerDescription.Arguments = argumentsList;
+            }
+
+            var workerArgumentList = GetArgumentList(workerSection, workerArgumentsSectionName);
+            if (workerArgumentList != null)
+            {
+                httpWorkerDescription.WorkerArguments = workerArgumentList;
+            }
+
+            httpWorkerDescription.ApplyDefaultsAndValidate(_scriptJobHostOptions.RootScriptPath, _logger);
+
+            // Set default working directory to function app root.
+            if (string.IsNullOrEmpty(httpWorkerDescription.WorkingDirectory))
+            {
+                httpWorkerDescription.WorkingDirectory = _scriptJobHostOptions.RootScriptPath;
+            }
+            else
+            {
+                // Compute working directory relative to fucntion app root.
+                if (!Path.IsPathRooted(httpWorkerDescription.WorkingDirectory))
+                {
+                    httpWorkerDescription.WorkingDirectory = Path.Combine(_scriptJobHostOptions.RootScriptPath, httpWorkerDescription.WorkingDirectory);
+                }
+            }
+
+            options.Arguments = new WorkerProcessArguments()
+            {
+                ExecutablePath = options.Description.DefaultExecutablePath,
+                WorkerPath = options.Description.DefaultWorkerPath
+            };
+
+            options.Arguments.ExecutableArguments.AddRange(options.Description.Arguments);
+            options.Port = GetUnusedTcpPort();
+        }
+
+        private static List<string> GetArgumentList(IConfigurationSection httpWorkerSection, string argumentSectionName)
+        {
+            var argumentsSection = httpWorkerSection.GetSection(argumentSectionName);
+            if (argumentsSection.Exists() && argumentsSection?.Value != null)
+            {
+                try
+                {
+                    return JsonConvert.DeserializeObject<List<string>>(argumentsSection.Value);
+                }
+                catch
+                {
+                }
+            }
+            return null;
         }
 
         internal static int GetUnusedTcpPort()

--- a/src/WebJobs.Script/Workers/Http/Configuration/HttpWorkerOptionsSetup.cs
+++ b/src/WebJobs.Script/Workers/Http/Configuration/HttpWorkerOptionsSetup.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
 
             if (customHandlerSection.Exists())
             {
+                _metricsLogger.LogEvent(MetricEventNames.CustomHandlerConfiguration);
                 ConfigureWorkerDescription(options, customHandlerSection);
                 return;
             }
@@ -52,7 +53,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
             if (httpWorkerSection.Exists())
             {
                 // TODO: Add aka.ms/link to new docs
-                _metricsLogger.LogEvent(MetricEventNames.HttpWorker);
                 _logger.LogWarning($"Section {ConfigurationSectionNames.HttpWorker} will be deprecated. Please use {ConfigurationSectionNames.CustomHandler} section.");
                 ConfigureWorkerDescription(options, httpWorkerSection);
                 // Explicity set this empty to differentiate between customHandler and httpWorker options.

--- a/src/WebJobs.Script/Workers/Http/DefaultHttpWorkerService.cs
+++ b/src/WebJobs.Script/Workers/Http/DefaultHttpWorkerService.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
         {
             if (scriptInvocationContext.FunctionMetadata.IsHttpInAndOutFunction())
             {
-                // type is empty for httpWorker. Opt-in for custom handler section.
+                // type is empty for httpWorker section. EnableForwardingHttpRequest is opt-in for custom handler section.
                 if (string.IsNullOrEmpty(_httpWorkerOptions.Type) || _httpWorkerOptions.EnableForwardingHttpRequest)
                 {
                     return ProcessHttpInAndOutInvocationRequest(scriptInvocationContext);

--- a/src/WebJobs.Script/Workers/Http/DefaultHttpWorkerService.cs
+++ b/src/WebJobs.Script/Workers/Http/DefaultHttpWorkerService.cs
@@ -40,7 +40,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
         {
             if (scriptInvocationContext.FunctionMetadata.IsHttpInAndOutFunction())
             {
-                return ProcessHttpInAndOutInvocationRequest(scriptInvocationContext);
+                // type is empty for httpWorker. Opt-in for custom handler section.
+                if (string.IsNullOrEmpty(_httpWorkerOptions.Type) || _httpWorkerOptions.EnableForwardingHttpRequest)
+                {
+                    return ProcessHttpInAndOutInvocationRequest(scriptInvocationContext);
+                }
+                return ProcessDefaultInvocationRequest(scriptInvocationContext);
             }
             return ProcessDefaultInvocationRequest(scriptInvocationContext);
         }
@@ -108,11 +113,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
                     {
                         if (httpScriptInvocationResult.Outputs == null || !httpScriptInvocationResult.Outputs.Any())
                         {
-                            _logger.LogDebug("Outputs not set on http response for invocationId:{invocationId}", scriptInvocationContext.ExecutionContext.InvocationId);
+                        _logger.LogWarning("Outputs not set on http response for invocationId:{invocationId}", scriptInvocationContext.ExecutionContext.InvocationId);
                         }
                         if (httpScriptInvocationResult.ReturnValue == null)
                         {
-                            _logger.LogDebug("ReturnValue not set on http response for invocationId:{invocationId}", scriptInvocationContext.ExecutionContext.InvocationId);
+                        _logger.LogWarning("ReturnValue not set on http response for invocationId:{invocationId}", scriptInvocationContext.ExecutionContext.InvocationId);
                         }
 
                         ProcessLogsFromHttpResponse(scriptInvocationContext, httpScriptInvocationResult);
@@ -165,7 +170,13 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
 
         private void AddRequestHeadersAndSetRequestUri(HttpRequestMessage httpRequestMessage, string functionName, string invocationId)
         {
-            httpRequestMessage.RequestUri = new Uri(new UriBuilder(WorkerConstants.HttpScheme, WorkerConstants.HostName, _httpWorkerOptions.Port, functionName).ToString());
+            string pathValue = functionName;
+            // _httpWorkerOptions.Type is populated only in customHandler section
+            if (httpRequestMessage.RequestUri != null && !string.IsNullOrEmpty(_httpWorkerOptions.Type))
+            {
+                pathValue = httpRequestMessage.RequestUri.AbsolutePath;
+            }
+            httpRequestMessage.RequestUri = new Uri(new UriBuilder(WorkerConstants.HttpScheme, WorkerConstants.HostName, _httpWorkerOptions.Port, pathValue).ToString());
             httpRequestMessage.Headers.Add(HttpWorkerConstants.InvocationIdHeaderName, invocationId);
             httpRequestMessage.Headers.Add(HttpWorkerConstants.HostVersionHeaderName, ScriptHost.Version);
             httpRequestMessage.Headers.UserAgent.ParseAdd($"{HttpWorkerConstants.UserAgentHeaderValue}/{ScriptHost.Version}");

--- a/src/WebJobs.Script/Workers/Http/HttpScriptInvocationResultExtensions.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpScriptInvocationResultExtensions.cs
@@ -3,12 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Dynamic;
 using System.Linq;
-using Microsoft.Azure.WebJobs.Script.Binding;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Script.Workers.Http
 {
@@ -33,7 +30,10 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
             if (httpScriptInvocationResult.ReturnValue != null)
             {
                 BindingMetadata returnParameterBindingMetadata = GetBindingMetadata(ScriptConstants.SystemReturnParameterBindingName, scriptInvocationContext);
-                scriptInvocationResult.Return = GetBindingValue(returnParameterBindingMetadata.DataType, httpScriptInvocationResult.ReturnValue);
+                if (returnParameterBindingMetadata != null)
+                {
+                    scriptInvocationResult.Return = GetBindingValue(returnParameterBindingMetadata.DataType, httpScriptInvocationResult.ReturnValue);
+                }
             }
             return scriptInvocationResult;
         }

--- a/src/WebJobs.Script/Workers/Http/HttpWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpWorkerConstants.cs
@@ -13,5 +13,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         // Child Process Env vars
         public const string PortEnvVarName = "FUNCTIONS_HTTPWORKER_PORT";
         public const string WorkerIdEnvVarName = "FUNCTIONS_HTTPWORKER_ID";
+        public const string FunctionAppRootVarName = "FUNCTIONS_APP_ROOT_PATH";
+        public const string CustomHandlerPortEnvVarName = "FUNCTIONS_CUSTOMHANDLER_PORT";
+        public const string CustomHandlerWorkerIdEnvVarName = "FUNCTIONS_CUSTOMHANDLER_WORKER_ID";
     }
 }

--- a/src/WebJobs.Script/Workers/Http/HttpWorkerContext.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpWorkerContext.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
-
 namespace Microsoft.Azure.WebJobs.Script.Workers.Http
 {
     // Arguments to start a worker process

--- a/src/WebJobs.Script/Workers/Http/HttpWorkerProcess.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpWorkerProcess.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
@@ -50,11 +51,14 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
                 RequestId = Guid.NewGuid().ToString(),
                 WorkerId = _workerId,
                 Arguments = _workerProcessArguments,
-                WorkingDirectory = _scriptRootPath,
+                WorkingDirectory = _httpWorkerOptions.Description.WorkingDirectory,
                 Port = _httpWorkerOptions.Port
             };
             workerContext.EnvironmentVariables.Add(HttpWorkerConstants.PortEnvVarName, _httpWorkerOptions.Port.ToString());
             workerContext.EnvironmentVariables.Add(HttpWorkerConstants.WorkerIdEnvVarName, _workerId);
+            workerContext.EnvironmentVariables.Add(HttpWorkerConstants.CustomHandlerPortEnvVarName, _httpWorkerOptions.Port.ToString());
+            workerContext.EnvironmentVariables.Add(HttpWorkerConstants.CustomHandlerWorkerIdEnvVarName, _workerId);
+            workerContext.EnvironmentVariables.Add(HttpWorkerConstants.FunctionAppRootVarName, _scriptRootPath);
             Process workerProcess = _processFactory.CreateWorkerProcess(workerContext);
             if (_environment.IsLinuxConsumption())
             {

--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerDescription.cs
@@ -1,13 +1,18 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.Workers
 {
     public abstract class WorkerDescription
     {
+        // Can be replaced for testing purposes
+        internal Func<string, bool> FileExists { get; set; } = File.Exists;
+
         /// <summary>
         /// Gets or sets the default executable path.
         /// </summary>
@@ -24,10 +29,39 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         public string WorkerDirectory { get; set; }
 
         /// <summary>
-        /// Gets or sets the command line args to pass to the worker
+        /// Gets or sets the command line args to pass to the worker. Will be appended after DefaultExecutablePath but before DefaultWorkerPath
         /// </summary>
-        public List<string> Arguments { get; set; }
+        public IList<string> Arguments { get; set; }
+
+        /// <summary>
+        /// Gets or sets the command line args to pass to the worker. Will be appended after DefaultWorkerPath
+        /// </summary>
+        public IList<string> WorkerArguments { get; set; }
 
         public abstract void ApplyDefaultsAndValidate(string workerDirectory, ILogger logger);
+
+        internal void ThrowIfFileNotExists(string inputFile, string paramName)
+        {
+            if (inputFile == null)
+            {
+                return;
+            }
+            if (!FileExists(inputFile))
+            {
+                throw new FileNotFoundException($"File {paramName}: {inputFile} does not exist.");
+            }
+        }
+
+        internal void ExpandEnvironmentVariables()
+        {
+            if (DefaultWorkerPath != null)
+            {
+                DefaultWorkerPath = Environment.ExpandEnvironmentVariables(DefaultWorkerPath);
+            }
+            if (DefaultExecutablePath != null)
+            {
+                DefaultExecutablePath = Environment.ExpandEnvironmentVariables(DefaultExecutablePath);
+            }
+        }
     }
 }

--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcess.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcess.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
                     _process.Exited += (sender, e) => OnProcessExited(sender, e);
                     _process.EnableRaisingEvents = true;
 
-                _workerProcessLogger?.LogInformation($"Starting worker process with FileName:{_process.StartInfo.FileName} WorkingDirectory:{_process.StartInfo.WorkingDirectory} Arguments:{_process.StartInfo.Arguments}");
+                    _workerProcessLogger?.LogInformation($"Starting worker process with FileName:{_process.StartInfo.FileName} WorkingDirectory:{_process.StartInfo.WorkingDirectory} Arguments:{_process.StartInfo.Arguments}");
                     _process.Start();
                     _workerProcessLogger?.LogInformation($"{_process.StartInfo.FileName} process with Id={_process.Id} started");
 
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
                 }
                 catch (Exception ex)
                 {
-                _workerProcessLogger.LogError(ex, $"Failed to start Worker Channel. Process fileName: {_process.StartInfo.FileName}");
+                    _workerProcessLogger.LogError(ex, $"Failed to start Worker Channel. Process fileName: {_process.StartInfo.FileName}");
                     return Task.FromException(ex);
                 }
             }

--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcess.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcess.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
                     _process.Exited += (sender, e) => OnProcessExited(sender, e);
                     _process.EnableRaisingEvents = true;
 
-                    _workerProcessLogger?.LogInformation($"Starting worker process:{_process.StartInfo.FileName} {_process.StartInfo.Arguments}");
+                _workerProcessLogger?.LogInformation($"Starting worker process with FileName:{_process.StartInfo.FileName} WorkingDirectory:{_process.StartInfo.WorkingDirectory} Arguments:{_process.StartInfo.Arguments}");
                     _process.Start();
                     _workerProcessLogger?.LogInformation($"{_process.StartInfo.FileName} process with Id={_process.Id} started");
 
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
                 }
                 catch (Exception ex)
                 {
-                    _workerProcessLogger.LogError(ex, "Failed to start Worker Channel");
+                _workerProcessLogger.LogError(ex, $"Failed to start Worker Channel. Process fileName: {_process.StartInfo.FileName}");
                     return Task.FromException(ex);
                 }
             }

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     if (ShouldAddWorkerConfig(workerDescription.Language))
                     {
                         workerDescription.FormatWorkerPathIfNeeded(_systemRuntimeInformation, _environment, _logger);
-                        workerDescription.ThrowIfDefaultWorkerPathNotExists();
+                        workerDescription.ThrowIfFileNotExists(workerDescription.DefaultWorkerPath, nameof(workerDescription.DefaultWorkerPath));
                         _workerDescripionDictionary[workerDescription.Language] = workerDescription;
                         _logger.LogDebug($"Added WorkerConfig for language: {workerDescription.Language}");
                     }
@@ -183,22 +183,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             return descriptionProfiles;
         }
 
-        private static WorkerDescription GetWorkerDescriptionFromProfiles(string key, Dictionary<string, RpcWorkerDescription> descriptionProfiles, RpcWorkerDescription defaultWorkerDescription)
-        {
-            RpcWorkerDescription profileDescription = null;
-            if (descriptionProfiles.TryGetValue(key, out profileDescription))
-            {
-                profileDescription.Arguments = profileDescription.Arguments?.Count > 0 ? profileDescription.Arguments : defaultWorkerDescription.Arguments;
-                profileDescription.DefaultExecutablePath = string.IsNullOrEmpty(profileDescription.DefaultExecutablePath) ? defaultWorkerDescription.DefaultExecutablePath : profileDescription.DefaultExecutablePath;
-                profileDescription.DefaultWorkerPath = string.IsNullOrEmpty(profileDescription.DefaultWorkerPath) ? defaultWorkerDescription.DefaultWorkerPath : profileDescription.DefaultWorkerPath;
-                profileDescription.Extensions = profileDescription.Extensions ?? defaultWorkerDescription.Extensions;
-                profileDescription.Language = string.IsNullOrEmpty(profileDescription.Language) ? defaultWorkerDescription.Language : profileDescription.Language;
-                profileDescription.WorkerDirectory = string.IsNullOrEmpty(profileDescription.WorkerDirectory) ? defaultWorkerDescription.WorkerDirectory : profileDescription.WorkerDirectory;
-                return profileDescription;
-            }
-            return defaultWorkerDescription;
-        }
-
         private static void GetWorkerDescriptionFromAppSettings(RpcWorkerDescription workerDescription, IConfigurationSection languageSection)
         {
             var defaultExecutablePathSetting = languageSection.GetSection($"{WorkerConstants.WorkerDescriptionDefaultExecutablePath}");
@@ -223,7 +207,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             var argumentsSection = languageSection.GetSection($"{WorkerConstants.WorkerDescriptionArguments}");
             if (argumentsSection.Value != null)
             {
-                workerDescription.Arguments.AddRange(Regex.Split(argumentsSection.Value, @"\s+"));
+                ((List<string>)workerDescription.Arguments).AddRange(Regex.Split(argumentsSection.Value, @"\s+"));
             }
         }
 

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
@@ -73,9 +73,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             }
         }
 
-        // Can be replaced for testing purposes
-        internal Func<string, bool> FileExists { private get; set; } = File.Exists;
-
         public override void ApplyDefaultsAndValidate(string workerDirectory, ILogger logger)
         {
             if (workerDirectory == null)
@@ -119,14 +116,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             if (DefaultWorkerPath.Contains(RpcWorkerConstants.RuntimeVersionPlaceholder) && !string.IsNullOrEmpty(DefaultRuntimeVersion))
             {
                 ValidateRuntimeVersion();
-            }
-        }
-
-        internal void ThrowIfDefaultWorkerPathNotExists()
-        {
-            if (!string.IsNullOrEmpty(DefaultWorkerPath) && !FileExists(DefaultWorkerPath))
-            {
-                throw new FileNotFoundException($"Did not find {nameof(DefaultWorkerPath)} for language: {Language}");
             }
         }
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_HttpWorker.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_HttpWorker.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         }
 
         [Fact]
-        public async Task HttpTrigger_PowerShell_Get_Succeeds()
+        public async Task HttpTrigger_HttpWorker_Get_Succeeds()
         {
             await InvokeHttpTrigger("HttpTrigger");
         }

--- a/test/WebJobs.Script.Tests/Configuration/HttpWorkerOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/HttpWorkerOptionsSetupTests.cs
@@ -15,7 +15,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
 using Xunit;
-using static Microsoft.Azure.WebJobs.Script.EnvironmentSettingNames;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 {
@@ -44,9 +43,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 FunctionTimeout = TimeSpan.FromSeconds(3)
             };
 
-            _rootPath = Path.Combine(Environment.CurrentDirectory, "ScriptHostTests");
-            Environment.SetEnvironmentVariable(AzureWebJobsScriptRoot, _rootPath);
-
+            _rootPath = Path.Combine(Environment.CurrentDirectory, "HttpWorkerOptionsSetupTests");
             if (!Directory.Exists(_rootPath))
             {
                 Directory.CreateDirectory(_rootPath);
@@ -76,14 +73,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                             }
                         }
                     }")]
+        [InlineData(@"{
+                    'version': '2.0',
+                    'customHandler': {
+                            'description': {
+                                'defaultExecutablePath': 'testExe'
+                            }
+                        }
+                    }")]
         public void MissingOrValid_HttpWorkerConfig_DoesNotThrowException(string hostJsonContent)
         {
             File.WriteAllText(_hostJsonFile, hostJsonContent);
             var configuration = BuildHostJsonConfiguration();
             HttpWorkerOptionsSetup setup = new HttpWorkerOptionsSetup(new OptionsWrapper<ScriptJobHostOptions>(_scriptJobHostOptions), configuration, _testLoggerFactory, _metricsLogger);
             HttpWorkerOptions options = new HttpWorkerOptions();
-            var ex = Record.Exception(() => setup.Configure(options));
-            Assert.Null(ex);
+
+            setup.Configure(options);
+
             if (options.Description != null && !string.IsNullOrEmpty(options.Description.DefaultExecutablePath))
             {
                 string expectedDefaultExecutablePath = Path.Combine(_scriptJobHostOptions.RootScriptPath, "testExe");
@@ -91,42 +97,70 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             }
         }
 
-        [Fact]
-        public void InValid_HttpWorkerConfig_Throws_HostConfigurationException()
-        {
-            string hostJsonContent = @"{
+        [Theory]
+        [InlineData(@"{
                     'version': '2.0',
                     'httpWorker': {
                             'invalid': {
                                 'defaultExecutablePath': 'testExe'
                             }
                         }
-                    }";
-            File.WriteAllText(_hostJsonFile, hostJsonContent);
-            var configuration = BuildHostJsonConfiguration();
-            HttpWorkerOptionsSetup setup = new HttpWorkerOptionsSetup(new OptionsWrapper<ScriptJobHostOptions>(_scriptJobHostOptions), configuration, _testLoggerFactory, _metricsLogger);
-            HttpWorkerOptions options = new HttpWorkerOptions();
-            var ex = Assert.Throws<HostConfigurationException>(() => setup.Configure(options));
-            Assert.Contains("Missing WorkerDescription for HttpWorker", ex.Message);
-        }
-
-        [Fact]
-        public void InValid_HttpWorkerConfig_Throws_ValidationException()
-        {
-            string hostJsonContent = @"{
+                    }")]
+        [InlineData(@"{
                     'version': '2.0',
                     'httpWorker': {
                             'description': {
                                 'langauge': 'testExe'
                             }
                         }
-                    }";
+                    }")]
+        public void InValid_HttpWorkerConfig_Throws_Exception(string hostJsonContent)
+        {
             File.WriteAllText(_hostJsonFile, hostJsonContent);
             var configuration = BuildHostJsonConfiguration();
             HttpWorkerOptionsSetup setup = new HttpWorkerOptionsSetup(new OptionsWrapper<ScriptJobHostOptions>(_scriptJobHostOptions), configuration, _testLoggerFactory, _metricsLogger);
             HttpWorkerOptions options = new HttpWorkerOptions();
-            var ex = Assert.Throws<ValidationException>(() => setup.Configure(options));
-            Assert.Contains("WorkerDescription DefaultExecutablePath cannot be empty", ex.Message);
+            var ex = Record.Exception(() => setup.Configure(options));
+            Assert.NotNull(ex);
+            if (options.Description == null)
+            {
+                Assert.IsType<HostConfigurationException>(ex);
+                Assert.Equal($"Missing worker Description.", ex.Message);
+            }
+            else
+            {
+                Assert.IsType<ValidationException>(ex);
+                Assert.Equal($"WorkerDescription DefaultExecutablePath cannot be empty", ex.Message);
+            }
+        }
+
+        [Fact]
+        public void CustomHandlerConfig_ExpandEnvVars()
+        {
+            string hostJsonContent = @"{
+                    'version': '2.0',
+                    'customHandler': {
+                            'description': {
+                                'defaultExecutablePath': '%TestEnv%',
+                                'defaultWorkerPath': '%TestEnv%'
+                            }
+                        }
+                    }";
+            try
+            {
+                Environment.SetEnvironmentVariable("TestEnv", "TestVal");
+                File.WriteAllText(_hostJsonFile, hostJsonContent);
+                var configuration = BuildHostJsonConfiguration();
+            HttpWorkerOptionsSetup setup = new HttpWorkerOptionsSetup(new OptionsWrapper<ScriptJobHostOptions>(_scriptJobHostOptions), configuration, _testLoggerFactory, _metricsLogger);
+                HttpWorkerOptions options = new HttpWorkerOptions();
+                setup.Configure(options);
+                Assert.Equal("TestVal", options.Description.DefaultExecutablePath);
+                Assert.Contains("TestVal", options.Description.DefaultWorkerPath);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("TestEnv", string.Empty);
+            }
         }
 
         [Theory]
@@ -148,7 +182,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                                 'defaultExecutablePath': 'node'
                             }
                         }
-                    }", true, false, false)]
+                    }", false, false, false)]
         [InlineData(@"{
                     'version': '2.0',
                     'httpWorker': {
@@ -174,9 +208,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             var configuration = BuildHostJsonConfiguration();
             HttpWorkerOptionsSetup setup = new HttpWorkerOptionsSetup(new OptionsWrapper<ScriptJobHostOptions>(_scriptJobHostOptions), configuration, _testLoggerFactory, _metricsLogger);
             HttpWorkerOptions options = new HttpWorkerOptions();
-            setup.Configure(options);
             Assert.True(_metricsLogger.LoggedEvents.Contains(MetricEventNames.HttpWorker));
 
+            setup.Configure(options);
             //Verify worker exe path is expected
             if (appendCurrentDirectoryToExe)
             {
@@ -209,6 +243,109 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             Assert.Equal("--xTest1 --xTest2", options.Description.Arguments[0]);
         }
 
+        [Theory]
+        [InlineData(@"{
+                    'version': '2.0',
+                    'customHandler': {
+                            'description': {
+                                'defaultExecutablePath': 'node',
+                                'arguments': ['httpWorker.js'],
+                                'workingDirectory': 'c:/myWorkingDir',
+                                'workerDirectory': 'c:/myWorkerDir'
+                            }
+                        }
+                    }", false, false, false)]
+        [InlineData(@"{
+                    'version': '2.0',
+                    'customHandler': {
+                            'description': {
+                                'defaultExecutablePath': 'node',
+                                'workingDirectory': 'myWorkingDir',
+                                'workerDirectory': 'myWorkerDir'
+                            }
+                        }
+                    }", true, true, true)]
+        public void CustomHandler_Config_ExpectedValues_WorkerDirectory_WorkingDirectory(string hostJsonContent, bool appendCurrentDirToDefaultExe, bool appendCurrentDirToWorkingDir, bool appendCurrentDirToWorkerDir)
+        {
+            File.WriteAllText(_hostJsonFile, hostJsonContent);
+            var configuration = BuildHostJsonConfiguration();
+            HttpWorkerOptionsSetup setup = new HttpWorkerOptionsSetup(new OptionsWrapper<ScriptJobHostOptions>(_scriptJobHostOptions), configuration, _testLoggerFactory);
+            HttpWorkerOptions options = new HttpWorkerOptions();
+            setup.Configure(options);
+            //Verify worker exe path is expected
+            if (appendCurrentDirToDefaultExe)
+            {
+                Assert.Equal(Path.Combine(_scriptJobHostOptions.RootScriptPath, "myWorkerDir", "node"), options.Description.DefaultExecutablePath);
+            }
+            else
+            {
+                Assert.Equal("node", options.Description.DefaultExecutablePath);
+            }
+
+            // Verify worker dir is expected
+            if (appendCurrentDirToWorkerDir)
+            {
+                Assert.Equal(Path.Combine(_scriptJobHostOptions.RootScriptPath, "myWorkerDir"), options.Description.WorkerDirectory);
+            }
+            else
+            {
+                Assert.Equal(@"c:/myWorkerDir", options.Description.WorkerDirectory);
+            }
+
+            //Verify workering Dir is expected
+            if (appendCurrentDirToWorkingDir)
+            {
+                Assert.Equal(Path.Combine(_scriptJobHostOptions.RootScriptPath, "myWorkingDir"), options.Description.WorkingDirectory);
+            }
+            else
+            {
+                Assert.Equal(@"c:/myWorkingDir", options.Description.WorkingDirectory);
+            }
+        }
+
+        [Fact]
+        public void HttpWorkerConfig_OverrideConfigViaEnvVars_Test()
+        {
+            string hostJsonContent = @"{
+                    'version': '2.0',
+                    'httpWorker': {
+                            'description': {
+                                'langauge': 'testExe',
+                                'defaultExecutablePath': 'dotnet',
+                                'defaultWorkerPath':'ManualTrigger/run.csx',
+                                'arguments': ['--xTest1 --xTest2'],
+                                'workerArguments': ['--xTest3 --xTest4']
+                            }
+                        }
+                    }";
+            try
+            {
+                File.WriteAllText(_hostJsonFile, hostJsonContent);
+                Environment.SetEnvironmentVariable("AzureFunctionsJobHost:httpWorker:description:defaultWorkerPath", "OneSecondTimer/run.csx");
+                Environment.SetEnvironmentVariable("AzureFunctionsJobHost:httpWorker:description:arguments", "[\"--xTest5\", \"--xTest6\", \"--xTest7\"]");
+                var configuration = BuildHostJsonConfiguration();
+                HttpWorkerOptionsSetup setup = new HttpWorkerOptionsSetup(new OptionsWrapper<ScriptJobHostOptions>(_scriptJobHostOptions), configuration, _testLoggerFactory);
+                HttpWorkerOptions options = new HttpWorkerOptions();
+                setup.Configure(options);
+                Assert.Equal("dotnet", options.Description.DefaultExecutablePath);
+                // Verify options are overridden
+                Assert.Contains("OneSecondTimer/run.csx", options.Description.DefaultWorkerPath);
+                Assert.Equal(3, options.Description.Arguments.Count);
+                Assert.Contains("--xTest5", options.Description.Arguments);
+                Assert.Contains("--xTest6", options.Description.Arguments);
+                Assert.Contains("--xTest7", options.Description.Arguments);
+
+                // Verify options not overridden
+                Assert.Equal(1, options.Description.WorkerArguments.Count);
+                Assert.Equal("--xTest3 --xTest4", options.Description.WorkerArguments.ElementAt(0));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("AzureFunctionsJobHost:httpWorker:description:defaultWorkerPath", string.Empty);
+                Environment.SetEnvironmentVariable("AzureFunctionsJobHost:httpWorker:description:arguments", string.Empty);
+            }
+        }
+
         [Fact]
         public void GetUnusedTcpPort_Succeeds()
         {
@@ -228,14 +365,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         private IConfiguration BuildHostJsonConfiguration(IEnvironment environment = null)
         {
             environment = environment ?? new TestEnvironment();
-
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(_loggerProvider);
 
             var configSource = new HostJsonFileConfigurationSource(_options, environment, loggerFactory, new TestMetricsLogger());
 
             var configurationBuilder = new ConfigurationBuilder()
-                .Add(configSource);
+                .Add(configSource)
+                .Add(new ScriptEnvironmentVariablesConfigurationSource());
 
             return configurationBuilder.Build();
         }

--- a/test/WebJobs.Script.Tests/Configuration/HttpWorkerOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/HttpWorkerOptionsSetupTests.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 Environment.SetEnvironmentVariable("TestEnv", "TestVal");
                 File.WriteAllText(_hostJsonFile, hostJsonContent);
                 var configuration = BuildHostJsonConfiguration();
-            HttpWorkerOptionsSetup setup = new HttpWorkerOptionsSetup(new OptionsWrapper<ScriptJobHostOptions>(_scriptJobHostOptions), configuration, _testLoggerFactory, _metricsLogger);
+                HttpWorkerOptionsSetup setup = new HttpWorkerOptionsSetup(new OptionsWrapper<ScriptJobHostOptions>(_scriptJobHostOptions), configuration, _testLoggerFactory, _metricsLogger);
                 HttpWorkerOptions options = new HttpWorkerOptions();
                 setup.Configure(options);
                 Assert.Equal("TestVal", options.Description.DefaultExecutablePath);
@@ -208,9 +208,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             var configuration = BuildHostJsonConfiguration();
             HttpWorkerOptionsSetup setup = new HttpWorkerOptionsSetup(new OptionsWrapper<ScriptJobHostOptions>(_scriptJobHostOptions), configuration, _testLoggerFactory, _metricsLogger);
             HttpWorkerOptions options = new HttpWorkerOptions();
-            Assert.True(_metricsLogger.LoggedEvents.Contains(MetricEventNames.HttpWorker));
-
             setup.Configure(options);
+
             //Verify worker exe path is expected
             if (appendCurrentDirectoryToExe)
             {
@@ -269,9 +268,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         {
             File.WriteAllText(_hostJsonFile, hostJsonContent);
             var configuration = BuildHostJsonConfiguration();
-            HttpWorkerOptionsSetup setup = new HttpWorkerOptionsSetup(new OptionsWrapper<ScriptJobHostOptions>(_scriptJobHostOptions), configuration, _testLoggerFactory);
+            HttpWorkerOptionsSetup setup = new HttpWorkerOptionsSetup(new OptionsWrapper<ScriptJobHostOptions>(_scriptJobHostOptions), configuration, _testLoggerFactory, _metricsLogger);
             HttpWorkerOptions options = new HttpWorkerOptions();
             setup.Configure(options);
+
+            Assert.True(_metricsLogger.LoggedEvents.Contains(MetricEventNames.CustomHandlerConfiguration));
+
             //Verify worker exe path is expected
             if (appendCurrentDirToDefaultExe)
             {
@@ -324,7 +326,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 Environment.SetEnvironmentVariable("AzureFunctionsJobHost:httpWorker:description:defaultWorkerPath", "OneSecondTimer/run.csx");
                 Environment.SetEnvironmentVariable("AzureFunctionsJobHost:httpWorker:description:arguments", "[\"--xTest5\", \"--xTest6\", \"--xTest7\"]");
                 var configuration = BuildHostJsonConfiguration();
-                HttpWorkerOptionsSetup setup = new HttpWorkerOptionsSetup(new OptionsWrapper<ScriptJobHostOptions>(_scriptJobHostOptions), configuration, _testLoggerFactory);
+                HttpWorkerOptionsSetup setup = new HttpWorkerOptionsSetup(new OptionsWrapper<ScriptJobHostOptions>(_scriptJobHostOptions), configuration, _testLoggerFactory, _metricsLogger);
                 HttpWorkerOptions options = new HttpWorkerOptions();
                 setup.Configure(options);
                 Assert.Equal("dotnet", options.Description.DefaultExecutablePath);

--- a/test/WebJobs.Script.Tests/HttpWorker/DefaultHttpWorkerServiceTests.cs
+++ b/test/WebJobs.Script.Tests/HttpWorker/DefaultHttpWorkerServiceTests.cs
@@ -10,6 +10,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Extensions;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Http;
 using Microsoft.Extensions.Logging;
@@ -18,6 +19,7 @@ using Microsoft.Net.Http.Headers;
 using Moq;
 using Moq.Protected;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
@@ -40,7 +42,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
             _testInvocationId = Guid.NewGuid();
             _httpWorkerOptions = new HttpWorkerOptions()
             {
-                Port = _defaultPort
+                Port = _defaultPort,
+                Type = string.Empty
             };
         }
 
@@ -76,6 +79,38 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
             Assert.True(testLogs.All(m => m.FormattedMessage.Contains("invocation log")));
             Assert.Equal(expectedHttpScriptInvocationResult.Outputs.Count(), invocationResult.Outputs.Count());
             Assert.Equal(expectedHttpScriptInvocationResult.ReturnValue, invocationResult.Return);
+        }
+
+        [Fact]
+        public async Task ProcessDefaultInvocationRequest_CustomHandler_EnableRequestForwarding_False()
+        {
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            var customHandlerOptions = new HttpWorkerOptions()
+            {
+                Port = _defaultPort,
+                Type = "http"
+            };
+            handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((request, token) => ValidateeSimpleHttpTriggerSentAsDefaultInvocationRequest(request))
+                .ReturnsAsync(HttpWorkerTestUtilities.GetValidHttpResponseMessageWithJsonRes());
+
+            _httpClient = new HttpClient(handlerMock.Object);
+            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(customHandlerOptions), _testLogger);
+            var testScriptInvocationContext = HttpWorkerTestUtilities.GetSimpleHttpTriggerScriptInvocationContext(TestFunctionName, _testInvocationId, _functionLogger);
+            await _defaultHttpWorkerService.InvokeAsync(testScriptInvocationContext);
+            var invocationResult = await testScriptInvocationContext.ResultSource.Task;
+
+            var expectedHttpScriptInvocationResult = HttpWorkerTestUtilities.GetHttpScriptInvocationResultWithJsonRes();
+            var testLogs = _functionLogger.GetLogMessages();
+            Assert.True(testLogs.Count() == expectedHttpScriptInvocationResult.Logs.Count());
+            Assert.True(testLogs.All(m => m.FormattedMessage.Contains("invocation log")));
+            Assert.Equal(expectedHttpScriptInvocationResult.Outputs.Count(), invocationResult.Outputs.Count());
+            Assert.Equal(expectedHttpScriptInvocationResult.ReturnValue, invocationResult.Return);
+            var responseJson = JObject.Parse(invocationResult.Outputs["res"].ToString());
+            Assert.Equal("my world", responseJson["Body"]);
+            Assert.Equal("201", responseJson["StatusCode"]);
         }
 
         [Fact]
@@ -167,6 +202,45 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
             _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger);
             var testScriptInvocationContext = HttpWorkerTestUtilities.GetSimpleHttpTriggerScriptInvocationContext(TestFunctionName, _testInvocationId, _functionLogger);
             await _defaultHttpWorkerService.ProcessHttpInAndOutInvocationRequest(testScriptInvocationContext);
+            var invocationResult = await testScriptInvocationContext.ResultSource.Task;
+            var expectedHttpResponseMessage = HttpWorkerTestUtilities.GetValidSimpleHttpResponseMessage();
+            var expectedResponseContent = await expectedHttpResponseMessage.Content.ReadAsStringAsync();
+
+            var testLogs = _functionLogger.GetLogMessages();
+            Assert.Equal(0, testLogs.Count());
+
+            Assert.Equal(1, invocationResult.Outputs.Count());
+            var httpOutputResponse = invocationResult.Outputs.FirstOrDefault().Value as HttpResponseMessage;
+            Assert.NotNull(httpOutputResponse);
+            Assert.Equal(expectedHttpResponseMessage.StatusCode, httpOutputResponse.StatusCode);
+            Assert.Equal(expectedResponseContent, await httpOutputResponse.Content.ReadAsStringAsync());
+
+            var response = invocationResult.Return as HttpResponseMessage;
+            Assert.NotNull(response);
+            Assert.Equal(expectedHttpResponseMessage.StatusCode, response.StatusCode);
+            Assert.Equal(expectedResponseContent, await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task ProcessSimpleHttpTriggerInvocationRequest_CustomHandler_EnableForwardingHttpRequest_True()
+        {
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            var customHandlerOptions = new HttpWorkerOptions()
+            {
+                Port = _defaultPort,
+                Type = "http",
+                EnableForwardingHttpRequest = true
+            };
+            handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+                .Callback<HttpRequestMessage, CancellationToken>((request, token) => ValidateSimpleHttpTriggerInvocationRequest(request))
+                .ReturnsAsync(HttpWorkerTestUtilities.GetValidSimpleHttpResponseMessage());
+
+            _httpClient = new HttpClient(handlerMock.Object);
+            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(customHandlerOptions), _testLogger);
+            var testScriptInvocationContext = HttpWorkerTestUtilities.GetSimpleHttpTriggerScriptInvocationContext(TestFunctionName, _testInvocationId, _functionLogger);
+            await _defaultHttpWorkerService.InvokeAsync(testScriptInvocationContext);
             var invocationResult = await testScriptInvocationContext.ResultSource.Task;
             var expectedHttpResponseMessage = HttpWorkerTestUtilities.GetValidSimpleHttpResponseMessage();
             var expectedResponseContent = await expectedHttpResponseMessage.Content.ReadAsStringAsync();
@@ -367,6 +441,30 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
                 Assert.True(httpScriptInvocationContext.Data.Keys.Contains(item.name));
                 Assert.Equal(JsonConvert.SerializeObject(item.val), httpScriptInvocationContext.Data[item.name]);
             }
+        }
+
+        private async void ValidateeSimpleHttpTriggerSentAsDefaultInvocationRequest(HttpRequestMessage httpRequestMessage)
+        {
+            Assert.Contains($"{HttpWorkerConstants.UserAgentHeaderValue}/{ScriptHost.Version}", httpRequestMessage.Headers.UserAgent.ToString());
+            Assert.Equal(_testInvocationId.ToString(), httpRequestMessage.Headers.GetValues(HttpWorkerConstants.InvocationIdHeaderName).Single());
+            Assert.Equal(ScriptHost.Version, httpRequestMessage.Headers.GetValues(HttpWorkerConstants.HostVersionHeaderName).Single());
+            Assert.Equal(httpRequestMessage.RequestUri.ToString(), $"http://127.0.0.1:{_defaultPort}/{TestFunctionName}");
+
+            HttpScriptInvocationContext httpScriptInvocationContext = await httpRequestMessage.Content.ReadAsAsync<HttpScriptInvocationContext>();
+
+            // Verify Metadata
+            var expectedMetadata = HttpWorkerTestUtilities.GetScriptInvocationBindingData();
+            Assert.Equal(expectedMetadata.Count(), httpScriptInvocationContext.Metadata.Count());
+            foreach (var key in expectedMetadata.Keys)
+            {
+                Assert.Equal(JsonConvert.SerializeObject(expectedMetadata[key]), httpScriptInvocationContext.Metadata[key]);
+            }
+
+            // Verify Data
+            Assert.True(httpScriptInvocationContext.Data.Keys.Contains("testInputReq"));
+            JObject resultHttpReq = JObject.FromObject(httpScriptInvocationContext.Data["testInputReq"]);
+            JObject expectedHttpRequest = await HttpWorkerTestUtilities.GetTestHttpRequest().GetRequestAsJObject();
+            Assert.True(JToken.DeepEquals(expectedHttpRequest, resultHttpReq));
         }
 
         private async void ValidateSimpleHttpTriggerInvocationRequest(HttpRequestMessage httpRequestMessage)

--- a/test/WebJobs.Script.Tests/HttpWorker/HttpScriptInvocationResultExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/HttpWorker/HttpScriptInvocationResultExtensionsTests.cs
@@ -3,21 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Net.Sockets;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Http;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Microsoft.Net.Http.Headers;
-using Moq;
-using Moq.Protected;
-using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
@@ -35,6 +23,24 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
             outputsFromWorker["httpOutput1"] = inputString;
             var actualResult = HttpScriptInvocationResultExtensions.GetHttpOutputBindingResponse("httpOutput1", outputsFromWorker);
             Assert.Equal(expectedOutput, actualResult);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ToScripInvocationResultTests(bool includeReturnValue)
+        {
+            var testInvocationContext = HttpWorkerTestUtilities.GetSimpleHttpTriggerScriptInvocationContext("test", Guid.NewGuid(), new TestLogger("test"));
+            var testHttpInvocationResult = HttpWorkerTestUtilities.GetHttpScriptInvocationResultWithJsonRes();
+            if (includeReturnValue)
+            {
+                testHttpInvocationResult.ReturnValue = "Hello return";
+            }
+            var result = testHttpInvocationResult.ToScriptInvocationResult(testInvocationContext);
+            Assert.Null(result.Return);
+
+            var resResult = JObject.Parse((string)result.Outputs["res"]);
+            Assert.Equal("my world", resResult["Body"]);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/HttpWorker/HttpWorkerTestUtilities.cs
+++ b/test/WebJobs.Script.Tests/HttpWorker/HttpWorkerTestUtilities.cs
@@ -35,7 +35,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
             httpRequest.Query = GetTestQueryParams();
             httpRequest.Headers[HeaderNames.AcceptCharset] = UTF8AcceptCharset;
             httpRequest.Headers[HeaderNames.Accept] = AcceptHeaderValue;
-
             var json = JsonConvert.SerializeObject(HttpContentStringValue);
             var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
             httpRequest.Body = stream;
@@ -51,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
         public static List<(string name, DataType type, object val)> GetSimpleHttpTriggerScriptInvocationInputs()
         {
             List<(string name, DataType type, object val)> inputs = new List<(string name, DataType type, object val)>();
-            inputs.Add(("myqueueItem", DataType.String, GetTestHttpRequest()));
+            inputs.Add(("testInputReq", DataType.String, GetTestHttpRequest()));
             return inputs;
         }
 
@@ -127,6 +126,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
             return new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new ObjectContent<HttpScriptInvocationResult>(GetTestHttpScriptInvocationResult(), new JsonMediaTypeFormatter())
+            };
+        }
+
+        public static HttpResponseMessage GetValidHttpResponseMessageWithJsonRes()
+        {
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ObjectContent<HttpScriptInvocationResult>(GetHttpScriptInvocationResultWithJsonRes(), new JsonMediaTypeFormatter())
             };
         }
 
@@ -240,6 +247,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
             functionMetadata.Bindings.Add(queueOutputRetrun);
             scriptInvocationContext.FunctionMetadata = functionMetadata;
             return scriptInvocationContext;
+        }
+
+        public static HttpScriptInvocationResult GetHttpScriptInvocationResultWithJsonRes()
+        {
+            JObject httpRes = new JObject();
+            httpRes["statusCode"] = "201";
+            httpRes["body"] = "my world";
+            return new HttpScriptInvocationResult()
+            {
+                Logs = new List<string>() { "invocation log1", "invocation log2" },
+                Outputs = new Dictionary<string, object>()
+                {
+                    { "res", httpRes }
+                }
+            };
         }
 
         public static ScriptInvocationContext GetSimpleHttpTriggerScriptInvocationContext(string functionName, Guid invocationId, ILogger testLogger)

--- a/test/WebJobs.Script.Tests/Workers/Http/HttpWorkerProcessTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Http/HttpWorkerProcessTests.cs
@@ -31,7 +31,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
             _httpWorkerOptions = new HttpWorkerOptions()
             {
                 Port = _workerPort,
-                Arguments = new WorkerProcessArguments() { ExecutablePath = "test" }
+                Arguments = new WorkerProcessArguments() { ExecutablePath = "test" },
+                Description = new HttpWorkerDescription()
+                {
+                   WorkingDirectory = @"c:\testDir"
+                }
             };
             _settingsManager = ScriptSettingsManager.Instance;
         }
@@ -53,6 +57,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
                 Assert.NotNull(childProcess.StartInfo.EnvironmentVariables);
                 Assert.Equal(childProcess.StartInfo.EnvironmentVariables[HttpWorkerConstants.PortEnvVarName], _workerPort.ToString());
                 Assert.Equal(childProcess.StartInfo.EnvironmentVariables[HttpWorkerConstants.WorkerIdEnvVarName], _testWorkerId);
+                Assert.Equal(childProcess.StartInfo.EnvironmentVariables[HttpWorkerConstants.CustomHandlerPortEnvVarName], _workerPort.ToString());
+                Assert.Equal(childProcess.StartInfo.EnvironmentVariables[HttpWorkerConstants.CustomHandlerWorkerIdEnvVarName], _testWorkerId);
                 childProcess.Dispose();
             }
         }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
@@ -113,11 +113,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         public void ReadWorkerProviderFromConfig_EmptyWorkerPath()
         {
             var configs = new List<TestRpcWorkerConfig>() { MakeTestConfig(testLanguage, new string[0], false, string.Empty, true) };
-            // Creates temp directory w/ worker.config.json and runs ReadWorkerProviderFromConfig
-            Dictionary<string, string> keyValuePairs = new Dictionary<string, string>
-            {
-                [$"{RpcWorkerConstants.LanguageWorkersSectionName}:{testLanguage}:{WorkerConstants.WorkerDescriptionArguments}"] = "--inspect=5689  --no-deprecation"
-            };
             TestMetricsLogger testMetricsLogger = new TestMetricsLogger();
 
             var workerConfigs = TestReadWorkerProviderFromConfig(configs, new TestLogger(testLanguage), testMetricsLogger);


### PR DESCRIPTION
This PR adds support to specify custom handler section in host.json as discussed in #6080

- Here is an example `host.json` that specifies `workingDirectory` 
```json
{
	"version": "2.0",
	"extensionBundle": {
		"id": "Microsoft.Azure.Functions.ExtensionBundle",
		"version": "[1.*, 2.0.0)"
	},
	"customHandler": {
		"description": {
			"defaultExecutablePath": "dotnet",
			"workingDirectory": "CSharpCustomHandlers/bin/Debug/netcoreapp2.2",
			"arguments": [ "CSharpCustomHandlers.dll" ]
		},
                "enableForwardingHttpRequest": true
	}
}
```
- Environment variables can be specified as part of any element in `description` following the format 
`%EnvVarName%`. Here is an example
```json
{
	"version": "2.0",
	"customHandler": {
		"type": "http",
		"enableForwardingHttpRequest": false,
		"description": {
			"defaultExecutablePath": "%GoWorkerEnv%",
			"arguments": [
				"%FUNCTIONS_CUSTOMHANDLER_PORT%"
			]
		}
	}
}
```

- Each element in `description` can also be overridden via EnvVars/AppSettings. Here is an example of AppSetting / Environment variable name to overrride arguments element
`AzureFunctionsJobHost:customHandler:description:arguments`

Fixes #5692, Fixes #5921, Fixes #5547, Fixes #6080, Fixes #5882, Fixes #5615

Note: httpWorker section will be deprecated sometime later. For now, it is still supported.