### PR TITLE
Add support to retry function execution on invocation failures

### DIFF
--- a/WebJobs.Script.sln
+++ b/WebJobs.Script.sln
@@ -327,6 +327,29 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HttpTrigger", "HttpTrigger"
 		sample\CustomHandler\HttpTrigger\function.json = sample\CustomHandler\HttpTrigger\function.json
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HttpTrigger-Retry", "HttpTrigger-Retry", "{821D5B92-2C3E-44F0-AA92-8B996DCB8E6C}"
+	ProjectSection(SolutionItems) = preProject
+		sample\Node\HttpTrigger-Retry\function.json = sample\Node\HttpTrigger-Retry\function.json
+		sample\Node\HttpTrigger-Retry\index.js = sample\Node\HttpTrigger-Retry\index.js
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NodeRetry", "NodeRetry", "{EEBAC197-FAD8-4214-9A12-76334BB3021A}"
+	ProjectSection(SolutionItems) = preProject
+		sample\NodeRetry\host.json = sample\NodeRetry\host.json
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HttpTrigger-FunctionJsonRetry", "HttpTrigger-FunctionJsonRetry", "{7935A7A4-191A-4A9B-B8DD-173968309EBF}"
+	ProjectSection(SolutionItems) = preProject
+		sample\NodeRetry\HttpTrigger-RetryFunctionJson\function.json = sample\NodeRetry\HttpTrigger-RetryFunctionJson\function.json
+		sample\NodeRetry\HttpTrigger-RetryFunctionJson\index.js = sample\NodeRetry\HttpTrigger-RetryFunctionJson\index.js
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HttpTrigger-HostJsonRetry", "HttpTrigger-HostJsonRetry", "{CF6D9CDA-2290-46DF-B162-2D422477288A}"
+	ProjectSection(SolutionItems) = preProject
+		sample\NodeRetry\HttpTrigger-RetryHostJson\function.json = sample\NodeRetry\HttpTrigger-RetryHostJson\function.json
+		sample\NodeRetry\HttpTrigger-RetryHostJson\index.js = sample\NodeRetry\HttpTrigger-RetryHostJson\index.js
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		test\WebJobs.Script.Tests.Shared\WebJobs.Script.Tests.Shared.projitems*{35c9ccb7-d8b6-4161-bb0d-bcfa7c6dcffb}*SharedItemsImports = 13
@@ -427,6 +450,10 @@ Global
 		{9A522D9D-2D86-4572-B7D1-ECBFBFAF312C} = {16351B76-87CA-4A8C-80A1-3DD83A0C4AA6}
 		{A59D3F65-53E5-4666-AEFE-882987A39A49} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
 		{209DC34B-762E-4B1B-B094-EBD7C4B972C2} = {A59D3F65-53E5-4666-AEFE-882987A39A49}
+		{821D5B92-2C3E-44F0-AA92-8B996DCB8E6C} = {9D87C796-7914-4A43-B843-579562393E10}
+		{EEBAC197-FAD8-4214-9A12-76334BB3021A} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
+		{7935A7A4-191A-4A9B-B8DD-173968309EBF} = {EEBAC197-FAD8-4214-9A12-76334BB3021A}
+		{CF6D9CDA-2290-46DF-B162-2D422477288A} = {EEBAC197-FAD8-4214-9A12-76334BB3021A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {85400884-5FFD-4C27-A571-58CB3C8CAAC5}

--- a/release_notes.md
+++ b/release_notes.md
@@ -7,6 +7,7 @@
 - Update PowerShell Worker to 3.0.552 (PS6) [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.552) and 3.0.549 (PS7) [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.549)
 - Update Java Worker to 1.8.0 [Release Note](https://github.com/Azure/azure-functions-java-worker/releases/tag/1.8.0)
 - Update Java Library to 1.4.0 [Release Note](https://github.com/Azure/azure-functions-java-library)
+- Added support for function execution retry on invocation failures [#6664](https://github.com/Azure/azure-functions-host/issues/6664)
 - **[BreakingChange]** Fixes [#400](https://github.com/Azure/azure-functions-java-worker/issues/400) which was a regression from the 1.7.1 release.
   There is potential of impact if the function code has taken a dependency on a feature in gson 2.8.6 as the dependency `gson-2.8.5.jar` is now included in the class path of the worker and will take precedence over the function's lib folder.
 - **Breaking Changes in CustomHandler**
@@ -28,3 +29,6 @@
 
 **Release sprint:** Sprint 84
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+84%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+84%22+label%3Afeature+is%3Aclosed) ]
+
+**Release sprint:** Sprint 85
+[ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+85%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+85%22+label%3Afeature+is%3Aclosed) ]

--- a/sample/NodeRetry/HttpTrigger-RetryFunctionJson/function.json
+++ b/sample/NodeRetry/HttpTrigger-RetryFunctionJson/function.json
@@ -17,6 +17,7 @@
   ],
   "retry": {
     "strategy": "fixedDelay",
-    "maxRetryCount": 4
+    "maxRetryCount": 4,
+    "delayInterval": "00:00:03"
   }
 }

