### PR TITLE
Update host build pipeline to account for integration test build scenario

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,6 +60,11 @@ jobs:
     inputs:
       filePath: '$(Build.Repository.LocalPath)\build\build-extensions.ps1'
       arguments: '-buildNumber "$(buildNumber)" -suffix "$(suffix)" -commitHash "$(Build.SourceVersion)"'
+  - task: PowerShell@2
+    condition: eq(variables['RUNBUILDFORINTEGRATIONTESTS'], 'True')
+    displayName: "Update host references"
+    inputs:
+      filePath: '$(Build.Repository.LocalPath)\build\update-hostreferences.ps1'
   - task: CopyFiles@2
     inputs:
       SourceFolder: '$(Build.Repository.LocalPath)\buildoutput'
@@ -75,6 +80,29 @@ jobs:
         **\WebJobs.Script.csproj
         **\WebJobs.Script.WebHost.csproj
         **\WebJobs.Script.Grpc.csproj
+  
+  - pwsh: |
+      foreach ($baseName in @("WebJobs.Script", "WebJobs.Script.WebHost", "WebJobs.Script.Grpc"))
+      {    
+        $packageName = "Microsoft.Azure." + $baseName + "*.nupkg"    
+        $sourcePath = "$(Build.Repository.LocalPath)/packages/$packageName"        
+        if (-not (test-path $sourcePath))    
+        {        
+          throw "Unable to find '$packageName' at './package'"    
+        }   
+        Copy-Item -Path $sourcePath -Destination $(Build.ArtifactStagingDirectory) -ErrorAction Stop -Verbose -Force}
+    condition: eq(variables['RUNBUILDFORINTEGRATIONTESTS'], 'True')
+    displayName: 'Copy package to ArtifactStagingDirectory'
+
+  - task: NuGetCommand@2
+    condition: eq(variables['RUNBUILDFORINTEGRATIONTESTS'], 'True')
+    inputs:
+      command: 'push'
+      packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'
+      nuGetFeedType: 'internal'
+      publishVstsFeed: 'e6a70c92-4128-439f-8012-382fe78d6396/f37f760c-aebd-443e-9714-ce725cd427df'
+      allowPackageConflicts: true
+ 
   - task: DotNetCoreCLI@2
     displayName: 'Build performance package'
     inputs:

--- a/build/update-hostreferences.ps1
+++ b/build/update-hostreferences.ps1
@@ -1,0 +1,46 @@
+    $response = $null
+    try
+    {
+        $url = "https://raw.githubusercontent.com/Azure/azure-functions-integration-tests/main/integrationTestsBuild/V3/HostBuild.json"
+          $response = Invoke-WebRequest -Uri $url -ErrorAction Stop       
+           }
+    catch
+    {
+        throw "Failed to download package list from '$url'"
+    }
+    if (-not $response.Content)
+    {
+        throw "Failed to download package list. Verify that the file located at '$url' is not empty."
+    }
+    $packagesToUpdate = @($response.Content | ConvertFrom-Json)
+
+    # Update packages references
+    write-host "Updating Package references"
+    $source = "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsPreRelease/nuget/v3/index.json"
+    
+    $currentDirectory = Get-Location
+
+    $path = "$PSScriptRoot\..\src\WebJobs.Script"
+    if (-not (Test-Path $path))
+    {
+        throw "Failed to find '$path' to update package references"
+    }
+
+    try
+    {
+        set-location $path
+
+        foreach ($package in $packagesToUpdate)
+        {
+            $packageInfo = & {NuGet list $package -Source $source}
+                 $packageName = $packageInfo.Split()[0]
+            $packageVersion = $packageInfo.Split()[1]
+
+            Write-host "Adding $packageName $packageVersion to project" -ForegroundColor Green
+            & { dotnet add package $packageName -v $packageVersion -s $source }
+        }
+    }
+    finally
+    {
+        Set-Location $currentDirectory
+    }

