### PR TITLE
allowing workers to handle .dll file extensions

### DIFF
--- a/src/WebJobs.Script/Host/FunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataProvider.cs
@@ -170,6 +170,13 @@ namespace Microsoft.Azure.WebJobs.Script
 
             // determine the script type based on the primary script file extension
             string extension = Path.GetExtension(scriptFilePath).ToLowerInvariant().TrimStart('.');
+            var workerConfig = workerConfigs.FirstOrDefault(config => config.Description.Extensions.Contains("." + extension));
+            if (workerConfig != null)
+            {
+                return workerConfig.Description.Language;
+            }
+
+            // If no worker claimed these extensions, use in-proc.
             switch (extension)
             {
                 case "csx":
@@ -178,11 +185,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 case "dll":
                     return DotNetScriptTypes.DotNetAssembly;
             }
-            var workerConfig = workerConfigs.FirstOrDefault(config => config.Description.Extensions.Contains("." + extension));
-            if (workerConfig != null)
-            {
-                return workerConfig.Description.Language;
-            }
+
             return null;
         }
 

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -256,16 +256,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
         }
 
-        public static IList<RpcWorkerConfig> GetTestWorkerConfigs()
+        public static IList<RpcWorkerConfig> GetTestWorkerConfigs(bool includeDllWorker = false)
         {
-            var nodeWorkerDesc = GetTestWorkerDescription("node", ".js");
-            var javaWorkerDesc = GetTestWorkerDescription("java", ".jar");
-
-            return new List<RpcWorkerConfig>()
+            var workerConfigs = new List<RpcWorkerConfig>
             {
-                new RpcWorkerConfig() { Description = nodeWorkerDesc },
-                new RpcWorkerConfig() { Description = javaWorkerDesc },
+                new RpcWorkerConfig() { Description = GetTestWorkerDescription("node", ".js") },
+                new RpcWorkerConfig() { Description = GetTestWorkerDescription("java", ".jar") }
             };
+
+            // Allow tests to have a worker that claims the .dll extension.
+            if (includeDllWorker)
+            {
+                workerConfigs.Add(new RpcWorkerConfig() { Description = GetTestWorkerDescription("dllWorker", ".dll") });
+            }
+
+            return workerConfigs;
         }
 
         public static LanguageWorkerOptions GetTestLanguageWorkerOptions()

--- a/test/WebJobs.Script.Tests/FunctionMetadataProviderTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionMetadataProviderTests.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -116,15 +115,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
-        [InlineData("node", "test.js")]
-        [InlineData("java", "test.jar")]
-        [InlineData("CSharp", "test.cs")]
-        [InlineData("CSharp", "test.csx")]
-        [InlineData("DotNetAssembly", "test.dll")]
-        [InlineData(null, "test.x")]
-        public void ParseLanguage_Returns_ExpectedLanguage(string language, string scriptFile)
+        [InlineData("node", "test.js", false)]
+        [InlineData("java", "test.jar", false)]
+        [InlineData("CSharp", "test.cs", false)]
+        [InlineData("CSharp", "test.csx", false)]
+        [InlineData("dllWorker", "test.dll", true)] // The test "dllWorker" will claim ".dll" extensions before falling back to DotNetAssembly
+        [InlineData("DotNetAssembly", "test.dll", false)]
+        [InlineData(null, "test.x", false)]
+        public void ParseLanguage_Returns_ExpectedLanguage(string language, string scriptFile, bool includeDllWorker)
         {
-            Assert.Equal(language, FunctionMetadataProvider.ParseLanguage(scriptFile, TestHelpers.GetTestWorkerConfigs()));
+            Assert.Equal(language, FunctionMetadataProvider.ParseLanguage(scriptFile, TestHelpers.GetTestWorkerConfigs(includeDllWorker: includeDllWorker)));
         }
 
         [Theory]


### PR DESCRIPTION
Currently the host sees a function.json with a scriptFile extension of `.dll` and it assumes in-proc. This prevents a language worker from handling this. This change switches the check so that in-proc is a fallback rather than the first option.