### PR TITLE
Prefer Interpretation in WebHostServiceProvider DryIoc Container for Linux Consumption

### DIFF
--- a/src/WebJobs.Script.WebHost/DependencyInjection/JobHostServiceProvider.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/JobHostServiceProvider.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
             // preferInterpretation will be set to true to significanly improve cold start in consumption mode
             // it will be set to false for premium and appservice plans to make sure throughput is not impacted
             // there is no throughput drop in consumption with this setting.
-            var preferInterpretation = SystemEnvironment.Instance.IsWindowsConsumption() || SystemEnvironment.Instance.IsLinuxConsumption() ? true : false;
+            var preferInterpretation = SystemEnvironment.Instance.IsConsumptionSku() ? true : false;
             var container = new Container(r => rules, preferInterpretation: preferInterpretation);
 
             container.Populate(descriptors);

--- a/src/WebJobs.Script.WebHost/DependencyInjection/WebHostServiceProvider.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/WebHostServiceProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
             // preferInterpretation will be set to true to significanly improve cold start in consumption mode
             // it will be set to false for premium and appservice plans to make sure throughput is not impacted
             // there is no throughput drop in consumption with this setting.
-            var preferInterpretation = SystemEnvironment.Instance.IsWindowsConsumption() ? true : false;
+            var preferInterpretation = SystemEnvironment.Instance.IsConsumptionSku() ? true : false;
             _container = new Container(_defaultContainerRules, preferInterpretation: preferInterpretation);
             _container.Populate(descriptors);
             _container.UseInstance<IServiceProvider>(this);

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -190,7 +190,12 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public static bool IsDynamicSku(this IEnvironment environment)
         {
-            return environment.IsWindowsConsumption() || environment.IsWindowsElasticPremium() || environment.IsLinuxConsumption();
+            return environment.IsConsumptionSku() || environment.IsWindowsElasticPremium();
+        }
+
+        public static bool IsConsumptionSku(this IEnvironment environment)
+        {
+            return environment.IsWindowsConsumption() || environment.IsLinuxConsumption();
         }
 
         /// <summary>

--- a/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
+++ b/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
@@ -197,5 +197,53 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.CloudName, cloudNameSetting);
             Assert.Equal(suffix, testEnvironment.GetVaultSuffix());
         }
+
+        [Theory]
+        [InlineData(ScriptConstants.DynamicSku, true)]
+        [InlineData("test", false)]
+        [InlineData("", false)]
+        [InlineData(null, false)]
+        public void Returns_IsWindowsConsumption(string websiteSku, bool isWindowsElasticPremium)
+        {
+            var testEnvironment = new TestEnvironment();
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, websiteSku);
+            Assert.Equal(isWindowsElasticPremium, testEnvironment.IsWindowsConsumption());
+            Assert.Equal(isWindowsElasticPremium, testEnvironment.IsConsumptionSku());
+            Assert.Equal(isWindowsElasticPremium, testEnvironment.IsDynamicSku());
+        }
+
+        [Theory]
+        [InlineData("website-instance-id", "container-name", false)]
+        [InlineData("website-instance-id", "", false)]
+        [InlineData("website-instance-id", null, false)]
+        [InlineData("", "container-name", true)]
+        [InlineData(null, "container-name", true)]
+        [InlineData("", "", false)]
+        [InlineData(null, "", false)]
+        [InlineData("", null, false)]
+        [InlineData(null, null, false)]
+        public void Returns_IsLinuxConsumption(string websiteInstanceId, string containerName, bool isLinuxConsumption)
+        {
+            var testEnvironment = new TestEnvironment();
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, websiteInstanceId);
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, containerName);
+            Assert.Equal(isLinuxConsumption, testEnvironment.IsLinuxConsumption());
+            Assert.Equal(isLinuxConsumption, testEnvironment.IsConsumptionSku());
+            Assert.Equal(isLinuxConsumption, testEnvironment.IsDynamicSku());
+        }
+
+        [Theory]
+        [InlineData(ScriptConstants.ElasticPremiumSku, true)]
+        [InlineData("test", false)]
+        [InlineData("", false)]
+        [InlineData(null, false)]
+        public void Returns_IsWindowsElasticPremium(string websiteSku, bool isWindowsElasticPremium)
+        {
+            var testEnvironment = new TestEnvironment();
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, websiteSku);
+            Assert.Equal(isWindowsElasticPremium, testEnvironment.IsWindowsElasticPremium());
+            Assert.Equal(isWindowsElasticPremium, testEnvironment.IsDynamicSku());
+            Assert.False(testEnvironment.IsConsumptionSku());
+        }
     }
 }


### PR DESCRIPTION
Noticed this was being done in JobHostServiceProvider but not in WebHostServiceProvider

<!-- Please provide all the information below.  -->

https://github.com/Azure/azure-functions-host/issues/7378

resolves https://github.com/Azure/azure-functions-host/issues/7378

### Pull request checklist

* [ X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
