### PR TITLE
exposing configurable worker timeouts

### DIFF
--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -132,7 +132,6 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
         public async Task StartWorkerProcessAsync()
         {
-            _workerConfig.ProcessStartupTimeout = TimeSpan.FromDays(1);
             _startSubscription = _inboundWorkerEvents.Where(msg => msg.MessageType == MsgType.StartStream)
                 .Timeout(_workerConfig.ProcessStartupTimeout)
                 .Take(1)

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -22,7 +22,6 @@ using Microsoft.Azure.WebJobs.Script.ManagedDependencies;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer;
-using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using static Microsoft.Azure.WebJobs.Script.Grpc.Messages.RpcLog.Types;
@@ -34,7 +33,6 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 {
     internal class GrpcWorkerChannel : IRpcWorkerChannel, IDisposable
     {
-        private readonly TimeSpan workerInitTimeout = TimeSpan.FromSeconds(30);
         private readonly IScriptEventManager _eventManager;
         private readonly RpcWorkerConfig _workerConfig;
         private readonly string _runtime;
@@ -48,7 +46,6 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         private WorkerInitResponse _initMessage;
         private string _workerId;
         private RpcWorkerChannelState _state;
-        private Queue<string> _processStdErrDataQueue = new Queue<string>(3);
         private IDictionary<string, Exception> _functionLoadErrors = new Dictionary<string, Exception>();
         private ConcurrentDictionary<string, ScriptInvocationContext> _executingInvocations = new ConcurrentDictionary<string, ScriptInvocationContext>();
         private IDictionary<string, BufferBlock<ScriptInvocationContext>> _functionInputBuffers = new ConcurrentDictionary<string, BufferBlock<ScriptInvocationContext>>();
@@ -135,8 +132,9 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
         public async Task StartWorkerProcessAsync()
         {
+            _workerConfig.ProcessStartupTimeout = TimeSpan.FromDays(1);
             _startSubscription = _inboundWorkerEvents.Where(msg => msg.MessageType == MsgType.StartStream)
-                .Timeout(TimeSpan.FromSeconds(WorkerConstants.ProcessStartTimeoutSeconds))
+                .Timeout(_workerConfig.ProcessStartupTimeout)
                 .Take(1)
                 .Subscribe(SendWorkerInitRequest, HandleWorkerStartStreamError);
 
@@ -192,7 +190,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         {
             _workerChannelLogger.LogDebug("Worker Process started. Received StartStream message");
             _inboundWorkerEvents.Where(msg => msg.MessageType == MsgType.WorkerInitResponse)
-                .Timeout(workerInitTimeout)
+                .Timeout(_workerConfig.InitializationTimeout)
                 .Take(1)
                 .Subscribe(WorkerInitResponse, HandleWorkerInitError);
 
@@ -294,7 +292,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
             _eventSubscriptions
                 .Add(_inboundWorkerEvents.Where(msg => msg.MessageType == MsgType.FunctionEnvironmentReloadResponse)
-                .Timeout(workerInitTimeout)
+                .Timeout(_workerConfig.EnvironmentReloadTimeout)
                 .Take(1)
                 .Subscribe((msg) => FunctionEnvironmentReloadResponse(msg.Message.FunctionEnvironmentReloadResponse, latencyEvent), HandleWorkerEnvReloadError));
 

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         public async Task StartWorkerProcessAsync()
         {
             _startSubscription = _inboundWorkerEvents.Where(msg => msg.MessageType == MsgType.StartStream)
-                .Timeout(_workerConfig.ProcessStartupTimeout)
+                .Timeout(_workerConfig.CountOptions.ProcessStartupTimeout)
                 .Take(1)
                 .Subscribe(SendWorkerInitRequest, HandleWorkerStartStreamError);
 
@@ -189,7 +189,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         {
             _workerChannelLogger.LogDebug("Worker Process started. Received StartStream message");
             _inboundWorkerEvents.Where(msg => msg.MessageType == MsgType.WorkerInitResponse)
-                .Timeout(_workerConfig.InitializationTimeout)
+                .Timeout(_workerConfig.CountOptions.InitializationTimeout)
                 .Take(1)
                 .Subscribe(WorkerInitResponse, HandleWorkerInitError);
 
@@ -291,7 +291,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
             _eventSubscriptions
                 .Add(_inboundWorkerEvents.Where(msg => msg.MessageType == MsgType.FunctionEnvironmentReloadResponse)
-                .Timeout(_workerConfig.EnvironmentReloadTimeout)
+                .Timeout(_workerConfig.CountOptions.EnvironmentReloadTimeout)
                 .Take(1)
                 .Subscribe((msg) => FunctionEnvironmentReloadResponse(msg.Message.FunctionEnvironmentReloadResponse, latencyEvent), HandleWorkerEnvReloadError));
 

--- a/src/WebJobs.Script/Description/Workers/Http/HttpFunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/Workers/Http/HttpFunctionDescriptorProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Azure.WebJobs.Script.Extensibility;
@@ -12,8 +13,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
     internal class HttpFunctionDescriptorProvider : WorkerFunctionDescriptorProvider
     {
         public HttpFunctionDescriptorProvider(ScriptHost host, ScriptJobHostOptions config, ICollection<IScriptBindingProvider> bindingProviders,
-            IFunctionInvocationDispatcher dispatcher, ILoggerFactory loggerFactory, IApplicationLifetime applicationLifetime)
-            : base(host, config, bindingProviders, dispatcher, loggerFactory, applicationLifetime)
+            IFunctionInvocationDispatcher dispatcher, ILoggerFactory loggerFactory, IApplicationLifetime applicationLifetime, TimeSpan workerInitializationTimeout)
+            : base(host, config, bindingProviders, dispatcher, loggerFactory, applicationLifetime, workerInitializationTimeout)
         {
         }
     }

--- a/src/WebJobs.Script/Description/Workers/Rpc/RpcFunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/Workers/Rpc/RpcFunctionDescriptorProvider.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         private readonly string _workerRuntime;
 
         public RpcFunctionDescriptorProvider(ScriptHost host, string workerRuntime, ScriptJobHostOptions config, ICollection<IScriptBindingProvider> bindingProviders,
-            IFunctionInvocationDispatcher dispatcher, ILoggerFactory loggerFactory, IApplicationLifetime applicationLifetime)
-            : base(host, config, bindingProviders, dispatcher, loggerFactory, applicationLifetime)
+            IFunctionInvocationDispatcher dispatcher, ILoggerFactory loggerFactory, IApplicationLifetime applicationLifetime, TimeSpan workerInitializationTimeout)
+            : base(host, config, bindingProviders, dispatcher, loggerFactory, applicationLifetime, workerInitializationTimeout)
         {
             _workerRuntime = workerRuntime;
         }

--- a/src/WebJobs.Script/Description/Workers/WorkerFunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/Workers/WorkerFunctionDescriptorProvider.cs
@@ -20,16 +20,18 @@ namespace Microsoft.Azure.WebJobs.Script.Description
     internal abstract class WorkerFunctionDescriptorProvider : FunctionDescriptorProvider
     {
         private readonly ILoggerFactory _loggerFactory;
-        private IFunctionInvocationDispatcher _dispatcher;
-        private IApplicationLifetime _applicationLifetime;
+        private readonly IFunctionInvocationDispatcher _dispatcher;
+        private readonly IApplicationLifetime _applicationLifetime;
+        private readonly TimeSpan _workerInitializationTimeout;
 
         public WorkerFunctionDescriptorProvider(ScriptHost host, ScriptJobHostOptions config, ICollection<IScriptBindingProvider> bindingProviders,
-            IFunctionInvocationDispatcher dispatcher, ILoggerFactory loggerFactory, IApplicationLifetime applicationLifetime)
+            IFunctionInvocationDispatcher dispatcher, ILoggerFactory loggerFactory, IApplicationLifetime applicationLifetime, TimeSpan workerInitializationTimeout)
             : base(host, config, bindingProviders)
         {
             _dispatcher = dispatcher;
             _loggerFactory = loggerFactory;
             _applicationLifetime = applicationLifetime;
+            _workerInitializationTimeout = workerInitializationTimeout;
         }
 
         public override async Task<(bool, FunctionDescriptor)> TryCreate(FunctionMetadata functionMetadata)
@@ -50,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         protected override IFunctionInvoker CreateFunctionInvoker(string scriptFilePath, BindingMetadata triggerMetadata, FunctionMetadata functionMetadata, Collection<FunctionBinding> inputBindings, Collection<FunctionBinding> outputBindings)
         {
-            return new WorkerFunctionInvoker(Host, triggerMetadata, functionMetadata, _loggerFactory, inputBindings, outputBindings, _dispatcher, _applicationLifetime);
+            return new WorkerFunctionInvoker(Host, triggerMetadata, functionMetadata, _loggerFactory, inputBindings, outputBindings, _dispatcher, _applicationLifetime, _workerInitializationTimeout);
         }
 
         protected override async Task<Collection<ParameterDescriptor>> GetFunctionParametersAsync(IFunctionInvoker functionInvoker, FunctionMetadata functionMetadata,

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -517,7 +517,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 var workerConfig = _languageWorkerOptions.Value.WorkerConfigs?.FirstOrDefault(c => c.Description.Language.Equals(_workerRuntime, StringComparison.OrdinalIgnoreCase));
 
                 // If there's no worker config, use the default (for legacy behavior; mostly for tests).
-                TimeSpan initializationTimeout = workerConfig?.InitializationTimeout ?? RpcWorkerConfig.DefaultInitializationTimeout;
+                TimeSpan initializationTimeout = workerConfig?.CountOptions?.InitializationTimeout ?? WorkerProcessCountOptions.DefaultInitializationTimeout;
 
                 _descriptorProviders.Add(new RpcFunctionDescriptorProvider(this, _workerRuntime, ScriptOptions, _bindingProviders,
                     _functionDispatcher, _loggerFactory, _applicationLifetime, initializationTimeout));

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -516,8 +516,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
                 var workerConfig = _languageWorkerOptions.Value.WorkerConfigs?.FirstOrDefault(c => c.Description.Language.Equals(_workerRuntime, StringComparison.OrdinalIgnoreCase));
 
-                // If there's no worker config, use the default (for legacy behavior).
-                TimeSpan initializationTimeout = workerConfig?.InitializationTimeout ?? new RpcWorkerConfig().InitializationTimeout;
+                // If there's no worker config, use the default (for legacy behavior; mostly for tests).
+                TimeSpan initializationTimeout = workerConfig?.InitializationTimeout ?? RpcWorkerConfig.DefaultInitializationTimeout;
 
                 _descriptorProviders.Add(new RpcFunctionDescriptorProvider(this, _workerRuntime, ScriptOptions, _bindingProviders,
                     _functionDispatcher, _loggerFactory, _applicationLifetime, initializationTimeout));

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Azure.WebJobs.Script
         private readonly Stopwatch _stopwatch = new Stopwatch();
         private readonly IOptions<JobHostOptions> _hostOptions;
         private readonly bool _isHttpWorker;
+        private readonly HttpWorkerOptions _httpWorkerOptions;
         private readonly IConfiguration _configuration;
         private readonly ScriptTypeLocator _typeLocator;
         private readonly IDebugStateProvider _debugManager;
@@ -65,6 +66,7 @@ namespace Microsoft.Azure.WebJobs.Script
         private readonly ILoggerFactory _loggerFactory = null;
         private readonly string _instanceId;
         private readonly IEnvironment _environment;
+        private readonly IOptions<LanguageWorkerOptions> _languageWorkerOptions;
         private static readonly int _processId = Process.GetCurrentProcess().Id;
 
         private IPrimaryHostStateProvider _primaryHostStateProvider;
@@ -72,7 +74,6 @@ namespace Microsoft.Azure.WebJobs.Script
         private ScriptSettingsManager _settingsManager;
         private ILogger _logger = null;
         private string _workerRuntime;
-
         private IList<IDisposable> _eventSubscriptions = new List<IDisposable>();
         private IFunctionInvocationDispatcher _functionDispatcher;
 
@@ -103,6 +104,7 @@ namespace Microsoft.Azure.WebJobs.Script
             IHttpRoutesManager httpRoutesManager,
             IApplicationLifetime applicationLifetime,
             IExtensionBundleManager extensionBundleManager,
+            IOptions<LanguageWorkerOptions> languageWorkerOptions,
             ScriptSettingsManager settingsManager = null)
             : base(options, jobHostContextFactory)
         {
@@ -121,6 +123,7 @@ namespace Microsoft.Azure.WebJobs.Script
             _hostIdProvider = hostIdProvider;
             _httpRoutesManager = httpRoutesManager;
             _isHttpWorker = httpWorkerOptions.Value.Description != null;
+            _httpWorkerOptions = httpWorkerOptions.Value;
             ScriptOptions = scriptHostOptions.Value;
             _scriptHostManager = scriptHostManager;
             FunctionErrors = new Dictionary<string, ICollection<string>>(StringComparer.OrdinalIgnoreCase);
@@ -134,6 +137,7 @@ namespace Microsoft.Azure.WebJobs.Script
             _hostLogPath = Path.Combine(ScriptOptions.RootLogPath, "Host");
 
             _workerRuntime = _environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName);
+            _languageWorkerOptions = languageWorkerOptions;
 
             _loggerFactory = loggerFactory;
             _logger = loggerFactory.CreateLogger(LogCategories.Startup);
@@ -499,7 +503,7 @@ namespace Microsoft.Azure.WebJobs.Script
             else if (_isHttpWorker)
             {
                 _logger.AddingDescriptorProviderForHttpWorker();
-                _descriptorProviders.Add(new HttpFunctionDescriptorProvider(this, ScriptOptions, _bindingProviders, _functionDispatcher, _loggerFactory, _applicationLifetime));
+                _descriptorProviders.Add(new HttpFunctionDescriptorProvider(this, ScriptOptions, _bindingProviders, _functionDispatcher, _loggerFactory, _applicationLifetime, _httpWorkerOptions.InitializationTimeout));
             }
             else if (string.Equals(_workerRuntime, RpcWorkerConstants.DotNetLanguageWorkerName, StringComparison.OrdinalIgnoreCase))
             {
@@ -509,7 +513,12 @@ namespace Microsoft.Azure.WebJobs.Script
             else
             {
                 _logger.AddingDescriptorProviderForLanguage(_workerRuntime);
-                _descriptorProviders.Add(new RpcFunctionDescriptorProvider(this, _workerRuntime, ScriptOptions, _bindingProviders, _functionDispatcher, _loggerFactory, _applicationLifetime));
+
+                var workerConfig = _languageWorkerOptions.Value.WorkerConfigs
+                    .FirstOrDefault(c => c.Description.Language.Equals(_workerRuntime, StringComparison.OrdinalIgnoreCase));
+
+                _descriptorProviders.Add(new RpcFunctionDescriptorProvider(this, _workerRuntime, ScriptOptions, _bindingProviders,
+                    _functionDispatcher, _loggerFactory, _applicationLifetime, workerConfig.InitializationTimeout));
             }
 
             // Codeless functions run side by side with regular functions.

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -514,11 +514,13 @@ namespace Microsoft.Azure.WebJobs.Script
             {
                 _logger.AddingDescriptorProviderForLanguage(_workerRuntime);
 
-                var workerConfig = _languageWorkerOptions.Value.WorkerConfigs
-                    .FirstOrDefault(c => c.Description.Language.Equals(_workerRuntime, StringComparison.OrdinalIgnoreCase));
+                var workerConfig = _languageWorkerOptions.Value.WorkerConfigs?.FirstOrDefault(c => c.Description.Language.Equals(_workerRuntime, StringComparison.OrdinalIgnoreCase));
+
+                // If there's no worker config, use the default (for legacy behavior).
+                TimeSpan initializationTimeout = workerConfig?.InitializationTimeout ?? new RpcWorkerConfig().InitializationTimeout;
 
                 _descriptorProviders.Add(new RpcFunctionDescriptorProvider(this, _workerRuntime, ScriptOptions, _bindingProviders,
-                    _functionDispatcher, _loggerFactory, _applicationLifetime, workerConfig.InitializationTimeout));
+                    _functionDispatcher, _loggerFactory, _applicationLifetime, initializationTimeout));
             }
 
             // Codeless functions run side by side with regular functions.

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -175,6 +175,8 @@ namespace Microsoft.Azure.WebJobs.Script
                     return NullHostedService.Instance;
                 });
 
+                // Wire this up early so that any early worker logs are guaranteed to be flushed if any other
+                // IHostedService has a slow startup.
                 services.AddSingleton<IHostedService, WorkerConsoleLogService>();
             });
 

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -174,6 +174,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
                     return NullHostedService.Instance;
                 });
