### PR TITLE
Crank: enable moving load generator to a separate VM

### DIFF
--- a/tools/Crank/Agent/VmDeployment/deploy-vm.ps1
+++ b/tools/Crank/Agent/VmDeployment/deploy-vm.ps1
@@ -1,0 +1,78 @@
+#!/usr/bin/env pwsh
+
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory = $true)]
+    [string]
+    $SubscriptionName,
+
+    [Parameter(Mandatory = $true)]
+    [string]
+    $BaseName,
+
+    [string]
+    $NamePostfix = '',
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('Linux', 'Windows')]
+    $OsType,
+
+    [switch]
+    $Docker,
+
+    [string]
+    $VmSize = 'Standard_E2s_v3',
+
+    [string]
+    $OsDiskType = 'Premium_LRS',
+
+    [string]
+    $Location = 'West Central US',
+
+    [string]
+    $UserName = 'Functions'
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($OsType -ne 'Linux') {
+    throw 'Only Linux is supported now'
+}
+
+$resourceGroupName = "FunctionsCrank-$OsType-$BaseName$NamePostfix"
+$vmName = "functions-crank-$OsType-$BaseName$NamePostfix".ToLower()
+Write-Verbose "Creating VM '$vmName' in resource group '$resourceGroupName'"
+
+Set-AzContext -Subscription $SubscriptionName | Out-Null
+
+New-AzResourceGroup -Name $resourceGroupName -Location $Location | Out-Null
+
+$vaultSubscriptionId = (Get-AzSubscription -SubscriptionName 'Antares-Demo').Id
+
+$customScriptParameters = @{
+    CrankBranch = 'master'
+    Docker = $Docker.IsPresent
+}
+
+New-AzResourceGroupDeployment `
+    -ResourceGroupName $resourceGroupName `
+    -TemplateFile "$PSScriptRoot\template.json" `
+    -TemplateParameterObject @{
+        vmName = $vmName
+        dnsLabelPrefix = $vmName
+        vmSize = $VmSize
+        osDiskType = $OsDiskType
+        adminUsername = $UserName
+        authenticationType = 'sshPublicKey'
+        vaultName = 'functions-crank-kv'
+        vaultResourceGroupName = 'FunctionsCrank'
+        vaultSubscription = $vaultSubscriptionId
+        secretName = 'LinuxCrankAgentVmSshKey-Public'
+        customScriptParameters = $customScriptParameters | ConvertTo-Json -Compress
+    } | Out-Null
+
+Write-Verbose 'Restarting the VM...'
+Restart-AzVM -ResourceGroupName $resourceGroupName -Name $vmName | Out-Null
+Start-Sleep -Seconds 30
+
+Write-Host "The crank VM is ready: $vmName"

--- a/tools/Crank/Agent/VmDeployment/deploy.ps1
+++ b/tools/Crank/Agent/VmDeployment/deploy.ps1
@@ -10,15 +10,15 @@ param (
     [string]
     $BaseName,
 
+    [string[]]
+    $NamePostfixes = @('-app', '-load'),
+
     [Parameter(Mandatory = $true)]
     [ValidateSet('Linux', 'Windows')]
     $OsType,
 
     [switch]
     $Docker,
-
-    [switch]
-    $SingleVm,
 
     [string]
     $VmSize = 'Standard_E2s_v3',
@@ -35,63 +35,23 @@ param (
 
 $ErrorActionPreference = 'Stop'
 
-#region Utilities
-
-function DeployCrankVm($NamePostfix) {
-    $resourceGroupName = "FunctionsCrank-$OsType-$BaseName$NamePostfix"
-    $vmName = "functions-crank-$OsType-$BaseName$NamePostfix".ToLower()
-    Write-Verbose "Creating VM '$vmName' in resource group '$resourceGroupName'"
-
-    Set-AzContext -Subscription $SubscriptionName | Out-Null
-
-    New-AzResourceGroup -Name $resourceGroupName -Location $Location | Out-Null
-
-    $vaultSubscriptionId = (Get-AzSubscription -SubscriptionName 'Antares-Demo').Id
-
-    $customScriptParameters = @{
-        CrankBranch = 'master'
-        Docker = $Docker.IsPresent
-    }
-
-    New-AzResourceGroupDeployment `
-        -ResourceGroupName $resourceGroupName `
-        -TemplateFile "$PSScriptRoot\template.json" `
-        -TemplateParameterObject @{
-            vmName = $vmName
-            dnsLabelPrefix = $vmName
-            vmSize = $VmSize
-            osDiskType = $OsDiskType
-            adminUsername = $UserName
-            authenticationType = 'sshPublicKey'
-            vaultName = 'functions-crank-kv'
-            vaultResourceGroupName = 'FunctionsCrank'
-            vaultSubscription = $vaultSubscriptionId
-            secretName = 'LinuxCrankAgentVmSshKey-Public'
-            customScriptParameters = $customScriptParameters | ConvertTo-Json -Compress
-        } | Out-Null
-
-    Write-Verbose 'Restarting the VM...'
-    Restart-AzVM -ResourceGroupName $resourceGroupName -Name $vmName | Out-Null
-    Start-Sleep -Seconds 30
-
-    Write-Host "The crank VM is ready: $vmName"
-}
-
-#endregion
-
-#region Main
-
 if ($OsType -ne 'Linux') {
     throw 'Only Linux is supported now'
 }
 
