### PR TITLE
[pack] Reset function providers on refresh

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Windows.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Windows.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             // verify the rest of the expected logs
             logLines = _loggerProvider.GetAllLogMessages().Where(p => p.FormattedMessage != null).Select(p => p.FormattedMessage).ToArray();
+
             Assert.True(logLines.Count(p => p.Contains("Stopping JobHost")) >= 1);
             Assert.Equal(1, logLines.Count(p => p.Contains("Creating StandbyMode placeholder function directory")));
             Assert.Equal(1, logLines.Count(p => p.Contains("StandbyMode placeholder function directory created")));
@@ -75,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(3, logLines.Count(p => p.Contains($"Starting Host (HostId={_expectedHostId}")));
             Assert.Equal(6, logLines.Count(p => p.Contains($"Loading functions metadata")));
             Assert.Equal(2, logLines.Count(p => p.Contains($"1 functions loaded")));
-            Assert.Equal(1, logLines.Count(p => p.Contains($"0 functions loaded")));
+            Assert.Equal(2, logLines.Count(p => p.Contains($"0 functions loaded")));
             Assert.Equal(3, logLines.Count(p => p.Contains($"Loading proxies metadata")));
             Assert.Equal(3, logLines.Count(p => p.Contains("Initializing Azure Function proxies")));
             Assert.Equal(2, logLines.Count(p => p.Contains($"1 proxies loaded")));

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -322,8 +322,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var managerServiceProvider = manager as IServiceProvider;
 
             var metadataProvider = new FunctionMetadataProvider(optionsMonitor, NullLogger<FunctionMetadataProvider>.Instance, new TestMetricsLogger());
-            var metadataManager = new FunctionMetadataManager(managerServiceProvider.GetService<IOptions<ScriptJobHostOptions>>(),
-                metadataProvider, managerServiceProvider.GetService<IEnumerable<IFunctionProvider>>(),
+            var metadataManager = new FunctionMetadataManager(managerServiceProvider.GetService<IOptions<ScriptJobHostOptions>>(), metadataProvider,
                 managerServiceProvider.GetService<IOptions<HttpWorkerOptions>>(), manager, factory, new OptionsWrapper<LanguageWorkerOptions>(workerOptions));
 
             return metadataManager;

--- a/test/WebJobs.Script.Tests.Shared/TestFunctionMetadataManager.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestFunctionMetadataManager.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             managerMock.As<IServiceProvider>().Setup(m => m.GetService(typeof(IOptions<LanguageWorkerOptions>))).Returns(languageWorkerOptions);
             managerMock.As<IServiceProvider>().Setup(m => m.GetService(typeof(ILoggerFactory))).Returns(loggerFactory);
 
-            return new FunctionMetadataManager(jobHostOptions, functionMetadataProvider, functionProviders, httpOptions, managerMock.Object, loggerFactory, languageWorkerOptions);
+            return new FunctionMetadataManager(jobHostOptions, functionMetadataProvider, httpOptions, managerMock.Object, loggerFactory, languageWorkerOptions);
         }
     }
 }


### PR DESCRIPTION
[Will add backport PR before merge]

This change will make sure that any time a force refresh occurs for function metadata, IFunctionProviders are reloaded to make sure no stale providers are used. We had an issue during a file change restart where before new ScriptHost starts, if FunctionMetadata is requested, we ended up giving stale data from IFunctionProviders of previous ScriptHost.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-host/issues/6673

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
