### PR TITLE
Create CODEOWNER file for python.props file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,10 @@
+# See https://help.github.com/articles/about-codeowners/
+# for more info about CODEOWNERS file
+#
+# It uses the same pattern rule for gitignore file
+# https://git-scm.com/docs/gitignore#_pattern_format
+#
+
+
+# Adding codeowner for Python specific files such that GitHub automatically adds python folks as a reviewer.
+build/python.props @vrdmr @Hazhzeng


### PR DESCRIPTION
### Issue describing the changes in this PR
Adding a CodeOwner file to the repo to automatically add the Python team as a reviewer when changing the `build/python.props` file.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
