### PR TITLE
Create TaskCompletionSource with RunContinuationsAsynchronously

### DIFF
--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerChannel.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerChannel.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         private ILogger _workerChannelLogger;
         private IMetricsLogger _metricsLogger;
         private IWorkerProcess _rpcWorkerProcess;
-        private TaskCompletionSource<bool> _reloadTask = new TaskCompletionSource<bool>();
+        private TaskCompletionSource<bool> _reloadTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         private TaskCompletionSource<bool> _workerInitTask = new TaskCompletionSource<bool>();
 
         internal RpcWorkerChannel(

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerChannel.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerChannel.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         private IMetricsLogger _metricsLogger;
         private IWorkerProcess _rpcWorkerProcess;
         private TaskCompletionSource<bool> _reloadTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        private TaskCompletionSource<bool> _workerInitTask = new TaskCompletionSource<bool>();
+        private TaskCompletionSource<bool> _workerInitTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         internal RpcWorkerChannel(
            string workerId,
@@ -211,7 +211,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             if (res.Result.IsFailure(out Exception reloadEnvironmentVariablesException))
             {
                 _workerChannelLogger.LogError(reloadEnvironmentVariablesException, "Failed to reload environment variables");
-                _reloadTask.SetResult(false);
+                _reloadTask.SetException(reloadEnvironmentVariablesException);
             }
             _reloadTask.SetResult(true);
             latencyEvent.Dispose();

--- a/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
@@ -202,6 +202,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             await _rpcWorkerChannelManager.SpecializeAsync();
 
+            // Wait for debouce task to start
+            await Task.Delay(6000);
             Assert.True(testMetricsLogger.EventsBegan.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels)
                 && testMetricsLogger.EventsEnded.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels));
 
@@ -228,6 +230,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             await _rpcWorkerChannelManager.SpecializeAsync();
 
+            // Wait for debouce task to start
+            await Task.Delay(6000);
             Assert.True(testMetricsLogger.EventsBegan.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels)
                 && testMetricsLogger.EventsEnded.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels));
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
@@ -181,7 +181,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             {
                 return testMetricsLogger.EventsBegan.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels)
                 && testMetricsLogger.EventsEnded.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels);
-            }, pollingInterval: 6000);
+            }, pollingInterval: 500);
 
             // Verify logs
             var traces = _testLogger.GetLogMessages();
@@ -211,7 +211,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             {
                 return testMetricsLogger.EventsBegan.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels)
                 && testMetricsLogger.EventsEnded.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels);
-            }, pollingInterval: 6000);
+            }, pollingInterval: 500);
 
             // Verify logs
             var traces = _testLogger.GetLogMessages();
@@ -241,7 +241,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             {
                 return testMetricsLogger.EventsBegan.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels)
                 && testMetricsLogger.EventsEnded.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels);
-            }, pollingInterval: 6000);
+            }, pollingInterval: 500);
 
             // Verify logs
             var traces = _testLogger.GetLogMessages();

--- a/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
@@ -177,9 +177,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             await _rpcWorkerChannelManager.SpecializeAsync();
             // Wait for debouce task to start
-            await Task.Delay(6000);
-            Assert.True(testMetricsLogger.EventsBegan.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels)
-                && testMetricsLogger.EventsEnded.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels));
+            await TestHelpers.Await(() =>
+            {
+                return testMetricsLogger.EventsBegan.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels)
+                && testMetricsLogger.EventsEnded.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels);
+            }, pollingInterval: 6000);
 
             // Verify logs
             var traces = _testLogger.GetLogMessages();
@@ -205,9 +207,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             await _rpcWorkerChannelManager.SpecializeAsync();
 
             // Wait for debouce task to start
-            await Task.Delay(6000);
-            Assert.True(testMetricsLogger.EventsBegan.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels)
-                && testMetricsLogger.EventsEnded.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels));
+            await TestHelpers.Await(() =>
+            {
+                return testMetricsLogger.EventsBegan.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels)
+                && testMetricsLogger.EventsEnded.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels);
+            }, pollingInterval: 6000);
 
             // Verify logs
             var traces = _testLogger.GetLogMessages();
@@ -233,9 +237,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             await _rpcWorkerChannelManager.SpecializeAsync();
 
             // Wait for debouce task to start
-            await Task.Delay(6000);
-            Assert.True(testMetricsLogger.EventsBegan.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels)
-                && testMetricsLogger.EventsEnded.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels));
+            await TestHelpers.Await(() =>
+            {
+                return testMetricsLogger.EventsBegan.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels)
+                && testMetricsLogger.EventsEnded.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels);
+            }, pollingInterval: 6000);
 
             // Verify logs
             var traces = _testLogger.GetLogMessages();

--- a/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
@@ -176,6 +176,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             IRpcWorkerChannel workerChannel = CreateTestChannel(languageWorkerName);
 
             await _rpcWorkerChannelManager.SpecializeAsync();
+            // Wait for debouce task to start
+            await Task.Delay(6000);
             Assert.True(testMetricsLogger.EventsBegan.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels)
                 && testMetricsLogger.EventsEnded.Contains(MetricEventNames.SpecializationScheduleShutdownStandbyChannels));
 


### PR DESCRIPTION
This is follow up from cold start analysis.

On my local machine, `SetResult` on task completion source was taking upto ~400ms which maps to latencies reported in metrics logs.

Creating TCS with with option `RunContinuationsAsynchronously`,  now takes ~30ms which maps to Functions logs - Time between environment reload request sent and received from the worker.

