### PR TITLE
Fixing issues with native assembly loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ tools/ExtensionsMetadataGenerator/packages
 /buildoutput
 /tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/runtimeassemblies.txt
 /tools/ExtensionsMetadataGenerator/test/ExtensionsMetadataGeneratorTests/runtimeAssemblies.txt
+
+local.settings.json
+msbuild.binlog

--- a/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
+++ b/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
@@ -409,16 +409,6 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 .Union(probingPaths.Select(p => Path.Combine(p, assetFileName)))
                 .FirstOrDefault(p => fileBase.Exists(p));
 
-            // Need to also probe with the parent directory as the base due to
-            // issue https://github.com/Azure/azure-functions-host/issues/6620
-            if (result == null)
-            {
-                string fallbackBasePath = Directory.GetParent(basePath).FullName;
-                string fallbackRuntimesPath = Path.Combine(fallbackBasePath, "runtimes");
-                result = rids.Select(r => Path.Combine(fallbackRuntimesPath, r, ridSubFolder, assetFileName))
-                    .FirstOrDefault(p => fileBase.Exists(p));
-            }
-
             return result;
         }
 

--- a/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
+++ b/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Abstractions;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -374,28 +375,48 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             return base.LoadUnmanagedDll(unmanagedDllName);
         }
 
