### PR TITLE
Fixing Crank test app paths

### DIFF
--- a/tools/Crank/benchmarks.yml
+++ b/tools/Crank/benchmarks.yml
@@ -31,11 +31,10 @@ scenarios:
     application:
       job: functionsServer
       environmentVariables:
-        HOME: "{{ TempPath }}"
+        HOME: "{{ HomePath }}"
         WEBSITE_SITE_NAME: "Test"
         WEBSITE_INSTANCE_ID: "8399B720-AB73-46D6-94DE-5A27871B3155"
         WEBSITE_OWNER_NAME: "A5F47496-A284-4788-A127-E79454330567+westuswebspace"
-        AzureWebJobsScriptRoot: "{{ FunctionAppPath }}"
         ASPNETCORE_URLS: "{{ AspNetUrls }}"
     load:
       job: bombardier
@@ -46,12 +45,11 @@ scenarios:
     application:
       job: functionsServer
       environmentVariables:
-        HOME: "{{ TempPath }}"
+        HOME: "{{ HomePath }}"
         WEBSITE_SITE_NAME: "Test"
         WEBSITE_INSTANCE_ID: "8399B720-AB73-46D6-94DE-5A27871B3155"
         WEBSITE_OWNER_NAME: "A5F47496-A284-4788-A127-E79454330567+westuswebspace"
         FUNCTIONS_LOGS_MOUNT_PATH: "{{ TempLogPath }}"
-        AzureWebJobsScriptRoot: "{{ FunctionAppPath }}"
         ASPNETCORE_URLS: "{{ AspNetUrls }}"
     load:
       job: bombardier

--- a/tools/Crank/run-benchmarks.ps1
+++ b/tools/Crank/run-benchmarks.ps1
@@ -64,13 +64,8 @@ $crankConfigPath = Join-Path `
 
 $isLinuxApp = $CrankAgentVm -match '\blinux\b'
 
-$functionAppPath = if ($isLinuxApp) {
-                       "/home/$UserName/FunctionApps/$FunctionApp"
-                   } else {
-                       "C:\FunctionApps\$FunctionApp"
-                   }
-
-$tmpPath = if ($isLinuxApp) { "/tmp" } else { 'C:\Temp' }
+$homePath = if ($isLinuxApp) { "/home/$UserName/FunctionApps/$FunctionApp" } else { "C:\FunctionApps\$FunctionApp" }
+$functionAppPath = if ($isLinuxApp) { "/home/$UserName/FunctionApps/$FunctionApp/site/wwwroot" } else { "C:\FunctionApps\$FunctionApp\site\wwwroot" }
 $tmpLogPath = if ($isLinuxApp) { "/tmp/functions/log" } else { 'C:\Temp\Functions\Log' }
 
 if ($UseHttps) {
@@ -88,7 +83,7 @@ $crankArgs =
     '--profile', $profileName,
     '--variable', "CrankAgentVm=$CrankAgentVm",
     '--variable', "FunctionAppPath=`"$functionAppPath`"",
-    '--variable', "TempPath=`"$tmpPath`"",
+    '--variable', "HomePath=`"$homePath`"",
     '--variable', "TempLogPath=`"$tmpLogPath`"",
     '--variable', "BranchOrCommit=$BranchOrCommit",
     '--variable', "AspNetUrls=$aspNetUrls"


### PR DESCRIPTION
Normalizing the root path for test apps to \FunctionApps\<FunctionApp>\site\wwwroot so it works in all cases (e.g. even when simulating AppService with HOME set).