### PR TITLE
Update profile.ps1 template to set Disable-AzContextAutosave scope to process instead of current user.

### DIFF
--- a/src/WebJobs.Script/FileProvisioning/PowerShell/profile.ps1
+++ b/src/WebJobs.Script/FileProvisioning/PowerShell/profile.ps1
@@ -12,7 +12,7 @@
 # Authenticate with Azure PowerShell using MSI.
 # Remove this if you are not planning on using MSI or Azure PowerShell.
 if ($env:MSI_SECRET) {
-    Disable-AzContextAutosave
+    Disable-AzContextAutosave -Scope Process | Out-Null
     Connect-AzAccount -Identity
 }
 

--- a/test/WebJobs.Script.Tests/FileProvisioning/PowerShellFileProvisionerTests.cs
+++ b/test/WebJobs.Script.Tests/FileProvisioning/PowerShellFileProvisionerTests.cs
@@ -32,6 +32,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.FileAugmentation
         private const string PSGalleryEmptyFeedResourceFileName =
             "Microsoft.Azure.WebJobs.Script.Tests.Resources.FileProvisioning.PowerShell.PSGalleryEmptyFeed.xml";
 
+        private const string ProfileFileResourceFileName =
+            "Microsoft.Azure.WebJobs.Script.Tests.Resources.FileProvisioning.PowerShell.profile.ps1";
+
         private readonly string _scriptRootPath;
         private readonly ILoggerFactory _loggerFactory = new LoggerFactory();
         private readonly TestLoggerProvider _loggerProvider = new TestLoggerProvider();
@@ -57,6 +60,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.FileAugmentation
             string requirementsContent = File.ReadAllText(Path.Combine(_scriptRootPath, RequirementsPsd1FileName));
             string expectedContent = FileUtility.ReadResourceString(RequirementsPsd1PSGalleryOnlineResourceFileName);
             Assert.Equal(expectedContent, requirementsContent, StringComparer.OrdinalIgnoreCase);
+
+            string profileContent = File.ReadAllText(Path.Combine(_scriptRootPath, ProfilePs1FileName));
+            string expectedProfileContent = FileUtility.ReadResourceString(ProfileFileResourceFileName);
+            Assert.Equal(expectedProfileContent, profileContent, StringComparer.OrdinalIgnoreCase);
 
             ValidateLogs(_loggerProvider, _scriptRootPath);
         }

--- a/test/WebJobs.Script.Tests/Resources/FileProvisioning/PowerShell/profile.ps1
+++ b/test/WebJobs.Script.Tests/Resources/FileProvisioning/PowerShell/profile.ps1
@@ -1,4 +1,4 @@
-﻿# Azure Functions profile.ps1
+# Azure Functions profile.ps1
 #
 # This profile.ps1 will get executed every "cold start" of your Function App.
 # "cold start" occurs when:

--- a/test/WebJobs.Script.Tests/Resources/FileProvisioning/PowerShell/profile.ps1
+++ b/test/WebJobs.Script.Tests/Resources/FileProvisioning/PowerShell/profile.ps1
@@ -12,7 +12,7 @@
 # Authenticate with Azure PowerShell using MSI.
 # Remove this if you are not planning on using MSI or Azure PowerShell.
 if ($env:MSI_SECRET) {
-    Disable-AzContextAutosave
+    Disable-AzContextAutosave -Scope Process | Out-Null
     Connect-AzAccount -Identity
 }
 

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -109,13 +109,15 @@
     <None Remove="Resources\FileProvisioning\PowerShell\PSGallerySampleFeed.xml" />
     <None Remove="Resources\FileProvisioning\PowerShell\requirements_PSGalleryOffline.psd1" />
     <None Remove="Resources\FileProvisioning\PowerShell\requirements_PSGalleryOnline.psd1" />
+    <None Remove="Resources\FileProvisioning\PowerShell\profile.ps1" />
   </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="Resources\FileProvisioning\PowerShell\PSGallerySampleFeed.xml" />
     <EmbeddedResource Include="Resources\FileProvisioning\PowerShell\PSGalleryEmptyFeed.xml" />
     <EmbeddedResource Include="Resources\FileProvisioning\PowerShell\requirements_PSGalleryOffline.psd1" />
-    <EmbeddedResource Include="Resources\FileProvisioning\PowerShell\requirements_PSGalleryOnline.psd1">
+    <EmbeddedResource Include="Resources\FileProvisioning\PowerShell\requirements_PSGalleryOnline.psd1"/>
+    <EmbeddedResource Include="Resources\FileProvisioning\PowerShell\profile.ps1">
     <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Backporting changes to v2.

resolves https://github.com/Azure/azure-functions-host/issues/6610

By default, `Disable-AzContextAutosave` cmdlet call in the profile.ps1 defaults to scope user. We need to set this option for the process, so adding `-Scope Process`. Also, adding Out-Null to omit the cmdlet output. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