-        private string GetRuntimeNativeAssetPath(string assetFileName)
+        internal string GetRuntimeNativeAssetPath(string assetFileName)
         {
-            string basePath = _probingPaths[0];
-            const string ridSubFolder = "native";
-            string runtimesPath = Path.Combine(basePath, "runtimes");
-
-            List<string> rids = DependencyHelper.GetRuntimeFallbacks();
-
-            string result = rids.Select(r => Path.Combine(runtimesPath, r, ridSubFolder, assetFileName))
-                .Union(_probingPaths)
-                .FirstOrDefault(p => File.Exists(p));
+            string result = ProbeForNativeAsset(_probingPaths, assetFileName, FileUtility.Instance.File);
 
             if (result == null && _nativeLibraries != null)
             {
                 if (TryGetDepsAsset(_nativeLibraries, assetFileName, _currentRidFallback, out string relativePath))
                 {
+                    string basePath = _probingPaths[0];
+
                     string nativeLibraryFullPath = Path.Combine(basePath, relativePath);
                     if (File.Exists(nativeLibraryFullPath))
                     {
                         result = nativeLibraryFullPath;
                     }
                 }
+            }
+
+            return result;
+        }
+
+        internal static string ProbeForNativeAsset(IList<string> probingPaths, string assetFileName, FileBase fileBase)
+        {
+            string basePath = probingPaths[0];
+            const string ridSubFolder = "native";
+            const string runtimesSubFolder = "runtimes";
+            string runtimesPath = Path.Combine(basePath, runtimesSubFolder);
+
+            List<string> rids = DependencyHelper.GetRuntimeFallbacks();
+
+            string result = rids.Select(r => Path.Combine(runtimesPath, r, ridSubFolder, assetFileName))
+                .Union(probingPaths.Select(p => Path.Combine(p, assetFileName)))
+                .FirstOrDefault(p => fileBase.Exists(p));
+
+            // Need to also probe with the parent directory as the base due to
+            // issue https://github.com/Azure/azure-functions-host/issues/6620
+            if (result == null)
+            {
+                string fallbackBasePath = Directory.GetParent(basePath).FullName;
+                string fallbackRuntimesPath = Path.Combine(fallbackBasePath, "runtimes");
+                result = rids.Select(r => Path.Combine(fallbackRuntimesPath, r, ridSubFolder, assetFileName))
+                    .FirstOrDefault(p => fileBase.Exists(p));
             }
 
             return result;

--- a/test/CSharpPrecompiledTestProjects/CSharpPrecompiledTestProjects.sln
+++ b/test/CSharpPrecompiledTestProjects/CSharpPrecompiledTestProjects.sln
@@ -5,7 +5,11 @@ VisualStudioVersion = 16.0.30413.136
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebJobsStartupTests", "WebJobsStartupTests\WebJobsStartupTests.csproj", "{EB7FC98C-1EF9-40E3-B7B2-858AA2547B1F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyLoadContextRace", "AssemblyLoadContextRace\AssemblyLoadContextRace.csproj", "{1E882F3E-E1D1-4D56-A575-8530596705C3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyLoadContextRace", "AssemblyLoadContextRace\AssemblyLoadContextRace.csproj", "{1E882F3E-E1D1-4D56-A575-8530596705C3}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NativeDependencyOldSdk", "NativeDependencyOldSdk\NativeDependencyOldSdk.csproj", "{C2164420-D424-4737-8A21-CEADEC619FDB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NativeDependencyNoRuntimes", "NativeDependencyNoRuntimes\NativeDependencyNoRuntimes.csproj", "{928B573E-904B-4733-86A2-6CDBF78D24AA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +25,14 @@ Global
 		{1E882F3E-E1D1-4D56-A575-8530596705C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1E882F3E-E1D1-4D56-A575-8530596705C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1E882F3E-E1D1-4D56-A575-8530596705C3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C2164420-D424-4737-8A21-CEADEC619FDB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C2164420-D424-4737-8A21-CEADEC619FDB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C2164420-D424-4737-8A21-CEADEC619FDB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C2164420-D424-4737-8A21-CEADEC619FDB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{928B573E-904B-4733-86A2-6CDBF78D24AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{928B573E-904B-4733-86A2-6CDBF78D24AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{928B573E-904B-4733-86A2-6CDBF78D24AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{928B573E-904B-4733-86A2-6CDBF78D24AA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/test/CSharpPrecompiledTestProjects/NativeDependencyNoRuntimes/NativeDependencyNoRuntimes.cs
+++ b/test/CSharpPrecompiledTestProjects/NativeDependencyNoRuntimes/NativeDependencyNoRuntimes.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Data.Common;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+using Microsoft.Azure.Documents.Linq;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Extensions.Configuration;
+
+namespace NativeDependencyWithTargetFramework
+{
+    public class NativeDependencyNoRuntimes
+    {
+        private readonly IConfiguration _config;
+
+        public NativeDependencyNoRuntimes(IConfiguration config)
+        {
+            _config = config;
+        }
+
+        [FunctionName("NativeDependencyNoRuntimes")]
+        public async Task<IActionResult> Run(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)] HttpRequest req)
+        {
+            // Issue a query against Cosmos that forces a native assembly to load.
+
+            string cosmosConnection = _config.GetConnectionString("CosmosDB");
+            var builder = new DbConnectionStringBuilder()
+            {
+                ConnectionString = cosmosConnection
+            };
+
+            builder.TryGetValue("AccountEndpoint", out object dbUri);
+            builder.TryGetValue("AccountKey", out object dbKey);
+
+            var client = new DocumentClient(new Uri(dbUri.ToString()), dbKey.ToString());
+            Uri collUri = UriFactory.CreateDocumentCollectionUri("ItemDb", "ItemCollection");
+
+            var options = new FeedOptions
+            {
+                EnableCrossPartitionQuery = true
+            };
+
+            IDocumentQuery<Document> documentQuery = client.CreateDocumentQuery<Document>(collUri, "SELECT * FROM c WHERE STARTSWITH(c.id, @PartitionLeasePrefix)", options).AsDocumentQuery<Document>();
+
+            await documentQuery.ExecuteNextAsync();
+
+            return new OkResult();
+        }
+    }
+}

--- a/test/CSharpPrecompiledTestProjects/NativeDependencyNoRuntimes/NativeDependencyNoRuntimes.csproj
+++ b/test/CSharpPrecompiledTestProjects/NativeDependencyNoRuntimes/NativeDependencyNoRuntimes.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>    
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+  <Target Name="DeleteRuntimesFolder" AfterTargets="Build">
+    <!--Simulate what it looks like when we build against a runtime-->
+    <RemoveDir Directories="$(OutDir)\bin\runtimes" />    
+  </Target>
+</Project>

--- a/test/CSharpPrecompiledTestProjects/NativeDependencyNoRuntimes/host.json
+++ b/test/CSharpPrecompiledTestProjects/NativeDependencyNoRuntimes/host.json
@@ -1,0 +1,11 @@
+{
+    "version": "2.0",
+    "logging": {
+        "applicationInsights": {
+            "samplingExcludedTypes": "Request",
+            "samplingSettings": {
+                "isEnabled": true
+            }
+        }
+    }
+}

--- a/test/CSharpPrecompiledTestProjects/NativeDependencyOldSdk/NativeDependencyOldSdk.cs
+++ b/test/CSharpPrecompiledTestProjects/NativeDependencyOldSdk/NativeDependencyOldSdk.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Data.Common;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+using Microsoft.Azure.Documents.Linq;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Extensions.Configuration;
+
+namespace NativeDependencyOldSdk
+{
+    public class NativeDependencyOldSdk
+    {
+        private readonly IConfiguration _config;
+        public NativeDependencyOldSdk(IConfiguration config)
+        {
+            _config = config;
+        }
+
+        [FunctionName("NativeDependencyOldSdk")]
+        public async Task<IActionResult> Run(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)] HttpRequest req)
+        {
+            // Issue a query against Cosmos that forces a native assembly to load.
+
+            string cosmosConnection = _config.GetConnectionString("CosmosDB");
+            var builder = new DbConnectionStringBuilder()
+            {
+                ConnectionString = cosmosConnection
+            };
+
+            builder.TryGetValue("AccountEndpoint", out object dbUri);
+            builder.TryGetValue("AccountKey", out object dbKey);
+
+            var client = new DocumentClient(new Uri(dbUri.ToString()), dbKey.ToString());
+            Uri collUri = UriFactory.CreateDocumentCollectionUri("ItemDb", "ItemCollection");
+
+            var options = new FeedOptions
+            {
+                EnableCrossPartitionQuery = true
+            };
+
+            IDocumentQuery<Document> documentQuery = client.CreateDocumentQuery<Document>(collUri, "SELECT * FROM c WHERE STARTSWITH(c.id, @PartitionLeasePrefix)", options).AsDocumentQuery<Document>();
+
+            await documentQuery.ExecuteNextAsync();
+
+            return new OkResult();
+        }
+    }
+}

--- a/test/CSharpPrecompiledTestProjects/NativeDependencyOldSdk/NativeDependencyOldSdk.csproj
+++ b/test/CSharpPrecompiledTestProjects/NativeDependencyOldSdk/NativeDependencyOldSdk.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">  
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <AzureFunctionsVersion>v2</AzureFunctionsVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <!--This test is specifically for a scenario where this Sdk version in v2 caused native assembly issues during a publish-->
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.26" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/test/CSharpPrecompiledTestProjects/NativeDependencyOldSdk/host.json
+++ b/test/CSharpPrecompiledTestProjects/NativeDependencyOldSdk/host.json
@@ -1,0 +1,11 @@
+{
+    "version": "2.0",
+    "logging": {
+        "applicationInsights": {
+            "samplingExcludedTypes": "Request",
+            "samplingSettings": {
+                "isEnabled": true
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/FunctionAssemblyLoadContextEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/FunctionAssemblyLoadContextEndToEndTests.cs
@@ -1,30 +1,134 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Tests.EndToEnd;
+using Microsoft.Extensions.Configuration;
+using Microsoft.WebJobs.Script.Tests;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
 {
+    [Trait(TestTraits.Category, TestTraits.EndToEnd)]
+    [Trait(TestTraits.Group, nameof(CSharpEndToEndTests))]
     public class FunctionAssemblyLoadContextEndToEndTests : IDisposable
     {
-        HostProcessLauncher _launcher;
+        private readonly ITestOutputHelper _output;
+
+        private bool success = true;
+        private HostProcessLauncher _launcher;
+
+        public FunctionAssemblyLoadContextEndToEndTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
 
         [Fact]
         public async Task Fallback_IsThreadSafe()
         {
-            _launcher = new HostProcessLauncher("AssemblyLoadContextRace");
-            await _launcher.StartHostAsync();
+            await RunTest(async () =>
+            {
+                _launcher = new HostProcessLauncher("AssemblyLoadContextRace");
+                await _launcher.StartHostAsync();
 
-            var client = _launcher.HttpClient;
-            var response = await client.GetAsync($"api/Function1");
+                var client = _launcher.HttpClient;
+                var response = await client.GetAsync($"api/Function1");
 
-            // The function does all the validation internally.
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                // The function does all the validation internally.
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            });
         }
+
+        [Fact]
+        public async Task NativeDependency_Quirks()
+        {
+            // Test a specific bug that hit on v2 with earlier versions of the VS SDK, only 
+            // when publishing
+
+            await RunTest(async () =>
+            {
+                var config = TestHelpers.GetTestConfiguration();
+                var connStr = config.GetConnectionString("CosmosDB");
+                string cosmosKey = "ConnectionStrings__CosmosDB";
+
+                var envVars = new Dictionary<string, string>
+                {
+                    { cosmosKey, connStr }
+                };
+
+                _launcher = new HostProcessLauncher("NativeDependencyOldSdk", envVars, usePublishPath: true, "netcoreapp2.2");
+                await _launcher.StartHostAsync();
+
+                var client = _launcher.HttpClient;
+                var response = await client.GetAsync($"api/NativeDependencyOldSdk");
+
+                // The function does all the validation internally.
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            });
+        }
+
+        [Fact]
+        public async Task NativeDependency_NoRuntimes()
+        {
+            // Test that we load the correct native assembly when built against a rid, which removed
+            // the runtimes folder. We should be finding the assembly in the bin dir directly.
+
+            await RunTest(async () =>
+            {
+                var config = TestHelpers.GetTestConfiguration();
+                var connStr = config.GetConnectionString("CosmosDB");
+                string cosmosKey = "ConnectionStrings__CosmosDB";
+
+                var envVars = new Dictionary<string, string>
+                {
+                    { cosmosKey, connStr }
+                };
+
+                _launcher = new HostProcessLauncher("NativeDependencyNoRuntimes", envVars);
+                await _launcher.StartHostAsync();
+
+                var client = _launcher.HttpClient;
+                var response = await client.GetAsync($"api/NativeDependencyNoRuntimes");
+
+                // The function does all the validation internally.
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            });
+        }
+
+        private async Task RunTest(Func<Task> test)
+        {
+            try
+            {
+                await test();
+            }
+            catch (Exception)
+            {
+                success = false;
+                throw;
+            }
+        }
+
 
         public void Dispose()
         {
             _launcher?.Dispose();
+
+            if (!success)
+            {
+                // Dump logs to console
+                _output.WriteLine("=== Output ===");
+                foreach (var log in _launcher.OutputLogs)
+                {
+                    _output.WriteLine(log);
+                }
+
+                _output.WriteLine("=== Errors ===");
+                foreach (var log in _launcher.ErrorLogs)
+                {
+                    _output.WriteLine(log);
+                }
+            }
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/HostProcessLauncher.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/HostProcessLauncher.cs
@@ -14,10 +14,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
     /// </summary>
     public class HostProcessLauncher : IDisposable
     {
-        private const string TestPathTemplate = "..\\..\\..\\..\\..\\test\\CSharpPrecompiledTestProjects\\{0}\\bin\\Debug\\netcoreapp3.1";
+        private const string TestPathTemplate = "..\\..\\..\\..\\..\\test\\CSharpPrecompiledTestProjects\\{0}\\bin\\Debug\\{1}";
         private const int _port = 3479;
 
         private readonly string _testPath;
+        private readonly IDictionary<string, string> _envVars;
         private readonly Process _process = new Process();
         private readonly IList<string> _outputLogs = new List<string>();
         private readonly IList<string> _errorLogs = new List<string>();
@@ -29,9 +30,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
             return client;
         });
 
-        public HostProcessLauncher(string testProjectName)
+        public HostProcessLauncher(string testProjectName, IDictionary<string, string> envVars = null,
+            bool usePublishPath = false, string targetFramework = "netcoreapp3.1")
         {
-            _testPath = Path.GetFullPath(string.Format(TestPathTemplate, testProjectName));
+            _testPath = Path.GetFullPath(string.Format(TestPathTemplate, testProjectName, targetFramework));
+
+            if (usePublishPath)
+            {
+                _testPath = Path.Combine(_testPath, "publish");
+            }
+
+            _envVars = envVars ?? new Dictionary<string, string>();
         }
 
         internal HttpClient HttpClient => _lazyClient.Value;
@@ -56,7 +65,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                 ErrorDialog = false,
                 WorkingDirectory = workingDir
             };
+
             _process.StartInfo.Environment.Add("AzureWebJobsScriptRoot", _testPath);
+            _process.StartInfo.Environment.Add("AZURE_FUNCTIONS_ENVIRONMENT", "Development");
+
+            foreach (var envVar in _envVars)
+            {
+                _process.StartInfo.Environment.Add(envVar.Key, envVar.Value);
+            }
+
             _process.EnableRaisingEvents = true;
             _process.OutputDataReceived += Process_OutputDataReceived;
             _process.ErrorDataReceived += Process_ErrorDataReceived;

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -108,7 +108,7 @@
   <!-- Ensure this is built for tests; we cannot have a project reference due to conflicting nuget references -->  
   <Target Name="BuildTestProjects" AfterTargets="Build">
     <MSBuild Projects="..\CSharpPrecompiledTestProjects\CSharpPrecompiledTestProjects.sln" Targets="Restore" />
-    <MSBuild Projects="..\CSharpPrecompiledTestProjects\CSharpPrecompiledTestProjects.sln" Targets="Build" Properties="Configuration=Debug" />
+    <MSBuild Projects="..\CSharpPrecompiledTestProjects\CSharpPrecompiledTestProjects.sln" Targets="Publish" Properties="Configuration=Debug" />
   </Target>
   
 </Project>

--- a/test/WebJobs.Script.Tests/Description/DotNet/FunctionAssemblyLoadContextTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/FunctionAssemblyLoadContextTests.cs
@@ -3,15 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.IO;
+using System.IO.Abstractions;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 using Microsoft.Azure.WebJobs.Script.Description;
-using Microsoft.Azure.WebJobs.Script.Extensibility;
-using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
-using Microsoft.Extensions.DependencyModel;
 using Moq;
 using Xunit;
 
@@ -120,6 +117,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 : null;
 
             Assert.Equal(expectedMatch, assetPath);
+        }
+
+        [Theory]
+        [InlineData(@"c:\a\bin\runtimes\win\native\assembly.dll")]
+        [InlineData(@"c:\a\bin\assembly.dll")]
+        [InlineData(@"c:\a\runtimes\win\native\assembly.dll")]
+        public void ProbeForNativeAssets_FindsAsset(string assetPath)
+        {
+            var probingPaths = new List<string> { @"c:\a\bin" };
+
+            Mock<FileBase> mockFile = new Mock<FileBase>(MockBehavior.Strict);
+            mockFile
+                .Setup(m => m.Exists(It.IsAny<string>()))
+                .Returns<string>(s => s == assetPath);
+
+            string result = FunctionAssemblyLoadContext.ProbeForNativeAsset(probingPaths, "assembly.dll", mockFile.Object);
+            Assert.Equal(assetPath, result);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Description/DotNet/FunctionAssemblyLoadContextTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/FunctionAssemblyLoadContextTests.cs
@@ -122,7 +122,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Theory]
         [InlineData(@"c:\a\bin\runtimes\win\native\assembly.dll")]
         [InlineData(@"c:\a\bin\assembly.dll")]
-        [InlineData(@"c:\a\runtimes\win\native\assembly.dll")]
         public void ProbeForNativeAssets_FindsAsset(string assetPath)
         {
             var probingPaths = new List<string> { @"c:\a\bin" };


### PR DESCRIPTION
### Issue describing the changes in this PR

Native assembly probing was missing two scenarios:

- An assembly directly in the /bin path wasn't being found as the search was comparing directories, rather than files. This meant that a project published with a target runtime like "win-x64" wouldn't find the native asset.
- Due to a bug when publishing a v2 app with Microsoft.Net.Sdk.Functions 1.029 and earlier while also having .NET Core 3 on the machine, there is a chance that the native assets are not in the /bin folder, but one directory up. This was fixed in 1.0.30 but there are still apps that may have this scenario.

resolves #6619
resolves #6620

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #6666
* [x] I have added all required tests (Unit tests, E2E tests)