### PR TITLE
throwing exception for invalid services

### DIFF
--- a/src/WebJobs.Script.WebHost/DependencyInjection/JobHostScopedServiceProviderFactory.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/JobHostScopedServiceProviderFactory.cs
@@ -41,6 +41,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
                 // Log this to the WebHost's logger so we can track
                 ILogger logger = _rootProvider.GetService<ILogger<DependencyValidator>>();
                 logger.LogError(ex, "Invalid host services detected.");
+
+                // rethrow to prevent host startup
+                throw new HostInitializationException("Invalid host services detected.", ex);
             }
 
             if (_provider == null)

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                           return GetMetadataManager(montior, scriptManager, loggerFactory);
                       }, ServiceLifetime.Singleton));
 
-                      services.Replace(new ServiceDescriptor(typeof(IDependencyValidator), new TestDependencyValidator()));
+                      services.SkipDependencyValidation();
 
                       // Allows us to configure services as the last step, thereby overriding anything
                       services.AddSingleton(new PostConfigureServices(configureWebHostServices));
@@ -443,14 +443,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             public void ConfigureServices(IServiceCollection services)
             {
                 _postConfigure?.Invoke(services);
-            }
-        }
-
-        private class TestDependencyValidator : IDependencyValidator
-        {
-            public void Validate(IServiceCollection services)
-            {
-                // no-op for tests; this allows us to override anything
             }
         }
     }

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -111,6 +111,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                           return GetMetadataManager(montior, scriptManager, loggerFactory);
                       }, ServiceLifetime.Singleton));
 
+                      services.Replace(new ServiceDescriptor(typeof(IDependencyValidator), new TestDependencyValidator()));
+
                       // Allows us to configure services as the last step, thereby overriding anything
                       services.AddSingleton(new PostConfigureServices(configureWebHostServices));
                   })
@@ -441,6 +443,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             public void ConfigureServices(IServiceCollection services)
             {
                 _postConfigure?.Invoke(services);
+            }
+        }
+
+        private class TestDependencyValidator : IDependencyValidator
+        {
+            public void Validate(IServiceCollection services)
+            {
+                // no-op for tests; this allows us to override anything
             }
         }
     }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WarmupFunctionEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WarmupFunctionEndToEndTests.cs
@@ -116,6 +116,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                        services.Replace(new ServiceDescriptor(typeof(ISecretManagerProvider), new TestSecretManagerProvider(new TestSecretManager())));
                        services.Replace(new ServiceDescriptor(typeof(IOptionsMonitor<ScriptApplicationHostOptions>), optionsMonitor));
                        services.Replace(new ServiceDescriptor(typeof(IFunctionMetadataProvider), provider));
+
+                       services.SkipDependencyValidation();
                    });
 
                 // TODO: https://github.com/Azure/azure-functions-host/issues/4876

--- a/test/WebJobs.Script.Tests.Shared/TestServiceCollectionExtensions.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestServiceCollectionExtensions.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    internal static class TestServiceCollectionExtensions
+    {
+        public static IServiceCollection SkipDependencyValidation(this IServiceCollection services)
+        {
+            return services.Replace(new ServiceDescriptor(typeof(IDependencyValidator), new TestDependencyValidator()));
+        }
+
+        private class TestDependencyValidator : IDependencyValidator
+        {
+            public void Validate(IServiceCollection services)
+            {
+                // no-op for tests; this allows us to override anything
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Shared/WebJobs.Script.Tests.Shared.projitems
+++ b/test/WebJobs.Script.Tests.Shared/WebJobs.Script.Tests.Shared.projitems
@@ -26,6 +26,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)TestOptionsFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestOptionsMonitor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestScaleMonitor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestServiceCollectionExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestServiceProviderExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestTraits.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestHandler.cs" />

--- a/test/WebJobs.Script.Tests/Configuration/DefaultDependencyValidatorTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/DefaultDependencyValidatorTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 // Try removing system logger
                 var descriptor = s.Single(p => p.ImplementationType == typeof(SystemLoggerProvider));
                 s.Remove(descriptor);
-            });
+            }, expectSuccess: false);
 
             Assert.NotNull(invalidServicesMessage);
 

--- a/test/WebJobs.Script.Tests/Configuration/DefaultDependencyValidatorTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/DefaultDependencyValidatorTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         }
 
         [Fact]
-        public async Task Validator_InvalidServices_LogsError()
+        public async Task Validator_InvalidServices_ThrowsException()
         {
             LogMessage invalidServicesMessage = await RunTest(configureJobHost: s =>
             {
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             Assert.True(invalidServicesMessage == null, msg + invalidServicesMessage?.Exception?.ToString());
         }
 
-        private async Task<LogMessage> RunTest(Action<IServiceCollection> configureWebHost = null, Action<IServiceCollection> configureJobHost = null)
+        private async Task<LogMessage> RunTest(Action<IServiceCollection> configureWebHost = null, Action<IServiceCollection> configureJobHost = null, bool expectSuccess = true)
         {
             LogMessage invalidServicesMessage = null;
             TestLoggerProvider loggerProvider = new TestLoggerProvider();
@@ -108,8 +108,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 
                 await TestHelpers.Await(() =>
                 {
+                    string expectedMessage = "Host initialization";
+
+                    if (!expectSuccess)
+                    {
+                        expectedMessage = "A host error has occurred during startup operation";
+                    }
+
                     return loggerProvider.GetAllLogMessages()
-                        .FirstOrDefault(p => p.FormattedMessage.StartsWith("Host initialization")) != null;
+                            .FirstOrDefault(p => p.FormattedMessage.StartsWith(expectedMessage)) != null;
                 }, userMessageCallback: () => loggerProvider.GetLog());
 
                 invalidServicesMessage = loggerProvider.GetAllLogMessages()


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-host/issues/7677

implementation of breaking change: https://github.com/Azure/Azure-Functions/issues/2045

I validated this in a private site extension and the behavior is as expected: `Function host is not running.` and this banner in the portal:
![image](https://user-images.githubusercontent.com/1089915/134698834-4c65a561-cbd9-43ec-80b0-8393f26f5ab9.png)
