### PR TITLE
Update PowerShell Worker to 3.0.630 (PS6) and 3.0.629 (PS7)

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,6 +6,7 @@
 - Configure host.json to use workflow when creating a default host.json and app is identified as a logic app. (#6810)
 - Update Node.js Worker Version to [2.1.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v2.1.0)
 - Update Java Worker Version to [1.8.1](https://github.com/Azure/azure-functions-java-worker/releases/tag/1.8.1)
+- Update PowerShell Worker to [3.0.629](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.629) and [3.0.630](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.630)
 
 **Release sprint:** Sprint 89
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+89%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+89%22+label%3Afeature+is%3Aclosed) ]

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,7 +6,7 @@
 - Configure host.json to use workflow when creating a default host.json and app is identified as a logic app. (#6810)
 - Update Node.js Worker Version to [2.1.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v2.1.0)
 - Update Java Worker Version to [1.8.1](https://github.com/Azure/azure-functions-java-worker/releases/tag/1.8.1)
-- Update PowerShell Worker to [3.0.629](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.629) and [3.0.630](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.630)
+- Update PowerShell Worker to [3.0.629](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.629) (PS7) and [3.0.630](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.630) (PS6)
 
 **Release sprint:** Sprint 89
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+89%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+89%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -42,8 +42,8 @@
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.0.11020001-fabe022e" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.8.1" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.557" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.560" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.630" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.629" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.26" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.9" />


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Update PowerShell Worker to 3.0.630 (PS6) ([Release Notes](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.630)) and 3.0.629 (PS7) ([Release Notes](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.629))

### Pull request checklist

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [X] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)