### PR TITLE
[pack] Exposing API to allow load context resets to override base probing path

### DIFF
--- a/src/WebJobs.Script/Config/ExtensionBundleConfigurationHelper.cs
+++ b/src/WebJobs.Script/Config/ExtensionBundleConfigurationHelper.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using Microsoft.Azure.WebJobs.Script.Properties;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Hosting;
 using NuGet.Packaging;
 using NuGet.Versioning;
 
@@ -83,9 +82,9 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
                 && !string.IsNullOrEmpty(homeDirectory))
             {
                 string linuxDefaultPath = Path.Combine(Path.GetPathRoot(homeDirectory), ScriptConstants.DefaultExtensionBundleDirectory, options.Id);
-                string deploymentPackageBundlePath = Path.Combine(
-                    homeDirectory,
-                    "site", "wwwroot", ".azureFunctions", ScriptConstants.ExtensionBundleDirectory, options.Id);
+                string deploymentPackageBundlePath = Path.Combine(homeDirectory, "site", "wwwroot",
+                                                                  ScriptConstants.AzureFunctionsSystemDirectoryName,
+                                                                  ScriptConstants.ExtensionBundleDirectory, options.Id);
 
                 options.ProbingPaths.Add(linuxDefaultPath);
                 options.ProbingPaths.Add(deploymentPackageBundlePath);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
This enables bundles and the extension load process to set the base probing path (and root containing deps.json) when resetting the 
### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
