### PR TITLE
Do not throw version error on runtime mismatch

### DIFF
--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
@@ -182,10 +182,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
             OSPlatform os = systemRuntimeInformation.GetOSPlatform();
             Architecture architecture = systemRuntimeInformation.GetOSArchitecture();
+            string workerRuntime = environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName);
             string version = environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName);
             logger.LogDebug($"EnvironmentVariable {RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName}: {version}");
 
-            if (!string.IsNullOrEmpty(version))
+            // Only over-write DefaultRuntimeVersion if workerRuntime matches language for the worker config
+            if (!string.IsNullOrEmpty(workerRuntime) && workerRuntime.Equals(Language, StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(version))
             {
                 DefaultRuntimeVersion = version;
             }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
@@ -362,8 +362,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         [InlineData("%FUNCTIONS_WORKER_RUNTIME_VERSION%/{os}", "3.7/LINUX")]
         public void LanguageWorker_FormatWorkerPath_EnvironmentVersionSet(string defaultWorkerPath, string expectedPath)
         {
-            _testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName, "3.7");
-
+            _testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, "python");
             RpcWorkerDescription workerDescription = new RpcWorkerDescription()
             {
                 Arguments = new List<string>(),
@@ -551,6 +550,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         public void LanguageWorker_FormatWorkerPath_UnsupportedEnvironmentRuntimeVersion()
         {
             _testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName, "3.4");
+            _testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, "python");
 
             RpcWorkerDescription workerDescription = new RpcWorkerDescription()
             {
@@ -574,6 +574,28 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             var ex = Assert.Throws<NotSupportedException>(() => workerDescription.FormatWorkerPathIfNeeded(_testSysRuntimeInfo, _testEnvironment, testLogger));
             Assert.Equal(ex.Message, $"Version 3.4 is not supported for language {workerDescription.Language}");
+        }
+
+        [Fact]
+        public void LanguageWorker_FormatWorkerPath_DefualtRuntimeVersion_WorkerRuntimeMismatch()
+        {
+            _testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName, "13");
+            _testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, "node");
+
+            RpcWorkerDescription workerDescription = new RpcWorkerDescription()
+            {
+                Arguments = new List<string>(),
+                DefaultExecutablePath = "python",
+                SupportedRuntimeVersions = new List<string>() { "3.6", "3.7" },
+                DefaultWorkerPath = $"{RpcWorkerConstants.RuntimeVersionPlaceholder}/worker.py",
+                WorkerDirectory = string.Empty,
+                Extensions = new List<string>() { ".py" },
+                Language = "python",
+                DefaultRuntimeVersion = "3.7" // Ignore this if environment is set
+            };
+            var testLogger = new TestLogger("test");
+            workerDescription.FormatWorkerPathIfNeeded(_testSysRuntimeInfo, _testEnvironment, testLogger);
+            Assert.Equal("3.7", workerDescription.DefaultRuntimeVersion);
         }
 
         private IEnumerable<RpcWorkerConfig> TestReadWorkerProviderFromConfig(IEnumerable<TestRpcWorkerConfig> configs, ILogger testLogger, TestMetricsLogger testMetricsLogger, string language = null, Dictionary<string, string> keyValuePairs = null, bool appSvcEnv = false)

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
@@ -287,10 +287,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 Extensions = new List<string>(),
                 DefaultExecutablePath = defaultExecutablePath,
                 FileExists = path =>
-                                {
-                                    Assert.Equal(expectedExecutablePath, path);
-                                    return true;
-                                }
+                {
+                    Assert.Equal(expectedExecutablePath, path);
+                    return true;
+                }
             };
 
             workerDescription.ApplyDefaultsAndValidate(Directory.GetCurrentDirectory(), testLogger);
@@ -318,10 +318,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 Extensions = new List<string>(),
                 DefaultExecutablePath = defaultExecutablePath,
                 FileExists = path =>
-                                {
-                                    Assert.Equal(expectedExecutablePath, path);
-                                    return false;
-                                }
+                {
+                    Assert.Equal(expectedExecutablePath, path);
+                    return false;
+                }
             };
 
             workerDescription.ApplyDefaultsAndValidate(Directory.GetCurrentDirectory(), testLogger);
@@ -346,10 +346,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 Extensions = new List<string>(),
                 DefaultExecutablePath = defaultExecutablePath,
                 FileExists = path =>
