### PR TITLE
Crank script updates

### DIFF
--- a/tools/Crank/benchmarks.yml
+++ b/tools/Crank/benchmarks.yml
@@ -26,7 +26,6 @@ scenarios:
       job: bombardier
       variables:
         path: /api/Hello
-        duration: 180
   http-appsvc:
     application:
       job: functionsServer
@@ -40,7 +39,6 @@ scenarios:
       job: bombardier
       variables:
         path: /api/Hello
-        duration: 180
   http-linux-appsvc:
     application:
       job: functionsServer
@@ -55,7 +53,6 @@ scenarios:
       job: bombardier
       variables:
         path: /api/Hello
-        duration: 180
   aspnet-hello:
     application:
       job: aspnetServer
@@ -65,7 +62,6 @@ scenarios:
       job: bombardier
       variables:
         path: /api/Hello
-        duration: 180
 
 profiles:
   localHttps:

--- a/tools/Crank/run-benchmarks.ps1
+++ b/tools/Crank/run-benchmarks.ps1
@@ -28,7 +28,13 @@ param(
     $UseHttps = $true,
 
     [bool]
-    $Trace = $false
+    $Trace = $false,
+
+    [int]
+    $Duration = 15,
+
+    [int]
+    $Warmup = 15
 )
 
 $ErrorActionPreference = 'Stop'
@@ -89,11 +95,12 @@ $crankArgs =
     '--variable', "HomePath=`"$homePath`"",
     '--variable', "TempLogPath=`"$tmpLogPath`"",
     '--variable', "BranchOrCommit=$BranchOrCommit",
+    '--variable', "duration=$Duration",
+    '--variable', "warmup=$Warmup",
     '--variable', "AspNetUrls=$aspNetUrls"
 
 if ($Trace) {
     $crankArgs += '--application.dotnetTrace', $true
-    $crankArgs += '--application.collectCounters',  $true
 }
 
 if ($WriteResultsToDatabase) {


### PR DESCRIPTION
Changing default duration from 180 seconds to 15 seconds, and adding command line overrides for duration and warmup