### PR TITLE
Defer Script Host disposal during cold start

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -656,6 +656,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         /// <param name="instance">The <see cref="IHost"/> instance to remove</param>
         private async Task Orphan(IHost instance, CancellationToken cancellationToken = default)
         {
+            var isStandbyHost = false;
             try
             {
                 var scriptHost = (ScriptHost)instance?.Services.GetService<ScriptHost>();
@@ -663,6 +664,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 {
                     scriptHost.HostInitializing -= OnHostInitializing;
                     scriptHost.HostInitialized -= OnHostInitialized;
+                    isStandbyHost = scriptHost.IsStandbyHost;
                 }
             }
             catch (ObjectDisposedException)
@@ -684,7 +686,32 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 if (instance != null)
                 {
                     GetHostLogger(instance).LogDebug("Disposing ScriptHost.");
-                    instance.Dispose();
+
+                    if (isStandbyHost && !_scriptWebHostEnvironment.InStandbyMode)
+                    {
+                        // For cold start reasons delay disposing script host if specializing out of placeholder mode
+                        Utility.ExecuteAfterColdStartDelay(_environment, () =>
+                        {
+                            try
+                            {
+                                GetHostLogger(instance).LogDebug("Starting Standby ScriptHost dispose");
+                                instance.Dispose();
+                                _logger.LogDebug("Standby ScriptHost disposed");
+                            }
+                            catch (Exception e)
+                            {
+                                _logger.LogError(e, "Failed to dispose Standby ScriptHost instance");
+                                throw;
+                            }
+                        }, cancellationToken);
+
+                        GetHostLogger(instance).LogDebug("Standby ScriptHost marked for disposal");
+                    }
+                    else
+                    {
+                        instance.Dispose();
+                        GetHostLogger(instance).LogDebug("ScriptHost disposed");
+                    }
                 }
             }
         }

--- a/src/WebJobs.Script/Config/ScriptJobHostOptions.cs
+++ b/src/WebJobs.Script/Config/ScriptJobHostOptions.cs
@@ -117,5 +117,10 @@ namespace Microsoft.Azure.WebJobs.Script
         /// Gets or sets a value indicating whether the filesystem is read-only.
         /// </summary>
         public bool IsFileSystemReadOnly { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the ScriptHost is in standby mode.
+        /// </summary>
+        public bool IsStandbyConfiguration { get; set; }
     }
 }

--- a/src/WebJobs.Script/Config/ScriptJobHostOptionsSetup.cs
+++ b/src/WebJobs.Script/Config/ScriptJobHostOptionsSetup.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Script.Configuration
 {
-    internal class ScriptHostOptionsSetup : IConfigureOptions<ScriptJobHostOptions>
+    internal class ScriptJobHostOptionsSetup : IConfigureOptions<ScriptJobHostOptions>
     {
         private readonly IConfiguration _configuration;
         private readonly IEnvironment _environment;
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
         internal static readonly TimeSpan MaxFunctionTimeoutDynamic = TimeSpan.FromMinutes(10);
         internal static readonly TimeSpan DefaultFunctionTimeout = TimeSpan.FromMinutes(30);
 
-        public ScriptHostOptionsSetup(IConfiguration configuration, IEnvironment environment, IOptions<ScriptApplicationHostOptions> applicationHostOptions)
+        public ScriptJobHostOptionsSetup(IConfiguration configuration, IEnvironment environment, IOptions<ScriptApplicationHostOptions> applicationHostOptions)
         {
             _configuration = configuration;
             _environment = environment;
@@ -72,6 +72,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             options.IsSelfHost = webHostOptions.IsSelfHost;
             options.TestDataPath = webHostOptions.TestDataPath;
             options.IsFileSystemReadOnly = webHostOptions.IsFileSystemReadOnly;
+            options.IsStandbyConfiguration = webHostOptions.IsStandbyConfiguration;
         }
 
         private void ConfigureFunctionTimeout(ScriptJobHostOptions options)

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -185,6 +185,8 @@ namespace Microsoft.Azure.WebJobs.Script
             }
         }
 
