### PR TITLE
Update v4.x branch to be buildable using the .NET 6 preview7 SDK

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -2,7 +2,7 @@
   <Import Project=".\package.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.2</LangVersion>    
+    <LangVersion>latest</LangVersion>
     <MajorVersion>4</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
@@ -21,6 +21,7 @@
     <DebugType>embedded</DebugType>
     <UseSourceLink Condition="$(UseSourceLink) == '' And $(CI) != ''">true</UseSourceLink>
     <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile> <!-- https://github.com/dotnet/runtime/issues/54684 -->
+    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
   </PropertyGroup>
 
   <Target Name="GenerateSiteExtensionVersion">

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -20,7 +20,6 @@
   </PropertyGroup>
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>Microsoft.Azure.WebJobs.Script</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Script</RootNamespace>
     <NoWarn>NU5104</NoWarn>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -8,7 +8,6 @@
     <RootNamespace>Microsoft.Azure.WebJobs.Script.Tests.Integration</RootNamespace>
     <!-- Allow BinaryFormatter for tests -->
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG;SCRIPT_TEST;NETCOREAPP2_0</DefineConstants>


### PR DESCRIPTION
Ran into some compilation issues when using the preview7 SDK. Both of these were avoidable using global.json to specify the SDK version to build with, but I figure we should just address these now.

For compilation issue `Feature 'interpolated string handlers' is not available in C# 7.2`, see [here](https://github.com/dotnet/roslyn/issues/55345). The fix was to use the latest C# version.

For complation issue `error CS0104: 'IApplicationLifetime' is an ambiguous reference between 'Microsoft.AspNetCore.Hosting.IApplicationLifetime' and 'Microsoft.Extensions.Hosting.IApplicationLifetime'`, the fix was to disable implicit namespace imports (coming preview7 feature).

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] My changes **should not** be added to the release notes for the next release
* [x] My changes **do not** need to be backported to a previous version
* [x] My changes **do not** require unit tests