### PR TITLE
[Linux] Remove obsolete disable container api

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
@@ -72,18 +72,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
             return Ok(_instanceManager.GetInstanceInfo());
         }
 
-        [HttpPost]
-        [Route("admin/instance/disable")]
-        [Authorize(Policy = PolicyNames.AdminAuthLevel)]
-        public async Task<IActionResult> Disable([FromServices] IScriptHostManager hostManager)
-        {
-            _logger.LogDebug("Disabling container");
-            // Mark the container disabled. We check for this on host restart
-            await Utility.MarkContainerDisabled(_logger);
-            var tIgnore = Task.Run(() => hostManager.RestartHostAsync());
-            return Ok();
-        }
-
         [HttpGet]
         [Route("admin/instance/http-health")]
         public IActionResult GetHttpHealthStatus()

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     State = ScriptHostState.Default;
                 }
 
-                bool isOffline = Utility.CheckAppOffline(_environment, _applicationHostOptions.CurrentValue.ScriptPath);
+                bool isOffline = Utility.CheckAppOffline(_applicationHostOptions.CurrentValue.ScriptPath);
                 State = isOffline ? ScriptHostState.Offline : State;
                 bool hasNonTransientErrors = startupMode.HasFlag(JobHostStartupMode.HandlingNonTransientError);
                 bool handlingError = startupMode.HasFlag(JobHostStartupMode.HandlingError);

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -216,16 +216,6 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
-        /// Gets a value indicating whether this specific linux consumption container instance is in offline mode.
-        /// </summary>
-        /// <param name="environment">The environment to verify</param>
-        /// <returns><see cref="true"/> if running in a Linux Consumption App Service app and the container is in draining mode; otherwise, false.</returns>
-        public static bool IsLinuxConsumptionContainerDisabled(this IEnvironment environment)
-        {
-            return environment.IsLinuxConsumption() && Utility.IsContainerDisabled();
-        }
-
-        /// <summary>
         /// Gets a value indicating whether the application is running in a Linux App Service
         /// environment (Dedicated Linux).
         /// </summary>

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -78,7 +78,6 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string ExtensionsMetadataFileName = "extensions.json";
         public const string AppOfflineFileName = "app_offline.htm";
         public const string RunFromPackageFailedFileName = "FAILED TO INITIALIZE RUN FROM PACKAGE.txt";
-        public const string DisableContainerFileName = "container_offline";
         public const string ResourcePath = "Microsoft.Azure.WebJobs.Script.WebHost.Resources";
 
         public const string DefaultMasterKeyName = "master";

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -675,29 +675,8 @@ namespace Microsoft.Azure.WebJobs.Script
             return indexedFunctions.Where(m => functionDescriptors.Select(fd => fd.Metadata.Name).Contains(m.Name) == true);
         }
 
-        public static async Task MarkContainerDisabled(ILogger logger)
+        public static bool CheckAppOffline(string scriptPath)
         {
-            logger.LogDebug("Setting container instance offline");
-            var disableContainerFilePath = Path.Combine(Path.GetTempPath(), ScriptConstants.DisableContainerFileName);
-            if (!FileUtility.FileExists(disableContainerFilePath))
-            {
-                await FileUtility.WriteAsync(disableContainerFilePath, "This container instance is offline");
-            }
-        }
-
-        public static bool IsContainerDisabled()
-        {
-            return FileUtility.FileExists(Path.Combine(Path.GetTempPath(), ScriptConstants.DisableContainerFileName));
-        }
-
-        public static bool CheckAppOffline(IEnvironment environment, string scriptPath)
-        {
-            // Linux container environments have an additional way of putting a specific worker instance offline.
-            if (environment.IsLinuxConsumptionContainerDisabled())
-            {
-                return true;
-            }
-
             // check if we should be in an offline state
             string offlineFilePath = Path.Combine(scriptPath, ScriptConstants.AppOfflineFileName);
             if (FileUtility.FileExists(offlineFilePath))

--- a/src/WebJobs.Script/Workers/Rpc/RpcInitializationService.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcInitializationService.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
-            if (Utility.CheckAppOffline(_environment, _applicationHostOptions.CurrentValue.ScriptPath))
+            if (Utility.CheckAppOffline(_applicationHostOptions.CurrentValue.ScriptPath))
             {
                 _logger.LogDebug("App is offline. RpcInitializationService will not be started");
                 return;

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
@@ -2,11 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IO;
-using System.IO.Abstractions;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -92,51 +89,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             Assert.Equal(objectResult.StatusCode, 500);
             Assert.Equal(objectResult.Value, "Specialize MSI sidecar call failed. StatusCode=BadRequest");
-        }
-
-        [Fact(Skip = "Test seems flaky. Would run fine locally though. Needs investigation. Issue: https://github.com/Azure/azure-functions-host/issues/7340")]
-        public async Task Disable_Writes_To_DisableContainerFile_Restarts_ScriptHost()
-        {
-            var environment = new TestEnvironment();
-            var loggerFactory = new LoggerFactory();
-            var loggerProvider = new TestLoggerProvider();
-            loggerFactory.AddProvider(loggerProvider);
-
-            var startupContextProvider = new StartupContextProvider(environment, loggerFactory.CreateLogger<StartupContextProvider>());
-            var instanceController = new InstanceController(environment, null, loggerFactory, startupContextProvider);
-            var scriptHostManager = new Mock<IScriptHostManager>();
-
-            var fileSystem = new Mock<IFileSystem>();
-            var fileBase = new Mock<FileBase>();
-            fileBase.Setup(
-                    f => f.Exists(It.Is<string>(path => path.EndsWith(ScriptConstants.DisableContainerFileName))))
-                .Returns(false);
-            fileSystem.SetupGet(fs => fs.File).Returns(fileBase.Object);
-
-            var memoryStream = new MemoryStream();
-            fileSystem.Setup(s =>
-                    s.File.Open(It.Is<string>(path => path.EndsWith(ScriptConstants.DisableContainerFileName)), FileMode.Create, FileAccess.Write, FileShare.Read))
-                .Returns(memoryStream);
-
-            FileUtility.Instance = fileSystem.Object;
-
-            scriptHostManager.Setup(s => s.RestartHostAsync(It.IsAny<CancellationToken>()));
-
-            var actionResult = await instanceController.Disable(scriptHostManager.Object);
-
-            FileUtility.Instance = null;
-
-            scriptHostManager.Verify(s => s.RestartHostAsync(It.IsAny<CancellationToken>()), Times.Once);
-
-            // Remove BOM
-            var memoryStreamContents = Encoding.UTF8.GetString(memoryStream.ToArray()).Trim(new char[] { '\uFEFF' });
-
-            Assert.Equal("This container instance is offline", memoryStreamContents);
-
-            var okResult = actionResult as OkResult;
-
-            Assert.NotNull(okResult);
-            Assert.Equal(200, okResult.StatusCode);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/UtilityTests.cs
+++ b/test/WebJobs.Script.Tests/UtilityTests.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Dynamic;
 using System.Globalization;
 using System.IO;
-using System.IO.Abstractions;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -569,31 +568,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             validFunctions = Utility.GetValidFunctions(functionMetadatas, functionDescriptors);
             Assert.Empty(validFunctions);
-        }
-
-        [Theory]
-        [InlineData(true, true, true)]
-        [InlineData(true, false, false)]
-        [InlineData(false, true, false)]
-        [InlineData(false, false, false)]
-        public void AppOfflineTests(bool isLinuxContainerEnvironment, bool containerDisabledFileExists, bool appOffline)
-        {
-            var vars = new Dictionary<string, string>
-            {
-                { EnvironmentSettingNames.AzureWebsiteInstanceId, isLinuxContainerEnvironment ? string.Empty : "Website_instance_id" },
-                { EnvironmentSettingNames.ContainerName, isLinuxContainerEnvironment ? "Container-Name" : string.Empty }
-            };
-
-            var fileSystem = new Mock<IFileSystem>();
-            fileSystem.Setup(f =>
-                    f.File.Exists(It.Is<string>(path => path.EndsWith(ScriptConstants.DisableContainerFileName))))
-                .Returns(containerDisabledFileExists);
-            FileUtility.Instance = fileSystem.Object;
-
-            var checkAppOffline = Utility.CheckAppOffline(new TestEnvironment(vars), string.Empty);
-            Assert.Equal(appOffline, checkAppOffline);
-
-            FileUtility.Instance = null;
         }
 
         [Theory]

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcInitializationServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcInitializationServiceTests.cs
@@ -106,12 +106,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName)).Returns(string.Empty);
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ContainerName)).Returns("LinuxContainer");
 
