### PR TITLE
Remove hardcoded placeholder mode for linux consumption

### DIFF
--- a/src/WebJobs.Script.WebHost/Program.cs
+++ b/src/WebJobs.Script.WebHost/Program.cs
@@ -87,8 +87,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         {
             if (SystemEnvironment.Instance.IsLinuxConsumption())
             {
-                // Linux containers always start out in placeholder mode
-                SystemEnvironment.Instance.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
                 AppDomain.CurrentDomain.UnhandledException += CurrentDomainOnUnhandledException;
             }
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [X] Otherwise: Backport tracked by issue/PR #6847 
* [X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Enabling placeholders app setting should not be hardcoded inside the functions host. The control plane will add the app setting from now on to enable placeholders if this container is for a placeholder pool. If this is a pinned linux consumption container, then placeholders will not be enabled from the control plane side.
