### PR TITLE
Java worker Release 1.7.3-SNAPSHOT

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,6 +5,8 @@
 
 - Update Python Worker to 1.1.4([Release Note](https://github.com/Azure/azure-functions-python-worker/releases/tag/1.1.4))
 - Update Python Library to 1.3.0([Release Note](https://github.com/Azure/azure-functions-python-library/releases/tag/1.3.0))
+- Update Java Worker to 1.7.3-SNAPSHOT([Release Note](https://github.com/Azure/azure-functions-java-worker/releases/tag/1.7.3-SNAPSHOT))
+- Update Java Library to 1.4.0-SNAPSHOT([Release Note](https://github.com/Azure/azure-functions-java-library/releases/tag/1.4.0-SNAPSHOT))
 - Added an admin API to enable drain mode
 
 **Release sprint:** Sprint 79

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -42,7 +42,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.11020001-fabe022e" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.7.2-SNAPSHOT" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.7.3-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.0.4" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.291" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.293" />

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.0.4" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.7.2-SNAPSHOT" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.7.3-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
The main objective for this java release to create shading for jars. To not break customers we load the worker jars for worker and then user lib jars. So we should regardless load the worker jars although we are shading. This case covers loading the jars for the worker in case the user doesn't have any lib folders.

resolves #issue_for_this_pr
https://github.com/Azure/azure-functions-java-worker/issues/393

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
https://github.com/Azure/azure-functions-host/pull/6437