### PR TITLE
Use Path.Combine to form folder path for tests

### DIFF
--- a/src/WebJobs.Script/Host/DistributedLockManagers/BlobLeaseDistributedLockManager.cs
+++ b/src/WebJobs.Script/Host/DistributedLockManagers/BlobLeaseDistributedLockManager.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script
 {
     /// <summary>
     /// TODO: TEMP - implementation should be moved https://github.com/Azure/azure-webjobs-sdk/issues/2710
-    /// This is an overriden implementation based off the StorageBaseDistributedLockManager in Microsoft.Azure.WebJobs.Host.Storage package.
+    /// This is an overridden implementation based off the StorageBaseDistributedLockManager in Microsoft.Azure.WebJobs.Host.Storage package.
     /// Provides a BlobClient lease-based implementation of the <see cref="IDistributedLockManager"/> service for singleton locking.
     /// </summary>
     internal class BlobLeaseDistributedLockManager : IDistributedLockManager

--- a/src/WebJobs.Script/Timer/AzureStorageScheduleMonitor.cs
+++ b/src/WebJobs.Script/Timer/AzureStorageScheduleMonitor.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Timers
 {
     /// <summary>
     /// TODO: TEMP - implementation should be moved https://github.com/Azure/azure-webjobs-sdk/issues/2710
-    /// This is an overriden implementation based off the StorageScheduleMonitor in Microsoft.Azure.WebJobs.Extensions package.
+    /// This is an overridden implementation based off the StorageScheduleMonitor in Microsoft.Azure.WebJobs.Extensions package.
     /// <see cref="ScheduleMonitor"/> that stores schedule information in blob storage.
     /// </summary>
     internal class AzureStorageScheduleMonitor : ScheduleMonitor

--- a/test/WebJobs.Script.Tests.Integration/Controllers/ControllerScenarioTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/ControllerScenarioTestFixture.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
             HostOptions = new ScriptApplicationHostOptions
             {
                 IsSelfHost = true,
-                ScriptPath = Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample\csharp"),
+                ScriptPath = Path.Combine(Environment.CurrentDirectory, "..", "..", "..", "..", "..", "sample", "csharp"),
                 LogPath = Path.Combine(Path.GetTempPath(), @"Functions"),
                 SecretsPath = Path.Combine(Path.GetTempPath(), @"FunctionsTests\Secrets"),
                 HasParentScope = true
@@ -76,10 +76,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
                 .ConfigureAppConfiguration(c => c.AddEnvironmentVariables());
 
             ConfigureWebHostBuilder(webHostBuilder);
-            
-            // TODO: https://github.com/Azure/azure-functions-host/issues/4876
-            HttpServer = new TestServer(webHostBuilder);
 
+            HttpServer = new TestServer(webHostBuilder);
             HttpClient = HttpServer.CreateClient();
             HttpClient.BaseAddress = new Uri("https://localhost/");
 

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -57,11 +57,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             _hostOptions = new ScriptApplicationHostOptions
             {
-                ScriptPath = @"x:\root",
+                ScriptPath = Path.Combine("x:", "root"),
                 IsSelfHost = false,
-                LogPath = @"x:\tmp\log",
-                SecretsPath = @"x:\secrets",
-                TestDataPath = @"x:\sampledata"
+                LogPath = Path.Combine("x:", "tmp", "log"),
+                SecretsPath = Path.Combine("x:", "secrets"),
+                TestDataPath = Path.Combine("x:", "sampledata")
             };
 
             var jobHostOptions = new ScriptJobHostOptions

--- a/test/WebJobs.Script.Tests.Integration/Security/SecretManagerProviderTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Security/SecretManagerProviderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.IO;
 using System.Threading;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Script.WebHost;
@@ -25,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
 
             _options = new ScriptApplicationHostOptions
             {
-                SecretsPath = "c:\\path1"
+                SecretsPath = Path.Combine("c:", "path1")
             };
             var factory = new TestOptionsFactory<ScriptApplicationHostOptions>(_options);
             _tokenSource = new TestChangeTokenSource<ScriptApplicationHostOptions>();

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/HostProcessLauncher.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/HostProcessLauncher.cs
@@ -56,7 +56,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
             var dirPath = Path.GetDirectoryName(typeof(HostProcessLauncher).Assembly.Location);
             var dirName = new DirectoryInfo(dirPath).Name;
 
-            string workingDir = Path.GetFullPath($@"..\..\..\..\..\src\WebJobs.Script.WebHost\bin\Debug\{dirName}\");
+            string workingDir = Path.Combine("..", "..", "..", "..", "..", "src", "WebJobs.Script.WebHost", "bin", "Debug", $"{dirName}");
+            workingDir = Path.GetFullPath(workingDir);
             string filePath = Path.Combine(workingDir, "Microsoft.Azure.WebJobs.Script.WebHost.exe");
 
             outputHelper?.WriteLine($"Test: {_testPath}");

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/ProxyEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/ProxyEndToEndTests.cs
@@ -378,18 +378,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 // copy test files to temp directory, since accessing the metadata APIs will result
                 // in file creations (for test data files)
-                var scriptSource = Path.Combine(Environment.CurrentDirectory, @"..\..\..\TestScripts\Proxies");
+                var scriptSource = Path.Combine(Environment.CurrentDirectory, "..", "..", "..", "TestScripts", "Proxies");
                 _testHome = Path.Combine(Path.GetTempPath(), @"ProxyTests");
-                var scriptRoot = Path.Combine(_testHome, @"site\wwwroot");
+                var scriptRoot = Path.Combine(_testHome, "site", "wwwroot");
                 FileUtility.CopyDirectory(scriptSource, scriptRoot);
 
                 HostOptions = new ScriptApplicationHostOptions
                 {
                     IsSelfHost = true,
                     ScriptPath = scriptRoot,
-                    LogPath = Path.Combine(_testHome, @"LogFiles\Application\Functions"),
-                    SecretsPath = Path.Combine(_testHome, @"data\Functions\Secrets"),
-                    TestDataPath = Path.Combine(_testHome, @"data\Functions\SampleData")
+                    LogPath = Path.Combine(_testHome, "LogFiles", "Application", "Functions"),
+                    SecretsPath = Path.Combine(_testHome, "data", "Functions", "Secrets"),
+                    TestDataPath = Path.Combine(_testHome, "data", "Functions", "SampleData")
                 };
 
                 FileUtility.EnsureDirectoryExists(HostOptions.TestDataPath);

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
@@ -963,7 +963,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         public class TestFixture : EndToEndTestFixture
         {
             public TestFixture()
-                : base(Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample\csharp"), "samples", RpcWorkerConstants.DotNetLanguageWorkerName)
+                : base(Path.Combine(Environment.CurrentDirectory, @"..", "..", "..", "..", "..", "sample", "csharp"), "samples", RpcWorkerConstants.DotNetLanguageWorkerName)
             {
                 MockWebHookProvider = new Mock<IScriptWebHookProvider>(MockBehavior.Strict);
             }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CustomHandler.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CustomHandler.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             }
 
             public TestFixture()
-                : base(Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample\CustomHandler"), "samples", RpcWorkerConstants.PowerShellLanguageWorkerName)
+                : base(Path.Combine(Environment.CurrentDirectory, "..", "..", "..", "..", "..", "sample", "CustomHandler"), "samples", RpcWorkerConstants.PowerShellLanguageWorkerName)
             {
             }
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_HttpWorker.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_HttpWorker.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             }
 
             public TestFixture()
-                : base(Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample\HttpWorker"), "samples", RpcWorkerConstants.PowerShellLanguageWorkerName)
+                : base(Path.Combine(Environment.CurrentDirectory, "..", "..", "..", "..", "..", "sample", "HttpWorker"), "samples", RpcWorkerConstants.PowerShellLanguageWorkerName)
             {
             }
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Java.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Java.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             }
 
             public TestFixture()
-                : base(Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample\java"), "samples", RpcWorkerConstants.JavaLanguageWorkerName)
+                : base(Path.Combine(Environment.CurrentDirectory, "..", "..", "..", "..", "..", "sample", "java"), "samples", RpcWorkerConstants.JavaLanguageWorkerName)
             {
             }
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node.cs
@@ -288,7 +288,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal(initialTimestamp, timestamp);
 
             // now "touch" a file in the shared directory to trigger a restart
-            string sharedModulePath = Path.Combine(_fixture.Host.ScriptPath, "Shared\\test.js");
+            string sharedModulePath = Path.Combine(_fixture.Host.ScriptPath, "Shared", "test.js");
             File.SetLastWriteTimeUtc(sharedModulePath, DateTime.UtcNow);
 
             // wait for the module to be reloaded
@@ -362,7 +362,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 
             // Microsoft.Azure.WebJobs.Extensions.EventHubs
             public TestFixture()
-                : base(Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample\node"), "samples", RpcWorkerConstants.NodeLanguageWorkerName)
+                : base(Path.Combine(Environment.CurrentDirectory, "..", "..", "..", "..", "..", "sample", "node"), "samples", RpcWorkerConstants.NodeLanguageWorkerName)
             {
             }
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcesses.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcesses.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             }
 
             public MultiplepleProcessesTestFixture()
-                : base(Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample\node"), "samples", RpcWorkerConstants.NodeLanguageWorkerName, 3)
+                : base(Path.Combine(Environment.CurrentDirectory, @"..", "..", "..", "..", "..", "sample", "node"), "samples", RpcWorkerConstants.NodeLanguageWorkerName, 3)
             {
                 _nodeProcessesBeforeTestStarted = Process.GetProcessesByName("node").Select(p => p.Id);
                 _nodeProcessesBeforeTestStarted = _nodeProcessesBeforeTestStarted ?? new List<int>();

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_Retry.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_Retry.cs
@@ -50,9 +50,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             static TestFixture()
             {
             }
-            
+
             public TestFixture()
-                : base(Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample\NodeRetry"), "samples", RpcWorkerConstants.NodeLanguageWorkerName)
+                : base(Path.Combine(Environment.CurrentDirectory, @"..", "..", "..", "..", "..", "sample", "NodeRetry"), "samples", RpcWorkerConstants.NodeLanguageWorkerName)
             {
             }
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_PowerShell.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_PowerShell.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             }
 
             public TestFixture()
-                : base(Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample\PowerShell"), "samples", RpcWorkerConstants.PowerShellLanguageWorkerName)
+                : base(Path.Combine(Environment.CurrentDirectory, @"..", "..", "..", "..", "..", "sample", "PowerShell"), "samples", RpcWorkerConstants.PowerShellLanguageWorkerName)
             {
             }
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Python.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Python.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             }
 
             public TestFixture()
-                : base(Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample\Python"), "samples", RpcWorkerConstants.PythonLanguageWorkerName, 1, "3.7")
+                : base(Path.Combine(Environment.CurrentDirectory, @"..", "..", "..", "..", "..", "sample", "Python"), "samples", RpcWorkerConstants.PythonLanguageWorkerName, 1, "3.7")
             {
             }
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WarmupFunctionEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WarmupFunctionEndToEndTests.cs
@@ -41,9 +41,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             HttpResponseMessage response = await _fixture.HttpClient.GetAsync($"/admin/warmup");
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.False(response.Headers.Contains("myversion"), "/admin/warmup cannot be overriden by proxies." );
+            Assert.False(response.Headers.Contains("myversion"), "/admin/warmup cannot be overridden by proxies." );
         }
-        
+
         [Fact]
         public async Task Normal_Api_Warmup_HttpTrigger_Succeeds()
         {
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             HttpResponseMessage response = await _fixture.HttpClient.GetAsync("/admin/123");
 
             string content = await response.Content.ReadAsStringAsync();
-            Assert.False(response.Headers.Contains("myversion"), "/admin/* endpoints cannot be overriden by proxies.");
+            Assert.False(response.Headers.Contains("myversion"), "/admin/* endpoints cannot be overridden by proxies.");
         }
 
         [Fact]
@@ -69,8 +69,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             HttpResponseMessage response = await _fixture.HttpClient.GetAsync("/admin/host/status");
 
             string content = await response.Content.ReadAsStringAsync();
-            Assert.True(response.StatusCode.ToString("D") == "401", "/admin/* endpoints cannot be overriden by function routes.");
-            Assert.True(content == string.Empty, "/admin/* endpoints cannot be overriden by function routes.");
+            Assert.True(response.StatusCode.ToString("D") == "401", "/admin/* endpoints cannot be overridden by function routes.");
+            Assert.True(content == string.Empty, "/admin/* endpoints cannot be overridden by function routes.");
         }
 
 
@@ -83,18 +83,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 // copy test files to temp directory, since accessing the metadata APIs will result
                 // in file creations (for test data files)
-                var scriptSource = Path.Combine(Environment.CurrentDirectory, @"..\..\..\TestScripts\WarmupFunction");
+                var scriptSource = Path.Combine(Environment.CurrentDirectory, "..", "..", "..", "TestScripts", "WarmupFunction");
                 _testHome = Path.Combine(Path.GetTempPath(), @"WarmupFunction");
-                var scriptRoot = Path.Combine(_testHome, @"site\wwwroot");
+                var scriptRoot = Path.Combine(_testHome, "site", "wwwroot");
                 FileUtility.CopyDirectory(scriptSource, scriptRoot);
 
                 HostOptions = new ScriptApplicationHostOptions
                 {
                     IsSelfHost = true,
                     ScriptPath = scriptRoot,
-                    LogPath = Path.Combine(_testHome, @"LogFiles\Application\Functions"),
-                    SecretsPath = Path.Combine(_testHome, @"data\Functions\Secrets"),
-                    TestDataPath = Path.Combine(_testHome, @"data\Functions\SampleData")
+                    LogPath = Path.Combine(_testHome, "LogFiles", "Application", "Functions"),
+                    SecretsPath = Path.Combine(_testHome, "data", "Functions", "Secrets"),
+                    TestDataPath = Path.Combine(_testHome, "data", "Functions", "SampleData")
                 };
 
                 FileUtility.EnsureDirectoryExists(HostOptions.TestDataPath);

--- a/test/WebJobs.Script.Tests/DependencyTests.cs
+++ b/test/WebJobs.Script.Tests/DependencyTests.cs
@@ -40,9 +40,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public void Verify_DepsJsonChanges()
         {
             string depsJsonFileName = "Microsoft.Azure.WebJobs.Script.WebHost.deps.json";
-
             string oldDepsJson = Path.GetFullPath(depsJsonFileName);
-            var newDepsJson = Directory.GetFiles(Path.GetFullPath(@"..", "..", "..", "..", "..", "src", "WebJobs.Script.WebHost", "bin"), depsJsonFileName, SearchOption.AllDirectories).FirstOrDefault();
+            string webhostBinPath = Path.Combine("..", "..", "..", "..", "..", "src", "WebJobs.Script.WebHost", "bin");
+            string newDepsJson = Directory.GetFiles(Path.GetFullPath(webhostBinPath), depsJsonFileName, SearchOption.AllDirectories).FirstOrDefault();
 
             Assert.True(File.Exists(oldDepsJson), $"{oldDepsJson} not found.");
             Assert.True(File.Exists(newDepsJson), $"{newDepsJson} not found.");

--- a/test/WebJobs.Script.Tests/DependencyTests.cs
+++ b/test/WebJobs.Script.Tests/DependencyTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             string depsJsonFileName = "Microsoft.Azure.WebJobs.Script.WebHost.deps.json";
 
             string oldDepsJson = Path.GetFullPath(depsJsonFileName);
-            var newDepsJson = Directory.GetFiles(Path.GetFullPath(@"..\..\..\..\..\src\WebJobs.Script.WebHost\bin\"), depsJsonFileName, SearchOption.AllDirectories).FirstOrDefault();
+            var newDepsJson = Directory.GetFiles(Path.GetFullPath(@"..", "..", "..", "..", "..", "src", "WebJobs.Script.WebHost", "bin"), depsJsonFileName, SearchOption.AllDirectories).FirstOrDefault();
 
             Assert.True(File.Exists(oldDepsJson), $"{oldDepsJson} not found.");
             Assert.True(File.Exists(newDepsJson), $"{newDepsJson} not found.");

--- a/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public FunctionMetadataManagerTests()
         {
             _mockFunctionMetadataProvider = new Mock<IFunctionMetadataProvider>();
-            string functionsPath = Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample\node");
+            string functionsPath = Path.Combine(Environment.CurrentDirectory, @"..", "..", "..", "..", "..", "sample", "node");
             _defaultHttpWorkerOptions = new HttpWorkerOptions();
             _scriptJobHostOptions.RootScriptPath = functionsPath;
 

--- a/test/WebJobs.Script.Tests/FunctionMetadataProviderTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionMetadataProviderTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public void ReadFunctionMetadata_Succeeds()
         {
-            string functionsPath = Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample\node");
+            string functionsPath = Path.Combine(Environment.CurrentDirectory, @"..", "..", "..", "..", "..", "sample", "node");
             _scriptApplicationHostOptions.ScriptPath = functionsPath;
             var optionsMonitor = TestHelpers.CreateOptionsMonitor(_scriptApplicationHostOptions);
             var metadataProvider = new HostFunctionMetadataProvider(optionsMonitor, NullLogger<HostFunctionMetadataProvider>.Instance, _testMetricsLogger);
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public void ReadFunctionMetadata_With_Retry_Succeeds()
         {
-            string functionsPath = Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample\noderetry");
+            string functionsPath = Path.Combine(Environment.CurrentDirectory, @"..", "..", "..", "..", "..", "sample", "noderetry");
             _scriptApplicationHostOptions.ScriptPath = functionsPath;
             var optionsMonitor = TestHelpers.CreateOptionsMonitor(_scriptApplicationHostOptions);
             var metadataProvider = new HostFunctionMetadataProvider(optionsMonitor, NullLogger<HostFunctionMetadataProvider>.Instance, _testMetricsLogger);

--- a/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 TestDataPath = @"x:\test"
             };
 
-            string functionsPath = Path.Combine(Environment.CurrentDirectory, @"..\..\..\..\..\sample");
+            string functionsPath = Path.Combine(Environment.CurrentDirectory, @"..", "..", "..", "..", "..", "sample");
 
             var fileSystem = CreateFileSystem(_hostOptions);
             var loggerFactory = MockNullLoggerFactory.CreateLoggerFactory();
@@ -299,10 +299,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             string testData2 = "Test Data 2";
             string testData3 = TestHelpers.NewRandomString(ScriptConstants.MaxTestDataInlineStringLength + 1);
 
-            fileBase.Setup(f => f.Exists(Path.Combine(rootPath, @"function1\function.json"))).Returns(true);
-            fileBase.Setup(f => f.Exists(Path.Combine(rootPath, @"function1\main.py"))).Returns(true);
-            fileBase.Setup(f => f.ReadAllText(Path.Combine(rootPath, @"function1\function.json"))).Returns(function1);
-            fileBase.Setup(f => f.Open(Path.Combine(rootPath, @"function1\function.json"), It.IsAny<FileMode>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>())).Returns(() =>
+            fileBase.Setup(f => f.Exists(Path.Combine(rootPath, @"function1", "function.json"))).Returns(true);
+            fileBase.Setup(f => f.Exists(Path.Combine(rootPath, @"function1", "main.py"))).Returns(true);
+            fileBase.Setup(f => f.ReadAllText(Path.Combine(rootPath, @"function1", "function.json"))).Returns(function1);
+            fileBase.Setup(f => f.Open(Path.Combine(rootPath, @"function1", "function.json"), It.IsAny<FileMode>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>())).Returns(() =>
             {
                 return new MemoryStream(Encoding.UTF8.GetBytes(function1));
             });
@@ -311,10 +311,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 return new MemoryStream(Encoding.UTF8.GetBytes(testData1));
             });
 
-            fileBase.Setup(f => f.Exists(Path.Combine(rootPath, @"function2\function.json"))).Returns(true);
-            fileBase.Setup(f => f.Exists(Path.Combine(rootPath, @"function2\main.js"))).Returns(true);
-            fileBase.Setup(f => f.ReadAllText(Path.Combine(rootPath, @"function2\function.json"))).Returns(function2);
-            fileBase.Setup(f => f.Open(Path.Combine(rootPath, @"function2\function.json"), It.IsAny<FileMode>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>())).Returns(() =>
+            fileBase.Setup(f => f.Exists(Path.Combine(rootPath, @"function2", "function.json"))).Returns(true);
+            fileBase.Setup(f => f.Exists(Path.Combine(rootPath, @"function2", "main.js"))).Returns(true);
+            fileBase.Setup(f => f.ReadAllText(Path.Combine(rootPath, @"function2", "function.json"))).Returns(function2);
+            fileBase.Setup(f => f.Open(Path.Combine(rootPath, @"function2", "function.json"), It.IsAny<FileMode>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>())).Returns(() =>
             {
                 return new MemoryStream(Encoding.UTF8.GetBytes(function2));
             });
@@ -323,10 +323,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 return new MemoryStream(Encoding.UTF8.GetBytes(testData2));
             });
 
-            fileBase.Setup(f => f.Exists(Path.Combine(rootPath, @"function3\function.json"))).Returns(true);
-            fileBase.Setup(f => f.Exists(Path.Combine(rootPath, @"function3\main.js"))).Returns(true);
-            fileBase.Setup(f => f.ReadAllText(Path.Combine(rootPath, @"function3\function.json"))).Returns(function3);
-            fileBase.Setup(f => f.Open(Path.Combine(rootPath, @"function3\function.json"), It.IsAny<FileMode>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>())).Returns(() =>
+            fileBase.Setup(f => f.Exists(Path.Combine(rootPath, @"function3", "function.json"))).Returns(true);
+            fileBase.Setup(f => f.Exists(Path.Combine(rootPath, @"function3", "main.js"))).Returns(true);
+            fileBase.Setup(f => f.ReadAllText(Path.Combine(rootPath, @"function3", "function.json"))).Returns(function3);
+            fileBase.Setup(f => f.Open(Path.Combine(rootPath, @"function3", "function.json"), It.IsAny<FileMode>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>())).Returns(() =>
             {
                 return new MemoryStream(Encoding.UTF8.GetBytes(function3));
             });


### PR DESCRIPTION
Currently, we have a lot of hard coded path delimiters in our tests such as `..\..\..\` which is Windows specific and so these tests will fail on other platforms. Using Path.Combine so we can be more agnostic