### PR TITLE
[Rpc]Add processOptions in worker.config

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\build\common.props" />
   <Import Project="..\..\build\python.props" />
   <PropertyGroup>

--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcessCount.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcessCount.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Script.Workers
+{
+    public class WorkerProcessCount
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether to set FUNCTIONS_WORKER_PROCESS_COUNT to number of cpu cores on the host machine
+        /// </summary>
+        public bool SetWorkerCountToNumberOfCpuCores { get; set; }
+
+        /// <summary>
+        /// Gets or sets number of worker processes to start. Default process count is 1
+        /// </summary>
+        public int ProcessCount { get; set; } = 1;
+
+        /// <summary>
+        /// Gets or sets maximum number worker processes allowed. Default max process count is 10
+        /// </summary>
+        public int MaxProcessCount { get; set; } = 10;
+
+        /// <summary>
+        /// Gets or sets interval between process startups. Default 10secs
+        /// </summary>
+        public TimeSpan ProcessStartupInterval { get; set; } = TimeSpan.FromSeconds(10);
+    }
+}

--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcessCountOptions.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcessCountOptions.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Azure.WebJobs.Script.Workers
 {
-    public class WorkerProcessCount
+    public class WorkerProcessCountOptions
     {
         /// <summary>
         /// Gets or sets a value indicating whether to set FUNCTIONS_WORKER_PROCESS_COUNT to number of cpu cores on the host machine

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfig.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfig.cs
@@ -8,5 +8,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public RpcWorkerDescription Description { get; set; }
 
         public WorkerProcessArguments Arguments { get; set; }
+
+        public WorkerProcessCount Count { get; set; }
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfig.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfig.cs
@@ -9,6 +9,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         public WorkerProcessArguments Arguments { get; set; }
 
-        public WorkerProcessCount Count { get; set; }
+        public WorkerProcessCountOptions CountOptions { get; set; }
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -182,16 +182,19 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             }
 
             // Validate
-            if (workerProcessCount.ProcessCount >= 0)
+            if (workerProcessCount.ProcessCount <= 0)
             {
-                throw new ArgumentException($"{nameof(workerProcessCount.ProcessCount)} should be greater than 0 and less than {nameof(workerProcessCount.MaxProcessCount)} : workerProcessCount.MaxProcessCount");
+                throw new ArgumentOutOfRangeException($"{nameof(workerProcessCount.ProcessCount)}",  "ProcessCount must be greater than 0.");
             }
-
-            // Validate
             if (workerProcessCount.ProcessCount > workerProcessCount.MaxProcessCount)
             {
-                throw new ArgumentException($"{nameof(workerProcessCount.ProcessCount)} is greater than {nameof(workerProcessCount.MaxProcessCount)}");
+                throw new ArgumentException($"{nameof(workerProcessCount.ProcessCount)} must not be greater than {nameof(workerProcessCount.MaxProcessCount)}");
             }
+            if (workerProcessCount.ProcessStartupInterval.Ticks < 0)
+            {
+                throw new ArgumentOutOfRangeException($"{nameof(workerProcessCount.ProcessStartupInterval)}", "The TimeSpan must not be negative.");
+            }
+
             return workerProcessCount;
         }
 

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                         workerDescription.ThrowIfFileNotExists(workerDescription.DefaultWorkerPath, nameof(workerDescription.DefaultWorkerPath));
                         workerDescription.ExpandEnvironmentVariables();
 
-                        WorkerProcessCount workerProcessCount = GetWorkerProcessCount(workerConfig);
+                        WorkerProcessCountOptions workerProcessCount = GetWorkerProcessCount(workerConfig);
 
                         var arguments = new WorkerProcessArguments()
                         {
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                         {
                             Description = workerDescription,
                             Arguments = arguments,
-                            Count = workerProcessCount
+                            CountOptions = workerProcessCount
                         };
                         _workerDescripionDictionary[workerDescription.Language] = rpcWorkerconfig;
                         _logger.LogDebug($"Added WorkerConfig for language: {workerDescription.Language}");
@@ -161,11 +161,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             }
         }
 
