### PR TITLE
[pack] Fix keys APIs for functions without function.json

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/KeysController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/KeysController.cs
@@ -31,15 +31,17 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         private readonly IOptions<ScriptApplicationHostOptions> _applicationOptions;
         private readonly IFileSystem _fileSystem;
         private readonly IFunctionsSyncManager _functionsSyncManager;
+        private readonly IFunctionMetadataManager _functionMetadataManager;
         private readonly IScriptHostManager _hostManager;
 
-        public KeysController(IOptions<ScriptApplicationHostOptions> applicationOptions, ISecretManagerProvider secretManagerProvider, ILoggerFactory loggerFactory, IFileSystem fileSystem, IFunctionsSyncManager functionsSyncManager, IScriptHostManager hostManager)
+        public KeysController(IOptions<ScriptApplicationHostOptions> applicationOptions, ISecretManagerProvider secretManagerProvider, ILoggerFactory loggerFactory, IFileSystem fileSystem, IFunctionsSyncManager functionsSyncManager, IFunctionMetadataManager functionMetadataManager, IScriptHostManager hostManager)
         {
             _applicationOptions = applicationOptions;
             _secretManagerProvider = secretManagerProvider;
             _logger = loggerFactory.CreateLogger(ScriptConstants.LogCategoryKeysController);
             _fileSystem = fileSystem;
             _functionsSyncManager = functionsSyncManager;
+            _functionMetadataManager = functionMetadataManager;
             _hostManager = hostManager;
         }
 
@@ -285,9 +287,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
         private bool IsFunction(string functionName)
         {
-            string json = null;
+            if (_functionMetadataManager.TryGetFunctionMetadata(functionName, out _))
+            {
+                return true;
+            }
+
             string functionPath = Path.Combine(_applicationOptions.Value.ScriptPath, functionName);
-            return Utility.TryReadFunctionConfig(functionPath, out json, _fileSystem);
+            return Utility.TryReadFunctionConfig(functionPath, out _, _fileSystem);
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Controllers/KeysController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/KeysController.cs
@@ -287,13 +287,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
         private bool IsFunction(string functionName)
         {
-            if (_functionMetadataManager.TryGetFunctionMetadata(functionName, out _))
+            string functionPath = Path.Combine(_applicationOptions.Value.ScriptPath, functionName);
+            if (Utility.TryReadFunctionConfig(functionPath, out _, _fileSystem))
             {
                 return true;
             }
 
-            string functionPath = Path.Combine(_applicationOptions.Value.ScriptPath, functionName);
-            return Utility.TryReadFunctionConfig(functionPath, out _, _fileSystem);
+            return _functionMetadataManager.TryGetFunctionMetadata(functionName, out _);
         }
     }
 }


### PR DESCRIPTION
### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-host/issues/7147

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

The PR changes the code to rely on `IFunctionMetadataManager` as the source of truth for functions. The fallback logic is to check in the filesystem to avoid any edge cases for backward compatibility.
