### PR TITLE
Adding an API to enable the drain mode

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,6 +5,7 @@
 
 - Update Python Worker to 1.1.3([Release Note](https://github.com/Azure/azure-functions-python-worker/releases/tag/1.1.3))
 - Update Python Library to 1.3.0([Release Note](https://github.com/Azure/azure-functions-python-library/releases/tag/1.3.0))
+- Added an admin API to enable drain mode
 
 **Release sprint:** Sprint 79
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+79%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+79%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using DryIoc;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -99,6 +100,19 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
             _logger.LogInformation(message);
 
             return Ok(status);
+        }
+
+        [HttpGet]
+        [HttpPost]
+        [Route("admin/host/drain")]
+        [Authorize(Policy = PolicyNames.AdminAuthLevelOrInternal)]
+        public IActionResult Drain([FromServices] IDrainModeManager drainModeManager)
+        {
+            _logger.LogInformation("Received request for draining host");
+
+            // Stop call to some listeners get stuck, Not waiting for the stop call to complete
+            drainModeManager.EnableDrainModeAsync(CancellationToken.None).ConfigureAwait(false);
+            return Ok();
         }
 
         [HttpGet]

--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         [Authorize(Policy = PolicyNames.AdminAuthLevelOrInternal)]
         public IActionResult Drain([FromServices] IDrainModeManager drainModeManager)
         {
-            _logger.LogInformation("Received request for draining host");
+            _logger.LogDebug("Received request for draining host");
 
             // Stop call to some listeners get stuck, Not waiting for the stop call to complete
             drainModeManager.EnableDrainModeAsync(CancellationToken.None).ConfigureAwait(false);

--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using DryIoc;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;

--- a/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies;

--- a/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -97,6 +98,19 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         public IActionResult GetHttpHealthStatus()
         {
             // Reaching here implies that http health of the container is ok.
+            return Ok();
+        }
+
+        [HttpGet]
+        [HttpPost]
+        [Route("admin/instance/drain")]
+        [Authorize(Policy = PolicyNames.AdminAuthLevelOrInternal)]
+        public IActionResult Drain([FromServices] IDrainModeManager drainModeManager)
+        {
+            _logger.LogDebug("Received request for draining host");
+
+            // Stop call to some listeners get stuck, Not waiting for the stop call to complete
+            drainModeManager.EnableDrainModeAsync(CancellationToken.None).ConfigureAwait(false);
             return Ok();
         }
     }

--- a/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies;

--- a/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
@@ -101,18 +101,5 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
             // Reaching here implies that http health of the container is ok.
             return Ok();
         }
-
-        [HttpGet]
-        [HttpPost]
-        [Route("admin/instance/drain")]
-        [Authorize(Policy = PolicyNames.AdminAuthLevelOrInternal)]
-        public IActionResult Drain([FromServices] IDrainModeManager drainModeManager)
-        {
-            _logger.LogDebug("Received request for draining host");
-
-            // Stop call to some listeners get stuck, Not waiting for the stop call to complete
-            drainModeManager.EnableDrainModeAsync(CancellationToken.None).ConfigureAwait(false);
-            return Ok();
-        }
     }
 }

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -64,7 +64,7 @@
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
     <PackageReference Include="Microsoft.Azure.Storage.File" Version="11.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="4.0.1" />    
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.18" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.19" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.3" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="4.0.1" />
     <PackageReference Include="Microsoft.Azure.WebSites.DataProtection" Version="2.1.91-alpha" />

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.0.4" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.291" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.293" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.18" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.19" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.7" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.18" />

--- a/test/WebJobsStartupTests/WebJobsStartupTests.csproj
+++ b/test/WebJobsStartupTests/WebJobsStartupTests.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.18" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.19" />
     <PackageReference Include="Microsoft.Net.Sdk.Functions" Version="3.0.*" />
   </ItemGroup>
 


### PR DESCRIPTION
Documentation present in the issue below.
https://github.com/Azure/azure-webjobs-sdk/issues/2527

resolves #6268 

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [x] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by pr: https://github.com/Azure/azure-functions-host/pull/6338
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information
Additionally performed manual testing to understand behavior of extensions and have filed relevant issues on the individual extensions repo. Also tested thing is co-ordination with the Glenna and divya on private stamps.
related issues linked here: https://github.com/Azure/azure-functions-host/issues/5672#issuecomment-649052092