### PR TITLE
Reset release notes and updated host version to 3.3.0

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>7.2</LangVersion>
     <MajorVersion>3</MajorVersion>
-    <MinorVersion>2</MinorVersion>
+    <MinorVersion>3</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <Version Condition=" '$(BuildNumber)' != '' ">$(VersionPrefix)-$(BuildNumber)</Version>

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,4 +4,4 @@
 -->
 
 **Release sprint:** Sprint 107
-[ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+<successiveSprint>%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+104%22+label%3Afeature+is%3Aclosed) ]
+[ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+107%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+107%22+label%3Afeature+is%3Aclosed) ]

--- a/release_notes.md
+++ b/release_notes.md
@@ -2,13 +2,6 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-- Updated Azure.Core reference 1.17.0
-- Updated Azure.Identity reference to 1.4.1
-- Update Azure.Storage.Blobs to 12.9.0 (#7456)
-- Update Python Worker Version to [1.2.5](https://github.com/Azure/azure-functions-python-worker/releases/tag/1.2.5)
-- Add GRPC messages types to protobuf for worker indexing along with relevant functions and tests (#7541)
-- Updated PowerShell Worker (PS7) to [3.0.912](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.912)
 
-
-**Release sprint:** Sprint 104
+**Release sprint:** Sprint 107
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+<successiveSprint>%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+104%22+label%3Afeature+is%3Aclosed) ]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Resetting release notes and setting new version after merge to release branch for sprint 104 release.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
