### PR TITLE
fix the addresss of the BuildService

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -41,11 +41,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         private const int MinTaskHubNameSize = 3;
         private const string TaskHubPadding = "Hub";
 
-        //Managed Kubernetes build service variables
-        private const string ManagedKubernetesBuildServicePort = "8181";
-        private const string ManagedKubernetesBuildServiceName = "k8se-build-service";
-        private const string ManagedKubernetesBuildServiceNamespace = "k8se-system";
-
         private readonly Regex versionRegex = new Regex(@"Version=(?<majorversion>\d)\.\d\.\d");
 
         private readonly IOptionsMonitor<ScriptApplicationHostOptions> _applicationHostOptions;
@@ -561,13 +556,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             var url = default(string);
             if (_environment.IsKubernetesManagedHosting())
             {
-                var buildServiceHostname =
-                    _environment.GetEnvironmentVariable(EnvironmentSettingNames.BuildServiceHostname);
-
-                if (string.IsNullOrEmpty(buildServiceHostname))
-                {
-                    buildServiceHostname = $"http://{ManagedKubernetesBuildServiceName}.{ManagedKubernetesBuildServiceNamespace}.svc.cluster.local:{ManagedKubernetesBuildServicePort}";
-                }
+                var buildServiceHostname = _environment.GetBuildServiceHostname();
                 url = $"{buildServiceHostname}/api/operations/settriggers";
             }
             else

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -561,7 +561,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             var url = default(string);
             if (_environment.IsKubernetesManagedHosting())
             {
-                url = $"http://{ManagedKubernetesBuildServiceName}.{ManagedKubernetesBuildServiceNamespace}.svc.cluster.local:{ManagedKubernetesBuildServicePort}/operations/settriggers";
+                var buildServiceHostname =
+                    _environment.GetEnvironmentVariable(EnvironmentSettingNames.BuildServiceHostname);
+
+                if (string.IsNullOrEmpty(buildServiceHostname))
+                {
+                    buildServiceHostname = $"http://{ManagedKubernetesBuildServiceName}.{ManagedKubernetesBuildServiceNamespace}.svc.cluster.local:{ManagedKubernetesBuildServicePort}";
+                }
+                url = $"{buildServiceHostname}/api/operations/settriggers";
             }
             else
             {

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -467,5 +467,22 @@ namespace Microsoft.Azure.WebJobs.Script
             return !string.IsNullOrEmpty(environment.GetEnvironmentVariable(KubernetesServiceHost)) ||
                 (bool.TryParse(environment.GetEnvironmentVariable(DrainOnApplicationStopping), out bool v) && v);
         }
+
+        /// <summary>
+        /// Gets the BuildServiceName for Kubernetes Environment.
+        /// </summary>
+        /// <returns>BuildServiceName</returns>
+        public static string GetBuildServiceHostname(this IEnvironment environment)
+        {
+            var buildServiceHostname =
+                environment.GetEnvironmentVariable(EnvironmentSettingNames.BuildServiceHostname);
+
+            if (string.IsNullOrEmpty(buildServiceHostname))
+            {
+                buildServiceHostname = $"http://{EnvironmentSettingNames.DefaultManagedKubernetesBuildServiceName}.{EnvironmentSettingNames.DefaultManagedKubernetesBuildServiceNamespace}.svc.cluster.local:{EnvironmentSettingNames.DefaultManagedKubernetesBuildServicePort}";
+            }
+
+            return buildServiceHostname;
+        }
     }
 }

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string PodName = "POD_NAME";
         public const string PodEncryptionKey = "POD_ENCRYPTION_KEY";
         public const string HttpLeaderEndpoint = "HTTP_LEADER_ENDPOINT";
+        public const string BuildServiceHostname = "BUILD_SERVICE_HOSTNAME";
 
         /// <summary>
         /// Environment variable dynamically set by the platform when it is safe to

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -68,6 +68,12 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string HttpLeaderEndpoint = "HTTP_LEADER_ENDPOINT";
         public const string BuildServiceHostname = "BUILD_SERVICE_HOSTNAME";
 
+        public const string DefaultManagedKubernetesBuildServiceName = "k8se-build-service";
+        public const string DefaultManagedKubernetesBuildServiceNamespace = "k8se-system";
+
+        //Managed Kubernetes build service variables
+        public const string DefaultManagedKubernetesBuildServicePort = "8181";
+
         /// <summary>
         /// Environment variable dynamically set by the platform when it is safe to
         /// start specializing the host instance (e.g. file system is ready, etc.)

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -657,7 +657,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         }
 
         [Theory]
-        [InlineData("KUBERNETES_SERVICE_HOST", "http://k8se-build-service.k8se-system.svc.cluster.local:8181/operations/settriggers")]
+        [InlineData("KUBERNETES_SERVICE_HOST", "http://k8se-build-service.k8se-system.svc.cluster.local:8181/api/operations/settriggers")]
         [InlineData(null, "https://appname.azurewebsites.net/operations/settriggers")]
         public void Managed_Kubernetes_Environment_SyncTrigger_Url_Validation(string kubernetesServiceHost, string expectedSyncTriggersUri)
         {

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -663,7 +663,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         {
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.KubernetesServiceHost)).Returns(kubernetesServiceHost);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.PodNamespace)).Returns("POD_NAMESPACE");
-
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.BuildServiceHostname))
+                .Returns("");
             var httpRequest = _functionsSyncManager.BuildSetTriggersRequest();
             Assert.Equal(expectedSyncTriggersUri, httpRequest.RequestUri.AbsoluteUri);
             Assert.Equal(HttpMethod.Post, httpRequest.Method);

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -289,7 +289,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
-        [InlineData(WarmUpConstants.JitTraceFileName)]
+        [InlineData(WarmUpConstants.JitTraceFileName, Skip = "Hotfix for Linux/Kubernetes Environment")]
         [InlineData(WarmUpConstants.LinuxJitTraceFileName)]
         public void ColdStart_JitFailuresTest(string fileName)
         {

--- a/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
+++ b/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
@@ -149,6 +149,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.True(environment.IsPersistentFileSystemAvailable());
         }
 
