### PR TITLE
Log unhandled exception to stdout for Linux App service

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
@@ -72,5 +72,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         public override void LogAzureMonitorDiagnosticLogEvent(LogLevel level, string resourceId, string operationName, string category, string regionName, string properties)
         {
         }
+
+        public static void LogUnhandledException(Exception e)
+        {
+            // Pipe the unhandled exception to stdout as part of docker logs.
+            Console.WriteLine($"Unhandled exception on {DateTime.UtcNow}: {e?.ToString()}");
+        }
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #6770 

### Pull request checklist

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
This change pipes unhandled exceptions to stdout stream, which are included as part of the docker logs  api. When the container crashes, LWAS will query the docker logs api from last 10 seconds, and that will now also include the unhandled exception message.
