### PR TITLE
Crank http/https toggle param

### DIFF
--- a/tools/Crank/benchmarks.yml
+++ b/tools/Crank/benchmarks.yml
@@ -15,7 +15,7 @@ scenarios:
       job: server
       environmentVariables:
         AzureWebJobsScriptRoot: "{{ FunctionAppPath }}"
-        ASPNETCORE_URLS: "http://localhost:5000;https://localhost:5001"
+        ASPNETCORE_URLS: "{{ AspNetUrls }}"
     load:
       job: bombardier
       variables:
@@ -30,7 +30,7 @@ scenarios:
         WEBSITE_INSTANCE_ID: "8399B720-AB73-46D6-94DE-5A27871B3155"
         WEBSITE_OWNER_NAME: "A5F47496-A284-4788-A127-E79454330567+westuswebspace"
         AzureWebJobsScriptRoot: "{{ FunctionAppPath }}"
-        ASPNETCORE_URLS: "http://localhost:5000;https://localhost:5001"
+        ASPNETCORE_URLS: "{{ AspNetUrls }}"
     load:
       job: bombardier
       variables:
@@ -46,7 +46,7 @@ scenarios:
         WEBSITE_OWNER_NAME: "A5F47496-A284-4788-A127-E79454330567+westuswebspace"
         FUNCTIONS_LOGS_MOUNT_PATH: "{{ TempLogPath }}"
         AzureWebJobsScriptRoot: "{{ FunctionAppPath }}"
-        ASPNETCORE_URLS: "http://localhost:5000;https://localhost:5001"
+        ASPNETCORE_URLS: "{{ AspNetUrls }}"
     load:
       job: bombardier
       variables:
@@ -54,10 +54,21 @@ scenarios:
         duration: 180
 
 profiles:
-  local:
+  localHttps:
     variables:
       serverUri: https://localhost
       serverPort: 5001
+    jobs: 
+      application:
+        endpoints: 
+          - "http://{{ CrankAgentVm }}:5010"
+      load:
+        endpoints: 
+          - "http://{{ CrankAgentVm }}:5010"
+  local:
+    variables:
+      serverUri: http://localhost
+      serverPort: 5000
     jobs: 
       application:
         endpoints: 

--- a/tools/Crank/run-benchmarks.ps1
+++ b/tools/Crank/run-benchmarks.ps1
@@ -22,7 +22,10 @@ param(
     $RefreshCrankContoller,
 
     [string]
-    $UserName = 'Functions'
+    $UserName = 'Functions',
+
+    [bool]
+    $UseHttps = $true
 )
 
 $ErrorActionPreference = 'Stop'
@@ -69,15 +72,25 @@ $functionAppPath = Join-Path `
 $tmpPath = if ($isLinuxApp) { "/tmp" } else { 'C:\Temp' }
 $tmpLogPath = if ($isLinuxApp) { "/tmp/functions/log" } else { 'C:\Temp\Functions\Log' }
 
+if ($UseHttps) {
+    $aspNetUrls = "http://localhost:5000;https://localhost:5001"
+    $profile = "localHttps"
+}
+else {
+    $aspNetUrls = "http://localhost:5000"
+    $profile = "local"
+}
+
 $crankArgs =
     '--config', $crankConfigPath,
     '--scenario', $Scenario,
-    '--profile', 'local',
+    '--profile', $profile,
     '--variable', "CrankAgentVm=$CrankAgentVm",
     '--variable', "FunctionAppPath=`"$functionAppPath`"",
     '--variable', "TempPath=`"$tmpPath`"",
     '--variable', "TempLogPath=`"$tmpLogPath`"",
-    '--variable', "BranchOrCommit=$BranchOrCommit"
+    '--variable', "BranchOrCommit=$BranchOrCommit",
+    '--variable', "AspNetUrls=$aspNetUrls"
 
 if ($WriteResultsToDatabase) {
     Set-AzContext -Subscription 'Antares-Demo' > $null


### PR DESCRIPTION
The .NET Core development cert doesn't work on Linux (fails open ssl verification as described in [here](https://stackoverflow.com/questions/55485511/how-to-run-dotnet-dev-certs-https-trust)). To work around this, I'm adding an option to run a test using http rather than https.