### PR TITLE
   Linux consumption cold start improvements. Part - 2

### DIFF
--- a/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerInitializationHostService.cs
+++ b/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerInitializationHostService.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
                 var encryptedAssignmentContext = JsonConvert.DeserializeObject<EncryptedHostAssignmentContext>(startContext);
                 var assignmentContext = _startupContextProvider.SetContext(encryptedAssignmentContext);
 
-                bool success = _instanceManager.StartAssignment(assignmentContext, false);
+                bool success = _instanceManager.StartAssignment(assignmentContext);
                 _logger.LogInformation($"StartAssignment invoked (Success={success})");
             }
             else

--- a/src/WebJobs.Script.WebHost/Management/IInstanceManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/IInstanceManager.cs
@@ -11,10 +11,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
     {
         IDictionary<string, string> GetInstanceInfo();
 
-        Task<string> ValidateContext(HostAssignmentContext assignmentContext, bool isWarmup);
+        Task<string> ValidateContext(HostAssignmentContext assignmentContext);
 
-        bool StartAssignment(HostAssignmentContext assignmentContext, bool isWarmup);
+        bool StartAssignment(HostAssignmentContext assignmentContext);
 
-        Task<string> SpecializeMSISidecar(HostAssignmentContext assignmentContext, bool isWarmup);
+        Task<string> SpecializeMSISidecar(HostAssignmentContext assignmentContext);
     }
 }

--- a/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
 
         private readonly TimeSpan _memorySnapshotInterval = TimeSpan.FromMilliseconds(1000);
         private readonly TimeSpan _metricPublishInterval = TimeSpan.FromMilliseconds(30 * 1000);
+        private readonly TimeSpan _timerStartDelay = TimeSpan.FromSeconds(2);
         private readonly IOptionsMonitor<StandbyOptions> _standbyOptions;
         private readonly IDisposable _standbyOptionsOnChangeSubscription;
         private readonly string _requestUri;
@@ -251,8 +252,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         public void Start()
         {
             Initialize();
-            _processMonitorTimer = new Timer(OnProcessMonitorTimer, null, TimeSpan.Zero, _memorySnapshotInterval);
-            _metricsPublisherTimer = new Timer(OnFunctionMetricsPublishTimer, null, TimeSpan.Zero, _metricPublishInterval);
+            _processMonitorTimer = new Timer(OnProcessMonitorTimer, null, _timerStartDelay, _memorySnapshotInterval);
+            _metricsPublisherTimer = new Timer(OnFunctionMetricsPublishTimer, null, _timerStartDelay, _metricPublishInterval);
 
             _logger.LogInformation(string.Format("Starting metrics publisher for container : {0}. Publishing endpoint is {1}", _containerName, _requestUri));
         }

--- a/src/WebJobs.Script.WebHost/Models/EncryptedHostAssignmentContext.cs
+++ b/src/WebJobs.Script.WebHost/Models/EncryptedHostAssignmentContext.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
@@ -10,8 +9,5 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
     {
         [JsonProperty("encryptedContext")]
         public string EncryptedContext { get; set; }
-
-        [JsonProperty("isWarmup")]
-        public bool IsWarmup { get; set; }
     }
 }

