### PR TITLE
Skip parsing worker config files for dotnet apps

### DIFF
--- a/src/WebJobs.Script/Workers/Rpc/Configuration/LanguageWorkerOptionsSetup.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/LanguageWorkerOptionsSetup.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -25,6 +26,13 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         public void Configure(LanguageWorkerOptions options)
         {
+            string workerRuntime = _environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName);
+            if (!string.IsNullOrEmpty(workerRuntime) && workerRuntime.Equals(RpcWorkerConstants.DotNetLanguageWorkerName, System.StringComparison.OrdinalIgnoreCase))
+            {
+                // Skip parsing worker.config.json files for dotnet in-proc apps
+                options.WorkerConfigs = new List<RpcWorkerConfig>();
+                return;
+            }
             ISystemRuntimeInformation systemRuntimeInfo = new SystemRuntimeInformation();
             var configFactory = new RpcWorkerConfigFactory(_configuration, _logger, systemRuntimeInfo, _environment, _metricsLogger);
             options.WorkerConfigs = configFactory.GetConfigs();

--- a/test/WebJobs.Script.Tests/Configuration/LanguageWorkerOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/LanguageWorkerOptionsSetupTests.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
+{
+    public class LanguageWorkerOptionsSetupTests
+    {
+        [Theory]
+        [InlineData("DotNet")]
+        [InlineData("dotnet")]
+        [InlineData(null)]
+        [InlineData("node")]
+        public void LanguageWorkerOptions_Expected_ListOfConfigs(string workerRuntime)
+        {
+            var testEnvironment = new TestEnvironment();
+            var configurationBuilder = new ConfigurationBuilder()
+                .Add(new ScriptEnvironmentVariablesConfigurationSource());
+
+            var configuration = configurationBuilder.Build();
+            if (!string.IsNullOrEmpty(workerRuntime))
+            {
+                testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, workerRuntime);
+            }
+            LanguageWorkerOptionsSetup setup = new LanguageWorkerOptionsSetup(configuration, NullLoggerFactory.Instance, testEnvironment, new TestMetricsLogger());
+            LanguageWorkerOptions options = new LanguageWorkerOptions();
+            setup.Configure(options);
+            if (string.IsNullOrEmpty(workerRuntime))
+            {
+                Assert.Equal(4, options.WorkerConfigs.Count);
+            }
+            else if (workerRuntime.Equals(RpcWorkerConstants.DotNetLanguageWorkerName, StringComparison.OrdinalIgnoreCase))
+            {
+                Assert.Empty(options.WorkerConfigs);
+            }
+            else
+            {
+                Assert.Equal(1, options.WorkerConfigs.Count);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

If  `Functions_Worker_Runtime` is set to `dotnet` - avoid parsing worker.config.json files as they are not needed for in-proc dotnet function apps.

resolves #6750 
### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
