### PR TITLE
Added support for overwriting app insights endpoints for telemetry and quick pulse

### DIFF
--- a/src/WebJobs.Script.Host/WebJobs.Script.Host.csproj
+++ b/src/WebJobs.Script.Host/WebJobs.Script.Host.csproj
@@ -105,7 +105,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.NotificationHubs.1.0.7\lib\net45-full\Microsoft.Azure.NotificationHubs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.3.0-beta1-10663\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -135,13 +135,13 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.3.0-beta1-10663\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bot.Connector.DirectLine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Bot.Connector.DirectLine.3.0.0-beta\lib\net45\Microsoft.Bot.Connector.DirectLine.dll</HintPath>

--- a/src/WebJobs.Script.Host/packages.config
+++ b/src/WebJobs.Script.Host/packages.config
@@ -17,8 +17,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net471" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net471" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs" version="2.4.0-beta1-11751" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.4.0-beta1-11751" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs" version="2.4.0-beta1-11780" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.4.0-beta1-11780" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta9-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net471" />
@@ -28,8 +28,8 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.3.0-beta1-10663" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.4.0-beta1-11751" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.4.0-beta1-11751" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.4.0-beta1-11780" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.4.0-beta1-11780" targetFramework="net471" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net471" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net471" />
   <package id="Microsoft.Bot.Connector.DirectLine" version="3.0.0-beta" targetFramework="net471" />

--- a/src/WebJobs.Script.NuGet/WebJobs.Script.nuspec
+++ b/src/WebJobs.Script.NuGet/WebJobs.Script.nuspec
@@ -17,7 +17,7 @@
       <dependency id="Edge.js" version="6.11.3" />
       <dependency id="FSharp.Compiler.Service" version="9.0.1" />
       <dependency id="FSharp.Core" version="4.0.0.1" />
-      <dependency id="Microsoft.Azure.WebJobs" version="2.4.0-beta1-11751" />
+      <dependency id="Microsoft.Azure.WebJobs" version="2.4.0-beta1-11780" />
       <dependency id="Microsoft.ApplicationInsights.WindowsServer" version="2.4.1" />
       <dependency id="Microsoft.Azure.AppService.Proxy" version="1.0.0.3" />
       <dependency id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" />

--- a/src/WebJobs.Script.WebHost/App_Start/WebHostResolver.cs
+++ b/src/WebJobs.Script.WebHost/App_Start/WebHostResolver.cs
@@ -302,7 +302,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             if (!string.IsNullOrEmpty(_settingsManager.ApplicationInsightsInstrumentationKey))
             {
                 var config = GetScriptHostConfiguration(settings);
-                var clientFactory = new ScriptTelemetryClientFactory(_settingsManager.ApplicationInsightsInstrumentationKey, config.ApplicationInsightsSamplingSettings, config.LogFilter.Filter);
+                var clientFactory = new ScriptTelemetryClientFactory(
+                                            _settingsManager.ApplicationInsightsInstrumentationKey,
+                                            config.ApplicationInsightsSamplingSettings,
+                                            config.ApplicationInsightsIngestionEndpoint,
+                                            config.ApplicationInsightsLiveEndpoint,
+                                            config.LogFilter.Filter);
                 loggerFactory.AddApplicationInsights(clientFactory);
             }
 

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -178,7 +178,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.NotificationHubs.1.0.7\lib\net45-full\Microsoft.Azure.NotificationHubs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.3.0-beta1-10663\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -211,16 +211,16 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.3.0-beta1-10663\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.81-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>

--- a/src/WebJobs.Script.WebHost/packages.config
+++ b/src/WebJobs.Script.WebHost/packages.config
@@ -45,8 +45,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net471" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net471" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs" version="2.4.0-beta1-11751" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.4.0-beta1-11751" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs" version="2.4.0-beta1-11780" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.4.0-beta1-11780" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta9-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net471" />
@@ -57,9 +57,9 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.3.0-beta1-10663" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Logging" version="2.4.0-beta1-11751" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.4.0-beta1-11751" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.4.0-beta1-11751" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging" version="2.4.0-beta1-11780" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.4.0-beta1-11780" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.4.0-beta1-11780" targetFramework="net471" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.81-alpha" targetFramework="net471" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net471" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net471" />

--- a/src/WebJobs.Script/Config/ScriptHostConfiguration.cs
+++ b/src/WebJobs.Script/Config/ScriptHostConfiguration.cs
@@ -120,6 +120,16 @@ namespace Microsoft.Azure.WebJobs.Script
         public SamplingPercentageEstimatorSettings ApplicationInsightsSamplingSettings { get; set; }
 
         /// <summary>
