### PR TITLE
SyncTriggers hash blob update fix

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 // update the last hash value in storage
                 using (Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(hash)))
                 {
-                    await hashBlobClient.UploadAsync(stream);
+                    await hashBlobClient.UploadAsync(stream, overwrite: true);
                 }
                 _logger.LogDebug($"SyncTriggers hash updated to '{hash}'");
             }


### PR DESCRIPTION
In the move to storage v12 that happened as part of the recent secretless work (https://github.com/Azure/azure-functions-host/pull/7198), we regressed the FunctionsSyncManager hash blob update operation ([here](https://github.com/Azure/azure-functions-host/blob/6cef5808f90e3a9d3437209ab128361852120597/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs#L250)). Specifically in storage v12, you have to explicitly specify that you want to overwrite an existing blob ([BlobClient.UploadAsync](https://docs.microsoft.com/en-us/dotnet/api/azure.storage.blobs.blobclient.uploadasync?view=azure-dotnet#Azure_Storage_Blobs_BlobClient_UploadAsync_System_String_System_Boolean_System_Threading_CancellationToken_)). In the previous storage version, that wasn't the case ([CloudBlockBlob.UploadTextAsync](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.storage.blob.cloudblockblob.uploadtextasync?view=azure-dotnet-legacy)). Other locations in the secretless work we did specify the overwrite parameter, but missed it here.

With this regression in place, SyncTrigger has updates are failing in production for background sync operations, resulting in more sync requests to FE than should be happening.

We should review other places where we're calling UploadAsync to see if we need overwrite semantics there as well (e.g. [BlobChangeAnalysisStateProvider](https://github.com/Azure/azure-functions-host/blob/cbf9ad1b107c52531975f622d7f50f63ab31e592/src/WebJobs.Script.WebHost/BreakingChangeAnalysis/BlobChangeAnalysisStateProvider.cs#L80)).

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