+
+                services.AddSingleton<IHostedService, WorkerConsoleLogService>();
             });
 
             builder.ConfigureWebJobs((context, webJobsBuilder) =>
@@ -294,8 +296,6 @@ namespace Microsoft.Azure.WebJobs.Script
 
                 // Overriding IDistributedLockManager set by WebJobs.Host.Storage in AddAzureStorageCoreServices
                 services.AddSingleton<IDistributedLockManager>(provider => GetBlobLockManager(provider));
-
-                services.AddSingleton<IHostedService, WorkerConsoleLogService>();
 
                 if (SystemEnvironment.Instance.IsKubernetesManagedHosting())
                 {

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -143,16 +143,21 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <param name="pollingIntervalMilliseconds">The polling interval.</param>
         /// <param name="condition">The async condition to check</param>
         /// <returns>A Task representing the delay.</returns>
-        internal static async Task<bool> DelayAsync(int timeoutSeconds, int pollingIntervalMilliseconds, Func<Task<bool>> condition, CancellationToken cancellationToken)
+        internal static Task<bool> DelayAsync(int timeoutSeconds, int pollingIntervalMilliseconds, Func<Task<bool>> condition, CancellationToken cancellationToken)
         {
             TimeSpan timeout = TimeSpan.FromSeconds(timeoutSeconds);
-            TimeSpan delay = TimeSpan.FromMilliseconds(pollingIntervalMilliseconds);
+            TimeSpan pollingInterval = TimeSpan.FromMilliseconds(pollingIntervalMilliseconds);
+            return DelayAsync(timeout, pollingInterval, condition, cancellationToken);
+        }
+
+        internal static async Task<bool> DelayAsync(TimeSpan timeout, TimeSpan pollingInterval, Func<Task<bool>> condition, CancellationToken cancellationToken)
+        {
             TimeSpan timeWaited = TimeSpan.Zero;
             bool conditionResult = await condition();
             while (conditionResult && (timeWaited < timeout) && !cancellationToken.IsCancellationRequested)
             {
-                await Task.Delay(delay);
-                timeWaited += delay;
+                await Task.Delay(pollingInterval);
+                timeWaited += pollingInterval;
                 conditionResult = await condition();
             }
             return conditionResult;

--- a/src/WebJobs.Script/Workers/Http/Configuration/HttpWorkerOptions.cs
+++ b/src/WebJobs.Script/Workers/Http/Configuration/HttpWorkerOptions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.Azure.WebJobs.Script.Workers.Http
 {
     public class HttpWorkerOptions
@@ -14,5 +16,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
         public int Port { get; set; }
 
         public bool EnableForwardingHttpRequest { get; set; }
+
+        public TimeSpan InitializationTimeout { get; set; } = TimeSpan.FromSeconds(30);
     }
 }

--- a/src/WebJobs.Script/Workers/Http/DefaultHttpWorkerService.cs
+++ b/src/WebJobs.Script/Workers/Http/DefaultHttpWorkerService.cs
@@ -254,7 +254,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
 
         public async Task<bool> IsWorkerReady(CancellationToken cancellationToken)
         {
-            bool continueWaitingForWorker = await Utility.DelayAsync(WorkerConstants.WorkerInitTimeoutSeconds, WorkerConstants.WorkerReadyCheckPollingIntervalMilliseconds, async () =>
+            TimeSpan pollingInterval = TimeSpan.FromMilliseconds(WorkerConstants.WorkerReadyCheckPollingIntervalMilliseconds);
+            bool continueWaitingForWorker = await Utility.DelayAsync(_httpWorkerOptions.InitializationTimeout, pollingInterval, async () =>
             {
                 string requestUri = BuildAndGetUri();
                 try

--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcessCountOptions.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcessCountOptions.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
 {
     public class WorkerProcessCountOptions
     {
+        internal static readonly TimeSpan DefaultInitializationTimeout = TimeSpan.FromSeconds(10);
+
         /// <summary>
         /// Gets or sets a value indicating whether to set FUNCTIONS_WORKER_PROCESS_COUNT to number of cpu cores on the host machine
         /// </summary>
@@ -26,5 +28,33 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         /// Gets or sets interval between process startups. Default 10secs
         /// </summary>
         public TimeSpan ProcessStartupInterval { get; set; } = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// Gets or sets the process startup timeout. This is the time from when the process is
+        /// launched to when the StartStream message is received.
+        /// </summary>
+        public TimeSpan ProcessStartupTimeout { get; set; } = TimeSpan.FromSeconds(60);
+
+        /// <summary>
+        /// Gets or sets the worker initialization timeout. This is the time from when the WorkerInitRequest
+        /// is sent to when the WorkerInitResponse is received.
+        /// </summary>
+        public TimeSpan InitializationTimeout { get; set; } = DefaultInitializationTimeout;
+
+        /// <summary>
+        /// Gets or sets the worker environment reload timeout. This is the time from when the FunctionEnvironmentReloadRequest
+        /// is sent to when the FunctionEnvironmentReloadResponse is received.
+        /// </summary>
+        public TimeSpan EnvironmentReloadTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// Gets or sets interval between process restarts. Default 10secs
+        /// </summary>
+        public TimeSpan ProcessRestartInterval { get; set; } = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// Gets or sets the process shutdown timeout. Default 10secs
+        /// </summary>
+        public TimeSpan ProcessShutdownTimeout { get; set; } = TimeSpan.FromSeconds(10);
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfig.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfig.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 {
     public class RpcWorkerConfig
@@ -10,5 +12,23 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public WorkerProcessArguments Arguments { get; set; }
 
         public WorkerProcessCountOptions CountOptions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the process startup timeout. This is the time from when the process is
+        /// launched to when the StartStream message is received.
+        /// </summary>
+        public TimeSpan ProcessStartupTimeout { get; set; } = TimeSpan.FromSeconds(60);
+
+        /// <summary>
+        /// Gets or sets the worker initialization timeout. This is the time from when the WorkerInitRequest
+        /// is sent to when the WorkerInitResponse is received.
+        /// </summary>
+        public TimeSpan InitializationTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// Gets or sets the worker initialization timeout. This is the time from when the FunctionEnvironmentReloadRequest
+        /// is sent to when the FunctionEnvironmentReloadResponse is received.
+        /// </summary>
+        public TimeSpan EnvironmentReloadTimeout { get; set; } = TimeSpan.FromSeconds(30);
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfig.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfig.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 {
     public class RpcWorkerConfig
     {
+        internal static readonly TimeSpan DefaultInitializationTimeout = TimeSpan.FromSeconds(10);
+
         public RpcWorkerDescription Description { get; set; }
 
         public WorkerProcessArguments Arguments { get; set; }
@@ -23,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         /// Gets or sets the worker initialization timeout. This is the time from when the WorkerInitRequest
         /// is sent to when the WorkerInitResponse is received.
         /// </summary>
-        public TimeSpan InitializationTimeout { get; set; } = TimeSpan.FromSeconds(30);
+        public TimeSpan InitializationTimeout { get; set; } = DefaultInitializationTimeout;
 
         /// <summary>
         /// Gets or sets the worker environment reload timeout. This is the time from when the FunctionEnvironmentReloadRequest

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfig.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfig.cs
@@ -1,46 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 {
     public class RpcWorkerConfig
     {
-        internal static readonly TimeSpan DefaultInitializationTimeout = TimeSpan.FromSeconds(10);
-
         public RpcWorkerDescription Description { get; set; }
 
         public WorkerProcessArguments Arguments { get; set; }
 
         public WorkerProcessCountOptions CountOptions { get; set; }
-
-        /// <summary>
-        /// Gets or sets the process startup timeout. This is the time from when the process is
-        /// launched to when the StartStream message is received.
-        /// </summary>
-        public TimeSpan ProcessStartupTimeout { get; set; } = TimeSpan.FromSeconds(60);
-
-        /// <summary>
-        /// Gets or sets the worker initialization timeout. This is the time from when the WorkerInitRequest
-        /// is sent to when the WorkerInitResponse is received.
-        /// </summary>
-        public TimeSpan InitializationTimeout { get; set; } = DefaultInitializationTimeout;
-
-        /// <summary>
-        /// Gets or sets the worker environment reload timeout. This is the time from when the FunctionEnvironmentReloadRequest
-        /// is sent to when the FunctionEnvironmentReloadResponse is received.
-        /// </summary>
-        public TimeSpan EnvironmentReloadTimeout { get; set; } = TimeSpan.FromSeconds(30);
-
-        /// <summary>
-        /// Gets or sets interval between process restarts. Default 10secs
-        /// </summary>
-        public TimeSpan ProcessRestartInterval { get; set; } = TimeSpan.FromSeconds(10);
-
-        /// <summary>
-        /// Gets or sets the process shutdown timeout. Default 10secs
-        /// </summary>
-        public TimeSpan ProcessShutdownTimeout { get; set; } = TimeSpan.FromSeconds(10);
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfig.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfig.cs
@@ -26,9 +26,19 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public TimeSpan InitializationTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
         /// <summary>
-        /// Gets or sets the worker initialization timeout. This is the time from when the FunctionEnvironmentReloadRequest
+        /// Gets or sets the worker environment reload timeout. This is the time from when the FunctionEnvironmentReloadRequest
         /// is sent to when the FunctionEnvironmentReloadResponse is received.
         /// </summary>
         public TimeSpan EnvironmentReloadTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+        /// <summary>
+        /// Gets or sets interval between process restarts. Default 10secs
+        /// </summary>
+        public TimeSpan ProcessRestartInterval { get; set; } = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// Gets or sets the process shutdown timeout. Default 10secs
+        /// </summary>
+        public TimeSpan ProcessShutdownTimeout { get; set; } = TimeSpan.FromSeconds(10);
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -194,8 +194,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             }
             _maxProcessCount = workerConfig.CountOptions.ProcessCount;
             _processStartupInterval = workerConfig.CountOptions.ProcessStartupInterval;
-            _restartWait = workerConfig.ProcessRestartInterval;
-            _shutdownTimeout = workerConfig.ProcessShutdownTimeout;
+            _restartWait = workerConfig.CountOptions.ProcessRestartInterval;
+            _shutdownTimeout = workerConfig.CountOptions.ProcessShutdownTimeout;
             ErrorEventsThreshold = 3 * _maxProcessCount;
 
             if (Utility.IsSupportedRuntime(_workerRuntime, _workerConfigs))

--- a/src/WebJobs.Script/Workers/WorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/WorkerConstants.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.Azure.WebJobs.Script.Workers
 {
     public static class WorkerConstants
@@ -10,9 +8,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         public const string HostName = "127.0.0.1";
         public const string HttpScheme = "http";
 
-        public const int ProcessStartTimeoutSeconds = 60;
         public const int WorkerReadyCheckPollingIntervalMilliseconds = 25;
-        public const int WorkerInitTimeoutSeconds = 30;
         public const string WorkerConfigFileName = "worker.config.json";
         public const string DefaultWorkersDirectoryName = "workers";
 

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -263,33 +263,32 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             TimeSpan? processStartupInterval = null, TimeSpan? processRestartInterval = null, TimeSpan? processShutdownTimeout = null)
         {
             var defaultCountOptions = new WorkerProcessCountOptions();
-            var defaultWorkerOptions = new RpcWorkerConfig();
             TimeSpan startupInterval = processStartupInterval ?? defaultCountOptions.ProcessStartupInterval;
-            TimeSpan restartInterval = processRestartInterval ?? defaultWorkerOptions.ProcessRestartInterval;
-            TimeSpan shutdownTimeout = processShutdownTimeout ?? defaultWorkerOptions.ProcessShutdownTimeout;
+            TimeSpan restartInterval = processRestartInterval ?? defaultCountOptions.ProcessRestartInterval;
+            TimeSpan shutdownTimeout = processShutdownTimeout ?? defaultCountOptions.ProcessShutdownTimeout;
 
             var workerConfigs = new List<RpcWorkerConfig>
             {
                 new RpcWorkerConfig
                 {
                     Description = GetTestWorkerDescription("node", ".js"),
-                    ProcessRestartInterval = restartInterval,
-                    ProcessShutdownTimeout = shutdownTimeout,
                     CountOptions = new WorkerProcessCountOptions
                     {
                         ProcessCount = processCountValue,
-                        ProcessStartupInterval = startupInterval
+                        ProcessStartupInterval = startupInterval,
+                        ProcessRestartInterval = restartInterval,
+                        ProcessShutdownTimeout = shutdownTimeout
                     }
                 },
                 new RpcWorkerConfig
                 {
                     Description = GetTestWorkerDescription("java", ".jar"),
-                    ProcessRestartInterval = restartInterval,
-                    ProcessShutdownTimeout = shutdownTimeout,
                     CountOptions = new WorkerProcessCountOptions
                     {
                         ProcessCount = processCountValue,
-                        ProcessStartupInterval = startupInterval
+                        ProcessStartupInterval = startupInterval,
+                        ProcessRestartInterval = restartInterval,
+                        ProcessShutdownTimeout = shutdownTimeout
                     }
                 }
             };

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.Storage;
 using Microsoft.Azure.Storage.Blob;
 using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -258,12 +259,39 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
         }
 
-        public static IList<RpcWorkerConfig> GetTestWorkerConfigs(bool includeDllWorker = false, int processCountValue = 1)
+        public static IList<RpcWorkerConfig> GetTestWorkerConfigs(bool includeDllWorker = false, int processCountValue = 1,
+            TimeSpan? processStartupInterval = null, TimeSpan? processRestartInterval = null, TimeSpan? processShutdownTimeout = null)
         {
+            var defaultCountOptions = new WorkerProcessCountOptions();
+            var defaultWorkerOptions = new RpcWorkerConfig();
+            TimeSpan startupInterval = processStartupInterval ?? defaultCountOptions.ProcessStartupInterval;
+            TimeSpan restartInterval = processRestartInterval ?? defaultWorkerOptions.ProcessRestartInterval;
+            TimeSpan shutdownTimeout = processShutdownTimeout ?? defaultWorkerOptions.ProcessShutdownTimeout;
+
             var workerConfigs = new List<RpcWorkerConfig>
             {
-                new RpcWorkerConfig() { Description = GetTestWorkerDescription("node", ".js"), CountOptions = new Script.Workers.WorkerProcessCountOptions() { ProcessCount = processCountValue } },
-                new RpcWorkerConfig() { Description = GetTestWorkerDescription("java", ".jar"), CountOptions = new Script.Workers.WorkerProcessCountOptions() { ProcessCount = processCountValue } }
+                new RpcWorkerConfig
+                {
+                    Description = GetTestWorkerDescription("node", ".js"),
+                    ProcessRestartInterval = restartInterval,
+                    ProcessShutdownTimeout = shutdownTimeout,
+                    CountOptions = new WorkerProcessCountOptions
+                    {
+                        ProcessCount = processCountValue,
+                        ProcessStartupInterval = startupInterval
+                    }
+                },
+                new RpcWorkerConfig
+                {
+                    Description = GetTestWorkerDescription("java", ".jar"),
+                    ProcessRestartInterval = restartInterval,
+                    ProcessShutdownTimeout = shutdownTimeout,
+                    CountOptions = new WorkerProcessCountOptions
+                    {
+                        ProcessCount = processCountValue,
+                        ProcessStartupInterval = startupInterval
+                    }
+                }
             };
 
             // Allow tests to have a worker that claims the .dll extension.

--- a/test/WebJobs.Script.Tests/Description/Worker/TestWorkerFunctionInvoker.cs
+++ b/test/WebJobs.Script.Tests/Description/Worker/TestWorkerFunctionInvoker.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
@@ -14,8 +15,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
     internal class TestWorkerFunctionInvoker : WorkerFunctionInvoker
     {
         public TestWorkerFunctionInvoker(ScriptHost host, BindingMetadata bindingMetadata, FunctionMetadata functionMetadata, ILoggerFactory loggerFactory,
-        Collection<FunctionBinding> inputBindings, Collection<FunctionBinding> outputBindings, IFunctionInvocationDispatcher functionDispatcher, IApplicationLifetime applicationLifetime)
-        : base(host, bindingMetadata, functionMetadata, loggerFactory, inputBindings, outputBindings, functionDispatcher, applicationLifetime)
+        Collection<FunctionBinding> inputBindings, Collection<FunctionBinding> outputBindings, IFunctionInvocationDispatcher functionDispatcher, IApplicationLifetime applicationLifetime,
+        TimeSpan initializationTimeout)
+        : base(host, bindingMetadata, functionMetadata, loggerFactory, inputBindings, outputBindings, functionDispatcher, applicationLifetime, initializationTimeout)
         {
         }
 

--- a/test/WebJobs.Script.Tests/Description/Worker/WorkerFunctionInvokerTests.cs
+++ b/test/WebJobs.Script.Tests/Description/Worker/WorkerFunctionInvokerTests.cs
@@ -39,7 +39,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var sc = host.GetScriptHost();
 
             FunctionMetadata metaData = new FunctionMetadata();
-            _testFunctionInvoker = new TestWorkerFunctionInvoker(sc, null, metaData, NullLoggerFactory.Instance, null, new Collection<FunctionBinding>(), _mockFunctionInvocationDispatcher.Object, _applicationLifetime.Object);
+            _testFunctionInvoker = new TestWorkerFunctionInvoker(sc, null, metaData, NullLoggerFactory.Instance, null, new Collection<FunctionBinding>(),
+                _mockFunctionInvocationDispatcher.Object, _applicationLifetime.Object, TimeSpan.FromSeconds(5));
         }
 
         [Fact]
@@ -48,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             try
             {
                 _mockFunctionInvocationDispatcher.Setup(a => a.State).Returns(FunctionInvocationDispatcherState.Initializing);
-                await Task.WhenAny(_testFunctionInvoker.InvokeCore(new object[] { }, null), Task.Delay(TimeSpan.FromSeconds(500)));
+                await Task.WhenAny(_testFunctionInvoker.InvokeCore(new object[] { }, null), Task.Delay(TimeSpan.FromSeconds(30)));
             }
             catch (Exception)
             {
@@ -66,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public async Task FunctionDispatcher_DelaysInvoke_WhenNotReady(FunctionInvocationDispatcherState state, bool delaysExecution)
         {
             _mockFunctionInvocationDispatcher.Setup(a => a.State).Returns(state);
-            var timeoutTask = Task.Delay(TimeSpan.FromSeconds(5));
+            var timeoutTask = Task.Delay(TimeSpan.FromSeconds(2));
             var invokeCoreTask = _testFunctionInvoker.InvokeCore(new object[] { }, null);
             var result = await Task.WhenAny(invokeCoreTask, timeoutTask);
             if (delaysExecution)

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -54,9 +54,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _logger = new TestLogger("FunctionDispatcherTests");
             _testFunctionRpcService = new TestFunctionRpcService(_eventManager, _workerId, _logger, _expectedLogMsg);
             _testWorkerConfig = TestHelpers.GetTestWorkerConfigs().FirstOrDefault();
-            _testWorkerConfig.ProcessStartupTimeout = TimeSpan.FromSeconds(5);
-            _testWorkerConfig.InitializationTimeout = TimeSpan.FromSeconds(5);
-            _testWorkerConfig.EnvironmentReloadTimeout = TimeSpan.FromSeconds(5);
+            _testWorkerConfig.CountOptions.ProcessStartupTimeout = TimeSpan.FromSeconds(5);
+            _testWorkerConfig.CountOptions.InitializationTimeout = TimeSpan.FromSeconds(5);
+            _testWorkerConfig.CountOptions.EnvironmentReloadTimeout = TimeSpan.FromSeconds(5);
 
             _mockrpcWorkerProcess.Setup(m => m.StartProcessAsync()).Returns(Task.CompletedTask);
             _testEnvironment = new TestEnvironment();

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -54,6 +54,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _logger = new TestLogger("FunctionDispatcherTests");
             _testFunctionRpcService = new TestFunctionRpcService(_eventManager, _workerId, _logger, _expectedLogMsg);
             _testWorkerConfig = TestHelpers.GetTestWorkerConfigs().FirstOrDefault();
+            _testWorkerConfig.ProcessStartupTimeout = TimeSpan.FromSeconds(5);
+            _testWorkerConfig.InitializationTimeout = TimeSpan.FromSeconds(5);
+            _testWorkerConfig.EnvironmentReloadTimeout = TimeSpan.FromSeconds(5);
+
             _mockrpcWorkerProcess.Setup(m => m.StartProcessAsync()).Returns(Task.CompletedTask);
             _testEnvironment = new TestEnvironment();
             ILogger<MemoryMappedFileAccessor> mmapAccessorLogger = NullLogger<MemoryMappedFileAccessor>.Instance;

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Azure.WebJobs.Script.Description;
@@ -63,13 +62,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         {
             _testLoggerProvider.ClearAllLogMessages();
             int expectedProcessCount = 3;
-            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount);
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount, startupIntervals: TimeSpan.FromSeconds(1));
             await functionDispatcher.InitializeAsync(GetTestFunctionsList(RpcWorkerConstants.NodeLanguageWorkerName));
 
             var finalChannelCount = await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount);
             Assert.Equal(expectedProcessCount, finalChannelCount);
 
-            VerifyStartIntervals(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(15));
+            VerifyStartIntervals(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2));
         }
 
         [Fact]
@@ -101,10 +100,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var finalChannelCount = await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount, false);
             Assert.Equal(expectedProcessCount, finalChannelCount);
 
-            var logMessages = _testLoggerProvider.GetAllLogMessages().ToList();
+            await TestHelpers.Await(() =>
+            {
+                var logMessages = _testLoggerProvider.GetAllLogMessages().ToList();
 
-            Assert.Equal(logMessages.Where(x => x.FormattedMessage
-                .Contains("Failed to start a new language worker")).Count(), 3);
+                return logMessages.Where(x => x.FormattedMessage
+                    .Contains("Failed to start a new language worker")).Count() == 3;
+            });
         }
 
         [Fact]
@@ -494,12 +496,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.True(testLogs.Any(m => m.FormattedMessage.Contains("Removing errored webhost language worker channel for runtime")));
         }
 
-        private static RpcFunctionInvocationDispatcher GetTestFunctionDispatcher(int maxProcessCountValue = 1, bool addWebhostChannel = false, Mock<IWebHostRpcWorkerChannelManager> mockwebHostLanguageWorkerChannelManager = null, bool throwOnProcessStartUp = false)
+        private static RpcFunctionInvocationDispatcher GetTestFunctionDispatcher(int maxProcessCountValue = 1, bool addWebhostChannel = false, Mock<IWebHostRpcWorkerChannelManager> mockwebHostLanguageWorkerChannelManager = null,
+            bool throwOnProcessStartUp = false, TimeSpan? startupIntervals = null)
         {
             var eventManager = new ScriptEventManager();
             var metricsLogger = new Mock<IMetricsLogger>();
             var mockApplicationLifetime = new Mock<IApplicationLifetime>();
             var testEnv = new TestEnvironment();
+            TimeSpan intervals = startupIntervals ?? TimeSpan.FromMilliseconds(100);
 
             testEnv.SetEnvironmentVariable(RpcWorkerConstants.FunctionsWorkerProcessCountSettingName, maxProcessCountValue.ToString());
 
@@ -512,7 +516,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             var workerConfigOptions = new LanguageWorkerOptions
             {
-                WorkerConfigs = TestHelpers.GetTestWorkerConfigs(processCountValue: maxProcessCountValue)
+                WorkerConfigs = TestHelpers.GetTestWorkerConfigs(processCountValue: maxProcessCountValue, processStartupInterval: intervals,
+                                    processRestartInterval: intervals, processShutdownTimeout: TimeSpan.FromSeconds(1))
             };
             IRpcWorkerChannelFactory testLanguageWorkerChannelFactory = new TestRpcWorkerChannelFactory(eventManager, _testLogger, scriptOptions.Value.RootScriptPath, throwOnProcessStartUp);
             IWebHostRpcWorkerChannelManager testWebHostLanguageWorkerChannelManager = new TestRpcWorkerChannelManager(eventManager, _testLogger, scriptOptions.Value.RootScriptPath, testLanguageWorkerChannelFactory);
@@ -556,7 +561,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                     return allReadyForInvocations ? channels.All(ch => ch.IsChannelReadyForInvocations()) : true;
                 }
                 return false;
-            }, pollingInterval: expectedCount * 5 * 1000, timeout: 60 * 1000);
+            });
             return currentChannelCount;
         }
 
@@ -567,7 +572,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             {
                 currentChannelCount = channelManager.GetChannels(language).Count();
                 return currentChannelCount == expectedCount;
-            }, pollingInterval: 4 * 1000, timeout: 60 * 1000);
+            });
             return currentChannelCount;
         }
 