+        public bool IsStandbyHost => ScriptOptions.IsStandbyConfiguration;
+
         public ScriptSettingsManager SettingsManager
         {
             get

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -263,7 +263,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 // Configuration
                 services.AddSingleton<IOptions<ScriptApplicationHostOptions>>(new OptionsWrapper<ScriptApplicationHostOptions>(applicationHostOptions));
                 services.AddSingleton<IOptionsMonitor<ScriptApplicationHostOptions>>(new ScriptApplicationHostOptionsMonitor(applicationHostOptions));
-                services.ConfigureOptions<ScriptHostOptionsSetup>();
+                services.ConfigureOptions<ScriptJobHostOptionsSetup>();
                 services.ConfigureOptions<JobHostFunctionTimeoutOptionsSetup>();
                 // LanguageWorkerOptionsSetup should be registered in WebHostServiceCollection as well to enable starting worker processing in placeholder mode.
                 services.ConfigureOptions<LanguageWorkerOptionsSetup>();

--- a/test/WebJobs.Script.Tests/Configuration/ScriptJobHostOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ScriptJobHostOptionsSetupTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 {
-    public class ScriptHostOptionsSetupTests
+    public class ScriptJobHostOptionsSetupTests
     {
         [Fact]
         public void Configure_FileWatching()
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 { ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "fileWatchingEnabled"), "true" }
             };
 
-            ScriptHostOptionsSetup setup = CreateSetupWithConfiguration(settings);
+            ScriptJobHostOptionsSetup setup = CreateSetupWithConfiguration(settings);
 
             var options = new ScriptJobHostOptions();
 
@@ -114,13 +114,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 
             var options = GetConfiguredOptions(settings, environment);
 
-            Assert.Equal(ScriptHostOptionsSetup.DefaultFunctionTimeoutDynamic, options.FunctionTimeout);
+            Assert.Equal(ScriptJobHostOptionsSetup.DefaultFunctionTimeoutDynamic, options.FunctionTimeout);
 
             // When functionTimeout is set as null
             settings.Add(ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "functionTimeout"), string.Empty);
 
             options = GetConfiguredOptions(settings, environment);
-            Assert.Equal(ScriptHostOptionsSetup.DefaultFunctionTimeoutDynamic, options.FunctionTimeout);
+            Assert.Equal(ScriptJobHostOptionsSetup.DefaultFunctionTimeoutDynamic, options.FunctionTimeout);
 
             // TODO: DI Need to ensure JobHostOptions is correctly configured
             //var timeoutConfig = options.HostOptions.FunctionTimeout;
@@ -223,7 +223,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         public void Configure_TimeoutDefaultsNull_IfNotDynamic()
         {
             var options = GetConfiguredOptions(new Dictionary<string, string>());
-            Assert.Equal(ScriptHostOptionsSetup.DefaultFunctionTimeout, options.FunctionTimeout);
+            Assert.Equal(ScriptJobHostOptionsSetup.DefaultFunctionTimeout, options.FunctionTimeout);
 
             // When functionTimeout is set as null
             var settings = new Dictionary<string, string>
@@ -232,13 +232,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             };
 
             options = GetConfiguredOptions(settings);
-            Assert.Equal(ScriptHostOptionsSetup.DefaultFunctionTimeout, options.FunctionTimeout);
+            Assert.Equal(ScriptJobHostOptionsSetup.DefaultFunctionTimeout, options.FunctionTimeout);
         }
 
         [Fact]
         public void Configure_NoMaxTimeoutLimits_IfNotDynamic()
         {
-            var timeout = ScriptHostOptionsSetup.MaxFunctionTimeoutDynamic + TimeSpan.FromMinutes(10);
+            var timeout = ScriptJobHostOptionsSetup.MaxFunctionTimeoutDynamic + TimeSpan.FromMinutes(10);
             string configPath = ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "functionTimeout");
             var settings = new Dictionary<string, string>
             {
@@ -267,7 +267,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             string configPath = ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "functionTimeout");
             var settings = new Dictionary<string, string>
             {
-                { configPath, (ScriptHostOptionsSetup.MaxFunctionTimeoutDynamic + TimeSpan.FromSeconds(1)).ToString() }
+                { configPath, (ScriptJobHostOptionsSetup.MaxFunctionTimeoutDynamic + TimeSpan.FromSeconds(1)).ToString() }
             };
 
             var environment = new TestEnvironment();
@@ -277,7 +277,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             var expectedMessage = "FunctionTimeout must be greater than 00:00:01 and less than 00:10:00.";
             Assert.Equal(expectedMessage, ex.Message);
 
-            settings[configPath] = (ScriptHostOptionsSetup.MinFunctionTimeout - TimeSpan.FromSeconds(1)).ToString();
+            settings[configPath] = (ScriptJobHostOptionsSetup.MinFunctionTimeout - TimeSpan.FromSeconds(1)).ToString();
             ex = Assert.Throws<ArgumentException>(() => GetConfiguredOptions(settings, environment));
             Assert.Equal(expectedMessage, ex.Message);
 
@@ -292,7 +292,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             string configPath = ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "functionTimeout");
             var settings = new Dictionary<string, string>
             {
-                { configPath, (ScriptHostOptionsSetup.MinFunctionTimeout - TimeSpan.FromSeconds(1)).ToString() }
+                { configPath, (ScriptJobHostOptionsSetup.MinFunctionTimeout - TimeSpan.FromSeconds(1)).ToString() }
             };
 
             var ex = Assert.Throws<ArgumentException>(() => GetConfiguredOptions(settings));
