### PR TITLE
Fix ExternalConfigurationStartupValidator bug (#7667)

### DIFF
--- a/src/WebJobs.Script/DependencyInjection/ExternalConfigurationStartupValidator.cs
+++ b/src/WebJobs.Script/DependencyInjection/ExternalConfigurationStartupValidator.cs
@@ -43,8 +43,9 @@ namespace Microsoft.Azure.WebJobs.Script.DependencyInjection
 
             foreach (var function in functions)
             {
-                var trigger = function.Bindings.SingleOrDefault(b => b.IsTrigger);
-
+                // Only a single trigger per function is supported. For our purposes here we just take
+                // the first. If multiple are defined, that error will be handled on indexing.
+                var trigger = function.Bindings.FirstOrDefault(b => b.IsTrigger);
                 if (trigger == null)
                 {
                     continue;

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -167,7 +167,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             // store off a bit of the creation stack for easier debugging if this host doesn't shut down.
             var stack = new StackTrace(true).ToString().Split(Environment.NewLine).Take(5);
             _createdStack = string.Join($"{Environment.NewLine}    ", stack);
+
+            // cache startup logs since tests clear logs from time to time
+            StartupLogs = GetScriptHostLogMessages();
         }
+
+        public IList<LogMessage> StartupLogs { get; }
 
         public IServiceProvider JobHostServices => _hostService.Services;
 

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/MultipleTriggers/function.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/MultipleTriggers/function.json
@@ -1,0 +1,23 @@
+{
+    "bindings": [
+        {
+            "type": "httpTrigger",
+            "name": "req",
+            "direction": "in",
+            "methods": [ "get" ],
+            "authLevel": "anonymous"
+        },
+        {
+            "type": "httpTrigger",
+            "name": "req2",
+            "direction": "in",
+            "methods": [ "get" ],
+            "authLevel": "anonymous"
+        },
+        {
+            "type": "http",
+            "name": "res",
+            "direction": "out"
+        }
+    ]
+}

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/MultipleTriggers/run.csx
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/CSharp/MultipleTriggers/run.csx
@@ -1,0 +1,8 @@
+﻿using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
+
+public static IActionResult Run(HttpRequest req)
+{
+    return new OkResult();
+}

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpEndToEndTests.cs
@@ -20,6 +20,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.WebJobs.Script.Tests;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -274,6 +275,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             var hasWarning = logs.Any(p => p.Contains("project.json' should not be used to reference NuGet packages. Try creating a 'function.proj' file instead. Learn more: https://go.microsoft.com/fwlink/?linkid=2091419"));
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
             Assert.Equal(true, hasWarning);
+        }
+
+        [Fact]
+        public void MultipleTriggers_ShowsHelpfulMessage()
+        {
+            var logs = Fixture.Host.StartupLogs.Where(p => p.Level == LogLevel.Error && p.FormattedMessage.Contains("MultipleTriggers")).Select(p => p.FormattedMessage).Where(p => p != null).ToArray();
+            var log = logs.Single();
+            Assert.Equal("The 'MultipleTriggers' function is in error: Multiple trigger bindings defined. A function can only have a single trigger binding.", log);
         }
 
         [Fact]
@@ -578,7 +587,8 @@ namespace SecondaryDependency
                         "QueueTriggerToBlob",
                         "Scenarios",
                         "FunctionIndexingError",
-                        "MissingAssemblies"
+                        "MissingAssemblies",
+                        "MultipleTriggers"
                     };
                 });
 

--- a/test/WebJobs.Script.Tests/Configuration/ExternalConfigurationStartupValidatorTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ExternalConfigurationStartupValidatorTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -74,6 +75,48 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                     { _lookup, "abc" },
                     { _bindingExpressionLookup, "def" }
                 });
+        }
+
+        [Fact]
+        public void MultipleTriggers_Succeeds()
+        {
+            BindingMetadata bindingMetadata1 = new BindingMetadata
+            {
+                Type = "ATrigger",
+                Raw = JObject.FromObject(new
+                {
+                    key0 = "foo"
+                })
+            };
+
+            BindingMetadata bindingMetadata2 = new BindingMetadata
+            {
+                Type = "BTrigger",
+                Raw = JObject.FromObject(new
+                {
+                    key0 = "bar"
+                })
+            };
+
+            FunctionMetadata functionMetadata = new FunctionMetadata
+            {
+                Name = "test"
+            };
+
+            functionMetadata.Bindings.Add(bindingMetadata1);
+            functionMetadata.Bindings.Add(bindingMetadata2);
+
+            ICollection<FunctionMetadata> metadata = new Collection<FunctionMetadata>
+            {
+                functionMetadata
+            };
+
+            var metadataManager = new MockMetadataManager(metadata);
+            var config = _configBuilder.Build();
+
+            var validator = new ExternalConfigurationStartupValidator(config, metadataManager);
+            var invalidValues = validator.Validate(config);
+            Assert.Empty(invalidValues);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Description/FunctionDescriptorProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/FunctionDescriptorProviderTests.cs
@@ -56,11 +56,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             });
             functionMetadata.Bindings.Add(new BindingMetadata
             {
-                Name = "dupe"
+                Name = "dupe",
+                Type = "Blob"
             });
             functionMetadata.Bindings.Add(new BindingMetadata
             {
-                Name = "dupe"
+                Name = "dupe",
+                Type = "Blob"
             });
 
             var ex = Assert.Throws<InvalidOperationException>(() =>
@@ -69,6 +71,51 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             });
 
             Assert.Equal("Multiple bindings with name 'dupe' discovered. Binding names must be unique.", ex.Message);
+        }
+
+        [Fact]
+        public void ValidateFunction_NoBindingType_Throws()
+        {
+            FunctionMetadata functionMetadata = new FunctionMetadata();
+            functionMetadata.Bindings.Add(new BindingMetadata
+            {
+                Name = "a",
+                Type = "BlobTrigger"
+            });
+            functionMetadata.Bindings.Add(new BindingMetadata
+            {
+                Name = "b"
+            });
+
+            var ex = Assert.Throws<ArgumentException>(() =>
+            {
+                _provider.ValidateFunction(functionMetadata);
+            });
+
+            Assert.Equal("Binding 'b' is invalid. Bindings must specify a Type.", ex.Message);
+        }
+
+        [Fact]
+        public void ValidateFunction_MultipleTriggerBindings_Throws()
+        {
+            FunctionMetadata functionMetadata = new FunctionMetadata();
+            functionMetadata.Bindings.Add(new BindingMetadata
+            {
+                Name = "a",
+                Type = "BlobTrigger"
+            });
+            functionMetadata.Bindings.Add(new BindingMetadata
+            {
+                Name = "b",
+                Type = "QueueTrigger"
+            });
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+            {
+                _provider.ValidateFunction(functionMetadata);
+            });
+
+            Assert.Equal("Multiple trigger bindings defined. A function can only have a single trigger binding.", ex.Message);
         }
 
         [Fact]
@@ -173,7 +220,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             BindingMetadata bindingMetadata = new BindingMetadata
             {
-                Name = bindingName
+                Name = bindingName,
+                Type = "Blob"
             };
 
             if (bindingMetadata.IsReturn)


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-functions-host/issues/7667. Full validation of triggers happens later in the startup process during indexing [here](https://github.com/Azure/azure-webjobs-sdk/blob/11b99659a7f4fdd62bf1e0370cfd459cf5739f80/src/Microsoft.Azure.WebJobs.Host/Indexers/FunctionIndexer.cs#L183) and a proper error message will be logged then. For the purposes of this issue, we just need to be sure the config validator doesn't prematurely choke on this.