### PR TITLE
[LinuxConsumption] Add http health status endpoint for container liveness probe

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
@@ -91,5 +91,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
             var tIgnore = Task.Run(() => hostManager.RestartHostAsync());
             return Ok();
         }
+
+        [HttpGet]
+        [Route("admin/instance/http-health")]
+        public IActionResult GetHttpHealthStatus()
+        {
+            // Reaching here implies that http health of the container is ok.
+            return Ok();
+        }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
@@ -129,5 +129,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             Assert.NotNull(okResult);
             Assert.Equal(200, okResult.StatusCode);
         }
+
+        [Fact]
+        public void Http_Health_Status_Returns_Ok()
+        {
+            var loggerFactory = new LoggerFactory();
+            var loggerProvider = new TestLoggerProvider();
+            loggerFactory.AddProvider(loggerProvider);
+
+            var instanceController = new InstanceController(null, null, loggerFactory, null);
+        
+            var actionResult = instanceController.GetHttpHealthStatus();
+            var okResult = actionResult as OkResult;
+
+            Assert.NotNull(okResult);
+            Assert.Equal(200, okResult.StatusCode);
+        }
     }
 }


### PR DESCRIPTION
Adding a http health check endpoint which will be periodically polled to determine the container's http health status.