### PR TITLE
Adding option to disable environment name updates when in debug mode

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -2,6 +2,7 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Added a feature flag to opt out of the default behavior where the host sets the environment name to `Development` when running in debug mode. To disable the behavior, set the app setting: `AzureWebJobsFeatureFlags` to `DisableDevModeInDebug`
 
 **Release sprint:** Sprint 100
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+100%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+100%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -9,6 +9,7 @@ using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Host.Timers;
 using Microsoft.Azure.WebJobs.Script.ChangeAnalysis;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Middleware;
@@ -138,7 +139,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 });
 
             var debugStateProvider = rootServiceProvider.GetService<IDebugStateProvider>();
-            if (debugStateProvider.InDebugMode)
+            if (!FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableDevInDebug, environment) && debugStateProvider.InDebugMode)
             {
                 builder.UseEnvironment(EnvironmentName.Development);
             }

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -111,6 +111,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FeatureFlagAllowSynchronousIO = "AllowSynchronousIO";
         public const string FeatureFlagRelaxedAssemblyUnification = "RelaxedAssemblyUnification";
         public const string FeatureFlagEnableEnhancedScopes = "EnableEnhancedScopes";
+        public const string FeatureFlagDisableDevInDebug = "DisableDevModeInDebug";
 
         public const string AdminJwtValidAudienceFormat = "https://{0}.azurewebsites.net/azurefunctions";
         public const string AdminJwtValidIssuerFormat = "https://{0}.scm.azurewebsites.net";

--- a/test/WebJobs.Script.Tests/WebScriptHostBuilderExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/WebScriptHostBuilderExtensionsTests.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.WebJobs.Script.Tests;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public class WebScriptHostBuilderExtensionsTests
+    {
+        [Fact]
+        public void Test()
+        {
+            var builder = new HostBuilder().ConfigureDefaultTestWebScriptHost(null, null, false, configureRootServices: s =>
+                {
+                    s.AddSingleton<IEnvironment>(p =>
+                    {
+                        var environment = new TestEnvironment();
+                        environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagDisableDevInDebug);
+
+                        return environment;
+                    });
+
+                    var stateProvider = new Mock<IDebugStateProvider>();
+
+                    stateProvider.Setup(d => d.InDebugMode)
+                    .Returns(() => true);
+
+                    s.AddSingleton<IDebugStateProvider>(stateProvider.Object);
+                });
+
+            var host = builder.Build();
+
+            var hostingEnvironment = host.Services.GetRequiredService<IHostEnvironment>();
+
+            Assert.False(hostingEnvironment.IsDevelopment());
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This addresses a common source for #6239

Changing this behavior would be a breaking change. Adding this behind a feature flag for now (@brettsam , this is something I want to enable by default in 4.0)

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
