### PR TITLE
improve timeout if TestFunctionHost does not start

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -163,10 +163,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         private Task StartAsync()
         {
+            bool exit = false;
             var startTask = Task.Run(async () =>
             {
                 bool running = false;
-                while (!running)
+                while (!running && !exit)
                 {
                     running = await IsHostStarted();
 
@@ -183,6 +184,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
             else
             {
+                exit = true;
                 throw new Exception("Functions Host timed out trying to start.");
             }
         }


### PR DESCRIPTION
Porting @ankitkumarr's test change from here: https://github.com/Azure/azure-functions-host/pull/5962. This was made to v2.x and never made it to dev. This should better handle this if it's really caught in a loop.