### PR TITLE
Fix V2 unittest should not use Python3.8

### DIFF
--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
@@ -109,14 +109,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var configBuilder = ScriptSettingsManager.CreateDefaultConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>
                 {
-                    ["languageWorkers:python:defaultRuntimeVersion"] = "3.8"
+                    ["languageWorkers:python:defaultRuntimeVersion"] = "3.6"
                 });
             var config = configBuilder.Build();
             var scriptSettingsManager = new ScriptSettingsManager(config);
             var testLogger = new TestLogger("test");
             var testEnvVariables = new Dictionary<string, string>
             {
-                { "languageWorkers:python:defaultRuntimeVersion", "3.8" }
+                { "languageWorkers:python:defaultRuntimeVersion", "3.6" }
             };
             using (var variables = new TestScopedSettings(scriptSettingsManager, testEnvVariables))
             {
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 var pythonWorkerConfig = workerConfigs.Where(w => w.Description.Language.Equals("python", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
                 Assert.Equal(4, workerConfigs.Count);
                 Assert.NotNull(pythonWorkerConfig);
-                Assert.Equal("3.8", pythonWorkerConfig.Description.DefaultRuntimeVersion);
+                Assert.Equal("3.6", pythonWorkerConfig.Description.DefaultRuntimeVersion);
             }
         }
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This is a fix for Python worker unittest, for 2.x function app, we should not use 3.8 for defaultRuntimeVersion.

### Pull request checklist

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
