### PR TITLE
Removed obsolete NuGet feed reference.

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -5,7 +5,6 @@
     <add key="azure_app_service" value="https://www.myget.org/F/azure-appservice/api/v2" />
     <add key="azure_app_service_staging" value="https://www.myget.org/F/azure-appservice-staging/api/v2" />
     <add key="buildTools" value="https://www.myget.org/F/30de4ee06dd54956a82013fa17a3accb/" />
-    <add key="AspNetVNext" value="https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json" />
     <add key="Microsoft.Azure.Functions.PowerShellWorker" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/Microsoft.Azure.Functions.PowerShellWorker/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Recent builds are breaking due to the following error (see Additional Information section for example.)

`Unable to load the service index for source https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json.`

The feed no longer exists on MyGet and does not appear to be necessary for a successful build. Removing the NuGet.config reference to fix the build.

### Pull request checklist

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [X] Otherwise: Backport tracked by issue/PR #7046
* [X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
