### PR TITLE
Added suggested HttpClient usage analyzer.

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,7 +5,7 @@
 
 - Added warning for customer registering HttpClient with DI (#7674)
 - Updated Java Worker Version to [1.9.0](https://github.com/Azure/azure-functions-java-worker/releases/tag/1.9.0)
-
+- Added analyzer suggesting best HttpClient usage practices. (#7718)
 
 **Release sprint:** Sprint 111
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+111%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+111%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script.Analyzers/AvoidAsyncVoidAnalyzer.cs
+++ b/src/WebJobs.Script.Analyzers/AvoidAsyncVoidAnalyzer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Functions.Analyzers
         {
             var methodSymbol = (IMethodSymbol)context.Symbol;
 
-            if (!methodSymbol.IsFunction(context) || !methodSymbol.IsAsync || !methodSymbol.ReturnsVoid)
+            if (!methodSymbol.IsFunction(context.Compilation) || !methodSymbol.IsAsync || !methodSymbol.ReturnsVoid)
             {
                 return;
             }

--- a/src/WebJobs.Script.Analyzers/AvoidNonStaticHttpClientAnalyzer.cs
+++ b/src/WebJobs.Script.Analyzers/AvoidNonStaticHttpClientAnalyzer.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+using System.Net.Http;
+
+namespace Microsoft.Azure.Functions.Analyzers
+{
+    /// <summary>
+    /// AZF0002: Use static HttpClient
+    /// 
+    /// Cause:
+    /// An local declaration that happens inside a Function method, instantiates an HttpClient
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class AvoidNonStaticHttpClientAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(DiagnosticDescriptors.AvoidNonStaticHttpClient); } }
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterSyntaxNodeAction(AnalyzeNode, SyntaxKind.ObjectCreationExpression);
+        }
+
+        private static void AnalyzeNode(SyntaxNodeAnalysisContext context)
+        {
+            // check if object is created within function method
+            var containingSymbol = context.ContainingSymbol as IMethodSymbol;
+            if (containingSymbol is null || !containingSymbol.IsFunction(context.Compilation))
+            {
+                return;
+            }
+
+            // check if constructor is HttpClient
+            var httpClientTypeSymbol = context.SemanticModel.Compilation.GetTypeByMetadataName(typeof(HttpClient).FullName);
+            var nodeTypeSymbol = context.SemanticModel.GetTypeInfo(context.Node, context.CancellationToken).ConvertedType;
+
+            if (!httpClientTypeSymbol.IsAssignableFrom(nodeTypeSymbol))
+            {
+                return;
+            }
+
+            var diagnostic = Diagnostic.Create(DiagnosticDescriptors.AvoidNonStaticHttpClient, context.Node.GetLocation());
+            context.ReportDiagnostic(diagnostic);
+        }
+    }
+}

--- a/src/WebJobs.Script.Analyzers/Constants.cs
+++ b/src/WebJobs.Script.Analyzers/Constants.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Functions.Analyzers
 
         internal static class DiagnosticsCategories
         {
+            public const string Reliability = "Reliability";
             public const string Usage = "Usage";
         }
     }

--- a/src/WebJobs.Script.Analyzers/DiagnosticDescriptors.cs
+++ b/src/WebJobs.Script.Analyzers/DiagnosticDescriptors.cs
@@ -21,5 +21,11 @@ namespace Microsoft.Azure.Functions.Analyzers
                 messageFormat: "Async void can lead to unexpected behavior. Return Task instead.",
                 category: Constants.DiagnosticsCategories.Usage,
                 severity: DiagnosticSeverity.Error);
+
+        public static DiagnosticDescriptor AvoidNonStaticHttpClient { get; }
+            = Create(id: "AZF0002", title: "Inefficient HttpClient usage",
+                messageFormat: "Reuse HttpClient instances to avoid holding more connections than necessary. See helplink for more information.",
+                category: Constants.DiagnosticsCategories.Reliability,
+                severity: DiagnosticSeverity.Warning);
     }
 }

