### PR TITLE
Skip external config validation if RuntimeDrivenScaling is enabled in Elastic Premium

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -11,6 +11,7 @@
 - Updated [System.Data.SqlClient to 4.8.2](https://www.nuget.org/packages/System.Data.SqlClient/4.8.2)
 - Added direct refereces to [System.IO.Pipes](https://www.nuget.org/packages/System.IO.Pipes/4.3.0)  and [System.Threading.Overlapped](https://www.nuget.org/packages/System.Threading.Overlapped/4.3.0) to ensure System.Data.SqlClient package update does not impact unification 
 - Updated Java Worker Version to [1.8.2-SNAPSHOT](https://github.com/Azure/azure-functions-java-worker/releases/tag/1.8.2-SNAPSHOT)
+- Skip external config validation if RuntimeDrivenScaling is enabled in Elastic Premium sku (#6542)
 
 **Release sprint:** Sprint 89, 90, 91
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+89%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+89%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.WebJobs.Script
                             // Including Core Tools as a warning during development time.
                             if (environment.IsWindowsConsumption() ||
                                 environment.IsLinuxConsumption() ||
-                                environment.IsWindowsElasticPremium() ||
+                                (environment.IsWindowsElasticPremium() && !environment.IsRuntimeScaleMonitoringEnabled()) ||
                                 environment.IsCoreTools())
                             {
                                 var validator = s.GetService<ExternalConfigurationStartupValidator>();


### PR DESCRIPTION
### Issue describing the changes in this PR
Function host was throwing a host initialization exception when an configuration from external source was used in a trigger binding. The validation / exception was invalid when Runtime driven scaling was enabled for function app was hosted on elastic premium hosting plan. The change here is skips the validation for this specific case.

resolves #6542 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
