### PR TITLE
Worker Indexing - using GetAllWorkerChannelsAsync method in GetWorkerMetadata

### DIFF
--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -302,7 +302,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         // Gets metadata from worker
         public async Task<IEnumerable<RawFunctionMetadata>> GetWorkerMetadata()
         {
-            var channels = (await GetInitializedWorkerChannelsAsync()).ToArray();
+            // calling GetAllWorkerChannelsAsync() instead of GetInitializedWorkerChannelsAsync() as invocation buffers are not setup yet
+            var channels = (await GetAllWorkerChannelsAsync()).ToArray();
             return (channels != null && channels.Length > 0) ? await channels.First().GetFunctionMetadata() : null;
         }
 


### PR DESCRIPTION
Calling GetAllWorkerChannelsAsync() instead of GetInitializedWorkerChannelsAsync() as invocation buffers were not setup which is being checked by latter.