### PR TITLE
[pack] some artifact cleanup

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,12 +84,12 @@ jobs:
   - pwsh: |
       foreach ($baseName in @("WebJobs.Script", "WebJobs.Script.WebHost", "WebJobs.Script.Grpc"))
       {    
-        $packageName = "Microsoft.Azure." + $baseName + "*.nupkg"    
-        $sourcePath = "$(Build.Repository.LocalPath)/packages/$packageName"        
+        $packageName = "Microsoft.Azure." + $baseName + "*.nupkg"
+        $sourcePath = "$(Build.Repository.LocalPath)/packages/$packageName"
         if (-not (test-path $sourcePath))    
-        {        
-          throw "Unable to find '$packageName' at './package'"    
-        }   
+        {
+          throw "Unable to find '$packageName' at './package'"
+        }
         Copy-Item -Path $sourcePath -Destination $(Build.ArtifactStagingDirectory) -ErrorAction Stop -Verbose -Force}
     condition: eq(variables['RUNBUILDFORINTEGRATIONTESTS'], 'True')
     displayName: 'Copy package to ArtifactStagingDirectory'
@@ -108,7 +108,7 @@ jobs:
     inputs:
       command: 'custom'
       custom: 'pack'
-      arguments: '-o packages\WebJobs.Script.Performance.App'
+      arguments: '-o WebJobs.Script.Performance.App'
       projects: |
         **\WebJobs.Script.Performance.App.csproj
   - task: DotNetCoreCLI@2
@@ -158,14 +158,14 @@ jobs:
     inputs:
       command: 'custom'
       custom: 'pack'
-      arguments: '--no-build -c Release -o packages\WebJobs.Script.Abstractions'
+      arguments: '--no-build -c Release -o packages'
       projects: |
         **\WebJobs.Script.Abstractions.csproj
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
     displayName: 'ESRP CodeSigning: Nupkg'
     inputs:
       ConnectedServiceName: 'ESRP Service'
-      FolderPath: 'packages\WebJobs.Script.Abstractions'
+      FolderPath: 'packages'
       Pattern: 'Microsoft.Azure.WebJobs.Script.Abstractions*.nupkg'
       signConfigType: inlineSignParams
       inlineOperation: |
@@ -239,7 +239,7 @@ jobs:
     inputs:
       command: 'custom'
       custom: 'pack'
-      arguments: '--no-build -c Release -o packages\ExtensionsMetadataGenerator $(emgSuffixSwitch)'
+      arguments: '--no-build -c Release -o packages $(emgSuffixSwitch)'
       projects: |
         **\ExtensionsMetadataGenerator.csproj
         steps:
@@ -247,7 +247,7 @@ jobs:
     displayName: 'ESRP CodeSigning: Nupkg'
     inputs:
       ConnectedServiceName: 'ESRP Service'
-      FolderPath: 'packages\ExtensionsMetadataGenerator'
+      FolderPath: 'packages'
       Pattern: 'Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator*.nupkg'
       signConfigType: inlineSignParams
       inlineOperation: |
@@ -282,7 +282,7 @@ jobs:
     artifact: Symbols
   - publish: $(Build.Repository.LocalPath)\packages
     artifact: NugetPackages
-  - publish: $(Build.Repository.LocalPath)\packages\WebJobs.Script.Performance.App
+  - publish: $(Build.Repository.LocalPath)\WebJobs.Script.Performance.App
     artifact: Performance
 
 - job: RunUnitTests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,7 +68,7 @@ jobs:
   - task: CopyFiles@2
     inputs:
       SourceFolder: '$(Build.Repository.LocalPath)\buildoutput'
-      Contents: '*.zip'
+      Contents: '**\*.zip'
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
   - task: DotNetCoreCLI@2
     displayName: 'Build host packages'
@@ -272,28 +272,18 @@ jobs:
     displayName: 'Delete CodeSignSummary files'
     inputs:
       contents: '**\CodeSignSummary-*.md'
-  - publish: $(Build.ArtifactStagingDirectory)\Functions.3.0.$(buildNumber)${{ variables.artifactSuffix }}.zip
-    artifact: Functions.3.0.$(buildNumber)${{ variables.artifactSuffix }}
-  - publish: $(Build.ArtifactStagingDirectory)\Functions.2.1.$(buildNumber)${{ variables.artifactSuffix }}.zip
-    artifact: Functions.2.1.$(buildNumber)${{ variables.artifactSuffix }}
-  - publish: $(Build.ArtifactStagingDirectory)\Functions.Private.3.0.$(buildNumber)${{ variables.artifactSuffix }}.win-x32.inproc.zip
-    artifact: Functions.Private.3.0.$(buildNumber)${{ variables.artifactSuffix }}.win-x32.inproc
-  - publish: $(Build.ArtifactStagingDirectory)\Functions.Symbols.3.0.$(buildNumber)${{ variables.artifactSuffix }}.win-x64.zip
-    artifact: Functions.Symbols.3.0.$(buildNumber)${{ variables.artifactSuffix }}.win-x64
-  - publish: $(Build.ArtifactStagingDirectory)\Functions.Symbols.3.0.$(buildNumber)${{ variables.artifactSuffix }}.win-x86.zip
-    artifact: Functions.Symbols.3.0.$(buildNumber)${{ variables.artifactSuffix }}.win-x86
-  - publish: $(Build.Repository.LocalPath)\packages\Microsoft.Azure.WebJobs.Script.3.0.$(buildNumber)${{ variables.artifactSuffix }}.nupkg
-    artifact: Microsoft.Azure.WebJobs.Script.3.0.$(buildNumber)${{ variables.artifactSuffix }}
-  - publish: $(Build.Repository.LocalPath)\packages\ExtensionsMetadataGenerator
-    artifact: ExtensionsMetadataGenerator${{ variables.artifactSuffix }}
+  - publish: $(Build.ArtifactStagingDirectory)\V2SiteExtension
+    artifact: V2SiteExtension
+  - publish: $(Build.ArtifactStagingDirectory)\SiteExtension
+    artifact: SiteExtension
+  - publish: $(Build.ArtifactStagingDirectory)\PrivateSiteExtension
+    artifact: PrivateSiteExtension
+  - publish: $(Build.ArtifactStagingDirectory)\Symbols
+    artifact: Symbols
+  - publish: $(Build.Repository.LocalPath)\packages
+    artifact: NugetPackages
   - publish: $(Build.Repository.LocalPath)\packages\WebJobs.Script.Performance.App
