### PR TITLE
Disposing of DependencyTrackingTelemetryModule before host is disposed

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -721,6 +721,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         // A temporary fix until we are able to take App Insights 2.18.0. There is a potential
         // race during disposal where new DiagnosticListeners can throw exceptions after TelemetryConfiguration
         // is disposed, but before this module is disposed. This ensures the module disposes first.
+        // Tracking issue: https://github.com/Azure/azure-functions-host/issues/7450
         private void DisposeDependencyTrackingModule(IHost instance)
         {
             try

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -710,7 +710,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     }
                     else
                     {
-                        //DisposeDependencyTrackingModule(instance);
+                        DisposeDependencyTrackingModule(instance);
                         instance.Dispose();
                         _logger.LogDebug("ScriptHost disposed");
                     }

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ApplicationInsights.AspNetCore;
 using Microsoft.ApplicationInsights.AspNetCore.Extensions;
+using Microsoft.ApplicationInsights.DependencyCollector;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId;
 using Microsoft.Azure.WebJobs.Host;
@@ -709,10 +710,33 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     }
                     else
                     {
+                        //DisposeDependencyTrackingModule(instance);
                         instance.Dispose();
                         _logger.LogDebug("ScriptHost disposed");
                     }
                 }
+            }
+        }
+
+        // A temporary fix until we are able to take App Insights 2.18.0. There is a potential
+        // race during disposal where new DiagnosticListeners can throw exceptions after TelemetryConfiguration
+        // is disposed, but before this module is disposed. This ensures the module disposes first.
+        private void DisposeDependencyTrackingModule(IHost instance)
+        {
+            try
+            {
+                var module = instance?.Services.GetServices<ITelemetryModule>()
+                                      .SingleOrDefault(m => m is DependencyTrackingTelemetryModule)
+                                      as IDisposable;
+
+                module?.Dispose();
+
+                _logger.LogDebug($"{nameof(DependencyTrackingTelemetryModule)} disposed.");
+            }
+            catch (Exception ex)
+            {
+                // best effort.
+                _logger.LogDebug($"Unable to dispose {nameof(DependencyTrackingTelemetryModule)}. {ex}");
             }
         }
 

--- a/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -483,6 +484,51 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 new Mock<IApplicationLifetime>().Object, config);
 
             Assert.Equal(expectedResult, _hostService.ShouldEnforceSequentialRestart());
+        }
+
+        [Fact]
+        public async Task DependencyTrackingTelemetryModule_Race()
+        {
+            var hostBuilder = new HostBuilder()
+                .ConfigureAppConfiguration(c =>
+                {
+                    c.AddInMemoryCollection(new Dictionary<string, string>
+                    {
+                        { "APPINSIGHTS_INSTRUMENTATIONKEY", "some_key" },
+                    });
+                })
+                .ConfigureDefaultTestWebScriptHost();
+
+            var scriptHostBuilder = new Mock<IScriptHostBuilder>();
+            scriptHostBuilder.Setup(b => b.BuildHost(It.IsAny<bool>(), It.IsAny<bool>()))
+                    .Returns(hostBuilder.Build());
+
+            bool done = false;
+            var listenerTask = Task.Run(() =>
+            {
+                while (!done)
+                {
+                    using (new DiagnosticListener("Azure.SomeClient"))
+                    {
+                    }
+                }
+            });
+
+            using (_hostService = new WebJobsScriptHostService(
+                            _monitor, scriptHostBuilder.Object, NullLoggerFactory.Instance,
+                            _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object,
+                            _hostPerformanceManager, _healthMonitorOptions, new TestMetricsLogger(),
+                            new Mock<IApplicationLifetime>().Object, _mockConfig))
+            {
+                await _hostService.StartAsync(CancellationToken.None);
+
+                await Task.Delay(500);
+
+                await _hostService.StopAsync(CancellationToken.None);
+            }
+
+            done = true;
+            await listenerTask;
         }
 
         public void RestartHost()


### PR DESCRIPTION
*Note -- I originally made a commit has the fix commented out so I can verify it fails in CI. It failed 100% of the time locally.*

This fixes the error:
```
The specified configuration does not have a telemetry channel. (Parameter 'configuration')
```

Tactical change to fix a race condition during disposal of the `DependencyTrackingTelemetryModule`. It must be disposed before `TelemetryConfiguration`. This change explicitly disposes it before disposing the host.

This issue is fixed in ApplicationInsights here -- https://github.com/microsoft/ApplicationInsights-dotnet/pull/2294 -- but this won't be released until 2.0.18. Once we pull that version, we can delete this fix (but keep the test).