### PR TITLE
Minor metrics improvements for concurrent access

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
@@ -80,8 +80,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             SystemMetricEvent evt = eventHandle as SystemMetricEvent;
             if (evt != null)
             {
-                long latencyMS = 0;
-               
+                long latencyMS;
                 if (evt.StopWatch != null)
                 {
                     evt.StopWatch.Stop();
@@ -115,17 +114,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                             Data = evt.Data
                         };
                     },
-                    (name, evtToUpdate) =>
+                    (name, existing) =>
                     {
-                        // Aggregate into the existing event
-                        // While we'll be performing an aggregation later,
-                        // we retain the count so weighted averages can be performed
-                        evtToUpdate.Maximum = Math.Max(evtToUpdate.Maximum, latencyMS);
-                        evtToUpdate.Minimum = Math.Min(evtToUpdate.Minimum, latencyMS);
-                        evtToUpdate.Average += latencyMS;  // the average is calculated later - for now we sum
-                        evtToUpdate.Count++;
-
-                        return evtToUpdate;
+                        return new SystemMetricEvent
+                        {
+                            Maximum = Math.Max(existing.Maximum, latencyMS),
+                            Minimum = Math.Min(existing.Minimum, latencyMS),
+                            Average = existing.Average + latencyMS,
+                            Count = existing.Count + 1
+                        };
                     });
             }
         }

--- a/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
@@ -118,10 +118,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                     {
                         return new SystemMetricEvent
                         {
+                            FunctionName = existing.FunctionName,
+                            EventName = existing.EventName,
                             Maximum = Math.Max(existing.Maximum, latencyMS),
                             Minimum = Math.Min(existing.Minimum, latencyMS),
                             Average = existing.Average + latencyMS,
-                            Count = existing.Count + 1
+                            Count = existing.Count + 1,
+                            Data = existing.Data
                         };
                     });
             }
@@ -152,10 +155,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 {
                     return new SystemMetricEvent
                     {
+                        FunctionName = existing.FunctionName,
+                        EventName = existing.EventName,
                         Maximum = existing.Maximum,
                         Minimum = existing.Minimum,
                         Average = existing.Average,
-                        Count = existing.Count + 1
+                        Count = existing.Count + 1,
+                        Data = existing.Data
                     };
                 });
         }

--- a/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
@@ -81,9 +81,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             if (evt != null)
             {
                 long latencyMS = 0;
-                evt.StopWatch.Stop();
+               
                 if (evt.StopWatch != null)
                 {
+                    evt.StopWatch.Stop();
                     evt.Duration = evt.StopWatch.Elapsed;
                     latencyMS = evt.StopWatch.ElapsedMilliseconds;
                 }

--- a/src/WebJobs.Script/Extensions/FunctionMetadataExtensions.cs
+++ b/src/WebJobs.Script/Extensions/FunctionMetadataExtensions.cs
@@ -38,10 +38,12 @@ namespace Microsoft.Azure.WebJobs.Script
             if (!metadata.Properties.TryGetValue(FunctionIdKey, out object idObj)
                 || !(idObj is string))
             {
-                metadata.Properties[FunctionIdKey] = Guid.NewGuid().ToString();
+                string functionId = Guid.NewGuid().ToString();
+                metadata.Properties[FunctionIdKey] = functionId;
+                return functionId;
             }
 
-            return metadata.Properties[FunctionIdKey] as string;
+            return (string)idObj;
         }
 
         internal static void SetFunctionId(this FunctionMetadata metadata, string functionId)

--- a/src/WebJobs.Script/Extensions/IMetricsLoggerExtensions.cs
+++ b/src/WebJobs.Script/Extensions/IMetricsLoggerExtensions.cs
@@ -16,13 +16,15 @@ namespace Microsoft.Azure.WebJobs.Script
 
         private class DisposableEvent : IDisposable
         {
+            private static readonly string StopWatchResolution = $"{{\"IsStopwatchHighResolution:\" {Stopwatch.IsHighResolution}}}";
+
             private readonly object _metricEvent;
             private readonly IMetricsLogger _metricsLogger;
             private bool _disposed;
 
             public DisposableEvent(string eventName, string functionName, IMetricsLogger metricsLogger)
             {
-                _metricEvent = metricsLogger.BeginEvent(eventName, functionName, $"{{\"IsStopwatchHighResolution:\" {Stopwatch.IsHighResolution}}}");
+                _metricEvent = metricsLogger.BeginEvent(eventName, functionName, StopWatchResolution);
                 _metricsLogger = metricsLogger;
             }
 

--- a/test/WebJobs.Script.Tests.Integration/Diagnostics/MetricsEventManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Diagnostics/MetricsEventManagerTests.cs
@@ -137,7 +137,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Assert.Equal(1, _metricsEventManager.QueuedEvents.Count);
 
                 // verify the new event was aggregated into the existing
-                Assert.Equal(2 + i, initialEvent.Count);
+                SystemMetricEvent @event = _metricsEventManager.QueuedEvents[initialEvent.EventName];
+                Assert.Equal(2 + i, @event.Count);
             }
 
             Assert.Equal(1, _metricsEventManager.QueuedEvents.Count);
@@ -251,14 +252,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
                 Assert.Equal(1, _metricsEventManager.QueuedEvents.Count);
 
+                SystemMetricEvent @event = _metricsEventManager.QueuedEvents[initialEvent.EventName];
+
                 // verify the new event was aggregated into the existing
-                Assert.Equal(2 + i, initialEvent.Count);
+                Assert.Equal(2 + i, @event.Count);
                 long latencyMS = (long)latencyEvent.Duration.TotalMilliseconds;
-                Assert.Equal(initialEvent.Average, prevAvg + latencyMS);
-                Assert.Equal(initialEvent.Minimum, Math.Min(prevMin, latencyMS));
-                Assert.Equal(initialEvent.Maximum, Math.Max(prevMax, latencyMS));
-                prevMin = initialEvent.Minimum;
-                prevMax = initialEvent.Maximum;
+                Assert.Equal(prevAvg + latencyMS, @event.Average);
+                Assert.Equal(Math.Min(prevMin, latencyMS), @event.Minimum);
+                Assert.Equal(Math.Max(prevMax, latencyMS), @event.Maximum);
+                prevMin = @event.Minimum;
+                prevMax = @event.Maximum;
                 prevAvg += latencyMS;
             }
 


### PR DESCRIPTION
This PR introduces a few minor fixes related to the `Metrics` area of the host:

1. stopping a StopWatch is checked now
1. `QueuedEvents` no longer modifies existing entries. They are recreated to ensure that potential multiple writers don't perform dirty writes.
1. `FlushMetrics` separates obtaining a list of keys from removing them. With this is, if a new metric is reported between capturing a key and removing it it won't be lost. With previous approach using `.Clear()` there was a potential for loosing a metric.

A few remarks:

- I put changes into separate commits to make it easier to review or potentially create separate PRs.
- I'm new to this repo. I'm trying to add some minor improvements/fixes learning about the host implementation at the same time. 
