### PR TITLE
Restart only if needed

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
@@ -74,11 +74,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
             bool success, configChanged;
             FunctionMetadataResponse functionMetadataResponse;
-            using (fileMonitoringService.SuspendRestart())
+            using (fileMonitoringService.SuspendRestart(true))
             {
                 (success, configChanged, functionMetadataResponse) = await _functionsManager.CreateOrUpdate(name, functionMetadata, Request);
             }
-            await ScheduleRestartAsync(fileMonitoringService);
 
             if (success)
             {
@@ -175,11 +174,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
             bool deleted;
             string error;
-            using (fileMonitoringService.SuspendRestart())
+            using (fileMonitoringService.SuspendRestart(true))
             {
                 (deleted, error) = await _functionsManager.TryDeleteFunction(function);
             }
-            await ScheduleRestartAsync(fileMonitoringService);
 
             if (deleted)
             {
@@ -219,16 +217,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
             {
                 FileDownloadName = (System.Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME") ?? "functions") + ".zip"
             };
-        }
-
-        private async Task ScheduleRestartAsync(IFileMonitoringService fileMonitoringService)
-        {
-            Task restartTask = null;
-            using (System.Threading.ExecutionContext.SuppressFlow())
-            {
-                restartTask = fileMonitoringService.ScheduleRestartAsync(false);
-            }
-            await restartTask;
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/IFileMonitoringService.cs
+++ b/src/WebJobs.Script.WebHost/IFileMonitoringService.cs
@@ -9,10 +9,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 {
     public interface IFileMonitoringService : IHostedService
     {
-        IDisposable SuspendRestart();
-
-        void ResumeRestart();
-
-        Task ScheduleRestartAsync(bool shutdown);
+        IDisposable SuspendRestart(bool autoResume);
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Resolves #7089

### Issue describing the changes in this PR

We do not need explicitly call restart on function create/update/delete. Instead we need to call restart only if FileMonitoringService got an event for restart(appropriate file change).

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