-    artifact: WebJobs.Script.Performance.App${{ variables.artifactSuffix }}
-  - publish: $(Build.Repository.LocalPath)\packages\Microsoft.Azure.WebJobs.Script.Grpc.3.0.$(buildNumber)${{ variables.artifactSuffix }}.nupkg
-    artifact: Microsoft.Azure.WebJobs.Script.Grpc.3.0.$(buildNumber)${{ variables.artifactSuffix }}
-  - publish: $(Build.Repository.LocalPath)\packages\WebJobs.Script.Abstractions
-    artifact: Microsoft.Azure.WebJobs.Script.Abstractions${{ variables.artifactSuffix }}
-  - publish: $(Build.Repository.LocalPath)\packages\Microsoft.Azure.WebJobs.Script.WebHost.3.0.$(buildNumber)${{ variables.artifactSuffix }}.nupkg
-    artifact: Microsoft.Azure.WebJobs.Script.WebHost.3.0.$(buildNumber)${{ variables.artifactSuffix }}
+    artifact: Performance
 
 - job: RunUnitTests
   pool:

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -146,9 +146,9 @@ function CreateSiteExtensions() {
     Write-Host ""
 
     Write-Host "======================================"
-    Write-Host "Generating $hashesForHardlinksFile"    
+    Write-Host "Generating hashes for hard links"
     WriteHashesFile $siteExtensionPath/$extensionVersionNoSuffix
-    Write-Host "Done generating $siteExtensionPath/$extensionVersionNoSuffix"
+    Write-Host "Done generating hashes for hard links into "$siteExtensionPath/$extensionVersionNoSuffix"
     Write-Host "======================================"
     Write-Host  
     

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -150,9 +150,7 @@ function CreateSiteExtensions() {
     WriteHashesFile $siteExtensionPath/$extensionVersionNoSuffix
     Write-Host "Done generating $siteExtensionPath/$extensionVersionNoSuffix"
     Write-Host "======================================"
-    Write-Host
-
-  
+    Write-Host  
     
     Write-Host "======================================"
     $stopwatch.Reset()

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -148,9 +148,9 @@ function CreateSiteExtensions() {
     Write-Host "======================================"
     Write-Host "Generating hashes for hard links"
     WriteHashesFile $siteExtensionPath/$extensionVersionNoSuffix
-    Write-Host "Done generating hashes for hard links into "$siteExtensionPath/$extensionVersionNoSuffix"
+    Write-Host "Done generating hashes for hard links into $siteExtensionPath/$extensionVersionNoSuffix"
     Write-Host "======================================"
-    Write-Host  
+    Write-Host
     
     Write-Host "======================================"
     $stopwatch.Reset()


### PR DESCRIPTION
I wanted to remove as many references to versions as I could to make moving to v4 (and v5, v6, etc) more straight-forward.

I looked through the devops pipelines that I knew about to see if anything depended on these artifact names and I didn't find anything. I assumed that there wouldn't be any hard dependencies since the names would change every build. But I want to see if @yojagad, @sidkri, @madelinegordon, @Francisco-Gamino had any objections.

*For example, the "Deploy to myget" step of the release pipeline uses paths like `$(System.DefaultWorkingDirectory)/_Azure.azure-functions-host/*/Microsoft.Azure.WebJobs.Script.3.*.nupkg`, which will continue to work.*

Here's what the change looks like:

Current (https://azfunc.visualstudio.com/Azure%20Functions/_build/results?buildId=12712&view=artifacts&pathAsName=false&type=publishedArtifacts):
![image](https://user-images.githubusercontent.com/1089915/115728705-90a30c00-a339-11eb-82a9-f261e56fb5f5.png)


This change (https://azfunc.visualstudio.com/Azure%20Functions/_build/results?buildId=12732&view=artifacts&pathAsName=false&type=publishedArtifacts):
![image](https://user-images.githubusercontent.com/1089915/115728719-939dfc80-a339-11eb-8874-7803f60acac5.png)

