### PR TITLE
Added methods to skip cleaning of output assemblies to ExtensionsMetadataGenerator.

### DIFF
--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/BuildTasks/RemoveRuntimeDependencies.cs
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/BuildTasks/RemoveRuntimeDependencies.cs
@@ -21,8 +21,17 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.BuildTasks
         [Required]
         public string OutputPath { get; set; }
 
+        [Required]
+        public ITaskItem[] IgnoreFiles { get; set; }
+
         public override bool Execute()
         {
+            HashSet<string> ignoreFilesSet = new HashSet<string>();
+            foreach (ITaskItem item in IgnoreFiles)
+            {
+                ignoreFilesSet.Add(item.ItemSpec);
+            }
+
             Assembly assembly = typeof(RemoveRuntimeDependencies).Assembly;
             using (Stream resource = assembly.GetManifestResourceStream(assembly.GetName().Name + ".runtimeassemblies.txt"))
             using (var reader = new StreamReader(resource))
@@ -32,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.BuildTasks
                 {
                     string fileName = Path.Combine(OutputPath, assemblyName);
 
-                    if (File.Exists(fileName))
+                    if (File.Exists(fileName) && !ignoreFilesSet.Contains(assemblyName))
                     {
                         File.Delete(fileName);
                     }

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets
@@ -21,11 +21,11 @@
              AssemblyFile="$(_FunctionsExtensionsTaskAssemblyFullPath)"/>
   
   <Target Name="_FunctionsBuildCleanOutput" AfterTargets="_GenerateFunctionsExtensionsMetadataPostBuild" Condition="$(_FunctionsSkipCleanOutput) != 'true'" >
-    <RemoveRuntimeDependencies OutputPath="$(TargetDir)bin"/>
+    <RemoveRuntimeDependencies OutputPath="$(TargetDir)bin" IgnoreFiles="@(FunctionsPreservedDependencies)"/>
   </Target>
 
   <Target Name="_FunctionsPublishCleanOutput" AfterTargets="_GenerateFunctionsExtensionsMetadataPostPublish" Condition="$(_FunctionsSkipCleanOutput) != 'true'" >
-    <RemoveRuntimeDependencies OutputPath="$(PublishDir)bin"/>
+    <RemoveRuntimeDependencies OutputPath="$(PublishDir)bin" IgnoreFiles="@(FunctionsPreservedDependencies)"/>
   </Target>
   
   <UsingTask TaskName="GenerateFunctionsExtensionsMetadata"


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Resolves #5894 

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [x] Otherwise: Documentation issue linked to PR (https://github.com/MicrosoftDocs/azure-docs/pull/65127)
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This adds a new property that users can specify in their csproj to define how ExtensionsMetadataGenerator handles output clean up.

They can add the following:
```xml
  <ItemGroup>
    <FunctionsPreservedDependencies Include="Microsoft.AspNetCore.Http.dll" />
    <FunctionsPreservedDependencies Include="Microsoft.AspNetCore.Http.Extensions.dll" />
    <FunctionsPreservedDependencies Include="Microsoft.AspNetCore.Http.Features.dll" />
  </ItemGroup>
```
For every assembly/file in the build output they don't want deleted during the cleaning step.

Notes about the PR:
- I've made a PR for documenting this feature, but I'm unsure if it's really in the right place and would appreciate a review of the content/wording: https://github.com/MicrosoftDocs/azure-docs/pull/65127
- I'm open to suggestions on the name of these settings. I thought `FunctionsPreserveOutputAssembly` might be better, but went with what I did to match `FunctionsSkipCleanOutput`. I kept `FunctionsSkipCleanOutput` because I know some customers use and are familiar with `_FunctionsSkipCleanOutput` but that might not be a strong enough reason to keep it if we could come up with a better one.
- I looked into adding tests. My idea was to create a new test function app project (TestProject_SkipClean for instance) with some FunctionsSkipCleanOutputAssembly defined. Then traverse the file system to make sure those assemblies are still in the build output. However, I'm not sure how I can specify that the project should use the ExtensionMetadataGenerator from the project and not the one from `Microsoft.NET.Sdk.Functions`. I could use some help with this.
- I'm not sure if I should add to the Host's release notes. Isn't this on its own release cadence that's not tied to the host?

