### PR TITLE
[Linux consumption] Notify health events to mesh service process

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/IMeshServiceClient.cs
+++ b/src/WebJobs.Script.WebHost/Management/IMeshServiceClient.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
@@ -16,5 +17,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         Task MountFuse(string type, string filePath, string scriptPath);
 
         Task PublishContainerActivity(IEnumerable<ContainerFunctionExecutionActivity> activities);
+
+        Task NotifyHealthEvent(ContainerHealthEventType healthEventType, Type source, string details);
     }
 }

--- a/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
@@ -63,6 +63,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 if (context.MSIContext == null)
                 {
                     _logger.LogWarning("Skipping specialization of MSI sidecar since MSIContext was absent");
+                    await _meshServiceClient.NotifyHealthEvent(ContainerHealthEventType.Fatal, this.GetType(),
+                        "Could not specialize MSI sidecar");
                 }
                 else
                 {
@@ -250,7 +252,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, $"Assign failed");
+                _logger.LogError(ex, "Assign failed");
+                await _meshServiceClient.NotifyHealthEvent(ContainerHealthEventType.Fatal, GetType(), "Assign failed");
                 throw;
             }
             finally

--- a/src/WebJobs.Script.WebHost/Management/MeshServiceClient.cs
+++ b/src/WebJobs.Script.WebHost/Management/MeshServiceClient.cs
@@ -75,6 +75,29 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             }
         }
 
+        public async Task NotifyHealthEvent(ContainerHealthEventType healthEventType, Type source, string details)
+        {
+            var healthEvent = new ContainerHealthEvent()
+            {
+                EventTime = DateTime.UtcNow,
+                EventType = healthEventType,
+                Details = details,
+                Source = source.ToString()
+            };
+
+            var healthEventString = JsonConvert.SerializeObject(healthEvent);
+
+            _logger.LogInformation($"Posting health event {healthEventString}");
+
+            var responseMessage = await SendAsync(new[]
+            {
+                new KeyValuePair<string, string>(Operation, "add-health-event"),
+                new KeyValuePair<string, string>("healthEvent", healthEventString),
+            });
+
+            _logger.LogInformation($"Posted health event status: {responseMessage.StatusCode}");
+        }
+
         private async Task PublishActivities(IEnumerable<ContainerFunctionExecutionActivity> activities)
         {
             // Log one of the activities being published for debugging.

--- a/src/WebJobs.Script.WebHost/Management/NullMeshServiceClient.cs
+++ b/src/WebJobs.Script.WebHost/Management/NullMeshServiceClient.cs
@@ -42,5 +42,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         {
             return Task.CompletedTask;
         }
+
+        public Task NotifyHealthEvent(ContainerHealthEventType healthEventType, Type source, string details)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/WebJobs.Script.WebHost/Models/ContainerHealthEvent.cs
+++ b/src/WebJobs.Script.WebHost/Models/ContainerHealthEvent.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
+{
+    public class ContainerHealthEvent
+    {
+        public DateTime EventTime { get; set; }
+
+        public ContainerHealthEventType EventType { get; set; }
+
+        public string Source { get; set; }
+
+        public string Details { get; set; }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Models/ContainerHealthEventType.cs
+++ b/src/WebJobs.Script.WebHost/Models/ContainerHealthEventType.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Runtime.Serialization;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
+{
+    // Important: Needs to be in sync with container init process
+    public enum ContainerHealthEventType
+    {
+        [EnumMember]
+        Informational,
+
+        [EnumMember]
+        Warning,
+
+        [EnumMember]
+        Fatal
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         private readonly TestEnvironmentEx _environment;
         private readonly ScriptWebHostEnvironment _scriptWebEnvironment;
         private readonly InstanceManager _instanceManager;
+        private readonly Mock<IMeshServiceClient> _meshServiceClientMock;
         private readonly HttpClient _httpClient;
         private readonly LoggerFactory _loggerFactory = new LoggerFactory();
         private readonly TestOptionsFactory<ScriptApplicationHostOptions> _optionsFactory = new TestOptionsFactory<ScriptApplicationHostOptions>(new ScriptApplicationHostOptions() { ScriptPath = Path.GetTempPath() });
@@ -43,8 +44,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             _environment = new TestEnvironmentEx();
             _scriptWebEnvironment = new ScriptWebHostEnvironment(_environment);
+            _meshServiceClientMock = new Mock<IMeshServiceClient>(MockBehavior.Strict);
 
-            _instanceManager = new InstanceManager(_optionsFactory, _httpClient, _scriptWebEnvironment, _environment, _loggerFactory.CreateLogger<InstanceManager>(), new TestMetricsLogger(), null);
+            _instanceManager = new InstanceManager(_optionsFactory, _httpClient, _scriptWebEnvironment, _environment,
+                _loggerFactory.CreateLogger<InstanceManager>(), new TestMetricsLogger(), _meshServiceClientMock.Object);
 
             InstanceManager.Reset();
         }
@@ -126,6 +129,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 },
                 IsWarmupRequest = false
             };
+
+            _meshServiceClientMock.Setup(c => c.NotifyHealthEvent(ContainerHealthEventType.Fatal,
+                It.Is<Type>(t => t == typeof(InstanceManager)), "Assign failed")).Returns(Task.CompletedTask);
+
             bool result = _instanceManager.StartAssignment(context);
             Assert.True(result);
             Assert.True(_scriptWebEnvironment.InStandbyMode);
@@ -135,6 +142,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             var error = _loggerProvider.GetAllLogMessages().First(p => p.Level == LogLevel.Error);
             Assert.Equal("Assign failed", error.FormattedMessage);
             Assert.Equal("Kaboom!", error.Exception.Message);
+
+            _meshServiceClientMock.Verify(c => c.NotifyHealthEvent(ContainerHealthEventType.Fatal,
+                It.Is<Type>(t => t == typeof(InstanceManager)), "Assign failed"), Times.Once);
         }
 
         [Fact]
@@ -504,7 +514,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 MSIContext = new MSIContext()
             };
 
