### PR TITLE
Setting bundle Id based on app kind

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,10 +2,8 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-- Fixed [bug](https://github.com/Azure/azure-functions-durable-extension/issues/1467) in sync triggers operations for Durable Functions using custom storage account connection strings.
-- Update PowerShell Worker to 3.0.557 (PS6) [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.557) and 3.0.560 (PS7) [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.560)
-- Update Microsoft.Azure.WebJobs and Microsoft.Azure.WebJobs.Logging.ApplicationInsights to v3.0.25 [Release Notes](https://github.com/Azure/azure-webjobs-sdk/releases/tag/v3.0.25)
-- Update Microsoft.Azure.WebJobs.Extensions.Http to 3.0.9-10815
-- Update Python Worker to 1.1.8 [Release Note](https://github.com/Azure/azure-functions-python-worker/releases/tag/1.1.8)
-- Update Python Library to 1.5.0 [Release Note](https://github.com/Azure/azure-functions-python-library/releases/tag/1.5.0)
 - Configure host.json to use workflow when creating a default host.json and app is identified as a logic app. (#6810)
+
+
+**Release sprint:** Sprint 88	**Release sprint:** Sprint <successiveSprint>
+[ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+88%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+88%22+label%3Afeature+is%3Aclosed) ]

--- a/release_notes.md
+++ b/release_notes.md
@@ -8,6 +8,4 @@
 - Update Microsoft.Azure.WebJobs.Extensions.Http to 3.0.9-10815
 - Update Python Worker to 1.1.8 [Release Note](https://github.com/Azure/azure-functions-python-worker/releases/tag/1.1.8)
 - Update Python Library to 1.5.0 [Release Note](https://github.com/Azure/azure-functions-python-library/releases/tag/1.5.0)
-
-**Release sprint:** Sprint 87
-[ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+87%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+87%22+label%3Afeature+is%3Aclosed) ]
+- Configure host.json to use workflow when creating a default host.json and app is identified as a logic app. (#6810)

--- a/release_notes.md
+++ b/release_notes.md
@@ -5,5 +5,5 @@
 - Configure host.json to use workflow when creating a default host.json and app is identified as a logic app. (#6810)
 
 
-**Release sprint:** Sprint 88	**Release sprint:** Sprint <successiveSprint>
+**Release sprint:** Sprint 88
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+88%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+88%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
@@ -211,9 +211,12 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
                         _logger.HostConfigNotFound();
 
                         hostConfigObject = GetDefaultHostConfigObject();
+                        string bundleId = _configurationSource.Environment.IsLogicApp() ?
+                                            ScriptConstants.WorkFlowExtensionBundleId :
+                                            ScriptConstants.DefaultExtensionBundleId;
 
+                        hostConfigObject = TryAddBundleConfiguration(hostConfigObject, bundleId);
                         // Add bundle configuration if no file exists and file system is not read only
-                        hostConfigObject = TryAddBundleConfiguration(hostConfigObject);
                         TryWriteHostJson(configFilePath, hostConfigObject);
                     }
 
@@ -252,11 +255,11 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
                 }
             }
 
-            private JObject TryAddBundleConfiguration(JObject content)
+            private JObject TryAddBundleConfiguration(JObject content, string bundleId)
             {
                 if (!_configurationSource.Environment.IsFileSystemReadOnly())
                 {
-                    string bundleConfiguration = "{ 'id': 'Microsoft.Azure.Functions.ExtensionBundle', 'version': '[1.*, 2.0.0)'}";
+                    string bundleConfiguration = "{ 'id': '" + bundleId + "', 'version': '[1.*, 2.0.0)'}";
                     content.Add("extensionBundle", JToken.Parse(bundleConfiguration));
                     _logger.AddingExtensionBundleConfiguration(bundleConfiguration);
                 }

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -325,7 +325,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// </summary>
         public static bool IsLogicApp(this IEnvironment environment)
         {
-            string appKind = environment.GetEnvironmentVariable(AppKind).ToLower();
+            string appKind = environment.GetEnvironmentVariable(AppKind)?.ToLower();
             return !string.IsNullOrEmpty(appKind) && appKind.Contains(WorkFlowAppKind);
         }
 

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -326,7 +326,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public static bool IsLogicApp(this IEnvironment environment)
         {
             string appKind = environment.GetEnvironmentVariable(AppKind)?.ToLower();
-            return !string.IsNullOrEmpty(appKind) && appKind.Contains(WorkFlowAppKind);
+            return !string.IsNullOrEmpty(appKind) && appKind.Contains(ScriptConstants.WorkFlowAppKind);
         }
 
         /// <summary>

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -321,6 +321,15 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
+        /// Gets the computer name.
+        /// </summary>
+        public static bool IsLogicApp(this IEnvironment environment)
+        {
+            string appKind = environment.GetEnvironmentVariable(AppKind).ToLower();
+            return !string.IsNullOrEmpty(appKind) && appKind.Contains(WorkFlowAppKind);
+        }
+
+        /// <summary>
         /// Gets the Antares version.
         /// </summary>
         public static string GetAntaresVersion(this IEnvironment environment)

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -114,6 +114,5 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AntaresComputerName = "COMPUTERNAME";
 
         public const string AppKind = "APP_KIND";
-        public const string WorkFlowAppKind = "workflowapp";
     }
 }

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -112,5 +112,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
         // Machine identifier
         public const string AntaresComputerName = "COMPUTERNAME";
+
+        public const string AppKind = "APP_KIND";
+        public const string WorkFlowAppKind = "workflowapp";
     }
 }

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -165,6 +165,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string ExtensionBundleTemplatesFile = "templates.json";
         public const string ExtensionBundleResourcesFile = "Resources.json";
         public const string DefaultExtensionBundleId = "Microsoft.Azure.Functions.ExtensionBundle";
+        public const string WorkFlowExtensionBundleId = "Microsoft.Azure.Functions.ExtensionBundle.Workflows";
         public const string ExtensionBundleForAppServiceWindows = "win-any";
         public const string ExtensionBundleForAppServiceLinux = "linux-x64";
         public const string ExtensionBundleForNonAppServiceEnvironment = "any-any";

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -173,6 +173,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string Linux64BitRID = "linux-x64";
         public const string Windows64BitRID = "win-x64";
         public const string Windows32BitRID = "win-x86";
+        public const string WorkFlowAppKind = "workflowapp";
 
         public const string AzureMonitorTraceCategory = "FunctionAppLogs";
 

--- a/test/WebJobs.Script.Tests/Configuration/HostJsonFileConfigurationSourceTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/HostJsonFileConfigurationSourceTests.cs
@@ -48,12 +48,33 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         }
 
         [Fact]
