### PR TITLE
Fix ignoring of System assemblies was over matching to include non-system assemblies

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,6 +2,7 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Fix ignoring of System assemblies was over matching to include non-system assemblies (#7058)
 - Updated HTTP extension to [3.0.10](https://github.com/Azure/azure-webjobs-sdk-extensions/releases/tag/http-v3.0.10)
 - Updated Python Worker Version to [1.1.10](https://github.com/Azure/azure-functions-python-worker/releases/tag/1.1.10)
 - Configure host.json to use workflow when creating a default host.json and app is identified as a logic app. (#6810)

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/ExtensionsMetadataGenerator.cs
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/ExtensionsMetadataGenerator.cs
@@ -66,7 +66,7 @@ namespace ExtensionsMetadataGenerator
             logger.LogMessage($"'{outputPath}' successfully written.");
         }
 
-        public static bool AssemblyShouldBeSkipped(string fileName) => fileName.StartsWith("System", StringComparison.OrdinalIgnoreCase) || ExcludedAssemblies.Contains(fileName, StringComparer.OrdinalIgnoreCase);
+        public static bool AssemblyShouldBeSkipped(string fileName) => fileName.StartsWith("System.", StringComparison.OrdinalIgnoreCase) || ExcludedAssemblies.Contains(fileName, StringComparer.OrdinalIgnoreCase);
 
         public static string GenerateExtensionsJson(IEnumerable<ExtensionReference> extensionReferences)
         {

--- a/tools/ExtensionsMetadataGenerator/test/ExtensionsMetadataGeneratorTests/ExtensionsMetadataGeneratorTests.cs
+++ b/tools/ExtensionsMetadataGenerator/test/ExtensionsMetadataGeneratorTests/ExtensionsMetadataGeneratorTests.cs
@@ -126,6 +126,8 @@ namespace ExtensionsMetadataGeneratorTests
         [InlineData("microsoft.azure.webjobs.extensions.http.dll", true)]
         [InlineData("Microsoft.Azure.EventGrid.dll", false)]
         [InlineData("MyCoolExtension.dll", false)]
+        [InlineData("SystemCompanyName.dll", false)]
+        [InlineData("System.dll", true)]
         public void SomeAssembliesAreSkipped(string assemblyFileName, bool shouldSkip)
         {
             Assert.Equal(shouldSkip, ExtensionsMetadataGenerator.ExtensionsMetadataGenerator.AssemblyShouldBeSkipped(assemblyFileName));


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

The DI injection was trying to exclude System assembles (e.g. System.dll, System.IO.dll), however the string compare was matching on starts with "System" which could then match SystemCompanyFoo.dll too and break DI. In my case the company name starts with  System so it means the company name would have to be mangled in order to work correctly with this bug.

resolves #6549

### Pull request checklist

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [X] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information

This was also reported in #6549