### PR TITLE
Revert breaking change for Node.js worker

### DIFF
--- a/src/WebJobs.Script/Workers/MessageExtensions/ScriptInvocationContextExtensions.cs
+++ b/src/WebJobs.Script/Workers/MessageExtensions/ScriptInvocationContextExtensions.cs
@@ -77,29 +77,21 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             }
 
             // if this is an http request and the worker declares that it handles exclusion
-            // of http binding metadata, we'll skip those
-            if (context.FunctionMetadata.IsHttpInAndOutFunction() && excludeHttpTriggerMetadata)
+            // of req/$request binding data members
+            if (excludeHttpTriggerMetadata && bindingData.Value is HttpRequest)
             {
-                if (bindingData.Value is HttpRequest)
-                {
-                    // will exclude req/$request binding data members
-                    return true;
-                }
-
-                if (bindingData.Key.Equals("headers", StringComparison.OrdinalIgnoreCase) || bindingData.Key.Equals("query", StringComparison.OrdinalIgnoreCase))
-                {
-                    // these values are already part of the the request
-                    return true;
-                }
-            }
-
-            if (bindingData.Key.Equals("sys", StringComparison.OrdinalIgnoreCase) &&
-                bindingData.Value.GetType().Name.Equals("SystemBindingData", StringComparison.OrdinalIgnoreCase))
-            {
-                // The system binding data isn't RPC friendly. It's designed for in memory use in the binding
-                // pipeline (e.g. sys.RandGuid, etc.)
                 return true;
             }
+
+            // TODO: re-enable this code when properties are no longer required by Node.js worker
+            // https://github.com/Azure/azure-functions-host/issues/6319
+            //if (bindingData.Key.Equals("sys", StringComparison.OrdinalIgnoreCase) &&
+            //    bindingData.Value.GetType().Name.Equals("SystemBindingData", StringComparison.OrdinalIgnoreCase))
+            //{
+            //    // The system binding data isn't RPC friendly. It's designed for in memory use in the binding
+            //    // pipeline (e.g. sys.RandGuid, etc.)
+            //    return true;
+            //}
 
             return false;
         }

--- a/test/WebJobs.Script.Tests/Workers/ScriptInvocationContextExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ScriptInvocationContextExtensionsTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
         }
 
         [Fact]
-        public async Task ToRpcInvocationRequest_Http_OmitsDuplicateBindingData()
+        public async Task ToRpcInvocationRequest_Http_OmitsDuplicateBodyOfBindingData()
         {
             var logger = new TestLogger("test");
 
@@ -143,7 +143,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
 
             var result = await invocationContext.ToRpcInvocationRequest(logger, capabilities);
             Assert.Equal(1, result.InputData.Count);
-            Assert.Equal(0, result.TriggerMetadata.Count);
+            Assert.Equal(3, result.TriggerMetadata.Count);
+            Assert.True(result.TriggerMetadata.ContainsKey("headers"));
+            Assert.True(result.TriggerMetadata.ContainsKey("query"));
+            Assert.True(result.TriggerMetadata.ContainsKey("sys"));
         }
 
         private class TestPoco


### PR DESCRIPTION
In V3 versions before v3.0.14063, the node worker exposed to users `context.bindingData` that looked like this:
```
{
  invocationId: 'bc9059c0-d0a5-4ba5-9b79-e72a1f20fba7',
  query: {},
  headers: {
    accept: '*/*',
    'accept-Encoding': 'gzip, deflate',
     ...
  },
  sys: {
    methodName: 'HttpTrigger1',
    utcNow: '2020-07-07T17:57:06.0692413Z',
    randGuid: 'ac2e1805-9cc2-4af8-ad99-ab7f15aa3bb3'
  }
}
```

Now, with v3.0.14063, we only see this:
```
{
  invocationId: 'bc9059c0-d0a5-4ba5-9b79-e72a1f20fba7',
}
```

This represents a breaking change for Node.js customers and needs to be reverted until we can figure out a longer-term solution to trying to reduce content that gets sent over the wire for out-of-proc workers.