--- a/src/WebJobs.Script.WebHost/Models/HostAssignmentContext.cs
+++ b/src/WebJobs.Script.WebHost/Models/HostAssignmentContext.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
 {
@@ -36,6 +35,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
         [JsonProperty("Secrets")]
         public FunctionAppSecrets Secrets { get; set; }
 
+        // This will be true for dummy specialization calls to pre-jit specialization code.
+        // For warmup requests the Run-From-Pkg appsetting will point to a local endpoint that
+        // returns 200 to ensure downloading app contents succeeds.
+        // All the other fields will be empty.
+        [JsonProperty("isWarmupRequest")]
+        public bool IsWarmupRequest { get; set; }
+
         public long? PackageContentLength { get; set; }
 
         public string AzureFilesConnectionString
@@ -55,29 +61,29 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
             {
                 return new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage,
                     Environment[EnvironmentSettingNames.AzureWebsiteRunFromPackage],
-                    PackageContentLength);
+                    PackageContentLength, IsWarmupRequest);
             }
             else if (Environment.ContainsKey(EnvironmentSettingNames.AzureWebsiteAltZipDeployment))
             {
                 return new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteAltZipDeployment,
                     Environment[EnvironmentSettingNames.AzureWebsiteAltZipDeployment],
-                    PackageContentLength);
+                    PackageContentLength, IsWarmupRequest);
             }
             else if (Environment.ContainsKey(EnvironmentSettingNames.AzureWebsiteZipDeployment))
             {
                 return new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteZipDeployment,
                     Environment[EnvironmentSettingNames.AzureWebsiteZipDeployment],
-                    PackageContentLength);
+                    PackageContentLength, IsWarmupRequest);
             }
             else if (Environment.ContainsKey(EnvironmentSettingNames.ScmRunFromPackage))
             {
                 return new RunFromPackageContext(EnvironmentSettingNames.ScmRunFromPackage,
                     Environment[EnvironmentSettingNames.ScmRunFromPackage],
-                    PackageContentLength);
+                    PackageContentLength, IsWarmupRequest);
             }
             else
             {
-                return new RunFromPackageContext(string.Empty, string.Empty, PackageContentLength);
+                return new RunFromPackageContext(string.Empty, string.Empty, PackageContentLength, IsWarmupRequest);
             }
         }
 

--- a/src/WebJobs.Script.WebHost/Models/RunFromPackageContext.cs
+++ b/src/WebJobs.Script.WebHost/Models/RunFromPackageContext.cs
@@ -10,11 +10,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
 {
     public class RunFromPackageContext
     {
-        public RunFromPackageContext(string envVarName, string url, long? packageContentLength)
+        public RunFromPackageContext(string envVarName, string url, long? packageContentLength, bool isWarmupRequest)
         {
             EnvironmentVariableName = envVarName;
             Url = url;
             PackageContentLength = packageContentLength;
+            IsWarmUpRequest = isWarmupRequest;
         }
 
         public string EnvironmentVariableName { get; set; }
@@ -22,6 +23,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
         public string Url { get; set; }
 
         public long? PackageContentLength { get; set; }
+
+        public bool IsWarmUpRequest { get; }
 
         public bool IsScmRunFromPackage()
         {

--- a/src/WebJobs.Script.WebHost/StartupContextProvider.cs
+++ b/src/WebJobs.Script.WebHost/StartupContextProvider.cs
@@ -142,11 +142,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             string decryptedContext = SimpleWebTokenHelper.Decrypt(encryptedContext.EncryptedContext, environment: _environment);
             var hostAssignmentContext = JsonConvert.DeserializeObject<HostAssignmentContext>(decryptedContext);
 
-            // apply values from the context to our cached context
-            Context = new StartupContext
+            // Don't update StartupContext for warmup requests
+            if (!hostAssignmentContext.IsWarmupRequest)
             {
-                Secrets = hostAssignmentContext.Secrets
-            };
+                // apply values from the context to our cached context
+                Context = new StartupContext
+                {
+                    Secrets = hostAssignmentContext.Secrets
+                };
+            }
 
             return hostAssignmentContext;
         }

--- a/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
@@ -73,8 +73,11 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
         // Linux container specialization events
         public const string LinuxContainerSpecializationZipExtract = "linux.container.specialization.zip.extract";
         public const string LinuxContainerSpecializationZipDownload = "linux.container.specialization.zip.download";
+        public const string LinuxContainerSpecializationZipDownloadWarmup = "linux.container.specialization.zip.download.warmup";
         public const string LinuxContainerSpecializationZipWrite = "linux.container.specialization.zip.write";
+        public const string LinuxContainerSpecializationZipWriteWarmup = "linux.container.specialization.zip.write.warmup";
         public const string LinuxContainerSpecializationZipHead = "linux.container.specialization.zip.head";
+        public const string LinuxContainerSpecializationZipHeadWarmup = "linux.container.specialization.zip.head.warmup";
         public const string LinuxContainerSpecializationFuseMount = "linux.container.specialization.mount";
         public const string LinuxContainerSpecializationMSIInit = "linux.container.specialization.msi.init";
         public const string LinuxContainerSpecializationUnsquash = "linux.container.specialization.unsquash";

--- a/test/WebJobs.Script.Tests.Integration/ContainerManagement/LinuxContainerInitializationHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ContainerManagement/LinuxContainerInitializationHostServiceTests.cs
@@ -79,12 +79,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ContainerManagement
             _environment.SetEnvironmentVariable(ContainerEncryptionKey, containerEncryptionKey);
             AddLinuxConsumptionSettings(_environment);
 
-            _instanceManagerMock.Setup(manager => manager.StartAssignment(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context)), It.Is<bool>(w => !w))).Returns(true);
+            _instanceManagerMock.Setup(manager => manager.StartAssignment(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context) && !context.IsWarmupRequest))).Returns(true);
 
             var initializationHostService = new LinuxContainerInitializationHostService(_environment, _instanceManagerMock.Object, NullLogger<LinuxContainerInitializationHostService>.Instance, _startupContextProvider);
             await initializationHostService.StartAsync(CancellationToken.None);
 
