### PR TITLE
Allow overriding defaultWorkerRuntimeVersion

### DIFF
--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     // Check if any appsettings are provided for that langauge
                     var languageSection = _config.GetSection($"{RpcWorkerConstants.LanguageWorkersSectionName}:{workerDescription.Language}");
                     workerDescription.Arguments = workerDescription.Arguments ?? new List<string>();
-                    GetDefaultExecutablePathFromAppSettings(workerDescription, languageSection);
+                    GetWorkerDescriptionFromAppSettings(workerDescription, languageSection);
                     AddArgumentsFromAppSettings(workerDescription, languageSection);
 
                     // Validate workerDescription
@@ -199,10 +199,13 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             return defaultWorkerDescription;
         }
 
-        private static void GetDefaultExecutablePathFromAppSettings(WorkerDescription workerDescription, IConfigurationSection languageSection)
+        private static void GetWorkerDescriptionFromAppSettings(RpcWorkerDescription workerDescription, IConfigurationSection languageSection)
         {
-            var defaultExecutablePath = languageSection.GetSection($"{WorkerConstants.WorkerDescriptionDefaultExecutablePath}");
-            workerDescription.DefaultExecutablePath = defaultExecutablePath.Value != null ? defaultExecutablePath.Value : workerDescription.DefaultExecutablePath;
+            var defaultExecutablePathSetting = languageSection.GetSection($"{WorkerConstants.WorkerDescriptionDefaultExecutablePath}");
+            workerDescription.DefaultExecutablePath = defaultExecutablePathSetting.Value != null ? defaultExecutablePathSetting.Value : workerDescription.DefaultExecutablePath;
+
+            var defaultRuntimeVersionAppSetting = languageSection.GetSection($"{WorkerConstants.WorkerDescriptionDefaultRuntimeVersion}");
+            workerDescription.DefaultRuntimeVersion = defaultRuntimeVersionAppSetting.Value != null ? defaultRuntimeVersionAppSetting.Value : workerDescription.DefaultRuntimeVersion;
         }
 
         internal static void AddArgumentsFromAppSettings(RpcWorkerDescription workerDescription, IConfigurationSection languageSection)

--- a/src/WebJobs.Script/Workers/WorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/WorkerConstants.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         public const string WorkerDescriptionDefaultWorkerPath = "defaultWorkerPath";
         public const string WorkerDescription = "description";
         public const string WorkerDescriptionArguments = "arguments";
+        public const string WorkerDescriptionDefaultRuntimeVersion = "defaultRuntimeVersion";
 
         // Profiles
         public const string WorkerDescriptionProfiles = "profiles";

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -48,7 +48,8 @@
   <ItemGroup>
     <PackageReference Include="appinsights.testlogger" Version="1.0.0" />
     <PackageReference Include="FluentAssertions" Version="5.9.0" />    
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.0" />    
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="1.1.202005032" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.9.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" />


### PR DESCRIPTION
This fix allows overriding defaultRuntimeVersion for a worker via app setting
`languageWorkers:language:defaultRuntimeVersion`

For linux use double underscores instead of `:`, `languageWorkers__language__defaultRuntimeVersion`