### PR TITLE
Add test for no content type in HTTP trigger

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
@@ -626,6 +626,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         }
 
         [Fact]
+        public async Task HttpTrigger_Get_WithoutContentType_Succeeds()
+        {
+            await SamplesTestHelpers.InvokeAndValidateHttpTriggerWithoutContentType(_fixture, "HttpTrigger");
+        }
+
+        [Fact]
         public async Task Legacy_RequestTypes_Succeed()
         {
             var vars = new Dictionary<string, string>

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node.cs
@@ -117,6 +117,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         }
 
         [Fact]
+        public async Task HttpTrigger_Get_WithoutContentType_Succeeds()
+        {
+            await SamplesTestHelpers.InvokeAndValidateHttpTriggerWithoutContentType(_fixture, "HttpTrigger");
+        }
+
+        [Fact]
         public async Task InvokeProxy_GetsResponse()
         {
             string uri = "something";

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesTestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesTestHelpers.cs
@@ -28,7 +28,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             string masterKey = await fixture.Host.GetMasterKeyAsync();
             uri = $"api/{functionName}?code={masterKey}&name=Mathew";
             request = new HttpRequestMessage(HttpMethod.Get, uri);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/plain"));
+            response = await fixture.Host.HttpClient.SendAsync(request);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal("Hello Mathew", body);
+
+            // verify request suceeds without any content type set
+            uri = $"api/{functionName}?code={functionKey}&name=Mathew";
+            request = new HttpRequestMessage(HttpMethod.Get, uri);
+            response = await fixture.Host.HttpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal("Hello Mathew", body);
         }
 
         public static async Task<HttpResponseMessage> InvokeHttpTrigger(EndToEndTestFixture fixture, string functionName)

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesTestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesTestHelpers.cs
@@ -33,14 +33,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
             Assert.Equal("Hello Mathew", body);
-
-            // verify request suceeds without any content type set
-            uri = $"api/{functionName}?code={functionKey}&name=Mathew";
-            request = new HttpRequestMessage(HttpMethod.Get, uri);
-            response = await fixture.Host.HttpClient.SendAsync(request);
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
-            Assert.Equal("Hello Mathew", body);
         }
 
         public static async Task<HttpResponseMessage> InvokeHttpTrigger(EndToEndTestFixture fixture, string functionName)
@@ -51,6 +43,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/plain"));
 
             return await fixture.Host.HttpClient.SendAsync(request);
+        }
+
+        public static async Task InvokeAndValidateHttpTriggerWithoutContentType(EndToEndTestFixture fixture, string functionName)
+        {
+            string functionKey = await fixture.Host.GetFunctionSecretAsync(functionName);
+            string uri = $"api/{functionName}?code={functionKey}&name=Host";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
+
+            HttpResponseMessage response = await fixture.Host.HttpClient.SendAsync(request);
+            string body = await response.Content.ReadAsStringAsync();
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal("Hello Host", body);
         }
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-host/issues/6398

We may want to consider adding similar tests for no content-type in language workers. I will open an issue for Node. But at least this by covers the gap to avoid regressions like that.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