--- a/src/WebJobs.Script.Analyzers/MethodSymbolExtensions.cs
+++ b/src/WebJobs.Script.Analyzers/MethodSymbolExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Functions.Analyzers
 {
     internal static class MethodSymbolExtensions
     {
-        public static bool IsFunction(this IMethodSymbol symbol, SymbolAnalysisContext analysisContext)
+        public static bool IsFunction(this IMethodSymbol symbol, Compilation compilation)
         {
             var attributes = symbol.GetAttributes();
 
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Functions.Analyzers
                 return false;
             }
 
-            var attributeType = analysisContext.Compilation.GetTypeByMetadataName(Constants.Types.FunctionNameAttribute);
+            var attributeType = compilation.GetTypeByMetadataName(Constants.Types.FunctionNameAttribute);
 
             return attributes.Any(a => attributeType.IsAssignableFrom(a.AttributeClass, true));
         }

--- a/src/WebJobs.Script.Analyzers/WebJobs.Script.Analyzers.csproj
+++ b/src/WebJobs.Script.Analyzers/WebJobs.Script.Analyzers.csproj
@@ -10,10 +10,10 @@
     <PackageIcon>functions.png</PackageIcon>
     <PackageTags>Azure Functions, analyzers</PackageTags>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.0.0</Version>
-    <MajorMinorProductVersion>1.0</MajorMinorProductVersion>
+    <Version>1.1.0</Version>
+    <MajorMinorProductVersion>1.1</MajorMinorProductVersion>
     <AssemblyVersion>$(MajorMinorProductVersion).0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
+    <FileVersion>1.1.0.0</FileVersion>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SignAssembly>true</SignAssembly>

--- a/test/WebJobs.Script.Tests.Analyzers/AvoidNonStaticHttpClientAnalyzerTests.cs
+++ b/test/WebJobs.Script.Tests.Analyzers/AvoidNonStaticHttpClientAnalyzerTests.cs
@@ -1,0 +1,205 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Xunit;
+using AnalyzerTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<Microsoft.Azure.Functions.Analyzers.AvoidNonStaticHttpClientAnalyzer, Microsoft.CodeAnalysis.Testing.Verifiers.XUnitVerifier>;
+using Verify = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<Microsoft.Azure.Functions.Analyzers.AvoidNonStaticHttpClientAnalyzer>;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using System.Collections.Immutable;
+
+namespace WebJobs.Script.Tests.Analyzers
+{
+    public class AvoidNonStaticHttpClientAnalyzerTests
+    {
+        [Fact]
+        public async Task StaticHttpClient_NoDiagnostic()
+        {
+            string testCode = @"
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using System.Net.Http;
+
+namespace FunctionApp
+{
+    public static class SomeFunction
+    {
+        public static HttpClient httpClient = new HttpClient();
+
+        [FunctionName(nameof(SomeFunction))]
+        public static void Run([QueueTrigger(""myqueue-items"", Connection = """")] string myQueueItem, ILogger log)
+        {
+            httpClient.GetAsync(""https://www.microsoft.com"");
+        }
+    }
+}
+";
+
+            var test = new AnalyzerTest();
+            test.ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                new PackageIdentity("Microsoft.NET.Sdk.Functions", "3.0.11"),
+                new PackageIdentity("Microsoft.Azure.WebJobs.Extensions.Storage", "3.0.10")));
+
+            test.TestCode = testCode;
+
+            // 0 diagnostics expected
+
+            await test.RunAsync();
+        }
+
+
+        [Fact]
+        public async Task LocalHttpClientVariable_Diagnostic()
+        {
+            string testCode = @"
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using System.Net.Http;
+
+namespace FunctionApp
+{
+    public static class SomeFunction
+    {
+        [FunctionName(nameof(SomeFunction))]
+        public static void Run([QueueTrigger(""myqueue-items"", Connection = """")] string myQueueItem, ILogger log)
+        {
+                var httpClient = new HttpClient();
+        }
+    }
+}
+";
+
+            var test = new AnalyzerTest();
+            test.ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                new PackageIdentity("Microsoft.NET.Sdk.Functions", "3.0.11"),
+                new PackageIdentity("Microsoft.Azure.WebJobs.Extensions.Storage", "3.0.10")));
+
+            test.TestCode = testCode;
+
+            test.ExpectedDiagnostics.Add(Verify.Diagnostic()
+                .WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(13, 34, 13, 50));
+
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task LocalNestedHttpClientVariable_Diagnostic()
+        {
+            string testCode = @"
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using System.Net.Http;
+
+namespace FunctionApp
+{
+    public static class SomeFunction
+    {
+        [FunctionName(nameof(SomeFunction))]
+        public static void Run([QueueTrigger(""myqueue-items"", Connection = """")] string myQueueItem, ILogger log)
+        {
+            if (true)
+            {
+                using (var httpClient = new HttpClient())
+                {
+                    httpClient.GetAsync(""https://www.microsoft.com"");
+                }
+            }
+        }
+    }
+}
+";
+
+            var test = new AnalyzerTest();
+            test.ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                new PackageIdentity("Microsoft.NET.Sdk.Functions", "3.0.11"),
+                new PackageIdentity("Microsoft.Azure.WebJobs.Extensions.Storage", "3.0.10")));
+
+            test.TestCode = testCode;
+
+            test.ExpectedDiagnostics.Add(Verify.Diagnostic()
+                .WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(15, 41, 15, 57));
+
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task MethodArgument_Diagnostic()
+        {
+            string testCode = @"
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace FunctionApp
+{
+    public static class SomeFunction
+    {
+        [FunctionName(nameof(SomeFunction))]
+        public static void Run([QueueTrigger(""myqueue-items"", Connection = """")] string myQueueItem, ILogger log)
+            {
+                CallHttp(new HttpClient());
+            }
+            private static Task<HttpResponseMessage> CallHttp(HttpClient httpClient)
+            {
+                return httpClient.GetAsync(""https://www.microsoft.com"");
+            }
+        }
+    }
+";
+
+            var test = new AnalyzerTest();
+            test.ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                new PackageIdentity("Microsoft.NET.Sdk.Functions", "3.0.11"),
+                new PackageIdentity("Microsoft.Azure.WebJobs.Extensions.Storage", "3.0.10")));
+
+            test.TestCode = testCode;
+
+            test.ExpectedDiagnostics.Add(Verify.Diagnostic()
+                .WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(14, 26, 14, 42));
+
+            await test.RunAsync();
+        }
+
+        [Fact]
+        public async Task HttpClientDerivedClass_Diagnostic()
+        {
+            string testCode = @"
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using System.Net.Http;
+
+namespace FunctionApp
+{
+    public static class SomeFunction
+    {
+        [FunctionName(nameof(SomeFunction))]
+        public static void Run([QueueTrigger(""myqueue-items"", Connection = """")]string myQueueItem, ILogger log)
+        {
+            var httpClient = new CustomHttpClient();
+            httpClient.GetAsync(""https://www.microsoft.com"");
+        }
+    }
+
+    public class CustomHttpClient : HttpClient { }
+}
+";
+
+            var test = new AnalyzerTest();
+            test.ReferenceAssemblies = ReferenceAssemblies.Net.Net50.WithPackages(ImmutableArray.Create(
+                new PackageIdentity("Microsoft.NET.Sdk.Functions", "3.0.11"),
+                new PackageIdentity("Microsoft.Azure.WebJobs.Extensions.Storage", "3.0.10")));
+
+            test.TestCode = testCode;
+
+            test.ExpectedDiagnostics.Add(Verify.Diagnostic()
+                .WithSeverity(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning)
+                .WithSpan(13, 30, 13, 52));
+
+            await test.RunAsync();
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Addresses #7414

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [X] Otherwise: https://github.com/MicrosoftDocs/azure-docs-pr/pull/174020
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This implementation will raise the diagnostic, but I would like to have some more discussion about the code fix(es) themselves.

Currently, using reflection to get the full assembly name of `System.Net.Http.HttpClient` - however, might want to change this to a string for performance reasons, since analyzers should be fast, and reflection can be an expensive operation. Thoughts?