### PR TITLE
Log request/response between host and custom handler when running in core tools

### DIFF
--- a/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs
+++ b/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs
@@ -117,8 +117,7 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
         {
             if (MediaTypeHeaderValue.TryParse(request.ContentType, out MediaTypeHeaderValue mediaType))
             {
-                return mediaType != null && (string.Equals(mediaType.MediaType, "application/octet-stream", StringComparison.OrdinalIgnoreCase) ||
-                                mediaType.MediaType.IndexOf("multipart/", StringComparison.OrdinalIgnoreCase) >= 0);
+                return Utility.IsMediaTypeOctetOrMultipart(mediaType);
             }
             return false;
         }

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -121,6 +121,9 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string NugetXmlDocModeSettingName = "NUGET_XMLDOC_MODE";
         public const string NugetXmlDocSkipMode = "skip";
 
+        public const string MediatypeOctetStream = "application/octet-stream";
+        public const string MediatypeMutipartPrefix = "multipart/";
+
         public const int MaximumHostIdLength = 32;
         public const int DynamicSkuConnectionLimit = 50;
 

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
+using System.Net.Http.Headers;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -750,6 +751,12 @@ namespace Microsoft.Azure.WebJobs.Script
         public static string BuildStorageConnectionString(string accountName, string accessKey, string suffix)
         {
             return $"DefaultEndpointsProtocol=https;AccountName={accountName};AccountKey={accessKey};EndpointSuffix={suffix}";
+        }
+
+        public static bool IsMediaTypeOctetOrMultipart(MediaTypeHeaderValue mediaType)
+        {
+                return mediaType != null && (string.Equals(mediaType.MediaType, ScriptConstants.MediatypeOctetStream, StringComparison.OrdinalIgnoreCase) ||
+                                mediaType.MediaType.IndexOf(ScriptConstants.MediatypeMutipartPrefix, StringComparison.OrdinalIgnoreCase) >= 0);
         }
 
         private class FilteredExpandoObjectConverter : ExpandoObjectConverter

--- a/src/WebJobs.Script/Workers/Http/DefaultHttpWorkerService.cs
+++ b/src/WebJobs.Script/Workers/Http/DefaultHttpWorkerService.cs
@@ -75,7 +75,17 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
                     AddHeaders(httpRequestMessage, scriptInvocationContext.ExecutionContext.InvocationId.ToString());
 
                     _logger.LogDebug("Forwarding http request for httpTrigger function: '{functionName}' invocationId: '{invocationId}'", scriptInvocationContext.FunctionMetadata.Name, scriptInvocationContext.ExecutionContext.InvocationId);
+                    scriptInvocationContext.Logger.LogTrace($"Request:{httpRequestMessage}");
+                    if (httpRequestMessage.Content != null)
+                    {
+                        _logger.LogTrace(await httpRequestMessage.Content.ReadAsStringAsync());
+                    }
                     HttpResponseMessage invocationResponse = await _httpClient.SendAsync(httpRequestMessage);
+                    _logger.LogTrace($"Response:{invocationResponse}");
+                    if (invocationResponse.Content != null)
+                    {
+                        scriptInvocationContext.Logger.LogTrace(await invocationResponse.Content.ReadAsStringAsync());
+                    }
                     _logger.LogDebug("Received http response for httpTrigger function: '{functionName}' invocationId: '{invocationId}'", scriptInvocationContext.FunctionMetadata.Name, scriptInvocationContext.ExecutionContext.InvocationId);
 
                     BindingMetadata httpOutputBinding = scriptInvocationContext.FunctionMetadata.OutputBindings.FirstOrDefault();
@@ -126,7 +136,17 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
                     AddHeaders(httpRequestMessage, scriptInvocationContext.ExecutionContext.InvocationId.ToString());
 
                     _logger.LogDebug("Sending http request for function:{functionName} invocationId:{invocationId}", scriptInvocationContext.FunctionMetadata.Name, scriptInvocationContext.ExecutionContext.InvocationId);
+                    scriptInvocationContext.Logger.LogTrace($"Request:{httpRequestMessage}");
+                    if (httpRequestMessage.Content != null)
+                    {
+                        _logger.LogTrace(await httpRequestMessage.Content.ReadAsStringAsync());
+                    }
                     HttpResponseMessage response = await _httpClient.SendAsync(httpRequestMessage);