-                                {
-                                    Assert.True(false, "FileExists should not be called");
-                                    return false;
-                                }
+                {
+                    Assert.True(false, "FileExists should not be called");
+                    return false;
+                }
             };
 
             workerDescription.ApplyDefaultsAndValidate(Directory.GetCurrentDirectory(), testLogger);
@@ -362,7 +362,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         [InlineData("%FUNCTIONS_WORKER_RUNTIME_VERSION%/{os}", "3.7/LINUX")]
         public void LanguageWorker_FormatWorkerPath_EnvironmentVersionSet(string defaultWorkerPath, string expectedPath)
         {
+            _testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName, "3.7");
             _testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, "python");
+
             RpcWorkerDescription workerDescription = new RpcWorkerDescription()
             {
                 Arguments = new List<string>(),


### PR DESCRIPTION
Follow up from a CRI. Powershell function apps assigned to non-powershell placeholder template sites, fail to start after specialization with error:
```
Microsoft.Azure.WebJobs.Script.HostInitializationException : Did not find functions with language [powershell].
   at Microsoft.Azure.WebJobs.Script.Utility.VerifyFunctionsMatchSpecifiedLanguage(IEnumerable`1 functions,String workerRuntime,Boolean isPlaceholderMode,Boolean isHttpWorker) at D:\a\1\s\src\WebJobs.Script\Utility.cs : 561
   at async Microsoft.Azure.WebJobs.Script.ScriptHost.GetFunctionDescriptorsAsync(IEnumerable`1 functions,IEnumerable`1 descriptorProviders) at D:\a\1\s\src\WebJobs.Script\Host\ScriptHost.cs : 692
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at async Microsoft.Azure.WebJobs.Script.ScriptHost.InitializeFunctionDescriptorsAsync(IEnumerable`1 functionMetadata) at D:\a\1\s\src\WebJobs.Script\Host\ScriptHost.cs : 487
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at async Microsoft.Azure.WebJobs.Script.ScriptHost.InitializeAsync(CancellationToken cancellationToken) at D:\a\1\s\src\WebJobs.Script\Host\ScriptHost.cs : 298
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at async Microsoft.Azure.WebJobs.Script.ScriptHost.StartAsyncCore(CancellationToken cancellationToken) at D:\a\1\s\src\WebJobs.Script\Host\ScriptHost.cs : 251
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at async Microsoft.Extensions.Hosting.Internal.Host.StartAsync(CancellationToken cancellationToken)
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at async Microsoft.Azure.WebJobs.Script.WebHost.WebJobsScriptHostService.UnsynchronizedStartHostAsync(ScriptHostStartupOperation activeOperation,Int32 attemptCount,JobHostStartupMode startupMode) at D:\a\1\s\src\WebJobs.Script.WebHost\WebJobsScriptHostService.cs : 266
```

Root cause:
Powershell worker config is not indexed with the error:
```
System.NotSupportedException : Version 12 is not supported for language powershell
   at Microsoft.Azure.WebJobs.Script.Workers.Rpc.RpcWorkerDescription.ValidateRuntimeVersion() at D:\a\1\s\src\WebJobs.Script\Workers\Rpc\RpcWorkerDescription.cs : 153
   at Microsoft.Azure.WebJobs.Script.Workers.Rpc.RpcWorkerDescription.ValidateDefaultWorkerPathFormatters(ISystemRuntimeInformation systemRuntimeInformation) at D:\a\1\s\src\WebJobs.Script\Workers\Rpc\RpcWorkerDescription.cs : 121
   at Microsoft.Azure.WebJobs.Script.Workers.Rpc.RpcWorkerDescription.FormatWorkerPathIfNeeded(ISystemRuntimeInformation systemRuntimeInformation,IEnvironment environment,ILogger logger) at D:\a\1\s\src\WebJobs.Script\Workers\Rpc\RpcWorkerDescription.cs : 200
   at Microsoft.Azure.WebJobs.Script.Workers.Rpc.RpcWorkerConfigFactory.AddProvider(String workerDir) at D:\a\1\s\src\WebJobs.Script\Workers\Rpc\Configuration\RpcWorkerConfigFactory.cs : 156
```

Which causes validation error after specialization even though right environment variables are injected.

This fix is scoped to not throwing for invalid version if worker runtime does not match the language for a worker config.

Manually verified following scenario:
- Start host in placeholder mode for node 12
- Specialize host for Powershell Version 7