-        internal WorkerProcessCount GetWorkerProcessCount(JObject workerConfig)
+        internal WorkerProcessCountOptions GetWorkerProcessCount(JObject workerConfig)
         {
-            WorkerProcessCount workerProcessCount = workerConfig.Property(WorkerConstants.ProcessCount)?.Value.ToObject<WorkerProcessCount>();
+            WorkerProcessCountOptions workerProcessCount = workerConfig.Property(WorkerConstants.ProcessCount)?.Value.ToObject<WorkerProcessCountOptions>();
 
-            workerProcessCount = workerProcessCount ?? new WorkerProcessCount();
+            workerProcessCount = workerProcessCount ?? new WorkerProcessCountOptions();
 
             if (workerProcessCount.SetWorkerCountToNumberOfCpuCores)
             {

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -180,6 +180,13 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             {
                 workerProcessCount.ProcessCount = int.Parse(processCountEnvSetting) > 1 ? int.Parse(processCountEnvSetting) : 1;
             }
+
+            // Validate
+            if (workerProcessCount.ProcessCount >= 0)
+            {
+                throw new ArgumentException($"{nameof(workerProcessCount.ProcessCount)} should be greater than 0 and less than {nameof(workerProcessCount.MaxProcessCount)} : workerProcessCount.MaxProcessCount");
+            }
+
             // Validate
             if (workerProcessCount.ProcessCount > workerProcessCount.MaxProcessCount)
             {

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -173,8 +173,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             {
                 throw new InvalidOperationException($"WorkerCofig for runtime: {_workerRuntime} not found");
             }
-            _maxProcessCount = workerConfig.Count.ProcessCount;
-            _debouceMilliSeconds = (int)workerConfig.Count.ProcessStartupInterval.TotalMilliseconds;
+            _maxProcessCount = workerConfig.CountOptions.ProcessCount;
+            _debouceMilliSeconds = (int)workerConfig.CountOptions.ProcessStartupInterval.TotalMilliseconds;
             ErrorEventsThreshold = 3 * _maxProcessCount;
 
             if (functions == null || functions.Count() == 0)

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         private IEnumerable<FunctionMetadata> _functions;
         private ConcurrentStack<WorkerErrorEvent> _languageWorkerErrors = new ConcurrentStack<WorkerErrorEvent>();
         private CancellationTokenSource _processStartCancellationToken = new CancellationTokenSource();
-        private int _debouceMilliSeconds = (int)TimeSpan.FromSeconds(10).TotalMilliseconds;
+        private int _debounceMilliSeconds = (int)TimeSpan.FromSeconds(10).TotalMilliseconds;
 
         public RpcFunctionInvocationDispatcher(IOptions<ScriptJobHostOptions> scriptHostOptions,
             IMetricsLogger metricsLogger,
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         {
             for (var count = startIndex; count < _maxProcessCount; count++)
             {
-                startAction = startAction.Debounce(_processStartCancellationToken.Token, count * _debouceMilliSeconds);
+                startAction = startAction.Debounce(_processStartCancellationToken.Token, count * _debounceMilliSeconds);
                 startAction();
             }
         }
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 throw new InvalidOperationException($"WorkerCofig for runtime: {_workerRuntime} not found");
             }
             _maxProcessCount = workerConfig.CountOptions.ProcessCount;
-            _debouceMilliSeconds = (int)workerConfig.CountOptions.ProcessStartupInterval.TotalMilliseconds;
+            _debounceMilliSeconds = (int)workerConfig.CountOptions.ProcessStartupInterval.TotalMilliseconds;
             ErrorEventsThreshold = 3 * _maxProcessCount;
 
             if (functions == null || functions.Count() == 0)

--- a/src/WebJobs.Script/Workers/WorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/WorkerConstants.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         public const string WorkerDescriptionDefaultExecutablePath = "defaultExecutablePath";
         public const string WorkerDescriptionDefaultWorkerPath = "defaultWorkerPath";
         public const string WorkerDescription = "description";
+        public const string ProcessCount = "processOptions";
         public const string WorkerDescriptionArguments = "arguments";
         public const string WorkerDescriptionDefaultRuntimeVersion = "defaultRuntimeVersion";
 

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -256,12 +256,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
         }
 
-        public static IList<RpcWorkerConfig> GetTestWorkerConfigs(bool includeDllWorker = false)
+        public static IList<RpcWorkerConfig> GetTestWorkerConfigs(bool includeDllWorker = false, int processCountValue = 1)
         {
             var workerConfigs = new List<RpcWorkerConfig>
             {
-                new RpcWorkerConfig() { Description = GetTestWorkerDescription("node", ".js"), CountOptions = new Script.Workers.WorkerProcessCountOptions() },
-                new RpcWorkerConfig() { Description = GetTestWorkerDescription("java", ".jar"), CountOptions = new Script.Workers.WorkerProcessCountOptions() }
+                new RpcWorkerConfig() { Description = GetTestWorkerDescription("node", ".js"), CountOptions = new Script.Workers.WorkerProcessCountOptions() { ProcessCount = processCountValue } },
+                new RpcWorkerConfig() { Description = GetTestWorkerDescription("java", ".jar"), CountOptions = new Script.Workers.WorkerProcessCountOptions() { ProcessCount = processCountValue } }
             };
 
             // Allow tests to have a worker that claims the .dll extension.

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -260,8 +260,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             var workerConfigs = new List<RpcWorkerConfig>
             {
-                new RpcWorkerConfig() { Description = GetTestWorkerDescription("node", ".js") },
-                new RpcWorkerConfig() { Description = GetTestWorkerDescription("java", ".jar") }
+                new RpcWorkerConfig() { Description = GetTestWorkerDescription("node", ".js"), CountOptions = new Script.Workers.WorkerProcessCountOptions() },
+                new RpcWorkerConfig() { Description = GetTestWorkerDescription("java", ".jar"), CountOptions = new Script.Workers.WorkerProcessCountOptions() }
             };
 
             // Allow tests to have a worker that claims the .dll extension.

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         public async Task GetWorkerStatusesAsync_ReturnsExpectedResult()
         {
             int expectedProcessCount = 3;
-            var functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount.ToString());
+            var functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount);
             await functionDispatcher.InitializeAsync(GetTestFunctionsList(RpcWorkerConstants.NodeLanguageWorkerName));
 
             var finalChannelCount = await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount);
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         public async Task Starting_MultipleJobhostChannels_Succeeds()
         {
             int expectedProcessCount = 3;
-            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount.ToString());
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount);
             await functionDispatcher.InitializeAsync(GetTestFunctionsList(RpcWorkerConstants.NodeLanguageWorkerName));
 
             var finalChannelCount = await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount);
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         public async Task Starting_MultipleWebhostChannels_Succeeds()
         {
             int expectedProcessCount = 2;
-            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount.ToString(), true);
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount, true);
             await functionDispatcher.InitializeAsync(GetTestFunctionsList(RpcWorkerConstants.JavaLanguageWorkerName));
 
             var finalWebhostChannelCount = await WaitForWebhostWorkerChannelsToStartup(functionDispatcher.WebHostLanguageWorkerChannelManager, expectedProcessCount, "java");
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         {
             int expectedProcessCount = 3;
             List<Task> restartTasks = new List<Task>();
-            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount.ToString());
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount);
             await functionDispatcher.InitializeAsync(GetTestFunctionsList(RpcWorkerConstants.NodeLanguageWorkerName));
             await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount);
             Guid[] invocationIds = new Guid[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         public async Task Restart_ParticularWorkerChannel_Succeeds_OnlyThatIsDisposed()
         {
             int expectedProcessCount = 3;
-            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount.ToString());
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount);
             await functionDispatcher.InitializeAsync(GetTestFunctionsList(RpcWorkerConstants.NodeLanguageWorkerName));
             await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount);
             Guid invocationId = Guid.NewGuid();
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         public async Task ShutdownTests()
         {
             int expectedProcessCount = 2;
-            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount.ToString());
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount);
             await functionDispatcher.InitializeAsync(GetTestFunctionsList(RpcWorkerConstants.NodeLanguageWorkerName));
             await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount);
 
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         public async Task ShutdownTests_WithInfinitelyRunningTasks_Timesout()
         {
             int expectedProcessCount = 2;
-            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount.ToString());
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount);
             await functionDispatcher.InitializeAsync(GetTestFunctionsList(RpcWorkerConstants.NodeLanguageWorkerName));
             await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount);
 