@@ -327,7 +327,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 
         private ScriptJobHostOptions GetConfiguredOptions(Dictionary<string, string> settings, IEnvironment environment = null)
         {
-            ScriptHostOptionsSetup setup = CreateSetupWithConfiguration(settings, environment);
+            ScriptJobHostOptionsSetup setup = CreateSetupWithConfiguration(settings, environment);
 
             var options = new ScriptJobHostOptions();
 
@@ -336,7 +336,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             return options;
         }
 
-        private ScriptHostOptionsSetup CreateSetupWithConfiguration(Dictionary<string, string> settings = null, IEnvironment environment = null)
+        private ScriptJobHostOptionsSetup CreateSetupWithConfiguration(Dictionary<string, string> settings = null, IEnvironment environment = null)
         {
             var builder = new ConfigurationBuilder();
             environment = environment ?? SystemEnvironment.Instance;
@@ -348,7 +348,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 
             var configuration = builder.Build();
 
-            return new ScriptHostOptionsSetup(configuration, environment, new OptionsWrapper<ScriptApplicationHostOptions>(new ScriptApplicationHostOptions()));
+            return new ScriptJobHostOptionsSetup(configuration, environment, new OptionsWrapper<ScriptApplicationHostOptions>(new ScriptApplicationHostOptions()));
         }
     }
 }

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -17,6 +17,7 @@ using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -1424,6 +1425,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.False(scriptHost.IsFunction("DoesNotExist"));
             Assert.False(scriptHost.IsFunction(string.Empty));
             Assert.False(scriptHost.IsFunction(null));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task IsStandbyHost_ReturnsExpectedResult(bool isStandbyHost)
+        {
+            var host = TestHelpers.GetDefaultHost(o =>
+            {
+                o.IsStandbyConfiguration = isStandbyHost;
+            });
+            await host.StartAsync();
+            var scriptHost = host.GetScriptHost();
+
+            Assert.Equal(isStandbyHost, scriptHost.IsStandbyHost);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
@@ -352,6 +352,62 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public async Task DisposesScriptHost()
+        {
+            var metricsLogger = new TestMetricsLogger();
+
+            var services = new ServiceCollection()
+                .AddLogging(l =>
+                {
+                    l.Services.AddSingleton<ILoggerProvider, TestLoggerProvider>();
+                    l.AddFilter(_ => true);
+                })
+                .BuildServiceProvider();
+
+            var host = new Mock<IHost>();
+
+            host.Setup(h => h.Services)
+                .Returns(services);
+
+            host.Setup(h => h.Dispose())
+                .Callback(() =>
+                {
+                    services.Dispose();
+                });
+
+            var hostBuilder = new Mock<IScriptHostBuilder>();
+            hostBuilder.Setup(b => b.BuildHost(It.IsAny<bool>(), It.IsAny<bool>()))
+                .Returns(host.Object);
+
+            _webHostLoggerProvider = new TestLoggerProvider();
+            _loggerFactory = new LoggerFactory();
+            _loggerFactory.AddProvider(_webHostLoggerProvider);
+
+            _hostService = new WebJobsScriptHostService(
+                _monitor, hostBuilder.Object, _loggerFactory,
+                _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object,
+                _hostPerformanceManager, _healthMonitorOptions,
+                metricsLogger, new Mock<IApplicationLifetime>().Object,
+                _mockConfig);
+
+            var hostLogger = host.Object.GetTestLoggerProvider();
+
+            await _hostService.StartAsync(CancellationToken.None);
+            await _hostService.RestartHostAsync(CancellationToken.None);
+
+            Assert.True(AreRequiredMetricsGenerated(metricsLogger));
+
+            host.Verify(m => m.StopAsync(It.IsAny<CancellationToken>()), Times.Exactly(1));
+            host.Verify(m => m.Dispose(), Times.Exactly(1));
+
+            var allLogMessages = _webHostLoggerProvider.GetAllLogMessages();
+
+            Assert.Contains(allLogMessages,
+                m => m.FormattedMessage != null &&
+                     m.FormattedMessage.Contains("ScriptHost disposed"));
+        }
+
+        [Fact]
         public async Task HostRestart_BeforeStart_WaitsForStartToContinue()
         {
             _host = CreateMockHost();


### PR DESCRIPTION
Defer Script Host disposal during cold start

One of the steps during specialization is to restart host. This restart involves starting a new host and disposing the old host.

From profiling, disposal of the old host is the most expensive part in the restart operation. On a single core machine, while the restart is in progress, function invocation will be delayed during cold start. On most cold starts the host dispose seems to be getting scheduled only after cold start has completed so this doesn't impact cold start at lower percentiles. But if the ordering of execution happened to be reversed, the host dispose will increase cold start.

Fix is to defer the Host disposal by 5 seconds. The change reduces P90 cold start by 60%.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-host/issues/7305

### Pull request checklist

* [X ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
