### PR TITLE
[pack]Set Functions_Worker_Directory during specialization

### DIFF
--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerChannel.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerChannel.cs
@@ -292,7 +292,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     request.EnvironmentVariables.Add(entry.Key.ToString(), entry.Value.ToString());
                 }
             }
-
+            request.EnvironmentVariables.Add(WorkerConstants.FunctionsWorkerDirectorySettingName, _workerConfig.Description.WorkerDirectory);
             request.FunctionAppDirectory = _applicationHostOptions.CurrentValue.ScriptPath;
 
             return request;

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -323,7 +323,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                  {
                      { extension }
                  },
-                Language = language
+                Language = language,
+                WorkerDirectory = "testDir"
             };
         }
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerChannelTests.cs
@@ -331,6 +331,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.False(envReloadRequest.EnvironmentVariables.ContainsKey("TestEmpty"));
             Assert.True(envReloadRequest.EnvironmentVariables.ContainsKey("TestValid"));
             Assert.True(envReloadRequest.EnvironmentVariables["TestValid"] == "TestValue");
+            Assert.True(envReloadRequest.EnvironmentVariables.ContainsKey(WorkerConstants.FunctionsWorkerDirectorySettingName));
+            Assert.True(envReloadRequest.EnvironmentVariables[WorkerConstants.FunctionsWorkerDirectorySettingName] == "testDir");
         }
 
         [Fact]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Java worker needs the environment varaibles `FUNCTIONS_WORKER_DIRECTORY` . During specialization env vars are reloaded by the worker. Need to explicitly set this variaible during specialization.

resolves #6427

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #6429
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