-        public void MissingHostJson_CreatesDefaultFile()
+        public void MissingHostJson_CreatesHostJson_withDefaultExtensionBundleId()
         {
             Assert.False(File.Exists(_hostJsonFile));
             TestMetricsLogger testMetricsLogger = new TestMetricsLogger();
 
             BuildHostJsonConfiguration(testMetricsLogger);
+
+            AreExpectedMetricsGenerated(testMetricsLogger);
+
+            Assert.Equal(_hostJsonWithBundles, File.ReadAllText(_hostJsonFile));
+
+            var log = _loggerProvider.GetAllLogMessages().Single(l => l.FormattedMessage == "No host configuration file found. Creating a default host.json file.");
+            Assert.Equal(LogLevel.Information, log.Level);
+        }
+
+        [Fact]
+        public void MissingHostJson_CreatesHostJson_withWorkFlowExtensionBundleId()
+        {
+            var environment = new TestEnvironment(new Dictionary<string, string>
+            {
+                { EnvironmentSettingNames.AppKind, "workflowApp" }
+            });
+
+            Assert.False(File.Exists(_hostJsonFile));
+            TestMetricsLogger testMetricsLogger = new TestMetricsLogger();
+
+            BuildHostJsonConfiguration(testMetricsLogger, environment);
 
             AreExpectedMetricsGenerated(testMetricsLogger);
 
@@ -112,6 +133,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             {
                 { EnvironmentSettingNames.AzureWebsiteZipDeployment, "1" }
             });
+
             TestMetricsLogger testMetricsLogger = new TestMetricsLogger();
             IConfiguration config = BuildHostJsonConfiguration(testMetricsLogger, environment);
             AreExpectedMetricsGenerated(testMetricsLogger);

--- a/test/WebJobs.Script.Tests/Configuration/HostJsonFileConfigurationSourceTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/HostJsonFileConfigurationSourceTests.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
     public class HostJsonFileConfigurationSourceTests
     {
         private readonly string _hostJsonWithBundles = "{\r\n  \"version\": \"2.0\",\r\n  \"extensionBundle\": {\r\n    \"id\": \"Microsoft.Azure.Functions.ExtensionBundle\",\r\n    \"version\": \"[1.*, 2.0.0)\"\r\n  }\r\n}";
+        private readonly string _hostJsonWithWorkFlowBundle = "{\r\n  \"version\": \"2.0\",\r\n  \"extensionBundle\": {\r\n    \"id\": \"Microsoft.Azure.Functions.ExtensionBundle.Workflows\",\r\n    \"version\": \"[1.*, 2.0.0)\"\r\n  }\r\n}";
         private readonly string _defaultHostJson = "{\r\n  \"version\": \"2.0\"\r\n}";
         private readonly ScriptApplicationHostOptions _options;
         private readonly string _hostJsonFile;
@@ -78,7 +79,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 
             AreExpectedMetricsGenerated(testMetricsLogger);
 
-            Assert.Equal(_hostJsonWithBundles, File.ReadAllText(_hostJsonFile));
+            Assert.Equal(_hostJsonWithWorkFlowBundle, File.ReadAllText(_hostJsonFile));
 
             var log = _loggerProvider.GetAllLogMessages().Single(l => l.FormattedMessage == "No host configuration file found. Creating a default host.json file.");
             Assert.Equal(LogLevel.Information, log.Level);


### PR DESCRIPTION
Function runtime creates a default host.json when there is none present. The default host.json includes configuration that points to the default extension bundle created by functions team. Logic app (preview) requires a the use of the extension bundle created by logic apps team by default. This change uses the configures extension bundle created by logic apps when creating the default host.json.

resolves #6672

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)