@@ -576,7 +581,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             await TestHelpers.Await(() =>
             {
                 return functionDispatcher.State == FunctionInvocationDispatcherState.Initialized;
-            }, pollingInterval: 4 * 1000, timeout: 60 * 1000);
+            });
         }
 
         private IEnumerable<FunctionMetadata> GetTestFunctionsList(string runtime)
@@ -613,7 +618,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             for (int i = 1; i < startTimestamps.Count(); i++)
             {
                 var diff = startTimestamps[i] - startTimestamps[i - 1];
-                Assert.True(diff > from && diff < to);
+                Assert.True(diff > from && diff < to, $"Expected startup intervals between {from.TotalMilliseconds}ms and {to.TotalMilliseconds}ms. Actual: {diff.TotalMilliseconds}ms.");
             }
         }
     }


### PR DESCRIPTION
Part 1 of fix for https://github.com/Azure/azure-functions-dotnet-worker/issues/434

When debugging, dotnet-isolated worker pauses while waiting for the debugger to attach. This happens before we've sent the StartStream message from the worker to the host. This means that you can debug startup, etc, before the grpc communication even begins.

This change allows the worker process and initialization timeouts to be configured so that we can wait much longer in these scenarios while debugging. 

There will be a follow-up in the CLI to extend these timeouts if `--dotet-isolated-debug` is passed.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)