+                    _logger.LogTrace($"Response:{response}");
+                    if (response.Content != null)
+                    {
+                        scriptInvocationContext.Logger.LogTrace(await response.Content.ReadAsStringAsync());
+                    }
                     _logger.LogDebug("Received http response for function:{functionName} invocationId:{invocationId}", scriptInvocationContext.FunctionMetadata.Name, scriptInvocationContext.ExecutionContext.InvocationId);
 
                     // Only process output bindings if response is succeess code

--- a/test/WebJobs.Script.Tests/HttpWorker/DefaultHttpWorkerServiceTests.cs
+++ b/test/WebJobs.Script.Tests/HttpWorker/DefaultHttpWorkerServiceTests.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
     {
         private const string TestFunctionName = "testFunctionName";
         private HttpClient _httpClient;
+        private TestEnvironment _testEnvironment;
         private DefaultHttpWorkerService _defaultHttpWorkerService;
         private Guid _testInvocationId;
         private HttpWorkerOptions _httpWorkerOptions;
@@ -40,6 +41,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
         public DefaultHttpWorkerServiceTests()
         {
             _testLoggerFactory = new LoggerFactory();
+            _testEnvironment = new TestEnvironment();
             _testInvocationId = Guid.NewGuid();
             _httpWorkerOptions = new HttpWorkerOptions()
             {
@@ -69,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
                 .ReturnsAsync(HttpWorkerTestUtilities.GetValidHttpResponseMessage());
 
             _httpClient = new HttpClient(handlerMock.Object);
-            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger);
+            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger, _testEnvironment);
             var testScriptInvocationContext = HttpWorkerTestUtilities.GetScriptInvocationContext(TestFunctionName, _testInvocationId, _functionLogger);
             await _defaultHttpWorkerService.ProcessDefaultInvocationRequest(testScriptInvocationContext);
             var invocationResult = await testScriptInvocationContext.ResultSource.Task;
@@ -98,7 +100,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
                 .ReturnsAsync(HttpWorkerTestUtilities.GetValidHttpResponseMessageWithJsonRes());
 
             _httpClient = new HttpClient(handlerMock.Object);
-            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(customHandlerOptions), _testLogger);
+            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(customHandlerOptions), _testLogger, _testEnvironment);
             var testScriptInvocationContext = HttpWorkerTestUtilities.GetSimpleHttpTriggerScriptInvocationContext(TestFunctionName, _testInvocationId, _functionLogger);
             await _defaultHttpWorkerService.InvokeAsync(testScriptInvocationContext);
             var invocationResult = await testScriptInvocationContext.ResultSource.Task;
@@ -126,7 +128,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
                 .ReturnsAsync(HttpWorkerTestUtilities.GetValidHttpResponseMessage_DataType_Binary_Data());
 
             _httpClient = new HttpClient(handlerMock.Object);
-            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger);
+            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger, _testEnvironment);
             var testScriptInvocationContext = HttpWorkerTestUtilities.GetScriptInvocationContext(TestFunctionName, _testInvocationId, _functionLogger, WebJobs.Script.Description.DataType.Binary);
             await _defaultHttpWorkerService.ProcessDefaultInvocationRequest(testScriptInvocationContext);
             var invocationResult = await testScriptInvocationContext.ResultSource.Task;
@@ -162,7 +164,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
                 .ReturnsAsync(HttpWorkerTestUtilities.GetValidHttpResponseMessage_Binary_Data());
 
             _httpClient = new HttpClient(handlerMock.Object);
-            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger);
+            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger, _testEnvironment);
             var testScriptInvocationContext = HttpWorkerTestUtilities.GetScriptInvocationContext(TestFunctionName, _testInvocationId, _functionLogger);
             await _defaultHttpWorkerService.ProcessDefaultInvocationRequest(testScriptInvocationContext);
             var invocationResult = await testScriptInvocationContext.ResultSource.Task;
@@ -200,7 +202,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
                 .ReturnsAsync(HttpWorkerTestUtilities.GetSimpleNotFoundHttpResponseMessage());
 
             _httpClient = new HttpClient(handlerMock.Object);
-            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger);
+            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger, _testEnvironment);
             await _defaultHttpWorkerService.PingAsync();
             handlerMock.VerifyAll();
         }
@@ -217,7 +219,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
                 .ReturnsAsync(HttpWorkerTestUtilities.GetValidSimpleHttpResponseMessage());
 
             _httpClient = new HttpClient(handlerMock.Object);
