### PR TITLE
Add host.json for sync trigger payload

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -386,7 +386,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             {
                 try
                 {
-                    _logger.LogInformation("Reading host.json for SyncTrigger.");
                     var hostJson = JObject.Parse(await FileUtility.ReadAsync(hostJsonPath));
                     if (hostJson.TryGetValue("extensions", out JToken token))
                     {

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -383,7 +383,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             try
             {
                 _logger.LogInformation("Reading host.json for SyncTrigger.");
-                return JObject.Parse(await FileUtility.ReadAsync(hostJsonPath));
+                var hostJson = JObject.Parse(await FileUtility.ReadAsync(hostJsonPath));
+                if (hostJson.TryGetValue("extensions", out JToken token))
+                {
+                    return (JObject)token;
+                }
+                else
+                {
+                    return defaultJObject;
+                }
             }
             catch (JsonException ex)
             {

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -308,7 +308,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             // Add the host.json extensions to the payload
             if (_environment.IsKubernetesManagedHosting())
             {
-                JObject extensionsPayload = await GetHostJsonExtensionsAsync();
+                JObject extensionsPayload = await GetHostJsonExtensionsAsync(_applicationHostOptions, _logger);
                 if (extensionsPayload != null)
                 {
                     result.Add("extensions", extensionsPayload);
@@ -378,9 +378,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             };
         }
 
-        internal async Task<JObject> GetHostJsonExtensionsAsync()
+        internal static async Task<JObject> GetHostJsonExtensionsAsync(IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, ILogger logger)
         {
-            var hostOptions = _applicationHostOptions.CurrentValue.ToHostOptions();
+            var hostOptions = applicationHostOptions.CurrentValue.ToHostOptions();
             string hostJsonPath = Path.Combine(hostOptions.RootScriptPath, ScriptConstants.HostMetadataFileName);
             if (FileUtility.FileExists(hostJsonPath))
             {
@@ -398,7 +398,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 }
                 catch (JsonException ex)
                 {
-                    _logger.LogWarning($"Unable to parse host configuration file '{hostJsonPath}'. : {ex}");
+                    logger.LogWarning($"Unable to parse host configuration file '{hostJsonPath}'. : {ex}");
                     return null;
                 }
             }

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -382,12 +382,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             }
             catch (JsonException ex)
             {
-                _logger.LogWarning($"Unable to parse host configuration file '{scriptPath}'. : {ex}");
+                _logger.LogWarning($"Unable to parse host configuration file '{hostFilePath}'. : {ex}");
                 return defaultJObject;
             }
             catch (Exception ex) when (ex is FileNotFoundException || ex is DirectoryNotFoundException)
             {
-                _logger.LogWarning($"Unable to find host configuration file '{scriptPath}'. : {ex}");
+                _logger.LogWarning($"Unable to find host configuration file '{hostFilePath}'. : {ex}");
                 return defaultJObject;
             }
         }

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -304,8 +304,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             var functionDetails = await WebFunctionsManager.GetFunctionMetadataResponse(listableFunctions, hostOptions, _hostNameProvider);
             result.Add("functions", new JArray(functionDetails.Select(p => JObject.FromObject(p))));
 
-            // Add host.json to the pyaload
-            result.Add("host.json", GetHostJson());
+            // Add host.json to the payload
+            if (_environment.IsKubernetesManagedHosting())
+            {
+                result.Add("host.json", GetHostJson());
+            }
 
             // Add functions secrets to the payload
             // Only secret types we own/control can we cache directly

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -372,25 +372,25 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             };
         }
 
