### PR TITLE
[RpcWorker]Add environment variable FUNCTIONS_WORKER_DIRECTORY

### DIFF
--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerProcess.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerProcess.cs
@@ -19,12 +19,13 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         private readonly Uri _serverUri;
         private readonly string _scriptRootPath;
         private readonly WorkerProcessArguments _workerProcessArguments;
+        private readonly string _workerDirectory;
 
         internal RpcWorkerProcess(string runtime,
                                        string workerId,
                                        string rootScriptPath,
                                        Uri serverUri,
-                                       WorkerProcessArguments workerProcessArguments,
+                                       RpcWorkerConfig rpcWorkerConfig,
                                        IScriptEventManager eventManager,
                                        IWorkerProcessFactory processFactory,
                                        IProcessRegistry processRegistry,
@@ -40,12 +41,14 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             _workerId = workerId;
             _serverUri = serverUri;
             _scriptRootPath = rootScriptPath;
-            _workerProcessArguments = workerProcessArguments;
+            _workerProcessArguments = rpcWorkerConfig.Arguments;
+            _workerDirectory = rpcWorkerConfig.Description.WorkerDirectory;
         }
 
         internal override Process CreateWorkerProcess()
         {
             var workerContext = new RpcWorkerContext(Guid.NewGuid().ToString(), RpcWorkerConstants.DefaultMaxMessageLengthBytes, _workerId, _workerProcessArguments, _scriptRootPath, _serverUri);
+            workerContext.EnvironmentVariables.Add(WorkerConstants.FunctionsWorkerDirectorySettingName, _workerDirectory);
             return _processFactory.CreateWorkerProcess(workerContext);
         }
 

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerProcessFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerProcessFactory.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public IWorkerProcess Create(string workerId, string runtime, string scriptRootPath, RpcWorkerConfig workerConfig)
         {
             ILogger workerProcessLogger = _loggerFactory.CreateLogger($"Worker.rpcWorkerProcess.{runtime}.{workerId}");
-            return new RpcWorkerProcess(runtime, workerId, scriptRootPath, _rpcServer.Uri, workerConfig.Arguments, _eventManager, _workerProcessFactory, _processRegistry, workerProcessLogger, _consoleLogSource, _metricsLogger);
+            return new RpcWorkerProcess(runtime, workerId, scriptRootPath, _rpcServer.Uri, workerConfig, _eventManager, _workerProcessFactory, _processRegistry, workerProcessLogger, _consoleLogSource, _metricsLogger);
         }
     }
 }

--- a/src/WebJobs.Script/Workers/WorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/WorkerConstants.cs
@@ -20,6 +20,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         public const string WorkersDirectorySectionName = "workersDirectory";
         public const string WorkerDirectorySectionName = "workerDirectory";
 
+        // Environment variables names
+        public const string FunctionsWorkerDirectorySettingName = "FUNCTIONS_WORKER_DIRECTORY";
+
         // Worker description constants
         public const string WorkerDescriptionDefaultExecutablePath = "defaultExecutablePath";
         public const string WorkerDescriptionDefaultWorkerPath = "defaultWorkerPath";

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerProcessTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerProcessTests.cs
@@ -24,11 +24,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var rpcServer = new TestRpcServer();
             var languageWorkerConsoleLogSource = new Mock<IWorkerConsoleLogSource>();
             var testEnv = new TestEnvironment();
+            var testWorkerConfigs = TestHelpers.GetTestWorkerConfigs();
             _rpcWorkerProcess = new RpcWorkerProcess("node",
                 "testworkerId",
                 "testrootPath",
                 rpcServer.Uri,
-                null,
+                testWorkerConfigs.ElementAt(0),
                 _eventManager.Object,
                 workerProcessFactory.Object,
                 processRegistry.Object,


### PR DESCRIPTION
This PR, adds environment variable: `FUNCTIONS_WORKER_DIRECTORY` with value to set to location of `worker.config.json` file used to build the worker config for a given language.