### PR TITLE
Do not wait Sync Triggers on a function creation. Fixes #6669

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
@@ -146,7 +146,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             }
 
             // we need to sync triggers if config changed, or the files changed
-            await _functionsSyncManager.TrySyncTriggersAsync();
+            // we do not want to wait until TrySyncTriggersAsync is finished, there can be several function creations at once
+            _ = Task.Factory.StartNew(() => _functionsSyncManager.TrySyncTriggersAsync());
 
             (var success, var functionMetadataResult) = await TryGetFunction(name, request);
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #6669

We are waiting for 5 secs after a restart and then we dispose the scopes needed for web requests completions:
https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/DependencyInjection/ScopedResolver.cs#L34

So if an ARM template has several functions defined we will end up with the exception "DryIoc.ContainerException: 'Container is disposed and should not be used: Container is disposed". as Sync Trigger can't be executed in parallel

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
