### PR TITLE
Fixes slow start of multiple worker processes

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -12,6 +12,7 @@
 - Added direct refereces to [System.IO.Pipes](https://www.nuget.org/packages/System.IO.Pipes/4.3.0)  and [System.Threading.Overlapped](https://www.nuget.org/packages/System.Threading.Overlapped/4.3.0) to ensure System.Data.SqlClient package update does not impact unification 
 - Updated Java Worker Version to [1.8.2-SNAPSHOT](https://github.com/Azure/azure-functions-java-worker/releases/tag/1.8.2-SNAPSHOT)
 - Skip external config validation if RuntimeDrivenScaling is enabled in Elastic Premium sku (#6542)
+- Fixed issue where multiple worker processes are started slower than expected
 
 **Release sprint:** Sprint 89, 90, 91
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+89%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+89%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -146,8 +146,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         {
             for (var count = startIndex; count < _maxProcessCount; count++)
             {
-                startAction = startAction.Debounce(_processStartCancellationToken.Token, count * _debounceMilliSeconds);
-                startAction();
+                var debouncedAction = startAction.Debounce(_processStartCancellationToken.Token, count * _debounceMilliSeconds);
+                debouncedAction();
             }
         }
 

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
         }
 
-        public static IList<RpcWorkerConfig> GetTestWorkerConfigs(bool includeDllWorker = false, int processCountValue = 1)
+        public static IList<RpcWorkerConfig> GetTestWorkerConfigs(bool includeDllWorker = false, int processCountValue = 1, TimeSpan processStartupInterval = default)
         {
             var workerConfigs = new List<RpcWorkerConfig>
             {
@@ -268,6 +268,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             if (includeDllWorker)
             {
                 workerConfigs.Add(new RpcWorkerConfig() { Description = GetTestWorkerDescription("dllWorker", ".dll") });
+            }
+
+            if (processStartupInterval != default)
+            {
+                foreach (var config in workerConfigs)
+                {
+                    config.CountOptions.ProcessStartupInterval = processStartupInterval;
+                }
             }
 
             return workerConfigs;


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #7136 - with this fix workers should be started as originally intended and documented

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This is the least invasive version of the fix - just stops the debounce calls from being chained. However its not clear to me why this code is using debounce in the first place - the result of the debounce call is never shared, so no invocations will ever be prevented. The code might be clearer with the following implementation, let me know if you'd prefer this.

```csharp
        private void StartWorkerProcesses(int startIndex, Action startAction)
        {
            for (var count = startIndex; count < _maxProcessCount; count++)
            {
                Task.Delay(count * _debounceMilliSeconds).ContinueWith(t => startAction());
            }
        }
```

Other thing to look at is the new unit test - it uses a stopwatch to make sure that the workers start up in a reasonable time. The test might be flaky if it has to run in extremely slow environments. Let me know if you'd like a different approach used here.