### PR TITLE
Node worker 2.0.6

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.11020001-fabe022e" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.8.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.0.5" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.0.6" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.552" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.549" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.23-11785" />

--- a/src/WebJobs.Script/Workers/Rpc/MessageExtensions/RpcMessageConversionExtensions.cs
+++ b/src/WebJobs.Script/Workers/Rpc/MessageExtensions/RpcMessageConversionExtensions.cs
@@ -163,13 +163,13 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 Dictionary<string, object> parameters = (Dictionary<string, object>)routeData;
                 foreach (var pair in parameters)
                 {
-                    if (ShouldUseNullableValueDictionary(capabilities))
+                    if (pair.Value != null)
                     {
-                        http.NullableParams.Add(pair.Key, new NullableString { Value = pair.Value.ToString() });
-                    }
-                    else
-                    {
-                        if (pair.Value != null)
+                        if (ShouldUseNullableValueDictionary(capabilities))
+                        {
+                            http.NullableParams.Add(pair.Key, new NullableString { Value = pair.Value.ToString() });
+                        }
+                        else
                         {
                             http.Params.Add(pair.Key, pair.Value.ToString());
                         }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node.cs
@@ -145,6 +145,37 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         }
 
         [Fact]
+        public async Task HttpTrigger_EmptyQueryParams_Succeeds()
+        {
+            string functionKey = await _fixture.Host.GetFunctionSecretAsync("httptrigger");
+            string uri = $"api/httptrigger?code={functionKey}&empty=&name=Amy";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/plain"));
+
+            HttpResponseMessage response = await _fixture.Host.HttpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            string body = await response.Content.ReadAsStringAsync();
+            Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal("Hello Amy", body);
+        }
+
+        [Fact]
+        public async Task HttpTrigger_EmptyHeaderValues_Succeeds()
+        {
+            string functionKey = await _fixture.Host.GetFunctionSecretAsync("httptrigger");
+            string uri = $"api/httptrigger?code={functionKey}&name=Amy";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/plain"));
+            request.Headers.Add("EmptyValue", string.Empty);
+
+            HttpResponseMessage response = await _fixture.Host.HttpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            string body = await response.Content.ReadAsStringAsync();
+            Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal("Hello Amy", body);
+        }
+
+        [Fact]
         public async Task HttpTrigger_CustomRoute_Get_ReturnsExpectedResponse()
         {
             var id = "4e2796ae-b865-4071-8a20-2a15cbaf856c";

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.10.0" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.0.5" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.0.6" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.2" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.8.0" />
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />


### PR DESCRIPTION
Actually node worker 2.0.6: https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v2.0.6

Test caught a null exception if param is null - fixed logic and added e2e tests for the other changes introduced with node 2.0.6 