--- a/sample/NodeRetry/HttpTrigger-RetryFunctionJson/function.json
+++ b/sample/NodeRetry/HttpTrigger-RetryFunctionJson/function.json
@@ -1,0 +1,22 @@
+﻿{
+  "bindings": [
+    {
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "retry": {
+    "strategy": "fixedDelay",
+    "maxRetryCount": 4
+  }
+}

--- a/sample/NodeRetry/HttpTrigger-RetryFunctionJson/index.js
+++ b/sample/NodeRetry/HttpTrigger-RetryFunctionJson/index.js
@@ -1,0 +1,18 @@
+﻿var invocationCount = 0;
+
+module.exports = async function (context, req) {
+    const reset = req.query.reset;
+    invocationCount = reset ? 0 : invocationCount
+
+    context.log('JavaScript HTTP trigger function processed a request.invocationCount: ' + invocationCount);
+
+    invocationCount = invocationCount + 1;
+    const responseMessage = "invocationCount: " + invocationCount;
+    if (invocationCount < 4) {
+        throw new Error('An error occurred');
+    }
+    context.res = {
+        // status: 200, /* Defaults to 200 */
+        body: responseMessage
+    };
+}

--- a/sample/NodeRetry/HttpTrigger-RetryHostJson/function.json
+++ b/sample/NodeRetry/HttpTrigger-RetryHostJson/function.json
@@ -1,0 +1,18 @@
+{
+  "bindings": [
+    {
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/sample/NodeRetry/HttpTrigger-RetryHostJson/index.js
+++ b/sample/NodeRetry/HttpTrigger-RetryHostJson/index.js
@@ -1,0 +1,18 @@
+﻿var invocationCount = 0;
+
+module.exports = async function (context, req) {
+    const reset = req.query.reset;
+    invocationCount = reset ? 0 : invocationCount
+
+    context.log('JavaScript HTTP trigger function processed a request.invocationCount: ' + invocationCount);
+    
+    invocationCount = invocationCount + 1;
+    const responseMessage = "invocationCount: " + invocationCount;
+    if (invocationCount < 2) {
+        throw new Error('An error occurred');
+    }
+    context.res = {
+        // status: 200, /* Defaults to 200 */
+        body: responseMessage
+    };
+}

--- a/sample/NodeRetry/host.json
+++ b/sample/NodeRetry/host.json
@@ -1,0 +1,8 @@
+{
+  "version": "2.0",
+  "retry": {
+    "strategy": "fixedDelay",
+    "maxRetryCount": 2,
+    "delayInterval": "00:00:03"
+  }
+}

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -63,8 +63,8 @@
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.11020001-fabe022e" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
     <PackageReference Include="Microsoft.Azure.Storage.File" Version="11.1.7" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="4.0.1" />    
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.23-11785" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="4.0.1" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.3" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="4.0.1" />
     <PackageReference Include="Microsoft.Azure.WebSites.DataProtection" Version="2.1.91-alpha" />

--- a/src/WebJobs.Script/Config/ConfigurationSectionNames.cs
+++ b/src/WebJobs.Script/Config/ConfigurationSectionNames.cs
@@ -21,5 +21,6 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
         public const string Hsts = Http + ":hsts";
         public const string CustomHttpHeaders = Http + ":customHeaders";
         public const string EasyAuth = "easyauth";
+        public const string Retry = "retry";
     }
 }

--- a/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
         {
             private static readonly string[] WellKnownHostJsonProperties = new[]
             {
-                "version", "functionTimeout", "functions", "http", "watchDirectories", "watchFiles", "queues", "serviceBus",
+                "version", "functionTimeout", "retry", "functions", "http", "watchDirectories", "watchFiles", "queues", "serviceBus",
                 "eventHub", "singleton", "logging", "aggregator", "healthMonitor", "extensionBundle", "managedDependencies",
                 "customHandler", "httpWorker"
             };

--- a/src/WebJobs.Script/Config/ScriptHostOptionsSetup.cs
+++ b/src/WebJobs.Script/Config/ScriptHostOptionsSetup.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
                 {
                     options.FileLoggingMode = fileLoggingMode.Value;
                 }
+                Utility.ValidateRetryOptions(options.Retry);
             }
 
             // FunctionTimeout

--- a/src/WebJobs.Script/Config/ScriptJobHostOptions.cs
+++ b/src/WebJobs.Script/Config/ScriptJobHostOptions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
+using Microsoft.Azure.WebJobs.Script.Description;
 
 namespace Microsoft.Azure.WebJobs.Script
 {
@@ -106,5 +107,10 @@ namespace Microsoft.Azure.WebJobs.Script
         /// locally or via CLI.
         /// </summary>
         public bool IsSelfHost { get; set; }
+
+        /// <summary>
+        /// Gets or sets retry options to use on function executions on function invocation failures.
+        /// </summary>
+        public RetryOptions Retry { get; set; }
     }
 }

--- a/src/WebJobs.Script/CustomAttributeBuilderUtility.cs
+++ b/src/WebJobs.Script/CustomAttributeBuilderUtility.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Script.Description;
+
+namespace Microsoft.Azure.WebJobs.Script
+{
+    internal static class CustomAttributeBuilderUtility
+    {
+        internal static CustomAttributeBuilder GetRetryCustomAttributeBuilder(RetryOptions functionRetry)
+        {
+            switch (functionRetry.Strategy)
+            {
+                case RetryStrategy.FixedDelay:
+                    Type fixedDelayRetryType = typeof(FixedDelayRetryAttribute);
+                    ConstructorInfo fixedDelayRetryCtorInfo = fixedDelayRetryType.GetConstructor(new[] { typeof(int), typeof(string) });
+                    CustomAttributeBuilder fixedDelayRetryBuilder = new CustomAttributeBuilder(
+                    fixedDelayRetryCtorInfo,
+                    new object[] { functionRetry.MaxRetryCount, functionRetry.DelayInterval.ToString() });
+                    return fixedDelayRetryBuilder;
+                case RetryStrategy.ExponentialBackoff:
+                    Type exponentialBackoffRetryType = typeof(ExponentialBackoffRetryAttribute);
+                    ConstructorInfo exponentialBackoffDelayRetryCtorInfo = exponentialBackoffRetryType.GetConstructor(new[] { typeof(int), typeof(string), typeof(string) });
+                    CustomAttributeBuilder exponentialBackoffRetryBuilder = new CustomAttributeBuilder(
+                    exponentialBackoffDelayRetryCtorInfo,
+                    new object[] { functionRetry.MaxRetryCount, functionRetry.MinimumInterval.ToString(), functionRetry.MaximumInterval.ToString() });
+                    return exponentialBackoffRetryBuilder;
+            }
+            return null;
+        }
+
+        internal static CustomAttributeBuilder GetTimeoutCustomAttributeBuilder(TimeSpan functionTimeout)
+        {
+            Type timeoutType = typeof(TimeoutAttribute);
+            ConstructorInfo ctorInfo = timeoutType.GetConstructor(new[] { typeof(string) });
+
+            PropertyInfo[] propertyInfos = new[]
+            {
+                timeoutType.GetProperty("ThrowOnTimeout"),
+                timeoutType.GetProperty("TimeoutWhileDebugging")
+            };
+
+            // Hard-code these for now. Eventually elevate to config
+            object[] propertyValues = new object[]
+            {
+                true,
+                true
+            };
+
+            return new CustomAttributeBuilder(
+                ctorInfo,
+                new object[] { functionTimeout.ToString() },
+                propertyInfos,
+                propertyValues);
+        }
+    }
+}

--- a/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
@@ -11,7 +11,6 @@ using System.Reflection.Emit;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Binding;
-using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.Extensibility;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
@@ -216,7 +215,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
         }
 
-        protected static void ApplyMethodLevelAttributes(FunctionMetadata functionMetadata, BindingMetadata triggerMetadata, Collection<CustomAttributeBuilder> methodAttributes)
+        protected void ApplyMethodLevelAttributes(FunctionMetadata functionMetadata, BindingMetadata triggerMetadata, Collection<CustomAttributeBuilder> methodAttributes)
         {
             if (Utility.IsHttporManualTrigger(triggerMetadata.Type))
             {
@@ -225,6 +224,16 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 ConstructorInfo ctorInfo = typeof(NoAutomaticTriggerAttribute).GetConstructor(new Type[0]);
                 CustomAttributeBuilder attributeBuilder = new CustomAttributeBuilder(ctorInfo, new object[0]);
                 methodAttributes.Add(attributeBuilder);
+            }
+
+            // apply the retry settings from function.json
+            if (functionMetadata.Retry != null)
+            {
+                CustomAttributeBuilder retryCustomAttributeBuilder = CustomAttributeBuilderUtility.GetRetryCustomAttributeBuilder(functionMetadata.Retry);
+                if (retryCustomAttributeBuilder != null)
+                {
+                    methodAttributes.Add(retryCustomAttributeBuilder);
+                }
             }
         }
 

--- a/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
         }
 