-            _instanceManagerMock.Verify(manager => manager.StartAssignment(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context)), It.Is<bool>(w => !w)), Times.Once);
+            _instanceManagerMock.Verify(manager => manager.StartAssignment(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context) && !context.IsWarmupRequest)), Times.Once);
 
             var hostSecretw = _startupContextProvider.GetHostSecretsOrNull();
             Assert.Equal("test-key", hostSecretw.MasterKey);
@@ -107,11 +107,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ContainerManagement
             initializationHostService.Setup(service => service.Read(ContainerStartContextUri))
                 .Returns(Task.FromResult(serializedContext));
 
-            _instanceManagerMock.Setup(manager => manager.StartAssignment(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context)), It.Is<bool>(w => !w))).Returns(true);
+            _instanceManagerMock.Setup(manager => manager.StartAssignment(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context) && !context.IsWarmupRequest))).Returns(true);
 
             await initializationHostService.Object.StartAsync(CancellationToken.None);
 
-            _instanceManagerMock.Verify(manager => manager.StartAssignment(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context)), It.Is<bool>(w => !w)), Times.Once);
+            _instanceManagerMock.Verify(manager => manager.StartAssignment(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context) && !context.IsWarmupRequest)), Times.Once);
         }
 
         [Fact]
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ContainerManagement
             var initializationHostService = new LinuxContainerInitializationHostService(_environment, _instanceManagerMock.Object, NullLogger<LinuxContainerInitializationHostService>.Instance, _startupContextProvider);
             await initializationHostService.StartAsync(CancellationToken.None);
 
