### PR TITLE
DependencyTracking should be disabled in placeholder mode

### DIFF
--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using Microsoft.ApplicationInsights.DependencyCollector;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Azure.WebJobs.Extensions.Timers;
 using Microsoft.Azure.WebJobs.Host;
@@ -394,20 +393,11 @@ namespace Microsoft.Azure.WebJobs.Script
 
                 if (SystemEnvironment.Instance.IsPlaceholderModeEnabled())
                 {
-                    for (int i = 0; i < builder.Services.Count; i++)
-                    {
-                        // This is to avoid possible race condition during specialization when disposing old AI listeners created during placeholder mode.
-                        if (builder.Services[i].ServiceType == typeof(ITelemetryModule) && builder.Services[i].ImplementationFactory?.Method.ReturnType == typeof(DependencyTrackingTelemetryModule))
-                        {
-                            builder.Services.RemoveAt(i);
-                            break;
-                        }
-                    }
-
-                    // Disable auto-http tracking when in placeholder mode.
+                    // Disable auto-http and dependency tracking when in placeholder mode.
                     builder.Services.Configure<ApplicationInsightsLoggerOptions>(o =>
                     {
                         o.HttpAutoCollectionOptions.EnableHttpTriggerExtendedInfoCollection = false;
+                        o.EnableDependencyTracking = false;
                     });
                 }
             }

--- a/test/WebJobs.Script.Tests/Configuration/ApplicationInsightsConfigurationTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ApplicationInsightsConfigurationTests.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.ApplicationInsights.DependencyCollector;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
+{
+    public class ApplicationInsightsConfigurationTests
+    {
+        [Fact]
+        public void ServicesDisabled_InPlaceholderMode()
+        {
+            IHost host;
+            using (new TestScopedEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1"))
+            {
+                host = new HostBuilder()
+                    .ConfigureLogging((context, builder) =>
+                    {
+                        ScriptHostBuilderExtensions.ConfigureApplicationInsights(context, builder);
+                    })
+                    .ConfigureServices(s =>
+                    {
+                        s.AddSingleton<IEnvironment>(SystemEnvironment.Instance);
+                    })
+                    .Build();
+            }
+
+            // No DependencyTrackingTelemetryModule should be registered
+            var modules = host.Services.GetService<IEnumerable<ITelemetryModule>>();
+            Assert.Empty(modules.Where(m => m.GetType() == typeof(DependencyTrackingTelemetryModule)));
+
+            var appInsightsOptions = host.Services.GetService<IOptions<ApplicationInsightsLoggerOptions>>();
+            Assert.False(appInsightsOptions.Value.HttpAutoCollectionOptions.EnableHttpTriggerExtendedInfoCollection);
+        }
+    }
+}


### PR DESCRIPTION
*Correction -- it does *not* fix this*
~~Fix for seeing the following exception message during specialization:~~
```
The specified configuration does not have a telemetry channel. (Parameter 'configuration')
```

Refer back to [this code](https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/ScriptHostBuilderExtensions.cs#L399-L404) -- added in [March 2019](https://github.com/Azure/azure-functions-host/pull/4239/commits/92e5ef4386f5c622e5a1d93df1ba63da7e6b4964) by @safihamid. 

```csharp
// This is to avoid possible race condition during specialization when disposing old AI listeners created during placeholder mode.
if (builder.Services[i].ServiceType == typeof(ITelemetryModule) && builder.Services[i].ImplementationFactory?.Method.ReturnType == typeof(DependencyTrackingTelemetryModule))
{
    builder.Services.RemoveAt(i);
    break;
}
```

I'm not sure Hamid will remember what that race looked like since this was over 2 years ago -- and I can't seem to find mention of it anywhere. I assume he hit this during private stamp testing.

At the time, our DI registration for the `DependencyTrackingTelemetryModule` looked [like this](https://github.com/Azure/azure-webjobs-sdk/blob/a5043d2a6967c659528ba2bf94641a7d4bce672e/src/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/Extensions/ApplicationInsightsServiceCollectionExtensions.cs#L71):

```csharp
services.AddSingleton<ITelemetryModule, DependencyTrackingTelemetryModule>(provider =>
{
   ...
}
```

So the host code worked in removing that service registration while in placeholder mode, as we could see the factory's return type was `DependencyTrackingTelemetryModule`.

However, shortly after this, in Aug 2019, [this PR](https://github.com/Azure/azure-webjobs-sdk/pull/2243) went in that changed this factory to look like this:

```csharp
services.AddSingleton<ITelemetryModule>(provider =>
{
    ...
}
```

So now we do not know the return type of the factory. I suspect that this host code to remove the registration has not worked since then.