### PR TITLE
Fix Flaky Validate_HostLogs

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
             ValidateTelemetry(telemetry, expectedInvocationId, expectedOperationName, expectedCategory, SeverityLevel.Error);
         }
 
-        [Fact(Skip = "Disabled due to https://github.com/Azure/azure-functions-host/issues/6521")]
+        [Fact]
         public async Task Validate_HostLogs()
         {
             // Validate the host startup traces. Order by message string as the requests may come in

--- a/test/WebJobs.Script.Tests.Integration/Controllers/WarmupScenarios.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/WarmupScenarios.cs
@@ -6,14 +6,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Controllers
 {
-    public class WarmupScenarios
+    public class WarmupScenarios : IDisposable
     {
         private static readonly TimeSpan SemaphoreWaitTimeout = TimeSpan.FromSeconds(30);
 
@@ -85,6 +84,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Controllers
             // Better be successful
             Assert.True(response.IsSuccessStatusCode, "Warmup endpoint did not return a success status. " +
                 $"Instead found {response.StatusCode}");
+        }
+
+        public void Dispose()
+        {
+            _testHost.Dispose();
         }
 
         private class PausingScriptHostBuilder : IScriptHostBuilder

--- a/test/WebJobs.Script.Tests.Integration/Controllers/WarmupScenarios.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/WarmupScenarios.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Controllers
 
         public void Dispose()
         {
-            _testHost.Dispose();
+            _testHost?.Dispose();
         }
 
         private class PausingScriptHostBuilder : IScriptHostBuilder


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #6521 .

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This seems to be possibly due to some other test Host holding the lease on the blob. Most recent example of this https://azfunc.visualstudio.com/Azure%20Functions/_build/results?buildId=8572&view=logs&j=c68c283c-e579-5115-c911-5c3ac7f5af09&t=188f054b-4c24-59d9-f813-b2324ef559fd

This is also evident from storage logs below where you can see that an entity keeps trying to acquire lease on fvaz123231-46172260/host but keeps failing with "LeaseAlreadyPresent". There are also frequent lease renewals on this same blob

(navigate to 2020/10/13/1900 000000.log)
https://ms.portal.azure.com/#blade/Microsoft_Azure_Storage/ContainerMenuBlade/overview/storageAccountId/%2Fsubscriptions%2Fca01ee66-e03f-4d4f-abd8-ea53e5d4f226%2FresourceGroups%2Fazure-functions-host-ci-5%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fazurefunctionshostci5/path/%24logs/etag/%220x8D7986F34C2D428%22/defaultEncryptionScope/%24account-encryption-key/denyEncryptionScopeOverride//defaultId//publicAccessVal/none

Overriding the IHostIdProvider with a customProvider so that a there's a unique blob for this test just might fix the issue we have here. @brettsam Let me know if there's a better fix for this that I may have missed, please.