-if ($SingleVm) {
-    DeployCrankVm
-} else {
-    '-app', '-load' | ForEach-Object -Parallel { using:DeployCrankVm -NamePostfix $_ }
+$NamePostfixes | ForEach-Object -Parallel {
+    & "$using:PSScriptRoot/deploy-vm.ps1" `
+        -SubscriptionName $using:SubscriptionName `
+        -BaseName $using:BaseName `
+        -NamePostfix $_ `
+        -OsType $using:OsType `
+        -Docker:$using:Docker `
+        -VmSize $using:VmSize `
+        -OsDiskType $using:OsDiskType `
+        -Location $using:Location `
+        -UserName $using:UserName `
+        -Verbose:$using:VerbosePreference
 }
 
 # TODO: remove this warning when app deployment is automated
 Write-Warning "Remember to deploy the Function apps to /home/$UserName/FunctionApps"
-
-#endregion

--- a/tools/Crank/Agent/VmDeployment/deploy.ps1
+++ b/tools/Crank/Agent/VmDeployment/deploy.ps1
@@ -17,6 +17,9 @@ param (
     [switch]
     $Docker,
 
+    [switch]
+    $SeparateLoadVm,
+
     [string]
     $VmSize = 'Standard_E2s_v3',
 
@@ -32,47 +35,59 @@ param (
 
 $ErrorActionPreference = 'Stop'
 
+#region Utilities
+
+function DeployCrankVm {
+    $resourceGroupName = "FunctionsCrank-$OsType-$BaseName"
+    $vmName = "functions-crank-$OsType-$BaseName".ToLower()
+    Write-Verbose "Creating VM '$vmName' in resource group '$resourceGroupName'"
+
+    Set-AzContext -Subscription $SubscriptionName | Out-Null
+
+    New-AzResourceGroup -Name $resourceGroupName -Location $Location | Out-Null
+
+    $vaultSubscriptionId = (Get-AzSubscription -SubscriptionName 'Antares-Demo').Id
+
+    $customScriptParameters = @{
+        CrankBranch = 'master'
+        Docker = $Docker.IsPresent
+    }
+
+    New-AzResourceGroupDeployment `
+        -ResourceGroupName $resourceGroupName `
+        -TemplateFile "$PSScriptRoot\template.json" `
+        -TemplateParameterObject @{
+            vmName = $vmName
+            dnsLabelPrefix = $vmName
+            vmSize = $VmSize
+            osDiskType = $OsDiskType
+            adminUsername = $UserName
+            authenticationType = 'sshPublicKey'
+            vaultName = 'functions-crank-kv'
+            vaultResourceGroupName = 'FunctionsCrank'
+            vaultSubscription = $vaultSubscriptionId
+            secretName = 'LinuxCrankAgentVmSshKey-Public'
+            customScriptParameters = $customScriptParameters | ConvertTo-Json -Compress
+        }
+
+    Write-Verbose 'Restarting the VM...'
+    Restart-AzVM -ResourceGroupName $resourceGroupName -Name $vmName | Out-Null
+    Start-Sleep -Seconds 30
+}
+
+#endregion
+
+#region Main
+
 if ($OsType -ne 'Linux') {
     throw 'Only Linux is supported now'
 }
 
-$resourceGroupName = "FunctionsCrank-$OsType-$BaseName"
-$vmName = "functions-crank-$OsType-$BaseName".ToLower()
-Write-Verbose "Creating VM '$vmName' in resource group '$resourceGroupName'"
-
-Set-AzContext -Subscription $SubscriptionName | Out-Null
-
-New-AzResourceGroup -Name $resourceGroupName -Location $Location | Out-Null
-
-$vaultSubscriptionId = (Get-AzSubscription -SubscriptionName 'Antares-Demo').Id
-
-$customScriptParameters = @{
-    CrankBranch = 'master'
-    Docker = $Docker.IsPresent
-}
-
-New-AzResourceGroupDeployment `
-    -ResourceGroupName $resourceGroupName `
-    -TemplateFile "$PSScriptRoot\template.json" `
-    -TemplateParameterObject @{
-        vmName = $vmName
-        dnsLabelPrefix = $vmName
-        vmSize = $VmSize
-        osDiskType = $OsDiskType
-        adminUsername = $UserName
-        authenticationType = 'sshPublicKey'
-        vaultName = 'functions-crank-kv'
-        vaultResourceGroupName = 'FunctionsCrank'
-        vaultSubscription = $vaultSubscriptionId
-        secretName = 'LinuxCrankAgentVmSshKey-Public'
-        customScriptParameters = $customScriptParameters | ConvertTo-Json -Compress
-    }
-
-Write-Verbose 'Restarting the VM...'
-Restart-AzVM -ResourceGroupName $resourceGroupName -Name $vmName | Out-Null
-Start-Sleep -Seconds 30
+DeployCrankVm
 
 Write-Output "The crank VM is ready: $vmName"
 
 # TODO: remove this warning when app deployment is automated
 Write-Warning "Remember to deploy the Function apps to /home/$UserName/FunctionApps"
+
+#endregion

--- a/tools/Crank/Agent/VmDeployment/template.json
+++ b/tools/Crank/Agent/VmDeployment/template.json
@@ -256,6 +256,19 @@
                                             "destinationAddressPrefix": "*",
                                             "destinationPortRange": "5010"
                                         }
+                                    },
+                                    {
+                                        "name": "App-Port",
+                                        "properties": {
+                                            "priority": 1012,
+                                            "protocol": "*",
+                                            "access": "Allow",
+                                            "direction": "Inbound",
+                                            "sourceAddressPrefix": "*",
+                                            "sourcePortRange": "*",
+                                            "destinationAddressPrefix": "*",
+                                            "destinationPortRange": "5000"
+                                        }
                                     }
                                 ]
                             }

