### PR TITLE
Reset AssemblyLoadContext when FunctionMetadata is refreshed

### DIFF
--- a/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs
+++ b/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Azure.WebJobs.Script.DependencyInjection
         public async Task<IEnumerable<Type>> GetExtensionsStartupTypesAsync()
         {
             string binPath;
+            FunctionAssemblyLoadContext.ResetSharedContext();
             var functionMetadataCollection = _functionMetadataManager.GetFunctionMetadata(forceRefresh: true);
             HashSet<string> bindingsSet = null;
             var bundleConfigured = _extensionBundleManager.IsExtensionBundleConfigured();


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
Reset AssemblyLoadContext each time extension startup types are loaded. This is needed each time Function Metadata is force refreshed.

resolves #5789 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #6391
* [x] I have added all required tests (Unit tests, E2E tests)
    -  Does not repro consistently
    - Manually recreated what could have happened from the logs:
```
Starting host specialization
StandbyManager.ChangeToken callback has fired.
Starting language worker channel specialization
Completed language worker channel specialization
Restart requested.
Restarting host.
Active host changing from '49218a7b-3132-4119-9d67-99898286e14a' to '(null)'.
Startup operation '486de7c2-2dc4-41ba-8a79-1713be1f4f34' with parent id '(null)' created.
Startup operation '486de7c2-2dc4-41ba-8a79-1713be1f4f34' starting.
Building host: startup suppressed: 'False', configuration suppressed: 'False', startup operation id: '486de7c2-2dc4-41ba-8a79-1713be1f4f34'
 Host configuration applied.
 Reading host configuration file 'D:\home\site\wwwroot\host.json'
 Host configuration file read:  {host.json snippet} 
 Reading functions metadata
 2 functions found
 Loaded extension 'SignalR' (1.1.0.0)
Host restarted.
Loading functions metadata
3 functions loaded
Starting JobHost
Loading functions metadata
2 functions loaded
Fails to load starup types
```
       
 

            



<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
