### PR TITLE
Java worker release 1.8.0

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -14,5 +14,10 @@
 Exception is thrown if HttpOutputBindingResponse is not valid Json.
 - **[BreakingChange]**[CustomHandler]Send query params as JObject and Identities as JArray PR #6621
 
+- Update Java Worker to 1.8.0 [Release Note](https://github.com/Azure/azure-functions-java-worker/releases/tag/1.8.0)
+- Update Java Library to 1.4.0 [Release Note](https://github.com/Azure/azure-functions-java-library)
+- **[BreakingChange]** Fixes [#400](https://github.com/Azure/azure-functions-java-worker/issues/400) which was a regression from the 1.7.1 release.
+There is potential of impact if the function code has taken a dependency on a feature in gson 2.8.6 as the dependency `gson-2.8.5.jar` is now included in the class path of the worker and will take precedence over the function's lib folder.
+
 **Release sprint:** Sprint 84
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+84%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+84%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -42,7 +42,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.11020001-fabe022e" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.7.3-SNAPSHOT" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.8.0" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.0.5" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.446" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.452" />

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.0.5" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.2" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.7.3-SNAPSHOT" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.8.0" />
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />


### PR DESCRIPTION
Upgrade Java worker to 1.8.0
The release includes:

* Unshad Gson
* Upgrade Azure Functions Library to 1.4.0

Fix the issue
https://github.com/Azure/azure-functions-java-worker/issues/396
https://github.com/Azure/azure-functions-java-worker/issues/400

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [x] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
