### PR TITLE
Improve error handling for GetScriptHostServiceOrNull

### DIFF
--- a/src/WebJobs.Script/Extensions/IServiceProviderExtensions.cs
+++ b/src/WebJobs.Script/Extensions/IServiceProviderExtensions.cs
@@ -21,11 +21,19 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(serviceProvider));
             }
 
-            var hostManager = serviceProvider.GetService<IScriptHostManager>();
-            if (Utility.TryGetHostService(hostManager, out TService service))
+            try
             {
-                return service;
+                var hostManager = serviceProvider.GetService<IScriptHostManager>();
+                if (Utility.TryGetHostService(hostManager, out TService service))
+                {
+                    return service;
+                }
             }
+            catch
+            {
+                // can get exceptions if the host is being disposed
+            }
+
             return null;
         }
     }

--- a/test/WebJobs.Script.Tests/Extensions/ServiceProviderExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/ServiceProviderExtensionsTests.cs
@@ -36,5 +36,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
             var result = serviceProviderMock.Object.GetScriptHostServiceOrNull<ITestInterface>();
             Assert.Null(result);
         }
+
+        [Fact]
+        public void GetScriptHostServiceOrNull_ContainerDisposed_ReturnsNull()
+        {
+            var serviceProviderMock = new Mock<IServiceProvider>(MockBehavior.Strict);
+            serviceProviderMock.Setup(p => p.GetService(typeof(IScriptHostManager))).Throws(new ObjectDisposedException("test"));
+            var result = serviceProviderMock.Object.GetScriptHostServiceOrNull<ITestInterface>();
+            Assert.Null(result);
+        }
     }
 }


### PR DESCRIPTION
When the host is being disposed, this service provider helper can throw due to objects/containers being disposed.