### PR TITLE
Stop popping up console windows during programmatic builds

### DIFF
--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/BuildTasks/GenerateFunctionsExtensionsMetadata.cs
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/BuildTasks/GenerateFunctionsExtensionsMetadata.cs
@@ -37,7 +37,7 @@ namespace ExtensionsMetadataGenerator.BuildTasks
             var info = new ProcessStartInfo
             {
                 UseShellExecute = false,
-                CreateNoWindow = false,
+                CreateNoWindow = true,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true,
                 WorkingDirectory = Path.Combine(Path.GetDirectoryName(taskAssembly.Location), "..", "netstandard2.0", "generator"),


### PR DESCRIPTION
Changes GenerateFunctionsExtensionsMetadata MSBuild task to avoid popping up console window for dotnet.exe during programmatic builds launched from within processes that don't have a console window.

If the launching process has an associated console window (e.g. when MSBuild is launched from command line), CreateNoWindow = false has no effect. However, if the launching process does not have an allocated console window (which is what happens in the case of the Live Unit Testing feature in VS) then setting CreateNoWindow = false ends up popping up console window for the child dotnet.exe process.

This is particularly problematic for Live Unit Testing. Live Unit Testing constantly performs builds in the background as the user changes their code in the VS editor. Without this fix, any code change that requires to rebuild an Azure Functions project in the user's solution results in popping up the above console window. The repeated pop ups end up impeding the user's ability to type in the editor.

Since standard input and output are already being redirected, the popup console window was not particularly helpful anyways. I suspect the original intention of this code may have been to set CreateNoWindow = true and that it may have been set to false inadvertently.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)
