### PR TITLE
Fix spelling of occurred

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
@@ -102,16 +102,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
                 new EventId(514, nameof(StartupOperationWasCanceled)),
                 "Host startup operation '{operationId}' was canceled.");
 
-        private static readonly Action<ILogger, Guid, Exception> _errorOccuredDuringStartupOperation =
+        private static readonly Action<ILogger, Guid, Exception> _errorOccurredDuringStartupOperation =
             LoggerMessage.Define<Guid>(
                 LogLevel.Error,
-                new EventId(515, nameof(ErrorOccuredDuringStartupOperation)),
+                new EventId(515, nameof(ErrorOccurredDuringStartupOperation)),
                 "A host error has occurred during startup operation '{operationId}'.");
 
-        private static readonly Action<ILogger, Guid, Exception> _errorOccuredInactive =
+        private static readonly Action<ILogger, Guid, Exception> _errorOccurredInactive =
             LoggerMessage.Define<Guid>(
                 LogLevel.Warning,
-                new EventId(516, nameof(ErrorOccuredInactive)),
+                new EventId(516, nameof(ErrorOccurredInactive)),
                 "A host error has occurred on an inactive host during startup operation '{operationId}'.");
 
         private static readonly Action<ILogger, Guid, Exception> _cancellationRequested =
@@ -261,14 +261,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
             _startupOperationWasCanceled(logger, operationId, null);
         }
 
-        public static void ErrorOccuredDuringStartupOperation(this ILogger logger, Guid operationId, Exception ex)
+        public static void ErrorOccurredDuringStartupOperation(this ILogger logger, Guid operationId, Exception ex)
         {
-            _errorOccuredDuringStartupOperation(logger, operationId, ex);
+            _errorOccurredDuringStartupOperation(logger, operationId, ex);
         }
 
-        public static void ErrorOccuredInactive(this ILogger logger, Guid operationId, Exception ex)
+        public static void ErrorOccurredInactive(this ILogger logger, Guid operationId, Exception ex)
         {
-            _errorOccuredInactive(logger, operationId, ex);
+            _errorOccurredInactive(logger, operationId, ex);
         }
 
         public static void CancellationRequested(this ILogger logger, Guid operationId)

--- a/src/WebJobs.Script.WebHost/Helpers/TableStorageHelpers.cs
+++ b/src/WebJobs.Script.WebHost/Helpers/TableStorageHelpers.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Helpers
                 {
                     // best effort - if purge fails we log and ignore
                     // we'll try again another time
-                    logger.LogError(e, "Error occured when attempting to delete old diagnostic events tables.");
+                    logger.LogError(e, "Error occurred when attempting to delete old diagnostic events tables.");
                 }
             });
         }

--- a/src/WebJobs.Script.WebHost/Scale/TableStorageScaleMetricsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Scale/TableStorageScaleMetricsRepository.cs
@@ -377,7 +377,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 {
                     // best effort - if purge fails we log an ignore
                     // we'll try again another time
-                    _logger.LogError(e, "Error occured when attempting to delete old metrics tables.");
+                    _logger.LogError(e, "Error occurred when attempting to delete old metrics tables.");
                 }
             });
         }

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -316,14 +316,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 {
                     LastError = exc;
                     State = ScriptHostState.Error;
-                    logger.ErrorOccuredDuringStartupOperation(activeOperation.Id, exc);
+                    logger.ErrorOccurredDuringStartupOperation(activeOperation.Id, exc);
                 }
                 else
                 {
                     // Another host has been created before this host
                     // threw its startup exception. We want to make sure it
                     // doesn't control the state of the service.
-                    logger.ErrorOccuredInactive(activeOperation.Id, exc);
+                    logger.ErrorOccurredInactive(activeOperation.Id, exc);
                 }
 
                 attemptCount++;

--- a/test/WebJobs.Script.Tests/Diagnostics/DiagnosticEventLoggerTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/DiagnosticEventLoggerTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             {
                 var logger = provider.CreateLogger("MS_DiagnosticEvents");
 
-                logger.LogDiagnosticEvent(LogLevel.Error, 123, "FN123", "Actionable event occured", "https://fwlink", null);
+                logger.LogDiagnosticEvent(LogLevel.Error, 123, "FN123", "Actionable event occurred", "https://fwlink", null);
 
                 logger.LogInformation("Error code: {MS_errorCode}, Error Message: {message}, HelpLink: {MS_HelpLink}", "Erro123", "Unknown Error", "http://helpLink");
             }
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 
                 environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
 
-                logger.LogDiagnosticEvent(LogLevel.Error, 123, "FN123", "Actionable event occured", "https://fwlink", null);
+                logger.LogDiagnosticEvent(LogLevel.Error, 123, "FN123", "Actionable event occurred", "https://fwlink", null);
             }
 
             Assert.Equal(1, repository.Events.Count);


### PR DESCRIPTION
 Fixing the spelling mistakes in some method names and logs. If the logs being fixed will break anything, I can revert that but at the very least we should fix the method names?
 
 ### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

