### PR TITLE
improving DI scope behavior

### DIFF
--- a/src/WebJobs.Script.WebHost/DependencyInjection/DryIoc/Container.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/DryIoc/Container.cs
@@ -64,6 +64,8 @@ namespace DryIoc
     using MemberAssignmentExpr = System.Linq.Expressions.MemberAssignment;
     using FactoryDelegateExpr = System.Linq.Expressions.Expression<FactoryDelegate>;
     using global::Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection.DryIoc;
+    using global::Microsoft.Azure.WebJobs.Script;
+    using global::Microsoft.Azure.WebJobs.Script.Config;
 #endif
 
     /// <summary>IoC Container. Documentation is available at https://bitbucket.org/dadhi/dryioc. </summary>
@@ -1941,7 +1943,15 @@ namespace DryIoc
             _registry = registry;
 
             _singletonScope = singletonScope;
-            _scopeContext = scopeContext ?? new AsyncScopeContext();
+            
+            _scopeContext = scopeContext;
+
+            if (_scopeContext == null && !FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableEnhancedScopes))
+            {
+                // Enhanced scopes do not need this context.
+                _scopeContext = new AsyncScopeContext();
+            }
+
             _ownCurrentScope = ownCurrentScope;
 
             _disposed = disposed;

--- a/src/WebJobs.Script.WebHost/DependencyInjection/ScopedResolver.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/ScopedResolver.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading.Tasks;
 using DryIoc;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
@@ -55,6 +56,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
               }));
 
             var scope = new ServiceScope(resolver, scopedRoot);
+
+            if (FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableEnhancedScopes))
+            {
+                scopedContext.UseInstance<IServiceProvider>(scope.ServiceProvider);
+            }
+
             ChildScopes.TryAdd(scope, null);
 
             scope.DisposalTask.ContinueWith(t => ChildScopes.TryRemove(scope, out object _));

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -109,6 +109,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FeatureFlagEnableActionResultHandling = "EnableActionResultHandling";
         public const string FeatureFlagAllowSynchronousIO = "AllowSynchronousIO";
         public const string FeatureFlagRelaxedAssemblyUnification = "RelaxedAssemblyUnification";
+        public const string FeatureFlagEnableEnhancedScopes = "EnableEnhancedScopes";
 
         public const string AdminJwtValidAudienceFormat = "https://{0}.azurewebsites.net/azurefunctions";
         public const string AdminJwtValidIssuerFormat = "https://{0}.scm.azurewebsites.net";

--- a/test/WebJobs.Script.Tests/DependencyInjection/JobHostServiceProviderTests.cs
+++ b/test/WebJobs.Script.Tests/DependencyInjection/JobHostServiceProviderTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -12,6 +11,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.DependencyInjection
 {
     public class JobHostServiceProviderTests
     {
+        private delegate object ServiceFactory(Type type);
+
         [Fact]
         public void Dispose_OnJobHostScope_DoesNotDisposeRootSingletonService()
         {
@@ -86,6 +87,90 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.DependencyInjection
 
             // Disposing of the JobHost service provider should not dispose of root container services
             Assert.False(rootService.Disposed);
+        }
+
+        [Fact]
+        public void Scopes_ChildScopeIsIsolated()
+        {
+            using (new TestScopedEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagEnableEnhancedScopes))
+            {
+                var services = new ServiceCollection();
+                services.AddScoped<A>();
+
+                var rootScopeFactory = new WebHostServiceProvider(new ServiceCollection());
+                var jobHostProvider = new JobHostServiceProvider(services, rootScopeFactory, rootScopeFactory);
+
+                var a1 = jobHostProvider.GetService<A>();
+                jobHostProvider.CreateScope();
+                var a2 = jobHostProvider.GetService<A>();
+                Assert.NotNull(a1);
+                Assert.NotNull(a2);
+                Assert.Same(a1, a2);
+            }
+        }
+
+        [Fact]
+        public void Scopes_Factories()
+        {
+            using (new TestScopedEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagEnableEnhancedScopes))
+            {
+                IList<IServiceProvider> serviceProviders = new List<IServiceProvider>();
+
+                var services = new ServiceCollection();
+                services.AddTransient<A>(p =>
+                {
+                    serviceProviders.Add(p);
+                    return new A();
+                });
+
+                var rootScopeFactory = new WebHostServiceProvider(new ServiceCollection());
+                var jobHostProvider = new JobHostServiceProvider(services, rootScopeFactory, rootScopeFactory);
+
+                // Get this service twice.
+                // The IServiceProvider passed to the factory should be different because they are separate scopes.
+                var scope1 = jobHostProvider.CreateScope();
+                scope1.ServiceProvider.GetService<A>();
+
+                var scope2 = jobHostProvider.CreateScope();
+                scope2.ServiceProvider.GetService<A>();
+
+                Assert.Equal(2, serviceProviders.Count);
+                Assert.NotSame(serviceProviders[0], serviceProviders[1]);
+            }
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(ScriptConstants.FeatureFlagEnableEnhancedScopes)]
+        public void Scopes_DelegateFactory(string flag)
+        {
+            using (new TestScopedEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, flag))
+            {
+                var services = new ServiceCollection();
+
+                services.AddScoped<A>();
+                services.AddScoped<ServiceFactory>(provider => (type) => provider.GetRequiredService(type));
+
+                var rootScopeFactory = new WebHostServiceProvider(new ServiceCollection());
+                var jobHostProvider = new JobHostServiceProvider(services, rootScopeFactory, rootScopeFactory);
+
+                var scope1 = jobHostProvider.CreateScope();
+                var a1 = scope1.ServiceProvider.GetService<ServiceFactory>()(typeof(A));
+
+                var scope2 = jobHostProvider.CreateScope();
+                var a2 = scope2.ServiceProvider.GetService<ServiceFactory>()(typeof(A));
+
+                Assert.NotNull(a1);
+                Assert.NotNull(a2);
+                Assert.NotSame(a1, a2);
+            }
+        }
+
+        private class A
+        {
+            public A()
+            {
+            }
         }
 
         private class TestService : IService, IDisposable


### PR DESCRIPTION
resolves #5098, but hides the change behind a `EnableEnhancedScopes` feature flag

When resolving `IServiceProvider` from a scope, we were inadvertently resolving to the root `JobHostServiceProvider` scope, which meant you would get unexpected lifetimes for objects. Because changes this code can potentially have unexpected impact, we are hiding this behind a feature flag. In order to enable this new behavior, you can add an app setting of `AzureWebJobsFeatureFlags` with the value `EnableEnhancedScopes`.

After sufficient testing, we will make this the default behavior.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
