### PR TITLE
draft change for the hostId on keda issue

### DIFF
--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -296,6 +296,16 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
+        /// Gets a value indicating whether the application is running in Kubernetes
+        /// </summary>
+        /// <param name="environment">The environment to verify</param>
+        /// <returns><see cref="true"/> If running in a Kubernetes Azure App Service; otherwise, false.</returns>
+        public static bool IsKubernetesHosting(this IEnvironment environment)
+        {
+            return !string.IsNullOrEmpty(environment.GetEnvironmentVariable(KubernetesServiceHost));
+        }
+
+        /// <summary>
         /// Gets a value that uniquely identifies the site and slot.
         /// </summary>
         public static string GetAzureWebsiteUniqueSlotName(this IEnvironment environment)
@@ -310,6 +320,14 @@ namespace Microsoft.Azure.WebJobs.Script
             }
 
             return name?.ToLowerInvariant();
+        }
+
+        /// <summary>
+        /// Gets a value from AzureWebsiteName environment variables.
+        /// </summary>
+        public static string GetKubernetesHostname(this IEnvironment environment)
+        {
+            return environment.GetEnvironmentVariable(AzureWebsiteName);
         }
 
         /// <summary>

--- a/src/WebJobs.Script/Host/ScriptHostIdProvider.cs
+++ b/src/WebJobs.Script/Host/ScriptHostIdProvider.cs
@@ -52,6 +52,11 @@ namespace Microsoft.Azure.WebJobs.Script
                 string hostName = environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName);
                 hostId = hostName?.Replace(".azurewebsites.net", string.Empty);
             }
+            else if (environment.IsKubernetesHosting())
+            {
+                // The hostid is delivered from the AzureWebsiteName.
+                hostId = environment.GetKubernetesHostname() ?? Environment.MachineName;
+            }
             else
             {
                 // When running locally, derive a stable host ID from machine name


### PR DESCRIPTION
I started this PR for discussing the design.  

The issue is, on the KEDA environment, it refers to hostname on a container. That will be a pod name on kubernetes. 
When you scale out, on each pod, the hostid is different for the each pod. 
That cause issue for example timer trigger. (Timer trigger make it singleton even if scale out. It uses [leas blob](https://github.com/Azure/azure-webjobs-sdk-extensions/wiki/TimerTrigger#singleton-locks), it create a different lease lock blob container for each hostid. 

My current design is simply watch the `KUBERNETES_SERVICE_HOST` environment variables, if there is, refer to the ` WEBSITE_SITE_NAME` as the host name.  Customer need to set `WEBSITE_SITE_NAME` as an environment variables. 

However, I'm not sure if this design is harmful or not. For example we can introduce a special Environment Variable to avoid the side effect on existing Kubernetes hosting pod instead of `KUBERNETES_SERVICE_HOST`.
Once design is fixed, I'll write a test and closing this PR. 

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-host/issues/7128

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

