### PR TITLE
fix flaky test

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
@@ -13,8 +13,6 @@ using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Logging;
-using Microsoft.Azure.WebJobs.Script.Diagnostics;
-using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -235,7 +233,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
             ValidateTelemetry(telemetry, expectedInvocationId, expectedOperationName, expectedCategory, SeverityLevel.Error);
         }
 
-        [Fact(Skip = "Disabled due to https://github.com/Azure/azure-functions-host/issues/6521")]
+        [Fact]
         public async Task Validate_HostLogs()
         {
             // Validate the host startup traces. Order by message string as the requests may come in

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
@@ -78,16 +78,5 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
             // everything is flushed and can't affect subsequent tests.
             Thread.Sleep(2000);
         }
-
-        private class ScriptHostBuilder : IConfigureBuilder<IWebJobsBuilder>
-        {
-            public void Configure(IWebJobsBuilder builder)
-            {
-                builder.Services.Configure<ScriptJobHostOptions>(o =>
-                {
-                    o.Functions = new[] { "Scenarios", "HttpTrigger-Scenarios" };
-                });
-            }
-        }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/ScriptHostEndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/ScriptHostEndToEndTestFixture.cs
@@ -249,6 +249,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 await JobHost.StopAsync();
                 await Host.StopAsync();
                 JobHost.Dispose();
+                Host.Dispose();
             }
             Environment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, string.Empty);
         }

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -13,6 +14,7 @@ using System.Xml;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Script.ExtensionBundle;
 using Microsoft.Azure.WebJobs.Script.Models;
 using Microsoft.Azure.WebJobs.Script.WebHost;
@@ -42,6 +44,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         private readonly TestLoggerProvider _webHostLoggerProvider = new TestLoggerProvider();
         private readonly TestLoggerProvider _scriptHostLoggerProvider = new TestLoggerProvider();
         private readonly WebJobsScriptHostService _hostService;
+
+        private readonly Timer _stillRunningTimer;
+        private readonly DateTimeOffset _created = DateTimeOffset.UtcNow;
+        private readonly string _createdStack;
+        private readonly string _id = Guid.NewGuid().ToString();
+        private bool _timerFired = false;
 
         public TestFunctionHost(string scriptPath,
            Action<IServiceCollection> configureWebHostServices = null,
@@ -139,6 +147,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             lifetime.ApplicationStopping.Register(async () => await _testServer.Host.StopAsync());
 
             StartAsync().GetAwaiter().GetResult();
+
+            _stillRunningTimer = new Timer(StillRunningCallback, _testServer, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
+
+            // store off a bit of the creation stack for easier debugging if this host doesn't shut down.
+            var stack = new StackTrace(true).ToString().Split(Environment.NewLine).Take(5);
+            _createdStack = string.Join($"{Environment.NewLine}    ", stack);
         }
 
         public IServiceProvider JobHostServices => _hostService.Services;
@@ -170,6 +184,39 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public async Task RestartAsync(CancellationToken cancellationToken)
         {
             await _hostService.RestartHostAsync(cancellationToken);
+        }
+
+        private void StillRunningCallback(object state)
+        {
+            var idProvider = JobHostServices?.GetService<IHostIdProvider>();
+            var jobOptions = JobHostServices?.GetService<IOptions<ScriptJobHostOptions>>();
+
+            if (idProvider == null || jobOptions == null)
+            {
+                return;
+            }
+
+            var functions = jobOptions?.Value.Functions ?? new[] { "" };
+
+            string allowList = $"[{string.Join(", ", functions)}]";
+            string hostId = idProvider.GetHostIdAsync(CancellationToken.None).Result;
+
+            var ago = (int)(DateTime.UtcNow - _created).TotalSeconds;
+
+            // This helps debugging tests that may not be disposing their hosts.
+            StringBuilder sb = new StringBuilder();
+
+            sb.AppendLine($"A host created at '{_created:yyyy-MM-dd HH:mm:ss}' ({ago}s ago) is still running. Details:");
+            sb.AppendLine($"  Host id:      {hostId}");
+            sb.AppendLine($"  Test host id: {_id}");
+            sb.AppendLine($"  ScriptRoot:   {jobOptions.Value.RootScriptPath}");
+            sb.AppendLine($"  Allow list:   {allowList}");
+            sb.AppendLine($"  The captured stack from this test host's constructor:");
+            sb.AppendLine(_createdStack);
+
+            Console.Write(sb.ToString());
+
+            _timerFired = true;
         }
 
         private Task StartAsync()
@@ -288,6 +335,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             HttpClient.Dispose();
             _testServer.Dispose();
+
+            _stillRunningTimer.Change(-1, -1);
+            _stillRunningTimer?.Dispose();
+
+            if (_timerFired)
+            {
+                Console.WriteLine($"The test host with id {_id} is now disposed.");
+            }
         }
 
         private async Task<bool> IsHostStarted()

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         private readonly string _createdStack;
         private readonly string _id = Guid.NewGuid().ToString();
         private bool _timerFired = false;
