### PR TITLE
Reset function providers on refresh

### DIFF
--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -26,11 +26,10 @@ namespace Microsoft.Azure.WebJobs.Script
         private ILogger _logger;
         private IOptions<ScriptJobHostOptions> _scriptOptions;
         private ImmutableArray<FunctionMetadata> _functionMetadataArray;
-        private IEnumerable<IFunctionProvider> _functionProviders;
         private Dictionary<string, ICollection<string>> _functionErrors = new Dictionary<string, ICollection<string>>();
 
         public FunctionMetadataManager(IOptions<ScriptJobHostOptions> scriptOptions, IFunctionMetadataProvider functionMetadataProvider,
-            IEnumerable<IFunctionProvider> functionProviders, IOptions<HttpWorkerOptions> httpWorkerOptions, IScriptHostManager scriptHostManager, ILoggerFactory loggerFactory)
+            IOptions<HttpWorkerOptions> httpWorkerOptions, IScriptHostManager scriptHostManager, ILoggerFactory loggerFactory)
         {
             _scriptOptions = scriptOptions;
             _serviceProvider = scriptHostManager as IServiceProvider;
@@ -38,7 +37,6 @@ namespace Microsoft.Azure.WebJobs.Script
 
             _logger = loggerFactory.CreateLogger(LogCategories.Startup);
             _isHttpWorker = httpWorkerOptions?.Value?.Description != null;
-            _functionProviders = functionProviders;
 
             // Every time script host is re-intializing, we also need to re-initialize
             // services that change with the scope of the script host.
@@ -82,7 +80,6 @@ namespace Microsoft.Azure.WebJobs.Script
 
         private void InitializeServices()
         {
-            _functionProviders = _serviceProvider.GetService<IEnumerable<IFunctionProvider>>();
             _isHttpWorker = _serviceProvider.GetService<IOptions<HttpWorkerOptions>>()?.Value?.Description != null;
             _scriptOptions = _serviceProvider.GetService<IOptions<ScriptJobHostOptions>>();
 
@@ -158,16 +155,19 @@ namespace Microsoft.Azure.WebJobs.Script
 
         private void LoadCustomProviderFunctions(List<FunctionMetadata> functionMetadataList)
         {
-            if (_functionProviders != null && _functionProviders.Any())
+            // We always want to get the most updated function providers in case this list was changed.
+            IEnumerable<IFunctionProvider> functionProviders = _serviceProvider?.GetService<IEnumerable<IFunctionProvider>>();
+
+            if (functionProviders != null && functionProviders.Any())
             {
-                AddMetadataFromCustomProviders(functionMetadataList);
+                AddMetadataFromCustomProviders(functionProviders, functionMetadataList);
             }
         }
 
-        private void AddMetadataFromCustomProviders(List<FunctionMetadata> functionMetadataList)
+        private void AddMetadataFromCustomProviders(IEnumerable<IFunctionProvider> functionProviders, List<FunctionMetadata> functionMetadataList)
         {
             var functionProviderTasks = new List<Task<ImmutableArray<FunctionMetadata>>>();
-            foreach (var functionProvider in _functionProviders)
+            foreach (var functionProvider in functionProviders)
             {
                 functionProviderTasks.Add(functionProvider.GetFunctionMetadataAsync());
             }
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 }
             }
 
-            foreach (var functionProvider in _functionProviders)
+            foreach (var functionProvider in functionProviders)
             {
                 if (functionProvider.FunctionErrors == null)
                 {

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Windows.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Windows.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             // verify the rest of the expected logs
             logLines = _loggerProvider.GetAllLogMessages().Where(p => p.FormattedMessage != null).Select(p => p.FormattedMessage).ToArray();
+
             Assert.True(logLines.Count(p => p.Contains("Stopping JobHost")) >= 1);
             Assert.Equal(1, logLines.Count(p => p.Contains("Creating StandbyMode placeholder function directory")));
             Assert.Equal(1, logLines.Count(p => p.Contains("StandbyMode placeholder function directory created")));
@@ -75,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(3, logLines.Count(p => p.Contains($"Starting Host (HostId={_expectedHostId}")));
             Assert.Equal(6, logLines.Count(p => p.Contains($"Loading functions metadata")));
             Assert.Equal(2, logLines.Count(p => p.Contains($"1 functions loaded")));
-            Assert.Equal(1, logLines.Count(p => p.Contains($"0 functions loaded")));
+            Assert.Equal(2, logLines.Count(p => p.Contains($"0 functions loaded")));
             Assert.Equal(3, logLines.Count(p => p.Contains($"Loading proxies metadata")));
             Assert.Equal(3, logLines.Count(p => p.Contains("Initializing Azure Function proxies")));
             Assert.Equal(2, logLines.Count(p => p.Contains($"1 proxies loaded")));

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -347,8 +347,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var metadataProvider = new FunctionMetadataProvider(optionsMonitor, new OptionsWrapper<LanguageWorkerOptions>(workerOptions), NullLogger<FunctionMetadataProvider>.Instance, new TestMetricsLogger());
             var metadataManager = new FunctionMetadataManager(managerServiceProvider.GetService<IOptions<ScriptJobHostOptions>>(),
-                metadataProvider, managerServiceProvider.GetService<IEnumerable<IFunctionProvider>>(),
-                managerServiceProvider.GetService<IOptions<HttpWorkerOptions>>(), manager, factory);
+                metadataProvider, managerServiceProvider.GetService<IOptions<HttpWorkerOptions>>(), manager, factory);
 
             return metadataManager;
         }

--- a/test/WebJobs.Script.Tests.Shared/TestFunctionMetadataManager.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestFunctionMetadataManager.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             managerMock.As<IServiceProvider>().Setup(m => m.GetService(typeof(IOptions<HttpWorkerOptions>))).Returns(httpOptions);
             managerMock.As<IServiceProvider>().Setup(m => m.GetService(typeof(ILoggerFactory))).Returns(loggerFactory);
 
-            return new FunctionMetadataManager(jobHostOptions, functionMetadataProvider, functionProviders, httpOptions, managerMock.Object, loggerFactory);
+            return new FunctionMetadataManager(jobHostOptions, functionMetadataProvider, httpOptions, managerMock.Object, loggerFactory);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
@@ -180,6 +180,50 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal("Found duplicate FunctionMetadata with the name duplicateFunction", ex.Message);
         }
 