-        protected void ApplyMethodLevelAttributes(FunctionMetadata functionMetadata, BindingMetadata triggerMetadata, Collection<CustomAttributeBuilder> methodAttributes)
+        protected static void ApplyMethodLevelAttributes(FunctionMetadata functionMetadata, BindingMetadata triggerMetadata, Collection<CustomAttributeBuilder> methodAttributes)
         {
             if (Utility.IsHttporManualTrigger(triggerMetadata.Type))
             {

--- a/src/WebJobs.Script/Host/FunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataProvider.cs
@@ -8,6 +8,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
+using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions;
@@ -157,6 +158,11 @@ namespace Microsoft.Azure.WebJobs.Script
                 functionMetadata.Language = ParseLanguage(functionMetadata.ScriptFile, workerConfigs);
             }
             functionMetadata.EntryPoint = (string)configMetadata["entryPoint"];
+
+            //Retry
+            functionMetadata.Retry = configMetadata.Property(ConfigurationSectionNames.Retry)?.Value?.ToObject<RetryOptions>();
+            Utility.ValidateRetryOptions(functionMetadata.Retry);
+
             return functionMetadata;
         }
 

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -356,29 +356,18 @@ namespace Microsoft.Azure.WebJobs.Script
             // apply the timeout settings to our type
             if (scriptConfig.FunctionTimeout != null)
             {
-                Type timeoutType = typeof(TimeoutAttribute);
-                ConstructorInfo ctorInfo = timeoutType.GetConstructor(new[] { typeof(string) });
-
-                PropertyInfo[] propertyInfos = new[]
-                {
-                    timeoutType.GetProperty("ThrowOnTimeout"),
-                    timeoutType.GetProperty("TimeoutWhileDebugging")
-                };
-
-                // Hard-code these for now. Eventually elevate to config
-                object[] propertyValues = new object[]
-                {
-                    true,
-                    true
-                };
-
-                CustomAttributeBuilder timeoutBuilder = new CustomAttributeBuilder(
-                    ctorInfo,
-                    new object[] { scriptConfig.FunctionTimeout.ToString() },
-                    propertyInfos,
-                    propertyValues);
-
+                var timeoutBuilder = CustomAttributeBuilderUtility.GetTimeoutCustomAttributeBuilder(scriptConfig.FunctionTimeout.Value);
                 customAttributes.Add(timeoutBuilder);
+            }
+            // apply retry settings for function execution
+            if (scriptConfig.Retry != null)
+            {
+                // apply the retry settings from host.json
+                var retryCustomAttributeBuilder = CustomAttributeBuilderUtility.GetRetryCustomAttributeBuilder(scriptConfig.Retry);
+                if (retryCustomAttributeBuilder != null)
+                {
+                    customAttributes.Add(retryCustomAttributeBuilder);
+                }
             }
 
             return customAttributes;

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -15,6 +15,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
@@ -755,8 +756,40 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public static bool IsMediaTypeOctetOrMultipart(MediaTypeHeaderValue mediaType)
         {
-                return mediaType != null && (string.Equals(mediaType.MediaType, ScriptConstants.MediatypeOctetStream, StringComparison.OrdinalIgnoreCase) ||
-                                mediaType.MediaType.IndexOf(ScriptConstants.MediatypeMutipartPrefix, StringComparison.OrdinalIgnoreCase) >= 0);
+            return mediaType != null && (string.Equals(mediaType.MediaType, ScriptConstants.MediatypeOctetStream, StringComparison.OrdinalIgnoreCase) ||
+                            mediaType.MediaType.IndexOf(ScriptConstants.MediatypeMutipartPrefix, StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+
+        public static void ValidateRetryOptions(RetryOptions
+            retryOptions)
+        {
+            if (retryOptions == null)
+            {
+                return;
+            }
+            switch (retryOptions.Strategy)
+            {
+                case RetryStrategy.FixedDelay:
+                    if (retryOptions.DelayInterval.Ticks <= 0)
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(retryOptions.DelayInterval));
+                    }
+                    // ensure values specified to create FixedDelayRetryAttribute are valid
+                    _ = new FixedDelayRetryAttribute(retryOptions.MaxRetryCount, retryOptions.DelayInterval.ToString());
+                    break;
+                case RetryStrategy.ExponentialBackoff:
+                    if (retryOptions.MinimumInterval.Ticks <= 0)
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(retryOptions.DelayInterval));
+                    }
+                    if (retryOptions.MaximumInterval.Ticks <= 0)
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(retryOptions.DelayInterval));
+                    }
+                    // ensure values specified to create ExponentialBackoffRetryAttribute are valid
+                    _ = new ExponentialBackoffRetryAttribute(retryOptions.MaxRetryCount, retryOptions.MinimumInterval.ToString(), retryOptions.MaximumInterval.ToString());
+                    break;
+            }
         }
 
         private class FilteredExpandoObjectConverter : ExpandoObjectConverter

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -50,7 +50,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.8" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.22" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Script.Abstractions" Version="1.0.0-preview" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.Abstractions" Version="1.0.1-preview" />
     <PackageReference Include="Microsoft.Build" Version="15.8.166" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.3.1" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.1.0" />

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -119,6 +119,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _testServer = new TestServer(builder) { BaseAddress = new Uri("https://localhost/") };
 
             HttpClient = _testServer.CreateClient();