@@ -165,35 +165,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             {
                 Assert.True(((TestRpcWorkerChannel)currChannel).ExecutionContexts.Count > 0);
             }
-        }
-
-        [Fact]
-        public void MaxProcessCount_Returns_Default()
-        {
-            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher();
-            Assert.Equal(1, functionDispatcher.MaxProcessCount);
-
-            functionDispatcher = GetTestFunctionDispatcher("0");
-            Assert.Equal(1, functionDispatcher.MaxProcessCount);
-
-            functionDispatcher = GetTestFunctionDispatcher("-1");
-            Assert.Equal(1, functionDispatcher.MaxProcessCount);
-        }
-
-        [Fact]
-        public void MaxProcessCount_ProcessCount_Set_Returns_ExpectedCount()
-        {
-            int expectedProcessCount = 3;
-            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount.ToString());
-            Assert.Equal(expectedProcessCount, functionDispatcher.MaxProcessCount);
-        }
-
-        [Fact]
-        public void MaxProcessCount_ProcessCount_Set_ExceedsMax_Returns_ExpectedCount()
-        {
-            int expectedProcessCount = 30;
-            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount.ToString());
-            Assert.Equal(10, functionDispatcher.MaxProcessCount);
         }
 
         [Fact]
@@ -307,7 +278,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         public async Task FunctionDispatcher_Restart_ErroredChannels_Succeeds()
         {
             int expectedProcessCount = 2;
-            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount.ToString());
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount);
             await functionDispatcher.InitializeAsync(GetTestFunctionsList(RpcWorkerConstants.NodeLanguageWorkerName));
 
             await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount);
