### PR TITLE
Update v2 Python Worker Version to 1.1.10

### DIFF
--- a/build/python.props
+++ b/build/python.props
@@ -1,5 +1,5 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="2.0.14494" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="2.1.1.10" />
   </ItemGroup>
 </Project>

--- a/release_notes.md
+++ b/release_notes.md
@@ -2,6 +2,7 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Update Python Worker Version to [1.1.10](https://github.com/Azure/azure-functions-python-worker/releases/tag/1.1.10)
 - Fixed [bug](https://github.com/Azure/azure-functions-durable-extension/issues/1504) in sync triggers operations for Durable Functions using custom storage account connection strings.
 - Update PowerShell Worker to 2.0.559 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v2.0.559)
 

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -51,7 +51,7 @@
     <PackageReference Include="appinsights.testlogger" Version="1.0.0" />
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="2.0.14494" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="2.1.1.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.9.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" />


### PR DESCRIPTION
Python Worker Release note [1.1.10](https://github.com/Azure/azure-functions-python-worker/releases/tag/1.1.10)

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)