### PR TITLE
Added new GRPC message types for worker indexing, along with relevant functions and tests

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,6 +4,7 @@
 -->
 - Update Azure.Storage.Blobs to 12.9.0 (#7456)
 - Update Python Worker Version to [1.2.4](https://github.com/Azure/azure-functions-python-worker/releases/tag/1.2.4)
+- Add GRPC messages types to protobuf for worker indexing along with relevant functions and tests (#7541)
 
 **Release sprint:** Sprint 104
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+<successiveSprint>%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+104%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -477,6 +477,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             {
                 if (metadata.Status != null && metadata.Status.IsFailure(out Exception metadataRequestEx))
                 {
+                    _workerChannelLogger.LogDebug($"Worker failed to index function {metadata.Id}");
                     _metadataRequestErrors[metadata.Id] = metadataRequestEx;
                 }
                 var functionMetadata = new FunctionMetadata()

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -477,7 +477,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             {
                 if (metadata.Status != null && metadata.Status.IsFailure(out Exception metadataRequestEx))
                 {
-                    _workerChannelLogger.LogDebug($"Worker failed to index function {metadata.Id}");
+                    _workerChannelLogger.LogError($"Worker failed to index function {metadata.Id}");
                     _metadataRequestErrors[metadata.Id] = metadataRequestEx;
                 }
                 var functionMetadata = new FunctionMetadata()

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -24,6 +24,7 @@ using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json.Linq;
 using static Microsoft.Azure.WebJobs.Script.Grpc.Messages.RpcLog.Types;
 using FunctionMetadata = Microsoft.Azure.WebJobs.Script.Description.FunctionMetadata;
 using MsgType = Microsoft.Azure.WebJobs.Script.Grpc.Messages.StreamingMessage.ContentOneofCase;
@@ -47,6 +48,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         private string _workerId;
         private RpcWorkerChannelState _state;
         private IDictionary<string, Exception> _functionLoadErrors = new Dictionary<string, Exception>();
+        private IDictionary<string, Messages.RpcException> _metadataRequestErrors = new Dictionary<string, Messages.RpcException>();
         private ConcurrentDictionary<string, ScriptInvocationContext> _executingInvocations = new ConcurrentDictionary<string, ScriptInvocationContext>();
         private IDictionary<string, BufferBlock<ScriptInvocationContext>> _functionInputBuffers = new ConcurrentDictionary<string, BufferBlock<ScriptInvocationContext>>();
         private ConcurrentDictionary<string, TaskCompletionSource<bool>> _workerStatusRequests = new ConcurrentDictionary<string, TaskCompletionSource<bool>>();
@@ -62,6 +64,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         private IWorkerProcess _rpcWorkerProcess;
         private TaskCompletionSource<bool> _reloadTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         private TaskCompletionSource<bool> _workerInitTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private TaskCompletionSource<List<FunctionMetadata>> _functionsIndexingTask = new TaskCompletionSource<List<FunctionMetadata>>(TaskCreationOptions.RunContinuationsAsynchronously);
         private TimeSpan _functionLoadTimeout = TimeSpan.FromMinutes(10);
         private bool _isSharedMemoryDataTransferEnabled;
 
@@ -400,10 +403,17 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         {
             try
             {
+                // do not send invocation requests for functions that failed to load or for functions that could not be indexed by the worker
                 if (_functionLoadErrors.ContainsKey(context.FunctionMetadata.GetFunctionId()))
                 {
                     _workerChannelLogger.LogDebug($"Function {context.FunctionMetadata.Name} failed to load");
                     context.ResultSource.TrySetException(_functionLoadErrors[context.FunctionMetadata.GetFunctionId()]);
+                    _executingInvocations.TryRemove(context.ExecutionContext.InvocationId.ToString(), out ScriptInvocationContext _);
+                }
+                else if (_metadataRequestErrors.ContainsKey(context.FunctionMetadata.GetFunctionId()))
+                {
+                    _workerChannelLogger.LogDebug($"Function {context.FunctionMetadata.Name} failed to load");
+                    context.ResultSource.TrySetException(new Exception(_metadataRequestErrors[context.FunctionMetadata.GetFunctionId()].Message));
                     _executingInvocations.TryRemove(context.ExecutionContext.InvocationId.ToString(), out ScriptInvocationContext _);
                 }
                 else
@@ -426,6 +436,69 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             {
                 context.ResultSource.TrySetException(invokeEx);
             }
+        }
+
+        // gets metadata from worker
+        public Task<List<FunctionMetadata>> WorkerGetFunctionMetadata()
+        {
+            return SendWorkerMetadataRequest();
+        }
+
+        internal Task<List<FunctionMetadata>> SendWorkerMetadataRequest()
+        {
+            _eventSubscriptions.Add(_inboundWorkerEvents.Where(msg => msg.MessageType == MsgType.WorkerMetadataResponse)
+                        .Timeout(_functionLoadTimeout)
+                        .Take(1)
+                        .Subscribe((msg) => ProcessMetadata(msg.Message.WorkerMetadataResponse), HandleWorkerMetadataRequestError));
+
+            _workerChannelLogger.LogInformation("Sending WorkerMetadataRequest to {language} worker with worker ID {workerID}", _runtime, _workerId);
+
+            // sends the function app directory path to worker for indexing
+            SendStreamingMessage(new StreamingMessage
+            {
+                WorkerMetadataRequest = new WorkerMetadataRequest()
+                {
+                    Directory = _applicationHostOptions.CurrentValue.ScriptPath
+                }
+            });
+            return _functionsIndexingTask.Task;
+        }
+
+        // parse metadata response into FunctionMetadata objects
+        internal void ProcessMetadata(WorkerMetadataResponse workerMetadataResponse)
+        {
+            _workerChannelLogger.LogInformation("Received the worker response");
+
+            var responseStatus = workerMetadataResponse.OverallStatus;
+
+            var functions = new List<FunctionMetadata>();
+
+            foreach (var metadata in workerMetadataResponse.Results)
+            {
+                if (metadata.Status != null && metadata.Status.Status == 0)
+                {
+                    _metadataRequestErrors[metadata.Id] = metadata.Status.Exception;
+                }
+                var functionMetadata = new FunctionMetadata()
+                {
+                    FunctionDirectory = metadata.Directory,
+                    ScriptFile = metadata.ScriptFile,
+                    EntryPoint = metadata.EntryPoint,
+                    Name = metadata.Name,
+                    Language = metadata.Language
+                };
+
+                functionMetadata.SetFunctionId(metadata.Id);
+
+                foreach (string binding in metadata.Bindings)
+                {
+                    var functionBinding = BindingMetadata.Create(JObject.Parse(binding));
+                    functionMetadata.Bindings.Add(functionBinding);
+                }
+                functions.Add(functionMetadata);
+            }
+            // set it as task result because we cannot directly return from SendWorkerMetadataRequest
+            _functionsIndexingTask.SetResult(functions);
         }
 
         private async Task<object> GetBindingDataAsync(ParameterBinding binding, string invocationId)
@@ -627,6 +700,16 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         private void PublishWorkerErrorEvent(Exception exc)
         {
             _workerInitTask.SetException(exc);
+            if (_disposing || _disposed)
+            {
+                return;
+            }
+            _eventManager.Publish(new WorkerErrorEvent(_runtime, Id, exc));
+        }
+
+        internal void HandleWorkerMetadataRequestError(Exception exc)
+        {
+            _workerChannelLogger.LogError(exc, "Requesting metadata from worker failed.");
             if (_disposing || _disposed)
             {
                 return;

--- a/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
+++ b/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
@@ -75,6 +75,11 @@ message StreamingMessage {
     // Ask the worker to close any open shared memory resources for a given invocation
     CloseSharedMemoryResourcesRequest close_shared_memory_resources_request = 27;
     CloseSharedMemoryResourcesResponse close_shared_memory_resources_response = 28;
+
+    // Worker indexing message types
+    WorkerMetadataRequest worker_metadata_request = 29;
+    WorkerMetadataResponse worker_metadata_response = 30;
+    WorkerFunctionIndexingResponse worker_function_indexing_result = 31;
   }
 }
 
@@ -260,6 +265,51 @@ message RpcFunctionMetadata {
 
   // Is set to true for proxy
   bool is_proxy = 7;
+}
+
+// Host tells worker it is ready to receive metadata
+message WorkerMetadataRequest {
+  // base directory for function app
+  string directory = 1;
+}
+
+// Worker sends function metadata back to host
+message WorkerMetadataResponse {
+  // list of function indexing responses
+  repeated WorkerFunctionIndexingResponse results = 1;
+
+  // status of overall metadata request
+  StatusResult overall_status = 2;
+}
+
+// Message type that holds function metadata information
+message WorkerFunctionIndexingResponse {
+  // function name
+  string name = 4;
+
+  // base directory for the Function
+  string directory = 1;
+
+  // Script file specified
+  string script_file = 2;
+
+  // Entry point specified
+  string entry_point = 3;
+
+  // Function id
+  string id = 11;
+
+  // Bindings info
+  repeated string bindings = 6;
+
+  // Is set to true for proxy
+  bool is_proxy = 7;
+
+  // Function indexing status
+  StatusResult status = 8;
+
+  // Function language
+  string language = 9;
 }
 
 // Host requests worker to invoke a Function

--- a/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
+++ b/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
@@ -77,9 +77,9 @@ message StreamingMessage {
     CloseSharedMemoryResourcesResponse close_shared_memory_resources_response = 28;
 
     // Worker indexing message types
-    WorkerMetadataRequest worker_metadata_request = 29;
-    WorkerMetadataResponse worker_metadata_response = 30;
-    WorkerFunctionIndexingResponse worker_function_indexing_result = 31;
+    WorkerFunctionMetadataRequest worker_function_metadata_request = 29;
+    WorkerFunctionMetadataResponse worker_function_metadata_response = 30;
+    WorkerFunctionMetadata worker_function_metadata = 31;
   }
 }
 
@@ -268,22 +268,22 @@ message RpcFunctionMetadata {
 }
 
 // Host tells worker it is ready to receive metadata
-message WorkerMetadataRequest {
+message WorkerFunctionMetadataRequest {
   // base directory for function app
   string directory = 1;
 }
 
 // Worker sends function metadata back to host
-message WorkerMetadataResponse {
+message WorkerFunctionMetadataResponse {
   // list of function indexing responses
-  repeated WorkerFunctionIndexingResponse results = 1;
+  repeated WorkerFunctionMetadata results = 1;
 
   // status of overall metadata request
   StatusResult overall_status = 2;
 }
 
 // Message type that holds function metadata information
-message WorkerFunctionIndexingResponse {
+message WorkerFunctionMetadata {
   // function name
   string name = 4;
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -435,6 +435,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
+        public void ReceivesInboundEvent_WorkerMetadataResponse()
+        {
+            var functionMetadata = GetTestFunctionsList("python");
+            var functions = _workerChannel.WorkerGetFunctionMetadata();
+            _testFunctionRpcService.PublishWorkerMetadataResponse("TestFunctionId1", functionMetadata);
+            var traces = _logger.GetLogMessages();
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Received the worker response")));
+        }
+
+        [Fact]
         public void FunctionLoadRequest_IsExpected()
         {
             FunctionMetadata metadata = new FunctionMetadata()

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -441,7 +441,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var functions = _workerChannel.WorkerGetFunctionMetadata();
             _testFunctionRpcService.PublishWorkerMetadataResponse("TestFunctionId1", functionMetadata);
             var traces = _logger.GetLogMessages();
-            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Received the worker response")));
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, $"Received the worker function metadata response from worker {_workerChannel.Id}")));
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Workers/Rpc/TestFunctionRpcService.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/TestFunctionRpcService.cs
@@ -175,10 +175,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 Status = StatusResult.Types.Status.Success
             };
 
-            WorkerMetadataResponse overallResponse = new WorkerMetadataResponse();
+            WorkerFunctionMetadataResponse overallResponse = new WorkerFunctionMetadataResponse();
             foreach (FunctionMetadata response in functionMetadata)
             {
-                WorkerFunctionIndexingResponse indexingResponse = new WorkerFunctionIndexingResponse()
+                WorkerFunctionMetadata indexingResponse = new WorkerFunctionMetadata()
                 {
                     Name = response.Name,
                     Language = response.Language
@@ -189,7 +189,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             StreamingMessage responseMessage = new StreamingMessage()
             {
-                WorkerMetadataResponse = overallResponse
+                WorkerFunctionMetadataResponse = overallResponse
             };
             _eventManager.Publish(new InboundGrpcEvent(_workerId, responseMessage));
         }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/TestFunctionRpcService.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/TestFunctionRpcService.cs
@@ -3,11 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reactive.Linq;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.Grpc.Eventing;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
-using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
@@ -162,6 +164,32 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             StreamingMessage responseMessage = new StreamingMessage()
             {
                 StartStream = startStream
+            };
+            _eventManager.Publish(new InboundGrpcEvent(_workerId, responseMessage));
+        }
+
+        public void PublishWorkerMetadataResponse(string workerId, IEnumerable<FunctionMetadata> functionMetadata)
+        {
+            StatusResult statusResult = new StatusResult()
+            {
+                Status = StatusResult.Types.Status.Success
+            };
+
+            WorkerMetadataResponse overallResponse = new WorkerMetadataResponse();
+            foreach (FunctionMetadata response in functionMetadata)
+            {
+                WorkerFunctionIndexingResponse indexingResponse = new WorkerFunctionIndexingResponse()
+                {
+                    Name = response.Name,
+                    Language = response.Language
+                };
+
+                overallResponse.Results.Add(indexingResponse);
+            }
+
+            StreamingMessage responseMessage = new StreamingMessage()
+            {
+                WorkerMetadataResponse = overallResponse
             };
             _eventManager.Publish(new InboundGrpcEvent(_workerId, responseMessage));
         }


### PR DESCRIPTION
### Protobuf needs to support sending and receiving worker metadata requests/responses

This PR adds the new worker indexing GRPC message types to the protobuf. It also adds some functions into GrpcWorkerChannel.cs to send/receive the metadata requests and responses, along with a test to check this sending and receiving functionality. 

Resolves #7513 and #7514 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)