-            _instanceManagerMock.Verify(manager => manager.StartAssignment(It.IsAny<HostAssignmentContext>(), It.Is<bool>(w => !w)), Times.Never);
+            _instanceManagerMock.Verify(manager => manager.StartAssignment(It.IsAny<HostAssignmentContext>()), Times.Never);
         }
 
         private static string GetEncryptedHostAssignmentContext(HostAssignmentContext hostAssignmentContext, string containerEncryptionKey)

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
@@ -128,6 +127,158 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             Assert.NotNull(okResult);
             Assert.Equal(200, okResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task Assignment_Sets_Secrets_Context()
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
+
+            var scriptWebEnvironment = new ScriptWebHostEnvironment(environment);
+
+            var loggerFactory = new LoggerFactory();
+            var loggerProvider = new TestLoggerProvider();
+            loggerFactory.AddProvider(loggerProvider);
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+            handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK
+            });
+
+            var instanceManager = new InstanceManager(_optionsFactory, new HttpClient(handlerMock.Object), scriptWebEnvironment, environment, loggerFactory.CreateLogger<InstanceManager>(), new TestMetricsLogger(), null);
+            var startupContextProvider = new StartupContextProvider(environment, loggerFactory.CreateLogger<StartupContextProvider>());
+
+            InstanceManager.Reset();
+
+            var instanceController = new InstanceController(environment, instanceManager, loggerFactory, startupContextProvider);
+
+            const string containerEncryptionKey = "/a/vXvWJ3Hzgx4PFxlDUJJhQm5QVyGiu0NNLFm/ZMMg=";
+            var hostAssignmentContext = new HostAssignmentContext
+            {
+                Environment = new Dictionary<string, string>()
+                {
+                    [EnvironmentSettingNames.AzureWebsiteRunFromPackage] = "http://localhost:1234"
+                }
+            };
+            hostAssignmentContext.Secrets = new FunctionAppSecrets();
+            hostAssignmentContext.IsWarmupRequest = false; // non-warmup Request
+
+            var encryptedHostAssignmentValue = SimpleWebTokenHelper.Encrypt(JsonConvert.SerializeObject(hostAssignmentContext), containerEncryptionKey.ToKeyBytes());
+
+            var encryptedHostAssignmentContext = new EncryptedHostAssignmentContext()
+            {
+                EncryptedContext = encryptedHostAssignmentValue
+            };
+
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, containerEncryptionKey);
+
+            await instanceController.Assign(encryptedHostAssignmentContext);
+            Assert.NotNull(startupContextProvider.Context);
+        }
+
+        [Fact]
+        public async Task Assignment_Does_Not_Set_Secrets_Context_For_Warmup_Request()
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
+
+            var scriptWebEnvironment = new ScriptWebHostEnvironment(environment);
+
+            var loggerFactory = new LoggerFactory();
+            var loggerProvider = new TestLoggerProvider();
+            loggerFactory.AddProvider(loggerProvider);
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+            handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+            {
+            StatusCode = HttpStatusCode.OK
+            });
+
+            var instanceManager = new InstanceManager(_optionsFactory, new HttpClient(handlerMock.Object), scriptWebEnvironment, environment, loggerFactory.CreateLogger<InstanceManager>(), new TestMetricsLogger(), null);
+            var startupContextProvider = new StartupContextProvider(environment, loggerFactory.CreateLogger<StartupContextProvider>());
+
+            InstanceManager.Reset();
+
+            var instanceController = new InstanceController(environment, instanceManager, loggerFactory, startupContextProvider);
+
+            const string containerEncryptionKey = "/a/vXvWJ3Hzgx4PFxlDUJJhQm5QVyGiu0NNLFm/ZMMg=";
+            var hostAssignmentContext = new HostAssignmentContext
+            {
+                Environment = new Dictionary<string, string>()
+                    {
+                        [EnvironmentSettingNames.AzureWebsiteRunFromPackage] = "http://localhost:1234"
+                    }
+            };
+            hostAssignmentContext.Secrets = new FunctionAppSecrets();
+            hostAssignmentContext.IsWarmupRequest = true; // Warmup Request
+
+            var encryptedHostAssignmentValue = SimpleWebTokenHelper.Encrypt(JsonConvert.SerializeObject(hostAssignmentContext), containerEncryptionKey.ToKeyBytes());
+
+            var encryptedHostAssignmentContext = new EncryptedHostAssignmentContext()
+            {
+                EncryptedContext = encryptedHostAssignmentValue
+            };
+
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, containerEncryptionKey);
+
+            await instanceController.Assign(encryptedHostAssignmentContext);
+            Assert.Null(startupContextProvider.Context);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        public async Task Assignment_Invokes_InstanceManager_Methods_For_Warmup_Requests_Also(bool isWarmupRequest, bool shouldInvokeMethod)
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
+            
+            var loggerFactory = new LoggerFactory();
+            var loggerProvider = new TestLoggerProvider();
+            loggerFactory.AddProvider(loggerProvider);
+
+            var instanceManager = new Mock<IInstanceManager>();
+            var startupContextProvider = new StartupContextProvider(environment, loggerFactory.CreateLogger<StartupContextProvider>());
+
+            InstanceManager.Reset();
+
+            var instanceController = new InstanceController(environment, instanceManager.Object, loggerFactory,
+                startupContextProvider);
+
+            const string containerEncryptionKey = "/a/vXvWJ3Hzgx4PFxlDUJJhQm5QVyGiu0NNLFm/ZMMg=";
+            var hostAssignmentContext = new HostAssignmentContext
+            {
+                Environment = new Dictionary<string, string>()
+            };
+            hostAssignmentContext.IsWarmupRequest = isWarmupRequest;
+
+            var encryptedHostAssignmentValue =
+                SimpleWebTokenHelper.Encrypt(JsonConvert.SerializeObject(hostAssignmentContext),
+                    containerEncryptionKey.ToKeyBytes());
+
+            var encryptedHostAssignmentContext = new EncryptedHostAssignmentContext()
+            {
+                EncryptedContext = encryptedHostAssignmentValue
+            };
+
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, containerEncryptionKey);
+            
+            await instanceController.Assign(encryptedHostAssignmentContext);
+
+            instanceManager.Verify(i => i.ValidateContext(It.IsAny<HostAssignmentContext>()),
+                shouldInvokeMethod ? Times.Once() : Times.Never());
+            instanceManager.Verify(i => i.SpecializeMSISidecar(It.IsAny<HostAssignmentContext>()),
+                shouldInvokeMethod ? Times.Once() : Times.Never());
+            instanceManager.Verify(i => i.StartAssignment(It.IsAny<HostAssignmentContext>()),
+                shouldInvokeMethod ? Times.Once() : Times.Never());
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
@@ -79,8 +79,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                     AllowedOrigins = allowedOrigins,
                     SupportCredentials = supportCredentials,
                 },
