### PR TITLE
Get shared memory directories (in Unix) from AppSettings 

### DIFF
--- a/src/WebJobs.Script.Grpc/Extensions/RpcSharedMemoryDataExtensions.cs
+++ b/src/WebJobs.Script.Grpc/Extensions/RpcSharedMemoryDataExtensions.cs
@@ -13,6 +13,11 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.Extensions
     {
         internal static async Task<RpcSharedMemory> ToRpcSharedMemoryAsync(this object value, ILogger logger, string invocationId, ISharedMemoryManager sharedMemoryManager)
         {
+            if (value == null)
+            {
+                return new RpcSharedMemory();
+            }
+
             if (!sharedMemoryManager.IsSupported(value))
             {
                 return null;

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
@@ -11,6 +11,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public const string FunctionWorkerRuntimeVersionSettingName = "FUNCTIONS_WORKER_RUNTIME_VERSION";
         public const string FunctionsWorkerProcessCountSettingName = "FUNCTIONS_WORKER_PROCESS_COUNT";
         public const string FunctionsWorkerSharedMemoryDataTransferEnabledSettingName = "FUNCTIONS_WORKER_SHARED_MEMORY_DATA_TRANSFER_ENABLED";
+        // Comma-separated list of directories where shared memory maps can be created for data transfer between host and worker.
+        // This will override the default directories.
+        public const string FunctionsUnixSharedMemoryDirectories = "FUNCTIONS_UNIX_SHARED_MEMORY_DIRECTORIES";
         public const string DotNetLanguageWorkerName = "dotnet";
         public const string NodeLanguageWorkerName = "node";
         public const string JavaLanguageWorkerName = "java";

--- a/src/WebJobs.Script/Workers/SharedMemoryDataTransfer/MemoryMappedFileAccessorUnix.cs
+++ b/src/WebJobs.Script/Workers/SharedMemoryDataTransfer/MemoryMappedFileAccessorUnix.cs
@@ -167,12 +167,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer
                 string path = Path.Combine(directory, SharedMemoryConstants.TempDirSuffix);
                 if (Directory.Exists(path))
                 {
-                    // If the directory already exists (maybe from a previous run of the host) then clean it up and start afresh
                     Logger.LogTrace("Found directory for shared memory usage: {Directory}", path);
                     try
                     {
+                        // If the directory already exists (maybe from a previous run of the host) then clean it up and start afresh
+                        // The previously created memory maps in that directory are not needed and we need to should clean up the memory
                         Directory.Delete(path);
-                        validDirectories.Add(path);
                         Logger.LogTrace("Cleaned up existing directory for shared memory usage: {Directory}", path);
                     }
                     catch (Exception exception)

--- a/src/WebJobs.Script/Workers/SharedMemoryDataTransfer/MemoryMappedFileAccessorUnix.cs
+++ b/src/WebJobs.Script/Workers/SharedMemoryDataTransfer/MemoryMappedFileAccessorUnix.cs
@@ -191,7 +191,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer
                     }
                     else
                     {
-                        Logger.LogWarning("Cannot create directory for shared memory usage: {Directory}", path);
+                        Logger.LogWarning("Directory for shared memory usage does not exist: {Directory}", path);
                     }
                 }
                 catch (Exception exception)
@@ -200,7 +200,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer
                 }
             }
 
-            Logger.LogDebug("Valid directories for shared memory usage: {Directories}", validDirectories);
+            Logger.LogDebug("Valid directories for shared memory usage: {Directories}", string.Join(",", validDirectories));
             return validDirectories;
         }
 

--- a/src/WebJobs.Script/Workers/SharedMemoryDataTransfer/MemoryMappedFileAccessorUnix.cs
+++ b/src/WebJobs.Script/Workers/SharedMemoryDataTransfer/MemoryMappedFileAccessorUnix.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer
                     {
                         // If the directory already exists (maybe from a previous run of the host) then clean it up and start afresh
                         // The previously created memory maps in that directory are not needed and we need to should clean up the memory
-                        Directory.Delete(path);
+                        Directory.Delete(path, recursive: true);
                         Logger.LogTrace("Cleaned up existing directory for shared memory usage: {Directory}", path);
                     }
                     catch (Exception exception)