-            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger);
+            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger, _testEnvironment);
             var testScriptInvocationContext = HttpWorkerTestUtilities.GetSimpleHttpTriggerScriptInvocationContext(TestFunctionName, _testInvocationId, _functionLogger);
             await _defaultHttpWorkerService.ProcessHttpInAndOutInvocationRequest(testScriptInvocationContext);
             var invocationResult = await testScriptInvocationContext.ResultSource.Task;
@@ -255,7 +257,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
                 .ReturnsAsync(HttpWorkerTestUtilities.GetValidSimpleHttpResponseMessage());
 
             _httpClient = new HttpClient(handlerMock.Object);
-            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(customHandlerOptions), _testLogger);
+            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(customHandlerOptions), _testLogger, _testEnvironment);
             var testScriptInvocationContext = HttpWorkerTestUtilities.GetSimpleHttpTriggerScriptInvocationContext(TestFunctionName, _testInvocationId, _functionLogger);
             await _defaultHttpWorkerService.InvokeAsync(testScriptInvocationContext);
             var invocationResult = await testScriptInvocationContext.ResultSource.Task;
@@ -286,7 +288,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
             {
                 Port = 8080,
             };
-            DefaultHttpWorkerService defaultHttpWorkerService = new DefaultHttpWorkerService(new HttpClient(), new OptionsWrapper<HttpWorkerOptions>(testOptions), _testLogger);
+            DefaultHttpWorkerService defaultHttpWorkerService = new DefaultHttpWorkerService(new HttpClient(), new OptionsWrapper<HttpWorkerOptions>(testOptions), _testLogger, _testEnvironment);
             Assert.Equal(expectedUriString, defaultHttpWorkerService.BuildAndGetUri(pathValue));
         }
 
@@ -294,7 +296,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
         public void AddHeadersTest()
         {
             HttpWorkerOptions testOptions = new HttpWorkerOptions();
-            DefaultHttpWorkerService defaultHttpWorkerService = new DefaultHttpWorkerService(new HttpClient(), new OptionsWrapper<HttpWorkerOptions>(testOptions), _testLogger);
+            DefaultHttpWorkerService defaultHttpWorkerService = new DefaultHttpWorkerService(new HttpClient(), new OptionsWrapper<HttpWorkerOptions>(testOptions), _testLogger, _testEnvironment);
             HttpRequestMessage input = new HttpRequestMessage();
             string invocationId = Guid.NewGuid().ToString();
 
@@ -318,7 +320,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
                 });
 
             _httpClient = new HttpClient(handlerMock.Object);
-            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger);
+            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger, _testEnvironment);
             var testScriptInvocationContext = HttpWorkerTestUtilities.GetSimpleHttpTriggerScriptInvocationContext(TestFunctionName, _testInvocationId, _functionLogger);
             await _defaultHttpWorkerService.ProcessHttpInAndOutInvocationRequest(testScriptInvocationContext);
             var invocationResult = await testScriptInvocationContext.ResultSource.Task;
@@ -350,7 +352,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
                 .ReturnsAsync(HttpWorkerTestUtilities.GetHttpResponseMessageWithJsonContent());
 
             _httpClient = new HttpClient(handlerMock.Object);
-            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger);
+            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger, _testEnvironment);
             var testScriptInvocationContext = HttpWorkerTestUtilities.GetScriptInvocationContext(TestFunctionName, _testInvocationId, _functionLogger);
             await _defaultHttpWorkerService.ProcessDefaultInvocationRequest(testScriptInvocationContext);
             var invocationResult = await testScriptInvocationContext.ResultSource.Task;
@@ -370,7 +372,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
                 .ReturnsAsync(HttpWorkerTestUtilities.GetHttpResponseMessageWithStringContent());
 
             _httpClient = new HttpClient(handlerMock.Object);
-            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger);
+            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger, _testEnvironment);
             var testScriptInvocationContext = HttpWorkerTestUtilities.GetScriptInvocationContext(TestFunctionName, _testInvocationId, _testLogger);
             await _defaultHttpWorkerService.ProcessDefaultInvocationRequest(testScriptInvocationContext);
             await Assert.ThrowsAsync<UnsupportedMediaTypeException>(async () => await testScriptInvocationContext.ResultSource.Task);
