### PR TITLE
Add a test to expose issue #7539

### DIFF
--- a/test/WebJobs.Script.Tests/DependencyInjection/JobHostServiceProviderTests.cs
+++ b/test/WebJobs.Script.Tests/DependencyInjection/JobHostServiceProviderTests.cs
@@ -88,6 +88,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.DependencyInjection
             // Disposing of the JobHost service provider should not dispose of root container services
             Assert.False(rootService.Disposed);
         }
+        
+        [Fact]
+        public void GetRequiredService_OnJobHost_ShouldThrowAnInvalidOperationExceptionWhenAServiceCannotBeResolved()
+        {
+            var services = new ServiceCollection();
+            var rootScopeFactory = new WebHostServiceProvider(new ServiceCollection());
+            var jobHostServiceProvider = new JobHostServiceProvider(services, rootScopeFactory, rootScopeFactory);
+
+            var recordedException = Record.Exception(() => jobHostServiceProvider.GetRequiredService(typeof(IService)));
+            Assert.NotNull(recordedException);
+            Assert.IsType<InvalidOperationException>(recordedException);
+        }
 
         [Fact]
         public void Scopes_ChildScopeIsIsolated()


### PR DESCRIPTION
GetRequiredService_OnJobHost_ShouldThrowAnInvalidOperationExceptionWhenAServiceCannotBeResolved

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Adding a test to expose this issue https://github.com/Azure/azure-functions-host/issues/7539

GetRequiredService is supposed to throw when there is an issue but instead returns null.

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] My changes **should not** be added to the release notes for the next release
* [ ] My changes **do not** need to be backported to a previous version
* [ ] I have added all required tests (Unit tests, E2E tests)

### Additional information

Additional PR information
