### PR TITLE
Sequential JobHost restart if config set

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -466,13 +466,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                     using (var activeOperation = ScriptHostStartupOperation.Create(cancellationToken, _logger))
                     {
-                        bool.TryParse(_config.GetSection(ConfigurationSectionNames.SequentialJobHostRestart).Value, out bool enforceSequentialOrder);
                         Task startTask, stopTask;
 
                         // If we are running in development mode with core tools, do not overlap the restarts.
                         // Overlapping restarts are problematic when language worker processes are listening
                         // to the same debug port
-                        if (enforceSequentialOrder)
+                        if (ShouldEnforceSequentialRestart())
                         {
                             stopTask = Orphan(previousHost, cancellationToken);
                             await stopTask;
@@ -505,6 +504,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     _hostStartSemaphore.Release();
                 }
             }
+        }
+
+        internal bool ShouldEnforceSequentialRestart()
+        {
+            bool.TryParse(_config.GetSection(ConfigurationSectionNames.SequentialJobHostRestart).Value, out bool enforceSequentialOrder);
+            return enforceSequentialOrder;
         }
 
         private void OnHostInitializing(object sender, EventArgs e)

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -508,8 +508,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         internal bool ShouldEnforceSequentialRestart()
         {
-            bool.TryParse(_config.GetSection(ConfigurationSectionNames.SequentialJobHostRestart).Value, out bool enforceSequentialOrder);
-            return enforceSequentialOrder;
+            var sequentialRestartSetting = _config.GetSection(ConfigurationSectionNames.SequentialJobHostRestart);
+            if (sequentialRestartSetting != null)
+            {
+                bool.TryParse(sequentialRestartSetting.Value, out bool enforceSequentialOrder);
+                return enforceSequentialOrder;
+            }
+
+            return false;
         }
 
         private void OnHostInitializing(object sender, EventArgs e)

--- a/src/WebJobs.Script/Config/ConfigurationSectionNames.cs
+++ b/src/WebJobs.Script/Config/ConfigurationSectionNames.cs
@@ -22,5 +22,6 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
         public const string CustomHttpHeaders = Http + ":customHeaders";
         public const string EasyAuth = "easyauth";
         public const string Retry = "retry";
+        public const string SequentialJobHostRestart = JobHost + ":sequentialRestart";
     }
 }

--- a/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         private ILoggerFactory _loggerFactory;
         private Mock<IScriptWebHostEnvironment> _mockScriptWebHostEnvironment;
         private Mock<IEnvironment> _mockEnvironment;
+        private IConfiguration _mockConfig;
         private OptionsWrapper<HostHealthMonitorOptions> _healthMonitorOptions;
         private HostPerformanceManager _hostPerformanceManager;
         private Mock<IHost> _host;
@@ -55,6 +56,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _healthMonitorOptions = new OptionsWrapper<HostHealthMonitorOptions>(new HostHealthMonitorOptions());
             var serviceProviderMock = new Mock<IServiceProvider>(MockBehavior.Strict);
             _hostPerformanceManager = new HostPerformanceManager(_mockEnvironment.Object, _healthMonitorOptions, serviceProviderMock.Object);
+            _mockConfig = new Mock<IConfiguration>().Object;
         }
 
         private Mock<IHost> CreateMockHost(SemaphoreSlim disposedSemaphore = null)
@@ -104,7 +106,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             _hostService = new WebJobsScriptHostService(
                 _monitor, hostBuilder.Object, NullLoggerFactory.Instance,
-                _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object, _hostPerformanceManager, _healthMonitorOptions, metricsLogger, new Mock<IApplicationLifetime>().Object);
+                _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object,
+                _hostPerformanceManager, _healthMonitorOptions, metricsLogger,
+                new Mock<IApplicationLifetime>().Object, _mockConfig);
 
             await _hostService.StartAsync(CancellationToken.None);
             Assert.True(AreRequiredMetricsGenerated(metricsLogger));
@@ -129,7 +133,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             _hostService = new WebJobsScriptHostService(
                 _monitor, hostBuilder.Object, _loggerFactory,
-                _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object, _hostPerformanceManager, _healthMonitorOptions, metricsLogger, new Mock<IApplicationLifetime>().Object);
+                _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object,
+                _hostPerformanceManager, _healthMonitorOptions,
+                metricsLogger, new Mock<IApplicationLifetime>().Object,
+                _mockConfig);
 
             await _hostService.StartAsync(CancellationToken.None);
             Assert.True(AreRequiredMetricsGenerated(metricsLogger));
@@ -181,7 +188,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             _hostService = new WebJobsScriptHostService(
                 _monitor, hostBuilder.Object, _loggerFactory,
-                _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object, _hostPerformanceManager, _healthMonitorOptions, metricsLogger, new Mock<IApplicationLifetime>().Object);
+                _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object,
+                _hostPerformanceManager, _healthMonitorOptions,
+                metricsLogger, new Mock<IApplicationLifetime>().Object,
+                _mockConfig);
 
             TestLoggerProvider hostALogger = hostA.Object.GetTestLoggerProvider();
             TestLoggerProvider hostBLogger = hostB.Object.GetTestLoggerProvider();
@@ -254,7 +264,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             _hostService = new WebJobsScriptHostService(
                 _monitor, hostBuilder.Object, _loggerFactory,
-                _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object, _hostPerformanceManager, _healthMonitorOptions, metricsLogger, new Mock<IApplicationLifetime>().Object);
+                _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object,
+                _hostPerformanceManager, _healthMonitorOptions,
+                metricsLogger, new Mock<IApplicationLifetime>().Object,
+                _mockConfig);
 
             TestLoggerProvider hostALogger = hostA.Object.GetTestLoggerProvider();
 
@@ -321,7 +334,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             _hostService = new WebJobsScriptHostService(
                _monitor, hostBuilder.Object, NullLoggerFactory.Instance,
-               _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object, _hostPerformanceManager, _healthMonitorOptions, metricsLogger, new Mock<IApplicationLifetime>().Object);
+               _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object,
+               _hostPerformanceManager, _healthMonitorOptions, metricsLogger,
+               new Mock<IApplicationLifetime>().Object, _mockConfig);
 
             Task startTask = _hostService.StartAsync(CancellationToken.None);
 
@@ -351,7 +366,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             _hostService = new WebJobsScriptHostService(
                _monitor, hostBuilder.Object, _loggerFactory,
-               _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object, _hostPerformanceManager, _healthMonitorOptions, metricsLogger, new Mock<IApplicationLifetime>().Object);
+               _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object,
+               _hostPerformanceManager, _healthMonitorOptions, metricsLogger,
+               new Mock<IApplicationLifetime>().Object, _mockConfig);
 
             // Simulate a call to specialize coming from the PlaceholderSpecializationMiddleware. This
             // can happen before we ever start the service, which could create invalid state.


### PR DESCRIPTION
Here's one way we can achieve non-overlapping workers. Help with name of config would be appreciated! Also debating whether we should actually just do this off of `_environment.IsCoreTools()` since I don't think this is the cleanest solution and I don't feel great about exposing what I feel is a bit of a hacky capability to users. Maybe better to tie to core tools and make the assumption that core tools == local development?

Another option is to move all language worker channel management to the WebHost level and get rid of the JobHost worker channel manager, but in that case we would also need to re-do how we notify a WebHost service to restart workers on a file change (or other JobHost restart). However, this solution would be a lot more refactoring and more impactful. This should be a targeted fix.

Will need to add `AzureFunctionsJobHost__SequentialRestart = true` to core tools

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information
