### PR TITLE
Add environment variable for AzureMonitorDiagnosticLogger dynamic enablement

### DIFF
--- a/src/WebJobs.Script.WebHost/DependencyInjection/DependencyValidator/DependencyValidator.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/DependencyValidator/DependencyValidator.cs
@@ -57,7 +57,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
                 .OptionalExternal("Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherHostedService", "Microsoft.Extensions.Diagnostics.HealthChecks", "adb9793829ddae60"); // Popularly-registered by Health Check Monitor.
 
             expected.ExpectSubcollection<ILoggerProvider>()
-                .Expect<AzureMonitorDiagnosticLoggerProvider>()
                 .Expect<FunctionFileLoggerProvider>()
                 .Expect<HostFileLoggerProvider>()
                 .Expect<SystemLoggerProvider>();

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             ILoggerFactory configLoggerFactory = rootServiceProvider.GetService<ILoggerFactory>();
             IDependencyValidator validator = rootServiceProvider.GetService<IDependencyValidator>();
             IMetricsLogger metricsLogger = rootServiceProvider.GetService<IMetricsLogger>();
+            IEnvironment environment = rootServiceProvider.GetService<IEnvironment>();
 
             builder.UseServiceProviderFactory(new JobHostScopedServiceProviderFactory(rootServiceProvider, rootScopeFactory, validator))
                 .ConfigureServices(services =>
@@ -66,14 +67,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     loggingBuilder.Services.AddSingleton<ILoggerFactory, ScriptLoggerFactory>();
 
                     loggingBuilder.AddWebJobsSystem<SystemLoggerProvider>();
-                    loggingBuilder.Services.AddSingleton<ILoggerProvider, AzureMonitorDiagnosticLoggerProvider>();
+                    if (environment.IsAzureMonitorEnabled())
+                    {
+                        loggingBuilder.Services.AddSingleton<ILoggerProvider, AzureMonitorDiagnosticLoggerProvider>();
+                    }
 
                     ConfigureRegisteredBuilders(loggingBuilder, rootServiceProvider);
                 })
                 .ConfigureServices(services =>
                 {
                     var webHostEnvironment = rootServiceProvider.GetService<IScriptWebHostEnvironment>();
-                    var environment = rootServiceProvider.GetService<IEnvironment>();
 
                     if (FunctionsSyncManager.IsSyncTriggersEnvironment(webHostEnvironment, environment))
                     {

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using static Microsoft.Azure.WebJobs.Script.EnvironmentSettingNames;
 
@@ -44,6 +45,20 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             bool.TryParse(environment.GetEnvironmentVariable(EasyAuthEnabled), out bool isEasyAuthEnabled);
             return isEasyAuthEnabled;
+        }
+
+        /// <summary>
+        /// Returns true if any Functions AzureMonitor log categories are enabled.
+        /// </summary>
+        public static bool IsAzureMonitorEnabled(this IEnvironment environment)
+        {
+            string value = environment.GetEnvironmentVariable(AzureMonitorCategories);
+            if (value == null)
+            {
+                return true;
+            }
+            string[] categories = value.Split(',');
+            return categories.Contains(ScriptConstants.AzureMonitorTraceCategory);
         }
 
         public static bool IsRunningAsHostedSiteExtension(this IEnvironment environment)

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string RoleInstanceId = "RoleInstanceId";
         public const string HealthPingEnabled = "WEBSITE_FUNCTIONS_HEALTH_PING_ENABLED";
         public const string TestDataCapEnabled = "WEBSITE_FUNCTIONS_TESTDATA_CAP_ENABLED";
+        public const string AzureMonitorCategories = "WEBSITE_FUNCTIONS_AZUREMONITOR_CATEGORIES";
 
         /// <summary>
         /// Environment variable dynamically set by the platform when it is safe to

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -173,6 +173,8 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string Windows64BitRID = "win-x64";
         public const string Windows32BitRID = "win-x86";
 
+        public const string AzureMonitorTraceCategory = "FunctionAppLogs";
+
         public static readonly ImmutableArray<string> HttpMethods = ImmutableArray.Create("get", "post", "delete", "head", "patch", "put", "options");
         public static readonly ImmutableArray<string> AssemblyFileTypes = ImmutableArray.Create(".dll", ".exe");
         public static readonly string HostUserAgent = $"azure-functions-host/{ScriptHost.Version}";

--- a/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
@@ -40,6 +40,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
         }
 
         [Theory]
+        [InlineData(null, true)]
+        [InlineData("", false)]
+        [InlineData("Foo,FunctionAppLogs,Bar", true)]
+        [InlineData("Foo,Bar", false)]
+        public void IsAzureMonitorEnabled_ReturnsExpectedResult(string value, bool expected)
+        {
+            IEnvironment env = new TestEnvironment();
+            if (value != null)
+            {
+                env.SetEnvironmentVariable(EnvironmentSettingNames.AzureMonitorCategories, value);
+            }
+
+            Assert.Equal(expected, EnvironmentExtensions.IsAzureMonitorEnabled(env));
+        }
+
+        [Theory]
         [InlineData("RD281878FCB8E7", "RD281878FCB8E7")]
         [InlineData("", "")]
         [InlineData(null, "")]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Description

Defines an environment variable that enables AzureMonitor logging categories to be flowed to the host. The AzureMontitor logger is relatively expensive, so we should only register it when needed. DWAS will be updated to flow the log categories to us via this new environment variable. For backwards compatability, if the env var isn't present, we keep the current behavior (logger present).

TFS work item for Antares side: https://msazure.visualstudio.com/One/_workitems/edit/8521884

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
