### PR TITLE
Update Node.js Worker to 2.1.0

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,7 +4,7 @@
 -->
 - Update Python Worker Version to [1.1.10](https://github.com/Azure/azure-functions-python-worker/releases/tag/1.1.10)
 - Configure host.json to use workflow when creating a default host.json and app is identified as a logic app. (#6810)
-
+- Update Node.js Worker Version to [2.1.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v2.1.0)
 
 **Release sprint:** Sprint 89
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+89%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+89%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script/Host/FunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataProvider.cs
@@ -240,9 +240,11 @@ namespace Microsoft.Azure.WebJobs.Script
                 {
                     // if there is a "run" file, that file is primary,
                     // for Node, any index.js file is primary
+                    // TODO #6955: Get default function file name from language worker configs
                     functionPrimary = functionFiles.FirstOrDefault(p =>
                         fileSystem.Path.GetFileNameWithoutExtension(p).ToLowerInvariant() == "run" ||
-                        fileSystem.Path.GetFileName(p).ToLowerInvariant() == "index.js");
+                        fileSystem.Path.GetFileName(p).ToLowerInvariant() == "index.js" ||
+                        fileSystem.Path.GetFileName(p).ToLowerInvariant() == "index.mjs");
                 }
             }
 

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.11020001-fabe022e" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.8.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.0.6" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.557" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.560" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.26" />

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.10.0" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.0.6" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.3" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.8.0" />
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />


### PR DESCRIPTION
Change also to support index.mjs in the simplest way possible. This is being done to make sure ES Modules make it into this next deployment, while saving the engineering improvement to do this the right, extensible way for a later item this sprint: https://github.com/Azure/azure-functions-host/issues/6955 . **Will remove hard-coding soon!**

Node.js Worker 2.1.0: https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v2.1.0

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-nodejs-worker/issues/344

### Pull request checklist

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [X] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] I have added all required tests (Unit tests, E2E tests)