+                IsWarmupRequest = false
             };
-            bool result = _instanceManager.StartAssignment(context, isWarmup: false);
+            bool result = _instanceManager.StartAssignment(context);
             Assert.True(result);
             Assert.True(_scriptWebEnvironment.InStandbyMode);
 
@@ -106,7 +107,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             // calling again should return false, since we're no longer
             // in placeholder mode
             _loggerProvider.ClearAllLogMessages();
-            result = _instanceManager.StartAssignment(context, isWarmup: false);
+            result = _instanceManager.StartAssignment(context);
             Assert.False(result);
 
             logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
@@ -124,9 +125,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 {
                     // force the assignment to fail
                     { "throw", "test" }
-                }
+                },
+                IsWarmupRequest = false
             };
-            bool result = _instanceManager.StartAssignment(context, isWarmup: false);
+            bool result = _instanceManager.StartAssignment(context);
             Assert.True(result);
             Assert.True(_scriptWebEnvironment.InStandbyMode);
 
@@ -143,9 +145,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
             var context = new HostAssignmentContext
             {
-                Environment = new Dictionary<string, string>()
+                Environment = new Dictionary<string, string>(),
+                IsWarmupRequest = false
             };
-            bool result = _instanceManager.StartAssignment(context, isWarmup: false);
+            bool result = _instanceManager.StartAssignment(context);
             Assert.True(result);
             Assert.True(_scriptWebEnvironment.InStandbyMode);
 
@@ -175,9 +178,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 Environment = new Dictionary<string, string>()
                 {
                     { EnvironmentSettingNames.ScmRunFromPackage, sasUri.ToString() }
-                }
+                },
+                IsWarmupRequest = false
             };
-            bool result = _instanceManager.StartAssignment(context, isWarmup: false);
+            bool result = _instanceManager.StartAssignment(context);
             Assert.True(result);
 
             Thread.Sleep(assignmentWaitPeriod);
@@ -185,17 +189,59 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             Assert.False(_scriptWebEnvironment.InStandbyMode);
 
             var logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
