### PR TITLE
Update Java Worker to 1.8.1

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,6 +5,7 @@
 - Update Python Worker Version to [1.1.10](https://github.com/Azure/azure-functions-python-worker/releases/tag/1.1.10)
 - Configure host.json to use workflow when creating a default host.json and app is identified as a logic app. (#6810)
 - Update Node.js Worker Version to [2.1.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v2.1.0)
+- Update Java Worker Version to [1.8.1](https://github.com/Azure/azure-functions-java-worker/releases/tag/1.8.1)
 
 **Release sprint:** Sprint 89
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+89%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+89%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -40,7 +40,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.11020001-fabe022e" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.8.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.8.1" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.557" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.560" />

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.3" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.8.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.8.1" />
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />


### PR DESCRIPTION
Change to support Distributed Tracing Scenario for Linux Consumption Plan. We update `%AZURE_FUNCTIONS_MESH_JAVA_OPTS%` argument in the `worker.config.json` That is internal argument that is not allowed to modify by users. We are going to inject Java Application Insights Agent using this argument. 

### Issue describing the changes in this PR

No issue. Related for supporting Distributed Tracing for Java Consumption plan.

* [Release: Azure Functions Java Worker 1.8.1](https://github.com/Azure/azure-functions-java-worker/releases/tag/1.8.1)


### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

