### PR TITLE
Fix scale status API race condition (#6826)

### DIFF
--- a/test/WebJobs.Script.Tests/Controllers/Admin/HostControllerTests.cs
+++ b/test/WebJobs.Script.Tests/Controllers/Admin/HostControllerTests.cs
@@ -6,6 +6,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using System.Net;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs.Host.Scale;
@@ -114,8 +115,28 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var scaleManagerMock = new Mock<FunctionsScaleManager>(MockBehavior.Strict);
             var scaleStatusResult = new ScaleStatusResult { Vote = ScaleVote.ScaleOut };
             scaleManagerMock.Setup(p => p.GetScaleStatusAsync(context)).ReturnsAsync(scaleStatusResult);
-            var result = (ObjectResult)(await _hostController.GetScaleStatus(context, scaleManagerMock.Object));
+            var scriptHostManagerMock = new Mock<IScriptHostManager>(MockBehavior.Strict);
+            var serviceProviderMock = scriptHostManagerMock.As<IServiceProvider>();
+            serviceProviderMock.Setup(p => p.GetService(typeof(FunctionsScaleManager))).Returns(scaleManagerMock.Object);
+            var result = (ObjectResult)(await _hostController.GetScaleStatus(context, scriptHostManagerMock.Object));
             Assert.Same(result.Value, scaleStatusResult);
+        }
+
+        [Fact]
+        public async Task GetScaleStatus_FunctionsScaleManager_Null_ReturnsServiceUnavailable()
+        {
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsRuntimeScaleMonitoringEnabled)).Returns("1");
+
+            var context = new ScaleStatusContext
+            {
+                WorkerCount = 5
+            };
+            var scriptHostManagerMock = new Mock<IScriptHostManager>(MockBehavior.Strict);
+            var serviceProviderMock = scriptHostManagerMock.As<IServiceProvider>();
+            serviceProviderMock.Setup(p => p.GetService(typeof(FunctionsScaleManager))).Returns(null);
+            var result = (StatusCodeResult)(await _hostController.GetScaleStatus(context, scriptHostManagerMock.Object));
+
+            Assert.Equal(StatusCodes.Status503ServiceUnavailable, result.StatusCode);
         }
 
         [Fact]
@@ -126,7 +147,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 WorkerCount = 5
             };
             var scaleManagerMock = new Mock<FunctionsScaleManager>(MockBehavior.Strict);
-            var result = (BadRequestObjectResult)(await _hostController.GetScaleStatus(context, scaleManagerMock.Object));
+            var scriptHostManagerMock = new Mock<IScriptHostManager>(MockBehavior.Strict);
+            var serviceProviderMock = scriptHostManagerMock.As<IServiceProvider>();
+            serviceProviderMock.Setup(p => p.GetService(typeof(FunctionsScaleManager))).Returns(scaleManagerMock.Object);
+            var result = (BadRequestObjectResult)(await _hostController.GetScaleStatus(context, scriptHostManagerMock.Object));
             Assert.Equal(HttpStatusCode.BadRequest, (HttpStatusCode)result.StatusCode);
             Assert.Equal("Runtime scale monitoring is not enabled.", result.Value);
         }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Resolves https://github.com/Azure/azure-functions-host/issues/6826. In a recent CRI investigation we saw a Premium customer with RTS enabled, whose host was in an error loop. ScaleController continued to ping the admin/host/scale/status endpoint, and those calls were resulting in errors due to this issue.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR https://github.com/Azure/azure-functions-host/pull/6838
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