--- a/build/update-hostreferences.ps1
+++ b/build/update-hostreferences.ps1
@@ -1,68 +1,70 @@
-    $response = $null
-
-    function WriteLog
+function WriteLog
+{
+    param (
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Message,
+        [Switch]
+        $Throw
+    )
+    $Message = (Get-Date -Format G)  + " -- $Message"
+    if ($Throw)
     {
-        param (
-            [Parameter(Mandatory=$true)]
-            [ValidateNotNullOrEmpty()]
-            [System.String]
-            $Message,
+        throw $Message
+    }
+    Write-Host $Message
+}
+WriteLog "Script started."
+# Make sure the project path exits
+$path = "$PSScriptRoot\..\src\WebJobs.Script"
+if (-not (Test-Path $path))
+{
+    WriteLog "Failed to find '$path' to update package references" -Throw
+}
+# Download the list of pacakges to update
+$response = $null
+try
+{
+    $url = "https://raw.githubusercontent.com/Azure/azure-functions-integration-tests/main/integrationTestsBuild/V3/HostBuild.json"
+    $response = Invoke-WebRequest -Uri $url -ErrorAction Stop       
+}
+catch
+{
+    WriteLog "Failed to download package list from '$url'" -Throw
+}
+if (-not $response.Content)
+{
+    WriteLog "Failed to download package list. Verify that the file located at '$url' is not empty." -Throw
+}
+$packagesToUpdate = @($response.Content | ConvertFrom-Json)
+if (!$packagesToUpdate.Count)
+{
+    WriteLog "There are no packages to update in '$url'" -Throw
+}
 
-            [Switch]
-            $Throw
-        )
-
-        $Message = (Get-Date -Format G)  + " -- $Message"
-
-        if ($Throw)
+# Update packages references
+WriteLog "Updating Package references"
+$source = "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsPreRelease/nuget/v3/index.json"
+$currentDirectory = Get-Location
+try
+{
+    set-location $path
+    foreach ($package in $packagesToUpdate)
+    {
+        $packageInfo = & {NuGet list $package -Source $source}
+        $packageName = $packageInfo.Split()[0]
+        $packageVersion = $packageInfo.Split()[1]
+        WriteLog "Adding '$packageName' '$packageVersion' to project"
+        & { dotnet add package $packageName -v $packageVersion -s $source }
+        if ($LASTEXITCODE -ne 0)
         {
-            throw $Message
-        }
-
-        Write-Host $Message
+            WriteLog "dotnet add package $packageName -v $packageVersion -s $source failed" -Throw    
+        }        
     }
-    try
-    {
-        $url = "https://raw.githubusercontent.com/Azure/azure-functions-integration-tests/main/integrationTestsBuild/V3/HostBuild.json"
-          $response = Invoke-WebRequest -Uri $url -ErrorAction Stop       
-           }
-    catch
-    {
-        throw "Failed to download package list from '$url'"
-    }
-    if (-not $response.Content)
-    {
-        throw "Failed to download package list. Verify that the file located at '$url' is not empty."
-    }
-    $packagesToUpdate = @($response.Content | ConvertFrom-Json)
-
-    # Update packages references
-    WriteLog "Updating Package references"
-    $source = "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsPreRelease/nuget/v3/index.json"
-    
-    $currentDirectory = Get-Location
-
-    $path = "$PSScriptRoot\..\src\WebJobs.Script"
-    if (-not (Test-Path $path))
-    {
-        throw "Failed to find '$path' to update package references"
-    }
-
-    try
-    {
-        set-location $path
-
-        foreach ($package in $packagesToUpdate)
-        {
-            $packageInfo = & {NuGet list $package -Source $source}
-                 $packageName = $packageInfo.Split()[0]
-            $packageVersion = $packageInfo.Split()[1]
-
-            WriteLog "Adding $packageName $packageVersion to project" 
-            & { dotnet add package $packageName -v $packageVersion -s $source }
-        }
-    }
-    finally
-    {
-        Set-Location $currentDirectory
-    }
+}
+finally
+{
+    Set-Location $currentDirectory
+}
+WriteLog "Script completed."

--- a/build/update-hostreferences.ps1
+++ b/build/update-hostreferences.ps1
@@ -5,23 +5,30 @@ function WriteLog
         [ValidateNotNullOrEmpty()]
         [System.String]
         $Message,