+        private bool _isDisposed = false;
 
         public TestFunctionHost(string scriptPath,
            Action<IServiceCollection> configureWebHostServices = null,
@@ -333,15 +334,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public void Dispose()
         {
-            HttpClient.Dispose();
-            _testServer.Dispose();
-
-            _stillRunningTimer.Change(-1, -1);
-            _stillRunningTimer?.Dispose();
-
-            if (_timerFired)
+            if (!_isDisposed)
             {
-                Console.WriteLine($"The test host with id {_id} is now disposed.");
+                HttpClient.Dispose();
+                _testServer.Dispose();
+
+                _stillRunningTimer?.Change(-1, -1);
+                _stillRunningTimer?.Dispose();
+
+                if (_timerFired)
+                {
+                    Console.WriteLine($"The test host with id {_id} is now disposed.");
+                }
+
+                _isDisposed = true;
             }
         }
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CodelessEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CodelessEndToEndTests.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Management.Models;
@@ -41,28 +40,30 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                 var provider = new TestCodelessFunctionProvider(metadata, null);
 
                 var functions = allowedList != null ? new[] { allowedList, "testFn" } : null;
-                var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { provider }, testEnvironment);
-
-                // Make sure unauthorized does not work
-                var unauthResponse = await host.HttpClient.GetAsync("http://localhost/api/testFn?name=Ankit");
-                Assert.Equal(HttpStatusCode.Unauthorized, unauthResponse.StatusCode);
-
-                var testFnKey = await host.GetFunctionSecretAsync("testFn");
-                var responseName = await host.HttpClient.GetAsync($"http://localhost/api/testFn?code={testFnKey}&name=Ankit");
-                var responseNoName = await host.HttpClient.GetAsync($"http://localhost/api/testFn?code={testFnKey}");
-
-                Assert.Equal(HttpStatusCode.OK, responseName.StatusCode);
-                Assert.Equal(HttpStatusCode.OK, responseNoName.StatusCode);
-
-                Assert.Equal("Codeless Provider ran a function successfully with no name parameter.", await responseNoName.Content.ReadAsStringAsync());
-                Assert.Equal("Hello, Ankit! Codeless Provider ran a function successfully.", await responseName.Content.ReadAsStringAsync());
-
-                // Regular functions should work as expected
-                if (allowedList != null)
+                using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { provider }, testEnvironment))
                 {
-                    string key = await host.GetFunctionSecretAsync(allowedList);
-                    var notCodeless = await host.HttpClient.GetAsync($"http://localhost/api/{allowedList}?code={key}");
-                    Assert.Equal(HttpStatusCode.OK, notCodeless.StatusCode);
+
+                    // Make sure unauthorized does not work
+                    var unauthResponse = await host.HttpClient.GetAsync("http://localhost/api/testFn?name=Ankit");
+                    Assert.Equal(HttpStatusCode.Unauthorized, unauthResponse.StatusCode);
+
+                    var testFnKey = await host.GetFunctionSecretAsync("testFn");
+                    var responseName = await host.HttpClient.GetAsync($"http://localhost/api/testFn?code={testFnKey}&name=Ankit");
+                    var responseNoName = await host.HttpClient.GetAsync($"http://localhost/api/testFn?code={testFnKey}");
+
+                    Assert.Equal(HttpStatusCode.OK, responseName.StatusCode);
+                    Assert.Equal(HttpStatusCode.OK, responseNoName.StatusCode);
+
+                    Assert.Equal("Codeless Provider ran a function successfully with no name parameter.", await responseNoName.Content.ReadAsStringAsync());
+                    Assert.Equal("Hello, Ankit! Codeless Provider ran a function successfully.", await responseName.Content.ReadAsStringAsync());
+
+                    // Regular functions should work as expected
+                    if (allowedList != null)
+                    {
+                        string key = await host.GetFunctionSecretAsync(allowedList);
+                        var notCodeless = await host.HttpClient.GetAsync($"http://localhost/api/{allowedList}?code={key}");
+                        Assert.Equal(HttpStatusCode.OK, notCodeless.StatusCode);
+                    }
                 }
             }
         }
