### PR TITLE
Enforce ordering of functions in synctriggers payload

### DIFF
--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 Errors = _functionErrors.Where(kvp => functionsAllowList.Any(functionName => functionName.Equals(kvp.Key, StringComparison.CurrentCultureIgnoreCase))).ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray());
             }
 
-            return functionMetadataList.ToImmutableArray();
+            return functionMetadataList.OrderBy(f => f.Name, StringComparer.OrdinalIgnoreCase).ToImmutableArray();
         }
 
         internal bool IsScriptFileDetermined(FunctionMetadata functionMetadata)

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -715,8 +715,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                         return new[]
                         {
                             Path.Combine(rootPath, "bin"),
-                            Path.Combine(rootPath, "function1"),
                             Path.Combine(rootPath, "function2"),
+                            Path.Combine(rootPath, "function1"),
                             Path.Combine(rootPath, "function3")
                         };
                     }

--- a/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
@@ -160,6 +160,41 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public void FunctionMetadataManager_SortsMetadata_FromFunctionProviders()
+        {
+            var functionMetadataCollection = new Collection<FunctionMetadata>();
+            var mockFunctionMetadataProvider = new Mock<IFunctionMetadataProvider>();
+            var mockFunctionProvider = new Mock<IFunctionProvider>();
+            var workerConfigs = TestHelpers.GetTestWorkerConfigs();
+
+            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadata(workerConfigs, false)).Returns(new Collection<FunctionMetadata>().ToImmutableArray());
+            mockFunctionMetadataProvider.Setup(m => m.FunctionErrors).Returns(new Dictionary<string, ICollection<string>>().ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray()));
+
+            const string aFunction = "aFunction";
+            const string bFunction = "bFunction";
+            const string cFunction = "cFunction";
+
+            // Add in unsorted order
+            functionMetadataCollection.Add(GetTestFunctionMetadata("b.dll", name: bFunction));
+            functionMetadataCollection.Add(GetTestFunctionMetadata("a.dll", name: aFunction));
+            functionMetadataCollection.Add(GetTestFunctionMetadata("c.dll", name: cFunction));
+            functionMetadataCollection.Add(GetTestFunctionMetadata("null.dll", name: null));
+
+            mockFunctionProvider.Setup(m => m.GetFunctionMetadataAsync()).ReturnsAsync(functionMetadataCollection.ToImmutableArray());
+
+            FunctionMetadataManager testFunctionMetadataManager = TestFunctionMetadataManager.GetFunctionMetadataManager(new OptionsWrapper<ScriptJobHostOptions>(_scriptJobHostOptions),
+                mockFunctionMetadataProvider.Object, new List<IFunctionProvider>() { mockFunctionProvider.Object }, new OptionsWrapper<HttpWorkerOptions>(_defaultHttpWorkerOptions), MockNullLoggerFactory.CreateLoggerFactory(), new OptionsWrapper<LanguageWorkerOptions>(TestHelpers.GetTestLanguageWorkerOptions()));
+            var functionMetadata = testFunctionMetadataManager.LoadFunctionMetadata();
+
+            Assert.Equal(4, functionMetadata.Length);
+
+            Assert.Null(functionMetadata[0].Name);
+            Assert.True(string.Equals(aFunction, functionMetadata[1].Name));
+            Assert.True(string.Equals(bFunction, functionMetadata[2].Name));
+            Assert.True(string.Equals(cFunction, functionMetadata[3].Name));
+        }
+
+        [Fact]
         public void FunctionMetadataManager_ThrowsError_DuplicateFunctions_FromFunctionProviders()
         {
             var functionMetadataCollection = new Collection<FunctionMetadata>();


### PR DESCRIPTION
  Background synctriggers task compares hashes of current and last known synctriggers payload to avoid unnecessary /synctriggers call to update the site metadata. Currently the ordering of functions in Synctriggers payload is non deterministic since it relies EnumerateDirectories() which is implemented differently on Linux and Windows. This leads to unnecessary updates to the site metadata if the function app has more than 1 function even though the triggers themselves haven't been updated. Fix is to sort the functions before calculating the hash.

Fixes https://github.com/Azure/azure-functions-host/issues/6686

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-host/issues/6686

### Pull request checklist

* [X ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [X ] Otherwise: Backport tracked by issue/PR https://github.com/Azure/azure-functions-host/issues/6686
* [X ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