+            HttpClient.Timeout = TimeSpan.FromMinutes(5);
 
             var manager = _testServer.Host.Services.GetService<IScriptHostManager>();
             _hostService = manager as WebJobsScriptHostService;

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_Retry.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_Retry.cs
@@ -2,26 +2,12 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.EventHubs;
-using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Config;
-using Microsoft.Azure.WebJobs.Script.Models;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.WebJobs.Script.Tests;
-using Microsoft.Azure.Storage.Blob;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_Retry.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_Retry.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Models;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.WebJobs.Script.Tests;
+using Microsoft.Azure.Storage.Blob;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
+{
+    [Trait(TestTraits.Category, TestTraits.EndToEnd)]
+    [Trait(TestTraits.Group, TestTraits.SamplesEndToEnd)]
+    public class SamplesEndToEndTests_Node_Retry : IClassFixture<SamplesEndToEndTests_Node_Retry.TestFixture>
+    {
+        private readonly ScriptSettingsManager _settingsManager;
+        private TestFixture _fixture;
+
+        public SamplesEndToEndTests_Node_Retry(TestFixture fixture)
+        {
+            _fixture = fixture;
+            _settingsManager = ScriptSettingsManager.Instance;
+        }
+
+        [Fact]
+        public async Task HttpTrigger_RetryFunctionJson_Get_Succeeds()
+        {
+            var response = await SamplesTestHelpers.InvokeHttpTrigger(_fixture, "HttpTrigger-RetryFunctionJson");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            string body = await response.Content.ReadAsStringAsync();
+            Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal("invocationCount: 4", body);
+        }
+
+        [Fact]
+        public async Task HttpTrigger_RetryHostJson_Get_Succeeds()
+        {
+            var response = await SamplesTestHelpers.InvokeHttpTrigger(_fixture, "HttpTrigger-RetryHostJson");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            string body = await response.Content.ReadAsStringAsync();
+            Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal("invocationCount: 2", body);
+        }
+
+        public class TestFixture : EndToEndTestFixture
+        {
+            static TestFixture()
+            {
+            }
+            
+            public TestFixture()
+                : base(Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample\NodeRetry"), "samples", RpcWorkerConstants.NodeLanguageWorkerName)
+            {
+            }
+
+            public override void ConfigureScriptHost(IWebJobsBuilder webJobsBuilder)
+            {
+                base.ConfigureScriptHost(webJobsBuilder);
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Configuration/ScriptHostOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ScriptHostOptionsSetupTests.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Azure.WebJobs.Script.Configuration;
-using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Xunit;
@@ -140,6 +140,75 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             var options = GetConfiguredOptions(settings);
 
             Assert.Equal(TimeSpan.FromSeconds(30), options.FunctionTimeout);
+        }
+
+        [Theory]
+        [InlineData("fixedDelay", "3", "00:00:05", false)]
+        [InlineData("invalid", "3", "00:00:05", true)]
+        [InlineData("fixedDelay", "3", null, true)]
+        [InlineData("fixedDelay", "3", "-10000000000", true)]
+        [InlineData("fixedDelay", "3", "10000000000:00000000:40000", true)]
+        public void Configure_AppliesRetry_FixedDelay(string expectedStrategy, string maxRetryCount, string delayInterval, bool throwsError)
+        {
+            var settings = new Dictionary<string, string>
+            {
+                { ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "retry", "strategy"), expectedStrategy },
+                { ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "retry", "maxRetryCount"), maxRetryCount },
+                { ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "retry", "delayInterval"), delayInterval }
+            };
+            if (string.IsNullOrEmpty(delayInterval))
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => GetConfiguredOptions(settings));
+                return;
+            }
+            if (throwsError)
+            {
+                Assert.Throws<InvalidOperationException>(() => GetConfiguredOptions(settings));
+                return;
+            }
+            var options = GetConfiguredOptions(settings);
+            Assert.Equal(RetryStrategy.FixedDelay, options.Retry.Strategy);
+            Assert.Equal(int.Parse(maxRetryCount), options.Retry.MaxRetryCount);
+            Assert.Equal(TimeSpan.Parse(delayInterval), options.Retry.DelayInterval);
+        }
+
+        [Theory]
+        [InlineData("ExponentialBackoff", "3", "00:00:05", "00:30:00", false)]
+        [InlineData("ExponentialBackoff", "sdfsdfd", "00:00:05", "00:30:00", true)]
+        [InlineData("ExponentialBackoff", "5", "00:35:05", "00:30:00", true)]
+        [InlineData("ExponentialBackoff", "5", null, "00:30:00", true)]
+        [InlineData("ExponentialBackoff", "5", "00:35:05", null, true)]
+        public void Configure_AppliesRetry_ExponentialBackOffDelay(string expectedStrategy, string maxRetryCount, string minimumInterval, string maximumInterval, bool throwsError)
+        {
+            var settings = new Dictionary<string, string>
+            {
+                { ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "retry", "strategy"), expectedStrategy },
+                { ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "retry", "maxRetryCount"), maxRetryCount },
+                { ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "retry", "minimumInterval"), minimumInterval },
+                { ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "retry", "maximumInterval"), maximumInterval }
+            };
+            if (string.IsNullOrEmpty(minimumInterval) || string.IsNullOrEmpty(maximumInterval))
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => GetConfiguredOptions(settings));
+                return;
+            }
+            var minIntervalTimeSpan = TimeSpan.Parse(minimumInterval);
+            var maxIntervalTimeSpan = TimeSpan.Parse(maximumInterval);
+            if (throwsError)
+            {
+                if (minIntervalTimeSpan > maxIntervalTimeSpan)
+                {
+                    Assert.Throws<ArgumentException>(() => GetConfiguredOptions(settings));
+                    return;
+                }
+                Assert.Throws<InvalidOperationException>(() => GetConfiguredOptions(settings));
+                return;
+            }
+            var options = GetConfiguredOptions(settings);
+            Assert.Equal(RetryStrategy.ExponentialBackoff, options.Retry.Strategy);
+            Assert.Equal(int.Parse(maxRetryCount), options.Retry.MaxRetryCount);
+            Assert.Equal(minIntervalTimeSpan, options.Retry.MinimumInterval);
+            Assert.Equal(maxIntervalTimeSpan, options.Retry.MaximumInterval);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/FunctionMetadataProviderTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionMetadataProviderTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public void ReadFunctionMetadata_With_Retry_Succeeds()
         {
-            string functionsPath = Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample\node-retry");
+            string functionsPath = Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample\noderetry");
             _scriptApplicationHostOptions.ScriptPath = functionsPath;
             var optionsMonitor = TestHelpers.CreateOptionsMonitor(_scriptApplicationHostOptions);
             var metadataProvider = new FunctionMetadataProvider(optionsMonitor, NullLogger<FunctionMetadataProvider>.Instance, _testMetricsLogger);
@@ -50,15 +50,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             Assert.Equal(2, functionMetadatas.Length);
 
-            var functionMetadataWithRetry = functionMetadatas.Where(f => f.Name.Contains("retry", StringComparison.OrdinalIgnoreCase));
+            var functionMetadataWithRetry = functionMetadatas.Where(f => f.Name.Contains("HttpTrigger-RetryFunctionJson", StringComparison.OrdinalIgnoreCase));
             Assert.Single(functionMetadataWithRetry);
             var retry = functionMetadataWithRetry.FirstOrDefault().Retry;
             Assert.NotNull(retry);
             Assert.Equal(RetryStrategy.FixedDelay, retry.Strategy);
-            Assert.Equal(2, retry.MaxRetryCount);
-            Assert.Equal(TimeSpan.Parse("00:00:10"), TimeSpan.FromSeconds(10));
+            Assert.Equal(4, retry.MaxRetryCount);
+            Assert.Equal(TimeSpan.Parse("00:00:03"), retry.DelayInterval);
 
-            var functionMetadata = functionMetadatas.Where(f => !f.Name.Contains("retry", StringComparison.OrdinalIgnoreCase));
+            var functionMetadata = functionMetadatas.Where(f => !f.Name.Contains("HttpTrigger-RetryFunctionJson", StringComparison.OrdinalIgnoreCase));
             Assert.Single(functionMetadataWithRetry);
             Assert.Null(functionMetadata.FirstOrDefault().Retry);
         }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Functions host changes to add retry support : https://github.com/Azure/azure-webjobs-sdk/pull/2463

Retry can be added in `host.json` for function app level or can be added in `function.json` for function level. If both are specified, `function.json` takes precedence.

```json
"retry": {
    "strategy": "fixedDelay",
    "maxRetryCount": 2,
    "delayInterval": "00:00:10"
  }
``` 
resolves #6664

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [x] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #6684
* [x] I have added all required tests (Unit tests, E2E tests)

Note: Documentation for this feature is tracked internally.