+        [Fact]
+        public void FunctionMetadataManager_ResetProviders_OnRefresh()
+        {
+            var functionMetadataCollection = new Collection<FunctionMetadata>();
+            var mockFunctionErrors = new Dictionary<string, ImmutableArray<string>>();
+            var mockFunctionMetadataProvider = new Mock<IFunctionMetadataProvider>();
+            var mockFunctionProvider = new Mock<IFunctionProvider>();
+            var workerConfigs = TestHelpers.GetTestWorkerConfigs();
+
+            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadata(false)).Returns(new Collection<FunctionMetadata>().ToImmutableArray());
+            mockFunctionMetadataProvider.Setup(m => m.FunctionErrors).Returns(new Dictionary<string, ICollection<string>>().ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray()));
+
+            functionMetadataCollection.Add(GetTestFunctionMetadata("somefile.dll", name: "myFunction"));
+
+            mockFunctionProvider.Setup(m => m.GetFunctionMetadataAsync()).ReturnsAsync(functionMetadataCollection.ToImmutableArray());
+            mockFunctionProvider.Setup(m => m.FunctionErrors).Returns(mockFunctionErrors.ToImmutableDictionary());
+
+            var managerMock = new Mock<IScriptHostManager>();
+
+            FunctionMetadataManager testFunctionMetadataManager = TestFunctionMetadataManager.GetFunctionMetadataManager(new OptionsWrapper<ScriptJobHostOptions>(_scriptJobHostOptions), managerMock,
+                mockFunctionMetadataProvider.Object, new List<IFunctionProvider>() { mockFunctionProvider.Object }, new OptionsWrapper<HttpWorkerOptions>(_defaultHttpWorkerOptions), MockNullLoggerFactory.CreateLoggerFactory());
+
+            testFunctionMetadataManager.LoadFunctionMetadata();
+
+            Assert.Equal(0, testFunctionMetadataManager.Errors.Count);
+            Assert.Equal(1, testFunctionMetadataManager.GetFunctionMetadata(true).Length);
+            Assert.Equal("myFunction", testFunctionMetadataManager.GetFunctionMetadata(true).FirstOrDefault()?.Name);
+
+            functionMetadataCollection = new Collection<FunctionMetadata>
+            {
+                GetTestFunctionMetadata("somefile.dll", name: "newFunction")
+            };
+
+            mockFunctionProvider = new Mock<IFunctionProvider>();
+            mockFunctionProvider.Setup(m => m.GetFunctionMetadataAsync()).ReturnsAsync(functionMetadataCollection.ToImmutableArray());
+
+            managerMock.As<IServiceProvider>().Setup(m => m.GetService(typeof(IEnumerable<IFunctionProvider>))).Returns(new List<IFunctionProvider>() { mockFunctionProvider.Object });
+            testFunctionMetadataManager.LoadFunctionMetadata();
+
+            Assert.Equal(0, testFunctionMetadataManager.Errors.Count);
+            Assert.Equal(1, testFunctionMetadataManager.GetFunctionMetadata(true).Length);
+            Assert.Equal("newFunction", testFunctionMetadataManager.GetFunctionMetadata(true).FirstOrDefault()?.Name);
+        }
+
         [Theory]
         [InlineData("")]
         [InlineData(null)]


### PR DESCRIPTION
Backport of https://github.com/Azure/azure-functions-host/commit/f54f8ea2a3de30fb2148abd540ca7efd047ab10a

This change will make sure that any time a force refresh occurs for function metadata, IFunctionProviders are reloaded to make sure no stale providers are used. We had an issue during a file change restart where before new ScriptHost starts, if FunctionMetadata is requested, we ended up giving stale data from IFunctionProviders of previous ScriptHost.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
