### PR TITLE
[pack] updating version details

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,10 +39,9 @@ jobs:
   condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.InitializePipeline.outputs['Initialize.BuildArtifacts'], true)))
   variables:
     ${{ if or( eq( variables['Build.Reason'], 'PullRequest' ), and( not( contains( variables['Build.SourceBranch'], 'release/4.' ) ), not( contains( variables['Build.SourceBranch'], 'release/ExtensionsMetadataGenerator/' ) ) ) ) }}:
-      suffixTemp: ci
-      packSuffixSwitchTemp: --version-suffix ci
+      suffixTemp: $(buildNumber)
+      packSuffixSwitchTemp: --version-suffix $(buildNumber)
       emgSuffixSwitchTemp: --version-suffix ci$(buildNumber)
-      artifactSuffix: -ci
     suffix: $[variables.suffixTemp] # this resolves to an empty string if it is missing
     packSuffixSwitch: $[variables.packSuffixSwitchTemp]
     emgSuffixSwitch: $[variables.emgSuffixSwitchTemp]
@@ -54,7 +53,7 @@ jobs:
     displayName: "Build artifacts"
     inputs:
       filePath: '$(Build.Repository.LocalPath)\build\build-extensions.ps1'
-      arguments: '-buildNumber "$(buildNumber)" -suffix "$(suffix)" -commitHash "$(Build.SourceVersion)"'
+      arguments: '-buildNumber "$(buildNumber)" -suffix "$(suffix)"'
   - task: PowerShell@2
     condition: eq(variables['RUNBUILDFORINTEGRATIONTESTS'], 'True')
     displayName: "Update host references"
@@ -70,7 +69,7 @@ jobs:
     inputs:
       command: 'custom'
       custom: 'pack'
-      arguments: -o packages -p:BuildNumber=$(buildNumber) -p:CommitHash=$(Build.SourceVersion) -c Release $(packSuffixSwitch)
+      arguments: -o packages -p:BuildNumber=$(buildNumber) -c Release $(packSuffixSwitch)
       projects: |
         **\WebJobs.Script.csproj
         **\WebJobs.Script.WebHost.csproj
@@ -110,7 +109,7 @@ jobs:
     displayName: 'Build Abstractions and ExtensionsMetadataGenerator'
     inputs:
       command: 'build'
-      arguments: '-c Release -p:CommitHash=$(Build.SourceVersion)'
+      arguments: '-c Release'
       projects: |
         **\ExtensionsMetadataGenerator.csproj
         **\WebJobs.Script.Abstractions.csproj

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -1,7 +1,6 @@
 param (
   [string]$buildNumber = "0",  
-  [string]$suffix = "",
-  [string]$commitHash = "N/A",
+  [string]$suffix = "",  
   [string]$hashesForHardlinksFile = "hashesForHardlinks.txt"
 )
 
@@ -15,7 +14,7 @@ if ($hasSuffix) {
 }
 
 # use the same logic as the projects to generate the site extension version
-$cmd = "build", "$rootDir\build\common.props", "/t:GenerateSiteExtensionVersion", "-restore:False", "-o", "$buildOutput", "/p:BuildNumber=$buildNumber",  "/p:CommitHash=$commitHash", $suffixCmd, "-v", "q", "--nologo", "-clp:NoSummary"
+$cmd = "build", "$rootDir\build\common.props", "/t:GenerateSiteExtensionVersion", "-restore:False", "-o", "$buildOutput", "/p:BuildNumber=$buildNumber", $suffixCmd, "-v", "q", "--nologo", "-clp:NoSummary"
 & dotnet $cmd
 
 $versionTxt = "$rootDir\buildoutput\version.txt"
@@ -55,7 +54,7 @@ function BuildRuntime([string] $targetRid, [bool] $isSelfContained) {
         throw "Project path '$projectPath' does not exist."
     }
 
-    $cmd = "publish", "$PSScriptRoot\..\src\WebJobs.Script.WebHost\WebJobs.Script.WebHost.csproj", "-r", "$targetRid", "--self-contained", "$isSelfContained", "-o", "$publishTarget", "-v", "m", "/p:BuildNumber=$buildNumber", "/p:IsPackable=false", "/p:CommitHash=$commitHash", "-c", "Release", $suffixCmd
+    $cmd = "publish", "$PSScriptRoot\..\src\WebJobs.Script.WebHost\WebJobs.Script.WebHost.csproj", "-r", "$targetRid", "--self-contained", "$isSelfContained", "-o", "$publishTarget", "-v", "m", "/p:BuildNumber=$buildNumber", "/p:IsPackable=false", "-c", "Release", $suffixCmd
 
     Write-Host "======================================"
     Write-Host "Building $targetRid"