--- a/src/WebJobs.Script/Workers/SharedMemoryDataTransfer/SharedMemoryConstants.cs
+++ b/src/WebJobs.Script/Workers/SharedMemoryDataTransfer/SharedMemoryConstants.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer
         /// <summary>
         /// Minimum size (in number of bytes) an object must be in order for it to be transferred over shared memory.
         /// If the object is smaller than this, gRPC is used.
+        /// Note: This needs to be consistent among the host and workers.
+        ///       e.g. in the Python worker, it is defined in shared_memory_constants.py
         /// </summary>
         public const long MinObjectBytesForSharedMemoryTransfer = 1024 * 1024; // 1 MB
 
@@ -40,6 +42,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer
         /// Maximum size (in number of bytes) an object can be in order for it to be transferred over shared memory.
         /// This limit is imposed because initializing objects like <see cref="byte[]"/> greater than 2GB is not allowed.
         /// Ref: https://stackoverflow.com/a/3944336/3132415
+        /// Note: This needs to be consistent among the host and workers.
+        ///       e.g. in the Python worker, it is defined in shared_memory_constants.py
         /// </summary>
         public const long MaxObjectBytesForSharedMemoryTransfer = ((long)2 * 1024 * 1024 * 1024) - 1; // 2 GB
 

--- a/src/WebJobs.Script/Workers/SharedMemoryDataTransfer/SharedMemoryMap.cs
+++ b/src/WebJobs.Script/Workers/SharedMemoryDataTransfer/SharedMemoryMap.cs
@@ -195,6 +195,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer
         public async Task<byte[]> CopyStreamAsync(int offset, int count)
         {
             Stream contentStream = await GetStreamAsync();
+            if (contentStream == null)
+            {
+                _logger.LogError("Cannot get stream for shared memory map: {MapName}", _mapName);
+                return null;
+            }
+
             int contentLength = (int)contentStream.Length;
             if (contentLength == 0)
             {

--- a/test/WebJobs.Script.Tests/Workers/MemoryMappedFileAccessorTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/MemoryMappedFileAccessorTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
         }
 
         /// <summary>
-        /// 
+        /// Verify that when the AppSetting is specified, the directory used for shared memory is picked from the AppSetting and the default is not used.
         /// </summary>
         [Fact]
         public void Use_AppSetting_Directory_Unix()

--- a/test/WebJobs.Script.Tests/Workers/MemoryMappedFileAccessorTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/MemoryMappedFileAccessorTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.IO.MemoryMappedFiles;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer;
 using Microsoft.Extensions.Logging;
@@ -192,6 +193,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             string directoryWithSuffix = $"{directory}/{SharedMemoryConstants.TempDirSuffix}";
             DirectoryInfo dirInfo = Directory.CreateDirectory(directoryWithSuffix);
             DateTime oldCreationTime = dirInfo.CreationTimeUtc;
+
+            // Sleep for 10ms so that the timestamp on when we created the directory above and when MemoryMappedFileAccessor creates the directory has significant difference.
+            // This will make it possible to check if the directory was created again by MemoryMappedFileAccessor by comparing the timestamps.
+            Thread.Sleep(10);
 
             List<string> validDirectories = mapAccessor.GetValidDirectories();
             Assert.Contains(directoryWithSuffix, validDirectories);

--- a/test/WebJobs.Script.Tests/Workers/MemoryMappedFileAccessorTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/MemoryMappedFileAccessorTests.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             Assert.Equal(1, validDirectories.Count);
 
             // Cleanup
-            Directory.Delete(expectedDirectory);
+            Directory.Delete(expectedDirectory, recursive: true);
         }
 
         /// <summary>
