### PR TITLE
Revert "[pack] Reacting to ScriptHost configuration changes for AzureStorageProvider (#7424)"

### DIFF
--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -454,15 +454,10 @@ namespace Microsoft.Azure.WebJobs.Script
         private static IDistributedLockManager GetBlobLockManager(IServiceProvider provider)
         {
             var azureStorageProvider = provider.GetRequiredService<IAzureStorageProvider>();
-            var configuration = provider.GetRequiredService<IConfiguration>();
             var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
             try
             {
-                // BlobLeaseDistributedLockManager is created during ScriptHost service registration since it is
-                // conditioned on having a valid storage connection. The configuration should be from the IServiceProvider
-                // that registers the IDistributedLockManager.
-                // The configuration used by AzureStorageProvider will be updated through the IScriptHostManager.HostInitializing event handler
-                var container = azureStorageProvider.GetBlobContainerClient(configuration);
+                var container = azureStorageProvider.GetBlobContainerClient();
                 return new BlobLeaseDistributedLockManager(loggerFactory, azureStorageProvider);
             }
             catch (InvalidOperationException)

--- a/src/WebJobs.Script/StorageProvider/BlobServiceClientProvider.cs
+++ b/src/WebJobs.Script/StorageProvider/BlobServiceClientProvider.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Azure.WebJobs.Script.StorageProvider
     /// </summary>
     internal class BlobServiceClientProvider : StorageClientProvider<BlobServiceClient, BlobClientOptions>
     {
-        public BlobServiceClientProvider(AzureComponentFactory componentFactory, AzureEventSourceLogForwarder logForwarder, ILogger<BlobServiceClient> logger)
-            : base(componentFactory, logForwarder, logger) { }
+        public BlobServiceClientProvider(IConfiguration configuration, AzureComponentFactory componentFactory, AzureEventSourceLogForwarder logForwarder, ILogger<BlobServiceClient> logger)
+            : base(configuration, componentFactory, logForwarder, logger) { }
 
         /// <inheritdoc/>
         protected override string ServiceUriSubDomain

--- a/src/WebJobs.Script/StorageProvider/IAzureStorageProvider.cs
+++ b/src/WebJobs.Script/StorageProvider/IAzureStorageProvider.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Azure.Storage.Blobs;
-using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.WebJobs.Script
 {
@@ -14,8 +13,8 @@ namespace Microsoft.Azure.WebJobs.Script
     {
         bool TryGetBlobServiceClientFromConnectionString(out BlobServiceClient client, string connectionString);
 
-        bool TryGetBlobServiceClientFromConnection(out BlobServiceClient client, string connection, IConfiguration configurationOverride = null);
+        bool TryGetBlobServiceClientFromConnection(out BlobServiceClient client, string connection);
 
-        BlobContainerClient GetBlobContainerClient(IConfiguration configurationOverride = null);
+        BlobContainerClient GetBlobContainerClient();
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/Host/SingletonTests/SingletonEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/SingletonTests/SingletonEndToEndTests.cs
@@ -25,7 +25,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using Microsoft.Azure.WebJobs.Host;
-using Microsoft.WebJobs.Script.Tests;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Host.SingletonTests
 {
@@ -656,7 +655,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Host.SingletonTests
                     });
 
                     services.AddSingleton<IDistributedLockManager, BlobLeaseDistributedLockManager>();
-                    TestHostBuilderExtensions.AddMockedSingleton<IScriptHostManager>(services);
                     services.AddAzureStorageProvider();
                 });
 

--- a/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/FunctionGeneratorEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/FunctionGeneratorEndToEndTests.cs
@@ -11,7 +11,6 @@ using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.WebJobs.Script.Tests;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
@@ -70,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 {
                     s.AddSingleton<ITypeLocator>(new TestTypeLocator(functionType));
                     s.AddSingleton<ILoggerFactory>(new LoggerFactory());
-                    TestHostBuilderExtensions.AddMockedSingleton<IScriptHostManager>(s);
+
                     s.AddAzureStorageProvider();
                 });
 

--- a/test/WebJobs.Script.Tests.Integration/Storage/BlobStorageProviderTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Storage/BlobStorageProviderTests.cs
@@ -36,14 +36,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Storage
         [Fact]
         public async Task TestBlobStorageProvider_TryConnectionName()
         {
-            Assert.True(_blobServiceClientProvider.TryGet(StorageConnection, _configuration, out BlobServiceClient client));
+            Assert.True(_blobServiceClientProvider.TryGet(StorageConnection, out BlobServiceClient client));
             await VerifyServiceAvailable(client);
         }
 
         [Fact]
         public async Task TestBlobStorageProvider_ConnectionName()
         {
-            BlobServiceClient client = _blobServiceClientProvider.Get(StorageConnection, _configuration);
+            BlobServiceClient client = _blobServiceClientProvider.Get(StorageConnection);
             await VerifyServiceAvailable(client);
         }
 
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Storage
         {
             var resolver = new DefaultNameResolver(_configuration);
 
-            BlobServiceClient client = _blobServiceClientProvider.Get(StorageConnection, resolver, _configuration);
+            BlobServiceClient client = _blobServiceClientProvider.Get(StorageConnection, resolver);
             await VerifyServiceAvailable(client);
         }
 

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -20,7 +20,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
-using Microsoft.WebJobs.Script.Tests;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
@@ -408,7 +407,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 {
                     // Override configuration
                     services.AddSingleton(configuration);
-                    TestHostBuilderExtensions.AddMockedSingleton<IScriptHostManager>(services);
                     services.AddAzureStorageProvider();
                     if (storageOptions != null)
                     {


### PR DESCRIPTION
This reverts commit 80061a7da06cb285de51d159321e0d186886a466.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Reverting the hotfix that addressed Timers being unable to start due to custom configuration sources that adds AzureWebJobsStorage due to incident.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