@@ -391,7 +393,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
                 });
 
             _httpClient = new HttpClient(handlerMock.Object);
-            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger);
+            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger, _testEnvironment);
             var testScriptInvocationContext = HttpWorkerTestUtilities.GetScriptInvocationContext(TestFunctionName, _testInvocationId, _testLogger);
             await _defaultHttpWorkerService.ProcessDefaultInvocationRequest(testScriptInvocationContext);
             await Assert.ThrowsAsync<HttpRequestException>(async () => await testScriptInvocationContext.ResultSource.Task);
@@ -410,7 +412,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
                 .ReturnsAsync(HttpWorkerTestUtilities.GetValidHttpResponseMessage());
 
             _httpClient = new HttpClient(handlerMock.Object);
-            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger);
+            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger, _testEnvironment);
             _defaultHttpWorkerService.ProcessLogsFromHttpResponse(HttpWorkerTestUtilities.GetScriptInvocationContext(TestFunctionName, _testInvocationId, _functionLogger), httpScriptInvocationResult);
             var testLogs = _functionLogger.GetLogMessages();
             if (httpScriptInvocationResult.Logs != null && httpScriptInvocationResult.Logs.Any())
@@ -437,7 +439,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
                 Type = type,
                 EnableForwardingHttpRequest = enableForwardingHttpRequest,
             };
-            DefaultHttpWorkerService defaultHttpWorkerService = new DefaultHttpWorkerService(new HttpClient(), new OptionsWrapper<HttpWorkerOptions>(testOptions), _testLogger);
+            DefaultHttpWorkerService defaultHttpWorkerService = new DefaultHttpWorkerService(new HttpClient(), new OptionsWrapper<HttpWorkerOptions>(testOptions), _testLogger, _testEnvironment);
             string actualValue = defaultHttpWorkerService.GetPathValue(testOptions, functionName, testHttpRequest);
             Assert.Equal(actualValue, expectedValue);
         }
@@ -454,7 +456,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
                 .Throws(new HttpRequestException("Invalid http worker service", new SocketException()));
 
             _httpClient = new HttpClient(handlerMock.Object);
-            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger);
+            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger, _testEnvironment);
 
             bool workerReady = await _defaultHttpWorkerService.IsWorkerReady(CancellationToken.None);
             Assert.False(workerReady);
@@ -475,7 +477,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
                 .ReturnsAsync(HttpWorkerTestUtilities.GetValidHttpResponseMessage());
 
             _httpClient = new HttpClient(handlerMock.Object);
-            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger);
+            _defaultHttpWorkerService = new DefaultHttpWorkerService(_httpClient, new OptionsWrapper<HttpWorkerOptions>(_httpWorkerOptions), _testLogger, _testEnvironment);
 
             bool workerReady = await _defaultHttpWorkerService.IsWorkerReady(CancellationToken.None);
             Assert.True(workerReady);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
- Add trace level for request and responses between custom handler and host only when running in Core Tools.

resolves #6388 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #6461
* [ ] I have added all required tests (Unit tests, E2E tests)


<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
Manually tested logs after setting core tools environment variable to true.

Sample logs:
```
trce: Function.SimpleHttpTrigger.User[0]
      Invocation Request:Method: GET, RequestUri: 'http://127.0.0.1:21195/api/SimpleHttpTrigger?name=pgopa', Version: 1.1, Content: <null>, Headers:
      {
        Host: localhost:2554
        X-Azure-Functions-HostVersion: 3.0.1.0
        X-Azure-Functions-InvocationId: 8892a2f8-3037-4d05-b8bd-3d608a8b88fd
        User-Agent: Azure-Functions-Host/3.0.1.0
      }
trce: Function.SimpleHttpTrigger.User[0]
      Invocation Response:StatusCode: 200, ReasonPhrase: 'OK', Version: 1.1, Content: System.Net.Http.HttpConnectionResponseContent, Headers:
      {
        Date: Tue, 21 Jul 2020 23:30:49 GMT
        Content-Length: 26
        Content-Type: text/plain; charset=utf-8
```

Sampe host.json
```
{
	"version": "2.0",
	"logging": {
       "LogLevel": {
		"Function.SimpleHttpTrigger":"Trace"
        }
       },
	"customHandler": {	    
		"description": {
			"defaultExecutablePath": "GoCustomHandlers.exe"
		},
		"enableForwardingHttpRequest":true
	}
}
```
