### PR TITLE
adding HostDisposedException to help track down source of disposal exceptions

### DIFF
--- a/src/WebJobs.Script.WebHost/DependencyInjection/JobHostServiceProvider.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/JobHostServiceProvider.cs
@@ -105,9 +105,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
             {
                 return _currentResolver.CreateChildScope(_rootScopeFactory);
             }
-            catch (ContainerException ex) when (ex.Error == 39)
+            catch (ContainerException ex) when (ex.Error == Error.ContainerIsDisposed)
             {
-                // container is disposed
                 throw new HostDisposedException(_currentResolver.GetType().FullName, ex);
             }
         }

--- a/src/WebJobs.Script.WebHost/DependencyInjection/JobHostServiceProvider.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/JobHostServiceProvider.cs
@@ -101,7 +101,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
 
         public IServiceScope CreateScope()
         {
-            return _currentResolver.CreateChildScope(_rootScopeFactory);
+            try
+            {
+                return _currentResolver.CreateChildScope(_rootScopeFactory);
+            }
+            catch (ContainerException ex) when (ex.Error == 39)
+            {
+                // container is disposed
+                throw new HostDisposedException(_currentResolver.GetType().FullName, ex);
+            }
         }
 
         public void Dispose()

--- a/src/WebJobs.Script.WebHost/Diagnostics/ScriptLoggerFactory.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/ScriptLoggerFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -23,7 +24,19 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         public ILogger CreateLogger(string categoryName)
         {
-            return _factory.CreateLogger(categoryName);
+            return CreateLoggerInternal(categoryName);
+        }
+
+        internal virtual ILogger CreateLoggerInternal(string categoryName)
+        {
+            try
+            {
+                return _factory.CreateLogger(categoryName);
+            }
+            catch (ObjectDisposedException ex)
+            {
+                throw new HostDisposedException(typeof(ScriptLoggerFactory).FullName, ex);
+            }
         }
 
         public void Dispose()