@@ -87,28 +88,29 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                 var provider = new TestCodelessFunctionProvider(metadata, null);
 
                 var functions = allowedList != null ? new[] { "testFn2", allowedList } : new[] { "testFn2" };
-                var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { provider }, testEnvironment);
-
-                // Make sure unauthorized does not work
-                var unauthResponse = await host.HttpClient.GetAsync("http://localhost/api/testFn2?name=Ankit");
-                Assert.Equal(HttpStatusCode.Unauthorized, unauthResponse.StatusCode);
-
-                var testFn1Key = await host.GetFunctionSecretAsync("testFn1");
-                var testFn2Key = await host.GetFunctionSecretAsync("testFn2");
-                var test1 = await host.HttpClient.GetAsync($"http://localhost/api/testFn1?name=Ankit&code={testFn1Key}");
-                var test2 = await host.HttpClient.GetAsync($"http://localhost/api/testFn2?name=Ankit&code={testFn2Key}");
-
-                Assert.Equal(HttpStatusCode.NotFound, test1.StatusCode);
-                Assert.Equal(HttpStatusCode.OK, test2.StatusCode);
-
-                Assert.Equal("Hello, Ankit! Codeless Provider ran a function successfully.", await test2.Content.ReadAsStringAsync());
-
-                // Regular functions should work as expected
-                if (allowedList != null)
+                using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { provider }, testEnvironment))
                 {
-                    string key = await host.GetFunctionSecretAsync(allowedList);
-                    var notCodeless = await host.HttpClient.GetAsync($"http://localhost/api/{allowedList}?code={key}");
-                    Assert.Equal(HttpStatusCode.OK, notCodeless.StatusCode);
+                    // Make sure unauthorized does not work
+                    var unauthResponse = await host.HttpClient.GetAsync("http://localhost/api/testFn2?name=Ankit");
+                    Assert.Equal(HttpStatusCode.Unauthorized, unauthResponse.StatusCode);
+
+                    var testFn1Key = await host.GetFunctionSecretAsync("testFn1");
+                    var testFn2Key = await host.GetFunctionSecretAsync("testFn2");
+                    var test1 = await host.HttpClient.GetAsync($"http://localhost/api/testFn1?name=Ankit&code={testFn1Key}");
+                    var test2 = await host.HttpClient.GetAsync($"http://localhost/api/testFn2?name=Ankit&code={testFn2Key}");
+
+                    Assert.Equal(HttpStatusCode.NotFound, test1.StatusCode);
+                    Assert.Equal(HttpStatusCode.OK, test2.StatusCode);
+
+                    Assert.Equal("Hello, Ankit! Codeless Provider ran a function successfully.", await test2.Content.ReadAsStringAsync());
+
+                    // Regular functions should work as expected
+                    if (allowedList != null)
+                    {
+                        string key = await host.GetFunctionSecretAsync(allowedList);
+                        var notCodeless = await host.HttpClient.GetAsync($"http://localhost/api/{allowedList}?code={key}");
+                        Assert.Equal(HttpStatusCode.OK, notCodeless.StatusCode);
+                    }
                 }
             }
         }
