### PR TITLE
[pack] Fix BlobStorageSecretRepoError

### DIFF
--- a/src/WebJobs.Script/StorageProvider/AzureStorageProvider.cs
+++ b/src/WebJobs.Script/StorageProvider/AzureStorageProvider.cs
@@ -39,8 +39,8 @@ namespace Microsoft.Azure.WebJobs.Script
             {
                 _ = scriptHostManager ?? throw new ArgumentNullException(nameof(scriptHostManager));
                 _configuration = new ConfigurationBuilder()
-                    .AddConfiguration(configuration)
                     .Add(new ActiveHostConfigurationSource(scriptHostManager))
+                    .AddConfiguration(configuration)
                     .Build();
             }
         }

--- a/test/WebJobs.Script.Tests.Integration/Storage/AzureStorageProviderTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Storage/AzureStorageProviderTests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Storage
 
             var azureStorageProvider = GetAzureStorageProvider(webHostConfiguration, jobHostConfiguration);
             Assert.True(azureStorageProvider.TryGetBlobServiceClientFromConnection(out BlobServiceClient client, "Storage1"));
-            Assert.Equal("jobHostAccount", client.AccountName, ignoreCase: true);
+            Assert.Equal("webHostAccount", client.AccountName, ignoreCase: true);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #7537

Tests before and after the fix

Before the fix

https://wawswus.kusto.windows.net/wawsprod
FunctionsLogs
| where PreciseTimeStamp between (datetime(2021-07-13 04:00:00.1869752)..datetime(2021-07-13 06:00:00.1869752))
| where AppName has "functiondevyojagad"
| where HostVersion == "3.1.1.0"
| where Summary == "There was an error performing a read operation on the Blob Storage Secret Repository. Please ensure the \'AzureWebJobsStorage\' connection string is valid."

After the fix

https://wawswus.kusto.windows.net/wawsprod
FunctionsLogs
| where PreciseTimeStamp between (datetime(2021-07-13 04:00:00.1869752)..datetime(2021-07-13 06:00:00.1869752))
| where AppName has "functiondevyojagad"
| where HostVersion == "3.2.0.0"
| where Summary == "There was an error performing a read operation on the Blob Storage Secret Repository. Please ensure the \'AzureWebJobsStorage\' connection string is valid."

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
