### PR TITLE
[pack] updating private assemblies list

### DIFF
--- a/src/WebJobs.Script/runtimeassemblies.json
+++ b/src/WebJobs.Script/runtimeassemblies.json
@@ -3,6 +3,26 @@
 {
   "runtimeAssemblies": [
     {
+      "name": "Microsoft.Azure.KeyVault.Core",
+      "resolutionPolicy": "private"
+    },
+    {
+      "name": "Microsoft.OData.Core",
+      "resolutionPolicy": "private"
+    },
+    {
+      "name": "Microsoft.OData.Edm",
+      "resolutionPolicy": "private"
+    },
+    {
+      "name": "Microsoft.Spatial",
+      "resolutionPolicy": "private"
+    },
+    {
+      "name": "Microsoft.Azure.Storage.Common",
+      "resolutionPolicy": "private"
+    },
+    {
       "name": "Microsoft.Azure.DocumentDB.Core",
       "resolutionPolicy": "private"
     },


### PR DESCRIPTION
v2 version of #6208, but without the need to re-add `System.Interactive.Async` as this is already included with our reference to AspNetCore 2.2.8 