+        /// Gets or sets the IngestionEndpoint to be used for Application Insights <see cref="ServerTelemetryChannel"/>
+        /// </summary>
+        public string ApplicationInsightsIngestionEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the LiveEndpoint to be used for Application Insights <see cref="QuickPulseTelemetryModule"/>
+        /// </summary>
+        public string ApplicationInsightsLiveEndpoint { get; set; }
+
+        /// <summary>
         /// Gets or sets the <see cref="ILoggerFactoryBuilder"/> used to register <see cref="ILoggerProvider"/>s with
         /// the host's <see cref="ILoggerFactory"/>.
         /// </summary>

--- a/src/WebJobs.Script/Diagnostics/DefaultLoggerFactoryBuilder.cs
+++ b/src/WebJobs.Script/Diagnostics/DefaultLoggerFactoryBuilder.cs
@@ -28,7 +28,12 @@ namespace Microsoft.Azure.WebJobs.Script
                 metricsLogger?.LogEvent(MetricEventNames.ApplicationInsightsEnabled);
 
                 ITelemetryClientFactory clientFactory = scriptConfig.HostConfig.GetService<ITelemetryClientFactory>() ??
-                    new ScriptTelemetryClientFactory(settingsManager.ApplicationInsightsInstrumentationKey, scriptConfig.ApplicationInsightsSamplingSettings, scriptConfig.LogFilter.Filter);
+                    new ScriptTelemetryClientFactory(
+                            settingsManager.ApplicationInsightsInstrumentationKey,
+                            scriptConfig.ApplicationInsightsSamplingSettings,
+                            scriptConfig.ApplicationInsightsIngestionEndpoint,
+                            scriptConfig.ApplicationInsightsLiveEndpoint,
+                            scriptConfig.LogFilter.Filter);
 
                 scriptConfig.HostConfig.LoggerFactory.AddApplicationInsights(clientFactory);
             }

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -1793,6 +1793,16 @@ namespace Microsoft.Azure.WebJobs.Script
                         }
                     }
                 }
+
+                if (configSection.TryGetValue("ingestionEndpoint", out value))
+                {
+                    scriptConfig.ApplicationInsightsIngestionEndpoint = (string)value;
+                }
+
+                if (configSection.TryGetValue("liveEndpoint", out value))
+                {
+                    scriptConfig.ApplicationInsightsLiveEndpoint = (string)value;
+                }
             }
         }
 

--- a/src/WebJobs.Script/Host/ScriptTelemetryClientFactory.cs
+++ b/src/WebJobs.Script/Host/ScriptTelemetryClientFactory.cs
@@ -20,6 +20,21 @@ namespace Microsoft.Azure.WebJobs.Script
         {
         }
 
+        public ScriptTelemetryClientFactory(
+                    string instrumentationKey,
+                    SamplingPercentageEstimatorSettings samplingSettings,
+                    string ingestionEndpoint,
+                    string liveEndpoint,
+                    Func<string, LogLevel, bool> filter)
+            : base(
+                  instrumentationKey,
+                  samplingSettings,
+                  ingestionEndpoint,
+                  liveEndpoint,
+                  filter)
+        {
+        }
+
         public override TelemetryClient Create()
         {
             TelemetryClient client = base.Create();

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -111,7 +111,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.NotificationHubs.1.0.7\lib\net45-full\Microsoft.Azure.NotificationHubs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.3.0-beta1-10663\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -144,13 +144,13 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.3.0-beta1-10663\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bot.Connector.DirectLine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Bot.Connector.DirectLine.3.0.0-beta\lib\net45\Microsoft.Bot.Connector.DirectLine.dll</HintPath>

--- a/src/WebJobs.Script/packages.config
+++ b/src/WebJobs.Script/packages.config
@@ -21,8 +21,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net471" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net471" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs" version="2.4.0-beta1-11751" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.4.0-beta1-11751" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs" version="2.4.0-beta1-11780" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.4.0-beta1-11780" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta9-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net471" />
@@ -33,8 +33,8 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.3.0-beta1-10663" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.4.0-beta1-11751" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.4.0-beta1-11751" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.4.0-beta1-11780" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.4.0-beta1-11780" targetFramework="net471" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net471" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net471" />
   <package id="Microsoft.Bot.Connector.DirectLine" version="3.0.0-beta" targetFramework="net471" />

--- a/test/TestFunctions/TestFunctions.csproj
+++ b/test/TestFunctions/TestFunctions.csproj
@@ -34,7 +34,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.3.0-beta1-10663\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -43,7 +43,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Http.1.2.0-beta1-10663\lib\net45\Microsoft.Azure.WebJobs.Extensions.Http.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>

--- a/test/TestFunctions/packages.config
+++ b/test/TestFunctions/packages.config
@@ -3,8 +3,8 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net471" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net471" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs" version="2.4.0-beta1-11751" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.4.0-beta1-11751" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs" version="2.4.0-beta1-11780" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.4.0-beta1-11780" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Http" version="1.2.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net471" />

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
                 _channel = channel;
             }
 
