### PR TITLE
Fixing metrics Timespan persistence

### DIFF
--- a/src/WebJobs.Script.WebHost/Scale/TableEntityConverter.cs
+++ b/src/WebJobs.Script.WebHost/Scale/TableEntityConverter.cs
@@ -96,6 +96,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Scale
                     entityProperty = new EntityProperty(value.ToObject<long>());
                     return true;
                 case JTokenType.String:
+                case JTokenType.TimeSpan:
                     entityProperty = new EntityProperty(value.ToObject<string>());
                     return true;
                 default:

--- a/test/WebJobs.Script.Tests.Integration/Scale/TableStorageScaleMetricsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Scale/TableStorageScaleMetricsRepositoryTests.cs
@@ -90,13 +90,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Scale
             Assert.Equal(3, result.Count);
 
             // simulate 10 sample iterations
+            var start = DateTime.UtcNow;
             for (int i = 0; i < 10; i++)
             {
                 Dictionary<IScaleMonitor, ScaleMetrics> metricsMap = new Dictionary<IScaleMonitor, ScaleMetrics>();
 
                 metricsMap.Add(monitor1, new TestScaleMetrics1 { Count = i });
                 metricsMap.Add(monitor2, new TestScaleMetrics2 { Num = i });
-                metricsMap.Add(monitor3, new TestScaleMetrics3 { Length = i });
+                metricsMap.Add(monitor3, new TestScaleMetrics3 { Length = i, TimeSpan = DateTime.UtcNow - start });
 
                 await _repository.WriteMetricsAsync(metricsMap);
             }
@@ -127,6 +128,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Scale
                 var currSample = (TestScaleMetrics3)monitorMetricsList[i];
                 Assert.Equal(i, currSample.Length);
                 Assert.NotEqual(default(DateTime), currSample.Timestamp);
+                Assert.NotEqual(default(TimeSpan), currSample.TimeSpan);
             }
 
             // if no monitors are presented result will be empty

--- a/test/WebJobs.Script.Tests.Shared/TestScaleMonitor.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestScaleMonitor.cs
@@ -79,6 +79,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
     public class TestScaleMetrics3 : ScaleMetrics
     {
+        public TimeSpan TimeSpan { get; set; }
+
         public int Length { get; set; }
     }
 


### PR DESCRIPTION
Currently we're not actually persisting Timespan types when writing table metrics. This currently affects QueueTrigger/ServiceBusTrigger since they both have Timespan properties for QueueTime.

Currently our TableEntityConverter skips persistence of property types it doesn't know how to convert, meaning Timespans weren't being written.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR https://github.com/Azure/azure-functions-host/pull/6915
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
