### PR TITLE
Add support for __init__.py as default scriptFile for Python

### DIFF
--- a/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
@@ -240,11 +240,13 @@ namespace Microsoft.Azure.WebJobs.Script
                 {
                     // if there is a "run" file, that file is primary,
                     // for Node, any index.js file is primary
+                    // for Python, __init__.py file is primary
                     // TODO #6955: Get default function file name from language worker configs
                     functionPrimary = functionFiles.FirstOrDefault(p =>
                         fileSystem.Path.GetFileNameWithoutExtension(p).ToLowerInvariant() == "run" ||
                         fileSystem.Path.GetFileName(p).ToLowerInvariant() == "index.js" ||
-                        fileSystem.Path.GetFileName(p).ToLowerInvariant() == "index.mjs");
+                        fileSystem.Path.GetFileName(p).ToLowerInvariant() == "index.mjs" ||
+                        fileSystem.Path.GetFileName(p).ToLowerInvariant() == "__init__.py");
                 }
             }
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Tactical fix for #6955. Needed to support in-portal adding of function triggers for Python apps. Currently, all non-HTTP trigger functions will be invalid because the host is unable to find the main script file for Python.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
