### PR TITLE
setting DependencyInjection.Abstractions to always use runtime's version

### DIFF
--- a/src/WebJobs.Script/runtimeassemblies.json
+++ b/src/WebJobs.Script/runtimeassemblies.json
@@ -504,7 +504,7 @@
     },
     {
       "name": "Microsoft.Extensions.DependencyInjection.Abstractions",
-      "resolutionPolicy": "minorMatchOrLower"
+      "resolutionPolicy": "runtimeVersion"
     },
     {
       "name": "Microsoft.Extensions.DependencyModel",


### PR DESCRIPTION
Needed for .NET worker changes.