### PR TITLE
Updated Functions host build extensions for integration tests build

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -8,5 +8,6 @@
     <add key="buildTools" value="https://www.myget.org/F/30de4ee06dd54956a82013fa17a3accb/" />
     <add key="AspNetVNext" value="https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json" />
     <add key="Microsoft.Azure.Functions.PowerShellWorker" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/Microsoft.Azure.Functions.PowerShellWorker/nuget/v3/index.json" />
+    <add key="AzureFunctionsPreRelease" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsPreRelease/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
- Changes to build-extensions.ps1 to account for periodic integration tests - Added a flag (integrationTestsBuild) which will indicate whether we execute the following: pull latest versions of all workers from prerelease feed and updates those references in Webjobs.Script.csproj.

- Updated Nuget.config to include the prerelease feed, which will contain the latest builds of all workers every time the integration test pipeline is run. 

resolves: (Issue related to this PR is located in the integration tests repo currently.)


* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)


Note: In line 55 of build-extensions.ps1, I edited the path so that the script would run successfully on my local machine. This seems to be a consistent issue for the build generally; may need to backtrack before checking into dev, or discuss how to allow for this script to be functional locally and remotely. 
