### PR TITLE
Worker Indexing - Moving common validate logic to utility

### DIFF
--- a/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
@@ -19,8 +19,6 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 {
     public abstract class FunctionDescriptorProvider
     {
-        private static readonly Regex BindingNameValidationRegex = new Regex(string.Format("^([a-zA-Z][a-zA-Z0-9]{{0,127}}|{0})$", Regex.Escape(ScriptConstants.SystemReturnParameterBindingName)));
-
         protected FunctionDescriptorProvider(ScriptHost host, ScriptJobHostOptions config, ICollection<IScriptBindingProvider> bindingProviders)
         {
             Host = host;

--- a/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
@@ -211,15 +211,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         protected internal virtual void ValidateBinding(BindingMetadata bindingMetadata)
         {
-            if (bindingMetadata.Name == null || !BindingNameValidationRegex.IsMatch(bindingMetadata.Name))
-            {
-                throw new ArgumentException($"The binding name {bindingMetadata.Name} is invalid. Please assign a valid name to the binding.");
-            }
-
-            if (bindingMetadata.IsReturn && bindingMetadata.Direction != BindingDirection.Out)
-            {
-                throw new ArgumentException($"{ScriptConstants.SystemReturnParameterBindingName} bindings must specify a direction of 'out'.");
-            }
+            Utility.ValidateBinding(bindingMetadata);
 
             if (bindingMetadata.Type == null)
             {

--- a/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
                     functionName = Path.GetFileName(functionDirectory);
 
-                    ValidateName(functionName);
+                    Utility.ValidateName(functionName);
 
                     JObject functionConfig = JObject.Parse(json);
 
@@ -106,14 +106,6 @@ namespace Microsoft.Azure.WebJobs.Script
                     Utility.AddFunctionError(_functionErrors, functionName, Utility.FlattenException(ex, includeSource: false), isFunctionShortName: true);
                 }
                 return null;
-            }
-        }
-
-        internal void ValidateName(string name, bool isProxy = false)
-        {
-            if (!Utility.IsValidFunctionName(name))
-            {
-                throw new InvalidOperationException(string.Format("'{0}' is not a valid {1} name.", name, isProxy ? "proxy" : "function"));
             }
         }
 

--- a/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Azure.WebJobs.Script
 {
     public class WorkerFunctionMetadataProvider : IFunctionMetadataProvider
     {
-        private static readonly Regex BindingNameValidationRegex = new Regex(string.Format("^([a-zA-Z][a-zA-Z0-9]{{0,127}}|{0})$", Regex.Escape(ScriptConstants.SystemReturnParameterBindingName)));
         private readonly Dictionary<string, ICollection<string>> _functionErrors = new Dictionary<string, ICollection<string>>();
         private readonly ILogger _logger;
         private readonly IFunctionInvocationDispatcher _dispatcher;
@@ -145,17 +144,7 @@ namespace Microsoft.Azure.WebJobs.Script
             {
                 var functionBinding = BindingMetadata.Create(JObject.Parse(binding));
 
-                // validate binding name
-                if (functionBinding.Name == null || !BindingNameValidationRegex.IsMatch(functionBinding.Name))
-                {
-                    throw new ArgumentException($"The binding name {functionBinding.Name} is invalid. Please assign a valid name to the binding.");
-                }
-
-                // validate that output binding has correct direction
-                if (functionBinding.IsReturn && functionBinding.Direction != BindingDirection.Out)
-                {
-                    throw new ArgumentException($"{ScriptConstants.SystemReturnParameterBindingName} bindings must specify a direction of 'out'.");
-                }
+                Utility.ValidateBinding(functionBinding);
 
                 // Ensure no duplicate binding names exist
                 if (bindingNames.Contains(functionBinding.Name))

--- a/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 var function = rawFunction.Metadata;
                 try
                 {
-                    ValidateName(function.Name);
+                    Utility.ValidateName(function.Name);
 
                     function.Language = SystemEnvironment.Instance.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName);
 
@@ -126,14 +126,6 @@ namespace Microsoft.Azure.WebJobs.Script
                 }
             }
             return validatedMetadata;
-        }
-
-        internal static void ValidateName(string name, bool isProxy = false)
-        {
-            if (!Utility.IsValidFunctionName(name))
-            {
-                throw new InvalidOperationException(string.Format("'{0}' is not a valid {1} name.", name, isProxy ? "proxy" : "function"));
-            }
         }
 
         internal static FunctionMetadata ValidateBindings(IEnumerable<string> rawBindings, FunctionMetadata function)

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -564,7 +564,7 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             if (!IsValidFunctionName(name))
             {
-                throw new InvalidOperationException(string.Format("'{0}' is not a valid {1} name.", name, isProxy ? "proxy" : "function"));
+                throw new InvalidOperationException(string.Format("'{0}' is not a valid {1} name.", name, "function"));
             }
         }
 

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Azure.WebJobs.Script
         private const string SasVersionQueryParam = "sv";
 
         private static readonly Regex FunctionNameValidationRegex = new Regex(@"^[a-z][a-z0-9_\-]{0,127}$(?<!^host$)", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        private static readonly Regex BindingNameValidationRegex = new Regex(string.Format("^([a-zA-Z][a-zA-Z0-9]{{0,127}}|{0})$", Regex.Escape(ScriptConstants.SystemReturnParameterBindingName)));
 
         private static readonly string UTF8ByteOrderMark = Encoding.UTF8.GetString(Encoding.UTF8.GetPreamble());
         private static readonly FilteredExpandoObjectConverter _filteredExpandoObjectConverter = new FilteredExpandoObjectConverter();
@@ -544,6 +545,19 @@ namespace Microsoft.Azure.WebJobs.Script
                 functionErrors[functionName] = functionErrorCollection = new Collection<string>();
             }
             functionErrorCollection.Add(error);
+        }
+
+        public static void ValidateBinding(BindingMetadata bindingMetadata)
+        {
+            if (bindingMetadata.Name == null || !BindingNameValidationRegex.IsMatch(bindingMetadata.Name))
+            {
+                throw new ArgumentException($"The binding name {bindingMetadata.Name} is invalid. Please assign a valid name to the binding.");
+            }
+
+            if (bindingMetadata.IsReturn && bindingMetadata.Direction != BindingDirection.Out)
+            {
+                throw new ArgumentException($"{ScriptConstants.SystemReturnParameterBindingName} bindings must specify a direction of 'out'.");
+            }
         }
 
         internal static bool TryReadFunctionConfig(string scriptDir, out string json, IFileSystem fileSystem = null)

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -560,7 +560,7 @@ namespace Microsoft.Azure.WebJobs.Script
             }
         }
 
