### PR TITLE
Log exception details from outermost exception always

### DIFF
--- a/src/WebJobs.Script.WebHost/Extensions/ExceptionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Extensions/ExceptionExtensions.cs
@@ -21,15 +21,9 @@ namespace System
                 innerException = innerException.InnerException;
             }
 
-            // If innerMost exception does not have the stack trace, default to the outermost one.
-            if (innerException.StackTrace == null || innerException.StackTrace.Length < 1)
-            {
-                innerException = exception;
-            }
-
             string exceptionType = innerException.GetType().ToString();
             string exceptionMessage = Sanitizer.Sanitize(innerException.Message);
-            string exceptionDetails = Sanitizer.Sanitize(innerException.ToFormattedString());
+            string exceptionDetails = Sanitizer.Sanitize(exception.ToFormattedString());
 
             return (exceptionType, exceptionMessage, exceptionDetails);
         }

--- a/src/WebJobs.Script.WebHost/Extensions/ExceptionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Extensions/ExceptionExtensions.cs
@@ -21,6 +21,12 @@ namespace System
                 innerException = innerException.InnerException;
             }
 
+            // If innerMost exception does not have the stack trace, default to the outermost one.
+            if (innerException.StackTrace == null || innerException.StackTrace.Length < 1)
+            {
+                innerException = exception;
+            }
+
             string exceptionType = innerException.GetType().ToString();
             string exceptionMessage = Sanitizer.Sanitize(innerException.Message);
             string exceptionDetails = Sanitizer.Sanitize(innerException.ToFormattedString());

--- a/test/WebJobs.Script.Tests/Extensions/ExceptionExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/ExceptionExtensionsTests.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
 
             Assert.Equal("System.InvalidOperationException", exceptionType);
             Assert.Equal("Some inner exception", exceptionMessage);
+            Console.WriteLine($"ExceptionExceptionsTests: {exceptionDetails}");
             Assert.Contains("System.Exception : some outer exception ---> System.InvalidOperationException : Some inner exception \r\n   End of inner exception\r\n   at Microsoft.Azure.WebJobs.Script.Tests.Extensions.ExceptionExtensionsTests.GetExceptionDetails_ReturnsExpectedResult() at D:\\Repo_Functions\\runtime\\azure-functions-host\\test\\WebJobs.Script.Tests\\Extensions\\ExceptionExtensionsTests.cs : 20", exceptionDetails);
         }
     }

--- a/test/WebJobs.Script.Tests/Extensions/ExceptionExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/ExceptionExtensionsTests.cs
@@ -28,8 +28,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
 
             Assert.Equal("System.InvalidOperationException", exceptionType);
             Assert.Equal("Some inner exception", exceptionMessage);
-            Console.WriteLine($"ExceptionExceptionsTests: {exceptionDetails}");
-            Assert.Contains("System.Exception : some outer exception ---> System.InvalidOperationException : Some inner exception \r\n   End of inner exception\r\n   at Microsoft.Azure.WebJobs.Script.Tests.Extensions.ExceptionExtensionsTests.GetExceptionDetails_ReturnsExpectedResult() at D:\\Repo_Functions\\runtime\\azure-functions-host\\test\\WebJobs.Script.Tests\\Extensions\\ExceptionExtensionsTests.cs : 20", exceptionDetails);
+            Assert.Contains("System.Exception : some outer exception ---> System.InvalidOperationException : Some inner exception \r\n   End of inner exception\r\n   at Microsoft.Azure.WebJobs.Script.Tests.Extensions.ExceptionExtensionsTests.GetExceptionDetails_ReturnsExpectedResult()", exceptionDetails);
+            Assert.Contains("Extensions\\ExceptionExtensionsTests.cs : 20", exceptionDetails);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Extensions/ExceptionExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/ExceptionExtensionsTests.cs
@@ -26,9 +26,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
 
             (string exceptionType, string exceptionMessage, string exceptionDetails) = fullException.GetExceptionDetails();
 