--- a/src/WebJobs.Script/HostDisposedException.cs
+++ b/src/WebJobs.Script/HostDisposedException.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.Serialization;
+using Microsoft.Azure.WebJobs.Host.Listeners;
+
+namespace Microsoft.Azure.WebJobs.Script
+{
+    /// <summary>
+    /// An exception that indicates that a service was used on a disposed host.
+    /// </summary>
+    [Serializable]
+    public class HostDisposedException : Exception
+    {
+        // For this exception, we want a full stack trace to pinpoint the method
+        // that is trying to use a disposed host.
+        private readonly string _stackTraceString;
+
+        public HostDisposedException(string disposedObjectName, Exception inner)
+            : base(GetDefaultMessage(disposedObjectName), inner)
+        {
+            _stackTraceString = GetStackTraceString();
+        }
+
+        protected HostDisposedException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            if (info == null)
+            {
+                throw new ArgumentNullException(nameof(info));
+            }
+
+            _stackTraceString = info.GetString("FullStackTraceString");
+        }
+
+        public override string StackTrace => _stackTraceString;
+
+        public string GetStackTraceString()
+        {
+            return new StackTrace(true).ToString();
+        }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+
+            info.AddValue("FullStackTraceString", _stackTraceString);
+        }
+
+        private static string GetDefaultMessage(string disposedObjectName)
+        {
+            string message = $"The host is disposed and cannot be used. Disposed object: '{disposedObjectName}'";
+
+            var stack = new StackTrace(true);
+
+            foreach (StackFrame frame in stack.GetFrames())
+            {
+                Type declaringType = frame.GetMethod()?.DeclaringType;
+
+                if (typeof(IListener).IsAssignableFrom(declaringType))
+                {
+                    message += $"; Found IListener in stack trace: '{declaringType.AssemblyQualifiedName}'";
+                }
+            }
+
+            return message;
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -13,7 +13,6 @@ using System.Xml;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.ExtensionBundle;
 using Microsoft.Azure.WebJobs.Script.Models;
 using Microsoft.Azure.WebJobs.Script.WebHost;
@@ -44,12 +43,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         private readonly TestLoggerProvider _scriptHostLoggerProvider = new TestLoggerProvider();
         private readonly WebJobsScriptHostService _hostService;
 
+        public TestFunctionHost(string scriptPath,
+           Action<IServiceCollection> configureWebHostServices = null,
+           Action<IWebJobsBuilder> configureScriptHostWebJobsBuilder = null,
+           Action<IConfigurationBuilder> configureScriptHostAppConfiguration = null,
+           Action<ILoggingBuilder> configureScriptHostLogging = null,
+           Action<IServiceCollection> configureScriptHostServices = null)
+            : this(scriptPath, Path.Combine(Path.GetTempPath(), @"Functions"), configureWebHostServices, configureScriptHostWebJobsBuilder,
+                  configureScriptHostAppConfiguration, configureScriptHostLogging, configureScriptHostServices)
+        {
+        }
+
         public TestFunctionHost(string scriptPath, string logPath,
-            Action<IServiceCollection> configureWebHostServices = null,
-            Action<IWebJobsBuilder> configureScriptHostWebJobsBuilder = null,
-            Action<IConfigurationBuilder> configureScriptHostAppConfiguration = null,
-            Action<ILoggingBuilder> configureScriptHostLogging = null,
-            Action<IServiceCollection> configureScriptHostServices = null)
+        Action<IServiceCollection> configureWebHostServices = null,
+        Action<IWebJobsBuilder> configureScriptHostWebJobsBuilder = null,
+        Action<IConfigurationBuilder> configureScriptHostAppConfiguration = null,
+        Action<ILoggingBuilder> configureScriptHostLogging = null,
+        Action<IServiceCollection> configureScriptHostServices = null)
         {
             _appRoot = scriptPath;
 

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -55,11 +55,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         public TestFunctionHost(string scriptPath, string logPath,
-        Action<IServiceCollection> configureWebHostServices = null,
-        Action<IWebJobsBuilder> configureScriptHostWebJobsBuilder = null,
-        Action<IConfigurationBuilder> configureScriptHostAppConfiguration = null,
-        Action<ILoggingBuilder> configureScriptHostLogging = null,
-        Action<IServiceCollection> configureScriptHostServices = null)
+            Action<IServiceCollection> configureWebHostServices = null,
+            Action<IWebJobsBuilder> configureScriptHostWebJobsBuilder = null,
+            Action<IConfigurationBuilder> configureScriptHostAppConfiguration = null,
+            Action<ILoggingBuilder> configureScriptHostLogging = null,
+            Action<IServiceCollection> configureScriptHostServices = null)
         {
             _appRoot = scriptPath;
 

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/CustomTrigger/function.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/CustomTrigger/function.json
@@ -1,0 +1,9 @@
+﻿{
+  "bindings": [
+    {
+      "type": "customTrigger",
+      "name": "input",
+      "direction": "in"
+    }
+  ]
+}

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/CustomTrigger/run.csx
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/CustomTrigger/run.csx
@@ -1,0 +1,6 @@
+﻿
+using System;
+
+public static void Run(string input)
+{    
+}

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/HostDisposedExceptionTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/HostDisposedExceptionTests.cs
@@ -1,0 +1,203 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Description;
+using Microsoft.Azure.WebJobs.Host.Bindings;
+using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Azure.WebJobs.Host.Protocols;
+using Microsoft.Azure.WebJobs.Host.Triggers;
+using Microsoft.Azure.WebJobs.Script.Tests.EndToEnd;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.WebJobs.Script.Tests;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Integration
+{
+    [Trait(TestTraits.Category, TestTraits.EndToEnd)]
+    [Trait(TestTraits.Group, nameof(CSharpEndToEndTests))]
+    public class HostDisposedExceptionTests
+    {
+        [Fact]
+        public async Task DisposedScriptLoggerFactory_UsesFullStackTrace()
+        {
+            var host = new TestFunctionHost(@"TestScripts\CSharp",
+                configureScriptHostServices: s =>
+                {
+                    s.AddSingleton<IExtensionConfigProvider, CustomTriggerExtensionConfigProvider>();
+                    s.Configure<ScriptJobHostOptions>(o => o.Functions = new[] { "CustomTrigger" });
+                });
+
+            await CustomListener.RunAsync("one");
+
+            host.Dispose();
+
+            // In this scenario, the logger throws an exception before we enter the try/catch for the function invocation.
+            var ex = await Assert.ThrowsAsync<HostDisposedException>(() => CustomListener.RunAsync("two"));
+
+            Assert.Equal($"The host is disposed and cannot be used. Disposed object: '{typeof(ScriptLoggerFactory).FullName}'; Found IListener in stack trace: '{typeof(CustomListener).AssemblyQualifiedName}'", ex.Message);
+            Assert.Contains("CustomListener.RunAsync", ex.StackTrace);
+        }
+
+        [Fact]
+        public async Task DisposedResolver_UsesFullStackTrace()
+        {
+            var host = new TestFunctionHost(@"TestScripts\CSharp",
+                configureScriptHostServices: s =>
+                {
+                    s.AddSingleton<IExtensionConfigProvider, CustomTriggerExtensionConfigProvider>();
+                    s.Configure<ScriptJobHostOptions>(o => o.Functions = new[] { "CustomTrigger" });
+                    s.AddSingleton<ILoggerFactory, TestScriptLoggerFactory>();
+                });
+
+            await CustomListener.RunAsync("one");
+
+            host.Dispose();
+
+            // In this scenario, the function is considered failed even though the function itself was never called.
+            var result = await CustomListener.RunAsync("two");
+
+            Assert.False(result.Succeeded);
+
+            var ex = result.Exception;
+            Assert.Equal($"The host is disposed and cannot be used. Disposed object: '{typeof(ScopedResolver).FullName}'; Found IListener in stack trace: '{typeof(CustomListener).AssemblyQualifiedName}'", ex.Message);
+            Assert.Contains("CustomListener.RunAsync", ex.StackTrace);
+        }
+
+        [Fact]
+        public void Serialization()
+        {
+            HostDisposedException originalEx = new HostDisposedException("someObject", new ObjectDisposedException("someObject"));
+            HostDisposedException deserializedEx;
+
+            BinaryFormatter bf = new BinaryFormatter();
+            using (MemoryStream ms = new MemoryStream())
+            {
+                bf.Serialize(ms, originalEx);
+                ms.Seek(0, 0);
+                deserializedEx = (HostDisposedException)bf.Deserialize(ms);
+            }
+
+            Assert.Equal(originalEx.ToString(), deserializedEx.ToString());
+        }
+
+        private class TestScriptLoggerFactory : ScriptLoggerFactory
+        {
+            public static bool ShouldWait { get; set; } = false;
+
+            public TestScriptLoggerFactory(IEnumerable<ILoggerProvider> providers, IOptionsMonitor<LoggerFilterOptions> filterOption)
+                : base(providers, filterOption)
+            {
+            }
+
+            internal override ILogger CreateLoggerInternal(string categoryName)
+            {
+                try
+                {
+                    return base.CreateLoggerInternal(categoryName);
+                }
+                catch (HostDisposedException)
+                {
+                    // Simulate the race where the logger succeeds and later the container fails.
+                    return NullLogger.Instance;
+                }
+            }
+        }
+
+        [Binding]
+        public class CustomTriggerAttribute : Attribute
+        {
+        }
+
+        private class CustomTriggerExtensionConfigProvider : IExtensionConfigProvider
+        {
+            public void Initialize(ExtensionConfigContext context)
+            {
+                var rule = context.AddBindingRule<CustomTriggerAttribute>();
+                rule.BindToTrigger<string>(new CustomTriggerAttributeBindingProvider());
+            }
+        }
+
+        private class CustomTriggerAttributeBindingProvider : ITriggerBindingProvider
+        {
+            public Task<ITriggerBinding> TryCreateAsync(TriggerBindingProviderContext context)
+            {
+                ParameterInfo parameter = context.Parameter;
+                CustomTriggerAttribute attribute = parameter.GetCustomAttribute<CustomTriggerAttribute>(inherit: false);
+                if (attribute == null)
+                {
+                    return Task.FromResult<ITriggerBinding>(null);
+                }
+
+                return Task.FromResult<ITriggerBinding>(new CustomTriggerBinding());
+            }
+        }
+
+        private class CustomTriggerBinding : ITriggerBinding
+        {
+            private readonly IReadOnlyDictionary<string, object> _emptyBindingData = new Dictionary<string, object>();
+
+            public Type TriggerValueType => typeof(string);
+
+            public IReadOnlyDictionary<string, Type> BindingDataContract { get; } = new Dictionary<string, Type>();
+
+            public Task<ITriggerData> BindAsync(object value, ValueBindingContext context)
+            {
+                return Task.FromResult<ITriggerData>(new TriggerData(null, _emptyBindingData));
+            }
+
+            public Task<IListener> CreateListenerAsync(ListenerFactoryContext context)
+            {
+                return Task.FromResult<IListener>(new CustomListener(context.Executor));
+            }
+
+            public ParameterDescriptor ToParameterDescriptor()
+            {
+                return new ParameterDescriptor();
+            }
+        }
+
+        private class CustomListener : IListener
+        {
+            private static ITriggeredFunctionExecutor _executor;
+
+            public CustomListener(ITriggeredFunctionExecutor executor)
+            {
+                _executor = executor;
+            }
+
+            public void Cancel()
+            {
+            }
+
+            public static Task<FunctionResult> RunAsync(string input)
+            {
+                return _executor.TryExecuteAsync(new TriggeredFunctionData() { TriggerValue = input }, CancellationToken.None);
+            }
+
+            public Task StartAsync(CancellationToken cancellationToken)
+            {
+                return Task.CompletedTask;
+            }
+
+            public Task StopAsync(CancellationToken cancellationToken)
+            {
+                return Task.CompletedTask;
+            }
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
This will help us get to the bottom of issues like #5240, #6622

**Note this is not a fix for the exceptions, but it gives us more context to investigate and improve the scenarios.**

These exceptions are thrown when the host has been disposed and yet there are functions still attempting to run on that host. As an example (the one I added in my test), this can happen if a Listener has a race where it returns back from `StopAsync()` before all invocations have started. Once all listeners return, the host assumes it's okay to dispose. This change will give us the full stack trace and additional details that will help us identify where this is happening in production.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)


Here's an example of the exception we would get previously:
```
DryIoc.ContainerException: Container is disposed and should not be used: Container is disposed.
You may include Dispose stack-trace into the message via:
container.With(rules => rules.WithCaptureContainerDisposeStackTrace())
   at DryIoc.Throw.It(Int32 error, Object arg0, Object arg1, Object arg2, Object arg3) in C:\git\functions_v3\azure-functions-host\src\WebJobs.Script.WebHost\DependencyInjection\DryIoc\Container.cs:line 9000
   at DryIoc.Container.ThrowIfContainerDisposed() in C:\git\functions_v3\azure-functions-host\src\WebJobs.Script.WebHost\DependencyInjection\DryIoc\Container.cs:line 412
   at DryIoc.Container.WithCurrentScope(IScope scope, Boolean preferInterpretaion) in C:\git\functions_v3\azure-functions-host\src\WebJobs.Script.WebHost\DependencyInjection\DryIoc\Container.cs:line 438
   at DryIoc.ResolverContext.OpenScope(IResolverContext r, Object name, Boolean trackInParent, Boolean preferInterpretation) in C:\git\functions_v3\azure-functions-host\src\WebJobs.Script.WebHost\DependencyInjection\DryIoc\Container.cs:line 2709
   at Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection.WebHostServiceProvider.CreateScope() in C:\git\functions_v3\azure-functions-host\src\WebJobs.Script.WebHost\DependencyInjection\WebHostServiceProvider.cs:line 51
   at Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection.ScopedResolver.CreateChildScope(IServiceScopeFactory rootScopeFactory) in C:\git\functions_v3\azure-functions-host\src\WebJobs.Script.WebHost\DependencyInjection\ScopedResolver.cs:line 43
   at Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection.JobHostServiceProvider.CreateScope() in C:\git\functions_v3\azure-functions-host\src\WebJobs.Script.WebHost\DependencyInjection\JobHostServiceProvider.cs:line 106
   at Microsoft.Azure.WebJobs.Host.Executors.FunctionInstance.get_InstanceServices() in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Executors\FunctionInstance.cs:line 50
   at Microsoft.Azure.WebJobs.Host.Executors.FunctionExecutor.ExecuteWithLoggingAsync(IFunctionInstanceEx instance, FunctionStartedMessage message, FunctionInstanceLogEntry instanceLogEntry, ParameterHelper parameterHelper, ILogger logger, CancellationToken cancellationToken) in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Executors\FunctionExecutor.cs:line 224
   at Microsoft.Azure.WebJobs.Host.Executors.FunctionExecutor.TryExecuteAsyncCore(IFunctionInstanceEx functionInstanceEx, CancellationToken cancellationToken, ILogger logger) in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Executors\FunctionExecutor.cs:line 97
```

And here's after (called from a new unit test):
```
Microsoft.Azure.WebJobs.Script.HostDisposedException: The host is disposed and cannot be used. Disposed object: 'Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection.ScopedResolver'; Found IListener in stack trace: 'Microsoft.Azure.WebJobs.Script.Tests.Integration.HostDisposedExceptionTests+CustomListener, Microsoft.Azure.WebJobs.Script.Tests.Integration, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null'
 ---> DryIoc.ContainerException: Container is disposed and should not be used: Container is disposed.
You may include Dispose stack-trace into the message via:
container.With(rules => rules.WithCaptureContainerDisposeStackTrace())
   at DryIoc.Throw.It(Int32 error, Object arg0, Object arg1, Object arg2, Object arg3) in C:\git\functions_v3\azure-functions-host\src\WebJobs.Script.WebHost\DependencyInjection\DryIoc\Container.cs:line 9000
   at DryIoc.Container.ThrowIfContainerDisposed() in C:\git\functions_v3\azure-functions-host\src\WebJobs.Script.WebHost\DependencyInjection\DryIoc\Container.cs:line 412
   at DryIoc.Container.WithCurrentScope(IScope scope, Boolean preferInterpretaion) in C:\git\functions_v3\azure-functions-host\src\WebJobs.Script.WebHost\DependencyInjection\DryIoc\Container.cs:line 438
   at DryIoc.ResolverContext.OpenScope(IResolverContext r, Object name, Boolean trackInParent, Boolean preferInterpretation) in C:\git\functions_v3\azure-functions-host\src\WebJobs.Script.WebHost\DependencyInjection\DryIoc\Container.cs:line 2709
   at Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection.WebHostServiceProvider.CreateScope() in C:\git\functions_v3\azure-functions-host\src\WebJobs.Script.WebHost\DependencyInjection\WebHostServiceProvider.cs:line 51
   at Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection.ScopedResolver.CreateChildScope(IServiceScopeFactory rootScopeFactory) in C:\git\functions_v3\azure-functions-host\src\WebJobs.Script.WebHost\DependencyInjection\ScopedResolver.cs:line 43
   at Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection.JobHostServiceProvider.CreateScope() in C:\git\functions_v3\azure-functions-host\src\WebJobs.Script.WebHost\DependencyInjection\JobHostServiceProvider.cs:line 106
   --- End of inner exception stack trace ---
   at Microsoft.Azure.WebJobs.Script.HostDisposedException.GetStackTraceString() in C:\git\functions_v3\azure-functions-host\src\WebJobs.Script\HostDisposedException.cs:line 42
   at Microsoft.Azure.WebJobs.Script.HostDisposedException..ctor(String disposedObjectName, Exception inner) in C:\git\functions_v3\azure-functions-host\src\WebJobs.Script\HostDisposedException.cs:line 24
   at Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection.JobHostServiceProvider.CreateScope() in C:\git\functions_v3\azure-functions-host\src\WebJobs.Script.WebHost\DependencyInjection\JobHostServiceProvider.cs:line 106
   at Microsoft.Azure.WebJobs.Host.Executors.FunctionInstance.get_InstanceServices() in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Executors\FunctionInstance.cs:line 50
   at Microsoft.Azure.WebJobs.Host.Executors.FunctionExecutor.ExecuteWithLoggingAsync(IFunctionInstanceEx instance, FunctionStartedMessage message, FunctionInstanceLogEntry instanceLogEntry, ParameterHelper parameterHelper, ILogger logger, CancellationToken cancellationToken) in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Executors\FunctionExecutor.cs:line 224
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Microsoft.Azure.WebJobs.Host.Executors.FunctionExecutor.ExecuteWithLoggingAsync(IFunctionInstanceEx instance, FunctionStartedMessage message, FunctionInstanceLogEntry instanceLogEntry, ParameterHelper parameterHelper, ILogger logger, CancellationToken cancellationToken)
   at Microsoft.Azure.WebJobs.Host.Executors.FunctionExecutor.TryExecuteAsyncCore(IFunctionInstanceEx functionInstanceEx, CancellationToken cancellationToken, ILogger logger) in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Executors\FunctionExecutor.cs:line 97
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Microsoft.Azure.WebJobs.Host.Executors.FunctionExecutor.TryExecuteAsyncCore(IFunctionInstanceEx functionInstanceEx, CancellationToken cancellationToken, ILogger logger)
   at Microsoft.Azure.WebJobs.Host.Executors.FunctionExecutor.TryExecuteAsync(IFunctionInstance functionInstance, CancellationToken cancellationToken) in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Executors\FunctionExecutor.cs:line 77
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Microsoft.Azure.WebJobs.Host.Executors.FunctionExecutor.TryExecuteAsync(IFunctionInstance functionInstance, CancellationToken cancellationToken)
   at Microsoft.Azure.WebJobs.Host.Executors.FunctionExecutorExtensions.TryExecuteAsync(IFunctionExecutor executor, Func`1 instanceFactory, ILoggerFactory loggerFactory, CancellationToken cancellationToken) in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Executors\FunctionExecutorExtensions.cs:line 30
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Microsoft.Azure.WebJobs.Host.Executors.FunctionExecutorExtensions.TryExecuteAsync(IFunctionExecutor executor, Func`1 instanceFactory, ILoggerFactory loggerFactory, CancellationToken cancellationToken)
   at Microsoft.Azure.WebJobs.Host.Executors.TriggeredFunctionExecutor`1.TryExecuteAsync(TriggeredFunctionData input, CancellationToken cancellationToken) in C:\projects\azure-webjobs-sdk-rqm4t\src\Microsoft.Azure.WebJobs.Host\Executors\TriggeredFunctionExecutor.cs:line 59
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at Microsoft.Azure.WebJobs.Host.Executors.TriggeredFunctionExecutor`1.TryExecuteAsync(TriggeredFunctionData input, CancellationToken cancellationToken)
   at Microsoft.Azure.WebJobs.Script.Tests.Integration.HostDisposedExceptionTests.CustomListener.RunAsync(String input) in C:\git\functions_v3\azure-functions-host\test\WebJobs.Script.Tests.Integration\WebHostEndToEnd\HostDisposedExceptionTests.cs:line 185
   at Microsoft.Azure.WebJobs.Script.Tests.Integration.HostDisposedExceptionTests.DisposedResolver_UsesFullStackTrace() in C:\git\functions_v3\azure-functions-host\test\WebJobs.Script.Tests.Integration\WebHostEndToEnd\HostDisposedExceptionTests.cs:line 68
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.ExecutionContextCallback(Object s)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)
   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext()
   at System.Runtime.CompilerServices.TaskAwaiter.<>c.<OutputWaitEtwEvents>b__12_0(Action innerContinuation, Task innerTask)
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.ContinuationWrapper.Invoke()
   at System.Threading.Tasks.SynchronizationContextAwaitTaskContinuation.<>c__DisplayClass6_0.<GetActionLogDelegate>b__0()
   at System.Threading.Tasks.SynchronizationContextAwaitTaskContinuation.<>c.<.cctor>b__8_0(Object state)
   at Xunit.Sdk.AsyncTestSyncContext.<>c__DisplayClass7_0.<Post>b__0() in C:\Dev\xunit\xunit\src\xunit.execution\Sdk\AsyncTestSyncContext.cs:line 58
   at Xunit.Sdk.XunitWorkerThread.<>c.<QueueUserWorkItem>b__4_0(Object _) in C:\Dev\xunit\xunit\src\common\XunitWorkerThread.cs:line 92
   at System.Threading.QueueUserWorkItemCallbackDefaultContext.Execute()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback()

```