@@ -202,7 +202,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             Assert.True(newCreationTime > oldCreationTime);
 
             // Cleanup
-            Directory.Delete(directoryWithSuffix);
+            Directory.Delete(directoryWithSuffix, recursive: true);
         }
 
         /// <summary>

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             }
             else
             {
-                _mapAccessor = new MemoryMappedFileAccessorUnix(mmapAccessorLogger);
+                _mapAccessor = new MemoryMappedFileAccessorUnix(mmapAccessorLogger, _testEnvironment);
             }
             _sharedMemoryManager = new SharedMemoryManager(_loggerFactory, _mapAccessor);
 

--- a/test/WebJobs.Script.Tests/Workers/ScriptInvocationContextExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ScriptInvocationContextExtensionsTests.cs
@@ -24,12 +24,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
     public class ScriptInvocationContextExtensionsTests : IDisposable
     {
         private readonly ILoggerFactory _loggerFactory = MockNullLoggerFactory.CreateLoggerFactory();
+        private readonly IEnvironment _testEnvironment;
         private readonly IMemoryMappedFileAccessor _mapAccessor;
         private readonly ISharedMemoryManager _sharedMemoryManager;
 
         public ScriptInvocationContextExtensionsTests()
         {
             ILogger<MemoryMappedFileAccessor> logger = NullLogger<MemoryMappedFileAccessor>.Instance;
+            _testEnvironment = new TestEnvironment();
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -37,8 +39,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             }
             else
             {
-                _mapAccessor = new MemoryMappedFileAccessorUnix(logger);
+                _mapAccessor = new MemoryMappedFileAccessorUnix(logger, _testEnvironment);
             }
+
             _sharedMemoryManager = new SharedMemoryManager(_loggerFactory, _mapAccessor);
         }
 

--- a/test/WebJobs.Script.Tests/Workers/SharedMemoryManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/SharedMemoryManagerTests.cs
@@ -23,11 +23,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
 
         private readonly ILoggerFactory _loggerFactory;
 
+        private readonly IEnvironment _testEnvironment;
+
         public SharedMemoryManagerTests()
         {
             _loggerFactory = MockNullLoggerFactory.CreateLoggerFactory();
 
             ILogger<MemoryMappedFileAccessor> logger = NullLogger<MemoryMappedFileAccessor>.Instance;
+
+            _testEnvironment = new TestEnvironment();
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -35,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             }
             else
             {
-                _mapAccessor = new MemoryMappedFileAccessorUnix(logger);
+                _mapAccessor = new MemoryMappedFileAccessorUnix(logger, _testEnvironment);
             }
         }
 

--- a/test/WebJobs.Script.Tests/Workers/SharedMemoryMapTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/SharedMemoryMapTests.cs
@@ -18,9 +18,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
     /// </summary>
     public class SharedMemoryMapTests
     {
+        private readonly ILoggerFactory _loggerFactory;
+
         private readonly IMemoryMappedFileAccessor _mapAccessor;
 
-        private readonly ILoggerFactory _loggerFactory;
+        private readonly IEnvironment _testEnvironment;
 
         public SharedMemoryMapTests()
         {
@@ -28,13 +30,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
 
             ILogger<MemoryMappedFileAccessor> logger = NullLogger<MemoryMappedFileAccessor>.Instance;
 
+            _testEnvironment = new TestEnvironment();
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 _mapAccessor = new MemoryMappedFileAccessorWindows(logger);
             }
             else
             {
-                _mapAccessor = new MemoryMappedFileAccessorUnix(logger);
+                _mapAccessor = new MemoryMappedFileAccessorUnix(logger, _testEnvironment);
             }
         }
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
Provides ability to specify custom paths for use with shared memory in Unix. If not provided, the default (`/dev/shm`) is used.
This can be helpful when running on macOS, for example, where the user needs to create a volume manually before it can be used for shared memory data transfer and `/dev/shm` is not allowed in macOS.

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
