### PR TITLE
Simplify RpcWorkerChannel Initialization in PlaceholderMode

### DIFF
--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -494,7 +494,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public static HashSet<string> GetLanguageWorkerListToStartInPlaceholder(this IEnvironment environment)
         {
             string placeholderList = environment.GetEnvironmentVariableOrDefault(RpcWorkerConstants.FunctionWorkerPlaceholderModeListSettingName, string.Empty);
-            var placeholderRuntimeSet = new HashSet<string>(placeholderList.Split(';'));
+            var placeholderRuntimeSet = new HashSet<string>(placeholderList.Split(';', StringSplitOptions.RemoveEmptyEntries).Select(p => p.Trim());
             string workerRuntime = environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName);
             if (!string.IsNullOrEmpty(workerRuntime))
             {

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -488,6 +489,19 @@ namespace Microsoft.Azure.WebJobs.Script
                 return concurrencyEnabled && string.IsNullOrEmpty(environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionsWorkerProcessCountSettingName));
             }
             return false;
+        }
+
+        public static HashSet<string> GetLanguageWorkerListToStartInPlaceholder(this IEnvironment environment)
+        {
+            string placeholderList = environment.GetEnvironmentVariableOrDefault(RpcWorkerConstants.FunctionWorkerPlaceholderModeListSettingName, string.Empty);
+            var placeholderRuntimeSet = new HashSet<string>(placeholderList.Split(';'));
+            string workerRuntime = environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName);
+            if (!string.IsNullOrEmpty(workerRuntime))
+            {
+                placeholderRuntimeSet.Add(workerRuntime);
+            }
+            placeholderRuntimeSet.Remove(string.Empty);
+            return placeholderRuntimeSet;
         }
     }
 }

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -494,13 +494,12 @@ namespace Microsoft.Azure.WebJobs.Script
         public static HashSet<string> GetLanguageWorkerListToStartInPlaceholder(this IEnvironment environment)
         {
             string placeholderList = environment.GetEnvironmentVariableOrDefault(RpcWorkerConstants.FunctionWorkerPlaceholderModeListSettingName, string.Empty);
-            var placeholderRuntimeSet = new HashSet<string>(placeholderList.Split(';', StringSplitOptions.RemoveEmptyEntries).Select(p => p.Trim());
+            var placeholderRuntimeSet = new HashSet<string>(placeholderList.Trim().Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).Select(p => p.Trim()));
             string workerRuntime = environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName);
             if (!string.IsNullOrEmpty(workerRuntime))
             {
                 placeholderRuntimeSet.Add(workerRuntime);
             }
-            placeholderRuntimeSet.Remove(string.Empty);
             return placeholderRuntimeSet;
         }
     }

--- a/src/WebJobs.Script/Workers/Rpc/RpcInitializationService.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcInitializationService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         private readonly string _workerRuntime;
         private readonly int _rpcServerShutdownTimeoutInMilliseconds;
