### PR TITLE
[pack]Copy 3.0.xxxx SiteExtension to 2.1.xxxx

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -246,6 +246,8 @@ jobs:
       contents: '**\CodeSignSummary-*.md'
   - publish: $(Build.ArtifactStagingDirectory)\Functions.3.0.$(buildNumber)${{ variables.artifactSuffix }}.zip
     artifact: Functions.3.0.$(buildNumber)${{ variables.artifactSuffix }}
+  - publish: $(Build.ArtifactStagingDirectory)\Functions.2.1.$(buildNumber)${{ variables.artifactSuffix }}.zip
+    artifact: Functions.2.1.$(buildNumber)${{ variables.artifactSuffix }}
   - publish: $(Build.ArtifactStagingDirectory)\Functions.Private.3.0.$(buildNumber)${{ variables.artifactSuffix }}.win-x32.inproc.zip
     artifact: Functions.Private.3.0.$(buildNumber)${{ variables.artifactSuffix }}.win-x32.inproc
   - publish: $(Build.ArtifactStagingDirectory)\Functions.Symbols.3.0.$(buildNumber)${{ variables.artifactSuffix }}.win-x64.zip

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -1,5 +1,5 @@
 param (
-  [string]$buildNumber = "19068",
+  [string]$buildNumber = "0",
   [string]$extensionVersion = "3.0.$buildNumber",
   [string]$v2CompatibleExtensionVersion = "2.1.$buildNumber",
   [string]$suffix = "",

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -172,7 +172,7 @@ function WriteHashesFile([string] $directoryPath) {
   New-Item -Path "$directoryPath/../temp_hashes" -ItemType Directory | Out-Null
   $temp_current = (Get-Location)
   Set-Location $directoryPath
-  Get-ChildItem -Recurse $directoryPath | where { $_.PsIsContainer -eq $false } | Foreach-Object { "Hash:" + [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes((Get-FileHash -Algorithm MD5 $_.FullName).Hash)) + " FileName:" + (Resolve-Path -Relative -Path $_.FullName) } | Out-File -FilePath "$directoryPath\..\temp_hashes\hashes.txt"
+  Get-ChildItem -Recurse $directoryPath | where { $_.PsIsContainer -eq $false } | Foreach-Object { "Hash:" + [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes((Get-FileHash -Algorithm MD5 $_.FullName).Hash)) + " FileName:" + (Resolve-Path -Relative -Path $_.FullName) } | Out-File -FilePath "$directoryPath\..\temp_hashes\hashesForHardlinks.txt"
   Move-Item -Path "$directoryPath/../temp_hashes/hashes.txt" -Destination "$directoryPath" -Force
   Set-Location $temp_current
   Remove-Item "$directoryPath/../temp_hashes" -Recurse -Force > $null

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -12,7 +12,7 @@ $buildOutput = Join-Path $rootDir "buildoutput"
 $hasSuffix = ![string]::IsNullOrEmpty($suffix)
 
 $extensionVersionNoSuffix = $extensionVersion
-$v2CompatibleExtensionVersionNoSuffix = $v2CompatibleExtensionVersionNoSuffix
+$v2CompatibleExtensionVersionNoSuffix = $v2CompatibleExtensionVersion
 
 if ($hasSuffix) {
   $extensionVersion = "$extensionVersion-$suffix"

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -149,7 +149,7 @@ function CreateSiteExtensions() {
     Write-Host "--------"
     WriteHashesFile $siteExtensionPath/$extensionVersionNoSuffix
     ZipContent $siteExtensionPath "$buildOutput\Functions.$extensionVersion$runtimeSuffix.zip"
-    Copy-Item "$buildOutput\Functions.$extensionVersion$runtimeSuffix.zip" -Destination "$buildOutput\Functions.$$v2CompatibleExtensionVersion$runtimeSuffix.zip"
+    Copy-Item "$buildOutput\Functions.$extensionVersion$runtimeSuffix.zip" -Destination "$buildOutput\Functions.$v2CompatibleExtensionVersion$runtimeSuffix.zip"
     
     
     Remove-Item $siteExtensionPath -Recurse -Force > $null

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -1,6 +1,7 @@
 param (
   [string]$buildNumber = "0",
   [string]$extensionVersion = "3.0.$buildNumber",
+  [string]$v2CompatibleExtensionVersion = "2.1.$buildNumber",
   [string]$suffix = "",
   [string]$commitHash = "N/A"
 )
@@ -82,6 +83,7 @@ function BuildRuntime([string] $targetRid, [bool] $isSelfContained) {
     Write-Host ""
 
     ZipContent $symbolsTarget "$buildOutput\Functions.Symbols.$extensionVersion$runtimeSuffix.zip"
+    Copy-Item "$buildOutput\Functions.Symbols.$extensionVersion$runtimeSuffix.zip" -Destination "$buildOutput\Functions.Symbols.$v2CompatibleExtensionVersion$runtimeSuffix.zip"
 }
 
 function GetFolderSizeInMb([string] $rootPath) {
@@ -147,6 +149,8 @@ function CreateSiteExtensions() {
     Write-Host "--------"
     WriteHashesFile $siteExtensionPath/$extensionVersionNoSuffix
     ZipContent $siteExtensionPath "$buildOutput\Functions.$extensionVersion$runtimeSuffix.zip"
+    Copy-Item "$buildOutput\Functions.$extensionVersion$runtimeSuffix.zip" -Destination "$buildOutput\Functions.$$v2CompatibleExtensionVersion$runtimeSuffix.zip"
+    
     
     Remove-Item $siteExtensionPath -Recurse -Force > $null
     
@@ -159,6 +163,7 @@ function CreateSiteExtensions() {
     Write-Host ""
     
     ZipContent $siteExtensionPath "$buildOutput\Functions.Private.$extensionVersion.win-x32.inproc.zip"
+    Copy-Item "$buildOutput\Functions.Private.$extensionVersion.win-x32.inproc.zip" -Destination "$buildOutput\Functions.Private.$v2CompatibleExtensionVersion.win-x32.inproc.zip"
     
     Remove-Item $siteExtensionPath -Recurse -Force > $null
 }

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -160,9 +160,8 @@ function CreateSiteExtensions() {
 
     Write-Host "======================================"
     Write-Host "Copying $extensionVersion site extension to generate $v2CompatibleExtensionVersion."
-    Copy-Item -Path $officialSiteExtensionPath -Destination $officialV2CompatibleSiteExtensionPath\$v2CompatibleExtensionVersion -Force -Recurse > $null
+    Copy-Item -Path $officialSiteExtensionPath -Destination $officialV2CompatibleSiteExtensionPath\$v2CompatibleExtensionVersionNoSuffix -Force -Recurse > $null
     Copy-Item $rootDir\src\WebJobs.Script.WebHost\extension.xml $officialV2CompatibleSiteExtensionPath > $null
-    Write-Host "officialV2CompatibleSiteExtensionPath $officialV2CompatibleSiteExtensionPath"
     ZipContent $officialV2CompatibleSiteExtensionPath "$buildOutput\Functions.$v2CompatibleExtensionVersion$runtimeSuffix.zip"
     Write-Host "======================================"
     

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -12,9 +12,11 @@ $buildOutput = Join-Path $rootDir "buildoutput"
 $hasSuffix = ![string]::IsNullOrEmpty($suffix)
 
 $extensionVersionNoSuffix = $extensionVersion
+$v2CompatibleExtensionVersionNoSuffix = $v2CompatibleExtensionVersionNoSuffix
 
 if ($hasSuffix) {
   $extensionVersion = "$extensionVersion-$suffix"
+  $v2CompatibleExtensionVersion = "$v2CompatibleExtensionVersion-$suffix"
 }
 
 function ZipContent([string] $sourceDirectory, [string] $target)
@@ -126,7 +128,7 @@ function CreateSiteExtensions() {
     # The official site extension needs to be nested inside a folder with its version.
     # Not using the suffix (eg: '-ci') here as it may not work correctly in a private stamp
     $officialSiteExtensionPath = "$siteExtensionPath\$extensionVersionNoSuffix"
-    $officialV2CompatibleSiteExtensionPath = "$v2CompatibleSiteExtensionPath\$v2CompatibleExtensionVersion"
+    $officialV2CompatibleSiteExtensionPath = "$v2CompatibleSiteExtensionPath\$v2CompatibleExtensionVersionNoSuffix"
     
     Write-Host "======================================"
     Write-Host "Copying build to temp directory to prepare for zipping official site extension."
@@ -151,9 +153,9 @@ function CreateSiteExtensions() {
     Write-Host "Generating $hashesForHardlinksFile"
     Write-Host "======================================"
     WriteHashesFile $siteExtensionPath/$extensionVersionNoSuffix
+    Write-Host "Done generating $hashesForHardlinksFile"
     Write-Host "======================================"
 
-    Write-Host "siteExtensionPath: $siteExtensionPath officialSiteExtensionPath: $officialSiteExtensionPath" 
     ZipContent $siteExtensionPath "$buildOutput\Functions.$extensionVersion$runtimeSuffix.zip"
 
     Write-Host "======================================"
@@ -198,6 +200,7 @@ if (Test-Path $buildOutput) {
     Remove-Item $buildOutput -Recurse -Force
 }
 Write-Host "Extensions version: $extensionVersion"
+Write-Host "V2 compatible Extensions version: $v2CompatibleExtensionVersion"
 Write-Host ""
 
 BuildRuntime "win-x86"

--- a/src/WebJobs.Script.Grpc/generate_protos.bat
+++ b/src/WebJobs.Script.Grpc/generate_protos.bat
@@ -34,7 +34,7 @@ setlocal
 @rem enter Script.Rpc directory
 cd /d %~dp0
 
-set NUGET_PATH="E:\nuget\packages"
+set NUGET_PATH="%UserProfile%\.nuget\packages"
 set GRPC_TOOLS_PATH=%NUGET_PATH%\grpc.tools\2.27.0\tools\windows_x86
 set PROTO_PATH=.\azure-functions-language-worker-protobuf\src\proto
 set PROTO=.\azure-functions-language-worker-protobuf\src\proto\FunctionRpc.proto

--- a/src/WebJobs.Script.Grpc/generate_protos.bat
+++ b/src/WebJobs.Script.Grpc/generate_protos.bat
@@ -34,7 +34,7 @@ setlocal
 @rem enter Script.Rpc directory
 cd /d %~dp0
 
-set NUGET_PATH="%UserProfile%\.nuget\packages"
+set NUGET_PATH="E:\nuget\packages"
 set GRPC_TOOLS_PATH=%NUGET_PATH%\grpc.tools\2.27.0\tools\windows_x86
 set PROTO_PATH=.\azure-functions-language-worker-protobuf\src\proto
 set PROTO=.\azure-functions-language-worker-protobuf\src\proto\FunctionRpc.proto


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
- Updated build script to copy site extension output 3.0.xxxx to 2.1.xxxx
- Starting end of october build 2.1.xxxx will be part of windows deployment
- When running in Azure, any apps with `Functions_Extension_Version` set to `~2` will run using Site Extension: 2.1.xxxx , this will ensure apps are running with V2 Compatibility flag on 

resolves #6592

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