-            Assert.Collection(logs,
-                p => Assert.StartsWith("Starting Assignment", p),
-                p => Assert.StartsWith("Applying 1 app setting(s)", p),
-                p => Assert.StartsWith("Downloading zip contents from", p),
-                p => Assert.EndsWith(" bytes downloaded", p),
-                p => Assert.EndsWith(" bytes written", p),
-                p => Assert.StartsWith("Running: ", p),
-                p => Assert.StartsWith("Output:", p),
-                p => Assert.True(p.StartsWith("bash:") || p.StartsWith("/usr/bin/bash:")),
-                p => Assert.StartsWith("exitCode:", p),
-                p => Assert.StartsWith("Triggering specialization", p));
+            if (logs.Length == 10)
+            {
+                Assert.Collection(logs,
+                    p => Assert.StartsWith("Starting Assignment", p),
+                    p => Assert.StartsWith("Applying 1 app setting(s)", p),
+                    p => Assert.StartsWith("Downloading zip contents from", p),
+                    p => Assert.EndsWith(" bytes downloaded. IsWarmupRequest = False", p),
+                    p => Assert.EndsWith(" bytes written. IsWarmupRequest = False", p),
+                    p => Assert.StartsWith("Running: ", p),
+                    p => Assert.StartsWith("Output:", p),
+                    p => Assert.True(true), // this line varies depending on whether WSL is on the machine; just ignore it
+                    p => Assert.StartsWith("exitCode:", p),
+                    p => Assert.StartsWith("Triggering specialization", p));
+            }
+            else
+            {
+                Assert.Collection(logs,
+                    p => Assert.StartsWith("Starting Assignment", p),
+                    p => Assert.StartsWith("Applying 1 app setting(s)", p),
+                    p => Assert.StartsWith("Downloading zip contents from", p),
+                    p => Assert.EndsWith(" bytes downloaded. IsWarmupRequest = False", p),
+                    p => Assert.EndsWith(" bytes written. IsWarmupRequest = False", p),
+                    p => Assert.StartsWith("Running: ", p),
+                    p => Assert.StartsWith("Error running bash", p),
+                    p => Assert.StartsWith("Triggering specialization", p));
+            }
+        }
+
+        [Fact]
+        public async void StartAssignment_Does_Not_Assign_Settings_For_Warmup_Request()
+        {
+            var contentRoot = Path.Combine(Path.GetTempPath(), @"FunctionsTest");
+            var zipFilePath = Path.Combine(contentRoot, "content.zip");
+            await TestHelpers.CreateContentZip(contentRoot, zipFilePath, Path.Combine(@"TestScripts", "DotNet"));
+
+            IConfiguration configuration = TestHelpers.GetTestConfiguration();
+            string connectionString = configuration.GetWebJobsConnectionString(ConnectionStringNames.Storage);
+            Uri sasUri = await TestHelpers.CreateBlobSas(connectionString, zipFilePath, "scm-run-from-pkg-test", "NonEmpty.zip");
+
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
+            var context = new HostAssignmentContext
+            {
+                Environment = new Dictionary<string, string>()
+                {
+                    { EnvironmentSettingNames.ScmRunFromPackage, sasUri.ToString() }
+                },
+                IsWarmupRequest = true
+            };
+            bool result = _instanceManager.StartAssignment(context);
+            Assert.True(result);
+
+            var logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
+            Assert.False(logs.Any(l => l.StartsWith("Starting Assignment.")));
         }
 
         [Fact]
@@ -211,9 +257,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 Environment = new Dictionary<string, string>()
                 {
                     { EnvironmentSettingNames.ScmRunFromPackage, sasUri.ToString() }
-                }
+                },
+                IsWarmupRequest = false
             };
-            bool result = _instanceManager.StartAssignment(context, isWarmup: false);
+            bool result = _instanceManager.StartAssignment(context);
             Assert.True(result);
 
             Thread.Sleep(assignmentWaitPeriod);
@@ -235,7 +282,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             var context = new HostAssignmentContext();
             context.Environment = new Dictionary<string, string>();
-            bool result = _instanceManager.StartAssignment(context, isWarmup: false);
+            context.IsWarmupRequest = false;
+            bool result = _instanceManager.StartAssignment(context);
             Assert.False(result);
         }
 
@@ -250,16 +298,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             {
                 SiteId = 1234,
                 SiteName = "TestSite",
-                Environment = environment
+                Environment = environment,
+                IsWarmupRequest = false
             };
 
