### PR TITLE
Removing process limit (CPU) check from http throttle

### DIFF
--- a/src/WebJobs.Script.WebHost/Middleware/HttpThrottleMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/HttpThrottleMiddleware.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
             {
                 // only check host status periodically
                 Collection<string> exceededCounters = new Collection<string>();
-                _rejectRequests = await performanceManager.IsUnderHighLoadAsync(exceededCounters);
+                _rejectRequests = performanceManager.PerformanceCountersExceeded(exceededCounters);
                 _lastPerformanceCheck = DateTime.UtcNow;
                 if (_rejectRequests)
                 {

--- a/test/WebJobs.Script.Tests/Middleware/HttpThrottleMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Middleware/HttpThrottleMiddlewareTests.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _requestQueue = new HttpRequestQueue(new OptionsWrapper<HttpOptions>(_httpOptions));
 
             bool isOverloaded = false;
-            _performanceManager.Setup(p => p.IsUnderHighLoadAsync(It.IsAny<Collection<string>>(), null)).Returns(() => Task.FromResult(isOverloaded));
+            _performanceManager.Setup(p => p.PerformanceCountersExceeded(It.IsAny<Collection<string>>(), It.IsAny<ILogger>())).Returns(() => isOverloaded);
 
             RequestDelegate next = async (ctxt) =>
             {
@@ -269,7 +269,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             bool highLoad = false;
             int highLoadQueryCount = 0;
-            _performanceManager.Setup(p => p.IsUnderHighLoadAsync(It.IsAny<Collection<string>>(), It.IsAny<ILogger>()))
+            _performanceManager.Setup(p => p.PerformanceCountersExceeded(It.IsAny<Collection<string>>(), It.IsAny<ILogger>()))
                 .Callback<Collection<string>, ILogger>((exceededCounters, tw) =>
                 {
                     if (highLoad)
@@ -280,7 +280,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 }).Returns(() =>
                 {
                     highLoadQueryCount++;
-                    return Task.FromResult(highLoad);
+                    return highLoad;
                 });
 
             // issue some requests while not under high load


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Reverting the addition of Process level limit checks (CPU) from the http throttle middleware check. That check was added in https://github.com/Azure/azure-functions-host/commit/826c0b520c1e81d2f3106d08711c08f1bce4aa95, extending the previous performance counter checks with a CPU check as well. While this change was made over 6 months ago, it wasn't actually active due to another bug which was recently fixed in https://github.com/Azure/azure-functions-host/pull/6867. That fix has went live recently activating the previously added CPU check. It turns out this CPU check may be too sensitive causing customers to experience 429s during high load. That was the original intent, since when the host returns 429s it triggers app scale out - the FE sees the 429s + special header and will attempt to scale out then retry the request. Normally that retry which happens in the FE means customers won't see the 429, but if scale out is slow the retry may also fail resulting in the 429 being returned.

The CPU check will continue to be active for scale health pings sent from the FE http scale logic, which is handled by [this](admin/host/ping) code. That logic has been active for many months and hasn't changed recently. So while we're removing this check from the http throttle middleware, it will continue to be used to affect scale out. The difference is that the FE pings aren't customer facing, so can't result in 429s being returned.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
