### PR TITLE
K8SE enviornment host id based upon WEBSITE_SITE_NAME and WEBSITE_SLOT_NAME environment variables

### DIFF
--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -285,7 +285,7 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
-        /// Gets a value indicating whether the application is running in Kubernetes App Service enviornment(K8SE)
+        /// Gets a value indicating whether the application is running in Kubernetes App Service environment(K8SE)
         /// </summary>
         /// <param name="environment">The environment to verify</param>
         /// <returns><see cref="true"/> If running in a Kubernetes Azure App Service; otherwise, false.</returns>

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -285,6 +285,18 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
+        /// Gets a value indicating whether the application is running in Kuberneted App Service
+        /// </summary>
+        /// <param name="environment">The environment to verify</param>
+        /// <returns><see cref="true"/> If running in a Kubernetes Azure App Service; otherwise, false.</returns>
+        public static bool IsKubernetesAppService(this IEnvironment environment)
+        {
+            return !string.IsNullOrEmpty(environment.GetEnvironmentVariable(KubernetesServiceHost))
+                && !string.IsNullOrEmpty(environment.GetEnvironmentVariable(PodNamespace))
+                && string.Equals(environment.GetEnvironmentVariable(PodNamespace).Trim(), KubernetesAppServiceNamespace, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
         /// Gets a value that uniquely identifies the site and slot.
         /// </summary>
         public static string GetAzureWebsiteUniqueSlotName(this IEnvironment environment)

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -285,11 +285,11 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
-        /// Gets a value indicating whether the application is running in Kuberneted App Service
+        /// Gets a value indicating whether the application is running in Kubernetes App Service enviornment(K8SE)
         /// </summary>
         /// <param name="environment">The environment to verify</param>
         /// <returns><see cref="true"/> If running in a Kubernetes Azure App Service; otherwise, false.</returns>
-        public static bool IsKubernetesAppService(this IEnvironment environment)
+        public static bool IsKubernetesManagedHosting(this IEnvironment environment)
         {
             return !string.IsNullOrEmpty(environment.GetEnvironmentVariable(KubernetesServiceHost))
                 && !string.IsNullOrEmpty(environment.GetEnvironmentVariable(PodNamespace))

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -292,8 +292,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public static bool IsKubernetesManagedHosting(this IEnvironment environment)
         {
             return !string.IsNullOrEmpty(environment.GetEnvironmentVariable(KubernetesServiceHost))
-                && !string.IsNullOrEmpty(environment.GetEnvironmentVariable(PodNamespace))
-                && string.Equals(environment.GetEnvironmentVariable(PodNamespace).Trim(), KubernetesAppServiceNamespace, StringComparison.OrdinalIgnoreCase);
+                && !string.IsNullOrEmpty(environment.GetEnvironmentVariable(PodNamespace));
         }
 
         /// <summary>

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -59,6 +59,10 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string TestDataCapEnabled = "WEBSITE_FUNCTIONS_TESTDATA_CAP_ENABLED";
         public const string AzureMonitorCategories = "WEBSITE_FUNCTIONS_AZUREMONITOR_CATEGORIES";
 
+        //Function in Kubernetes
+        public const string PodNamespace = "POD_NAMESPACE";
+        public const string KubernetesAppServiceNamespace = "k8se-apps";
+
         /// <summary>
         /// Environment variable dynamically set by the platform when it is safe to
         /// start specializing the host instance (e.g. file system is ready, etc.)

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -61,7 +61,6 @@ namespace Microsoft.Azure.WebJobs.Script
 
         //Function in Kubernetes
         public const string PodNamespace = "POD_NAMESPACE";
-        public const string KubernetesAppServiceNamespace = "k8se-apps";
 
         /// <summary>
         /// Environment variable dynamically set by the platform when it is safe to

--- a/src/WebJobs.Script/Host/ScriptHostIdProvider.cs
+++ b/src/WebJobs.Script/Host/ScriptHostIdProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Script
             // If the user has explicitly set the HostID via host.json, it will overwrite
             // what we set here
             string hostId = null;
-            if (environment.IsAppService())
+            if (environment.IsAppService() || environment.IsKubernetesAppService())
             {
                 string uniqueSlotName = environment?.GetAzureWebsiteUniqueSlotName();
                 if (!string.IsNullOrEmpty(uniqueSlotName))

--- a/src/WebJobs.Script/Host/ScriptHostIdProvider.cs
+++ b/src/WebJobs.Script/Host/ScriptHostIdProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Script
             // If the user has explicitly set the HostID via host.json, it will overwrite
             // what we set here
             string hostId = null;
-            if (environment.IsAppService() || environment.IsKubernetesAppService())
+            if (environment.IsAppService() || environment.IsKubernetesManagedHosting())
             {
                 string uniqueSlotName = environment?.GetAzureWebsiteUniqueSlotName();
                 if (!string.IsNullOrEmpty(uniqueSlotName))

--- a/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
+++ b/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
@@ -149,6 +149,30 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.True(environment.IsPersistentFileSystemAvailable());
         }
 
+        [Fact]
+        public void IsKubernetesAppService_NoKubernetesServiceHost_ReturnsFalse()
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(PodNamespace, KubernetesAppServiceNamespace);
+            Assert.False(environment.IsKubernetesAppService());
+        }
+
+        [Fact]
+        public void IsKubernetesAppService_NoKubernetesServiceHost_NoK8seNamespace_ReturnsFalse()
+        {
+            var environment = new TestEnvironment();
+            Assert.False(environment.IsKubernetesAppService());
+        }
+
+        [Fact]
+        public void IsKubernetesAppService_KubernetesServiceHost_K8seNamespace_ReturnsTrue()
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(KubernetesServiceHost, "10.0.0.1");
+            environment.SetEnvironmentVariable(PodNamespace, KubernetesAppServiceNamespace);
+            Assert.True(environment.IsKubernetesAppService());
+        }
+
         [Theory]
         [InlineData("1", true)]
         [InlineData("https://functionstest.blob.core.windows.net/microsoft/functionapp.zip", true)]

--- a/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
+++ b/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
@@ -149,30 +149,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.True(environment.IsPersistentFileSystemAvailable());
         }
 
-        [Fact]
-        public void IsKubernetesAppService_NoKubernetesServiceHost_ReturnsFalse()
-        {
-            var environment = new TestEnvironment();
-            environment.SetEnvironmentVariable(PodNamespace, KubernetesAppServiceNamespace);
-            Assert.False(environment.IsKubernetesAppService());
-        }
-
-        [Fact]
-        public void IsKubernetesAppService_NoKubernetesServiceHost_NoK8seNamespace_ReturnsFalse()
-        {
-            var environment = new TestEnvironment();
-            Assert.False(environment.IsKubernetesAppService());
-        }
-
-        [Fact]
-        public void IsKubernetesAppService_KubernetesServiceHost_K8seNamespace_ReturnsTrue()
-        {
-            var environment = new TestEnvironment();
-            environment.SetEnvironmentVariable(KubernetesServiceHost, "10.0.0.1");
-            environment.SetEnvironmentVariable(PodNamespace, KubernetesAppServiceNamespace);
-            Assert.True(environment.IsKubernetesAppService());
-        }
-
         [Theory]
         [InlineData("1", true)]
         [InlineData("https://functionstest.blob.core.windows.net/microsoft/functionapp.zip", true)]

--- a/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Xunit;
+using static Microsoft.Azure.WebJobs.Script.EnvironmentSettingNames;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
 {
@@ -160,6 +161,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
             }
 
             Assert.Equal(expected, EnvironmentExtensions.IsV2CompatibilityMode(env));
+        }
+
+        [Theory]
+        [InlineData(KubernetesAppServiceNamespace, "10.0.0.1", true)]
+        [InlineData("non-k8se-apps", "10.0.0.1", false)]
+        [InlineData("k8se-apps", null, false)]
+        [InlineData(null, "10.0.0.1", false)]
+        [InlineData(null, null, false)]
+        public void IsKubernetesManagedHosting_ReturnsExpectedResult(string podNamespace, string kubernetesServiceHost, bool expected)
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(KubernetesServiceHost, kubernetesServiceHost);
+            environment.SetEnvironmentVariable(PodNamespace, podNamespace);
+            Assert.Equal(expected, environment.IsKubernetesManagedHosting());
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
@@ -164,8 +164,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
         }
 
         [Theory]
-        [InlineData(KubernetesAppServiceNamespace, "10.0.0.1", true)]
-        [InlineData("non-k8se-apps", "10.0.0.1", false)]
+        [InlineData("k8se-apps-ns", "10.0.0.1", true)]
         [InlineData("k8se-apps", null, false)]
         [InlineData(null, "10.0.0.1", false)]
         [InlineData(null, null, false)]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

The change in this PR:
Enables the detection of function app running in Kubernetes App service environment (K8SE) environment to generate function
host id based upon WEBSITE_SITE_NAME and WEBSITE_SLOT_NAME environment variables, as per existing logic.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

