### PR TITLE
A couple logging performance improvements + Benchmarks

### DIFF
--- a/WebJobs.Script.sln
+++ b/WebJobs.Script.sln
@@ -350,6 +350,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "HttpTrigger-HostJsonRetry",
 		sample\NodeRetry\HttpTrigger-RetryHostJson\index.js = sample\NodeRetry\HttpTrigger-RetryHostJson\index.js
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebJobs.Script.Tests.Benchmarks", "test\Benchmarks\Microsoft.Azure.WebJobs.Script.Tests.Benchmarks.csproj", "{09D16953-A048-4E6B-B366-1E0D7E5EF86E}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		test\WebJobs.Script.Tests.Shared\WebJobs.Script.Tests.Shared.projitems*{35c9ccb7-d8b6-4161-bb0d-bcfa7c6dcffb}*SharedItemsImports = 13
@@ -389,6 +391,10 @@ Global
 		{9A522D9D-2D86-4572-B7D1-ECBFBFAF312C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9A522D9D-2D86-4572-B7D1-ECBFBFAF312C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9A522D9D-2D86-4572-B7D1-ECBFBFAF312C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{09D16953-A048-4E6B-B366-1E0D7E5EF86E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{09D16953-A048-4E6B-B366-1E0D7E5EF86E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{09D16953-A048-4E6B-B366-1E0D7E5EF86E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{09D16953-A048-4E6B-B366-1E0D7E5EF86E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -454,6 +460,7 @@ Global
 		{EEBAC197-FAD8-4214-9A12-76334BB3021A} = {FF9C0818-30D3-437A-A62D-7A61CA44F459}
 		{7935A7A4-191A-4A9B-B8DD-173968309EBF} = {EEBAC197-FAD8-4214-9A12-76334BB3021A}
 		{CF6D9CDA-2290-46DF-B162-2D422477288A} = {EEBAC197-FAD8-4214-9A12-76334BB3021A}
+		{09D16953-A048-4E6B-B366-1E0D7E5EF86E} = {AFB0F5F7-A612-4F4A-94DD-8B69CABF7970}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {85400884-5FFD-4C27-A571-58CB3C8CAAC5}

--- a/src/WebJobs.Script.WebHost/Middleware/FunctionInvocationMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/FunctionInvocationMiddleware.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
                 // Add the request to the logging scope. This allows the App Insights logger to
                 // record details about the request.
                 ILoggerFactory loggerFactory = context.RequestServices.GetService<ILoggerFactory>();
-                ILogger logger = loggerFactory.CreateLogger(LogCategories.CreateFunctionCategory(functionExecution.Descriptor.Name));
+                ILogger logger = loggerFactory.CreateLogger(functionExecution.Descriptor.LogCategory);
                 var scopeState = new Dictionary<string, object>()
                 {
                     [ScriptConstants.LoggerHttpRequest] = context.Request,

--- a/src/WebJobs.Script.WebHost/Properties/AssemblyInfo.cs
+++ b/src/WebJobs.Script.WebHost/Properties/AssemblyInfo.cs
@@ -4,4 +4,5 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.Script.Tests")]
+[assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.Script.Tests.Benchmarks")]
 [assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.Script.Tests.Integration")]

--- a/src/WebJobs.Script/Description/FunctionDescriptor.cs
+++ b/src/WebJobs.Script/Description/FunctionDescriptor.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection.Emit;
+using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Binding;
 
 namespace Microsoft.Azure.WebJobs.Script.Description
@@ -37,6 +38,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             TriggerParameter = Parameters?.FirstOrDefault(p => p.IsTrigger);
             TriggerBinding = InputBindings?.SingleOrDefault(p => p.Metadata.IsTrigger);
             HttpTriggerAttribute = GetTriggerAttributeOrNull<HttpTriggerAttribute>();
+            LogCategory = LogCategories.CreateFunctionCategory(Name);
         }
 
         public string Name { get; internal set; }
@@ -58,6 +60,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         public FunctionBinding TriggerBinding { get; }
 
         public virtual HttpTriggerAttribute HttpTriggerAttribute { get; }
+
+        public string LogCategory { get; }
 
         private TAttribute GetTriggerAttributeOrNull<TAttribute>()
         {

--- a/src/WebJobs.Script/Extensions/ScriptLoggingBuilderExtensions.cs
+++ b/src/WebJobs.Script/Extensions/ScriptLoggingBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Collections.Concurrent;
 using System.Linq;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Azure.WebJobs.Script;
@@ -12,6 +13,8 @@ namespace Microsoft.Extensions.Logging
 {
     public static class ScriptLoggingBuilderExtensions
     {
+        private static ConcurrentDictionary<string, bool> _filteredCategoryCache = new ConcurrentDictionary<string, bool>();
+
         public static ILoggingBuilder AddDefaultWebJobsFilters(this ILoggingBuilder builder)
         {
             builder.SetMinimumLevel(LogLevel.None);
@@ -26,9 +29,14 @@ namespace Microsoft.Extensions.Logging
             return builder;
         }
 
-        private static bool Filter(string category, LogLevel actualLevel, LogLevel minLevel)
+        internal static bool Filter(string category, LogLevel actualLevel, LogLevel minLevel)
         {
-            return actualLevel >= minLevel && ScriptConstants.SystemLogCategoryPrefixes.Where(p => category.StartsWith(p)).Any();
+            return actualLevel >= minLevel && IsFiltered(category);
+        }
+
+        private static bool IsFiltered(string category)
+        {
+            return _filteredCategoryCache.GetOrAdd(category, c => ScriptConstants.SystemLogCategoryPrefixes.Where(p => category.StartsWith(p)).Any());
         }
 
         public static void AddConsoleIfEnabled(this ILoggingBuilder builder, HostBuilderContext context)

--- a/src/WebJobs.Script/Properties/AssemblyInfo.cs
+++ b/src/WebJobs.Script/Properties/AssemblyInfo.cs
@@ -16,5 +16,6 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.Script.WebHost")]
 [assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.Script.WebHost.Core")]
 [assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.Script.Tests")]
+[assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.Script.Tests.Benchmarks")]
 [assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.Script.Tests.Integration")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/test/Benchmarks/Extensions/ScriptLoggingBuilderExtensionsBenchmarks.cs
+++ b/test/Benchmarks/Extensions/ScriptLoggingBuilderExtensionsBenchmarks.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Benchmarks
+{
+    public class ScriptLoggingBuilderExtensionsBenchmarks
+    {
+        [Benchmark]
+        public void Filter()
+        {
+            ScriptLoggingBuilderExtensions.Filter("test", LogLevel.Information, LogLevel.Information);
+        }
+    }
+}

--- a/test/Benchmarks/Microsoft.Azure.WebJobs.Script.Tests.Benchmarks.csproj
+++ b/test/Benchmarks/Microsoft.Azure.WebJobs.Script.Tests.Benchmarks.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AssemblyName>Microsoft.Azure.WebJobs.Script.Tests.Benchmarks</AssemblyName>
+    <RootNamespace>Microsoft.Azure.WebJobs.Script.Tests.Benchmarks</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\WebJobs.Script.WebHost\WebJobs.Script.WebHost.csproj" />
+    <ProjectReference Include="..\..\src\WebJobs.Script\WebJobs.Script.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Benchmarks/Program.cs
+++ b/test/Benchmarks/Program.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using BenchmarkDotNet.Running;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Benchmarks
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        }
+    }
+}


### PR DESCRIPTION
Making a couple minor logging performance improvements, and adding a BenchmarksDotNet project that we can start using for benchmarking. As a sample, I added a benchmark for this change. Here's the before/after results:

| Method |     Mean |    Error |   StdDev |   Median |
|------- |---------:|---------:|---------:|---------:|
| Filter | 473.3 ns | 14.60 ns | 42.13 ns | 458.4 ns |


| Method |     Mean |    Error |   StdDev |   Median |
|------- |---------:|---------:|---------:|---------:|
| Filter | 45.65 ns | 1.301 ns | 3.733 ns | 44.18 ns |

So over a 10x improvement. Now this filtering is a small part of the total request pipeline, so the impact will be minimal, however it's just something I noticed showing up in profiles.

Going forward, we can add more benchmarks for performance critical hotpath methods.
