### PR TITLE
improving native asset probing

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
+++ b/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
@@ -5,11 +5,11 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
-using System.Threading;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Extensions.DependencyModel;
@@ -373,28 +373,48 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             return base.LoadUnmanagedDll(unmanagedDllName);
         }
 
-        private string GetRuntimeNativeAssetPath(string assetFileName)
+        internal string GetRuntimeNativeAssetPath(string assetFileName)
         {
-            string basePath = _probingPaths[0];
-            const string ridSubFolder = "native";
-            string runtimesPath = Path.Combine(basePath, "runtimes");
-
-            List<string> rids = DependencyHelper.GetRuntimeFallbacks();
-
-            string result = rids.Select(r => Path.Combine(runtimesPath, r, ridSubFolder, assetFileName))
-                .Union(_probingPaths)
-                .FirstOrDefault(p => File.Exists(p));
+            string result = ProbeForNativeAsset(_probingPaths, assetFileName, FileUtility.Instance.File);
 
             if (result == null && _nativeLibraries != null)
             {
                 if (TryGetDepsAsset(_nativeLibraries, assetFileName, _currentRidFallback, out string relativePath))
                 {
+                    string basePath = _probingPaths[0];
+
                     string nativeLibraryFullPath = Path.Combine(basePath, relativePath);
                     if (File.Exists(nativeLibraryFullPath))
                     {
                         result = nativeLibraryFullPath;
                     }
                 }
+            }
+
+            return result;
+        }
+
+        internal static string ProbeForNativeAsset(IList<string> probingPaths, string assetFileName, FileBase fileBase)
+        {
+            string basePath = probingPaths[0];
+            const string ridSubFolder = "native";
+            const string runtimesSubFolder = "runtimes";
+            string runtimesPath = Path.Combine(basePath, runtimesSubFolder);
+
+            List<string> rids = DependencyHelper.GetRuntimeFallbacks();
+
+            string result = rids.Select(r => Path.Combine(runtimesPath, r, ridSubFolder, assetFileName))
+                .Union(probingPaths.Select(p => Path.Combine(p, assetFileName)))
+                .FirstOrDefault(p => fileBase.Exists(p));
+
+            // Need to also probe with the parent directory as the base due to
+            // issue https://github.com/Azure/azure-functions-host/issues/6620
+            if (result == null)
+            {
+                string fallbackBasePath = Directory.GetParent(basePath).FullName;
+                string fallbackRuntimesPath = Path.Combine(fallbackBasePath, "runtimes");
+                result = rids.Select(r => Path.Combine(fallbackRuntimesPath, r, ridSubFolder, assetFileName))
+                    .FirstOrDefault(p => fileBase.Exists(p));
             }
 
             return result;

--- a/test/WebJobs.Script.Tests/Description/DotNet/FunctionAssemblyLoadContextTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/FunctionAssemblyLoadContextTests.cs
@@ -3,15 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.IO;
+using System.IO.Abstractions;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 using Microsoft.Azure.WebJobs.Script.Description;
-using Microsoft.Azure.WebJobs.Script.Extensibility;
-using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
-using Microsoft.Extensions.DependencyModel;
 using Moq;
 using Xunit;
 
@@ -120,6 +117,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 : null;
 
             Assert.Equal(expectedMatch, assetPath);
+        }
+
+        [Theory]
+        [InlineData(@"c:\a\bin\runtimes\win\native\assembly.dll")]
+        [InlineData(@"c:\a\bin\assembly.dll")]
+        [InlineData(@"c:\a\runtimes\win\native\assembly.dll")]
+        public void ProbeForNativeAssets_FindsAsset(string assetPath)
+        {
+            var probingPaths = new List<string> { @"c:\a\bin" };
+
+            Mock<FileBase> mockFile = new Mock<FileBase>(MockBehavior.Strict);
+            mockFile
+                .Setup(m => m.Exists(It.IsAny<string>()))
+                .Returns<string>(s => s == assetPath);
+
+            string result = FunctionAssemblyLoadContext.ProbeForNativeAsset(probingPaths, "assembly.dll", mockFile.Object);
+            Assert.Equal(assetPath, result);
         }
     }
 }


### PR DESCRIPTION
Native assembly probing was missing two scenarios:
- An assembly directly in the `/bin` path wasn't being found as the search was comparing directories, rather than files. This meant that a project published with a target runtime like "win-x64" wouldn't find the native asset.
- Due to a bug when publishing a v2 app with Microsoft.Net.Sdk.Functions 1.029 and earlier while also having .NET Core 3 on the machine, there is a chance that the native assets are not in the `/bin` folder, but one directory up. This was fixed in 1.0.30 but there are still apps that may have this scenario.

resolves #6619 
resolves #6620 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
