### PR TITLE
Do not restart all workers on timeout if worker for an invocation id is not found

### DIFF
--- a/src/WebJobs.Script.WebHost/WebScriptHostExceptionHandler.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostExceptionHandler.cs
@@ -53,12 +53,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             if (!functionInvocationDispatcher.State.Equals(FunctionInvocationDispatcherState.Default))
             {
                 _logger.LogWarning($"A function timeout has occurred. Restarting worker process executing invocationId '{timeoutException.InstanceId}'.", exceptionInfo.SourceException);
-                bool result = await functionInvocationDispatcher.RestartWorkerWithInvocationIdAsync(timeoutException.InstanceId.ToString());
-                if (!result)
-                {
-                    _logger.LogWarning($"Restarting all language worker processes since invocation Id '{timeoutException.InstanceId}' was not found.", exceptionInfo.SourceException);
-                    await functionInvocationDispatcher.RestartAllWorkersAsync();
-                }
+                // If invocation id is not found in any of the workers => worker is already disposed. No action needed.
+                await functionInvocationDispatcher.RestartWorkerWithInvocationIdAsync(timeoutException.InstanceId.ToString());
                 _logger.LogWarning("Restart of language worker process(es) completed.", exceptionInfo.SourceException);
             }
             else


### PR DESCRIPTION
This is a follow up from a CRI

- Host assigns invocations to a worker
- One invocation timeouts out.  Restarts worker channel.
- Eventually all the invocations assigned to a worker timeout because worker is disposed.
- This causes restarting all the channels again and again until all the invocations assigned to the worker disposed are drained.

Fix:

If a worker for an invocation is not found => worker is already disposed. No action needed.