### PR TITLE
Update functionmetadata validation condition

### DIFF
--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Azure.WebJobs.Script
         private readonly IFunctionMetadataProvider _functionMetadataProvider;
         private bool _isHttpWorker;
         private bool _servicesReset = false;
-        private bool _jobHostServicesInitialized = false;
         private ILogger _logger;
         private IOptions<ScriptJobHostOptions> _scriptOptions;
         private IOptions<LanguageWorkerOptions> _languageWorkerOptions;
@@ -51,10 +50,6 @@ namespace Microsoft.Azure.WebJobs.Script
             scriptHostManager.HostInitializing += (s, e) =>
             {
                 InitializeServices();
-
-                // Once ScriptHost has initialized, functionMetadata has loaded the new services,
-                // it now works under the context of ScriptHost using the ScriptHost level config
-                _jobHostServicesInitialized = true;
             };
         }
 
@@ -172,7 +167,7 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             try
             {
-                if (string.IsNullOrEmpty(functionMetadata.ScriptFile) && !_isHttpWorker && !functionMetadata.IsProxy() && _jobHostServicesInitialized)
+                if (string.IsNullOrEmpty(functionMetadata.ScriptFile) && !_isHttpWorker && !functionMetadata.IsProxy() && _servicesReset)
                 {
                     throw new FunctionConfigurationException(_functionConfigurationErrorMessage);
                 }


### PR DESCRIPTION
Fixes #6227 . The previous approach used _jobHostServicesInitialized which works alright in normal cases but during specialization, it gets set to true in placeholder mode and remains true even after specialization kicks in causing functionmetadata to be removed. This consequently causes the startup types to not be loaded after specialization.

The current approach uses _servicesReset instead.