### PR TITLE
Using Script host logger after disposal breaks Host restart

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -705,12 +705,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                             }
                         }, cancellationToken);
 
-                        GetHostLogger(instance).LogDebug("Standby ScriptHost marked for disposal");
+                        _logger.LogDebug("Standby ScriptHost marked for disposal");
                     }
                     else
                     {
                         instance.Dispose();
-                        GetHostLogger(instance).LogDebug("ScriptHost disposed");
+                        _logger.LogDebug("ScriptHost disposed");
                     }
                 }
             }


### PR DESCRIPTION
https://github.com/Azure/azure-functions-host/commit/916c255778588951371ffc0da74b7a2c3f1ec2b8 added an extra log entry. But the logger used could have been disposed already. The fix uses the WebJobsScriptHostService logger which is always guaranteed to be available.

resolves https://github.com/Azure/azure-functions-host/issues/7396

### Pull request checklist

* [ X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
