### PR TITLE
Updating Microsoft.Extensions.Azure version

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -37,12 +37,12 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Dependencies needed for Storage Providers -->
-    <PackageReference Include="Azure.Core" Version="1.17.0" />
+    <PackageReference Include="Azure.Core" Version="1.19.0" />
     <PackageReference Include="Azure.Identity" Version="1.4.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.9.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.31-11877" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="4.0.4-11874" />
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.0-beta.2" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>

--- a/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
+++ b/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
@@ -344,7 +344,7 @@
           "lib/netstandard1.1/Autofac.dll": {}
         }
       },
-      "Azure.Core/1.17.0": {
+      "Azure.Core/1.19.0": {
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
           "System.Buffers": "4.5.1",
@@ -358,8 +358,8 @@
         },
         "runtime": {
           "lib/netcoreapp2.1/Azure.Core.dll": {
-            "assemblyVersion": "1.17.0.0",
-            "fileVersion": "1.1700.21.40204"
+            "assemblyVersion": "1.19.0.0",
+            "fileVersion": "1.1900.21.45105"
           }
         },
         "compile": {
@@ -368,7 +368,7 @@
       },
       "Azure.Identity/1.4.1": {
         "dependencies": {
-          "Azure.Core": "1.17.0",
+          "Azure.Core": "1.19.0",
           "Microsoft.Identity.Client": "4.30.1",
           "Microsoft.Identity.Client.Extensions.Msal": "2.18.4",
           "System.Memory": "4.5.4",
@@ -403,7 +403,7 @@
       },
       "Azure.Storage.Common/12.8.0": {
         "dependencies": {
-          "Azure.Core": "1.17.0"
+          "Azure.Core": "1.19.0"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Storage.Common.dll": {
@@ -2087,9 +2087,9 @@
           "lib/netstandard1.3/Microsoft.DotNet.PlatformAbstractions.dll": {}
         }
       },
-      "Microsoft.Extensions.Azure/1.1.0-beta.2": {
+      "Microsoft.Extensions.Azure/1.1.1": {
         "dependencies": {
-          "Azure.Core": "1.17.0",
+          "Azure.Core": "1.19.0",
           "Azure.Identity": "1.4.1",
           "Microsoft.Extensions.Configuration.Abstractions": "3.1.9",
           "Microsoft.Extensions.Configuration.Binder": "3.1.9",
@@ -2099,8 +2099,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Extensions.Azure.dll": {
-            "assemblyVersion": "1.1.0.0",
-            "fileVersion": "1.100.21.10801"
+            "assemblyVersion": "1.1.1.0",
+            "fileVersion": "1.100.121.45201"
           }
         },
         "compile": {
@@ -4470,7 +4470,7 @@
       },
       "Microsoft.Azure.WebJobs.Script/3.3.0": {
         "dependencies": {
-          "Azure.Core": "1.17.0",
+          "Azure.Core": "1.19.0",
           "Azure.Identity": "1.4.1",
           "Azure.Storage.Blobs": "12.9.0",
           "Microsoft.AspNetCore.Http.Features": "3.1.0",
@@ -4492,7 +4492,7 @@
           "Microsoft.CodeAnalysis.CSharp.Scripting": "3.3.1",
           "Microsoft.CodeAnalysis.Common": "3.3.1",
           "Microsoft.DotNet.PlatformAbstractions": "2.1.0",
-          "Microsoft.Extensions.Azure": "1.1.0-beta.2",
+          "Microsoft.Extensions.Azure": "1.1.1",
           "Microsoft.Extensions.DiagnosticAdapter": "1.1.0",
           "Microsoft.Extensions.Hosting.Abstractions": "3.1.0",
           "Microsoft.Extensions.Logging": "3.1.9",
@@ -6179,12 +6179,12 @@
       "path": "autofac/4.6.2",
       "hashPath": "autofac.4.6.2.nupkg.sha512"
     },
-    "Azure.Core/1.17.0": {
+    "Azure.Core/1.19.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ByJGsP7zqeMG+QFLEpd0ILzWVlRtB1ZWwgkqNWEN2KV0axRyWZDm6uPsKtsfBkNeiPtr4fUW0NSZez69TBSGrA==",
-      "path": "azure.core/1.17.0",
-      "hashPath": "azure.core.1.17.0.nupkg.sha512"
+      "sha512": "sha512-lcDjG635DPE4fU5tqSueVMmzrx0QrIfPuY0+y6evHN5GanQ0GB+/4nuMHMmoNPwEow6OUPkJu4cZQxfHJQXPdA==",
+      "path": "azure.core/1.19.0",
+      "hashPath": "azure.core.1.19.0.nupkg.sha512"
     },
     "Azure.Identity/1.4.1": {
       "type": "package",
@@ -6949,12 +6949,12 @@
       "path": "microsoft.dotnet.platformabstractions/2.1.0",
       "hashPath": "microsoft.dotnet.platformabstractions.2.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Azure/1.1.0-beta.2": {
+    "Microsoft.Extensions.Azure/1.1.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-yBNWSyp8gyPkP9F+q7cO7IsgaBRJnmH6+hdzRN13Ji4Vxsqg3Kq63kId0nKKkZNBa8YiZKBQY95/qwFgQ5QSCA==",
-      "path": "microsoft.extensions.azure/1.1.0-beta.2",
-      "hashPath": "microsoft.extensions.azure.1.1.0-beta.2.nupkg.sha512"
+      "sha512": "sha512-3BruEhX5qrQ7wSX/2qw6rQJNBuXgXg3gHZyN/64eVpZRPjkgE4+OhrRIpWbNqw+XPg9pGzzjfwdri9v4eOdtsw==",
+      "path": "microsoft.extensions.azure/1.1.1",
+      "hashPath": "microsoft.extensions.azure.1.1.1.nupkg.sha512"
     },
     "Microsoft.Extensions.Caching.Abstractions/2.2.0": {
       "type": "package",


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Resolves issue with User Assigned identity usage for secretless Functions failing due to overly aggressive factory in Microsoft.Extensions.Azure. This is fixed in v1.1.1 of that package. 

### Pull request checklist

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] I have added all required tests (Unit tests, E2E tests)