-            protected override ITelemetryChannel CreateTelemetryChannel()
+            protected override ITelemetryChannel CreateTelemetryChannel(string ingestionEndpoint)
             {
                 return _channel;
             }

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -127,7 +127,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.NotificationHubs.1.0.7\lib\net45-full\Microsoft.Azure.NotificationHubs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.3.0-beta1-10663\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -160,16 +160,16 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.3.0-beta1-10663\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.81-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>

--- a/test/WebJobs.Script.Tests.Integration/packages.config
+++ b/test/WebJobs.Script.Tests.Integration/packages.config
@@ -29,8 +29,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net471" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net471" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs" version="2.4.0-beta1-11751" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.4.0-beta1-11751" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs" version="2.4.0-beta1-11780" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.4.0-beta1-11780" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta9-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net471" />
@@ -41,9 +41,9 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.3.0-beta1-10663" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Logging" version="2.4.0-beta1-11751" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.4.0-beta1-11751" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.4.0-beta1-11751" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging" version="2.4.0-beta1-11780" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.4.0-beta1-11780" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.4.0-beta1-11780" targetFramework="net471" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.81-alpha" targetFramework="net471" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net471" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net471" />

--- a/test/WebJobs.Script.Tests.Shared/TestChannelLoggerFactoryBuilder.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestChannelLoggerFactoryBuilder.cs
@@ -65,7 +65,7 @@ namespace Microsoft.WebJobs.Script.Tests
             _channel = channel;
         }
 
-        protected override ITelemetryChannel CreateTelemetryChannel()
+        protected override ITelemetryChannel CreateTelemetryChannel(string ingestionEndpoint)
         {
             return _channel;
         }

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -133,7 +133,7 @@
       <HintPath>..\..\packages\Microsoft.Azure.NotificationHubs.1.0.7\lib\net45-full\Microsoft.Azure.NotificationHubs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Core.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Extensions, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.2.3.0-beta1-10663\lib\net45\Microsoft.Azure.WebJobs.Extensions.dll</HintPath>
@@ -166,16 +166,16 @@
       <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Extensions.Twilio.1.3.0-beta1-10663\lib\net45\Microsoft.Azure.WebJobs.Extensions.Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Host, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.Host.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.4.0-beta1-11534\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.Logging.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebJobs.ServiceBus, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.4.0-beta1-11751\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Azure.WebJobs.ServiceBus.2.4.0-beta1-11780\lib\net45\Microsoft.Azure.WebJobs.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Azure.WebSites.DataProtection, Version=0.1.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Azure.WebSites.DataProtection.0.1.81-alpha\lib\net46\Microsoft.Azure.WebSites.DataProtection.dll</HintPath>

--- a/test/WebJobs.Script.Tests/packages.config
+++ b/test/WebJobs.Script.Tests/packages.config
@@ -30,8 +30,8 @@
   <package id="Microsoft.Azure.Mobile.Client" version="3.1.0" targetFramework="net471" />
   <package id="Microsoft.Azure.NotificationHubs" version="1.0.7" targetFramework="net471" />
   <package id="Microsoft.Azure.ServiceBus.EventProcessorHost" version="2.2.10" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs" version="2.4.0-beta1-11751" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.4.0-beta1-11751" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs" version="2.4.0-beta1-11780" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="2.4.0-beta1-11780" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions" version="2.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.ApiHub" version="1.0.0-beta9-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.BotFramework" version="1.0.15-beta" targetFramework="net471" />
@@ -42,9 +42,9 @@
   <package id="Microsoft.Azure.WebJobs.Extensions.NotificationHubs" version="1.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.SendGrid" version="2.3.0-beta1-10663" targetFramework="net471" />
   <package id="Microsoft.Azure.WebJobs.Extensions.Twilio" version="1.3.0-beta1-10663" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Logging" version="2.4.0-beta1-11751" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.4.0-beta1-11751" targetFramework="net471" />
-  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.4.0-beta1-11751" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging" version="2.4.0-beta1-11780" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" version="2.4.0-beta1-11780" targetFramework="net471" />
+  <package id="Microsoft.Azure.WebJobs.ServiceBus" version="2.4.0-beta1-11780" targetFramework="net471" />
   <package id="Microsoft.Azure.WebSites.DataProtection" version="0.1.81-alpha" targetFramework="net471" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net471" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net471" />


### PR DESCRIPTION


<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #6651 

This adds an "endpointAddress" and "quickPulseServiceEndpoint" property in the "applicationInsights" section of their host.json. These values are passed to webjobs where they overwrite the appropriate configs.

Testing this in the government cloud, I was able to get Live Metrics (quick pulse) and request logs working in app insights (which I couldn't get working without these changes).

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md` -- **There is no such file for v1**
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
