### PR TITLE
Enforce ordering of functions in synctriggers payload

### DIFF
--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 Errors = _functionErrors.Where(kvp => functionsWhiteList.Any(functionName => functionName.Equals(kvp.Key, StringComparison.CurrentCultureIgnoreCase))).ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray());
             }
 
-            return functionMetadataList.ToImmutableArray();
+            return functionMetadataList.OrderBy(f => f.Name, StringComparer.OrdinalIgnoreCase).ToImmutableArray();
         }
 
         internal bool IsScriptFileDetermined(FunctionMetadata functionMetadata)

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -715,8 +715,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                         return new[]
                         {
                             Path.Combine(rootPath, "bin"),
-                            Path.Combine(rootPath, "function1"),
                             Path.Combine(rootPath, "function2"),
+                            Path.Combine(rootPath, "function1"),
                             Path.Combine(rootPath, "function3")
                         };
                     }


### PR DESCRIPTION
Background synctriggers task compares hashes of current and last known synctriggers payload to avoid unnecessary /synctriggers call to update the site metadata. Currently the ordering of functions in Synctriggers payload is non deterministic since it relies EnumerateDirectories() which is implemented differently on Linux and Windows. This leads to unnecessary updates to the site metadata if the function app has more than 1 function even though the triggers themselves haven't been updated. Fix is to sort the functions before calculating the hash.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-host/issues/6686

### Pull request checklist

* [ X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
Backport of https://github.com/Azure/azure-functions-host/pull/6803