-            string error = await _instanceManager.ValidateContext(assignmentContext, isWarmup: false);
+            string error = await _instanceManager.ValidateContext(assignmentContext);
             Assert.Equal("Invalid zip url specified (StatusCode: NotFound)", error);
 
             var logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
             Assert.Collection(logs,
-                p => Assert.StartsWith("Validating host assignment context (SiteId: 1234, SiteName: 'TestSite')", p),
-                p => Assert.StartsWith($"Will be using {EnvironmentSettingNames.AzureWebsiteZipDeployment} app setting as zip url", p),
+                p => Assert.StartsWith("Validating host assignment context (SiteId: 1234, SiteName: 'TestSite'. IsWarmup: 'False')", p),
+                p => Assert.StartsWith($"Will be using {EnvironmentSettingNames.AzureWebsiteZipDeployment} app setting as zip url. IsWarmup: 'False'", p),
                 p => Assert.StartsWith("linux.container.specialization.zip.head failed", p),
                 p => Assert.StartsWith("linux.container.specialization.zip.head failed", p),
                 p => Assert.StartsWith("linux.container.specialization.zip.head failed", p),
@@ -274,16 +323,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             {
                 SiteId = 1234,
                 SiteName = "TestSite",
-                Environment = environment
+                Environment = environment,
+                IsWarmupRequest = false
             };
 
-            string error = await _instanceManager.ValidateContext(assignmentContext, isWarmup: false);
+            string error = await _instanceManager.ValidateContext(assignmentContext);
             Assert.Null(error);
 
             string[] expectedOutputLines =
             {
-                "Validating host assignment context (SiteId: 1234, SiteName: 'TestSite')",
-                $"Will be using  app setting as zip url"
+                "Validating host assignment context (SiteId: 1234, SiteName: 'TestSite'. IsWarmup: 'False')",
+                $"Will be using  app setting as zip url. IsWarmup: 'False"
             };
 
             var logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
@@ -305,16 +355,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             {
                 SiteId = 1234,
                 SiteName = "TestSite",
-                Environment = environment
+                Environment = environment,
+                IsWarmupRequest = false
             };
 
-            string error = await _instanceManager.ValidateContext(assignmentContext, isWarmup: false);
+            string error = await _instanceManager.ValidateContext(assignmentContext);
             Assert.Null(error);
 
             string[] expectedOutputLines =
             {
-                "Validating host assignment context (SiteId: 1234, SiteName: 'TestSite')",
-                $"Will be using {EnvironmentSettingNames.AzureWebsiteZipDeployment} app setting as zip url"
+                "Validating host assignment context (SiteId: 1234, SiteName: 'TestSite'. IsWarmup: 'False')",
+                $"Will be using {EnvironmentSettingNames.AzureWebsiteZipDeployment} app setting as zip url. IsWarmup: 'False"
             };
 
             var logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
@@ -337,16 +388,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             {
                 SiteId = 1234,
                 SiteName = "TestSite",
-                Environment = environment
+                Environment = environment,
+                IsWarmupRequest = false
             };
 
-            string error = await _instanceManager.ValidateContext(assignmentContext, isWarmup: false);
+            string error = await _instanceManager.ValidateContext(assignmentContext);
             Assert.Null(error);
 
             string[] expectedOutputLines =
             {
-                "Validating host assignment context (SiteId: 1234, SiteName: 'TestSite')",
-                $"Will be using {EnvironmentSettingNames.ScmRunFromPackage} app setting as zip url"
+                "Validating host assignment context (SiteId: 1234, SiteName: 'TestSite'. IsWarmup: 'False')",
+                $"Will be using {EnvironmentSettingNames.ScmRunFromPackage} app setting as zip url. IsWarmup: 'False"
             };
 
             var logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
@@ -369,16 +421,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             {
                 SiteId = 1234,
                 SiteName = "TestSite",
-                Environment = environment
+                Environment = environment,
+                IsWarmupRequest = false
             };
 
-            string error = await _instanceManager.ValidateContext(assignmentContext, isWarmup: false);
+            string error = await _instanceManager.ValidateContext(assignmentContext);
             Assert.Null(error);
 
             string[] expectedOutputLines =
             {
-                "Validating host assignment context (SiteId: 1234, SiteName: 'TestSite')",
-                $"Will be using {EnvironmentSettingNames.AzureWebsiteZipDeployment} app setting as zip url"
+                "Validating host assignment context (SiteId: 1234, SiteName: 'TestSite'. IsWarmup: 'False')",
+                $"Will be using {EnvironmentSettingNames.AzureWebsiteZipDeployment} app setting as zip url. IsWarmup: 'False"
             };
 
             var logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
@@ -400,10 +453,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             {
                 SiteId = 1234,
                 SiteName = "TestSite",
-                Environment = environment
+                Environment = environment,
+                IsWarmupRequest = false
             };
 
-            string error = await _instanceManager.SpecializeMSISidecar(assignmentContext, isWarmup: false);
+            string error = await _instanceManager.SpecializeMSISidecar(assignmentContext);
             Assert.Null(error);
 
             var logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
@@ -422,12 +476,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             {
                 SiteId = 1234,
                 SiteName = "TestSite",
-                Environment = environment
+                Environment = environment,
+                IsWarmupRequest = false
             };
 
             var instanceManager = GetInstanceManagerForMSISpecialization(assignmentContext, HttpStatusCode.OK);
 
-            string error = await instanceManager.SpecializeMSISidecar(assignmentContext, isWarmup: false);
+            string error = await instanceManager.SpecializeMSISidecar(assignmentContext);
             Assert.Null(error);
 
             var logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
@@ -435,6 +490,31 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 p => Assert.StartsWith("MSI enabled status: True", p),
                 p => Assert.StartsWith("Specializing sidecar at http://localhost:8081", p),
                 p => Assert.StartsWith("Specialize MSI sidecar returned OK", p));
