### PR TITLE
[pack] FunctionAssemblyLoadContext: handling multiple assemblies with dependencies on different versions of runtime assemblies

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/RuntimeAsset.cs
+++ b/src/WebJobs.Script/Description/DotNet/RuntimeAsset.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 
 namespace Microsoft.Azure.WebJobs.Script.Description
@@ -8,16 +9,23 @@ namespace Microsoft.Azure.WebJobs.Script.Description
     [DebuggerDisplay("{" + nameof(Display) + ",nq}")]
     public class RuntimeAsset
     {
-        public RuntimeAsset(string rid, string path)
+        public RuntimeAsset(string rid, string path, string assemblyVersion)
         {
             Rid = rid;
             Path = path;
+
+            if (!string.IsNullOrEmpty(assemblyVersion))
+            {
+                AssemblyVersion = new Version(assemblyVersion);
+            }
         }
 
         public string Rid { get; }
 
         public string Path { get; }
 
-        private string Display => $"({Rid ?? "no RID"}) - {Path}";
+        public Version AssemblyVersion { get; }
+
+        private string Display => $"({Rid ?? "no RID"}) - {Path} - {AssemblyVersion}";
     }
 }

--- a/test/CSharpPrecompiledTestProjects/CSharpPrecompiledTestProjects.sln
+++ b/test/CSharpPrecompiledTestProjects/CSharpPrecompiledTestProjects.sln
@@ -11,6 +11,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NativeDependencyOldSdk", "N
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NativeDependencyNoRuntimes", "NativeDependencyNoRuntimes\NativeDependencyNoRuntimes.csproj", "{928B573E-904B-4733-86A2-6CDBF78D24AA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MultipleDependencyVersions", "MultipleDependencyVersions\MultipleDependencyVersions.csproj", "{D0AF8295-7CBF-45EB-914F-7105A9F53B69}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Dependencies", "Dependencies", "{297CEDAC-BB8E-4875-A3FF-7BA7A4916E73}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dependency55", "DependencyA\Dependency55.csproj", "{BC456A9E-D140-4B1A-84D9-AB82556F5881}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dependency56", "Dependency56\Dependency56.csproj", "{B3B098F6-B2B8-4219-AA52-29F55427496A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,9 +41,25 @@ Global
 		{928B573E-904B-4733-86A2-6CDBF78D24AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{928B573E-904B-4733-86A2-6CDBF78D24AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{928B573E-904B-4733-86A2-6CDBF78D24AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D0AF8295-7CBF-45EB-914F-7105A9F53B69}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D0AF8295-7CBF-45EB-914F-7105A9F53B69}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D0AF8295-7CBF-45EB-914F-7105A9F53B69}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D0AF8295-7CBF-45EB-914F-7105A9F53B69}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BC456A9E-D140-4B1A-84D9-AB82556F5881}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC456A9E-D140-4B1A-84D9-AB82556F5881}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC456A9E-D140-4B1A-84D9-AB82556F5881}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC456A9E-D140-4B1A-84D9-AB82556F5881}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B3B098F6-B2B8-4219-AA52-29F55427496A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B3B098F6-B2B8-4219-AA52-29F55427496A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B3B098F6-B2B8-4219-AA52-29F55427496A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B3B098F6-B2B8-4219-AA52-29F55427496A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{BC456A9E-D140-4B1A-84D9-AB82556F5881} = {297CEDAC-BB8E-4875-A3FF-7BA7A4916E73}
+		{B3B098F6-B2B8-4219-AA52-29F55427496A} = {297CEDAC-BB8E-4875-A3FF-7BA7A4916E73}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {61422CE7-BD7A-46C1-9589-6ED6EE3AB8BC}

--- a/test/CSharpPrecompiledTestProjects/Dependency56/Dependency56.csproj
+++ b/test/CSharpPrecompiledTestProjects/Dependency56/Dependency56.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.IdentityModel.Protocols" Version="5.6.0" />
+  </ItemGroup>
+  
+</Project>

--- a/test/CSharpPrecompiledTestProjects/Dependency56/TypeGetter.cs
+++ b/test/CSharpPrecompiledTestProjects/Dependency56/TypeGetter.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Dependency56
+{
+    public static class TypeGetter
+    {
+        public static Type ReturnSecurityKeyType()
+        {
+            return typeof(SecurityKey);
+        }
+    }
+}

