### PR TITLE
Make MetricEvent.Completed more robust (#6973)

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
@@ -79,18 +79,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             SystemMetricEvent evt = eventHandle as SystemMetricEvent;
             if (evt != null)
             {
-                long latencyMS = 0;
-                evt.StopWatch.Stop();
-                if (evt.StopWatch != null)
-                {
-                    evt.Duration = evt.StopWatch.Elapsed;
-                    latencyMS = evt.StopWatch.ElapsedMilliseconds;
-                }
-                else
-                {
-                    evt.Duration = DateTime.UtcNow - evt.Timestamp;
-                    latencyMS = (long)evt.Duration.TotalMilliseconds;
-                }
+                evt.Complete();
+                long latencyMS = (long)evt.Duration.TotalMilliseconds;
 
                 // event aggregation is based on this key
                 // for each unique key, there will be only 1
@@ -165,6 +155,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         internal void FunctionCompleted(FunctionStartedEvent completedEvent)
         {
+            completedEvent.Complete();
             _functionActivityTracker.FunctionCompleted(completedEvent);
         }
 

--- a/src/WebJobs.Script.WebHost/Diagnostics/WebHostMetricsLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/WebHostMetricsLogger.cs
@@ -54,7 +54,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         {
             if (metricEvent is FunctionStartedEvent completedEvent)
             {
-                completedEvent.Duration = DateTime.UtcNow - completedEvent.Timestamp;
                 _metricsEventManager.FunctionCompleted(completedEvent);
             }
             else

--- a/src/WebJobs.Script/Diagnostics/MetricEvent.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEvent.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
 
         public Stopwatch StopWatch { get; set; }
 
-        public TimeSpan Duration { get; set; }
+        public TimeSpan Duration { get; private set; }
 
         public string Data { get; set; }
 
@@ -22,12 +22,21 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
 
         public string SlotName { get; set; }
 
-        public bool Completed
+        public bool Completed { get; private set; }
+
+        public void Complete()
         {
-            get
+            if (StopWatch != null)
             {
-                return Duration != default(TimeSpan);
+                StopWatch.Stop();
+                Duration = StopWatch.Elapsed;
             }
+            else
+            {
+                Duration = DateTime.UtcNow - Timestamp;
+            }
+
+            Completed = true;
         }
     }
 }


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-functions-host/issues/6973.