-        internal JObject GetHostJson()
+        internal Task<JObject> GetHostJsonAsync()
         {
             var defaultJObject = new JObject();
-            var scriptPath = _applicationHostOptions.CurrentValue?.ScriptPath;
-            string hostFilePath = Path.Combine(scriptPath, ScriptConstants.HostMetadataFileName);
+            var hostOptions = _applicationHostOptions.CurrentValue.ToHostOptions();
+            string hostJsonPath = Path.Combine(hostOptions.RootScriptPath, ScriptConstants.HostMetadataFileName);
             try
             {
                 _logger.LogInformation("Reading host.json for SyncTrigger.");
-                string json = File.ReadAllText(scriptPath);
-                return JObject.Parse(json);
+                return JObject.Parse(await FileUtility.ReadAsync(hostJsonPath));
+
             }
             catch (JsonException ex)
             {
-                _logger.LogWarning($"Unable to parse host configuration file '{hostFilePath}'. : {ex}");
+                _logger.LogWarning($"Unable to parse host configuration file '{hostJsonPath}'. : {ex}");
                 return defaultJObject;
             }
             catch (Exception ex) when (ex is FileNotFoundException || ex is DirectoryNotFoundException)
             {
-                _logger.LogWarning($"Unable to find host configuration file '{hostFilePath}'. : {ex}");
+                _logger.LogWarning($"Unable to find host configuration file '{hostJsonPath}'. : {ex}");
                 return defaultJObject;
             }
         }

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -387,7 +387,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             }
             catch (Exception ex) when (ex is FileNotFoundException || ex is DirectoryNotFoundException)
             {
-                _logger.LogWarning($"Unable to find host configuration file '{scriptPath}'. : {ex.Message} : {ex.StackTrace}");
+                _logger.LogWarning($"Unable to find host configuration file '{scriptPath}'. : {ex}");
                 return defaultJObject;
             }
         }

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -382,7 +382,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             }
             catch (JsonException ex)
             {
-                _logger.LogWarning($"Unable to parse host configuration file '{scriptPath}'. : {ex.Message} : {ex.StackTrace}");
+                _logger.LogWarning($"Unable to parse host configuration file '{scriptPath}'. : {ex}");
                 return defaultJObject;
             }
             catch (Exception ex) when (ex is FileNotFoundException || ex is DirectoryNotFoundException)

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -344,7 +344,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 Assert.True(logMessages[0].StartsWith("Making SyncTriggers request"));
                 var startIdx = logMessages[0].IndexOf("Content=") + 8;
                 var endIdx = logMessages[0].LastIndexOf(')');
-                var sanitizedContent = logMessages[1].Substring(startIdx, endIdx - startIdx);
+                var sanitizedContent = logMessages[0].Substring(startIdx, endIdx - startIdx);
                 var sanitizedObject = JObject.Parse(sanitizedContent);
                 JToken value = null;
                 var secretsLogged = sanitizedObject.TryGetValue("secrets", out value);
@@ -403,7 +403,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 var logMessages = _loggerProvider.GetAllLogMessages().Where(m => m.Category.Equals(SyncManagerLogCategory)).Select(p => p.FormattedMessage).ToArray();
 
                 Assert.True(logMessages[0].Contains("Content="));
-                Assert.Equal(expectedErrorMessage, logMessages[0]);
+                Assert.Equal(expectedErrorMessage, logMessages[1]);
             }
         }
 

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -145,6 +145,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 $"{{\"name\":\"myQueueItem\",\"type\":\"activityTrigger\",\"direction\":\"in\",\"queueName\":\"myqueue-items\",\"connection\":\"{postedConnection}\",\"functionName\":\"function3\"{taskHubSegment}}}]";
         }
 
