### PR TITLE
Remove RegexOptions.Compiled for code paths executed during cold start.

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/Compilation/Raw/RawAssemblyCompilation.cs
+++ b/src/WebJobs.Script/Description/DotNet/Compilation/Raw/RawAssemblyCompilation.cs
@@ -14,7 +14,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 {
     public class RawAssemblyCompilation : IDotNetCompilation
     {
-        private static readonly Regex _entryPointRegex = new Regex("^(?<typename>.*)\\.(?<methodname>\\S*)$", RegexOptions.Compiled);
+        // RegexOptions.Compiled is specifically removed as it impacts the cold start. The default uses interpreter.
+        private static readonly Regex _entryPointRegex = new Regex("^(?<typename>.*)\\.(?<methodname>\\S*)$");
         private readonly string _assemblyFilePath;
         private readonly string _entryPointName;
 

--- a/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 {
     public abstract class FunctionDescriptorProvider
     {
-        private static readonly Regex BindingNameValidationRegex = new Regex(string.Format("^([a-zA-Z][a-zA-Z0-9]{{0,127}}|{0})$", Regex.Escape(ScriptConstants.SystemReturnParameterBindingName)), RegexOptions.Compiled);
+        private static readonly Regex BindingNameValidationRegex = new Regex(string.Format("^([a-zA-Z][a-zA-Z0-9]{{0,127}}|{0})$", Regex.Escape(ScriptConstants.SystemReturnParameterBindingName)));
 
         protected FunctionDescriptorProvider(ScriptHost host, ScriptJobHostOptions config, ICollection<IScriptBindingProvider> bindingProviders)
         {

--- a/src/WebJobs.Script/Host/ProxyFunctionProvider.cs
+++ b/src/WebJobs.Script/Host/ProxyFunctionProvider.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Script
 {
     public class ProxyFunctionProvider : IFunctionProvider, IDisposable
     {
-        private static readonly Regex ProxyNameValidationRegex = new Regex(@"[^a-zA-Z0-9_-]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex ProxyNameValidationRegex = new Regex(@"[^a-zA-Z0-9_-]", RegexOptions.IgnoreCase);
         private readonly ReaderWriterLockSlim _metadataLock = new ReaderWriterLockSlim();
         private readonly IOptions<ScriptJobHostOptions> _scriptOptions;
         private readonly IEnvironment _environment;

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Script
         // i.e.: "f-<functionname>"
         public const string AssemblyPrefix = "f-";
         public const string AssemblySeparator = "__";
-        private static readonly Regex FunctionNameValidationRegex = new Regex(@"^[a-z][a-z0-9_\-]{0,127}$(?<!^host$)", RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        private static readonly Regex FunctionNameValidationRegex = new Regex(@"^[a-z][a-z0-9_\-]{0,127}$(?<!^host$)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
         private static readonly string UTF8ByteOrderMark = Encoding.UTF8.GetString(Encoding.UTF8.GetPreamble());
         private static readonly FilteredExpandoObjectConverter _filteredExpandoObjectConverter = new FilteredExpandoObjectConverter();


### PR DESCRIPTION
The default uses interpreter rather than compile into MSIL. We do not need compiled regexes for codes that run only during cold start. based on profiles, compiling regexes are taking between 20-50 msec of cold start.

<!-- Please provide all the information below.  -->

### Pull request checklist

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

 