### PR TITLE
[Port] Deserialize HttpOutputBinding response and convert to ExpandoObject

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,6 +6,14 @@
 - Update Python Worker to 1.1.5 [Release Note](https://github.com/Azure/azure-functions-python-worker/releases/tag/1.1.5)
 - Update Python Library to 1.3.1 [Release Note](https://github.com/Azure/azure-functions-python-library/releases/tag/1.3.1)
 - Add a new host.json property "watchFiles" for restarting the Host when files are modified.
+- [CustomHandler][Breaking] If enableForwardingHttpRequest is false, http output binding response is expected to be a valid Json object with following optional fields :
+`{
+"statusCode" : "",
+"status" : "",
+"body": "",
+"headers" : {}
+}`
+Exception is thrown if HttpOutputBindingResponse is not valid Json.
 
 **Release sprint:** Sprint 84
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+84%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+84%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script/Workers/Http/HttpScriptInvocationResultExtensions.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpScriptInvocationResultExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Linq;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Newtonsoft.Json;
@@ -78,19 +79,25 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
 
         internal static object GetHttpOutputBindingResponse(string bindingName, IDictionary<string, object> outputsFromWorker)
         {
-            HttpOutputBindingResponse httpOut = new HttpOutputBindingResponse();
+            dynamic httpOutput = new ExpandoObject();
+
             if (outputsFromWorker.TryGetValue(bindingName, out object outputBindingValue))
             {
                 try
                 {
-                    httpOut = JsonConvert.DeserializeObject<HttpOutputBindingResponse>(outputBindingValue.ToString());
+                    HttpOutputBindingResponse httpOutputBindingResponse = JsonConvert.DeserializeObject<HttpOutputBindingResponse>(outputBindingValue.ToString());
+
+                    httpOutput.StatusCode = httpOutputBindingResponse.StatusCode;
+                    httpOutput.Status = httpOutputBindingResponse.Status;
+                    httpOutput.Body = httpOutputBindingResponse.Body;
+                    httpOutput.Headers = httpOutputBindingResponse.Headers;
                 }
-                catch
+                catch (Exception ex)
                 {
-                    //ignore
+                    throw new InvalidOperationException("Failed while trying to Deserialize to httpOutputBindingResponse. Output is not in expected format", ex.InnerException);
                 }
             }
-            return JsonConvert.SerializeObject(httpOut);
+            return httpOutput;
         }
 
         private static BindingMetadata GetBindingMetadata(string outputBidingName, ScriptInvocationContext scriptInvocationContext)

--- a/test/WebJobs.Script.Tests/HttpWorker/DefaultHttpWorkerServiceTests.cs
+++ b/test/WebJobs.Script.Tests/HttpWorker/DefaultHttpWorkerServiceTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -115,13 +116,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
 
             var expectedHttpScriptInvocationResult = HttpWorkerTestUtilities.GetHttpScriptInvocationResultWithJsonRes();
             var testLogs = _functionLogger.GetLogMessages();
+            var response = invocationResult.Outputs["res"] as ExpandoObject;
+            response.TryGetValue<object>("Body", out var body, ignoreCase: true);
+            response.TryGetValue<object>("StatusCode", out var statusCode, ignoreCase: true);
+
             Assert.True(testLogs.Count() == expectedHttpScriptInvocationResult.Logs.Count());
             Assert.True(testLogs.All(m => m.FormattedMessage.Contains("invocation log")));
             Assert.Equal(expectedHttpScriptInvocationResult.Outputs.Count(), invocationResult.Outputs.Count());
             Assert.Equal(expectedHttpScriptInvocationResult.ReturnValue, invocationResult.Return);
-            var responseJson = JObject.Parse(invocationResult.Outputs["res"].ToString());
-            Assert.Equal("my world", responseJson["Body"]);
-            Assert.Equal("201", responseJson["StatusCode"]);
+            Assert.Equal("my world", body);
+            Assert.Equal("201", statusCode);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/HttpWorker/HttpScriptInvocationResultExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/HttpWorker/HttpScriptInvocationResultExtensionsTests.cs
@@ -3,8 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
+using System.Dynamic;
 using Microsoft.Azure.WebJobs.Script.Workers.Http;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -14,15 +15,25 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
     {
         [Theory]
         [InlineData("{\"statusCode\": \"204\"}", "{\"StatusCode\":\"204\",\"Status\":null,\"Body\":null,\"Headers\":null}")]
+        [InlineData("{}", "{\"StatusCode\":null,\"Status\":null,\"Body\":null,\"Headers\":null}")]
         [InlineData("{\"body\": \"hello\"}", "{\"StatusCode\":null,\"Status\":null,\"Body\":\"hello\",\"Headers\":null}")]
         [InlineData("{\"body\": \"hello\", \"statusCode\":\"300\"}", "{\"StatusCode\":\"300\",\"Status\":null,\"Body\":\"hello\",\"Headers\":null}")]
         [InlineData("{\"body\":\"foobar\",\"statusCode\":\"301\",\"headers\":{\"header1\":\"header1Value\",\"header2\":\"header2Value\"}}", "{\"StatusCode\":\"301\",\"Status\":null,\"Body\":\"foobar\",\"Headers\":{\"header1\":\"header1Value\",\"header2\":\"header2Value\"}}")]
-        public void GetHttpOutputBindingResponse_ReturnsExpected(string inputString, string expectedOutput)
+        [InlineData("SomeBlah", "", true)]
+        public void GetHttpOutputBindingResponse_ReturnsExpected(string inputString, string expectedOutput = "", bool isExceptionExpected = false)
         {
             Dictionary<string, object> outputsFromWorker = new Dictionary<string, object>();
             outputsFromWorker["httpOutput1"] = inputString;
-            var actualResult = HttpScriptInvocationResultExtensions.GetHttpOutputBindingResponse("httpOutput1", outputsFromWorker);
-            Assert.Equal(expectedOutput, actualResult);
+            if (isExceptionExpected)
+            {
+                Assert.Throws<InvalidOperationException>(() => HttpScriptInvocationResultExtensions.GetHttpOutputBindingResponse("httpOutput1", outputsFromWorker));
+            }
+            else
+            {
+                var actualResult = HttpScriptInvocationResultExtensions.GetHttpOutputBindingResponse("httpOutput1", outputsFromWorker);
+                Assert.True(actualResult is ExpandoObject);
+                Assert.Equal(expectedOutput, JsonConvert.SerializeObject(actualResult));
+            }
         }
 
         [Theory]
@@ -38,9 +49,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
             }
             var result = testHttpInvocationResult.ToScriptInvocationResult(testInvocationContext);
             Assert.Null(result.Return);
-
-            var resResult = JObject.Parse((string)result.Outputs["res"]);
-            Assert.Equal("my world", resResult["Body"]);
+            ExpandoObject output = result.Outputs["res"] as ExpandoObject;
+            output.TryGetValue<object>("Body", out var resResult, ignoreCase: true);
+            Assert.Equal("my world", resResult);
         }
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Backport for https://github.com/Azure/azure-functions-host/commit/c4100a7f0ad561c12d5f6b24ae1cba4270e9c6c8

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