+
         [Switch]
         $Throw
     )
+
     $Message = (Get-Date -Format G)  + " -- $Message"
+
     if ($Throw)
     {
         throw $Message
     }
+
     Write-Host $Message
 }
+
 WriteLog "Script started."
+
 # Make sure the project path exits
 $path = "$PSScriptRoot\..\src\WebJobs.Script"
 if (-not (Test-Path $path))
 {
     WriteLog "Failed to find '$path' to update package references" -Throw
 }
+
 # Download the list of pacakges to update
 $response = $null
 try
@@ -33,10 +40,12 @@ catch
 {
     WriteLog "Failed to download package list from '$url'" -Throw
 }
+
 if (-not $response.Content)
 {
     WriteLog "Failed to download package list. Verify that the file located at '$url' is not empty." -Throw
 }
+
 $packagesToUpdate = @($response.Content | ConvertFrom-Json)
 if (!$packagesToUpdate.Count)
 {
@@ -46,17 +55,22 @@ if (!$packagesToUpdate.Count)
 # Update packages references
 WriteLog "Updating Package references"
 $source = "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsPreRelease/nuget/v3/index.json"
+
 $currentDirectory = Get-Location
 try
 {
     set-location $path
+
     foreach ($package in $packagesToUpdate)
     {
         $packageInfo = & {NuGet list $package -Source $source}
         $packageName = $packageInfo.Split()[0]
         $packageVersion = $packageInfo.Split()[1]
+
         WriteLog "Adding '$packageName' '$packageVersion' to project"
+
         & { dotnet add package $packageName -v $packageVersion -s $source }
+
         if ($LASTEXITCODE -ne 0)
         {
             WriteLog "dotnet add package $packageName -v $packageVersion -s $source failed" -Throw    
@@ -67,4 +81,5 @@ finally
 {
     Set-Location $currentDirectory
 }
+
 WriteLog "Script completed."

--- a/build/update-hostreferences.ps1
+++ b/build/update-hostreferences.ps1
@@ -1,4 +1,26 @@
     $response = $null
+
+    function WriteLog
+    {
+        param (
+            [Parameter(Mandatory=$true)]
+            [ValidateNotNullOrEmpty()]
+            [System.String]
+            $Message,
+
+            [Switch]
+            $Throw
+        )
+
+        $Message = (Get-Date -Format G)  + " -- $Message"
+
+        if ($Throw)
+        {
+            throw $Message
+        }
+
+        Write-Host $Message
+    }
     try
     {
         $url = "https://raw.githubusercontent.com/Azure/azure-functions-integration-tests/main/integrationTestsBuild/V3/HostBuild.json"
@@ -15,7 +37,7 @@
     $packagesToUpdate = @($response.Content | ConvertFrom-Json)
 
     # Update packages references
-    write-host "Updating Package references"
+    WriteLog "Updating Package references"
     $source = "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsPreRelease/nuget/v3/index.json"
     
     $currentDirectory = Get-Location
@@ -36,7 +58,7 @@
                  $packageName = $packageInfo.Split()[0]
             $packageVersion = $packageInfo.Split()[1]
 
-            Write-host "Adding $packageName $packageVersion to project" -ForegroundColor Green
+            WriteLog "Adding $packageName $packageVersion to project" 
             & { dotnet add package $packageName -v $packageVersion -s $source }
         }
     }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Changes added for integration tests build: 

- Added RUNINTEGRATIONTESTSBUILD flag to the host build, so that when it is set to "True" the steps for integration test build will run. (default is "False")

- Added script (update-hostreferences.ps1) to the build folder - updates references to the packages built whenever the integration tests pipeline runs. Script only runs when RUNINTEGRATIONTESTSBUILD = 'True'

- pushes binaries (Webjobs.Script, Webjobs.Script.Grpc, Webjobs.Script.WebHost) to AzureFunctionsPreRelease feed (when RUNINTEGRATIONTESTSBUILD = 'True')

resolves https://github.com/Azure/azure-functions-integration-tests/issues/3 (repo is currently private)

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

