### PR TITLE
Crank: Report a warning on bad responses

### DIFF
--- a/tools/Crank/run-benchmarks.ps1
+++ b/tools/Crank/run-benchmarks.ps1
@@ -98,6 +98,14 @@ if ($WriteResultsToDatabase) {
     $crankArgs += '--table', 'FunctionsPerf'
 }
 
-& $InvokeCrankCommand $crankArgs
+& $InvokeCrankCommand $crankArgs 2>&1 | Tee-Object -Variable crankOutput
+
+$badResponses = $crankOutput | Where-Object { $_ -match '\bBad responses\b\s*\|\s*(\S*)\s' } | ForEach-Object { $Matches[1] }
+if ($null -eq $badResponses) {
+    Write-Warning "Could not detect the number of bad responses. The performance results may be unreliable."
+}
+if ($badResponses -ne 0) {
+    Write-Warning "Detected $badResponses bad response(s). The performance results may be unreliable."
+}
 
 #endregion


### PR DESCRIPTION
When Crank reports a non-zero number of bad responses, it usually indicates a misconfiguration, so the performance report may not be reflecting the intended scenario. In order to make this issue more visible, parse Crank output and emit a warning.