-        private HashSet<string> _placeholderLanguageWorkersList;
+        private HashSet<string> _placeholderLanguageWorkersList = new HashSet<string>();
 
         public RpcInitializationService(IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, IEnvironment environment, IRpcServer rpcServer, IWebHostRpcWorkerChannelManager rpcWorkerChannelManager, ILogger<RpcInitializationService> logger)
         {
@@ -104,11 +104,17 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         internal Task InitializeChannelsAsync()
         {
+            if (_placeholderLanguageWorkersList == null)
+            {
+                throw new ArgumentNullException(nameof(_placeholderLanguageWorkersList));
+            }
+
             if (_environment.IsPlaceholderModeEnabled())
             {
-                if (_placeholderLanguageWorkersList != null && _placeholderLanguageWorkersList.Count() != 0)
+                _logger.LogDebug("Initializing language worker channels '{placholderChannelList}' in placeholder mode.", string.Join(",", _placeholderLanguageWorkersList));
+
+                if (_placeholderLanguageWorkersList.Count() != 0)
                 {
-                    _logger.LogDebug("Initializing language worker channels {placholderChannelList} in placeholder mode.", string.Join(",", _placeholderLanguageWorkersList));
                     return Task.WhenAll(_placeholderLanguageWorkersList.Select(runtime =>
                     _webHostRpcWorkerChannelManager.InitializeChannelAsync(runtime)));
                 }

--- a/src/WebJobs.Script/Workers/Rpc/RpcInitializationService.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcInitializationService.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
             if (_environment.IsPlaceholderModeEnabled())
             {
-                _logger.LogDebug("Initializing language worker channels '{placholderChannelList}' in placeholder mode.", string.Join(",", _placeholderLanguageWorkersList));
+                _logger.LogDebug("Initializing language worker channels. {workerRuntimeSetting}: '{workerRuntime}', placeholderChannelList: '{placeholderChannelList}' in placeholder mode.", nameof(RpcWorkerConstants.FunctionWorkerRuntimeSettingName), _workerRuntime, string.Join(",", _placeholderLanguageWorkersList));
 
                 if (_placeholderLanguageWorkersList.Count() != 0)
                 {

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
     public static class RpcWorkerConstants
     {
         public const string FunctionWorkerRuntimeSettingName = "FUNCTIONS_WORKER_RUNTIME";
+        // semicolon seperated string - list of runtimes to start in placeholder mode
+        public const string FunctionWorkerPlaceholderModeListSettingName = "FUNCTIONS_WORKER_RUNTIME_PLACEHOLDERMODE_LIST";
         public const string FunctionWorkerRuntimeVersionSettingName = "FUNCTIONS_WORKER_RUNTIME_VERSION";
         public const string FunctionsWorkerProcessCountSettingName = "FUNCTIONS_WORKER_PROCESS_COUNT";
         public const string FunctionsWorkerSharedMemoryDataTransferEnabledSettingName = "FUNCTIONS_WORKER_SHARED_MEMORY_DATA_TRANSFER_ENABLED";

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
     {
         public const string FunctionWorkerRuntimeSettingName = "FUNCTIONS_WORKER_RUNTIME";
         // semicolon seperated string - list of runtimes to start in placeholder mode
-        public const string FunctionWorkerPlaceholderModeListSettingName = "FUNCTIONS_WORKER_RUNTIME_PLACEHOLDERMODE_LIST";
+        public const string FunctionWorkerPlaceholderModeListSettingName = "FUNCTIONS_WORKER_RUNTIME_PLACEHOLDER_MODE_LIST";
         public const string FunctionWorkerRuntimeVersionSettingName = "FUNCTIONS_WORKER_RUNTIME_VERSION";
         public const string FunctionsWorkerProcessCountSettingName = "FUNCTIONS_WORKER_PROCESS_COUNT";
         public const string FunctionsWorkerSharedMemoryDataTransferEnabledSettingName = "FUNCTIONS_WORKER_SHARED_MEMORY_DATA_TRANSFER_ENABLED";

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Java.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Java.cs
@@ -50,8 +50,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.True(javaProcessesAfter.Count() > 0);
             // Verify number of java processes before and after restart are the same.
             Assert.Equal(javaProcessesBefore.Count(), javaProcessesAfter.Count());
-            // Verify Java same java process is used after host restart
-            var result = javaProcessesBefore.Where(pId1 => !javaProcessesAfter.Any(pId2 => pId2 == pId1));
+            // Verify Java different java process is used after host restart
+            var result = javaProcessesBefore.Where(pId1 => javaProcessesAfter.Any(pId2 => pId2 == pId1));
             Assert.Equal(0, result.Count());
         }
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Java.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Java.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         }
 
         [Fact]
-        public async Task JavaProcess_Same_AfterHostRestart()
+        public async Task JavaProcess_Different_AfterHostRestart()
         {
             IEnumerable<int> javaProcessesBefore = Process.GetProcessesByName("java").Select(p => p.Id);
             Assert.True(javaProcessesBefore.Count() > 0);

--- a/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
@@ -271,6 +271,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
         [InlineData(null, null, "")]
         [InlineData("node", "python;java", "node;python;java")]
         [InlineData("", "node;python", "node;python")]
+        [InlineData("", "python;java;", "python;java")]
         [InlineData("node", "", "node")]
         public void GetLanguageWorkerListToStartInPlaceholder_ReturnsExpectedResult(string workerRuntime, string workerRuntimeList, string expected)
         {

--- a/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
@@ -269,6 +269,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
 
         [Theory]
         [InlineData(null, null, "")]
+        [InlineData("", "", "")]
         [InlineData("node", "python;java", "node;python;java")]
         [InlineData("", "node;python", "node;python")]
         [InlineData("", "python;java;", "python;java")]

--- a/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Xunit;
 using static Microsoft.Azure.WebJobs.Script.EnvironmentSettingNames;
@@ -264,6 +265,26 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
             environment.SetEnvironmentVariable(RpcWorkerConstants.FunctionsWorkerDynamicConcurrencyEnabled, concurrencyEnabledValue);
             environment.SetEnvironmentVariable(RpcWorkerConstants.FunctionsWorkerProcessCountSettingName, processCountValue);
             Assert.Equal(expected, environment.IsWorkerDynamicConcurrencyEnabled());
+        }
+
+        [Theory]
+        [InlineData(null, null, "")]
+        [InlineData("node", "python;java", "node;python;java")]
+        [InlineData("", "node;python", "node;python")]
+        [InlineData("node", "", "node")]
+        public void GetLanguageWorkerListToStartInPlaceholder_ReturnsExpectedResult(string workerRuntime, string workerRuntimeList, string expected)
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, workerRuntime);
+            environment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerPlaceholderModeListSettingName, workerRuntimeList);
+            var resultSet = environment.GetLanguageWorkerListToStartInPlaceholder();
+            if (string.IsNullOrEmpty(expected))
+            {
+                Assert.Empty(resultSet);
+                return;
+            }
+            var expectedSet = new HashSet<string>(expected.Split(';'));
+            Assert.True(resultSet.SetEquals(expectedSet));
         }
 
         [Theory]

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcInitializationServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcInitializationServiceTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.IO.Abstractions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
@@ -61,131 +60,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
-        public async Task RpcInitializationService_Initializes_RpcServerAndChannels_Windows_PlaceHolderMode()
-        {
-            IRpcServer testRpcServer = new TestRpcServer();
-            var mockEnvironment = new Mock<IEnvironment>();
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode)).Returns("1");
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName)).Returns(string.Empty);
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)).Returns("functionsPlaceholderTemplateSite");
-
-            _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
-            await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.JavaLanguageWorkerName), Times.Once);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.PythonLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.NodeLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.PowerShellLanguageWorkerName), Times.Never);
-            Assert.Contains("testserver", testRpcServer.Uri.ToString());
-            await testRpcServer.ShutdownAsync();
-        }
-
-        [Fact]
-        public async Task RpcInitializationService_Initializes_RpcServerOnly_Windows_NoPlaceHolderMode()
-        {
-            IRpcServer testRpcServer = new TestRpcServer();
-            var mockEnvironment = new Mock<IEnvironment>();
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode)).Returns("0");
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName)).Returns(string.Empty);
-
-            _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
-            await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.JavaLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.PythonLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.NodeLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.PowerShellLanguageWorkerName), Times.Never);
-            Assert.Contains("testserver", testRpcServer.Uri.ToString());
-            await testRpcServer.ShutdownAsync();
-        }
-
-        [Fact]
-        public async Task RpcInitializationService_Initializes_RpcServerAndChannels_LinuxConsumption_PlaceHolderMode()
-        {
-            IRpcServer testRpcServer = new TestRpcServer();
-            var mockEnvironment = new Mock<IEnvironment>();
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode)).Returns("1");
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName)).Returns(string.Empty);
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ContainerName)).Returns("LinuxContainer");
-
-            _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
-            await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.PythonLanguageWorkerName), Times.Once);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.NodeLanguageWorkerName), Times.Once);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.JavaLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.PowerShellLanguageWorkerName), Times.Never);
-            Assert.Contains("testserver", testRpcServer.Uri.ToString());
-            await testRpcServer.ShutdownAsync();
-        }
-
-        [Fact]
-        public async Task RpcInitializationService_Initializes_RpcServerOnly_LinuxConsumption_NoPlaceHolderMode()
-        {
-            IRpcServer testRpcServer = new TestRpcServer();
-            var mockEnvironment = new Mock<IEnvironment>();
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode)).Returns("0");
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName)).Returns(string.Empty);
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ContainerName)).Returns("LinuxContainer");
-
-            _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
-            await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.PythonLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.NodeLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.JavaLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.PowerShellLanguageWorkerName), Times.Never);
-            Assert.Contains("testserver", testRpcServer.Uri.ToString());
-            await testRpcServer.ShutdownAsync();
-        }
-
-        [Fact]
-        public async Task RpcInitializationService_Initializes_RpcServerAndChannels_LinuxAppService_PlaceHolderMode()
-        {
-            IRpcServer testRpcServer = new TestRpcServer();
-            var mockEnvironment = new Mock<IEnvironment>();
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsLogsMountPath)).Returns(@"d:\test");
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId)).Returns("1234");
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode)).Returns("1");
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName)).Returns(string.Empty);
-
-            _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
-            await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.PythonLanguageWorkerName), Times.Once);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.NodeLanguageWorkerName), Times.Once);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.JavaLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.PowerShellLanguageWorkerName), Times.Never);
-            Assert.Contains("testserver", testRpcServer.Uri.ToString());
-            await testRpcServer.ShutdownAsync();
-        }
-
-        [Fact]
-        public async Task RpcInitializationService_Initializes_RpcServerOnly_LinuxAppService_NoPlaceHolderMode()
-        {
-            IRpcServer testRpcServer = new TestRpcServer();
-            var mockEnvironment = new Mock<IEnvironment>();
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsLogsMountPath)).Returns(@"d:\test");
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId)).Returns("1234");
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode)).Returns("0");
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName)).Returns(string.Empty);
-
-            _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
-            await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.PythonLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.NodeLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.JavaLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.PowerShellLanguageWorkerName), Times.Never);
-            Assert.Contains("testserver", testRpcServer.Uri.ToString());
-            await testRpcServer.ShutdownAsync();
-        }
-
-        [Fact]
-        public async Task RpcInitializationService_Initializes_RpcServerAndChannels_WebHostLevel_WorkerRuntime_Set_Node_NoPlaceHolderMode()
+        public async Task RpcInitializationService_Initializes_RpcServerAndChannels_WorkerRuntime_Set_Node_NoPlaceHolderMode()
         {
             IRpcServer testRpcServer = new TestRpcServer();
             var mockEnvironment = new Mock<IEnvironment>();
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName)).Returns(RpcWorkerConstants.NodeLanguageWorkerName);
-
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
-            _rpcInitializationService.AddSupportedWebHostLevelRuntime(RpcWorkerConstants.NodeLanguageWorkerName);
             await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.NodeLanguageWorkerName), Times.Once);
