### PR TITLE
[Backport] Notify health events to mesh service process

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/IMeshServiceClient.cs
+++ b/src/WebJobs.Script.WebHost/Management/IMeshServiceClient.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
@@ -16,5 +17,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         Task MountFuse(string type, string filePath, string scriptPath);
 
         Task PublishContainerActivity(IEnumerable<ContainerFunctionExecutionActivity> activities);
+
+        Task NotifyHealthEvent(ContainerHealthEventType healthEventType, Type source, string details);
     }
 }

--- a/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
@@ -63,6 +63,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 if (context.MSIContext == null)
                 {
                     _logger.LogWarning("Skipping specialization of MSI sidecar since MSIContext was absent");
+                    await _meshServiceClient.NotifyHealthEvent(ContainerHealthEventType.Fatal, this.GetType(),
+                        "Could not specialize MSI sidecar");
                 }
                 else
                 {
@@ -250,7 +252,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, $"Assign failed");
+                _logger.LogError(ex, "Assign failed");
+                await _meshServiceClient.NotifyHealthEvent(ContainerHealthEventType.Fatal, GetType(), "Assign failed");
                 throw;
             }
             finally

--- a/src/WebJobs.Script.WebHost/Management/MeshServiceClient.cs
+++ b/src/WebJobs.Script.WebHost/Management/MeshServiceClient.cs
@@ -75,6 +75,29 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             }
         }
 
+        public async Task NotifyHealthEvent(ContainerHealthEventType healthEventType, Type source, string details)
+        {
+            var healthEvent = new ContainerHealthEvent()
+            {
+                EventTime = DateTime.UtcNow,
+                EventType = healthEventType,
+                Details = details,
+                Source = source.ToString()
+            };
+
+            var healthEventString = JsonConvert.SerializeObject(healthEvent);
+
+            _logger.LogInformation($"Posting health event {healthEventString}");
+
+            var responseMessage = await SendAsync(new[]
+            {
+                new KeyValuePair<string, string>(Operation, "add-health-event"),
+                new KeyValuePair<string, string>("healthEvent", healthEventString),
+            });
+
+            _logger.LogInformation($"Posted health event status: {responseMessage.StatusCode}");
+        }
+
         private async Task PublishActivities(IEnumerable<ContainerFunctionExecutionActivity> activities)
         {
             // Log one of the activities being published for debugging.

--- a/src/WebJobs.Script.WebHost/Management/NullMeshServiceClient.cs
+++ b/src/WebJobs.Script.WebHost/Management/NullMeshServiceClient.cs
@@ -41,5 +41,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         {
             return Task.CompletedTask;
         }
+
+        public Task NotifyHealthEvent(ContainerHealthEventType healthEventType, Type source, string details)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/WebJobs.Script.WebHost/Models/ContainerHealthEvent.cs
+++ b/src/WebJobs.Script.WebHost/Models/ContainerHealthEvent.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
+{
+    public class ContainerHealthEvent
+    {
+        public DateTime EventTime { get; set; }
+
+        public ContainerHealthEventType EventType { get; set; }
+
+        public string Source { get; set; }
+
+        public string Details { get; set; }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Models/ContainerHealthEventType.cs
+++ b/src/WebJobs.Script.WebHost/Models/ContainerHealthEventType.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Runtime.Serialization;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
+{
+    // Important: Needs to be in sync with container init process
+    public enum ContainerHealthEventType
+    {
+        [EnumMember]
+        Informational,
+
+        [EnumMember]
+        Warning,
+
+        [EnumMember]
+        Fatal
+    }
+}


### PR DESCRIPTION
Notifies mesh service process of fatal errors during specialization. These events are used to monitor overall container health.

<!-- Please provide all the information below.  -->

Backport of https://github.com/Azure/azure-functions-host/commit/c73bc1510fbff3e936cfa4dd788a86ff9b29c90e

resolves https://github.com/Azure/azure-functions-host/issues/5222

### Pull request checklist

* [X ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
