### PR TITLE
Adding a unit test to track number of failed PGOs.

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -18,7 +18,9 @@ using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
 using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Middleware;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Diagnostics.JitTrace;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -265,6 +267,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(1, workerOptionsAtJobhostLevel.Value.WorkerConfigs.Count);
             var rpcChannelAfterSpecialization = (RpcWorkerChannel)channelFactory.Create("/", "powershell", null, 0, workerOptionsAtJobhostLevel.Value.WorkerConfigs);
             Assert.Equal("7", rpcChannelAfterSpecialization.Config.Description.DefaultRuntimeVersion);
+        }
+
+        [Fact]
+        public void ColdStart_JitFailuresTest()
+        {
+            var path = Path.Combine(Path.GetDirectoryName(new Uri(typeof(HostWarmupMiddleware).Assembly.CodeBase).LocalPath), WarmUpConstants.PreJitFolderName, WarmUpConstants.JitTraceFileName);
+
+            var file = new FileInfo(path);
+
+            if (file.Exists)
+            {
+                JitTraceRuntime.Prepare(file, out int successfulPrepares, out int failedPrepares);
+
+                // using 50 as approximate number of allowed failures before we need to regenrate a new PGO file.
+                Assert.True(failedPrepares < 50, $"Number of failed PGOs have increased. Current number of failures are {failedPrepares}. This will definitely impact cold start! Time to regenrate PGOs and update the coldstart.jittrace file!");
+            }
         }
 
         private IWebHostBuilder CreateStandbyHostBuilder(params string[] functions)

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -276,12 +276,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var file = new FileInfo(path);
 
-            Assert.True(file.Exists, $"{file.FullName} does not exist!");
+            Assert.True(file.Exists, $"Expected PGO file '{file.FullName}' does not exist. The file was either renamed or deleted.");
 
             JitTraceRuntime.Prepare(file, out int successfulPrepares, out int failedPrepares);
 
-            // using 50 as approximate number of allowed failures before we need to regenrate a new PGO file.
-            Assert.True(failedPrepares < 50, $"Number of failed PGOs have increased. Current number of failures are {failedPrepares}. This will definitely impact cold start! Time to regenrate PGOs and update the coldstart.jittrace file!");
+            var failurePercentage = (double) failedPrepares / successfulPrepares * 100;
+            
+            // using 1% as approximate number of allowed failures before we need to regenrate a new PGO file.
+            Assert.True( failurePercentage < 1.0 , $"Number of failed PGOs are more than 1 percent! Current number of failures are {failedPrepares}. This will definitely impact cold start! Time to regenrate PGOs and update the {WarmUpConstants.JitTraceFileName} file!");
         }
 
         private IWebHostBuilder CreateStandbyHostBuilder(params string[] functions)

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -276,13 +276,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var file = new FileInfo(path);
 
-            if (file.Exists)
-            {
-                JitTraceRuntime.Prepare(file, out int successfulPrepares, out int failedPrepares);
+            Assert.True(file.Exists, $"{file.FullName} does not exist!");
 
-                // using 50 as approximate number of allowed failures before we need to regenrate a new PGO file.
-                Assert.True(failedPrepares < 50, $"Number of failed PGOs have increased. Current number of failures are {failedPrepares}. This will definitely impact cold start! Time to regenrate PGOs and update the coldstart.jittrace file!");
-            }
+            JitTraceRuntime.Prepare(file, out int successfulPrepares, out int failedPrepares);
+
+            // using 50 as approximate number of allowed failures before we need to regenrate a new PGO file.
+            Assert.True(failedPrepares < 50, $"Number of failed PGOs have increased. Current number of failures are {failedPrepares}. This will definitely impact cold start! Time to regenrate PGOs and update the coldstart.jittrace file!");
         }
 
         private IWebHostBuilder CreateStandbyHostBuilder(params string[] functions)


### PR DESCRIPTION
This ensures we check the failures with every commit
and if numbers jump more than 50 then we need to regenerate PGO.