+            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.NodeLanguageWorkerName), Times.Never);
             Assert.Contains("testserver", testRpcServer.Uri.ToString());
             await testRpcServer.ShutdownAsync();
         }
@@ -199,7 +81,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode)).Returns("1");
 
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
-            _rpcInitializationService.AddSupportedWebHostLevelRuntime(RpcWorkerConstants.NodeLanguageWorkerName);
 
             await _rpcInitializationService.StartAsync(CancellationToken.None);
             _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.NodeLanguageWorkerName), Times.Once);
@@ -208,46 +89,35 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
-        public async Task RpcInitializationService_Initializes_RpcServerOnly_WebHostLevel_WorkerRuntime_Set_RuntimeNotSupported()
+        public async Task RpcInitializationService_Initializes_RpcServer_RpcChannels_PlaceholderMode()
+        {
+            IRpcServer testRpcServer = new TestRpcServer();
+            var mockEnvironment = new Mock<IEnvironment>();
+            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode)).Returns("1");
+            mockEnvironment.Setup(p => p.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName)).Returns(RpcWorkerConstants.NodeLanguageWorkerName);
+            mockEnvironment.Setup(p => p.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerPlaceholderModeListSettingName)).Returns($"{RpcWorkerConstants.PythonLanguageWorkerName};{RpcWorkerConstants.JavaLanguageWorkerName};");
+
+            _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
+            await _rpcInitializationService.StartAsync(CancellationToken.None);
+            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.NodeLanguageWorkerName), Times.Once);
+            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.JavaLanguageWorkerName), Times.Once);
+            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.PythonLanguageWorkerName), Times.Once);
+            Assert.Contains("testserver", testRpcServer.Uri.ToString());
+            await testRpcServer.ShutdownAsync();
+        }
+
+        [Fact]
+        public async Task RpcInitializationService_Initializes_RpcServer_DoesNot_Initialize_RpcChannels_NoPlaceholderMode()
         {
             IRpcServer testRpcServer = new TestRpcServer();
             var mockEnvironment = new Mock<IEnvironment>();
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName)).Returns(RpcWorkerConstants.NodeLanguageWorkerName);
+            mockEnvironment.Setup(p => p.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerPlaceholderModeListSettingName)).Returns($"{RpcWorkerConstants.PythonLanguageWorkerName};{RpcWorkerConstants.JavaLanguageWorkerName};");
 
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
             await _rpcInitializationService.StartAsync(CancellationToken.None);
             _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.NodeLanguageWorkerName), Times.Never);
             _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.JavaLanguageWorkerName), Times.Never);
