### PR TITLE
Allow deleting non-reserved-system-keys that start with underscore 

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/KeysController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/KeysController.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
             }
         }
 
-        internal async Task<Dictionary<string, string>> GetHostSecretsByScope(string secretsScope, bool includeMasterInSystemKeys = false)
+        private async Task<Dictionary<string, string>> GetHostSecretsByScope(string secretsScope, bool includeMasterInSystemKeys = false)
         {
             var hostSecrets = await _secretManagerProvider.Current.GetHostSecretsAsync();
 

--- a/src/WebJobs.Script.WebHost/Controllers/KeysController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/KeysController.cs
@@ -254,8 +254,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                 return BadRequest("Invalid key name.");
             }
 
-            HostSecretsInfo hostSecrets = await _secretManagerProvider.Current.GetHostSecretsAsync();
-            if (hostSecrets.SystemKeys != null && hostSecrets.SystemKeys.TryGetValue(keyName, out string _))
+            if (IsBuiltInSystemKeyName(keyName))
             {
                 // System keys cannot be deleted.
                 return BadRequest("Cannot delete System Key.");
@@ -273,6 +272,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
             _logger.LogDebug(string.Format(Resources.TraceKeysApiSecretChange, keyName, keyScope ?? "host", "Deleted"));
 
             return StatusCode(StatusCodes.Status204NoContent);
+        }
+
+        internal bool IsBuiltInSystemKeyName(string keyName)
+        {
+            if (keyName.Equals(MasterKeyName, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+            return false;
         }
 
         private bool IsFunction(string functionName)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
- Allow deleting keys that start with `_` if the key is not a built in system key such as `_master`

resolves #6468

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #6493 
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
