### PR TITLE
Crank: Enable running Crank agent on Docker containers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -41,6 +41,8 @@
 *.fs text=auto
 *.fsx text=auto
 *.hs text=auto
+*.ps1 text=auto
+*.sh text=auto
 
 *.csproj text=auto
 *.vbproj text=auto

--- a/tools/Crank/Agent/Linux/Docker/Dockerfile
+++ b/tools/Crank/Agent/Linux/Docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM crank-agent
+
+ENTRYPOINT [ "/app/crank-agent", "--url", "http://*:5010" ]

--- a/tools/Crank/Agent/Linux/Docker/build.sh
+++ b/tools/Crank/Agent/Linux/Docker/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker build -t functions-crank-agent -f Dockerfile ../../

--- a/tools/Crank/Agent/Linux/Docker/run.sh
+++ b/tools/Crank/Agent/Linux/Docker/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+docker run -it --name functions-crank-agent -d --network host --restart always --privileged \
+--mount type=bind,source=/home/Functions/FunctionApps/HelloApp,target=/home/Functions/FunctionApps/HelloApp \
+-v /var/run/docker.sock:/var/run/docker.sock functions-crank-agent "$@"

--- a/tools/Crank/Agent/Linux/Docker/stop.sh
+++ b/tools/Crank/Agent/Linux/Docker/stop.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+docker stop functions-crank-agent
+docker rm functions-crank-agent

--- a/tools/Crank/Agent/Linux/bootstrap.sh
+++ b/tools/Crank/Agent/Linux/bootstrap.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-mkdir /home/Functions/github
-cd /home/Functions/github
+mkdir ~/github
+cd ~/github
 git clone https://github.com/Azure/azure-functions-host.git
 cd azure-functions-host
 git checkout dev
 
 cd tools/Crank/Agent
-chmod -R +x *.sh
-chmod -R +x *.ps1
+sudo find . -name "*.sh" -exec sudo chmod +xr {} \;
+sudo find . -name "*.ps1" -exec sudo chmod +xr {} \;
+
 Linux/install-powershell.sh
-sudo -H -u Functions ./setup-crank-agent.ps1 -CrankBranch master
+
+./setup-crank-agent-json.ps1 -ParametersJson $1 -Verbose

--- a/tools/Crank/Agent/Linux/install-docker.sh
+++ b/tools/Crank/Agent/Linux/install-docker.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Following instructions at https://docs.docker.com/engine/install/ubuntu
+
+sudo apt-get update
+
+sudo apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg-agent \
+    software-properties-common
+
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+
+sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+
+sudo groupadd docker
+sudo usermod -aG docker Functions
+newgrp docker
+
+sudo setfacl --modify user:Functions:rw /var/run/docker.sock
+
+sudo systemctl enable docker

--- a/tools/Crank/Agent/VmDeployment/template.json
+++ b/tools/Crank/Agent/VmDeployment/template.json
@@ -65,6 +65,12 @@
             "metadata": {
                 "description": "The name of the subscription that contains the keyvault."
             }
+        },
+        "customScriptParameters": {
+            "type": "string",
+            "metadata": {
+                "description": "Parameters passed to the custom script."
+            }
         }
     },
     "resources": [
@@ -139,6 +145,12 @@
                             "type": "string",
                             "metadata": {
                                 "description": "The OS disk type."
+                            }
+                        },
+                        "customScriptParameters": {
+                            "type": "string",
+                            "metadata": {
+                                "description": "Parameters passed to the custom script."
                             }
                         },
                         "virtualNetworkName": {
@@ -344,7 +356,7 @@
                                     "fileUris": [
                                         "https://raw.githubusercontent.com/Azure/azure-functions-host/dev/tools/Crank/Agent/Linux/bootstrap.sh"
                                     ],
-                                    "commandToExecute": "./bootstrap.sh"
+                                    "commandToExecute": "[concat('mv bootstrap.sh /home/Functions/ && cd /home/Functions && chmod +xr bootstrap.sh && sudo -H -u Functions ./bootstrap.sh \"', replace(parameters('customScriptParameters'), '\"', '\\\"'), '\"')]"
                                 },
                                 "publisher": "Microsoft.Azure.Extensions",
                                 "type": "CustomScript",