@@ -328,7 +299,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         public async Task FunctionDispatcher_Restart_ErroredChannels_And_Changes_State()
         {
             int expectedProcessCount = 1;
-            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount.ToString());
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount);
             Assert.Equal(FunctionInvocationDispatcherState.Default, functionDispatcher.State);
             // Add worker
             await functionDispatcher.InitializeAsync(GetTestFunctionsList(RpcWorkerConstants.NodeLanguageWorkerName));
@@ -348,7 +319,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         public async Task FunctionDispatcher_Restart_ErroredChannels_And_DoesNot_Change_State()
         {
             int expectedProcessCount = 2;
-            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount.ToString());
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount);
             Assert.Equal(FunctionInvocationDispatcherState.Default, functionDispatcher.State);
             // Add worker
             await functionDispatcher.InitializeAsync(GetTestFunctionsList(RpcWorkerConstants.NodeLanguageWorkerName));
@@ -365,7 +336,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         public async Task FunctionDispatcher_Restart_ErroredChannels_ExceedsLimit()
         {
             int expectedProcessCount = 2;
-            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount.ToString());
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount);
             await functionDispatcher.InitializeAsync(GetTestFunctionsList(RpcWorkerConstants.NodeLanguageWorkerName));
 
             await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount);
@@ -384,7 +355,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         public async Task FunctionDispatcher_Restart_ErroredChannels_OnWorkerRestart_NotAffectedByLimit()
         {
             int expectedProcessCount = 2;
-            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount.ToString());
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount);
             await functionDispatcher.InitializeAsync(GetTestFunctionsList(RpcWorkerConstants.NodeLanguageWorkerName));
 
             await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount);
@@ -404,7 +375,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         [Fact]
         public async Task FunctionDispatcher_Error_WithinThreshold_BucketFills()
         {
-            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher("1");
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(1);
             await functionDispatcher.InitializeAsync(GetTestFunctionsList(RpcWorkerConstants.NodeLanguageWorkerName));
             await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, 1);
             for (int i = 0; i < 3; ++i)
