### PR TITLE
[Rpc]Expand environment variables in worker.config.json after hydrating worker path

### DIFF
--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -152,6 +152,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                         workerDescription.FormatWorkerPathIfNeeded(_systemRuntimeInformation, _environment, _logger);
                         workerDescription.ThrowIfFileNotExists(workerDescription.DefaultWorkerPath, nameof(workerDescription.DefaultWorkerPath));
                         _workerDescripionDictionary[workerDescription.Language] = workerDescription;
+                        workerDescription.ExpandEnvironmentVariables();
                         _logger.LogDebug($"Added WorkerConfig for language: {workerDescription.Language}");
                     }
                 }

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
@@ -87,7 +87,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             {
                 DefaultWorkerPath = Path.Combine(WorkerDirectory, DefaultWorkerPath);
             }
-            ExpandEnvironmentVariables();
             if (string.IsNullOrEmpty(Language))
             {
                 throw new ValidationException($"WorkerDescription {nameof(Language)} cannot be empty");

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.Configuration;
-using Moq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
@@ -132,27 +131,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         public void DefaultWorkerConfigs_Overrides_VersionAppSetting()
         {
             var testEnvironment = new TestEnvironment();
-            var testEnvVariables = new Dictionary<string, string>
-            {
-                { "FUNCTIONS_WORKER_RUNTIME_VERSION", "7.0" },
-                { "FUNCTIONS_WORKER_RUNTIME", "Powershell" }
-            };
             testEnvironment.SetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME_VERSION", "7.0");
             testEnvironment.SetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME", "powerShell");
-            var configBuilder = ScriptSettingsManager.CreateDefaultConfigurationBuilder()
-                .AddInMemoryCollection(testEnvVariables);
+            var configBuilder = ScriptSettingsManager.CreateDefaultConfigurationBuilder();
             var config = configBuilder.Build();
             var scriptSettingsManager = new ScriptSettingsManager(config);
             var testLogger = new TestLogger("test");
-            using (var variables = new TestScopedSettings(scriptSettingsManager, testEnvVariables))
-            {
-                var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, testEnvironment, new TestMetricsLogger());
-                var workerConfigs = configFactory.GetConfigs();
-                var powershellWorkerConfig = workerConfigs.Where(w => w.Description.Language.Equals("powershell", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
-                Assert.Equal(1, workerConfigs.Count);
-                Assert.NotNull(powershellWorkerConfig);
-                Assert.Equal("7", powershellWorkerConfig.Description.DefaultRuntimeVersion);
-            }
+            var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, testEnvironment, new TestMetricsLogger());
+            var workerConfigs = configFactory.GetConfigs();
+            var powershellWorkerConfig = workerConfigs.Where(w => w.Description.Language.Equals("powershell", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+            Assert.Equal(1, workerConfigs.Count);
+            Assert.NotNull(powershellWorkerConfig);
+            Assert.Equal("7", powershellWorkerConfig.Description.DefaultRuntimeVersion);
         }
 
         [Theory]

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
@@ -106,26 +105,53 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         [Fact]
         public void DefaultWorkerConfigs_Overrides_DefaultWorkerRuntimeVersion_AppSetting()
         {
-            var configBuilder = ScriptSettingsManager.CreateDefaultConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string>
-                {
-                    ["languageWorkers:python:defaultRuntimeVersion"] = "3.8"
-                });
-            var config = configBuilder.Build();
-            var scriptSettingsManager = new ScriptSettingsManager(config);
-            var testLogger = new TestLogger("test");
             var testEnvVariables = new Dictionary<string, string>
             {
                 { "languageWorkers:python:defaultRuntimeVersion", "3.8" }
             };
+            var configBuilder = ScriptSettingsManager.CreateDefaultConfigurationBuilder()
+                .AddInMemoryCollection(testEnvVariables);
+            var config = configBuilder.Build();
+            var scriptSettingsManager = new ScriptSettingsManager(config);
+            var testLogger = new TestLogger("test");
             using (var variables = new TestScopedSettings(scriptSettingsManager, testEnvVariables))
             {
                 var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger());
                 var workerConfigs = configFactory.GetConfigs();
                 var pythonWorkerConfig = workerConfigs.Where(w => w.Description.Language.Equals("python", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                var powershellWorkerConfig = workerConfigs.Where(w => w.Description.Language.Equals("powershell", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
                 Assert.Equal(4, workerConfigs.Count);
                 Assert.NotNull(pythonWorkerConfig);
+                Assert.NotNull(powershellWorkerConfig);
                 Assert.Equal("3.8", pythonWorkerConfig.Description.DefaultRuntimeVersion);
+                Assert.Equal("6", powershellWorkerConfig.Description.DefaultRuntimeVersion);
+            }
+        }
+
+        [Fact]
+        public void DefaultWorkerConfigs_Overrides_VersionAppSetting()
+        {
+            var testEnvironment = new TestEnvironment();
+            var testEnvVariables = new Dictionary<string, string>
+            {
+                { "FUNCTIONS_WORKER_RUNTIME_VERSION", "7.0" },
+                { "FUNCTIONS_WORKER_RUNTIME", "Powershell" }
+            };
+            testEnvironment.SetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME_VERSION", "7.0");
+            testEnvironment.SetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME", "powerShell");
+            var configBuilder = ScriptSettingsManager.CreateDefaultConfigurationBuilder()
+                .AddInMemoryCollection(testEnvVariables);
+            var config = configBuilder.Build();
+            var scriptSettingsManager = new ScriptSettingsManager(config);
+            var testLogger = new TestLogger("test");
+            using (var variables = new TestScopedSettings(scriptSettingsManager, testEnvVariables))
+            {
+                var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, testEnvironment, new TestMetricsLogger());
+                var workerConfigs = configFactory.GetConfigs();
+                var powershellWorkerConfig = workerConfigs.Where(w => w.Description.Language.Equals("powershell", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                Assert.Equal(1, workerConfigs.Count);
+                Assert.NotNull(powershellWorkerConfig);
+                Assert.Equal("7", powershellWorkerConfig.Description.DefaultRuntimeVersion);
             }
         }
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #6351

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #6353
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
