### PR TITLE
Ignore nuget warnings

### DIFF
--- a/src/WebJobs.Script.Abstractions/WebJobs.Script.Abstractions.csproj
+++ b/src/WebJobs.Script.Abstractions/WebJobs.Script.Abstractions.csproj
@@ -13,6 +13,7 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Script.Abstractions</RootNamespace>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
+    <NoWarn>NU5125;NU5104;NU5048</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>

--- a/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
+++ b/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Script.Grpc</RootNamespace>
     <Ext Condition="'$(OS)' == 'Windows_NT'">bat</Ext>
     <Ext Condition="'$(OS)' != 'Windows_NT'">sh</Ext>
+    <NoWarn>NU5125;NU5104;NU5048</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -9,6 +9,7 @@
     <IsPackable Condition="'$(IsPackable)' != ''">true</IsPackable>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <TieredCompilation>false</TieredCompilation>
+    <NoWarn>NU5125;NU5104;NU5048</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">
     <PublishReadyToRun>true</PublishReadyToRun>

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -5,6 +5,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/Azure/azure-webjobs-sdk/dev/webjobs.png</PackageIconUrl>
     <AssemblyName>Microsoft.Azure.WebJobs.Script</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Script</RootNamespace>
+    <NoWarn>NU5125;NU5104;NU5048</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>


### PR DESCRIPTION
dotnet pack started failing with errors:

```
/src/azure-functions-host/src/WebJobs.Script/WebJobs.Script.csproj : error NU1605: Detected package downgrade: Microsoft.Azure.WebJobs from 3.0.20 to 3.0.19. Reference the package directly from the project to select a different version.  [/src/azure-functions-host/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj]
/src/azure-functions-host/src/WebJobs.Script/WebJobs.Script.csproj : error NU1605:  Microsoft.Azure.WebJobs.Script -> Microsoft.Azure.WebJobs.Extensions 4.0.1 -> Microsoft.Azure.WebJobs.Host.Storage 4.0.1 -> Microsoft.Azure.WebJobs (>= 3.0.20)  [/src/azure-functions-host/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj]
/src/azure-functions-host/src/WebJobs.Script/WebJobs.Script.csproj : error NU1605:  Microsoft.Azure.WebJobs.Script -> Microsoft.Azure.WebJobs (>= 3.0.19) [/src/azure-functions-host/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj]
The command '/bin/sh -c BUILD_NUMBER=$(echo ${HOST_VERSION} | cut -d'.' -f 3) &&     git clone --branch v${HOST_VERSION} https://github.com/Azure/azure-functions-host /src/azure-functions-host &&     cd /src/azure-functions-host &&     HOST_COMMIT=$(git rev-list -1 HEAD) &&     dotnet publish -v q /p:BuildNumber=$BUILD_NUMBER /p:CommitHash=$HOST_COMMIT src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj -c Release --output /azure-functions-host &&     mv /azure-functions-host/workers /workers && mkdir /azure-functions-host/workers &&     rm -rf /root/.local /root/.nuget /src' returned a non-zero code: 1
```

**Note:All the docker image builds are failing as host is built inside the docker**