-            var fileSystem = new Mock<IFileSystem>();
-            fileSystem.Setup(f =>
-                    f.File.Exists(It.Is<string>(path => path.EndsWith(ScriptConstants.DisableContainerFileName))))
-                .Returns(false);
-            FileUtility.Instance = fileSystem.Object;
-
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
             await _rpcInitializationService.StartAsync(CancellationToken.None);
             _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.PythonLanguageWorkerName), Times.Once);
@@ -120,33 +114,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.PowerShellLanguageWorkerName), Times.Never);
             Assert.Contains("testserver", testRpcServer.Uri.ToString());
             await testRpcServer.ShutdownAsync();
-
-            FileUtility.Instance = null;
-        }
-
-        [Fact]
-        public async Task RpcInitializationService_Does_Not_Initialize_RpcServerAndChannels_LinuxConsumption_DisabledContainer()
-        {
-            IRpcServer testRpcServer = new TestRpcServer();
-            var mockEnvironment = new Mock<IEnvironment>();
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ContainerName)).Returns("LinuxContainer");
-
-            var fileSystem = new Mock<IFileSystem>();
-            fileSystem.Setup(f =>
-                    f.File.Exists(It.Is<string>(path => path.EndsWith(ScriptConstants.DisableContainerFileName))))
-                .Returns(true);
-            FileUtility.Instance = fileSystem.Object;
-
-            _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
-            await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.PythonLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.NodeLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.JavaLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.PowerShellLanguageWorkerName), Times.Never);
-            Assert.DoesNotContain("testserver", testRpcServer.Uri.ToString());
-            await testRpcServer.ShutdownAsync();
-
-            FileUtility.Instance = null;
         }
 
         [Fact]
@@ -158,12 +125,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName)).Returns(string.Empty);
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ContainerName)).Returns("LinuxContainer");
 
-            var fileSystem = new Mock<IFileSystem>();
-            fileSystem.Setup(f =>
-                    f.File.Exists(It.Is<string>(path => path.EndsWith(ScriptConstants.DisableContainerFileName))))
-                .Returns(false);
-            FileUtility.Instance = fileSystem.Object;
-
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
             await _rpcInitializationService.StartAsync(CancellationToken.None);
             _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.PythonLanguageWorkerName), Times.Never);
@@ -172,8 +133,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.PowerShellLanguageWorkerName), Times.Never);
             Assert.Contains("testserver", testRpcServer.Uri.ToString());
             await testRpcServer.ShutdownAsync();
-
-            FileUtility.Instance = null;
         }
 
         [Fact]


### PR DESCRIPTION
API was originally added as a temporary workaround for lack of a drain mode api.

<!-- Please provide all the information below.  -->

Fixes https://github.com/Azure/azure-functions-host/issues/7355
https://github.com/Azure/azure-functions-host/issues/7340
### Pull request checklist

* [X ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