@@ -67,6 +66,11 @@ function BuildRuntime([string] $targetRid, [bool] $isSelfContained) {
     Write-Host ""
     
     & dotnet $cmd
+
+    if ($LASTEXITCODE -ne 0)
+    {
+      exit $LASTEXITCODE
+    }
 
     Write-Host ""
     Write-Host "Moving symbols to $symbolsTarget"

--- a/build/common.props
+++ b/build/common.props
@@ -7,20 +7,19 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">0</BuildNumber>
-    <PreviewVersion>5</PreviewVersion>
+    <PreviewVersion></PreviewVersion>
     <PreviewString Condition="'$(PreviewVersion)' != ''">-preview.$(PreviewVersion).$(BuildNumber)</PreviewString>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <VersionSuffixWithDash Condition=" '$(VersionSuffix)' != '' ">-$(VersionSuffix)</VersionSuffixWithDash>
     <Version>$(VersionPrefix)$(PreviewString)$(VersionSuffixWithDash)</Version>
     <AssemblyVersion>$(MajorVersion).0.0.0</AssemblyVersion>
     <FileVersion>$(VersionPrefix).$(BuildNumber)</FileVersion>
-    <CommitHash Condition="$(CommitHash) == ''">N/A</CommitHash>        
-    <InformationalVersion>$(Version)+$(CommitHash)</InformationalVersion>
+
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)..\src.ruleset</CodeAnalysisRuleSet>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
+
+    <ContinuousIntegrationBuild Condition="'$(TF_BUILD)' == 'true'">true"</ContinuousIntegrationBuild>
     <DebugType>embedded</DebugType>
-    <UseSourceLink Condition="$(UseSourceLink) == '' And $(CI) != ''">true</UseSourceLink>
-    <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile> <!-- https://github.com/dotnet/runtime/issues/54684 -->
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
   </PropertyGroup>
 
@@ -32,27 +31,9 @@
       <WriteLinesToFile File="$(VersionFile)" Lines="$(Version)" Overwrite="true" />
   </Target>
 
-  <PropertyGroup Condition="'$(UseSourceLink)' == 'true'">
-    <SourceLink>$(BaseIntermediateOutputPath)source_link.json</SourceLink>
-  </PropertyGroup>
-  
-  <Target Name="GenerateSourceLink" BeforeTargets="CoreCompile" Condition="'$(UseSourceLink)' == 'true'">
-    <PropertyGroup>
-      <SrcRootDirectory>$([System.IO.Directory]::GetParent($(MSBuildThisFileDirectory.TrimEnd("\"))))</SrcRootDirectory>
-      <SourceLinkRoot>$(SrcRootDirectory.Replace("\", "\\"))</SourceLinkRoot>
-    </PropertyGroup>
-    <Message Importance="high" Text="Generating SourceLink..."></Message>
-    <Exec Command="git config --get remote.origin.url" ConsoleToMsBuild="true">
-      <Output TaskParameter="ConsoleOutput" PropertyName="RemoteUri" />
-    </Exec>
-
-    <Exec Command="git rev-parse HEAD" ConsoleToMsBuild="true" Condition = " '$(LatestCommit)' == '' ">
-      <Output TaskParameter="ConsoleOutput" PropertyName="LatestCommit" />
-    </Exec>
-
-    <!-- Write out the source file for this project to point at raw.githubusercontent.com -->
-    <WriteLinesToFile File="$(BaseIntermediateOutputPath)source_link.json" Overwrite="true" Lines='{"documents": { "$(SourceLinkRoot)\\*" : "$(RemoteUri.Replace(".git", "").Replace("github.com", "raw.githubusercontent.com"))/$(LatestCommit)/*" }}' />
-  </Target>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+  </ItemGroup>
   
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)..\stylecop.json" Link="stylecop.json" />

--- a/build/common.props
+++ b/build/common.props
@@ -20,7 +20,8 @@
 
     <ContinuousIntegrationBuild Condition="'$(TF_BUILD)' == 'true'">true"</ContinuousIntegrationBuild>
     <DebugType>embedded</DebugType>
-    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+    <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile><!-- https://github.com/dotnet/runtime/issues/54684 -->
+    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>    
   </PropertyGroup>
 
   <Target Name="GenerateSiteExtensionVersion">


### PR DESCRIPTION
We've been using the SourceLink.GitHub package in other repos for a while now. It automatically sets some things up for us which allows us to simplify some of the build scripts. Our file details still look like:

![image](https://user-images.githubusercontent.com/1089915/137395708-0918422f-7300-48de-a3c2-50776696f0a8.png)
