### PR TITLE
Ensuring default context load fallback uses deps if present

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
+++ b/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
@@ -119,6 +119,11 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             // runtime/default context loaded assembly against a function assembly)
             if (!_sharedContextAssembliesInFallbackLoad.ContainsKey(assemblyName.Name))
             {
+                if (Shared.TryLoadDepsDependency(assemblyName, out Assembly assembly))
+                {
+                    return assembly;
+                }
+
                 return Shared.LoadCore(assemblyName);
             }
 


### PR DESCRIPTION
2.0 port of #6142 