### PR TITLE
AssemblyLoadContext fix

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
+++ b/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             if (TryGetRuntimeAssembly(assemblyName, out ScriptRuntimeAssembly scriptRuntimeAssembly))
             {
                 // There are several possible scenarios:
-                //  1. The assembly was found and the policy evaluator succeeeded.
+                //  1. The assembly was found and the policy evaluator succeeded.
                 //     - Return the assembly.
                 //
                 //  2. The assembly was not found (meaning the policy evaluator wasn't able to run).

--- a/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
+++ b/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
@@ -224,7 +224,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 //     a. We did not adjust the requested assembly name via the deps file.
                 //        - This means that the DefaultLoadContext is looking for the correct version. Return null and let
                 //          it handle the load attempt.
-                //     b. We adjusted the requested assembly name via the deps file.
+                //     b. We adjusted the requested assembly name via the deps file. If we return null the DefaultLoadContext would attempt to
+                //        load the original assembly version, which may be incorrect if we had to adjust it forward past the runtime's version.
                 //        i.  The adjusted assembly name is higher than the runtime's version.
                 //            - Do not trust the DefaultLoadContext to handle this as it may resolve to the runtime's assembly. Instead,
                 //              call LoadCore() to ensure the adjusted assembly is loaded.

--- a/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
+++ b/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
@@ -201,16 +201,16 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         protected override Assembly Load(AssemblyName assemblyName)
         {
-            bool isNameAdjusted = TryAdjustRuntimeAssemblyFromDepsFile(assemblyName, out AssemblyName adjustedAssemblyName);
+            bool isNameAdjusted = TryAdjustRuntimeAssemblyFromDepsFile(assemblyName, out assemblyName);
 
             // Try to load from deps references, if available
-            if (TryLoadDepsDependency(adjustedAssemblyName, out Assembly assembly))
+            if (TryLoadDepsDependency(assemblyName, out Assembly assembly))
             {
                 return assembly;
             }
 
             // If this is a runtime restricted assembly, load it based on unification rules
-            if (TryGetRuntimeAssembly(adjustedAssemblyName, out ScriptRuntimeAssembly scriptRuntimeAssembly))
+            if (TryGetRuntimeAssembly(assemblyName, out ScriptRuntimeAssembly scriptRuntimeAssembly))
             {
                 // There are several possible scenarios:
                 //  1. The assembly was found and the policy evaluator succeeeded.
@@ -233,7 +233,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 //            - Return null and let the DefaultLoadContext handle it. It may come back here due to fallback logic, but
                 //              ultimately it will unify on the runtime version.
 
-                if (ShouldUseRuntimeAssembly(adjustedAssemblyName, scriptRuntimeAssembly, out assembly))
+                if (ShouldUseRuntimeAssembly(assemblyName, scriptRuntimeAssembly, out assembly))
                 {
                     // Scenarios 1 and 2a
                     return assembly;
@@ -247,10 +247,10 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                     }
 
                     AssemblyName runtimeAssemblyName = assembly.GetName();
-                    if (IsHigherThan(adjustedAssemblyName, runtimeAssemblyName))
+                    if (IsHigherThan(assemblyName, runtimeAssemblyName))
                     {
                         // Scenario 3bi.
-                        return LoadCore(adjustedAssemblyName);
+                        return LoadCore(assemblyName);
                     }
 
                     // Scenario 3bii.
@@ -260,12 +260,12 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
             // If the assembly being requested matches a host assembly, we'll use
             // the host assembly instead of loading it in this context:
-            if (TryLoadHostEnvironmentAssembly(adjustedAssemblyName, out assembly))
+            if (TryLoadHostEnvironmentAssembly(assemblyName, out assembly))
             {
                 return assembly;
             }
 
-            return LoadCore(adjustedAssemblyName);
+            return LoadCore(assemblyName);
         }
 
         internal bool IsHigherThan(AssemblyName name1, AssemblyName name2)

--- a/test/CSharpPrecompiledTestProjects/CSharpPrecompiledTestProjects.sln
+++ b/test/CSharpPrecompiledTestProjects/CSharpPrecompiledTestProjects.sln
@@ -11,13 +11,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NativeDependencyOldSdk", "N
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NativeDependencyNoRuntimes", "NativeDependencyNoRuntimes\NativeDependencyNoRuntimes.csproj", "{928B573E-904B-4733-86A2-6CDBF78D24AA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MultipleDependencyVersions", "MultipleDependencyVersions\MultipleDependencyVersions.csproj", "{D0AF8295-7CBF-45EB-914F-7105A9F53B69}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MultipleDependencyVersions", "MultipleDependencyVersions\MultipleDependencyVersions.csproj", "{D0AF8295-7CBF-45EB-914F-7105A9F53B69}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Dependencies", "Dependencies", "{297CEDAC-BB8E-4875-A3FF-7BA7A4916E73}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dependency55", "DependencyA\Dependency55.csproj", "{BC456A9E-D140-4B1A-84D9-AB82556F5881}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dependency55", "DependencyA\Dependency55.csproj", "{BC456A9E-D140-4B1A-84D9-AB82556F5881}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dependency56", "Dependency56\Dependency56.csproj", "{B3B098F6-B2B8-4219-AA52-29F55427496A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dependency56", "Dependency56\Dependency56.csproj", "{B3B098F6-B2B8-4219-AA52-29F55427496A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReferenceOlderRuntimeAssembly", "ReferenceOlderRuntimeAssembly\ReferenceOlderRuntimeAssembly.csproj", "{C3E99727-F4A3-47D9-9DF6-8EE85AE0C29A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -53,6 +55,10 @@ Global
 		{B3B098F6-B2B8-4219-AA52-29F55427496A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B3B098F6-B2B8-4219-AA52-29F55427496A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B3B098F6-B2B8-4219-AA52-29F55427496A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3E99727-F4A3-47D9-9DF6-8EE85AE0C29A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3E99727-F4A3-47D9-9DF6-8EE85AE0C29A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3E99727-F4A3-47D9-9DF6-8EE85AE0C29A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3E99727-F4A3-47D9-9DF6-8EE85AE0C29A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/test/CSharpPrecompiledTestProjects/ReferenceOlderRuntimeAssembly/Properties/serviceDependencies.json
+++ b/test/CSharpPrecompiledTestProjects/ReferenceOlderRuntimeAssembly/Properties/serviceDependencies.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "appInsights1": {
+      "type": "appInsights"
+    },
+    "storage1": {
+      "type": "storage",
+      "connectionId": "AzureWebJobsStorage"
+    }
+  }
+}

--- a/test/CSharpPrecompiledTestProjects/ReferenceOlderRuntimeAssembly/Properties/serviceDependencies.local.json
+++ b/test/CSharpPrecompiledTestProjects/ReferenceOlderRuntimeAssembly/Properties/serviceDependencies.local.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "appInsights1": {
+      "type": "appInsights.sdk"
+    },
+    "storage1": {
+      "type": "storage.emulator",
+      "connectionId": "AzureWebJobsStorage"
+    }
+  }
+}

--- a/test/CSharpPrecompiledTestProjects/ReferenceOlderRuntimeAssembly/ReferenceOlderRuntimeAssembly.cs
+++ b/test/CSharpPrecompiledTestProjects/ReferenceOlderRuntimeAssembly/ReferenceOlderRuntimeAssembly.cs
@@ -1,0 +1,32 @@
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Extensions.Hosting;
+
+namespace ReferenceOlderRuntimeAssembly
+{
+    public class ReferenceOlderRuntimeAssembly
+    {
+        public static IHostingEnvironment StartupEnv;
+        private readonly IHostingEnvironment _env;
+
+        public ReferenceOlderRuntimeAssembly(IHostingEnvironment env)
+        {
+            _env = env;
+        }
+
+        [FunctionName("ReferenceOlderRuntimeAssembly")]
+        public IActionResult Run(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)] HttpRequest req)
+        {
+            if (_env == null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            return new OkResult();
+        }
+    }
+}

--- a/test/CSharpPrecompiledTestProjects/ReferenceOlderRuntimeAssembly/ReferenceOlderRuntimeAssembly.csproj
+++ b/test/CSharpPrecompiledTestProjects/ReferenceOlderRuntimeAssembly/ReferenceOlderRuntimeAssembly.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/test/CSharpPrecompiledTestProjects/ReferenceOlderRuntimeAssembly/host.json
+++ b/test/CSharpPrecompiledTestProjects/ReferenceOlderRuntimeAssembly/host.json
@@ -1,0 +1,11 @@
+{
+    "version": "2.0",
+    "logging": {
+        "applicationInsights": {
+            "samplingExcludedTypes": "Request",
+            "samplingSettings": {
+                "isEnabled": true
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/FunctionAssemblyLoadContextEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/FunctionAssemblyLoadContextEndToEndTests.cs
@@ -114,6 +114,24 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
             });
         }
 
+        [Fact]
+        public async Task ReferenceOlderRuntimeAssembly()
+        {
+            // Test that we still return host version, even if it's a major version below. 
+
+            await RunTest(async () =>
+            {
+                _launcher = new HostProcessLauncher("ReferenceOlderRuntimeAssembly");
+                await _launcher.StartHostAsync();
+
+                var client = _launcher.HttpClient;
+                var response = await client.GetAsync($"api/ReferenceOlderRuntimeAssembly");
+
+                // The function does all the validation internally.
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            });
+        }
+
         private async Task RunTest(Func<Task> test)
         {
             try

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/FunctionAssemblyLoadContextEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/FunctionAssemblyLoadContextEndToEndTests.cs
@@ -117,7 +117,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
         [Fact]
         public async Task ReferenceOlderRuntimeAssembly()
         {
-            // Test that we still return host version, even if it's a major version below. 
+            // Test that we still return host version, even if it's a major version below.
+            // The test project used repros the scenario because it references the Storage extension, 
+            // which has references to Extensions.Hosting.Abstractions 2.1. The project itself directly
+            // references 2.2 of this assembly and before the fix, would throw an exception on Startup.
 
             await RunTest(async () =>
             {


### PR DESCRIPTION
Ready for review. Here's a comment from the PR that explains the whole scenario. In #6566 I added the logic to adjust our dependency loading based on the deps file. The scenario that was missing (and this fixes) is 3(b)(ii)

From a user standpoint, this is typically happening when there is a reference to version `2.2.+` of something like `Microsoft.Extensions.Hosting.Abstractions` or `Microsoft.Extensions.Configuration.Abstractions`. Until this hotfix is applied, the fix is to:
1. Pin back to 3.0.15815.
2. Update these references to 2.1 and re-deploy.

```
There are several possible scenarios:
  1. The assembly was found and the policy evaluator succeeded.
     - Return the assembly.

  2. The assembly was not found (meaning the policy evaluator wasn't able to run).
     - Return null as there's not much else we can do. This will fail and come back to this context
       through the fallback logic for another attempt. This is likely an error case so let it fail.

  3. The assembly was found but the policy evaluator failed.
     a. We did not adjust the requested assembly name via the deps file.
        - This means that the DefaultLoadContext is looking for the correct version. Return null and let
         it handle the load attempt.
     b. We adjusted the requested assembly name via the deps file. If we return null the DefaultLoadContext would attempt to
        load the original assembly version, which may be incorrect if we had to adjust it forward past the runtime's version.
        i.  The adjusted assembly name is higher than the runtime's version.
            - Do not trust the DefaultLoadContext to handle this as it may resolve to the runtime's assembly. Instead,
              call LoadCore() to ensure the adjusted assembly is loaded.
        ii. The adjusted assembly name is still lower than or equal to the runtime's version (this likely means
            a lower major version).
            - Return null and let the DefaultLoadContext handle it. It may come back here due to fallback logic, but
              ultimately it will unify on the runtime version.
```