--- a/tools/Crank/Agent/VmDeployment/template.json
+++ b/tools/Crank/Agent/VmDeployment/template.json
@@ -258,7 +258,7 @@
                                         }
                                     },
                                     {
-                                        "name": "App-Port",
+                                        "name": "Benchmark-App",
                                         "properties": {
                                             "priority": 1012,
                                             "protocol": "*",

--- a/tools/Crank/benchmarks.yml
+++ b/tools/Crank/benchmarks.yml
@@ -66,7 +66,7 @@ scenarios:
 profiles:
   default:
     variables:
-      serverUri: http:///{{ CrankAgentAppVm }}
+      serverUri: http://{{ CrankAgentAppVm }}
       serverPort: 5000
     jobs: 
       application:

--- a/tools/Crank/benchmarks.yml
+++ b/tools/Crank/benchmarks.yml
@@ -66,12 +66,12 @@ scenarios:
 profiles:
   default:
     variables:
-      serverUri: http://localhost
+      serverUri: http:///{{ CrankAgentAppVm }}
       serverPort: 5000
     jobs: 
       application:
         endpoints: 
-          - "http://{{ CrankAgentVm }}:5010"
+          - "http://{{ CrankAgentAppVm }}:5010"
       load:
         endpoints: 
-          - "http://{{ CrankAgentVm }}:5010"
+          - "http://{{ CrankAgentLoadVm }}:5010"

--- a/tools/Crank/run-benchmarks.ps1
+++ b/tools/Crank/run-benchmarks.ps1
@@ -81,8 +81,8 @@ $homePath = if ($isLinuxApp) { "/home/$UserName/FunctionApps/$FunctionApp" } els
 $functionAppPath = if ($isLinuxApp) { "/home/$UserName/FunctionApps/$FunctionApp/site/wwwroot" } else { "C:\FunctionApps\$FunctionApp\site\wwwroot" }
 $tmpLogPath = if ($isLinuxApp) { "/tmp/functions/log" } else { 'C:\Temp\Functions\Log' }
 
- $aspNetUrls = "http://$($CrankAgentAppVm):5000"
- $profileName = "default"
+$aspNetUrls = "http://$($CrankAgentAppVm):5000"
+$profileName = "default"
 
 $crankArgs =
     '--config', $crankConfigPath,

--- a/tools/Crank/run-benchmarks.ps1
+++ b/tools/Crank/run-benchmarks.ps1
@@ -1,7 +1,11 @@
 param(
     [Parameter(Mandatory = $true)]
     [string]
-    $CrankAgentVm,
+    $CrankAgentAppVm,
+
+    [Parameter(Mandatory = $true)]
+    [string]
+    $CrankAgentLoadVm,
 
     [string]
     $BranchOrCommit = 'dev',
@@ -71,13 +75,13 @@ $crankConfigPath = Join-Path `
                     -Path (Split-Path $PSCommandPath -Parent) `
                     -ChildPath 'benchmarks.yml'
 
-$isLinuxApp = $CrankAgentVm -match '\blinux\b'
+$isLinuxApp = $CrankAgentAppVm -match '\blinux\b'
 
 $homePath = if ($isLinuxApp) { "/home/$UserName/FunctionApps/$FunctionApp" } else { "C:\FunctionApps\$FunctionApp" }
 $functionAppPath = if ($isLinuxApp) { "/home/$UserName/FunctionApps/$FunctionApp/site/wwwroot" } else { "C:\FunctionApps\$FunctionApp\site\wwwroot" }
 $tmpLogPath = if ($isLinuxApp) { "/tmp/functions/log" } else { 'C:\Temp\Functions\Log' }
 
- $aspNetUrls = "http://localhost:5000"
+ $aspNetUrls = "http://$($CrankAgentAppVm):5000"
  $profileName = "default"
 
 $crankArgs =
@@ -87,7 +91,8 @@ $crankArgs =
     '--chart',
     '--chart-type hex',
     '--application.collectCounters', $true,
-    '--variable', "CrankAgentVm=$CrankAgentVm",
+    '--variable', "CrankAgentAppVm=$CrankAgentAppVm",
+    '--variable', "CrankAgentLoadVm=$CrankAgentLoadVm",
     '--variable', "FunctionAppPath=`"$functionAppPath`"",
     '--variable', "HomePath=`"$homePath`"",
     '--variable', "TempLogPath=`"$tmpLogPath`"",

--- a/tools/Crank/run-benchmarks.ps1
+++ b/tools/Crank/run-benchmarks.ps1
@@ -84,43 +84,56 @@ $tmpLogPath = if ($isLinuxApp) { "/tmp/functions/log" } else { 'C:\Temp\Function
 $aspNetUrls = "http://$($CrankAgentAppVm):5000"
 $profileName = "default"
 
-$crankArgs =
-    '--config', $crankConfigPath,
-    '--scenario', $Scenario,
-    '--profile', $profileName,
-    '--chart',
-    '--chart-type hex',
-    '--application.collectCounters', $true,
-    '--variable', "CrankAgentAppVm=$CrankAgentAppVm",
-    '--variable', "CrankAgentLoadVm=$CrankAgentLoadVm",
-    '--variable', "FunctionAppPath=`"$functionAppPath`"",
-    '--variable', "HomePath=`"$homePath`"",
-    '--variable', "TempLogPath=`"$tmpLogPath`"",
-    '--variable', "BranchOrCommit=$BranchOrCommit",
-    '--variable', "duration=$Duration",
-    '--variable', "warmup=$Warmup",
-    '--variable', "AspNetUrls=$aspNetUrls"
+$patchedConfigFile = New-TemporaryFile |
+    ForEach-Object { Rename-Item -Path $_.FullName -NewName ($_.Name + '.yml') -PassThru }
 
-if ($Trace) {
-    $crankArgs += '--application.collect', $true
+try {
+    # This is a temporary hack to work around a Crank issue: variables are not expanded in some contexts.
+    # So, we patch the config file with the required data.
+    Get-Content -Path $crankConfigPath |
+        ForEach-Object { $_ -replace 'serverUri: http://{{ CrankAgentAppVm }}', "serverUri: http://$CrankAgentAppVm" } |
+        Out-File -FilePath $patchedConfigFile.FullName
+
+    $crankArgs =
+        '--config', $patchedConfigFile.FullName,
+        '--scenario', $Scenario,
+        '--profile', $profileName,
+        '--chart',
+        '--chart-type hex',
+        '--application.collectCounters', $true,
+        '--variable', "CrankAgentAppVm=$CrankAgentAppVm",
+        '--variable', "CrankAgentLoadVm=$CrankAgentLoadVm",
+        '--variable', "FunctionAppPath=`"$functionAppPath`"",
+        '--variable', "HomePath=`"$homePath`"",
+        '--variable', "TempLogPath=`"$tmpLogPath`"",
+        '--variable', "BranchOrCommit=$BranchOrCommit",
+        '--variable', "duration=$Duration",
+        '--variable', "warmup=$Warmup",
+        '--variable', "AspNetUrls=$aspNetUrls"
+
+    if ($Trace) {
+        $crankArgs += '--application.collect', $true
+    }
+
+    if ($WriteResultsToDatabase) {
+        Set-AzContext -Subscription 'Antares-Demo' > $null
+        $sqlPassword = (Get-AzKeyVaultSecret -vaultName 'functions-crank-kv' -name 'SqlAdminPassword').SecretValueText
+
+        $sqlConnectionString = "Server=tcp:functions-crank-sql.database.windows.net,1433;Initial Catalog=functions-crank-db;Persist Security Info=False;User ID=Functions;Password=$sqlPassword;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
+
+        $crankArgs += '--sql', $sqlConnectionString
+        $crankArgs += '--table', 'FunctionsPerf'
+    }
+
+    if ($Iterations -gt 1) {
+        $crankArgs += '--iterations', $Iterations
+        $crankArgs += '--display-iterations'
+    }
+
+    & $InvokeCrankCommand $crankArgs 2>&1 | Tee-Object -Variable crankOutput
+} finally {
+    Remove-Item -Path $patchedConfigFile.FullName
 }
-
-if ($WriteResultsToDatabase) {
-    Set-AzContext -Subscription 'Antares-Demo' > $null
-    $sqlPassword = (Get-AzKeyVaultSecret -vaultName 'functions-crank-kv' -name 'SqlAdminPassword').SecretValueText
-
-    $sqlConnectionString = "Server=tcp:functions-crank-sql.database.windows.net,1433;Initial Catalog=functions-crank-db;Persist Security Info=False;User ID=Functions;Password=$sqlPassword;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
-
-    $crankArgs += '--sql', $sqlConnectionString
-    $crankArgs += '--table', 'FunctionsPerf'
-}
-
-if ($Iterations -gt 1) {
-    $crankArgs += '--iterations', $Iterations
-    $crankArgs += '--display-iterations'
-}
-
-& $InvokeCrankCommand $crankArgs 2>&1 | Tee-Object -Variable crankOutput
 
 $badResponses = $crankOutput | Where-Object { $_ -match '\bBad responses\b\s*\|\s*(\S*)\s' } | ForEach-Object { $Matches[1] }
 if ($null -eq $badResponses) {

--- a/tools/Crank/run-benchmarks.ps1
+++ b/tools/Crank/run-benchmarks.ps1
@@ -120,8 +120,7 @@ if ($Iterations -gt 1) {
 $badResponses = $crankOutput | Where-Object { $_ -match '\bBad responses\b\s*\|\s*(\S*)\s' } | ForEach-Object { $Matches[1] }
 if ($null -eq $badResponses) {
     Write-Warning "Could not detect the number of bad responses. The performance results may be unreliable."
-}
-if ($badResponses -ne 0) {
+} elseif ($badResponses -ne 0) {
     Write-Warning "Detected $badResponses bad response(s). The performance results may be unreliable."
 }
 


### PR DESCRIPTION
### Issue describing the changes in this PR

The `tools/Crank/Agent/VmDeployment/deploy.ps1` script can now deploy and configure multiple Crank VMs. The number of VMs can be controlled by the optional `NamePostfixes` parameter. By default, it creates two VMs with names ending with `-app` and `-load`.

The `tools/Crank/benchmarks.yml` script now requires two VM name parameters instead of one: `CrankAgentAppVm` and `CrankAgentAppVm`. If required, you can still specify the same VM in both parameters to get the old behavior (both app and load on the same VM).

### Pull request checklist

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