@@ -136,25 +138,26 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                 var providerTwo = new TestCodelessFunctionProvider(metadataList2, null);
 
                 var functions = allowedList != null ? new[] { allowedList, "testFn2", "testFn1" } : null;
-                var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { providerOne, providerTwo }, testEnvironment);
-
-                var testFn1Key = await host.GetFunctionSecretAsync("testFn1");
-                var testFn2Key = await host.GetFunctionSecretAsync("testFn2");
-                var test1 = await host.HttpClient.GetAsync($"http://localhost/api/testFn1?name=Ankit&code={testFn1Key}");
-                var test2 = await host.HttpClient.GetAsync($"http://localhost/api/testFn2?name=Ankit&code={testFn2Key}");
-
-                Assert.Equal(HttpStatusCode.OK, test1.StatusCode);
-                Assert.Equal(HttpStatusCode.OK, test2.StatusCode);
-
-                Assert.Equal("Hello, Ankit! Codeless Provider ran a function successfully.", await test1.Content.ReadAsStringAsync());
-                Assert.Equal("Hello, Ankit! Codeless Provider ran a function successfully.", await test2.Content.ReadAsStringAsync());
-
-                // Regular functions should work as expected
-                if (allowedList != null)
+                using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { providerOne, providerTwo }, testEnvironment))
                 {
-                    string key = await host.GetFunctionSecretAsync(allowedList);
-                    var notCodeless = await host.HttpClient.GetAsync($"http://localhost/api/{allowedList}?code={key}");
-                    Assert.Equal(HttpStatusCode.OK, notCodeless.StatusCode);
+                    var testFn1Key = await host.GetFunctionSecretAsync("testFn1");
+                    var testFn2Key = await host.GetFunctionSecretAsync("testFn2");
+                    var test1 = await host.HttpClient.GetAsync($"http://localhost/api/testFn1?name=Ankit&code={testFn1Key}");
+                    var test2 = await host.HttpClient.GetAsync($"http://localhost/api/testFn2?name=Ankit&code={testFn2Key}");
+
+                    Assert.Equal(HttpStatusCode.OK, test1.StatusCode);
+                    Assert.Equal(HttpStatusCode.OK, test2.StatusCode);
+
+                    Assert.Equal("Hello, Ankit! Codeless Provider ran a function successfully.", await test1.Content.ReadAsStringAsync());
+                    Assert.Equal("Hello, Ankit! Codeless Provider ran a function successfully.", await test2.Content.ReadAsStringAsync());
+
+                    // Regular functions should work as expected
+                    if (allowedList != null)
+                    {
+                        string key = await host.GetFunctionSecretAsync(allowedList);
+                        var notCodeless = await host.HttpClient.GetAsync($"http://localhost/api/{allowedList}?code={key}");
+                        Assert.Equal(HttpStatusCode.OK, notCodeless.StatusCode);
+                    }
                 }
             }
         }
@@ -183,19 +186,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                 var providerTwo = new TestCodelessFunctionProvider(metadataList2, null);
 
                 var functions = allowedList != null ? new[] { allowedList, "testFn2", "testFn1" } : null;
