### PR TITLE
Fix typo in Durable Functions sync trigger logic

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -30,6 +30,7 @@
             - Metadata / Input binding data of type DateTime will not be serialzed as string
     If you are using these properties, please ensure your app is able to detect and handle the new schema.
 - Fixes [#6031](https://github.com/Azure/azure-functions-host/issues/6031), an issue where having a large number of secrets in a Key Vault Secrets Repository would cause Function and Host secrets to regenerate constantly. These secrets should no longer regenerate due to this error.
+- Fixed [bug](https://github.com/Azure/azure-functions-durable-extension/issues/1467) in sync triggers operations for Durable Functions using custom storage account connection strings.
 
 **Release sprint:** Sprint 84
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+84%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+84%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         private const string TaskHubName = "taskHubName";
         private const string Connection = "connection";
         private const string DurableTaskV1StorageConnectionName = "azureStorageConnectionStringName";
-        private const string DurableTaskV2StorageOptions = "storageOptions";
+        private const string DurableTaskV2StorageOptions = "storageProvider";
         private const string DurableTaskV2StorageConnectionName = "connectionStringName";
         private const string DurableTask = "durableTask";
 

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -538,7 +538,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
                 var azureStorageConfig = new JObject();
                 azureStorageConfig["connectionStringName"] = "DurableConnection";
-                durableConfig["storageOptions"] = azureStorageConfig;
+                durableConfig["storageProvider"] = azureStorageConfig;
 
                 var hostConfig = GetHostConfig(durableConfig, useBundles: false);
 


### PR DESCRIPTION
Current sync trigger logic looks for "storageOptions" subsection of the
host.json for trigger information, but it should be looking under
"storageProvider" subsection.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-durable-extension/issues/1467.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR https://github.com/Azure/azure-functions-durable-extension/issues/1504
* [x] I have added all required tests (Unit tests, E2E tests)