@@ -422,7 +393,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         [Fact]
         public async Task FunctionDispatcher_Error_BeyondThreshold_BucketIsAtOne()
         {
-            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher("1");
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher();
             await functionDispatcher.InitializeAsync(GetTestFunctionsList(RpcWorkerConstants.NodeLanguageWorkerName));
             await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, 1);
             for (int i = 1; i < 10; ++i)
@@ -441,7 +412,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         public async Task FunctionDispatcher_DoNot_Restart_ErroredChannels_If_WorkerRuntime_DoesNotMatch()
         {
             int expectedProcessCount = 1;
-            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount.ToString());
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount);
             await functionDispatcher.InitializeAsync(GetTestFunctionsList(RpcWorkerConstants.NodeLanguageWorkerName));
             await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount);
             _javaTestChannel.RaiseWorkerError();
@@ -479,17 +450,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.False(testLogs.Any(m => m.FormattedMessage.Contains("Removing errored webhost language worker channel for runtime")));
         }
 
-        private static RpcFunctionInvocationDispatcher GetTestFunctionDispatcher(string maxProcessCountValue = null, bool addWebhostChannel = false, Mock<IWebHostRpcWorkerChannelManager> mockwebHostLanguageWorkerChannelManager = null, bool throwOnProcessStartUp = false)
+        private static RpcFunctionInvocationDispatcher GetTestFunctionDispatcher(int maxProcessCountValue = 1, bool addWebhostChannel = false, Mock<IWebHostRpcWorkerChannelManager> mockwebHostLanguageWorkerChannelManager = null, bool throwOnProcessStartUp = false)
         {
             var eventManager = new ScriptEventManager();
             var metricsLogger = new Mock<IMetricsLogger>();
             var mockApplicationLifetime = new Mock<IApplicationLifetime>();
             var testEnv = new TestEnvironment();
 
-            if (!string.IsNullOrEmpty(maxProcessCountValue))
-            {
-                testEnv.SetEnvironmentVariable(RpcWorkerConstants.FunctionsWorkerProcessCountSettingName, maxProcessCountValue);
-            }
+            testEnv.SetEnvironmentVariable(RpcWorkerConstants.FunctionsWorkerProcessCountSettingName, maxProcessCountValue.ToString());
 
             var loggerFactory = MockNullLoggerFactory.CreateLoggerFactory();
 
@@ -502,7 +470,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             var workerConfigOptions = new LanguageWorkerOptions
             {
-                WorkerConfigs = TestHelpers.GetTestWorkerConfigs()
+                WorkerConfigs = TestHelpers.GetTestWorkerConfigs(processCountValue: maxProcessCountValue)
             };
             IRpcWorkerChannelFactory testLanguageWorkerChannelFactory = new TestRpcWorkerChannelFactory(eventManager, _testLogger, scriptOptions.Value.RootScriptPath, throwOnProcessStartUp);
             IWebHostRpcWorkerChannelManager testWebHostLanguageWorkerChannelManager = new TestRpcWorkerChannelManager(eventManager, _testLogger, scriptOptions.Value.RootScriptPath, testLanguageWorkerChannelFactory);

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
@@ -159,7 +159,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             {
                 _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
             }
-            var expectedWorkersDir = Path.Combine(Path.GetDirectoryName(new Uri(typeof(RpcWorkerConfigFactory).Assembly.CodeBase).LocalPath), RpcWorkerConstants.DefaultWorkersDirectoryName);
             var config = new ConfigurationBuilder().Build();
             var testLogger = new TestLogger("test");
             RpcWorkerConfigFactory rpcWorkerConfigFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger());


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #6671 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information

Added support for customize multiple worker processes in `worker.config.json`

```json
{
  "description": {
    "language": "node",
    "extensions": [ ".js" ],
    "defaultExecutablePath": "node",
    "defaultWorkerPath": "dist/src/nodejsWorker.js"
  },
  "processOptions": {
    "processCount": 5,
    "maxProcessCount": 12,
    "processStartUpInterval": "00:00:05"
  }
}
```

If `processOptions` section is not specified,  following defaults will be applied:

`processCount` :  1
`maxProcessCount` : 10
`processStartUpInterval` : 00:00:10
