### PR TITLE
[Linux Consumption] Add support for secretless Run-From-Package

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
@@ -28,13 +28,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         private readonly IMetricsLogger _metricsLogger;
         private readonly IMeshServiceClient _meshServiceClient;
         private readonly IRunFromPackageHandler _runFromPackageHandler;
+        private readonly IPackageDownloadHandler _packageDownloadHandler;
         private readonly IEnvironment _environment;
         private readonly IOptionsFactory<ScriptApplicationHostOptions> _optionsFactory;
         private readonly HttpClient _client;
         private readonly IScriptWebHostEnvironment _webHostEnvironment;
 
         public InstanceManager(IOptionsFactory<ScriptApplicationHostOptions> optionsFactory, HttpClient client, IScriptWebHostEnvironment webHostEnvironment,
-            IEnvironment environment, ILogger<InstanceManager> logger, IMetricsLogger metricsLogger, IMeshServiceClient meshServiceClient, IRunFromPackageHandler runFromPackageHandler)
+            IEnvironment environment, ILogger<InstanceManager> logger, IMetricsLogger metricsLogger, IMeshServiceClient meshServiceClient, IRunFromPackageHandler runFromPackageHandler,
+            IPackageDownloadHandler packageDownloadHandler)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
             _webHostEnvironment = webHostEnvironment ?? throw new ArgumentNullException(nameof(webHostEnvironment));
@@ -42,6 +44,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             _metricsLogger = metricsLogger;
             _meshServiceClient = meshServiceClient;
             _runFromPackageHandler = runFromPackageHandler ?? throw new ArgumentNullException(nameof(runFromPackageHandler));
+            _packageDownloadHandler = packageDownloadHandler ?? throw new ArgumentNullException(nameof(packageDownloadHandler));
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
             _optionsFactory = optionsFactory ?? throw new ArgumentNullException(nameof(optionsFactory));
         }
@@ -64,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 {
                     _logger.LogWarning("Skipping specialization of MSI sidecar since MSIContext was absent");
                     await _meshServiceClient.NotifyHealthEvent(ContainerHealthEventType.Fatal, this.GetType(),
-                        "Could not specialize MSI sidecar");
+                        "Could not specialize MSI sidecar since MSIContext was empty");
                 }
                 else
                 {
@@ -89,6 +92,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                         {
                             var message = $"Specialize MSI sidecar call failed. StatusCode={response.StatusCode}";
                             _logger.LogError(message);
+                            await _meshServiceClient.NotifyHealthEvent(ContainerHealthEventType.Fatal, this.GetType(),
+                                "Failed to specialize MSI sidecar");
                             return message;
                         }
                     }
@@ -120,7 +125,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             {
                 // Based on profiling download code jit-ing holds up cold start.
                 // Pre-jit to avoid paying the cost later.
-                Task.Run(async () => await _runFromPackageHandler.Download(context.GetRunFromPkgContext()));
+                Task.Run(async () => await _packageDownloadHandler.Download(context.GetRunFromPkgContext()));
                 return true;
             }
             else if (_assignmentContext == null)
