### PR TITLE
[Linux consumption] Reinitialize MSI sidecar on container restarts

### DIFF
--- a/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerInitializationHostService.cs
+++ b/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerInitializationHostService.cs
@@ -55,6 +55,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
 
                 bool success = _instanceManager.StartAssignment(assignmentContext);
                 _logger.LogInformation($"StartAssignment invoked (Success={success})");
+
+                await _instanceManager.SpecializeMSISidecar(assignmentContext);
             }
             else
             {

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
@@ -284,25 +284,51 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             Assert.False(result);
         }
 
-        [Fact(Skip = "https://github.com/Azure/azure-functions-host/issues/6643")]
+        [Fact]
         public async Task ValidateContext_InvalidZipUrl_WebsiteUseZip_ReturnsError()
         {
-            var environment = new Dictionary<string, string>()
+            var environmentSettings = new Dictionary<string, string>()
             {
                 { EnvironmentSettingNames.AzureWebsiteZipDeployment, "http://invalid.com/invalid/dne" }
             };
+
+            var environment = new TestEnvironment();
+            foreach (var (key, value) in environmentSettings)
+            {
+                environment.SetEnvironmentVariable(key, value);
+            }
+
+            var scriptWebEnvironment = new ScriptWebHostEnvironment(environment);
+
+            var loggerFactory = new LoggerFactory();
+            var loggerProvider = new TestLoggerProvider();
+            loggerFactory.AddProvider(loggerProvider);
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+            handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.NotFound
+            });
+
+            var instanceManager = new InstanceManager(_optionsFactory, new HttpClient(handlerMock.Object),
+                scriptWebEnvironment, environment, loggerFactory.CreateLogger<InstanceManager>(),
+                new TestMetricsLogger(), null);
+
             var assignmentContext = new HostAssignmentContext
             {
                 SiteId = 1234,
                 SiteName = "TestSite",
-                Environment = environment,
+                Environment = environmentSettings,
                 IsWarmupRequest = false
             };
 
-            string error = await _instanceManager.ValidateContext(assignmentContext);
+            string error = await instanceManager.ValidateContext(assignmentContext);
             Assert.Equal("Invalid zip url specified (StatusCode: NotFound)", error);
 
-            var logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
+            var logs = loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
             Assert.Collection(logs,
                 p => Assert.StartsWith("Validating host assignment context (SiteId: 1234, SiteName: 'TestSite'. IsWarmup: 'False')", p),
                 p => Assert.StartsWith($"Will be using {EnvironmentSettingNames.AzureWebsiteZipDeployment} app setting as zip url. IsWarmup: 'False'", p),


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

When container restarts due to failures, all the processes in the container will remain unspecialized. This change re-specializes MSI process after a restart.

resolves https://github.com/Azure/azure-functions-host/issues/6643

### Pull request checklist

* [ X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [X ] Otherwise: Backport tracked by issue/PR https://github.com/Azure/azure-functions-host/issues/6643
* [X ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
