### PR TITLE
Reset releaes_note.md and common.props to 3.1.0

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -4,14 +4,14 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>7.2</LangVersion>
     <MajorVersion>3</MajorVersion>
-    <MinorVersion>2</MinorVersion>
+    <MinorVersion>1</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <Version Condition=" '$(BuildNumber)' != '' ">$(VersionPrefix)-$(BuildNumber)</Version>
     <Version Condition=" '$(Version)' == '' ">$(VersionPrefix)</Version>
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
     <FileVersion>$(VersionPrefix).0</FileVersion>
-    <CommitHash Condition="$(CommitHash) == ''">N/A</CommitHash>
+    <CommitHash Condition="$(CommitHash) == ''">N/A</CommitHash>        
     <InformationalVersion>$(Version) Commit hash: $(CommitHash)</InformationalVersion>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\src.ruleset</CodeAnalysisRuleSet>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
@@ -23,7 +23,7 @@
   <PropertyGroup Condition="'$(UseSourceLink)' == 'true'">
     <SourceLink>$(BaseIntermediateOutputPath)source_link.json</SourceLink>
   </PropertyGroup>
-
+  
   <Target Name="GenerateSourceLink" BeforeTargets="CoreCompile" Condition="'$(UseSourceLink)' == 'true'">
     <PropertyGroup>
       <SrcRootDirectory>$([System.IO.Directory]::GetParent($(MSBuildThisFileDirectory.TrimEnd("\"))))</SrcRootDirectory>
@@ -41,7 +41,7 @@
     <!-- Write out the source file for this project to point at raw.githubusercontent.com -->
     <WriteLinesToFile File="$(BaseIntermediateOutputPath)source_link.json" Overwrite="true" Lines='{"documents": { "$(SourceLinkRoot)\\*" : "$(RemoteUri.Replace(".git", "").Replace("github.com", "raw.githubusercontent.com"))/$(LatestCommit)/*" }}' />
   </Target>
-
+  
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\stylecop.json" Link="stylecop.json" />
   </ItemGroup>

--- a/release_notes.md
+++ b/release_notes.md
@@ -2,14 +2,17 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Capture diagnostic events
+- Added a feature flag to opt out of the default behavior where the host sets the environment name to `Development` when running in debug mode. To disable the behavior, set the app setting: `AzureWebJobsFeatureFlags` to `DisableDevModeInDebug`
+- Reorder CORS and EasyAuth middleware to prevent EasyAuth from blocking CORS requests (#7315)
+- Updated PowerShell Worker (PS7) to [3.0.833](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.833)
+- Add IDistributedLockManager for Kubernetes environment (#7327)
+- Call EnableDrainModeAsync on ApplicationStopping (#7262)
+- Added Roslyn analyzer projects and avoid async void analyzer (#5612)
+- Updated Node Worker to [2.1.2](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v2.1.2)
+- Updated Python Worker to [1.2.3](https://github.com/Azure/azure-functions-python-worker/releases/tag/1.2.3)
 
-Fixes issue with AzureStorageProvider using the wrong configuration in custom startup scenarios (#7424) [ [bug](https://github.com/Azure/azure-functions-host/issues/7440) ]
-
-**Release sprint:** Sprint 101
-[ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+101%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+101%22+label%3Afeature+is%3Aclosed) ]
-
-Replace 101 with the next sprint that will be released.
-
-Send a PR to the dev branch with the above two changes.
-
-When the PR is approved and merged, complete this step.
+**Release sprint:** Sprint 100
+[ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+100%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+100%22+label%3Afeature+is%3Aclosed) ]
+- Update App Service Authentication/Authorization on Linux Consumption from 1.4.0 to 1.4.5. Release notes for this feature captured at https://github.com/Azure/app-service-announcements/issues. (#7205)
+- Add v12 Storage-dependent implementations to Functions Host to support Managed Identity integration


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr
Due to the hotfix release of https://github.com/Azure/azure-functions-host/releases/tag/v3.0.15960,
we're expecting to version our host (3.1.0) in the next standard release

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