+        private void CreateDefaultHostJson()
+        {
+            ResetMockFileSystem(new JObject().ToString());
+        }
+
         private void ResetMockFileSystem(string hostJsonContent = null, string extensionsJsonContent = null)
         {
             var fileSystem = CreateFileSystem(_hostOptions, hostJsonContent, extensionsJsonContent);
@@ -211,6 +216,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         public async Task TrySyncTriggers_PostsExpectedContent(bool cacheEnabled)
         {
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteArmCacheEnabled)).Returns(cacheEnabled ? "1" : "0");
+            CreateDefaultHostJson();
 
             using (var env = new TestScopedEnvironmentVariable(_vars))
             {
@@ -269,6 +275,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             Assert.Equal("bbb", (string)function1Secrets["secrets"]["TestFunctionKey2"]);
 
             var logs = _loggerProvider.GetAllLogMessages().Where(m => m.Category.Equals(SyncManagerLogCategory)).ToList();
+            Console.WriteLine("******************* VerifyResultWithCacheOne Search start");
+            foreach (var message in logs)
+            {
+                Console.WriteLine($"***: {message}");
+            }
+            Console.WriteLine("******************* VerifyResultWithCacheOne Search end");
             var log = logs[1];
             int startIdx = log.FormattedMessage.IndexOf("Content=") + 8;
             int endIdx = log.FormattedMessage.LastIndexOf(')');
@@ -378,6 +390,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         [Fact]
         public async Task TrySyncTriggers_BackgroundSync_SetTriggersFailure_HashNotUpdated()
         {
+            CreateDefaultHostJson();
             using (var env = new TestScopedEnvironmentVariable(_vars))
             {
                 var hashBlob = await _functionsSyncManager.GetHashBlobAsync();

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -269,12 +269,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             Assert.Equal("bbb", (string)function1Secrets["secrets"]["TestFunctionKey2"]);
 
             var logs = _loggerProvider.GetAllLogMessages().Where(m => m.Category.Equals(SyncManagerLogCategory)).ToList();
-            Console.WriteLine("******************* VerifyResultWithCacheOne Search start");
-            foreach (var message in logs)
-            {
-                Console.WriteLine($"***: {message}");
-            }
-            Console.WriteLine("******************* VerifyResultWithCacheOne Search end");
+
             var log = logs[0];
             int startIdx = log.FormattedMessage.IndexOf("Content=") + 8;
             int endIdx = log.FormattedMessage.LastIndexOf(')');
@@ -406,12 +401,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
                 // verify log statements
                 var logMessages = _loggerProvider.GetAllLogMessages().Where(m => m.Category.Equals(SyncManagerLogCategory)).Select(p => p.FormattedMessage).ToArray();
-                Console.WriteLine("******************* Log Contents Search start");
-                foreach (var message in logMessages)
-                {
-                    Console.WriteLine($"***: {message}");
-                }
-                Console.WriteLine("******************* Log Contents Search end");
+
                 Assert.True(logMessages[0].Contains("Content="));
                 Assert.Equal(expectedErrorMessage, logMessages[0]);
             }

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -400,6 +400,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
                 // verify log statements
                 var logMessages = _loggerProvider.GetAllLogMessages().Where(m => m.Category.Equals(SyncManagerLogCategory)).Select(p => p.FormattedMessage).ToArray();
+                Console.WriteLine("******************* Log Contents Search start");
+                foreach (var message in logMessages)
+                {
+                    Console.WriteLine($"***: {message}");
+                }
+                Console.WriteLine("******************* Log Contents Search end");
                 Assert.True(logMessages[1].Contains("Content="));
                 Assert.Equal(expectedErrorMessage, logMessages[1]);
             }

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -269,7 +269,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             Assert.Equal("bbb", (string)function1Secrets["secrets"]["TestFunctionKey2"]);
 
             var logs = _loggerProvider.GetAllLogMessages().Where(m => m.Category.Equals(SyncManagerLogCategory)).ToList();
-            var log = logs[0];
+            var log = logs[1];
             int startIdx = log.FormattedMessage.IndexOf("Content=") + 8;
             int endIdx = log.FormattedMessage.LastIndexOf(')');
             var triggersLog = log.FormattedMessage.Substring(startIdx, endIdx - startIdx).Trim();
@@ -340,16 +340,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
                 // verify log statements
                 var logMessages = _loggerProvider.GetAllLogMessages().Where(m => m.Category.Equals(SyncManagerLogCategory)).Select(p => p.FormattedMessage).ToArray();
-                Assert.True(logMessages[0].StartsWith("Making SyncTriggers request"));
-                var startIdx = logMessages[0].IndexOf("Content=") + 8;
-                var endIdx = logMessages[0].LastIndexOf(')');
-                var sanitizedContent = logMessages[0].Substring(startIdx, endIdx - startIdx);
+                Assert.True(logMessages[1].StartsWith("Making SyncTriggers request"));
+                var startIdx = logMessages[1].IndexOf("Content=") + 8;
+                var endIdx = logMessages[1].LastIndexOf(')');
+                var sanitizedContent = logMessages[1].Substring(startIdx, endIdx - startIdx);
                 var sanitizedObject = JObject.Parse(sanitizedContent);
                 JToken value = null;
                 var secretsLogged = sanitizedObject.TryGetValue("secrets", out value);
                 Assert.False(secretsLogged);
-                Assert.Equal("SyncTriggers call succeeded.", logMessages[1]);
-                Assert.Equal($"SyncTriggers hash updated to '{hash}'", logMessages[2]);
+                Assert.Equal("SyncTriggers call succeeded.", logMessages[2]);
+                Assert.Equal($"SyncTriggers hash updated to '{hash}'", logMessages[3]);
 
                 // now sync again - don't expect a sync triggers call this time
                 _loggerProvider.ClearAllLogMessages();
@@ -400,7 +400,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
                 // verify log statements
                 var logMessages = _loggerProvider.GetAllLogMessages().Where(m => m.Category.Equals(SyncManagerLogCategory)).Select(p => p.FormattedMessage).ToArray();
-                Assert.True(logMessages[0].Contains("Content="));
+                Assert.True(logMessages[1].Contains("Content="));
                 Assert.Equal(expectedErrorMessage, logMessages[1]);
             }
         }