--- a/test/CSharpPrecompiledTestProjects/DependencyA/Dependency55.csproj
+++ b/test/CSharpPrecompiledTestProjects/DependencyA/Dependency55.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.IdentityModel.Protocols" Version="5.5.0" />
+  </ItemGroup>
+
+</Project>

--- a/test/CSharpPrecompiledTestProjects/DependencyA/TypeGetter.cs
+++ b/test/CSharpPrecompiledTestProjects/DependencyA/TypeGetter.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Dependency55
+{
+    public static class TypeGetter
+    {
+        public static Type ReturnSecurityKeyType()
+        {
+            return typeof(SecurityKey);
+        }
+    }
+}

--- a/test/CSharpPrecompiledTestProjects/MultipleDependencyVersions/MultipleDependencyVersions.cs
+++ b/test/CSharpPrecompiledTestProjects/MultipleDependencyVersions/MultipleDependencyVersions.cs
@@ -12,8 +12,10 @@ namespace MultipleDependencyVersions
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)] HttpRequest req)
         {
-            Type t56 = Dependency56.TypeGetter.ReturnSecurityKeyType();
+            // The host uses version 5.5 of this assembly, but the deps.json says that the app
+            // should use 5.6.
             Type t55 = Dependency55.TypeGetter.ReturnSecurityKeyType();
+            Type t56 = Dependency56.TypeGetter.ReturnSecurityKeyType();
 
             if (!Equals(t55, t56) || !Equals(t55.Assembly, t56.Assembly))
             {

--- a/test/CSharpPrecompiledTestProjects/MultipleDependencyVersions/MultipleDependencyVersions.cs
+++ b/test/CSharpPrecompiledTestProjects/MultipleDependencyVersions/MultipleDependencyVersions.cs
@@ -1,0 +1,26 @@
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+
+namespace MultipleDependencyVersions
+{
+    public static class MultipleDependencyVersions
+    {
+        [FunctionName("MultipleDependencyVersions")]
+        public static IActionResult Run(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)] HttpRequest req)
+        {
+            Type t56 = Dependency56.TypeGetter.ReturnSecurityKeyType();
+            Type t55 = Dependency55.TypeGetter.ReturnSecurityKeyType();
+
+            if (!Equals(t55, t56) || !Equals(t55.Assembly, t56.Assembly))
+            {
+                throw new InvalidOperationException();
+            }
+
+            return new OkResult();
+        }
+    }
+}

