### PR TITLE
Update pipeline to build all ExtensionsMetadataGenerator release branches

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,14 +8,14 @@ pr:
     include:
     - dev
     - release/3.0
-    - release/ExtensionsMetadataGenerator/1.1
+    - release/ExtensionsMetadataGenerator/*
 
 trigger:
   branches:
     include:
     - dev
     - release/3.0
-    - release/ExtensionsMetadataGenerator/1.1
+    - release/ExtensionsMetadataGenerator/*
 
 jobs:
 - job: InitializePipeline
@@ -39,7 +39,7 @@ jobs:
   dependsOn: InitializePipeline
   condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.InitializePipeline.outputs['Initialize.BuildArtifacts'], true)))
   variables:
-    ${{ if or( eq( variables['Build.Reason'], 'PullRequest' ), and( not( endswith( variables['Build.SourceBranch'], 'release/3.0' ) ), not( endswith( variables['Build.SourceBranch'], 'release/ExtensionsMetadataGenerator/1.1' ) ) ) ) }}:
+    ${{ if or( eq( variables['Build.Reason'], 'PullRequest' ), and( not( endswith( variables['Build.SourceBranch'], 'release/3.0' ) ), not( contains( variables['Build.SourceBranch'], 'release/ExtensionsMetadataGenerator/' ) ) ) ) }}:
       suffixTemp: ci
       packSuffixSwitchTemp: --version-suffix ci
       emgSuffixSwitchTemp: --version-suffix ci$(buildNumber)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Right now, the branch is set to build releases/ExtensionsMetadataGenerator/1.1, but it should be building all ExtensionsMetadataGenerator release branches

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
