### PR TITLE
[pack] add DOTNET_ADD_GLOBAL_TOOLS_TO_PATH to avoid inaccessible files

### DIFF
--- a/src/WebJobs.Script/BindingExtensions/ExtensionsManager.cs
+++ b/src/WebJobs.Script/BindingExtensions/ExtensionsManager.cs
@@ -202,6 +202,7 @@ namespace Microsoft.Azure.WebJobs.Script.BindingExtensions
         private void SetupProcessEnvironment(ProcessStartInfo startInfo)
         {
             TryAdd(startInfo.Environment, EnvironmentSettingNames.DotnetSkipFirstTimeExperience, "true");
+            TryAdd(startInfo.Environment, EnvironmentSettingNames.DotnetAddGlobalToolsToPath, "false");
             TryAdd(startInfo.Environment, NugetXmlDocModeSettingName, NugetXmlDocSkipMode);
         }
 

--- a/src/WebJobs.Script/BindingExtensions/ExtensionsManager.cs
+++ b/src/WebJobs.Script/BindingExtensions/ExtensionsManager.cs
@@ -203,6 +203,7 @@ namespace Microsoft.Azure.WebJobs.Script.BindingExtensions
         {
             TryAdd(startInfo.Environment, EnvironmentSettingNames.DotnetSkipFirstTimeExperience, "true");
             TryAdd(startInfo.Environment, EnvironmentSettingNames.DotnetAddGlobalToolsToPath, "false");
+            TryAdd(startInfo.Environment, EnvironmentSettingNames.DotnetNoLogo, "true");
             TryAdd(startInfo.Environment, NugetXmlDocModeSettingName, NugetXmlDocSkipMode);
         }
 

--- a/src/WebJobs.Script/Description/DotNet/PackageManager.cs
+++ b/src/WebJobs.Script/Description/DotNet/PackageManager.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 };
 
                 startInfo.Environment.Add(EnvironmentSettingNames.DotnetSkipFirstTimeExperience, "true");
+                startInfo.Environment.Add(EnvironmentSettingNames.DotnetAddGlobalToolsToPath, "false");
 
                 var process = new Process { StartInfo = startInfo };
                 process.ErrorDataReceived += ProcessDataReceived;

--- a/src/WebJobs.Script/Description/DotNet/PackageManager.cs
+++ b/src/WebJobs.Script/Description/DotNet/PackageManager.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
                 startInfo.Environment.Add(EnvironmentSettingNames.DotnetSkipFirstTimeExperience, "true");
                 startInfo.Environment.Add(EnvironmentSettingNames.DotnetAddGlobalToolsToPath, "false");
+                startInfo.Environment.Add(EnvironmentSettingNames.DotnetNoLogo, "true");
 
                 var process = new Process { StartInfo = startInfo };
                 process.ErrorDataReceived += ProcessDataReceived;

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string MsiEndpoint = "MSI_ENDPOINT";
         public const string MsiSecret = "MSI_SECRET";
         public const string DotnetSkipFirstTimeExperience = "DOTNET_SKIP_FIRST_TIME_EXPERIENCE";
+        public const string DotnetAddGlobalToolsToPath = "DOTNET_ADD_GLOBAL_TOOLS_TO_PATH";
         public const string AzureFilesConnectionString = "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING";
         public const string AzureFilesContentShare = "WEBSITE_CONTENTSHARE";
         public const string AzureWebsiteRuntimeSiteName = "WEBSITE_DEPLOYMENT_ID";

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string MsiSecret = "MSI_SECRET";
         public const string DotnetSkipFirstTimeExperience = "DOTNET_SKIP_FIRST_TIME_EXPERIENCE";
         public const string DotnetAddGlobalToolsToPath = "DOTNET_ADD_GLOBAL_TOOLS_TO_PATH";
+        public const string DotnetNoLogo = "DOTNET_NOLOGO";
         public const string AzureFilesConnectionString = "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING";
         public const string AzureFilesContentShare = "WEBSITE_CONTENTSHARE";
         public const string AzureWebsiteRuntimeSiteName = "WEBSITE_DEPLOYMENT_ID";


### PR DESCRIPTION
### Issue describing the changes in this PR

Resolves https://github.com/Azure/azure-functions-host/issues/5893

In response to changes here: https://github.com/dotnet/cli/pull/11029

**NOTE:** I could also remove `DOTNET_SKIP_FIRST_TIME_EXPERIENCE` since it's deprecated in 3.0.1+, I'm just worried about breaks for anything that may be running with 3.0.0 (Linux?). Let me know what you think though!

Similar to: https://github.com/Azure/azure-functions-host/commit/3dcce2915295202095d46cdd6e83db3496a33f6d

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR https://github.com/Azure/azure-functions-host/pull/6517
* [ ] I have added all required tests (Unit tests, E2E tests)