-            Assert.Contains("testserver", testRpcServer.Uri.ToString());
-            await testRpcServer.ShutdownAsync();
-        }
-
-        [Fact]
-        public async Task RpcInitializationService_Initializes_RpcServerOnly_WebHostLevel_WorkerRuntime_NotSet_NoPlaceHolderMode()
-        {
-            IRpcServer testRpcServer = new TestRpcServer();
-            var mockEnvironment = new Mock<IEnvironment>();
-
-            _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
-            _rpcInitializationService.AddSupportedWebHostLevelRuntime(RpcWorkerConstants.NodeLanguageWorkerName);
-
-            await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.JavaLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.NodeLanguageWorkerName), Times.Never);
-            Assert.Contains("testserver", testRpcServer.Uri.ToString());
-            await testRpcServer.ShutdownAsync();
-        }
-
-        [Fact]
-        public async Task RpcInitializationService_Initializes_RpcServerOnly_WorkerRuntime_Set_Python_NoPlaceHolderMode()
-        {
-            IRpcServer testRpcServer = new TestRpcServer();
-            var mockEnvironment = new Mock<IEnvironment>();
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName)).Returns(RpcWorkerConstants.PythonLanguageWorkerName);
-
-            _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger);
-
-            await _rpcInitializationService.StartAsync(CancellationToken.None);
             _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(RpcWorkerConstants.PythonLanguageWorkerName), Times.Never);
             Assert.Contains("testserver", testRpcServer.Uri.ToString());
             await testRpcServer.ShutdownAsync();
