### PR TITLE
Allow extension webhooks to accept OPTIONS requests

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
             return Accepted();
         }
 
-        [AcceptVerbs("GET", "POST", "DELETE")]
+        [AcceptVerbs("GET", "POST", "DELETE", "OPTIONS")]
         [Authorize(Policy = PolicyNames.SystemKeyAuthLevel)]
         [Route("runtime/webhooks/{extensionName}/{*extra}")]
         [RequiresRunningHost]


### PR DESCRIPTION
Allow extensions to handle CORs preflight requests themselves. This is needed in Logic Apps scenarios.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
