### PR TITLE
Include extension config when logging host.json

### DIFF
--- a/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             {
                 "version", "functionTimeout", "retry", "functions", "http", "watchDirectories", "watchFiles", "queues", "serviceBus",
                 "eventHub", "singleton", "logging", "aggregator", "healthMonitor", "extensionBundle", "managedDependencies",
-                "customHandler", "httpWorker"
+                "customHandler", "httpWorker", "extensions"
             };
 
             private readonly HostJsonFileConfigurationSource _configurationSource;


### PR DESCRIPTION
This change allows for diagnostics to detect common errors such as using a newly introduced host.json setting with an older extension that does not support that setting. The options logger for the extension won't log unrecognized settings, so the 'Host configuration file read' log entry is the best way to find those unrecognized settings.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #7427

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

Checked for test coverage for this host.json logging allowlist and couldn't find any. I verified this change manually by inspecting log output from modified functions host.
