### PR TITLE
Logging for out-of-proc languages also

### DIFF
--- a/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs
@@ -140,7 +140,9 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                     return (binding.Metadata.Name, bindingContext.DataType, bindingContext.Value);
                 });
 
-            return await Task.WhenAll(bindingTasks);
+            var result = await Task.WhenAll(bindingTasks);
+            _logger.LogInformation($"InputInformation: {binder.GetInformation()}");
+            return result;
         }
 
         private async Task BindOutputsAsync(object input, Binder binder, ScriptInvocationResult result)
@@ -169,6 +171,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             });
 
             await Task.WhenAll(outputBindingTasks);
+            _logger.LogInformation($"OutputInformation: {binder.GetInformation()}");
         }
 
         private object TransformInput(object input, Dictionary<string, object> bindingData)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
This PR introduces logging for resources accessed during binding of function parameters.
This is dependent on [this](https://github.com/Azure/azure-webjobs-sdk/pull/2540) PR being checked into Azure WebJobs SDK.

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