-            Assert.Equal(exceptionType, "System.InvalidOperationException");
-            Assert.Equal(exceptionMessage, "Some inner exception");
-            Assert.Equal(exceptionDetails, "System.Exception : some outer exception ---> System.InvalidOperationException : Some inner exception \r\n   End of inner exception\r\n   at Microsoft.Azure.WebJobs.Script.Tests.Extensions.ExceptionExtensionsTests.GetExceptionDetails_ReturnsExpectedResult() at D:\\Repo_Functions\\runtime\\azure-functions-host\\test\\WebJobs.Script.Tests\\Extensions\\ExceptionExtensionsTests.cs : 20");
+            Assert.Equal("System.InvalidOperationException", exceptionType);
+            Assert.Equal("Some inner exception", exceptionMessage);
+            Assert.Contains("System.Exception : some outer exception ---> System.InvalidOperationException : Some inner exception \r\n   End of inner exception\r\n   at Microsoft.Azure.WebJobs.Script.Tests.Extensions.ExceptionExtensionsTests.GetExceptionDetails_ReturnsExpectedResult() at D:\\Repo_Functions\\runtime\\azure-functions-host\\test\\WebJobs.Script.Tests\\Extensions\\ExceptionExtensionsTests.cs : 20", exceptionDetails);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Extensions/ExceptionExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/ExceptionExtensionsTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
+{
+    public class ExceptionExtensionsTests
+    {
+        [Fact]
+        public void GetExceptionDetails_ReturnsExpectedResult()
+        {
+            Exception innerException = new InvalidOperationException("Some inner exception");
+            Exception outerException = new Exception("some outer exception", innerException);
+            Exception fullException;
+
+            try
+            {
+                throw outerException;
+            }
+            catch (Exception e)
+            {
+                fullException = e;  // Outer exception will have stack trace whereas the inner exceptions's stack trace will be null
+            }
+
+            (string exceptionType, string exceptionMessage, string exceptionDetails) = fullException.GetExceptionDetails();
+
+            Assert.Equal(exceptionType, "System.Exception");
+            Assert.Equal(exceptionMessage, "some outer exception");
+            Assert.Equal(exceptionDetails, "System.Exception : some outer exception ---> System.InvalidOperationException : Some inner exception \r\n   End of inner exception\r\n   at Microsoft.Azure.WebJobs.Script.Tests.Extensions.ExceptionExtensionsTests.GetExceptionDetails_ReturnsExpectedResult() at D:\\Repo_Functions\\runtime\\azure-functions-host\\test\\WebJobs.Script.Tests\\Extensions\\ExceptionExtensionsTests.cs : 20");
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Extensions/ExceptionExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/ExceptionExtensionsTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
             }
             catch (Exception e)
             {
-                fullException = e;  // Outer exception will have stack trace whereas the inner exceptions's stack trace will be null
+                fullException = e;  // Outer exception will have stack trace whereas the inner exception's stack trace will be null
             }
 
             (string exceptionType, string exceptionMessage, string exceptionDetails) = fullException.GetExceptionDetails();

--- a/test/WebJobs.Script.Tests/Extensions/ExceptionExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/ExceptionExtensionsTests.cs
@@ -26,8 +26,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
 
             (string exceptionType, string exceptionMessage, string exceptionDetails) = fullException.GetExceptionDetails();
 
-            Assert.Equal(exceptionType, "System.Exception");
-            Assert.Equal(exceptionMessage, "some outer exception");
+            Assert.Equal(exceptionType, "System.InvalidOperationException");
+            Assert.Equal(exceptionMessage, "Some inner exception");
             Assert.Equal(exceptionDetails, "System.Exception : some outer exception ---> System.InvalidOperationException : Some inner exception \r\n   End of inner exception\r\n   at Microsoft.Azure.WebJobs.Script.Tests.Extensions.ExceptionExtensionsTests.GetExceptionDetails_ReturnsExpectedResult() at D:\\Repo_Functions\\runtime\\azure-functions-host\\test\\WebJobs.Script.Tests\\Extensions\\ExceptionExtensionsTests.cs : 20");
         }
     }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Workaround for https://github.com/Azure/azure-webjobs-sdk/issues/2576

Old PR is here https://github.com/Azure/azure-webjobs-sdk/pull/2579

When we encounter exceptions where the outer exception has full stack trace but the innerMost exception does not, we log the innerMost exception thus losing the trace. 

Details logged before this change
https://user-images.githubusercontent.com/26885664/93150245-715e4500-f6ad-11ea-84c3-389fb6c4cfa4.png

Details logged with this change (the outer exception)
![image](https://user-images.githubusercontent.com/26885664/93834705-a0d2fb80-fc31-11ea-8ba0-e5c264dc2138.png)

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