--- a/test/CSharpPrecompiledTestProjects/MultipleDependencyVersions/MultipleDependencyVersions.csproj
+++ b/test/CSharpPrecompiledTestProjects/MultipleDependencyVersions/MultipleDependencyVersions.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />    
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Dependency56\Dependency56.csproj" />
+    <ProjectReference Include="..\DependencyA\Dependency55.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/test/CSharpPrecompiledTestProjects/MultipleDependencyVersions/host.json
+++ b/test/CSharpPrecompiledTestProjects/MultipleDependencyVersions/host.json
@@ -1,0 +1,11 @@
+{
+    "version": "2.0",
+    "logging": {
+        "applicationInsights": {
+            "samplingExcludedTypes": "Request",
+            "samplingSettings": {
+                "isEnabled": true
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/FunctionAssemblyLoadContextEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/FunctionAssemblyLoadContextEndToEndTests.cs
@@ -96,6 +96,24 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
             });
         }
 
+        [Fact]
+        public async Task MultipleDepenendencyVersions()
+        {
+            // Test that we consult the deps file 
+
+            await RunTest(async () =>
+            {
+                _launcher = new HostProcessLauncher("MultipleDependencyVersions");
+                await _launcher.StartHostAsync();
+
+                var client = _launcher.HttpClient;
+                var response = await client.GetAsync($"api/MultipleDependencyVersions");
+
+                // The function does all the validation internally.
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            });
+        }
+
         private async Task RunTest(Func<Task> test)
         {
             try

--- a/test/WebJobs.Script.Tests/Description/DotNet/FunctionAssemblyLoadContextTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/FunctionAssemblyLoadContextTests.cs
@@ -50,15 +50,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             string testRid = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "win" : "unix";
 
             // Ensure runtime specific dependencies are resolved, with appropriate RID
-            FunctionAssemblyLoadContext.TryGetDepsAsset(depsAssemblies, "System.private.servicemodel", currentRidFallbacks, out string assemblyPath);
-            Assert.Equal($"runtimes/{testRid}/lib/netstandard2.0/System.Private.ServiceModel.dll", assemblyPath);
+            FunctionAssemblyLoadContext.TryGetDepsAsset(depsAssemblies, "System.private.servicemodel", currentRidFallbacks, out RuntimeAsset asset);
+            Assert.Equal($"runtimes/{testRid}/lib/netstandard2.0/System.Private.ServiceModel.dll", asset.Path);
 
-            FunctionAssemblyLoadContext.TryGetDepsAsset(depsAssemblies, "System.text.encoding.codepages", currentRidFallbacks, out assemblyPath);
-            Assert.Equal($"runtimes/{testRid}/lib/netstandard1.3/System.Text.Encoding.CodePages.dll", assemblyPath);
+            FunctionAssemblyLoadContext.TryGetDepsAsset(depsAssemblies, "System.text.encoding.codepages", currentRidFallbacks, out asset);
+            Assert.Equal($"runtimes/{testRid}/lib/netstandard1.3/System.Text.Encoding.CodePages.dll", asset.Path);
 
             // Ensure flattened dependency has expected path
-            FunctionAssemblyLoadContext.TryGetDepsAsset(depsAssemblies, "Microsoft.Azure.WebJobs.Host.Storage", currentRidFallbacks, out assemblyPath);
-            Assert.Equal($"Microsoft.Azure.WebJobs.Host.Storage.dll", assemblyPath);
+            FunctionAssemblyLoadContext.TryGetDepsAsset(depsAssemblies, "Microsoft.Azure.WebJobs.Host.Storage", currentRidFallbacks, out asset);
+            Assert.Equal($"Microsoft.Azure.WebJobs.Host.Storage.dll", asset.Path);
 
             // Ensure native libraries are resolved, with appropriate RID and path
             string nativeRid;
@@ -89,8 +89,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             string nativeAssetFileName = $"{nativePrefix}CpuMathNative.{nativeExtension}";
 
-            FunctionAssemblyLoadContext.TryGetDepsAsset(nativeLibraries, nativeAssetFileName, currentRidFallbacks, out string assetPath);
-            Assert.Contains($"runtimes/{nativeRid}/nativeassets/netstandard2.0/{nativeAssetFileName}", assetPath);
+            FunctionAssemblyLoadContext.TryGetDepsAsset(nativeLibraries, nativeAssetFileName, currentRidFallbacks, out asset);
+            Assert.Contains($"runtimes/{nativeRid}/nativeassets/netstandard2.0/{nativeAssetFileName}", asset.Path);
         }
 
         [Theory]
@@ -110,13 +110,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             string nativeAssetFileName = $"{prefix}Cosmos.CRTCompat.{suffix}";
 
-            FunctionAssemblyLoadContext.TryGetDepsAsset(nativeLibraries, nativeAssetFileName, ridFallback, out string assetPath);
+            bool result = FunctionAssemblyLoadContext.TryGetDepsAsset(nativeLibraries, nativeAssetFileName, ridFallback, out RuntimeAsset asset);
 
-            string expectedMatch = expectMatch
-                ? $"runtimes/{expectedNativeRid}/native/{nativeAssetFileName}"
-                : null;
-
-            Assert.Equal(expectedMatch, assetPath);
+            if (expectMatch)
+            {
+                Assert.True(result);
+                Assert.Equal($"runtimes/{expectedNativeRid}/native/{nativeAssetFileName}", asset.Path);
+            }
+            else
+            {
+                Assert.False(result);
+                Assert.Null(asset);
+            }
         }
 
         [Theory]


### PR DESCRIPTION
resolves #6555 

Description of the scenario is here: https://github.com/Azure/azure-functions-host/issues/6555#issuecomment-681157384

I'm submitting this now to get a build created. But we'll wait until @fabiocav returns from vacation and can provide a review before merging. I'll also see if I can add tests (but this is a tough scenario). This will all happen next sprint.

* [x] My changes **do not** require documentation changes
    * [x] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
