### PR TITLE
Make bindings parallel

### DIFF
--- a/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs
@@ -125,6 +125,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         private async Task<(string name, DataType type, object value)[]> BindInputsAsync(Binder binder)
         {
             var bindingTasks = _inputBindings
+                .AsParallel()
                 .Where(binding => !binding.Metadata.IsTrigger)
                 .Select(async (binding) =>
                 {
@@ -152,7 +153,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
             _handleScriptReturnValue(result);
 
-            var outputBindingTasks = _outputBindings.Select(async binding =>
+            var outputBindingTasks = _outputBindings.AsParallel().Select(async binding =>
             {
                 // apply the value to the binding
                 if (result.Outputs.TryGetValue(binding.Metadata.Name, out object value) && value != null)


### PR DESCRIPTION
### Issue describing the changes in this PR

resolves #6775

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

The bindings are processed serially. We could save some time processing the bindings in parallel.

The test to validate this was a Python function with 3 input bindings and 2 output bindings.
Each binding was less than 1KB and the access times in my machine for the inputs were around 2-3 milliseconds.
In the serial case, I was seeing ~7ms for processing all the inputs and with this change, it went under 3 ms.
For the output bindings, the times per binding were ~10ms per binding which ended up adding around 20ms.
With this approach the time went down to ~10ms for both outputs.

Note that a similar optimization also works in the Python side and we will open a separate issue for that side. 