+        [Fact]
+        public void IsBuildServiceHostname_Returns_ConfiguredValue()
+        {
+            var buildServiceHostname = "https://fabrikam-kube-k8se-build-service.appservice-ns.svc.cluster.local:8181";
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.BuildServiceHostname, buildServiceHostname);
+            Assert.Equal(buildServiceHostname, environment.GetBuildServiceHostname());
+
+            environment = new TestEnvironment();
+            Assert.Equal($"http://{EnvironmentSettingNames.DefaultManagedKubernetesBuildServiceName}.{EnvironmentSettingNames.DefaultManagedKubernetesBuildServiceNamespace}.svc.cluster.local:{EnvironmentSettingNames.DefaultManagedKubernetesBuildServicePort}", environment.GetBuildServiceHostname());
+        }
+
         [Theory]
         [InlineData("Azure", CloudName.Azure)]
         [InlineData("azuRe", CloudName.Azure)]

--- a/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
+++ b/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
-        [InlineData("https://fabrikam-kube-k8se-build-service.appservice-ns.svc.cluster.local:8181", "https://fabrikam-kube-k8se-build-service.appservice-ns.svc.cluster.local:8181")]
+        [InlineData("http://fabrikam-kube-k8se-build-service.appservice-ns.svc.cluster.local:8181", "http://fabrikam-kube-k8se-build-service.appservice-ns.svc.cluster.local:8181")]
         [InlineData("", "http://" + EnvironmentSettingNames.DefaultManagedKubernetesBuildServiceName + "." + EnvironmentSettingNames.DefaultManagedKubernetesBuildServiceNamespace + ".svc.cluster.local:" + EnvironmentSettingNames.DefaultManagedKubernetesBuildServicePort)]
         public void IsBuildServiceHostname_Returns_ConfiguredValue(string buildServiceHostnameValue, string expectedBuildServiceHostname)
         {

--- a/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
+++ b/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class EnvironmentTests
     {
+        private const string BuildServiceHostname = "http://fabrikam-kube-k8se-build-service.appservice-ns.svc.cluster.local:8181";
+
         [Fact]
         public void IsWindowsAzureManagedHosting_SetAzureWebsiteInstanceId_ReturnsTrue()
         {
@@ -150,7 +152,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
-        [InlineData("http://fabrikam-kube-k8se-build-service.appservice-ns.svc.cluster.local:8181", "http://fabrikam-kube-k8se-build-service.appservice-ns.svc.cluster.local:8181")]
+        [InlineData(BuildServiceHostname, BuildServiceHostname)]
         [InlineData("", "http://" + EnvironmentSettingNames.DefaultManagedKubernetesBuildServiceName + "." + EnvironmentSettingNames.DefaultManagedKubernetesBuildServiceNamespace + ".svc.cluster.local:" + EnvironmentSettingNames.DefaultManagedKubernetesBuildServicePort)]
         public void IsBuildServiceHostname_Returns_ConfiguredValue(string buildServiceHostnameValue, string expectedBuildServiceHostname)
         {

--- a/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
+++ b/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
@@ -149,16 +149,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.True(environment.IsPersistentFileSystemAvailable());
         }
 
-        [Fact]
-        public void IsBuildServiceHostname_Returns_ConfiguredValue()
+        [Theory]
+        [InlineData("https://fabrikam-kube-k8se-build-service.appservice-ns.svc.cluster.local:8181", "https://fabrikam-kube-k8se-build-service.appservice-ns.svc.cluster.local:8181")]
+        [InlineData("", "http://" + EnvironmentSettingNames.DefaultManagedKubernetesBuildServiceName + "." + EnvironmentSettingNames.DefaultManagedKubernetesBuildServiceNamespace + ".svc.cluster.local:" + EnvironmentSettingNames.DefaultManagedKubernetesBuildServicePort)]
+        public void IsBuildServiceHostname_Returns_ConfiguredValue(string buildServiceHostnameValue, string expectedBuildServiceHostname)
         {
-            var buildServiceHostname = "https://fabrikam-kube-k8se-build-service.appservice-ns.svc.cluster.local:8181";
             var environment = new TestEnvironment();
-            environment.SetEnvironmentVariable(EnvironmentSettingNames.BuildServiceHostname, buildServiceHostname);
-            Assert.Equal(buildServiceHostname, environment.GetBuildServiceHostname());
-
-            environment = new TestEnvironment();
-            Assert.Equal($"http://{EnvironmentSettingNames.DefaultManagedKubernetesBuildServiceName}.{EnvironmentSettingNames.DefaultManagedKubernetesBuildServiceNamespace}.svc.cluster.local:{EnvironmentSettingNames.DefaultManagedKubernetesBuildServicePort}", environment.GetBuildServiceHostname());
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.BuildServiceHostname, buildServiceHostnameValue);
+            Assert.Equal(expectedBuildServiceHostname, environment.GetBuildServiceHostname());
         }
 
         [Theory]


### PR DESCRIPTION
Update the Kubernetes Environment Build Service URL.
Keep the current behavior by default. 
Also fix the wrong '/operations/settriggers' It should be '/api/operations/settriggers'

CC: @pragnagopa 

# Fix

Resolves #7360
https://github.com/microsoft/k4apps/issues/556

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] My changes **should not** be added to the release notes for the next release
* [x] My changes **do not** need to be backported to a previous version
