### PR TITLE
[Linux Consumption] Add InProgress Function Execution Activity Count

### DIFF
--- a/src/WebJobs.Script.WebHost/Models/ContainerFunctionExecutionActivity.cs
+++ b/src/WebJobs.Script.WebHost/Models/ContainerFunctionExecutionActivity.cs
@@ -69,5 +69,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
                 return hashCode;
             }
         }
+
+        public bool IsFunctional()
+        {
+            return ExecutionStage == ExecutionStage.InProgress ||
+                   (ExecutionStage == ExecutionStage.Finished && Success);
+        }
     }
 }

--- a/src/WebJobs.Script.WebHost/Models/ContainerFunctionExecutionActivityRequest.cs
+++ b/src/WebJobs.Script.WebHost/Models/ContainerFunctionExecutionActivityRequest.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
+{
+    public class ContainerFunctionExecutionActivityRequest
+    {
+        public ContainerFunctionExecutionActivityRequest(IEnumerable<ContainerFunctionExecutionActivity> activities)
+        {
+            Activities = activities;
+            FunctionalActivitiesCount = Activities.Count(a => a.IsFunctional());
+        }
+
+        public IEnumerable<ContainerFunctionExecutionActivity> Activities { get; }
+
+        public int FunctionalActivitiesCount { get; }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/Management/ContainerFunctionExecutionActivityRequestTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/ContainerFunctionExecutionActivityRequestTests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
+{
+    public class ContainerFunctionExecutionActivityRequestTests
+    {
+        private const string FunctionName = "HttpTrigger1";
+        private const string TriggerType = "HttpTrigger";
+
+        [Fact]
+        public void HandlesActivitiesListWithNoFunctionalActivities()
+        {
+            var containerFunctionExecutionActivities = new List<ContainerFunctionExecutionActivity>();
+            containerFunctionExecutionActivities.Add(GetActivity(ExecutionStage.Started, true));
+            containerFunctionExecutionActivities.Add(GetActivity(ExecutionStage.Started, false));
+            containerFunctionExecutionActivities.Add(GetActivity(ExecutionStage.Finished, false));
+            containerFunctionExecutionActivities.Add(GetActivity(ExecutionStage.Failed, true));
+            containerFunctionExecutionActivities.Add(GetActivity(ExecutionStage.Failed, false));
+            containerFunctionExecutionActivities.Add(GetActivity(ExecutionStage.Succeeded, true));
+            containerFunctionExecutionActivities.Add(GetActivity(ExecutionStage.Succeeded, false));
+
+            var request = new ContainerFunctionExecutionActivityRequest(containerFunctionExecutionActivities);
+            Assert.Equal(7, request.Activities.Count());
+            Assert.Equal(0, request.FunctionalActivitiesCount);
+        }
+
+        [Fact]
+        public void ReturnsFunctionalActivitiesCount()
+        {
+            var containerFunctionExecutionActivities = new List<ContainerFunctionExecutionActivity>();
+            containerFunctionExecutionActivities.Add(GetActivity(ExecutionStage.Started, true));
+            containerFunctionExecutionActivities.Add(GetActivity(ExecutionStage.Started, false));
+            containerFunctionExecutionActivities.Add(GetActivity(ExecutionStage.Finished, false));
+            containerFunctionExecutionActivities.Add(GetActivity(ExecutionStage.Failed, true));
+            containerFunctionExecutionActivities.Add(GetActivity(ExecutionStage.Failed, false));
+            containerFunctionExecutionActivities.Add(GetActivity(ExecutionStage.Succeeded, true));
+            containerFunctionExecutionActivities.Add(GetActivity(ExecutionStage.Succeeded, false));
+
+            containerFunctionExecutionActivities.Add(GetActivity(ExecutionStage.InProgress, true));
+            containerFunctionExecutionActivities.Add(GetActivity(ExecutionStage.InProgress, false));
+            containerFunctionExecutionActivities.Add(GetActivity(ExecutionStage.InProgress, false));
+            containerFunctionExecutionActivities.Add(GetActivity(ExecutionStage.Finished, true));
+            containerFunctionExecutionActivities.Add(GetActivity(ExecutionStage.Finished, true));
+
+            var request = new ContainerFunctionExecutionActivityRequest(containerFunctionExecutionActivities);
+            Assert.Equal(12, request.Activities.Count());
+            Assert.Equal(5, request.FunctionalActivitiesCount);
+        }
+
+        [Fact]
+        public void HandlesEmptyActivitiesList()
+        {
+            var request =
+                new ContainerFunctionExecutionActivityRequest(Enumerable.Empty<ContainerFunctionExecutionActivity>());
+            Assert.Empty(request.Activities);
+            Assert.Equal(0, request.FunctionalActivitiesCount);
+        }
+
+        private static ContainerFunctionExecutionActivity GetActivity(ExecutionStage executionStage, bool success)
+        {
+            return new ContainerFunctionExecutionActivity(DateTime.UtcNow, FunctionName, executionStage, TriggerType,
+                success);
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/Management/ContainerFunctionExecutionActivityTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/ContainerFunctionExecutionActivityTests.cs
@@ -42,5 +42,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             Assert.Equal(expected, activity1.Equals(activity2));
             Assert.Equal(expected ? 1 : 2, hashSet.Count);
         }
+
+        [Theory]
+        [InlineData(ExecutionStage.Started, true, false)]
+        [InlineData(ExecutionStage.Started, false, false)]
+        [InlineData(ExecutionStage.InProgress, true, true)]
+        [InlineData(ExecutionStage.InProgress, false, true)]
+        [InlineData(ExecutionStage.Finished, true, true)]
+        [InlineData(ExecutionStage.Finished, false, false)]
+        [InlineData(ExecutionStage.Failed, true, false)]
+        [InlineData(ExecutionStage.Failed, false, false)]
+        [InlineData(ExecutionStage.Succeeded, true, false)]
+        [InlineData(ExecutionStage.Succeeded, false, false)]
+        public void Returns_IsFunctionalActivity(ExecutionStage stage, bool isSuccess, bool isFunctionalActivity)
+        {
+            var activity =
+                new ContainerFunctionExecutionActivity(DateTime.UtcNow, string.Empty, stage, string.Empty, isSuccess);
+            Assert.Equal(isFunctionalActivity, activity.IsFunctional());
+        }
     }
 }


### PR DESCRIPTION
 These events are aggregated to compute app idleness metric. Adding the count to the request payload in addition to the actual events allows for verification on the client side in case of serialization errors.

<!-- Please provide all the information below.  -->

https://github.com/Azure/azure-functions-host/issues/7409

### Pull request checklist

* [ X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