@@ -169,14 +174,34 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             }
             else if (!string.IsNullOrEmpty(pkgContext.Url) && pkgContext.Url != "1")
             {
-                // In AppService, ZipUrl == 1 means the package is hosted in azure files.
-                // Otherwise we expect zipUrl to be a blobUri to a zip or a squashfs image
-                (var error, var contentLength) = await ValidateBlobPackageContext(pkgContext);
-                if (string.IsNullOrEmpty(error))
+                if (Uri.TryCreate(pkgContext.Url, UriKind.Absolute, out var uri))
                 {
-                    assignmentContext.PackageContentLength = contentLength;
+                    if (Utility.IsResourceAzureBlobWithoutSas(uri))
+                    {
+                        // Note: this also means we skip validation for publicly available blobs
+                        _logger.LogDebug($"Skipping validation for {pkgContext.EnvironmentVariableName} with no SAS token");
+                        return null;
+                    }
+                    else
+                    {
+                        // In AppService, ZipUrl == 1 means the package is hosted in azure files.
+                        // Otherwise we expect zipUrl to be a blobUri to a zip or a squashfs image
+                        var (error, contentLength) = await ValidateBlobPackageContext(pkgContext);
+                        if (string.IsNullOrEmpty(error))
+                        {
+                            assignmentContext.PackageContentLength = contentLength;
+                        }
+                        return error;
+                    }
                 }
-                return error;
+                else
+                {
+                    var invalidUrlError = $"Invalid url for specified for {pkgContext.EnvironmentVariableName}";
+                    _logger.LogError(invalidUrlError);
+                    // For now we return null here instead of the actual error since this validation is new.
+                    // Eventually this could return the error message.
+                    return null;
+                }
             }
             else if (!string.IsNullOrEmpty(assignmentContext.AzureFilesConnectionString))
             {

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/IManagedIdentityTokenProvider.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/IManagedIdentityTokenProvider.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
+{
+    public interface IManagedIdentityTokenProvider
+    {
+        Task<string> GetManagedIdentityToken(string resourceUrl);
+    }
+}

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/IPackageDownloadHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/IPackageDownloadHandler.cs
@@ -6,11 +6,8 @@ using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
 {
-    public interface IRunFromPackageHandler
+    public interface IPackageDownloadHandler
     {
-        Task<bool> MountAzureFileShare(HostAssignmentContext assignmentContext);
-
-        Task<bool> ApplyBlobPackageContext(RunFromPackageContext pkgContext, string targetPath, bool azureFilesMounted,
-            bool throwOnFailure = true);
+        Task<string> Download(RunFromPackageContext pkgContext);
     }
 }

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/ManagedIdentityTokenProvider.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/ManagedIdentityTokenProvider.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
+{
+    public class ManagedIdentityTokenProvider : IManagedIdentityTokenProvider
+    {
+        private const string ApiVersion = "1.0";
+
+        private readonly IEnvironment _environment;
+        private readonly HttpClient _httpClient;
+        private readonly IMetricsLogger _metricsLogger;
+        private readonly ILogger<ManagedIdentityTokenProvider> _logger;
+
+        public ManagedIdentityTokenProvider(IEnvironment environment, HttpClient httpClient,
+            IMetricsLogger metricsLogger, ILogger<ManagedIdentityTokenProvider> logger)
+        {
+            _environment = environment;
+            _httpClient = httpClient;
+            _metricsLogger = metricsLogger;
+            _logger = logger;
+        }
+
+        private string GetRunFromPackageIdentity()
+        {
+            var runFromPackageIdentity = _environment.GetEnvironmentVariable(EnvironmentSettingNames.RunFromPackageManagedResourceId);
+            if (string.IsNullOrEmpty(runFromPackageIdentity))
+            {
+                _logger.LogDebug(
+                    $"No {EnvironmentSettingNames.RunFromPackageManagedResourceId} specified. Falling back to using {EnvironmentSettingNames.SystemAssignedManagedIdentity}");
+                return string.Empty;
+            }
+
+            if (string.Equals(EnvironmentSettingNames.SystemAssignedManagedIdentity, runFromPackageIdentity, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogDebug($"Using {EnvironmentSettingNames.SystemAssignedManagedIdentity} to download package");
+                // returning empty string defaults to system assigned identity
+                return string.Empty;
+            }
+
+            _logger.LogDebug($"Using Managed ResourceId {runFromPackageIdentity} to download package");
+            return runFromPackageIdentity;
+        }
+
+        private string GetTokenEndpoint(string resourceUrl)
+        {
+            if (!Utility.TryGetUriHost(resourceUrl, out var resourceHost))
+            {
+                throw new ArgumentException(nameof(resourceUrl));
+            }
+
+            var msiEndpoint = _environment.GetEnvironmentVariable(EnvironmentSettingNames.MsiEndpoint);
+            if (string.IsNullOrEmpty(msiEndpoint))
+            {
+                throw new InvalidOperationException("MSI is not enabled on the app. Failed to acquire ManagedIdentity token");
+            }
+
+            var tokenEndpoint =
+                $"{msiEndpoint}?api-version={ApiVersion}&resource={resourceHost}";
+
+            var resourceId = GetRunFromPackageIdentity();
+            if (!string.IsNullOrEmpty(resourceId))
+            {
+                tokenEndpoint = string.Concat(tokenEndpoint, $"&mi_res_id={resourceId}");
+            }
+
+            return tokenEndpoint;
+        }
+
+        public async Task<string> GetManagedIdentityToken(string resourceUrl)
+        {
+            var tokenEndpoint = GetTokenEndpoint(resourceUrl);
+            return await GetTokenWithRetries(tokenEndpoint);
+        }
+
+        private async Task<string> GetTokenWithRetries(string tokenEndpoint)
+        {
+            string token = null;
+            await Utility.InvokeWithRetriesAsync(async () =>
+            {
+                token = await GetToken(tokenEndpoint);
+            }, maxRetries: 2, TimeSpan.FromMilliseconds(100));
+
+            return token;
+        }
+
+        private async Task<string> GetToken(string tokenEndpoint)
+        {
+            try
+            {
+                using (_metricsLogger.LatencyEvent(MetricEventNames.LinuxContainerSpecializationFetchMIToken))
+                {
+                    using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, tokenEndpoint))
+                    {
+                        var msiToken = _environment.GetEnvironmentVariable(EnvironmentSettingNames.MsiSecret);
+                        httpRequestMessage.Headers.Add(ScriptConstants.XIdentityHeader, msiToken);
+                        using (var response = await _httpClient.SendAsync(httpRequestMessage))
+                        {
+                            response.EnsureSuccessStatusCode();
+                            var readAsStringAsync = await response.Content.ReadAsStringAsync();
+                            var msiResponse = JsonConvert.DeserializeObject<TokenServiceMsiResponse>(readAsStringAsync);
+                            return msiResponse.AccessToken;
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, nameof(GetToken));
+                throw;
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/PackageDownloadHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/PackageDownloadHandler.cs
@@ -1,0 +1,208 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
+{
+    public class PackageDownloadHandler : IPackageDownloadHandler
+    {
+        public const int AriaDownloadThreshold = 100 * 1024 * 1024;
+        public const string Aria2CExecutable = "aria2c";
+        private const string StorageBlobDownloadApiVersion = "2019-12-12";
+
+        private readonly HttpClient _httpClient;
+        private readonly IManagedIdentityTokenProvider _managedIdentityTokenProvider;
+        private readonly IBashCommandHandler _bashCommandHandler;
+        private readonly ILogger<PackageDownloadHandler> _logger;
+        private readonly IMetricsLogger _metricsLogger;
+
+        public PackageDownloadHandler(HttpClient httpClient, IManagedIdentityTokenProvider managedIdentityTokenProvider,
+            IBashCommandHandler bashCommandHandler, ILogger<PackageDownloadHandler> logger,
+            IMetricsLogger metricsLogger)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _managedIdentityTokenProvider = managedIdentityTokenProvider ?? throw new ArgumentNullException(nameof(managedIdentityTokenProvider));
+            _bashCommandHandler = bashCommandHandler ?? throw new ArgumentNullException(nameof(bashCommandHandler));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _metricsLogger = metricsLogger ?? throw new ArgumentNullException(nameof(metricsLogger));
+        }
+
+        public async Task<string> Download(RunFromPackageContext pkgContext)
+        {
+            if (Utility.TryCleanUrl(pkgContext.Url, out var cleanedUrl))
+            {
+                _logger.LogDebug($"Downloading app contents from '{cleanedUrl}'");
+            }
+            else
+            {
+                throw new InvalidOperationException("Invalid url for the package");
+            }
+
+            var isWarmupRequest = pkgContext.IsWarmUpRequest;
+            var needsManagedIdentityToken = !isWarmupRequest && await IsAuthenticationTokenNecessary(pkgContext.Url);
+            _logger.LogDebug(
+                $"{nameof(PackageDownloadHandler)}: Needs ManagedIdentity Token = {needsManagedIdentityToken} IsWarmupRequest = {isWarmupRequest}");
+
+            var zipUri = new Uri(pkgContext.Url);
+            var token = needsManagedIdentityToken
+                ? await _managedIdentityTokenProvider.GetManagedIdentityToken(zipUri.AbsoluteUri)
+                : string.Empty;
+
+            return await Download(pkgContext, zipUri, token);
+        }
+
+        private async Task<string> Download(RunFromPackageContext pkgContext, Uri zipUri, string token)
+        {
+            if (pkgContext.IsWarmUpRequest && !string.IsNullOrEmpty(token))
+            {
+                throw new Exception("Warmup requests do not support ManagedIdentity token");
+            }
+
+            var tmpPath = Path.GetTempPath();
+            var fileName = Path.GetFileName(zipUri.AbsolutePath);
+            var filePath = Path.Combine(tmpPath, fileName);
+
+            string downloadMetricName;
+            if (!string.IsNullOrEmpty(token))
+            {
+                downloadMetricName = MetricEventNames.LinuxContainerSpecializationZipDownloadUsingManagedIdentity;
+            }
+            else
+            {
+                downloadMetricName = pkgContext.IsWarmUpRequest
+                    ? MetricEventNames.LinuxContainerSpecializationZipDownloadWarmup
+                    : MetricEventNames.LinuxContainerSpecializationZipDownload;
+            }
+
+            var tokenPrefix = token == null ? "Null" : token.Substring(0, Math.Min(token.Length, 3));
+
+            // Aria download doesn't support MI Token or warmup requests
+            if (pkgContext.PackageContentLength != null && pkgContext.PackageContentLength > AriaDownloadThreshold && string.IsNullOrEmpty(token) && !pkgContext.IsWarmUpRequest)
+            {
+                _logger.LogDebug(
+                    $"Downloading zip contents using aria2c. IsWarmupRequest = {pkgContext.IsWarmUpRequest}. Managed Identity TokenPrefix = {tokenPrefix}");
+                AriaDownload(tmpPath, fileName, zipUri, pkgContext.IsWarmUpRequest, downloadMetricName);
+            }
+            else
+            {
+                _logger.LogDebug(
+                    $"Downloading zip contents using httpclient. IsWarmupRequest = {pkgContext.IsWarmUpRequest}. Managed Identity TokenPrefix = {tokenPrefix}");
+                await HttpClientDownload(filePath, zipUri, pkgContext.IsWarmUpRequest, token, downloadMetricName);
+            }
+
+            return filePath;
+        }
+
+        private void AriaDownload(string directory, string fileName, Uri zipUri, bool isWarmupRequest, string downloadMetricName)
+        {
+            (string stdout, string stderr, int exitCode) = _bashCommandHandler.RunBashCommand(
+                $"{Aria2CExecutable} --allow-overwrite -x12 -d {directory} -o {fileName} '{zipUri}'",
+                downloadMetricName);
+            if (exitCode != 0)
+            {
+                var msg = $"Error downloading package. stdout: {stdout}, stderr: {stderr}, exitCode: {exitCode}";
+                _logger.LogError(msg);
+                throw new InvalidOperationException(msg);
+            }
+            var fileInfo = FileUtility.FileInfoFromFileName(Path.Combine(directory, fileName));
+            _logger.LogInformation($"{fileInfo.Length} bytes downloaded. IsWarmupRequest = {isWarmupRequest}");
+        }
+
+        private async Task HttpClientDownload(string filePath, Uri zipUri, bool isWarmupRequest, string token, string downloadMetricName)
+        {
+            HttpResponseMessage response = null;
+            await Utility.InvokeWithRetriesAsync(async () =>
+            {
+                try
+                {
+                    using (_metricsLogger.LatencyEvent(downloadMetricName))
+                    {
+                        var request = new HttpRequestMessage(HttpMethod.Get, zipUri);
+
+                        if (!string.IsNullOrEmpty(token))
+                        {
+                            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                            request.Headers.Add(ScriptConstants.AzureVersionHeader, StorageBlobDownloadApiVersion);
+                        }
+
+                        response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+                        response.EnsureSuccessStatusCode();
+                    }
+                }
+                catch (Exception e)
+                {
+                    const string error = "Error downloading zip content";
+                    _logger.LogError(e, error);
+                    throw;
+                }
+                _logger.LogInformation($"{response.Content.Headers.ContentLength} bytes downloaded. IsWarmupRequest = {isWarmupRequest}");
+            }, 2, TimeSpan.FromSeconds(0.5));
+
+            using (_metricsLogger.LatencyEvent(isWarmupRequest ? MetricEventNames.LinuxContainerSpecializationZipWriteWarmup : MetricEventNames.LinuxContainerSpecializationZipWrite))
+            {
+                using (var content = await response.Content.ReadAsStreamAsync())
+                using (var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096, useAsync: true))
+                {
+                    await content.CopyToAsync(stream);
+                }
+                _logger.LogInformation($"{response.Content.Headers.ContentLength} bytes written. IsWarmupRequest = {isWarmupRequest}");
+            }
+        }
+
+        private async Task<bool> IsAuthenticationTokenNecessary(string resourceUrl)
+        {
+            if (!Uri.TryCreate(resourceUrl, UriKind.Absolute, out var resourceUri))
+            {
+                _logger.LogDebug("Token retrieval not required since site content url is invalid");
+                return false;
+            }
+
+            if (!Utility.IsResourceAzureBlobWithoutSas(resourceUri))
+            {
+                _logger.LogDebug("Token retrieval not required because site content is a SAS Azure Blob URL.");
+                return false;
+            }
+
+            if (await IsResourceAccessibleWithoutAuthorization(resourceUrl))
+            {
+                _logger.LogDebug("Token retrieval not required because site content zip is publicly accessible.");
+                return false;
+            }
+
+            return true;
+        }
+
+        private async Task<bool> IsResourceAccessibleWithoutAuthorization(string resourceUrl)
+        {
+            try
+            {
+                using (var cts = new CancellationTokenSource())
+                {
+                    cts.CancelAfter(TimeSpan.FromSeconds(5));
+                    using (var httpRequest = new HttpRequestMessage(HttpMethod.Head, resourceUrl))
+                    {
+                        using (var httpResponse = await _httpClient.SendAsync(httpRequest, cts.Token))
+                        {
+                            return httpResponse.StatusCode == HttpStatusCode.OK;
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, nameof(IsResourceAccessibleWithoutAuthorization));
+                return false;
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
@@ -14,29 +13,27 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
 {
     public class RunFromPackageHandler : IRunFromPackageHandler
     {
-        public const int AriaDownloadThreshold = 100 * 1024 * 1024;
-        public const string Aria2CExecutable = "aria2c";
         public const string UnsquashFSExecutable = "unsquashfs";
         private const string SquashfsPrefix = "Squashfs";
         private const string ZipPrefix = "Zip";
         private static readonly string[] _knownPackageExtensions = { ".squashfs", ".sfs", ".sqsh", ".img", ".fs" };
 
         private readonly IEnvironment _environment;
-        private readonly HttpClient _client;
         private readonly IMeshServiceClient _meshServiceClient;
         private readonly IBashCommandHandler _bashCommandHandler;
         private readonly IUnZipHandler _unZipHandler;
+        private readonly IPackageDownloadHandler _packageDownloadHandler;
         private readonly IMetricsLogger _metricsLogger;
         private readonly ILogger<RunFromPackageHandler> _logger;
 
-        public RunFromPackageHandler(IEnvironment environment, HttpClient client, IMeshServiceClient meshServiceClient,
-            IBashCommandHandler bashCommandHandler, IUnZipHandler unZipHandler, IMetricsLogger metricsLogger, ILogger<RunFromPackageHandler> logger)
+        public RunFromPackageHandler(IEnvironment environment, IMeshServiceClient meshServiceClient,
+            IBashCommandHandler bashCommandHandler, IUnZipHandler unZipHandler, IPackageDownloadHandler packageDownloadHandler, IMetricsLogger metricsLogger, ILogger<RunFromPackageHandler> logger)
         {
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
-            _client = client ?? throw new ArgumentNullException(nameof(client));
             _meshServiceClient = meshServiceClient ?? throw new ArgumentNullException(nameof(meshServiceClient));
             _bashCommandHandler = bashCommandHandler ?? throw new ArgumentNullException(nameof(bashCommandHandler));
-            _unZipHandler = unZipHandler;
+            _unZipHandler = unZipHandler ?? throw new ArgumentNullException(nameof(unZipHandler));
+            _packageDownloadHandler = packageDownloadHandler ?? throw new ArgumentNullException(nameof(packageDownloadHandler));
             _metricsLogger = metricsLogger ?? throw new ArgumentNullException(nameof(metricsLogger));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
@@ -55,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
                     : string.Empty;
 
                 // download zip and extract
-                var filePath = await Download(pkgContext);
+                var filePath = await _packageDownloadHandler.Download(pkgContext);
                 await UnpackPackage(filePath, targetPath, pkgContext, localSitePackagesPath);
 
                 string bundlePath = Path.Combine(targetPath, "worker-bundle");
@@ -167,49 +164,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
                 => options.Any(o => uri.AbsolutePath.EndsWith(o, StringComparison.OrdinalIgnoreCase));
         }
 
-        public async Task<string> Download(RunFromPackageContext pkgContext)
-        {
-            var zipUri = new Uri(pkgContext.Url);
-            if (!Utility.TryCleanUrl(zipUri.AbsoluteUri, out string cleanedUrl))
-            {
-                throw new InvalidOperationException("Invalid url for the package");
-            }
-
-            var tmpPath = Path.GetTempPath();
-            var fileName = Path.GetFileName(zipUri.AbsolutePath);
-            var filePath = Path.Combine(tmpPath, fileName);
-            if (pkgContext.PackageContentLength != null && pkgContext.PackageContentLength > AriaDownloadThreshold)
-            {
-                _logger.LogDebug($"Downloading zip contents from '{cleanedUrl}' using aria2c'");
-                AriaDownload(tmpPath, fileName, zipUri, pkgContext.IsWarmUpRequest);
-            }
-            else
-            {
-                _logger.LogDebug($"Downloading zip contents from '{cleanedUrl}' using httpclient'");
-                await HttpClientDownload(filePath, zipUri, pkgContext.IsWarmUpRequest);
-            }
-
-            return filePath;
-        }
-
-        private void AriaDownload(string directory, string fileName, Uri zipUri, bool isWarmupRequest)
-        {
-            var metricName = isWarmupRequest
-                ? MetricEventNames.LinuxContainerSpecializationZipDownloadWarmup
-                : MetricEventNames.LinuxContainerSpecializationZipDownload;
-            (string stdout, string stderr, int exitCode) = _bashCommandHandler.RunBashCommand(
-                $"{Aria2CExecutable} --allow-overwrite -x12 -d {directory} -o {fileName} '{zipUri}'",
-                metricName);
-            if (exitCode != 0)
-            {
-                var msg = $"Error downloading package. stdout: {stdout}, stderr: {stderr}, exitCode: {exitCode}";
-                _logger.LogError(msg);
-                throw new InvalidOperationException(msg);
-            }
-            var fileInfo = FileUtility.FileInfoFromFileName(Path.Combine(directory, fileName));
-            _logger.LogInformation($"{fileInfo.Length} bytes downloaded. IsWarmupRequest = {isWarmupRequest}");
-        }
-
         private async Task CreateBindMount(string sourcePath, string targetPath)
         {
             using (_metricsLogger.LatencyEvent(MetricEventNames.LinuxContainerSpecializationBindMount))
@@ -224,43 +178,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
 
             _bashCommandHandler.RunBashCommand($"{UnsquashFSExecutable} -f -d '{scriptPath}' '{filePath}'",
                 MetricEventNames.LinuxContainerSpecializationUnsquash);
-        }
-
-        private async Task HttpClientDownload(string filePath, Uri zipUri, bool isWarmupRequest)
-        {
-            HttpResponseMessage response = null;
-            await Utility.InvokeWithRetriesAsync(async () =>
-            {
-                try
-                {
-                    var downloadMetricName = isWarmupRequest
-                        ? MetricEventNames.LinuxContainerSpecializationZipDownloadWarmup
-                        : MetricEventNames.LinuxContainerSpecializationZipDownload;
-                    using (_metricsLogger.LatencyEvent(downloadMetricName))
-                    {
-                        var request = new HttpRequestMessage(HttpMethod.Get, zipUri);
-                        response = await _client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
-                        response.EnsureSuccessStatusCode();
-                    }
-                }
-                catch (Exception e)
-                {
-                    string error = $"Error downloading zip content";
-                    _logger.LogError(e, error);
-                    throw;
-                }
-                _logger.LogInformation($"{response.Content.Headers.ContentLength} bytes downloaded. IsWarmupRequest = {isWarmupRequest}");
-            }, 2, TimeSpan.FromSeconds(0.5));
-
-            using (_metricsLogger.LatencyEvent(isWarmupRequest ? MetricEventNames.LinuxContainerSpecializationZipWriteWarmup : MetricEventNames.LinuxContainerSpecializationZipWrite))
-            {
-                using (var content = await response.Content.ReadAsStreamAsync())
-                using (var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096, useAsync: true))
-                {
-                    await content.CopyToAsync(stream);
-                }
-                _logger.LogInformation($"{response.Content.Headers.ContentLength} bytes written. IsWarmupRequest = {isWarmupRequest}");
-            }
         }
 
         public async Task<bool> MountAzureFileShare(HostAssignmentContext assignmentContext)

--- a/src/WebJobs.Script.WebHost/Models/TokenServiceMsiResponse.cs
+++ b/src/WebJobs.Script.WebHost/Models/TokenServiceMsiResponse.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
+{
+    [JsonObject]
+    public class TokenServiceMsiResponse
+    {
+        [JsonProperty("access_token")]
+        public string AccessToken { get; set; }
+
+        [JsonProperty("expires_on")]
+        public string ExpiresOn { get; set; }
+
+        [JsonProperty("resource")]
+        public string Resource { get; set; }
+
+        [JsonProperty("token_type")]
+        public string TokenType { get; set; }
+
+        [JsonProperty("client_id")]
+        public string ClientId { get; set; }
+    }
+}

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -273,6 +273,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             });
 
             services.AddSingleton<IRunFromPackageHandler, RunFromPackageHandler>();
+            services.AddSingleton<IPackageDownloadHandler, PackageDownloadHandler>();
+            services.AddSingleton<IManagedIdentityTokenProvider, ManagedIdentityTokenProvider>();
             services.AddSingleton<IUnZipHandler, UnZipHandler>();
             services.AddSingleton<IBashCommandHandler, BashCommandHandler>();
         }

--- a/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
         public const string LinuxContainerSpecializationMountCifs = "linux.container.specialization.mount.cifs";
         public const string LinuxContainerSpecializationZipExtract = "linux.container.specialization.zip.extract";
         public const string LinuxContainerSpecializationZipDownload = "linux.container.specialization.zip.download";
+        public const string LinuxContainerSpecializationZipDownloadUsingManagedIdentity = "linux.container.specialization.zip.download.mi.token";
         public const string LinuxContainerSpecializationZipDownloadWarmup = "linux.container.specialization.zip.download.warmup";
         public const string LinuxContainerSpecializationZipWrite = "linux.container.specialization.zip.write";
         public const string LinuxContainerSpecializationZipWriteWarmup = "linux.container.specialization.zip.write.warmup";
@@ -82,6 +83,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
         public const string LinuxContainerSpecializationZipHeadWarmup = "linux.container.specialization.zip.head.warmup";
         public const string LinuxContainerSpecializationFuseMount = "linux.container.specialization.mount";
         public const string LinuxContainerSpecializationMSIInit = "linux.container.specialization.msi.init";
+        public const string LinuxContainerSpecializationFetchMIToken = "linux.container.specialization.fetch.mi.token";
         public const string LinuxContainerSpecializationUnsquash = "linux.container.specialization.unsquash";
         public const string LinuxContainerSpecializationFileCommand = "linux.container.specialization.file.command";
         public const string LinuxContainerSpecializationAzureFilesMount = "linux.container.specialization.azure.files.mount";

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.Azure.AppService.Proxy.Runtime.Configuration.Policies;
-
 namespace Microsoft.Azure.WebJobs.Script
 {
     public static class EnvironmentSettingNames
@@ -82,6 +80,8 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AzureWebsiteZipDeployment = "WEBSITE_USE_ZIP";
         public const string AzureWebsiteAltZipDeployment = "WEBSITE_RUN_FROM_ZIP";
         public const string AzureWebsiteRunFromPackage = "WEBSITE_RUN_FROM_PACKAGE";
+        public const string RunFromPackageManagedResourceId = "WEBSITE_RUN_FROM_PACKAGE_BLOB_MI_RESOURCE_ID";
+        public const string SystemAssignedManagedIdentity = "SystemAssigned";
         public const string RegionName = "REGION_NAME";
 
         // handling server side builds

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -97,6 +97,8 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AntaresColdStartHeaderName = "X-MS-COLDSTART";
         public const string SiteTokenHeaderName = "x-ms-site-restricted-token";
         public const string EasyAuthIdentityHeader = "x-ms-client-principal";
+        public const string AzureVersionHeader = "x-ms-version";
+        public const string XIdentityHeader = "X-IDENTITY-HEADER";
         public const string DynamicSku = "Dynamic";
         public const string ElasticPremiumSku = "ElasticPremium";
         public const string DefaultProductionSlotName = "production";

--- a/test/WebJobs.Script.Tests.Integration/Management/KubernetesPodControllerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/KubernetesPodControllerTests.cs
@@ -49,7 +49,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 StatusCode = HttpStatusCode.OK
             });
 
-            var instanceManager = new InstanceManager(_optionsFactory, new HttpClient(handlerMock.Object), scriptWebEnvironment, environment, loggerFactory.CreateLogger<InstanceManager>(), new TestMetricsLogger(), null, new Mock<IRunFromPackageHandler>().Object);
+            var instanceManager = new InstanceManager(_optionsFactory, new HttpClient(handlerMock.Object),
+                scriptWebEnvironment, environment, loggerFactory.CreateLogger<InstanceManager>(),
+                new TestMetricsLogger(), null, new Mock<IRunFromPackageHandler>().Object,
+                new Mock<IPackageDownloadHandler>(MockBehavior.Strict).Object);
             var startupContextProvider = new StartupContextProvider(environment, loggerFactory.CreateLogger<StartupContextProvider>());
 
             InstanceManager.Reset();
@@ -104,7 +107,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 StatusCode = HttpStatusCode.OK
             });
 
-            var instanceManager = new InstanceManager(_optionsFactory, new HttpClient(handlerMock.Object), scriptWebEnvironment, environment, loggerFactory.CreateLogger<InstanceManager>(), new TestMetricsLogger(), null, new Mock<IRunFromPackageHandler>().Object);
+            var instanceManager = new InstanceManager(_optionsFactory, new HttpClient(handlerMock.Object),
+                scriptWebEnvironment, environment, loggerFactory.CreateLogger<InstanceManager>(),
+                new TestMetricsLogger(), null, new Mock<IRunFromPackageHandler>().Object,
+                new Mock<IPackageDownloadHandler>(MockBehavior.Strict).Object);
             var startupContextProvider = new StartupContextProvider(environment, loggerFactory.CreateLogger<StartupContextProvider>());
 
             InstanceManager.Reset();

--- a/test/WebJobs.Script.Tests.Integration/Management/ManagedIdentityTokenProviderTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/ManagedIdentityTokenProviderTests.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.WebJobs.Script.Tests;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
+{
+    [Trait(TestTraits.Category, TestTraits.EndToEnd)]
+    [Trait(TestTraits.Group, TestTraits.ContainerInstanceTests)]
+    public class ManagedIdentityTokenProviderTests
+    {
+        private const string UriWithNoSasToken = "https://storageaccount.blob.core.windows.net/funcs/hello.zip";
+        private const string UriWithNoSasTokenHost = "https://storageaccount.blob.core.windows.net";
+        private const string MsiEndpoint = "http://localhost:8081/msi/token";
+        private const string UserAssignedIdentity =
+            "/subscriptions/aaaabbbb-cccc-dddd-eeee-fffgggghhh/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1";
+        private const string MSISecret = "msi-secret";
+        private const string AccessToken = "access-token";
+
+        private readonly TestEnvironment _environment;
+        private HttpClient _httpClient;
+
+        public ManagedIdentityTokenProviderTests()
+        {
+            _environment = new TestEnvironment();
+            _httpClient = new HttpClient();
+        }
+
+        private static TokenServiceMsiResponse GetTokenServiceMsiResponse()
+        {
+            return new TokenServiceMsiResponse()
+            {
+                AccessToken = AccessToken
+            };
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData(EnvironmentSettingNames.SystemAssignedManagedIdentity)]
+        public async Task UsesSystemAssignedIdentityToFetchToken(string resourceId)
+        {
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.MsiEndpoint, MsiEndpoint);
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.MsiSecret, MSISecret);
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.RunFromPackageManagedResourceId, resourceId);
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+            handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.Is<HttpRequestMessage>(s => MatchesVerb(s, HttpMethod.Get) && UrlMatchesSystemAssignedIdentity(s, UriWithNoSasTokenHost)),
+                ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(JsonConvert.SerializeObject(GetTokenServiceMsiResponse()))
+            });
+
+            _httpClient = new HttpClient(handlerMock.Object);
+
+            var tokenProvider = new ManagedIdentityTokenProvider(_environment, _httpClient, new TestMetricsLogger(), NullLogger<ManagedIdentityTokenProvider>.Instance);
+            var token = await tokenProvider.GetManagedIdentityToken(UriWithNoSasToken);
+            Assert.Equal(AccessToken, token);
+        }
+
+        [Fact]
+        public async Task UsesUserAssignedIdentityToFetchToken()
+        {
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.MsiEndpoint, MsiEndpoint);
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.MsiSecret, MSISecret);
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.RunFromPackageManagedResourceId, UserAssignedIdentity);
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+            handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.Is<HttpRequestMessage>(s => MatchesVerb(s, HttpMethod.Get) && UrlMatchesUserAssignedIdentity(s, UriWithNoSasTokenHost, UserAssignedIdentity)),
+                ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(JsonConvert.SerializeObject(GetTokenServiceMsiResponse()))
+            });
+
+            _httpClient = new HttpClient(handlerMock.Object);
+
+            var tokenProvider = new ManagedIdentityTokenProvider(_environment, _httpClient, new TestMetricsLogger(), NullLogger<ManagedIdentityTokenProvider>.Instance);
+            var token = await tokenProvider.GetManagedIdentityToken(UriWithNoSasToken);
+            Assert.Equal(AccessToken, token);
+        }
+
+        [Fact]
+        public async Task ThrowsIfMSINotEnabled()
+        {
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.MsiEndpoint, string.Empty);
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.MsiSecret, string.Empty);
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+            handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.Is<HttpRequestMessage>(s => MatchesVerb(s, HttpMethod.Get) && UrlMatchesSystemAssignedIdentity(s, UriWithNoSasTokenHost)),
+                ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(JsonConvert.SerializeObject(GetTokenServiceMsiResponse()))
+            });
+
+            _httpClient = new HttpClient(handlerMock.Object);
+
+            var tokenProvider = new ManagedIdentityTokenProvider(_environment, _httpClient, new TestMetricsLogger(),
+                NullLogger<ManagedIdentityTokenProvider>.Instance);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await tokenProvider.GetManagedIdentityToken(UriWithNoSasToken));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData("storageaccount")]
+        public async Task ThrowsOnInvalidUrls(string url)
+        {
+            var tokenProvider = new ManagedIdentityTokenProvider(_environment, _httpClient, new TestMetricsLogger(), NullLogger<ManagedIdentityTokenProvider>.Instance);
+            await Assert.ThrowsAsync<ArgumentException>(async () => await tokenProvider.GetManagedIdentityToken(url));
+        }
+
+        private static bool MatchesVerb(HttpRequestMessage s, HttpMethod httpMethod)
+        {
+            return s.Method == httpMethod;
+        }
+
+        private static bool UrlMatchesSystemAssignedIdentity(HttpRequestMessage r, string resourceHost)
+        {
+            return r.RequestUri.AbsoluteUri.Contains($"&resource={resourceHost}") && !r.RequestUri.AbsoluteUri.Contains("&mi_res_id=");
+        }
+
+        private static bool UrlMatchesUserAssignedIdentity(HttpRequestMessage r, string resourceHost, string resourceId)
+        {
+            return r.RequestUri.AbsoluteUri.Contains($"&resource={resourceHost}") && r.RequestUri.AbsoluteUri.Contains($"&mi_res_id={resourceId}");
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/Management/PackageDownloadHandlerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/PackageDownloadHandlerTests.cs
@@ -1,0 +1,411 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.IO.Abstractions;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.WebJobs.Script.Tests;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
+{
+    [Trait(TestTraits.Category, TestTraits.EndToEnd)]
+    [Trait(TestTraits.Group, TestTraits.ContainerInstanceTests)]
+    public class PackageDownloadHandlerTests : IDisposable
+    {
+        private const string BearerToken = "bearer-token";
+        private const string UriWithSasToken = "https://storageaccount.blob.core.windows.net/funcs/hello.zip?sv=secret";
+        private const string UriWithNoSasToken = "https://storageaccount.blob.core.windows.net/funcs/hello.zip";
+        private const string ZipFileName = "zip-file.zip";
+        private readonly Mock<IBashCommandHandler> _bashCmdHandlerMock;
+        private readonly Mock<IManagedIdentityTokenProvider> _managedIdentityTokenProvider;
+        private readonly ILogger<PackageDownloadHandler> _logger;
+        private readonly TestMetricsLogger _metricsLogger;
+
+        private HttpClient _httpClient;
+
+        public PackageDownloadHandlerTests()
+        {
+            _httpClient = new Mock<HttpClient>().Object;
+            _bashCmdHandlerMock = new Mock<IBashCommandHandler>(MockBehavior.Strict);
+            _managedIdentityTokenProvider = new Mock<IManagedIdentityTokenProvider>(MockBehavior.Strict);
+            _logger = NullLogger<PackageDownloadHandler>.Instance;
+            _metricsLogger = new TestMetricsLogger();
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData("abcd")]
+        [InlineData("http:/abcd")]
+        public async Task ThrowsExceptionForInvalidUrls(string url)
+        {
+            var downloader = new PackageDownloadHandler(_httpClient, _managedIdentityTokenProvider.Object,
+                _bashCmdHandlerMock.Object, _logger, _metricsLogger);
+            var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage, url, null, true);
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await downloader.Download(runFromPackageContext));
+        }
+
+        [Theory]
+        [InlineData(true, UriWithNoSasToken, null, false, false)] // warmup requests will never use token
+        [InlineData(true, UriWithSasToken, null, false, false)]
+        [InlineData(true, UriWithNoSasToken, 0, false, false)]
+        [InlineData(true, UriWithSasToken, 0, false, false)]
+        [InlineData(true, UriWithNoSasToken, PackageDownloadHandler.AriaDownloadThreshold - 1, false, false)]
+        [InlineData(true, UriWithSasToken, PackageDownloadHandler.AriaDownloadThreshold - 1, false, false)]
+        [InlineData(true, UriWithNoSasToken, PackageDownloadHandler.AriaDownloadThreshold + 1, false, false)]
+        [InlineData(true, UriWithSasToken, PackageDownloadHandler.AriaDownloadThreshold + 1, false, false)]
+        [InlineData(false, UriWithNoSasToken, null, false, true)]
+        [InlineData(false, UriWithSasToken, null, false, false)] // url has sas token. so no token.
+        [InlineData(false, UriWithNoSasToken, PackageDownloadHandler.AriaDownloadThreshold - 1, false, true)]
+        [InlineData(false, UriWithSasToken, PackageDownloadHandler.AriaDownloadThreshold - 1, false, false)]
+        [InlineData(false, UriWithNoSasToken, PackageDownloadHandler.AriaDownloadThreshold + 1, false, true)]
+        [InlineData(false, UriWithSasToken, PackageDownloadHandler.AriaDownloadThreshold + 1, true, false)]
+        public async Task DownloadsPackage(bool isWarmupRequest, string url, long? fileSize, bool expectedUsesAriaDownload, bool expectedDownloadUsingManagedIdentityToken)
+        {
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+            handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.Is<HttpRequestMessage>(s => MatchesVerb(s, HttpMethod.Head)),
+                ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.Unauthorized,
+                Content = new ReadOnlyMemoryContent(ReadOnlyMemory<byte>.Empty)
+            });
+
+            if (expectedDownloadUsingManagedIdentityToken)
+            {
+                handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(s => MatchesVerb(s, HttpMethod.Get) && HasBearerToken(s) && MatchesTargetUri(s, url)),
+                    ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new ReadOnlyMemoryContent(ReadOnlyMemory<byte>.Empty)
+                });
+
+                _managedIdentityTokenProvider.Setup(p => p.GetManagedIdentityToken(url)).Returns(Task.FromResult(BearerToken));
+            }
+            else
+            {
+                if (expectedUsesAriaDownload)
+                {
+                    _bashCmdHandlerMock.Setup(b =>
+                        b.RunBashCommand(
+                            It.Is<string>(s =>
+                                s.StartsWith(PackageDownloadHandler.Aria2CExecutable) && s.Contains(url)),
+                            MetricEventNames.LinuxContainerSpecializationZipDownload)).Returns(("", "", 0));
+                }
+                else
+                {
+                    handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                        ItExpr.Is<HttpRequestMessage>(s => MatchesVerb(s, HttpMethod.Get) && !HasBearerToken(s) && MatchesTargetUri(s, url)),
+                        ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.OK,
+                        Content = new ReadOnlyMemoryContent(ReadOnlyMemory<byte>.Empty)
+                    });
+                }
+            }
+
+            _httpClient = new HttpClient(handlerMock.Object);
+
+            var downloader = new PackageDownloadHandler(_httpClient, _managedIdentityTokenProvider.Object,
+                _bashCmdHandlerMock.Object, _logger, _metricsLogger);
+
+            var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage, url, fileSize, isWarmupRequest);
+            await downloader.Download(runFromPackageContext);
+
+            if (expectedDownloadUsingManagedIdentityToken)
+            {
+                handlerMock.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(s => MatchesVerb(s, HttpMethod.Head)),
+                    ItExpr.IsAny<CancellationToken>());
+
+                handlerMock.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(s => MatchesVerb(s, HttpMethod.Get) && HasBearerToken(s) && MatchesTargetUri(s, url)),
+                    ItExpr.IsAny<CancellationToken>());
+
+                _managedIdentityTokenProvider.Verify(p => p.GetManagedIdentityToken(url), Times.Once);
+            }
+            else
+            {
+                handlerMock.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Never(),
+                    ItExpr.Is<HttpRequestMessage>(s => MatchesVerb(s, HttpMethod.Head)),
+                    ItExpr.IsAny<CancellationToken>());
+
+                if (expectedUsesAriaDownload)
+                {
+                    _bashCmdHandlerMock.Verify(b =>
+                        b.RunBashCommand(
+                            It.Is<string>(s =>
+                                s.StartsWith(PackageDownloadHandler.Aria2CExecutable) && s.Contains(url)),
+                            MetricEventNames.LinuxContainerSpecializationZipDownload), Times.Once);
+                }
+                else
+                {
+                    handlerMock.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Never(),
+                        ItExpr.Is<HttpRequestMessage>(s => MatchesVerb(s, HttpMethod.Get) && HasBearerToken(s) && MatchesTargetUri(s, url)),
+                        ItExpr.IsAny<CancellationToken>());
+
+                    _bashCmdHandlerMock.Verify(b =>
+                        b.RunBashCommand(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+                }
+
+                _managedIdentityTokenProvider.Verify(p => p.GetManagedIdentityToken(It.IsAny<string>()), Times.Never);
+            }
+        }
+
+        [Fact]
+        public async Task DownloadsFileUsingManagedIdentity()
+        {
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+            handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.Is<HttpRequestMessage>(s => MatchesVerb(s, HttpMethod.Head)),
+                ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.Unauthorized,
+                Content = new ReadOnlyMemoryContent(ReadOnlyMemory<byte>.Empty)
+            });
+
+
+            handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.Is<HttpRequestMessage>(s => MatchesVerb(s, HttpMethod.Get) && HasBearerToken(s) && MatchesTargetUri(s, UriWithNoSasToken)),
+                ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new ReadOnlyMemoryContent(ReadOnlyMemory<byte>.Empty)
+            });
+
+            _httpClient = new HttpClient(handlerMock.Object);
+
+            _managedIdentityTokenProvider.Setup(p => p.GetManagedIdentityToken(UriWithNoSasToken)).Returns(Task.FromResult(BearerToken));
+
+            var downloader = new PackageDownloadHandler(_httpClient, _managedIdentityTokenProvider.Object,
+                _bashCmdHandlerMock.Object, _logger, _metricsLogger);
+
+            var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage, UriWithNoSasToken, 0, false);
+            await downloader.Download(runFromPackageContext);
+
+            handlerMock.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Once(),
+                ItExpr.Is<HttpRequestMessage>(s => MatchesVerb(s, HttpMethod.Head)),
+                ItExpr.IsAny<CancellationToken>());
+
+            handlerMock.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Once(),
+                ItExpr.Is<HttpRequestMessage>(s => MatchesVerb(s, HttpMethod.Get) && HasBearerToken(s) && MatchesTargetUri(s, UriWithNoSasToken)),
+                ItExpr.IsAny<CancellationToken>());
+
+            _managedIdentityTokenProvider.Verify(p => p.GetManagedIdentityToken(UriWithNoSasToken), Times.Once);
+        }
+
+        [Theory]
+        [InlineData(UriWithSasToken, true, false)]
+        [InlineData(UriWithSasToken, false, false)]
+        [InlineData(UriWithNoSasToken, true, false)]
+        [InlineData(UriWithNoSasToken, false, true)]
+        public async Task FetchesManagedIdentityToken(string url, bool isPublicUrl, bool expectedFetchesManagedIdentityToken)
+        {
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+            // urls with sas tokens are always publicly accessible
+            if (url == UriWithSasToken)
+            {
+                isPublicUrl = true;
+            }
+
+            var statusCode = isPublicUrl ? HttpStatusCode.OK : HttpStatusCode.Unauthorized;
+
+            handlerMock.Protected()
+                .Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(s => MatchesVerb(s, HttpMethod.Head)),
+                    ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+                    {StatusCode = statusCode, Content = new ReadOnlyMemoryContent(ReadOnlyMemory<byte>.Empty)});
+
+            if (expectedFetchesManagedIdentityToken)
+            {
+                handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(s => MatchesVerb(s, HttpMethod.Get) && HasBearerToken(s) && MatchesTargetUri(s, url)),
+                    ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new ReadOnlyMemoryContent(ReadOnlyMemory<byte>.Empty)
+                });
+            }
+            else
+            {
+                handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(s => MatchesVerb(s, HttpMethod.Get) && !HasBearerToken(s) && MatchesTargetUri(s, url)),
+                    ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new ReadOnlyMemoryContent(ReadOnlyMemory<byte>.Empty)
+                });
+            }
+
+            _httpClient = new HttpClient(handlerMock.Object);
+
+            if (expectedFetchesManagedIdentityToken)
+            {
+                _managedIdentityTokenProvider.Setup(p => p.GetManagedIdentityToken(url))
+                    .Returns(Task.FromResult(BearerToken));
+            }
+
+            var downloader = new PackageDownloadHandler(_httpClient, _managedIdentityTokenProvider.Object,
+                _bashCmdHandlerMock.Object, _logger, _metricsLogger);
+
+            var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage, url, 0, false);
+            await downloader.Download(runFromPackageContext);
+
+            if (expectedFetchesManagedIdentityToken)
+            {
+                _managedIdentityTokenProvider.Verify(p => p.GetManagedIdentityToken(url), Times.Once);
+                handlerMock.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(s => MatchesVerb(s, HttpMethod.Get) && HasBearerToken(s) && MatchesTargetUri(s, url)),
+                    ItExpr.IsAny<CancellationToken>());
+            }
+            else
+            {
+                _managedIdentityTokenProvider.Verify(p => p.GetManagedIdentityToken(It.IsAny<string>()), Times.Never);
+                handlerMock.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(s => MatchesVerb(s, HttpMethod.Get) && !HasBearerToken(s) && MatchesTargetUri(s, url)),
+                    ItExpr.IsAny<CancellationToken>());
+            }
+        }
+
+        private static bool MatchesVerb(HttpRequestMessage s, HttpMethod httpMethod)
+        {
+            return s.Method == httpMethod;
+        }
+
+        private static bool HasBearerToken(HttpRequestMessage r)
+        {
+            return r.Headers.Authorization != null && r.Headers.Authorization.Parameter == BearerToken;
+        }
+
+        private static bool MatchesTargetUri(HttpRequestMessage r, string url)
+        {
+            return r.RequestUri.AbsoluteUri.Equals(url);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task DownloadsLargeZipsUsingAria2c(bool isWarmupRequest)
+        {
+            var url = $"http://url/{ZipFileName}";
+
+            FileUtility.Instance = GetFileSystem().Object;
+            const int fileSize = PackageDownloadHandler.AriaDownloadThreshold + 1;
+
+            var expectedMetricName = isWarmupRequest
+                ? MetricEventNames.LinuxContainerSpecializationZipDownloadWarmup
+                : MetricEventNames.LinuxContainerSpecializationZipDownload;
+            
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+            if (isWarmupRequest)
+            {
+                handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(s => MatchesVerb(s, HttpMethod.Get) && MatchesTargetUri(s, url)),
+                    ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new ReadOnlyMemoryContent(ReadOnlyMemory<byte>.Empty)
+                });
+
+                _httpClient = new HttpClient(handlerMock.Object);
+            }
+            else
+            {
+                _bashCmdHandlerMock.Setup(b => b.RunBashCommand(It.Is<string>(s => s.StartsWith(PackageDownloadHandler.Aria2CExecutable)),
+                    expectedMetricName)).Returns(("", "", 0));
+            }
+
+            var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage, url, fileSize, isWarmupRequest);
+
+            var packageDownloadHandler = new PackageDownloadHandler(_httpClient, _managedIdentityTokenProvider.Object,
+                _bashCmdHandlerMock.Object, _logger, _metricsLogger);
+
+            var filePath = await packageDownloadHandler.Download(runFromPackageContext);
+
+            Assert.Equal(ZipFileName, Path.GetFileName(filePath), StringComparer.Ordinal);
+
+            if (isWarmupRequest)
+            {
+                handlerMock.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Once(),
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>());
+            }
+            else
+            {
+                _bashCmdHandlerMock.Verify(b => b.RunBashCommand(It.Is<string>(s => s.StartsWith(PackageDownloadHandler.Aria2CExecutable)),
+                    expectedMetricName), Times.Once);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task DownloadsZipsUsingHttpClient(bool isWarmupRequest)
+        {
+            FileUtility.Instance = GetFileSystem().Object;
+            var url = $"http://url/{ZipFileName}";
+            const int fileSize = PackageDownloadHandler.AriaDownloadThreshold - 1;
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+            handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new ReadOnlyMemoryContent(ReadOnlyMemory<byte>.Empty)
+            });
+
+            _httpClient = new HttpClient(handlerMock.Object);
+
+            var packageDownloadHandler = new PackageDownloadHandler(_httpClient, _managedIdentityTokenProvider.Object,
+                _bashCmdHandlerMock.Object, _logger, _metricsLogger);
+
+            var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage, url, fileSize, isWarmupRequest);
+            var filePath = await packageDownloadHandler.Download(runFromPackageContext);;
+
+            Assert.Equal(ZipFileName, Path.GetFileName(filePath), StringComparer.Ordinal);
+
+            handlerMock.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Once(),
+                ItExpr.Is<HttpRequestMessage>(r => IsZipDownloadRequest(r, url)),
+                ItExpr.IsAny<CancellationToken>());
+        }
+
+        public void Dispose()
+        {
+            FileUtility.Instance = null;
+        }
+
+        private static bool IsZipDownloadRequest(HttpRequestMessage httpRequestMessage, string filePath)
+        {
+            return httpRequestMessage.Method == HttpMethod.Get &&
+                   string.Equals(filePath, httpRequestMessage.RequestUri.AbsoluteUri);
+        }
+
+        private static Mock<IFileSystem> GetFileSystem()
+        {
+            var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
+            var fileInfo = new Mock<FileInfoBase>(MockBehavior.Strict);
+            fileInfo.SetupGet(f => f.Length).Returns(0);
+            fileSystem.Setup(f => f.FileInfo.FromFileName(It.IsAny<string>())).Returns(fileInfo.Object);
+            return fileSystem;
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/UtilityTests.cs
+++ b/test/WebJobs.Script.Tests/UtilityTests.cs
@@ -435,6 +435,33 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
+        [InlineData("", null, false)]
+        [InlineData(null, null, false)]
+        [InlineData("http://storage.blob.core.windows.net/functions/func.zip?sr=c&si=policy&sig=f%2BGLvBih%2BoFuQvckBSHWKMXwqGJHlPkESmZh9pjnHuc%3D",
+            "http://storage.blob.core.windows.net", true)]
+        [InlineData("http://storage.blob.core.windows.net/functions/func.zip",
+            "http://storage.blob.core.windows.net", true)]
+        [InlineData("https://storage.blob.core.windows.net/functions/func.zip",
+            "https://storage.blob.core.windows.net", true)]
+        [InlineData("https://storage.blob.core.windows.net/functions/func.zip?",
+            "https://storage.blob.core.windows.net", true)]
+        public void GetUriHostTests(string url, string expectedHost, bool expectedSuccess)
+        {
+            var success = Utility.TryGetUriHost(url, out var host);
+            Assert.Equal(expectedSuccess, success);
+            Assert.Equal(expectedHost, host);
+        }
+
+        [Theory]
+        [InlineData("http://storage.blob.core.windows.net/functions/func.zip?sr=c&si=policy&sig=f%2BGLvBih%2BoFuQvckBSHWKMXwqGJHlPkESmZh9pjnHuc%3D", true)]
+        [InlineData("http://storage.blob.core.windows.net/functions/func.zip?sr=c&si=policy&sv=abcd&sig=f%2BGLvBih%2BoFuQvckBSHWKMXwqGJHlPkESmZh9pjnHuc%3D", false)]
+        [InlineData("http://storage.blob.core.windows.net/functions/func.zip", true)]
+        public void GetAccountNameFromDomain(string url, bool isUrlWithNoSas)
+        {
+            Assert.Equal(isUrlWithNoSas, Utility.IsResourceAzureBlobWithoutSas(new Uri(url)));
+        }
+
+        [Theory]
         [InlineData("httpTrigger", true)]
         [InlineData("manualTrigger", true)]
         [InlineData("HttptRIGGER", true)]


### PR DESCRIPTION
Currently Run-From-Package only supports external urls with SAS tokens or publicly accessible blobs. This change allows the use of (System or User assigned) ManagedIdentity to authenticate with storage instead. Token retrieval is handled by TokenService which already has the required client secrets.

Fixes https://github.com/Azure/azure-functions-host/issues/7570

### Pull request checklist

* [ X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