-            var instanceManager = GetInstanceManagerForMSISpecialization(assignmentContext, HttpStatusCode.OK);
+            var instanceManager = GetInstanceManagerForMSISpecialization(assignmentContext, HttpStatusCode.OK, null);
 
             string error = await instanceManager.SpecializeMSISidecar(assignmentContext);
             Assert.Null(error);
@@ -532,7 +542,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 IsWarmupRequest = true
             };
 
-            var instanceManager = GetInstanceManagerForMSISpecialization(assignmentContext, HttpStatusCode.OK);
+            var instanceManager = GetInstanceManagerForMSISpecialization(assignmentContext, HttpStatusCode.OK, null);
 
             string error = await instanceManager.SpecializeMSISidecar(assignmentContext);
             Assert.Null(error);
@@ -558,7 +568,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 MSIContext = new MSIContext()
             };
 
-            var instanceManager = GetInstanceManagerForMSISpecialization(assignmentContext, HttpStatusCode.BadRequest);
+            var instanceManager = GetInstanceManagerForMSISpecialization(assignmentContext, HttpStatusCode.BadRequest, null);
 
             string error = await instanceManager.SpecializeMSISidecar(assignmentContext);
             Assert.NotNull(error);
@@ -588,7 +598,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 MSIContext = null
             };
 
-            var instanceManager = GetInstanceManagerForMSISpecialization(assignmentContext, HttpStatusCode.BadRequest);
+
+            var meshServiceClient = new Mock<IMeshServiceClient>(MockBehavior.Strict);
+            meshServiceClient.Setup(c => c.NotifyHealthEvent(ContainerHealthEventType.Fatal,
+                It.Is<Type>(t => t == typeof(InstanceManager)), "Could not specialize MSI sidecar")).Returns(Task.CompletedTask);
+
+            var instanceManager = GetInstanceManagerForMSISpecialization(assignmentContext, HttpStatusCode.BadRequest, meshServiceClient.Object);
 
             string error = await instanceManager.SpecializeMSISidecar(assignmentContext);
             Assert.Null(error);
@@ -597,6 +612,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             Assert.Collection(logs,
                 p => Assert.StartsWith("MSI enabled status: True", p),
                 p => Assert.StartsWith("Skipping specialization of MSI sidecar since MSIContext was absent", p));
+
+            meshServiceClient.Verify(c => c.NotifyHealthEvent(ContainerHealthEventType.Fatal,
+                It.Is<Type>(t => t == typeof(InstanceManager)), "Could not specialize MSI sidecar"), Times.Once);
         }
 
         [Fact]
@@ -710,7 +728,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 client => client.MountCifs(It.IsAny<string>(), It.IsAny<string>(), It.Is<string>(s => s != targetPath1)), Times.Never());
         }
 
-        private InstanceManager GetInstanceManagerForMSISpecialization(HostAssignmentContext hostAssignmentContext, HttpStatusCode httpStatusCode)
+        private InstanceManager GetInstanceManagerForMSISpecialization(HostAssignmentContext hostAssignmentContext,
+            HttpStatusCode httpStatusCode, IMeshServiceClient meshServiceClient)
         {
             var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
 
@@ -728,7 +747,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             InstanceManager.Reset();
 
             return new InstanceManager(_optionsFactory, new HttpClient(handlerMock.Object), _scriptWebEnvironment, _environment,
-                _loggerFactory.CreateLogger<InstanceManager>(), new TestMetricsLogger(), null);
+                _loggerFactory.CreateLogger<InstanceManager>(), new TestMetricsLogger(), meshServiceClient);
         }
 
         public void Dispose()


### PR DESCRIPTION
Notifies mesh service process of fatal errors during specialization. These events are used to monitor overall container health.

<!-- Please provide all the information below.  -->

related to https://github.com/Azure/azure-functions-host/issues/5222

### Pull request checklist

* [X ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [X ] Otherwise: Backport tracked by issue/PR https://github.com/Azure/azure-functions-host/issues/5222
* [ X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
Corresponding server side changes
https://github.com/Azure/azure-functions-docker-private/pull/131