### PR TITLE
Update specialization logic  for linux consumption containers running on pinned host versions

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
@@ -100,7 +100,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         {
             if (!_webHostEnvironment.InStandbyMode)
             {
-                _logger.LogError("Assign called while host is not in placeholder mode");
+                // This is only true when specializing pinned containers.
+                _logger.LogInformation("Assign called while host is not in placeholder mode.");
+            }
+
+            if (_environment.IsContainerReady())
+            {
+                _logger.LogError("Assign called while container is marked as specialized.");
                 return false;
             }
 

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
@@ -102,15 +102,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 p => Assert.StartsWith("Applying 1 app setting(s)", p),
                 p => Assert.StartsWith("Triggering specialization", p));
 
-            // calling again should return false, since we're no longer
-            // in placeholder mode
+            // calling again should return false, since we have 
+            // already marked the container as specialized.
             _loggerProvider.ClearAllLogMessages();
             result = _instanceManager.StartAssignment(context);
             Assert.False(result);
 
             logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
             Assert.Collection(logs,
-                p => Assert.StartsWith("Assign called while host is not in placeholder mode", p));
+                p => Assert.StartsWith("Assign called while host is not in placeholder mode.", p),
+                p => Assert.StartsWith("Assign called while container is marked as specialized.", p));
         }
 
         [Fact]
@@ -273,7 +274,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         }
 
         [Fact]
-        public void StartAssignment_ReturnsFalse_WhenNotInStandbyMode()
+        public void StartAssignment_ReturnsTrue_WhenNotInStandbyMode()
         {
             Assert.False(SystemEnvironment.Instance.IsPlaceholderModeEnabled());
 
@@ -281,7 +282,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             context.Environment = new Dictionary<string, string>();
             context.IsWarmupRequest = false;
             bool result = _instanceManager.StartAssignment(context);
-            Assert.False(result);
+            Assert.True(result);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

When an app is running on a pinned mode, we do not start in placeholder mode, since the container is already assigned to the customer app at the time of startup. This change updates our specialization logic to account for pinned containers running in non placeholder mode.

### Pull request checklist

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] I have added all required tests (Unit tests, E2E tests)
