### PR TITLE
Use CancellationToken during ScriptHost Initialization

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -246,7 +246,10 @@ namespace Microsoft.Azure.WebJobs.Script
 
         protected override async Task StartAsyncCore(CancellationToken cancellationToken)
         {
-            var ignore = LogInitializationAsync();
+            // Throw if cancellation occurred before initialization.
+            cancellationToken.ThrowIfCancellationRequested();
+
+            _ = LogInitializationAsync();
 
             await InitializeAsync(cancellationToken);
 
@@ -264,10 +267,6 @@ namespace Microsoft.Azure.WebJobs.Script
         /// </summary>
         public async Task InitializeAsync(CancellationToken cancellationToken = default)
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
             _stopwatch.Start();
             using (_metricsLogger.LatencyEvent(MetricEventNames.HostStartupLatency))
             {
@@ -482,10 +481,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// </summary>
         internal async Task InitializeFunctionDescriptorsAsync(IEnumerable<FunctionMetadata> functionMetadata, CancellationToken cancellationToken)
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
 
             AddFunctionDescriptors(functionMetadata);
 

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -530,15 +530,10 @@ namespace Microsoft.Azure.WebJobs.Script
             return true;
         }
 
-        internal static void VerifyFunctionsMatchSpecifiedLanguage(IEnumerable<FunctionMetadata> functions, string workerRuntime, bool isPlaceholderMode, bool isHttpWorker)
+        internal static void VerifyFunctionsMatchSpecifiedLanguage(IEnumerable<FunctionMetadata> functions, string workerRuntime, bool isPlaceholderMode, bool isHttpWorker, CancellationToken cancellationToken)
         {
-            if (isPlaceholderMode)
+            if (isPlaceholderMode || isHttpWorker || cancellationToken.IsCancellationRequested)
             {
-                return;
-            }
-            if (isHttpWorker)
-            {
-                // Do not enforce langauge for http worker
                 return;
             }
             if (!IsSingleLanguage(functions, workerRuntime))

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -532,10 +532,13 @@ namespace Microsoft.Azure.WebJobs.Script
 
         internal static void VerifyFunctionsMatchSpecifiedLanguage(IEnumerable<FunctionMetadata> functions, string workerRuntime, bool isPlaceholderMode, bool isHttpWorker, CancellationToken cancellationToken)
         {
-            if (isPlaceholderMode || isHttpWorker || cancellationToken.IsCancellationRequested)
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (isPlaceholderMode || isHttpWorker)
             {
                 return;
             }
+
             if (!IsSingleLanguage(functions, workerRuntime))
             {
                 if (string.IsNullOrEmpty(workerRuntime))

--- a/src/WebJobs.Script/Workers/Http/HttpFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpFunctionInvocationDispatcher.cs
@@ -89,10 +89,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
 
         public async Task InitializeAsync(IEnumerable<FunctionMetadata> functions, CancellationToken cancellationToken = default)
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
 
             if (functions == null || !functions.Any())
             {

--- a/src/WebJobs.Script/Workers/Http/HttpFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpFunctionInvocationDispatcher.cs
@@ -89,6 +89,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
 
         public async Task InitializeAsync(IEnumerable<FunctionMetadata> functions, CancellationToken cancellationToken = default)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
             if (functions == null || !functions.Any())
             {
                 // do not initialize function dispachter if there are no functions

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -164,6 +164,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         public async Task InitializeAsync(IEnumerable<FunctionMetadata> functions, CancellationToken cancellationToken = default)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
             if (_environment.IsPlaceholderModeEnabled())
             {
                 return;

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -164,10 +164,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         public async Task InitializeAsync(IEnumerable<FunctionMetadata> functions, CancellationToken cancellationToken = default)
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
 
             if (_environment.IsPlaceholderModeEnabled())
             {

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -1185,8 +1185,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             if (!placeholderMode && !httpWorker)
             {
                 cts.Cancel();
+                Assert.Throws<OperationCanceledException>(() => Utility.VerifyFunctionsMatchSpecifiedLanguage(functionsList, string.Empty, placeholderMode, httpWorker, cts.Token));
             }
-            Utility.VerifyFunctionsMatchSpecifiedLanguage(functionsList, string.Empty, placeholderMode, httpWorker, cts.Token);
+            else
+            {
+                Utility.VerifyFunctionsMatchSpecifiedLanguage(functionsList, string.Empty, placeholderMode, httpWorker, cts.Token);
+            }
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -1125,7 +1125,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 funcJS1
             };
 
-            HostInitializationException ex = Assert.Throws<HostInitializationException>(() => Utility.VerifyFunctionsMatchSpecifiedLanguage(functionsList, RpcWorkerConstants.DotNetLanguageWorkerName, false, false));
+            HostInitializationException ex = Assert.Throws<HostInitializationException>(() => Utility.VerifyFunctionsMatchSpecifiedLanguage(functionsList, RpcWorkerConstants.DotNetLanguageWorkerName, false, false, CancellationToken.None));
             Assert.Equal($"Did not find functions with language [{RpcWorkerConstants.DotNetLanguageWorkerName}].", ex.Message);
         }
 
@@ -1148,7 +1148,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 funcJS1, funcCS1
             };
 
-            Utility.VerifyFunctionsMatchSpecifiedLanguage(functionsList, RpcWorkerConstants.DotNetLanguageWorkerName, false, false);
+            Utility.VerifyFunctionsMatchSpecifiedLanguage(functionsList, RpcWorkerConstants.DotNetLanguageWorkerName, false, false, CancellationToken.None);
         }
 
         [Fact]
@@ -1164,13 +1164,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 funcJS1
             };
 
-            Utility.VerifyFunctionsMatchSpecifiedLanguage(functionsList, string.Empty, false, false);
+            Utility.VerifyFunctionsMatchSpecifiedLanguage(functionsList, string.Empty, false, false, CancellationToken.None);
         }
 
         [Theory]
         [InlineData(true, true)]
         [InlineData(true, false)]
-        public void VerifyFunctionsMatchSpecifiedLanguage_NoThrow_For_HttpWorkerOrPlaceholderMode(bool placeholderMode, bool httpWorker)
+        [InlineData(false, false)]
+        public void VerifyFunctionsMatchSpecifiedLanguage_NoThrow_For_HttpWorkerOrPlaceholderModeOrInitTaskCancelled(bool placeholderMode, bool httpWorker)
         {
             FunctionMetadata funcJS1 = new FunctionMetadata()
             {
@@ -1180,8 +1181,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 funcJS1
             };
-
-            Utility.VerifyFunctionsMatchSpecifiedLanguage(functionsList, string.Empty, placeholderMode, httpWorker);
+            CancellationTokenSource cts = new CancellationTokenSource();
+            if (!placeholderMode && !httpWorker)
+            {
+                cts.Cancel();
+            }
+            Utility.VerifyFunctionsMatchSpecifiedLanguage(functionsList, string.Empty, placeholderMode, httpWorker, cts.Token);
         }
 
         [Fact]
@@ -1202,7 +1207,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 funcJS1, funcCS1
             };
 
-            HostInitializationException ex = Assert.Throws<HostInitializationException>(() => Utility.VerifyFunctionsMatchSpecifiedLanguage(functionsList, string.Empty, false, false));
+            HostInitializationException ex = Assert.Throws<HostInitializationException>(() => Utility.VerifyFunctionsMatchSpecifiedLanguage(functionsList, string.Empty, false, false, CancellationToken.None));
             Assert.Equal($"Found functions with more than one language. Select a language for your function app by specifying {RpcWorkerConstants.FunctionWorkerRuntimeSettingName} AppSetting", ex.Message);
         }
 


### PR DESCRIPTION
Fixes #6120 

Manually tested E2E:
- Started host in Placeholder mode
- Specialize host in 1sec
- Error reproes before the fix and does not repro with the changes in the PR.