### PR TITLE
Log unhandled exception in Rpc Service

### DIFF
--- a/src/WebJobs.Script/Workers/Rpc/FunctionRpcService.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRpcService.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             {
                 // We catch the exception, just to report it, then re-throw it
                 _logger.LogError(rpcException, "Exception encountered while listening to EventStream");
-                throw rpcException;
+                throw;
             }
             finally
             {

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRpcService.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRpcService.cs
@@ -81,6 +81,10 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     while (await messageAvailable());
                 }
             }
+            catch (Exception rpcException)
+            {
+                _logger.LogError(rpcException, "Exception encountered while listening to EventStream");
+            }
             finally
             {
                 foreach (var sub in outboundEventSubscriptions)

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRpcService.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRpcService.cs
@@ -83,7 +83,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             }
             catch (Exception rpcException)
             {
+                // We catch the exception, just to report it, then re-throw it
                 _logger.LogError(rpcException, "Exception encountered while listening to EventStream");
+                throw rpcException;
             }
             finally
             {


### PR DESCRIPTION
This PR addresses: https://github.com/Azure/azure-functions-host/issues/6081
It's a simple fix, just adding a catch-all exception logger that may provide convenient context around previously swallowed exceptions in the RPC Service.

⚡ ⚡ 