### PR TITLE
[pack] Add support for file event subscribers

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,5 +3,7 @@
 - My change description (#PR)
 -->
 
+- Add a new host.json property "watchFiles" for restarting the Host when files are modified.
+
 **Release sprint:** Sprint 83
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+83%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+83%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script.WebHost/FileMonitoringService.cs
+++ b/src/WebJobs.Script.WebHost/FileMonitoringService.cs
@@ -248,9 +248,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     Shutdown();
                 }
             }
-            else if (string.Compare(fileName, ScriptConstants.HostMetadataFileName, StringComparison.OrdinalIgnoreCase) == 0 ||
-                string.Compare(fileName, ScriptConstants.FunctionMetadataFileName, StringComparison.OrdinalIgnoreCase) == 0 ||
-                string.Compare(fileName, ScriptConstants.ProxyMetadataFileName, StringComparison.OrdinalIgnoreCase) == 0)
+            else if (_scriptOptions.WatchFiles.Any(f => string.Equals(fileName, f, StringComparison.OrdinalIgnoreCase)))
             {
                 changeDescription = "File";
             }

--- a/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
         {
             private static readonly string[] WellKnownHostJsonProperties = new[]
             {
-                "version", "functionTimeout", "functions", "http", "watchDirectories", "queues", "serviceBus",
+                "version", "functionTimeout", "functions", "http", "watchDirectories", "watchFiles", "queues", "serviceBus",
                 "eventHub", "singleton", "logging", "aggregator", "healthMonitor", "extensionBundle", "managedDependencies",
                 "customHandler", "httpWorker"
             };

--- a/src/WebJobs.Script/Config/ScriptHostOptionsSetup.cs
+++ b/src/WebJobs.Script/Config/ScriptHostOptionsSetup.cs
@@ -30,6 +30,11 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             // Add the standard built in watched directories set to any the user may have specified
             options.WatchDirectories.Add("node_modules");
 
+            // Add the default files we need to watch
+            options.WatchFiles.Add(ScriptConstants.HostMetadataFileName);
+            options.WatchFiles.Add(ScriptConstants.FunctionMetadataFileName);
+            options.WatchFiles.Add(ScriptConstants.ProxyMetadataFileName);
+
             // Set default logging mode
             options.FileLoggingMode = FileLoggingMode.DebugOnly;
 

--- a/src/WebJobs.Script/Config/ScriptJobHostOptions.cs
+++ b/src/WebJobs.Script/Config/ScriptJobHostOptions.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.WebJobs.Script
             FileLoggingMode = FileLoggingMode.Never;
             InstanceId = Guid.NewGuid().ToString();
             WatchDirectories = new Collection<string>();
+            WatchFiles = new Collection<string>();
         }
 
         /// <summary>
@@ -69,6 +70,14 @@ namespace Microsoft.Azure.WebJobs.Script
         /// directories, the host will restart.
         /// </summary>
         public ICollection<string> WatchDirectories { get; set; }
+
+        /// <summary>
+        /// Gets or sets the collection of file names that
+        /// should be monitored for changes. If FileWatchingEnabled is true, these files
+        /// will be monitored. When a file from this list is added/modified/deleted,
+        /// the host will restart.
+        /// </summary>
+        public ICollection<string> WatchFiles { get; set; }
 
         /// <summary>
         /// Gets or sets a value governing when logs should be written to disk.

--- a/test/WebJobs.Script.Tests/Configuration/ScriptHostOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ScriptHostOptionsSetupTests.cs
@@ -35,6 +35,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             Assert.Equal(1, options.WatchDirectories.Count);
             Assert.Equal("node_modules", options.WatchDirectories.ElementAt(0));
 
+            Assert.Equal(3, options.WatchFiles.Count);
+            Assert.Contains("host.json", options.WatchFiles);
+            Assert.Contains("function.json", options.WatchFiles);
+            Assert.Contains("proxies.json", options.WatchFiles);
+
             // File watching disabled
             settings[ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "fileWatchingEnabled")] = bool.FalseString;
 
@@ -49,6 +54,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             settings[ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "fileWatchingEnabled")] = bool.TrueString;
             settings[ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "watchDirectories", "0")] = "Shared";
             settings[ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "watchDirectories", "1")] = "Tools";
+            settings[ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "watchFiles", "0")] = "myFirstFile.ext";
+            settings[ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "watchFiles", "1")] = "mySecondFile.ext";
 
             setup = CreateSetupWithConfiguration(settings);
 
@@ -60,6 +67,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             Assert.Equal("node_modules", options.WatchDirectories.ElementAt(0));
             Assert.Equal("Shared", options.WatchDirectories.ElementAt(1));
             Assert.Equal("Tools", options.WatchDirectories.ElementAt(2));
+
+            Assert.Equal(5, options.WatchFiles.Count);
+            Assert.Contains("host.json", options.WatchFiles);
+            Assert.Contains("function.json", options.WatchFiles);
+            Assert.Contains("proxies.json", options.WatchFiles);
+            Assert.Contains("myFirstFile.ext", options.WatchFiles);
+            Assert.Contains("mySecondFile.ext", options.WatchFiles);
         }
 
         [Fact(Skip = "ApplyConfiguration no longer exists. Validate logic (moved to HostJsonFileConfigurationSource)")]


### PR DESCRIPTION
A new `host.json` property that can be used to specify files that the host needs to monitor and restart on changes for. This is done to allow extensions to modify `IConfiguration` and extend our file watching by adding files they need to watch.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #6431 
### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [x] Otherwise: Documentation issue linked to PR -- https://github.com/Azure/azure-functions-host/issues/6580
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #issue_or_pr -- https://github.com/Azure/azure-functions-host/issues/6581
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