+        }
+
+        [Fact]
+        public async Task SpecializeMSISidecar_NoOp_ForWarmup_Request()
+        {
+            var environment = new Dictionary<string, string>()
+            {
+                { EnvironmentSettingNames.MsiEndpoint, "http://localhost:8081" },
+                { EnvironmentSettingNames.MsiSecret, "secret" }
+            };
+            var assignmentContext = new HostAssignmentContext
+            {
+                SiteId = 1234,
+                SiteName = "TestSite",
+                Environment = environment,
+                IsWarmupRequest = true
+            };
+
+            var instanceManager = GetInstanceManagerForMSISpecialization(assignmentContext, HttpStatusCode.OK);
+
+            string error = await instanceManager.SpecializeMSISidecar(assignmentContext);
+            Assert.Null(error);
+
+            var logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
+            Assert.Empty(logs);
         }
 
         [Fact]
@@ -449,12 +529,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             {
                 SiteId = 1234,
                 SiteName = "TestSite",
-                Environment = environment
+                Environment = environment,
+                IsWarmupRequest = false
             };
 
             var instanceManager = GetInstanceManagerForMSISpecialization(assignmentContext, HttpStatusCode.BadRequest);
 
-            string error = await instanceManager.SpecializeMSISidecar(assignmentContext, isWarmup: false);
+            string error = await instanceManager.SpecializeMSISidecar(assignmentContext);
             Assert.NotNull(error);
 
             var logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
@@ -496,7 +577,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                     [EnvironmentSettingNames.MsiEndpoint] = "endpoint",
                 },
                 SiteId = 1234,
-                SiteName = "TestSite"
+                SiteName = "TestSite",
+                IsWarmupRequest = false
             };
 
             var meshInitServiceClient = new Mock<IMeshServiceClient>(MockBehavior.Strict);
@@ -511,7 +593,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             var instanceManager = new InstanceManager(_optionsFactory, _httpClient, _scriptWebEnvironment, _environment,
                 _loggerFactory.CreateLogger<InstanceManager>(), new TestMetricsLogger(), meshInitServiceClient.Object);
 
-            instanceManager.StartAssignment(hostAssignmentContext, false);
+            instanceManager.StartAssignment(hostAssignmentContext);
 
             await TestHelpers.Await(() => !_scriptWebEnvironment.InStandbyMode, timeout: 5000);
 
@@ -551,7 +633,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                     [EnvironmentSettingNames.MsiEndpoint] = "endpoint",
                 },
                 SiteId = 1234,
-                SiteName = "TestSite"
+                SiteName = "TestSite",
+                IsWarmupRequest = false
             };
 
             var meshInitServiceClient = new Mock<IMeshServiceClient>(MockBehavior.Strict);
@@ -562,7 +645,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             var instanceManager = new InstanceManager(_optionsFactory, _httpClient, _scriptWebEnvironment, _environment,
                 _loggerFactory.CreateLogger<InstanceManager>(), new TestMetricsLogger(), meshInitServiceClient.Object);
 
-            instanceManager.StartAssignment(hostAssignmentContext, false);
+            instanceManager.StartAssignment(hostAssignmentContext);
 
             await Task.Delay(TimeSpan.FromSeconds(0.5));
 


### PR DESCRIPTION
    Part 1 - https://github.com/Azure/azure-functions-host/pull/6408/files
    This change addresses the following improvments based on profiling

    1. Metrics publisher invokes expensive Process apis to collect memory metrics during cold start. Deferring this by 2 seconds moves it out of critical path.
    2. Some of the operations in specialization code path were not being jit-ed since the warmup specialization call doesn't invoke all the operations. This change decrypts the host assignment context, validates and downloads a fake Website-Run-From-Pkg url to jit HttpDownload calls. The fake url points to a local endpoint and the downloaded contents are ignored.

    Fixes https://github.com/Azure/azure-functions-host/issues/6407

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [X ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
