### PR TITLE
[CustomHandler]Fix options parsing (#6306)

### DIFF
--- a/WebJobs.Script.sln
+++ b/WebJobs.Script.sln
@@ -310,6 +310,18 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HttpTrigger", "HttpTrigger"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobsStartupTests", "test\WebJobsStartupTests\WebJobsStartupTests.csproj", "{F5D74052-3807-410F-9A5A-B69A57127CF4}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CustomHandler", "CustomHandler", "{A59D3F65-53E5-4666-AEFE-882987A39A49}"
+	ProjectSection(SolutionItems) = preProject
+		sample\CustomHandler\host.json = sample\CustomHandler\host.json
+		sample\CustomHandler\proxies.json = sample\CustomHandler\proxies.json
+		sample\CustomHandler\server.js = sample\CustomHandler\server.js
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HttpTrigger", "HttpTrigger", "{209DC34B-762E-4B1B-B094-EBD7C4B972C2}"
+	ProjectSection(SolutionItems) = preProject
+		sample\CustomHandler\HttpTrigger\function.json = sample\CustomHandler\HttpTrigger\function.json
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		test\WebJobs.Script.Tests.Shared\WebJobs.Script.Tests.Shared.projitems*{35c9ccb7-d8b6-4161-bb0d-bcfa7c6dcffb}*SharedItemsImports = 13
@@ -407,6 +419,8 @@ Global
 		{0AE3CE25-4CD9-4769-AE58-399FC59CF70F} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
 		{BA45A727-34B7-484F-9B93-B1755AF09A2A} = {0AE3CE25-4CD9-4769-AE58-399FC59CF70F}
 		{F5D74052-3807-410F-9A5A-B69A57127CF4} = {AFB0F5F7-A612-4F4A-94DD-8B69CABF7970}
+		{A59D3F65-53E5-4666-AEFE-882987A39A49} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
+		{209DC34B-762E-4B1B-B094-EBD7C4B972C2} = {A59D3F65-53E5-4666-AEFE-882987A39A49}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {85400884-5FFD-4C27-A571-58CB3C8CAAC5}

--- a/sample/CustomHandler/HttpTrigger/function.json
+++ b/sample/CustomHandler/HttpTrigger/function.json
@@ -1,0 +1,18 @@
+{
+  "bindings": [
+    {
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/sample/CustomHandler/host.json
+++ b/sample/CustomHandler/host.json
@@ -1,0 +1,10 @@
+{
+  "version": "2.0",
+  "customHandler": {
+    "enableForwardingHttpRequest": true,
+    "description": {
+      "defaultExecutablePath": "node",
+      "arguments": [ "server.js" ]
+    }
+  }
+}

--- a/sample/CustomHandler/proxies.json
+++ b/sample/CustomHandler/proxies.json
@@ -1,0 +1,17 @@
+{
+  "proxies": {
+    "proxyroute": {
+      "matchCondition": {
+        "methods": [
+          "GET"
+        ],
+        "route": "/something"
+      },
+      "responseOverrides": {
+        "response.statusCode": "200",
+        "response.headers.Content-Type": "text/plain",
+        "response.body": "something"
+      }
+    }
+  }
+}

--- a/sample/CustomHandler/server.js
+++ b/sample/CustomHandler/server.js
@@ -1,0 +1,12 @@
+var http = require('http');
+const url = require('url');
+const port = process.env.FUNCTIONS_HTTPWORKER_PORT;
+console.log("port" + port);
+//create a server object:
+http.createServer(function (req, res) {
+  const reqUrl = url.parse(req.url, true);
+  console.log("Request handler random was called.");
+  res.writeHead(200, {"Content-Type": "application/json"});
+  var json = JSON.stringify({ functionName : req.url.replace("/","")});
+  res.end(json);
+}).listen(port); 

--- a/sample/HttpWorker/host.json
+++ b/sample/HttpWorker/host.json
@@ -3,7 +3,7 @@
 	"httpWorker": {
 		"description": {
 			"defaultExecutablePath": "node",
-			"defaultWorkerPath": "server.js"
+			"defaultWorkerPath":  "server.js"
 		}
 	}
 }

--- a/src/WebJobs.Script/Workers/Http/Configuration/HttpWorkerOptionsSetup.cs
+++ b/src/WebJobs.Script/Workers/Http/Configuration/HttpWorkerOptionsSetup.cs
@@ -111,12 +111,13 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
             };
 
             options.Arguments.ExecutableArguments.AddRange(options.Description.Arguments);
+            options.Arguments.WorkerArguments.AddRange(options.Description.WorkerArguments);
             options.Port = GetUnusedTcpPort();
         }
 
-        private static List<string> GetArgumentList(IConfigurationSection httpWorkerSection, string argumentSectionName)
+        private static List<string> GetArgumentList(IConfigurationSection workerConfigSection, string argumentSectionName)
         {
-            var argumentsSection = httpWorkerSection.GetSection(argumentSectionName);
+            var argumentsSection = workerConfigSection.GetSection(argumentSectionName);
             if (argumentsSection.Exists() && argumentsSection?.Value != null)
             {
                 try

--- a/src/WebJobs.Script/Workers/Http/HttpWorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpWorkerDescription.cs
@@ -42,19 +42,18 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
 
             ExpandEnvironmentVariables();
 
-            // If DefaultWorkerPath is not set then compute full path for DefaultExecutablePath from WorkingDirectory.
+            // If DefaultWorkerPath is not set then compute full path for DefaultExecutablePath from WorkingDirectory and check if DefaultExecutablePath exists
             // Empty DefaultWorkerPath or empty Arguments indicates DefaultExecutablePath is either a runtime on the system path or a file relative to WorkingDirectory.
             // No need to find full path for DefaultWorkerPath as WorkerDirectory will be set when launching the worker process.
             // DefaultWorkerPath can be specified as part of the arguments list
-            if (string.IsNullOrEmpty(DefaultWorkerPath) && !string.IsNullOrEmpty(DefaultExecutablePath) && !Path.IsPathRooted(DefaultExecutablePath) && !Arguments.Any())
+            if (!string.IsNullOrEmpty(DefaultExecutablePath) && !Path.IsPathRooted(DefaultExecutablePath))
             {
-                DefaultExecutablePath = Path.Combine(WorkerDirectory, DefaultExecutablePath);
-            }
-
-            // If DefaultWorkerPath is set and find full path from scriptRootDir
-            if (!string.IsNullOrEmpty(DefaultWorkerPath) && !Path.IsPathRooted(DefaultWorkerPath))
-            {
-                DefaultWorkerPath = Path.Combine(WorkerDirectory, DefaultWorkerPath);
+                var fullExePath = Path.Combine(WorkerDirectory, DefaultExecutablePath);
+                // Override DefaultExecutablePath only if the file exists. If file does not exist assume, this is a runtime available on system path
+                if (FileExists(fullExePath))
+                {
+                    DefaultExecutablePath = fullExePath;
+                }
             }
 
             if (string.IsNullOrEmpty(DefaultExecutablePath))

--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcess.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcess.cs
@@ -54,9 +54,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
                     _process.Exited += (sender, e) => OnProcessExited(sender, e);
                     _process.EnableRaisingEvents = true;
 
-                    _workerProcessLogger?.LogInformation($"Starting worker process with FileName:{_process.StartInfo.FileName} WorkingDirectory:{_process.StartInfo.WorkingDirectory} Arguments:{_process.StartInfo.Arguments}");
+                    _workerProcessLogger?.LogDebug($"Starting worker process with FileName:{_process.StartInfo.FileName} WorkingDirectory:{_process.StartInfo.WorkingDirectory} Arguments:{_process.StartInfo.Arguments}");
                     _process.Start();
-                    _workerProcessLogger?.LogInformation($"{_process.StartInfo.FileName} process with Id={_process.Id} started");
+                    _workerProcessLogger?.LogDebug($"{_process.StartInfo.FileName} process with Id={_process.Id} started");
 
                     _process.BeginErrorReadLine();
                     _process.BeginOutputReadLine();

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CustomHandler.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CustomHandler.cs
@@ -17,25 +17,25 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 {
     [Trait(TestTraits.Category, TestTraits.EndToEnd)]
     [Trait(TestTraits.Group, TestTraits.SamplesEndToEnd)]
-    public class SamplesEndToEndTests_HttpWorker : IClassFixture<SamplesEndToEndTests_HttpWorker.TestFixture>
+    public class SamplesEndToEndTests_CustomHandler : IClassFixture<SamplesEndToEndTests_CustomHandler.TestFixture>
     {
         private readonly ScriptSettingsManager _settingsManager;
         private TestFixture _fixture;
 
-        public SamplesEndToEndTests_HttpWorker(TestFixture fixture)
+        public SamplesEndToEndTests_CustomHandler(TestFixture fixture)
         {
             _fixture = fixture;
             _settingsManager = ScriptSettingsManager.Instance;
         }
 
         [Fact]
-        public async Task HttpTrigger_HttpWorker_Get_Succeeds()
+        public async Task HttpTrigger_CustomHandler_Get_Succeeds()
         {
             await InvokeHttpTrigger("HttpTrigger");
         }
 
         [Fact]
-        public async Task Proxy_HttpWorker_Get_Succeeds()
+        public async Task Proxy_CustomHandler_Get_Succeeds()
         {
             await InvokeProxy();
         }
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             }
 
             public TestFixture()
-                : base(Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample\HttpWorker"), "samples", RpcWorkerConstants.PowerShellLanguageWorkerName)
+                : base(Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample\CustomHandler"), "samples", RpcWorkerConstants.PowerShellLanguageWorkerName)
             {
             }
 

--- a/test/WebJobs.Script.Tests/Configuration/HttpWorkerOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/HttpWorkerOptionsSetupTests.cs
@@ -87,7 +87,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             var configuration = BuildHostJsonConfiguration();
             HttpWorkerOptionsSetup setup = new HttpWorkerOptionsSetup(new OptionsWrapper<ScriptJobHostOptions>(_scriptJobHostOptions), configuration, _testLoggerFactory, _metricsLogger);
             HttpWorkerOptions options = new HttpWorkerOptions();
-
+            options.Description = new HttpWorkerDescription();
+            options.Description.FileExists = path =>
+            {
+                return true;
+            };
             setup.Configure(options);
 
             if (options.Description != null && !string.IsNullOrEmpty(options.Description.DefaultExecutablePath))
@@ -227,7 +231,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             //Verify worker path is expected
             if (appendCurrentDirToWorkerPath)
             {
-                Assert.Equal(Path.Combine(_scriptJobHostOptions.RootScriptPath, "httpWorker.js"), options.Description.DefaultWorkerPath);
+                Assert.Equal("httpWorker.js", options.Description.DefaultWorkerPath);
             }
             else if (!workerPathSet)
             {
@@ -270,6 +274,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             var configuration = BuildHostJsonConfiguration();
             HttpWorkerOptionsSetup setup = new HttpWorkerOptionsSetup(new OptionsWrapper<ScriptJobHostOptions>(_scriptJobHostOptions), configuration, _testLoggerFactory, _metricsLogger);
             HttpWorkerOptions options = new HttpWorkerOptions();
+            options.Description = new HttpWorkerDescription();
+            options.Description.FileExists = path =>
+            {
+                return appendCurrentDirToDefaultExe;
+            };
             setup.Configure(options);
 
             Assert.True(_metricsLogger.LoggedEvents.Contains(MetricEventNames.CustomHandlerConfiguration));


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

PR fixes parsing customHandler options to support using a binary:

```json
"customHandler": {
		"enableForwardingHttpRequest": true,
		"description": {
			"defaultExecutablePath": "GoCustomHandlers.exe",
			"arguments": ["-hello"]
		}
	}
```

and using a a runtime that is part of the system path such as

```json
"customHandler": {
		"description": {
			"defaultExecutablePath": "node",
			"arguments": ["server.js"]
		}
	}
```

Porting fix.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