-        public static void ValidateName(string name, bool isProxy = false)
+        public static void ValidateName(string name)
         {
             if (!IsValidFunctionName(name))
             {

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -560,6 +560,14 @@ namespace Microsoft.Azure.WebJobs.Script
             }
         }
 
+        public static void ValidateName(string name, bool isProxy = false)
+        {
+            if (!IsValidFunctionName(name))
+            {
+                throw new InvalidOperationException(string.Format("'{0}' is not a valid {1} name.", name, isProxy ? "proxy" : "function"));
+            }
+        }
+
         internal static bool TryReadFunctionConfig(string scriptDir, out string json, IFileSystem fileSystem = null)
         {
             json = null;

--- a/test/WebJobs.Script.Tests/Description/FunctionDescriptorProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/FunctionDescriptorProviderTests.cs
@@ -197,16 +197,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [InlineData("_binding")]
         [InlineData("binding-test")]
         [InlineData("binding name")]
-        public void ValidateBinding_InvalidName_Throws(string bindingName)
+        public void ValidateBinding_InvalidType_Throws(string bindingName)
         {
             BindingMetadata bindingMetadata = new BindingMetadata
             {
-                Name = bindingName
+                Name = bindingName,
+                Type = null
             };
 
             var ex = Assert.Throws<ArgumentException>(() =>
             {
-                Utility.ValidateBinding(bindingMetadata);
+                _provider.ValidateBinding(bindingMetadata);
             });
 
             Assert.Equal($"The binding name {bindingName} is invalid. Please assign a valid name to the binding.", ex.Message);
@@ -216,7 +217,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [InlineData("bindingName")]
         [InlineData("binding1")]
         [InlineData(ScriptConstants.SystemReturnParameterBindingName)]
-        public void ValidateBinding_ValidName_DoesNotThrow(string bindingName)
+        public void ValidateBinding_ValidType_DoesNotThrow(string bindingName)
         {
             BindingMetadata bindingMetadata = new BindingMetadata
             {
@@ -231,7 +232,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             try
             {
-                Utility.ValidateBinding(bindingMetadata);
+                _provider.ValidateBinding(bindingMetadata);
             }
             catch (ArgumentException)
             {

--- a/test/WebJobs.Script.Tests/Description/FunctionDescriptorProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/FunctionDescriptorProviderTests.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [InlineData("_binding")]
         [InlineData("binding-test")]
         [InlineData("binding name")]
-        public void ValidateBinding_InvalidType_Throws(string bindingName)
+        public void ValidateBinding_InvalidName_Throws(string bindingName)
         {
             BindingMetadata bindingMetadata = new BindingMetadata
             {
@@ -217,7 +217,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [InlineData("bindingName")]
         [InlineData("binding1")]
         [InlineData(ScriptConstants.SystemReturnParameterBindingName)]
-        public void ValidateBinding_ValidType_DoesNotThrow(string bindingName)
+        public void ValidateBinding_ValidName_DoesNotThrow(string bindingName)
         {
             BindingMetadata bindingMetadata = new BindingMetadata
             {

--- a/test/WebJobs.Script.Tests/Description/FunctionDescriptorProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/FunctionDescriptorProviderTests.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var ex = Assert.Throws<ArgumentException>(() =>
             {
-                _provider.ValidateBinding(bindingMetadata);
+                Utility.ValidateBinding(bindingMetadata);
             });
 
             Assert.Equal($"The binding name {bindingName} is invalid. Please assign a valid name to the binding.", ex.Message);
@@ -231,7 +231,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             try
             {
-                _provider.ValidateBinding(bindingMetadata);
+                Utility.ValidateBinding(bindingMetadata);
             }
             catch (ArgumentException)
             {

--- a/test/WebJobs.Script.Tests/HostFunctionMetadataProviderTests.cs
+++ b/test/WebJobs.Script.Tests/HostFunctionMetadataProviderTests.cs
@@ -88,53 +88,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
-        [InlineData("")]
-        [InlineData("host")]
-        [InlineData("Host")]
-        [InlineData("-function")]
-        [InlineData("_function")]
-        [InlineData("function test")]
-        [InlineData("function.test")]
-        [InlineData("function0.1")]
-        public void ValidateFunctionName_ThrowsOnInvalidName(string functionName)
-        {
-            string functionsPath = "c:\testdir";
-            _scriptApplicationHostOptions.ScriptPath = functionsPath;
-            var optionsMonitor = TestHelpers.CreateOptionsMonitor(_scriptApplicationHostOptions);
-            var metadataProvider = new HostFunctionMetadataProvider(optionsMonitor, NullLogger<HostFunctionMetadataProvider>.Instance, _testMetricsLogger);
-
-            var ex = Assert.Throws<InvalidOperationException>(() =>
-            {
-                metadataProvider.ValidateName(functionName);
-            });
-
-            Assert.Equal(string.Format("'{0}' is not a valid function name.", functionName), ex.Message);
-        }
-
-        [Theory]
-        [InlineData("testwithhost")]
-        [InlineData("hosts")]
-        [InlineData("myfunction")]
-        [InlineData("myfunction-test")]
-        [InlineData("myfunction_test")]
-        public void ValidateFunctionName_DoesNotThrowOnValidName(string functionName)
-        {
-            string functionsPath = "c:\testdir";
-            _scriptApplicationHostOptions.ScriptPath = functionsPath;
-            var optionsMonitor = TestHelpers.CreateOptionsMonitor(_scriptApplicationHostOptions);
-            var metadataProvider = new HostFunctionMetadataProvider(optionsMonitor, NullLogger<HostFunctionMetadataProvider>.Instance, _testMetricsLogger);
-
-            try
-            {
-                metadataProvider.ValidateName(functionName);
-            }
-            catch (InvalidOperationException)
-            {
-                Assert.True(false, $"Valid function name {functionName} failed validation.");
-            }
-        }
-
-        [Theory]
         [InlineData("node", "test.js", false)]
         [InlineData("java", "test.jar", false)]
         [InlineData("CSharp", "test.cs", false)]

--- a/test/WebJobs.Script.Tests/UtilityTests.cs
+++ b/test/WebJobs.Script.Tests/UtilityTests.cs
@@ -476,6 +476,91 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
+        [InlineData("")]
+        [InlineData("host")]
+        [InlineData("Host")]
+        [InlineData("-function")]
+        [InlineData("_function")]
+        [InlineData("function test")]
+        [InlineData("function.test")]
+        [InlineData("function0.1")]
+        public void ValidateFunctionName_ThrowsOnInvalidName(string functionName)
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+            {
+                Utility.ValidateName(functionName);
+            });
+
+            Assert.Equal(string.Format("'{0}' is not a valid function name.", functionName), ex.Message);
+        }
+
+        [Theory]
+        [InlineData("testwithhost")]
+        [InlineData("hosts")]
+        [InlineData("myfunction")]
+        [InlineData("myfunction-test")]
+        [InlineData("myfunction_test")]
+        public void ValidateFunctionName_DoesNotThrowOnValidName(string functionName)
+        {
+            try
+            {
+                Utility.ValidateName(functionName);
+            }
+            catch (InvalidOperationException)
+            {
+                Assert.True(false, $"Valid function name {functionName} failed validation.");
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("_binding")]
+        [InlineData("binding-test")]
+        [InlineData("binding name")]
+        public void ValidateBinding_InvalidName_Throws(string bindingName)
+        {
+            BindingMetadata bindingMetadata = new BindingMetadata
+            {
+                Name = bindingName
+            };
+
+            var ex = Assert.Throws<ArgumentException>(() =>
+            {
+                Utility.ValidateBinding(bindingMetadata);
+            });
+
+            Assert.Equal($"The binding name {bindingName} is invalid. Please assign a valid name to the binding.", ex.Message);
+        }
+
+        [Theory]
+        [InlineData("bindingName")]
+        [InlineData("binding1")]
+        [InlineData(ScriptConstants.SystemReturnParameterBindingName)]
+        public void ValidateBinding_ValidName_DoesNotThrow(string bindingName)
+        {
+            BindingMetadata bindingMetadata = new BindingMetadata
+            {
+                Name = bindingName,
+                Type = "Blob"
+            };
+
+            if (bindingMetadata.IsReturn)
+            {
+                bindingMetadata.Direction = BindingDirection.Out;
+            }
+
+            try
+            {
+                Utility.ValidateBinding(bindingMetadata);
+            }
+            catch (ArgumentException)
+            {
+                Assert.True(false, $"Valid binding name '{bindingName}' failed validation.");
+            }
+        }
+
+        [Theory]
         [InlineData("createIsolationEnvironment", "tr-TR", true)]
         [InlineData("HttpTrigger2", "en-US", true)]
         [InlineData("HttptRIGGER", "ja-JP", true)]

--- a/test/WebJobs.Script.Tests/WorkerFunctionMetadataProviderTests.cs
+++ b/test/WebJobs.Script.Tests/WorkerFunctionMetadataProviderTests.cs
@@ -25,43 +25,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _scriptApplicationHostOptions = new ScriptApplicationHostOptions();
         }
 
-        [Theory]
-        [InlineData("")]
-        [InlineData("host")]
-        [InlineData("Host")]
-        [InlineData("-function")]
-        [InlineData("_function")]
-        [InlineData("function test")]
-        [InlineData("function.test")]
-        [InlineData("function0.1")]
-        public void ValidateFunctionName_ThrowsOnInvalidName(string functionName)
-        {
-            var ex = Assert.Throws<InvalidOperationException>(() =>
-            {
-                WorkerFunctionMetadataProvider.ValidateName(functionName);
-            });
-
-            Assert.Equal(string.Format("'{0}' is not a valid function name.", functionName), ex.Message);
-        }
-
-        [Theory]
-        [InlineData("testwithhost")]
-        [InlineData("hosts")]
-        [InlineData("myfunction")]
-        [InlineData("myfunction-test")]
-        [InlineData("myfunction_test")]
-        public void ValidateFunctionName_DoesNotThrowOnValidName(string functionName)
-        {
-            try
-            {
-                WorkerFunctionMetadataProvider.ValidateName(functionName);
-            }
-            catch (InvalidOperationException)
-            {
-                Assert.True(false, $"Valid function name {functionName} failed validation.");
-            }
-        }
-
         [Fact]
         public void ValidateBindings_NoBindings_Throws()
         {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

https://github.com/Azure/azure-functions-host/issues/7806

To move common validation logic into Utility -
HostFunctionMetadataProvider, WorkerFunctionMetadataProvider, and FunctionDescriptorProvider all seem to have similar validation logic that is based off each other. To reduce this code duplication, common elements across each of the validation pipelines should be moved to the Utility class. This has the potential to reduce test duplication too.

#### [Note]: The purpose of the PR is to verify if there is any more common logic to be moved to utility.