-                var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { providerOne, providerTwo }, testEnvironment);
+                using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { providerOne, providerTwo }, testEnvironment))
+                {
+                    var masterKey = await host.GetMasterKeyAsync();
+                    var listFunctionsResponse = await host.HttpClient.GetAsync($"http://localhost/admin/functions?code={masterKey}");
 
-                var masterKey = await host.GetMasterKeyAsync();
-                var listFunctionsResponse = await host.HttpClient.GetAsync($"http://localhost/admin/functions?code={masterKey}");
+                    // List Functions test
+                    string uri = "admin/functions";
+                    var request = new HttpRequestMessage(HttpMethod.Get, uri);
+                    request.Headers.Add(AuthenticationLevelHandler.FunctionsKeyHeaderName, "1234");
+                    var response = await host.HttpClient.SendAsync(request);
+                    var metadata = (await response.Content.ReadAsAsync<IEnumerable<FunctionMetadataResponse>>()).ToArray();
 
-                // List Functions test
-                string uri = "admin/functions";
-                var request = new HttpRequestMessage(HttpMethod.Get, uri);
-                request.Headers.Add(AuthenticationLevelHandler.FunctionsKeyHeaderName, "1234");
-                var response = await host.HttpClient.SendAsync(request);
-                var metadata = (await response.Content.ReadAsAsync<IEnumerable<FunctionMetadataResponse>>()).ToArray();
-
-                Assert.Equal(listCount, metadata.Length);
+                    Assert.Equal(listCount, metadata.Length);
+                }
             }
         }
 
@@ -222,14 +226,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                 var providerTwo = new TestCodelessFunctionProvider(metadataList2, null);
 
                 var functions = allowedList != null ? new[] { allowedList, "testFn2", "testFn1" } : null;
-                var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { providerOne, providerTwo }, testEnvironment);
-
-                // Sanity check for sync triggers
-                string uri = "admin/host/synctriggers";
-                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
-                request.Headers.Add(AuthenticationLevelHandler.FunctionsKeyHeaderName, await host.GetMasterKeyAsync());
-                HttpResponseMessage response = await host.HttpClient.SendAsync(request);
-                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { providerOne, providerTwo }, testEnvironment))
+                {
+                    // Sanity check for sync triggers
+                    string uri = "admin/host/synctriggers";
+                    HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
+                    request.Headers.Add(AuthenticationLevelHandler.FunctionsKeyHeaderName, await host.GetMasterKeyAsync());
+                    HttpResponseMessage response = await host.HttpClient.SendAsync(request);
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #6521

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

I added a new timer to `TestFunctionsHost` that will write out details like this every 30 seconds to catch any future incident where a test host isn't properly disposed. This gets written out via `Console.WriteLine()` so it's discoverable in DevOps logs. This is the log that made me realize the issue was in the Codeless tests.
```
A host created at '2020-11-10 20:53:33' (90s ago) is still running. Details:
   Host id:      fvaz45380-1389071801
   Test host id: 6c8cffce-f04e-499d-9372-18c22b6dca0a
   ScriptRoot:   D:\a\1\s\test\WebJobs.Script.Tests.Integration\bin\Debug\netcoreapp3.1\TestScripts\Node
   Allow list:   [HttpTrigger, testFn2, testFn1]
   The captured stack from the host constructor:
      at Microsoft.Azure.WebJobs.Script.Tests.TestFunctionHost..ctor(String scriptPath, String logPath, Action`1 configureWebHostServices, Action`1 configureScriptHostWebJobsBuilder, Action`1 configureScriptHostAppConfiguration, Action`1 configureScriptHostLogging, Action`1 configureScriptHostServices) in D:\a\1\s\test\WebJobs.Script.Tests.Integration\TestFunctionHost.cs:line 154
      at Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd.CodelessEndToEndTests.StartLocalHost(String baseTestPath, String sourceFunctionApp, String[] allowedList, IList`1 providers, IEnvironment testEnvironment) in D:\a\1\s\test\WebJobs.Script.Tests.Integration\WebHostEndToEnd\CodelessEndToEndTests.cs:line 245
      at Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd.CodelessEndToEndTests.CodelessFunction_CanUse_MultipleProviders(String path, String workerRuntime, String allowedList) in D:\a\1\s\test\WebJobs.Script.Tests.Integration\WebHostEndToEnd\CodelessEndToEndTests.cs:line 139
      at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
      at Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd.CodelessEndToEndTests.CodelessFunction_CanUse_MultipleProviders(String path, String workerRuntime, String allowedList)
```