--- a/test/WebJobs.Script.Tests/Managment/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Managment/FunctionsSyncManagerTests.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost.Management;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
+{
+    public class FunctionsSyncManagerTests
+    {
+        private const string HostJsonWithExtensions = @"
+{
+  ""version"": ""2.0"",
+  ""logging"": {
+    ""applicationInsights"": {
+      ""samplingSettings"": {
+        ""isEnabled"": true,
+        ""excludedTypes"": ""Request""
+      }
+    }
+  },
+  ""extensionBundle"": {
+    ""id"": ""Microsoft.Azure.Functions.ExtensionBundle"",
+    ""version"": ""[2.*, 3.0.0)""
+  },
+  ""extensions"": {
+    ""queues"": {
+      ""maxPollingInterval"": ""00:00:30"",
+      ""visibilityTimeout"": ""00:01:00"",
+      ""batchSize"": 16,
+      ""maxDequeueCount"": 5,
+      ""newBatchThreshold"": 8,
+      ""messageEncoding"": ""base64""
+    }
+  }
+}
+";
+
+        private const string HostJsonWithoutExtensions = @"{}";
+
+        private const string HostJsonWithWrongExtensions = @"
+{
+  ""version"": ""2.0"",
+  ""extensions"": {
+    ""queues"": 
+      ""maxPollingInterval"": ""00:00:30"",
+      ""visibilityTimeout"": ""00:01:00"",
+      ""batchSize"": 16,
+      ""maxDequeueCount"": 5,
+      ""newBatchThreshold"": 8,
+      ""messageEncoding"": ""base64""
+    }
+  }
+}
+";
+
+        [Theory]
+        [InlineData(HostJsonWithExtensions, false, false, "00:00:30")]
+        [InlineData(HostJsonWithoutExtensions, true, false, "")]
+        [InlineData(HostJsonWithExtensions, true, true, "")]
+        [InlineData(HostJsonWithWrongExtensions, true, false, "")]
+        public async Task GetHostJsonExtensionsAsyncTest(string hostJsonContents, bool isNull, bool skipWriteFile, string value)
+        {
+            var logger = new Mock<ILogger>();
+            var monitor = new Mock<IOptionsMonitor<ScriptApplicationHostOptions>>();
+            var options = new ScriptApplicationHostOptions();
+            var scriptPath = GetTempDirectory();
+            var hostJsonPath = Path.Combine(scriptPath, "host.json");
+            if (!skipWriteFile)
+            {
+                await FileUtility.WriteAsync(hostJsonPath, hostJsonContents);
+            }
+
+            options.ScriptPath = scriptPath;
+            monitor.Setup(x => x.CurrentValue).Returns(options);
+            var json = await FunctionsSyncManager.GetHostJsonExtensionsAsync(monitor.Object, logger.Object);
+            if (isNull)
+            {
+                Assert.Null(json);
+            }
+            else
+            {
+                Assert.Equal(value, json["queues"]?["maxPollingInterval"]);
+            }
+            await FileUtility.DeleteDirectoryAsync(scriptPath, true);
+        }
+
+        private string GetTempDirectory()
+        {
+            var temp = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(temp);
+            return temp;
+        }
+    }
+}


### PR DESCRIPTION
Under the Kubernetes Environment, We need to `host.json` payload for SyncTrigger scenario for transforming Durable Functions and LogicApp scenario. 

I currently testing this branch not finished, so that I make it Draft, However, this change should requires discussion with us. I just simply add the `host.json` payload on the current sync trigger payload. 

CC @pragnagopa , @ahmelsayed 

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-host/issues/7288 https://github.com/Azure/azure-functions-host/issues/7382

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

