### PR TITLE
Improve Linux Consumption cold start

### DIFF
--- a/src/WebJobs.Script.WebHost/DependencyInjection/JobHostServiceProvider.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/JobHostServiceProvider.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
             // preferInterpretation will be set to true to significanly improve cold start in consumption mode
             // it will be set to false for premium and appservice plans to make sure throughput is not impacted
             // there is no throughput drop in consumption with this setting.
-            var preferInterpretation = SystemEnvironment.Instance.IsWindowsConsumption() ? true : false;
+            var preferInterpretation = SystemEnvironment.Instance.IsWindowsConsumption() || SystemEnvironment.Instance.IsLinuxConsumption() ? true : false;
             var container = new Container(r => rules, preferInterpretation: preferInterpretation);
 
             container.Populate(descriptors);

--- a/src/WebJobs.Script.WebHost/Standby/WarmUpConstants.cs
+++ b/src/WebJobs.Script.WebHost/Standby/WarmUpConstants.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
     {
         public const string FunctionName = "WarmUp";
         public const string AlternateRoute = "CSharpHttpWarmup";
-        public const string PreJitFolderName = "PreJit";
+        public const string PreJitFolderName = "PreJIT";
         public const string JitTraceFileName = "coldstart.jittrace";
     }
 }


### PR DESCRIPTION
Thanks to Bala we got profiles from Linux Consumption for cold starts and noticed we are doing 550msec of JIT
and a big portion of it was because we were still compiling DryIoc in Linux consumption and PGO was not working in Linux because of a directory name casing issue.

There is still a big portion of JIT during /admin/instance/assign that we follow up separately.
