### PR TITLE
[pack] fixing pipelines build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,11 +54,7 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016' 
   steps:
-  - task: UseDotNet@2
-    inputs:
-      packageType: 'sdk'
-      version: '2.2.x'
-      performMultiLevelLookup: true
+  - template: build/pipelines/usedotnet.yml
   - task: PowerShell@2
     displayName: "Build artifacts"
     inputs:
@@ -66,12 +62,12 @@ jobs:
       arguments: '-buildNumber "$(buildNumber)" -suffix "$(suffix)"'
   - task: CopyFiles@2
     inputs:
-      SourceFolder: '..\..\..\buildoutput'
+      SourceFolder: '$(Build.Repository.LocalPath)\buildoutput'
       Contents: 'WebJobs.Script.Performance.App*.nupkg'
       TargetFolder: '$(Build.ArtifactStagingDirectory)\Performance'
   - task: CopyFiles@2
     inputs:
-      SourceFolder: '..\..\buildoutput'
+      SourceFolder: '$(Build.Repository.LocalPath)\buildoutput'
       Contents: '*.nupkg'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
   - task: CopyFiles@2
@@ -110,11 +106,7 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   steps: 
-  - task: UseDotNet@2
-    inputs:
-      packageType: 'sdk'
-      version: '2.2.x'
-      performMultiLevelLookup: true
+  - template: build/pipelines/usedotnet.yml
   - task: DotNetCoreCLI@2
     displayName: 'Unit Tests'
     inputs:
@@ -129,11 +121,7 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   steps: 
-  - task: UseDotNet@2
-    inputs:
-      packageType: 'sdk'
-      version: '2.2.x'
-      performMultiLevelLookup: true
+  - template: build/pipelines/usedotnet.yml
   - task: UseNode@1
     inputs:      
       version: '10.x'
@@ -185,11 +173,7 @@ jobs:
   pool:
     vmImage: 'vs2017-win2016'
   steps: 
-  - task: UseDotNet@2
-    inputs:
-      packageType: 'sdk'
-      version: '2.2.x'
-      performMultiLevelLookup: true
+  - template: build/pipelines/usedotnet.yml
   - task: UseNode@1
     inputs:
       version: '10.x'

--- a/build.cmd
+++ b/build.cmd
@@ -1,5 +1,5 @@
 @ECHO Off
-REM call dotnet --version
+REM call dotnet --info
 call dotnet restore WebJobs.Script.sln
 call dotnet build WebJobs.Script.sln
 REM call dotnet test WebJobs.Script.sln --no-build

--- a/build.cmd
+++ b/build.cmd
@@ -1,5 +1,5 @@
 @ECHO Off
-REM call dotnet --info
+REM call dotnet --version
 call dotnet restore WebJobs.Script.sln
 call dotnet build WebJobs.Script.sln
 REM call dotnet test WebJobs.Script.sln --no-build

--- a/build.ps1
+++ b/build.ps1
@@ -108,7 +108,7 @@ function AddDiaSymReaderToPath()
 
     $parent = Split-Path -Path $sdkBasePath.Trim()
     $maxValue = 0
-    Get-ChildItem $parent\2.2.* | 
+    Get-ChildItem $parent\2.2.* | ?{ $_.PSIsContainer } |
         ForEach-Object {
             $newVal = $_.Extension -replace '\.',''
             if($newVal -gt $maxValue) {
@@ -280,7 +280,8 @@ function cleanExtension([string] $bitness) {
     Get-ChildItem "$privateSiteExtensionPath\$bitness\workers\powershell\runtimes" -Exclude $keepRuntimes -ErrorAction SilentlyContinue |
         Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
 }
-  
+
+dotnet --info
 dotnet --version
 dotnet build .\WebJobs.Script.sln -v q /p:BuildNumber="$buildNumber"
 
@@ -296,12 +297,12 @@ $projects =
 foreach ($project in $projects)
 {
 
-  $cmd = "pack", "src\$project\$project.csproj", "-o", "..\..\buildoutput", "--no-build" , "-p:PackageVersion=$extensionVersion"
+  $cmd = "pack", "src\$project\$project.csproj", "-o", "$buildoutput", "--no-build" , "-p:PackageVersion=$extensionVersion"
   
   & dotnet $cmd  
 }
 
-$cmd = "pack", "tools\WebJobs.Script.Performance\WebJobs.Script.Performance.App\WebJobs.Script.Performance.App.csproj", "-o", "..\..\..\buildoutput"
+$cmd = "pack", "tools\WebJobs.Script.Performance\WebJobs.Script.Performance.App\WebJobs.Script.Performance.App.csproj", "-o", "$buildoutput"
 & dotnet $cmd
 
 AddDiaSymReaderToPath

--- a/build/pipelines/usedotnet.yml
+++ b/build/pipelines/usedotnet.yml
@@ -1,0 +1,21 @@
+steps: 
+- task: PowerShell@2
+  displayName: 'Set default dotnet path'
+  inputs:
+    targetType: 'inline'
+    script: |
+      $infoContent = dotnet --info
+      $sdkBasePath = $infoContent  |
+          Where-Object {$_ -match 'Base Path:'} |
+          ForEach-Object {
+              ($_ -replace '\s+Base Path:','').trim()
+          }    
+      Write-Host  "dotnet SDK path: $sdkBasePath"
+      $dotnetPath = (Get-Item $sdkBasePath).Parent.Parent.FullName
+      Write-Host "dotnet path: $dotnetPath"
+      Write-Host "##vso[task.setvariable variable=DotNetPath]$dotnetPath"
+- task: UseDotNet@2
+  inputs:
+    packageType: 'sdk'
+    version: '2.2.207'
+    installationPath: $(DotNetPath)


### PR DESCRIPTION
Fixes #6279 

Fixes a bunch of failures, ultimately due to .NET Core 2.2 being removed from devops VMs: https://github.com/actions/virtual-environments/issues/975