@@ -387,6 +399,9 @@
                     },
                     "osDiskType": {
                         "value": "[parameters('osDiskType')]"
+                    },
+                    "customScriptParameters": {
+                        "value": "[parameters('customScriptParameters')]"
                     },
                     "adminPasswordOrKey": {
                         "reference": {

--- a/tools/Crank/Agent/setup-crank-agent-json.ps1
+++ b/tools/Crank/Agent/setup-crank-agent-json.ps1
@@ -1,0 +1,13 @@
+#!/usr/bin/env pwsh
+
+[CmdletBinding()]
+param (
+    [string]$ParametersJson
+)
+
+$ErrorActionPreference = 'Stop'
+
+$parameters = @{}
+($ParametersJson | ConvertFrom-Json).PSObject.Properties | ForEach-Object { $parameters[$_.Name] = $_.Value }
+
+& "$PSScriptRoot/setup-crank-agent.ps1" @parameters -Verbose

--- a/tools/Crank/Agent/setup-crank-agent.ps1
+++ b/tools/Crank/Agent/setup-crank-agent.ps1
@@ -4,7 +4,8 @@
 param (
     [bool]$InstallDotNet = $true,
     [bool]$InstallCrankAgent = $true,
-    [string]$CrankBranch
+    [string]$CrankBranch,
+    [bool]$Docker = $false
 )
 
 $ErrorActionPreference = 'Stop'
@@ -25,24 +26,18 @@ function InstallDotNet {
     }
 }
 
-function New-TemporaryDirectory {
-    $parent = [System.IO.Path]::GetTempPath()
-    $name = [System.Guid]::NewGuid()
-    New-Item -ItemType Directory -Path (Join-Path $parent $name)
-}
+function BuildCrankAgent($CrankRepoPath) {
+    Push-Location $CrankRepoPath
+    try {
+        $logFileName = 'build.log'
+        Write-Verbose "Building crank (see $(Join-Path -Path $PWD -ChildPath $logFileName))..."
+        $buildCommand = $IsWindows ? '.\build.cmd' : './build.sh'
+        & $buildCommand -configuration Release -pack > $logFileName
 
-function BuildCrankAgent($BranchOrCommit) {
-    Write-Verbose "Cloning crank repo..."
-    git clone https://github.com/dotnet/crank.git > $null
-    git checkout $BranchOrCommit
-    Set-Location crank
-
-    $logFileName = 'build.log'
-    Write-Verbose "Building crank (see $(Join-Path -Path $PWD -ChildPath $logFileName))..."
-    $buildCommand = $IsWindows ? '.\build.cmd' : './build.sh'
-    & $buildCommand -configuration Release -pack > $logFileName
-
-    Join-Path -Path $PWD -ChildPath "artifacts/packages/Release/Shipping"
+        Join-Path -Path $PWD -ChildPath "artifacts/packages/Release/Shipping"
+    } finally {
+        Pop-Location
+    }
 }
 
 function GetDotNetToolsLocationArgs {
@@ -75,24 +70,55 @@ function InstallCrankAgentTool($LocalPackageSource) {
         $installArgs += '--add-source', $LocalPackageSource
     }
 
+    Write-Verbose "Invoking dotnet with arguments: $installArgs"
     & dotnet $installArgs
 }
 
+function EnsureDirectoryExists($Path) {
+    if (-not (Test-Path -PathType Container -Path $Path)) {
+        New-Item -ItemType Directory -Path $Path | Out-Null
+    }
+}
+
+function CloneCrankRepo {
+    Write-Verbose "Cloning crank repo..."
+    $githubPath = Join-Path -Path '~' -ChildPath 'github'
+    EnsureDirectoryExists $githubPath
+    Push-Location -Path $githubPath
+    try {
+        git clone https://github.com/dotnet/crank.git | Out-Null
+        Set-Location crank
+        if ($CrankBranch) {
+            git checkout $CrankBranch | Out-Null
+        }
+        $PWD.Path
+    } finally {
+        Pop-Location
+    }
+}
+
 function InstallCrankAgent {
-    if ($CrankBranch) {
-        $tempDir = New-TemporaryDirectory
-        Write-Verbose "Creating temporary directory: $($tempDir.FullName)"
-        Push-Location -Path $tempDir.FullName
+    $crankRepoPath = CloneCrankRepo
+
+    if ($Docker) {
+        Push-Location $crankRepoPath/docker/agent
         try {
-            $packagesDirectory = BuildCrankAgent -BranchOrCommit $CrankBranch
-            InstallCrankAgentTool -LocalPackageSource $packagesDirectory
+            # Build the docker-agent image
+            ./build.sh
+
+            # Build the functions-docker-agent image
+            Set-Location $PSScriptRoot/Linux/Docker
+            ./build.sh
         } finally {
             Pop-Location
-            Write-Verbose "Removing temporary directory: $($tempDir.FullName)"
-            Remove-Item $tempDir.FullName -Recurse -Force -ErrorAction Ignore
         }
     } else {
-        InstallCrankAgentTool
+        if ($CrankBranch) {
+            $packagesDirectory = BuildCrankAgent -CrankRepoPath $crankRepoPath
+            InstallCrankAgentTool -LocalPackageSource $packagesDirectory
+        } else {
+            InstallCrankAgentTool
+        }
     }
 }
 
@@ -137,23 +163,44 @@ function ScheduleCrankAgentStartLinux($RunScriptPath) {
 }
 
 function ScheduleCrankAgentStart {
-    Write-Verbose 'Scheduling crank-agent start...'
+    if ($Docker) {
+        Write-Verbose 'Starting crank-agent...'
 
-    $scriptPath = Join-Path -Path (Split-Path $PSCommandPath -Parent) -ChildPath 'run-crank-agent.ps1'
-
-    if ($IsWindows) {
-        ScheduleCrankAgentStartWindows -RunScriptPath $scriptPath -Credential (Get-Credential)
+        $functionAppsPath = Join-Path -Path '~' -ChildPath 'FunctionApps'
+        EnsureDirectoryExists -Path $functionAppsPath
+        $helloAppPath = Join-Path -Path $functionAppsPath -ChildPath 'HelloApp'
+        EnsureDirectoryExists -Path $helloAppPath
+        
+        & "$PSScriptRoot/Linux/Docker/run.sh"
     } else {
-        ScheduleCrankAgentStartLinux -RunScriptPath $scriptPath
-    }
+        Write-Verbose 'Scheduling crank-agent start...'
 
-    Write-Warning 'Please reboot to start crank-agent'
+        $scriptPath = Join-Path -Path (Split-Path $PSCommandPath -Parent) -ChildPath 'run-crank-agent.ps1'
+
+        if ($IsWindows) {
+            ScheduleCrankAgentStartWindows -RunScriptPath $scriptPath -Credential (Get-Credential)
+        } else {
+            ScheduleCrankAgentStartLinux -RunScriptPath $scriptPath
+        }
+
+        Write-Warning 'Please reboot to start crank-agent'
+    }
+}
+
+function InstallDocker {
+    Write-Verbose 'Installing Docker...'
+    if ($IsWindows) {
+        throw 'Using Docker on Windows is not supported yet'
+    } else {
+        & "$PSScriptRoot/Linux/install-docker.sh"
+    }
 }
 
 #endregion
 
 #region Main
 
+if ($Docker) { InstallDocker }
 if ($InstallDotNet) { InstallDotNet }
 if ($InstallCrankAgent) { InstallCrankAgent }
 ScheduleCrankAgentStart


### PR DESCRIPTION
Enable running Crank agent on Docker containers

When deploying a Linux VM, provide the `-Docker` switch to make Crank agent run on a Docker container.

Example:

``` PowerShell
.\deploy.ps1 -SubscriptionName 'MySub' -OsType Linux -Docker -BaseName MyCrank
```