@@ -293,50 +163,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             await _rpcInitializationService.OuterStopAsync(CancellationToken.None);
             testRpcServer.Verify(a => a.ShutdownAsync(), Times.Once);
             testRpcServer.Verify(a => a.KillAsync(), Times.Once);
-        }
-
-        [Theory]
-        [InlineData("1", "functionsPlaceholderTemplateSite", "1234", true)]
-        [InlineData("0", "functionsPlaceholderTemplateSite", "1234", false)]
-        [InlineData("1", "functionsPlaceholderTemplateSitejava", "1234", false)]
-        [InlineData("1", "functionsPlaceholderTemplateSite", "", true)]
-        public void ShouldStartStandbyPlaceholderChannels_Returns_ExpectedValue(string placeholderMode, string siteName, string siteInstanaceId, bool expectedResult)
-        {
-            Mock<IRpcServer> testRpcServer = new Mock<IRpcServer>();
-            var mockEnvironment = new Mock<IEnvironment>();
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode)).Returns(placeholderMode);
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)).Returns(siteName);
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId)).Returns(siteInstanaceId);
-            _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer.Object, _mockLanguageWorkerChannelManager.Object, _logger);
-            Assert.Equal(expectedResult, _rpcInitializationService.ShouldStartStandbyPlaceholderChannels());
-        }
-
-        [Theory]
-        [InlineData("1", "node", "1234", true)]
-        [InlineData("0", "node", "1234", false)]
-        [InlineData("1", "node", "", true)]
-        [InlineData("1", "Node", "", true)]
-        [InlineData("1", "powershell", "1234", true)]
-        [InlineData("0", "powershell", "1234", false)]
-        [InlineData("1", "powershell", "", true)]
-        [InlineData("1", "Powershell", "", true)]
-        [InlineData("1", "java", "1234", true)]
-        [InlineData("0", "java", "1234", false)]
-        [InlineData("0", "JAVA", "1234", false)]
-        [InlineData("1", "java", "", true)]
-        [InlineData("1", "", "1234", false)]
-        [InlineData("1", "dotnet", "1234", false)]
-        [InlineData("1", "python", "1234", true)]
-        [InlineData("0", "python", "1234", false)]
-        public void ShouldStartAsPlaceholderPool_Returns_ExpectedValue(string placeholderMode, string workerRuntime, string siteInstanaceId, bool expectedResult)
-        {
-            Mock<IRpcServer> testRpcServer = new Mock<IRpcServer>();
-            var mockEnvironment = new Mock<IEnvironment>();
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode)).Returns(placeholderMode);
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName)).Returns(workerRuntime);
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId)).Returns(siteInstanaceId);
-            _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer.Object, _mockLanguageWorkerChannelManager.Object, _logger);
-            Assert.Equal(expectedResult, _rpcInitializationService.ShouldStartAsPlaceholderPool());
         }
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #7791

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information

- Remove legacy code and OS restrictions
- Simplify which language workers host should start in placeholder mode by introducing new Environment Setting: `FUNCTIONS_WORKER_RUNTIME_PLACEHOLDERMODE_LIST` 
- If `FUNCTIONS_WORKER_RUNTIME` and `FUNCTIONS_WORKER_RUNTIME_PLACEHOLDERMODE_LIST` are set , host will start all the language workers mentioned in `FUNCTIONS_WORKER_RUNTIME` and `FUNCTIONS_WORKER_RUNTIME_PLACEHOLDERMODE_LIST`
- Related changes in Linux Consumption Images : https://github.com/Azure/azure-functions-docker-private/pull/241