### PR TITLE
[Linux consumption] Skip MSI sidecar reinitializtion if MSI absent

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/ContainerManagement/LinuxContainerInitializationHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ContainerManagement/LinuxContainerInitializationHostServiceTests.cs
@@ -71,6 +71,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ContainerManagement
                 }
             };
             hostAssignmentContext.Secrets = secrets;
+            hostAssignmentContext.MSIContext = new MSIContext();
 
             var encryptedHostAssignmentContext = GetEncryptedHostAssignmentContext(hostAssignmentContext, containerEncryptionKey);
             var serializedContext = JsonConvert.SerializeObject(new { encryptedContext = encryptedHostAssignmentContext });
@@ -103,6 +104,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ContainerManagement
         {
             var containerEncryptionKey = TestHelpers.GenerateKeyHexString();
             var hostAssignmentContext = GetHostAssignmentContext();
+            hostAssignmentContext.MSIContext = new MSIContext();
             var encryptedHostAssignmentContext = GetEncryptedHostAssignmentContext(hostAssignmentContext, containerEncryptionKey);
             var serializedContext = JsonConvert.SerializeObject(new { encryptedContext = encryptedHostAssignmentContext });
 

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
@@ -61,7 +61,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             const string containerEncryptionKey = "/a/vXvWJ3Hzgx4PFxlDUJJhQm5QVyGiu0NNLFm/ZMMg=";
             var hostAssignmentContext = new HostAssignmentContext
             {
-                Environment = new Dictionary<string, string>()
+                Environment = new Dictionary<string, string>(),
+                MSIContext = new MSIContext()
             };
 
             hostAssignmentContext.Environment[EnvironmentSettingNames.MsiEndpoint] = "http://localhost:8081";


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

https://github.com/Azure/azure-functions-host/pull/6902

resolves #issue_for_this_pr

### Pull request checklist

* [ X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [X ] Otherwise: Backport tracked by issue/PR https://github.com/Azure/azure-functions-host/pull/6902
* [X ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
