### PR TITLE
Update profile.ps1 template to set Disable-AzContextAutosave scope to process instead of current user.

### DIFF
--- a/src/WebJobs.Script/FileProvisioning/PowerShell/profile.ps1
+++ b/src/WebJobs.Script/FileProvisioning/PowerShell/profile.ps1
@@ -12,7 +12,7 @@
 # Authenticate with Azure PowerShell using MSI.
 # Remove this if you are not planning on using MSI or Azure PowerShell.
 if ($env:MSI_SECRET) {
-    Disable-AzContextAutosave
+    Disable-AzContextAutosave -Scope Process | Out-Null
     Connect-AzAccount -Identity
 }
 

--- a/test/WebJobs.Script.Tests/Resources/FileProvisioning/PowerShell/profile.ps1
+++ b/test/WebJobs.Script.Tests/Resources/FileProvisioning/PowerShell/profile.ps1
@@ -12,7 +12,7 @@
 # Authenticate with Azure PowerShell using MSI.
 # Remove this if you are not planning on using MSI or Azure PowerShell.
 if ($env:MSI_SECRET) {
-    Disable-AzContextAutosave
+    Disable-AzContextAutosave -Scope Process | Out-Null
     Connect-AzAccount -Identity
 }
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
resolves https://github.com/Azure/azure-functions-host/issues/6610

By default, `Disable-AzContextAutosave` cmdlet call in the profile.ps1 defaults to scope user. We need to set this option for the process, so adding `-Scope Process`. Also, adding Out-Null to omit the cmdlet output. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by https://github.com/Azure/azure-functions-host/pull/6615
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
