### PR TITLE
Update PowerShell Worker to 3.0.557 (PS6) and 3.0.560 (PS7)

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,6 +3,7 @@
 - My change description (#PR)
 -->
 - Fixed [bug](https://github.com/Azure/azure-functions-durable-extension/issues/1467) in sync triggers operations for Durable Functions using custom storage account connection strings.
+- Update PowerShell Worker to 3.0.557 (PS6) [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.557) and 3.0.560 (PS7) [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.560)
 
 **Release sprint:** Sprint 86
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+86%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+86%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -42,8 +42,8 @@
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.11020001-fabe022e" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.8.0" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.0.6" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.552" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.549" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.557" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.560" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.23" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.8" />


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Update PowerShell Worker to 3.0.557 (PS6) ([Release Notes](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.557)) and 3.0.560 (PS7) ([Release Notes](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.560))

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
