### PR TITLE
Drain mode cleanup: remove GET, return 202 Accepted

### DIFF
--- a/sample/CSharp/HttpTrigger-Cancellation/function.json
+++ b/sample/CSharp/HttpTrigger-Cancellation/function.json
@@ -1,0 +1,15 @@
+{
+    "bindings": [
+        {
+            "type": "httpTrigger",
+            "name": "req",
+            "direction": "in",
+            "methods": [ "get" ]
+        },
+        {
+            "type": "http",
+            "name": "$return",
+            "direction": "out"
+        }
+    ]
+}

--- a/sample/CSharp/HttpTrigger-Cancellation/run.csx
+++ b/sample/CSharp/HttpTrigger-Cancellation/run.csx
@@ -1,0 +1,26 @@
+﻿using System.Net;
+using System.Threading;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
+
+public static async Task<IActionResult> Run(HttpRequest req, ILogger log, CancellationToken token)
+{
+    log.LogInformation("C# HTTP trigger cancellation function processing a request.");
+
+    try
+    {
+        await Task.Delay(10000, token);
+        log.LogInformation("Function invocation successful.");
+        return new OkResult();
+
+    }
+    catch (OperationCanceledException)
+    {
+        log.LogInformation("Function invocation cancelled.");
+        return new NotFoundResult();
+    }
+    catch (Exception e)
+    {
+        return new StatusCodeResult(500);
+    }
+}

--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -105,7 +105,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
             return Ok(status);
         }
 
-        [HttpGet]
         [HttpPost]
         [Route("admin/host/drain")]
         [Authorize(Policy = PolicyNames.AdminAuthLevelOrInternal)]
@@ -132,7 +131,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
                                         _drainModeSemaphore.Release();
                                     });
-            return Ok();
+            return Accepted();
         }
 
         [HttpGet]

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/DrainModeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/DrainModeEndToEndTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.WebJobs.Script.Tests;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.IO;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
+{
+    [Trait(TestTraits.Category, TestTraits.EndToEnd)]
+    [Trait(TestTraits.Group, TestTraits.DrainModeEndToEnd)]
+    public class DrainModeEndToEndTests : DrainTestFixture
+    {
+        [Fact]
+        public async Task RunningHost_EnableDrainMode_ReturnsAccepted()
+        {
+            // Validate the drain state is "Disabled" initially
+            var response = await SamplesTestHelpers.InvokeDrainStatus(this);
+            var responseString = response.Content.ReadAsStringAsync().Result;
+            var drainStatus = JsonConvert.DeserializeObject<DrainModeStatus>(responseString);
+
+            Assert.Equal(drainStatus.State, DrainModeState.Disabled);
+
+            // Validate ability to call HttpTrigger without issues
+            response = await SamplesTestHelpers.InvokeHttpTrigger(this, "HttpTrigger");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            // Put the host in drain mode and validate returns Accepted
+            response = await SamplesTestHelpers.InvokeDrain(this);
+            Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+            // Validate the drain state is changed to "Completed"
+            response = await SamplesTestHelpers.InvokeDrainStatus(this);
+            responseString = response.Content.ReadAsStringAsync().Result;
+            drainStatus = JsonConvert.DeserializeObject<DrainModeStatus>(responseString);
+
+            Assert.Equal(DrainModeState.Completed, drainStatus.State);
+
+            // Validate HttpTrigger function is still working
+            response = await SamplesTestHelpers.InvokeHttpTrigger(this, "HttpTrigger");
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task RunningHost_EnableDrainMode_FunctionInvocationCancelled_ReturnsNotFound()
+        {
+            // Validate the drain state is "Disabled" initially
+            var response = await SamplesTestHelpers.InvokeDrainStatus(this);
+            var responseString = response.Content.ReadAsStringAsync().Result;
+            var drainStatus = JsonConvert.DeserializeObject<DrainModeStatus>(responseString);
+
+            Assert.Equal(drainStatus.State, DrainModeState.Disabled);
+
+            _ = Task.Run(async () =>
+            {
+                // Put the host in drain mode
+                await TestHelpers.Await(async () =>
+                {
+                    response = await SamplesTestHelpers.InvokeDrain(this);
+                    Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+                    return true;
+                }, 10000);
+
+            });
+
+            // Call function with cancellation token handler
+            response = await SamplesTestHelpers.InvokeHttpTrigger(this, "HttpTrigger-Cancellation");
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+    }
+
+    public class DrainTestFixture : EndToEndTestFixture
+    {
+        static DrainTestFixture()
+        {
+        }
+
+        public DrainTestFixture()
+            : base(Path.Combine(Environment.CurrentDirectory, "..", "..", "..", "..", "..", "sample", "CSharp"), "samples", RpcWorkerConstants.DotNetLanguageWorkerName)
+        {
+        }
+
+        public override void ConfigureScriptHost(IWebJobsBuilder webJobsBuilder)
+        {
+            base.ConfigureScriptHost(webJobsBuilder);
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/DrainModeStatusEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/DrainModeStatusEndToEndTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 {
     [Trait(TestTraits.Category, TestTraits.EndToEnd)]
     [Trait(TestTraits.Group, TestTraits.DrainModeEndToEnd)]
-    public class DrainModeStatusEndToEndTests : DrainTestFixture
+    public class DrainModeStatusEndToEndTests : DrainStatusTestFixture
     {
         [Fact]
         public async Task DrainStatus_RunningHost_ReturnsExpected()
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             var responseString = response.Content.ReadAsStringAsync().Result;
             var status = JsonConvert.DeserializeObject<DrainModeStatus>(responseString);
 
-            Assert.Equal(status.State, DrainModeState.Disabled);
+            Assert.Equal(DrainModeState.Disabled, status.State);
 
             ManualResetEvent resetEvent = new ManualResetEvent(false);
             _ = Task.Run(async () =>

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/DrainModeStatusEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/DrainModeStatusEndToEndTests.cs
@@ -64,13 +64,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         }
     }
 
-    public class DrainTestFixture : EndToEndTestFixture
+    public class DrainStatusTestFixture : EndToEndTestFixture
     {
-        static DrainTestFixture()
+        static DrainStatusTestFixture()
         {
         }
 
-        public DrainTestFixture()
+        public DrainStatusTestFixture()
             : base(Path.Combine(Environment.CurrentDirectory, "..", "..", "..", "..", "..", "sample", "NodeDrain"), "samples", RpcWorkerConstants.NodeLanguageWorkerName)
         {
         }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
@@ -512,7 +512,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             var response = await _fixture.Host.HttpClient.SendAsync(request);
             var metadata = (await response.Content.ReadAsAsync<IEnumerable<FunctionMetadataResponse>>()).ToArray();
 
-            Assert.Equal(16, metadata.Length);
+            Assert.Equal(17, metadata.Length);
             var function = metadata.Single(p => p.Name == "HttpTrigger-CustomRoute");
             Assert.Equal("https://somewebsite.azurewebsites.net/api/csharp/products/{category:alpha?}/{id:int?}/{extra?}", function.InvokeUrlTemplate.ToString());
 


### PR DESCRIPTION
1. We currently allow GET requests to the drain endpoint, however the design for the drain API is POST. Updating the controller to reflect this. I've spoken to the Antares and Atlas teams and they both already use POST so this will not be a breaking change

2. We're currently returning 200 OK on a fire and forget call where returning 202 Accepted is more fitting, the PR is updating the drain API to return 202. I have spoken to the Antares and Atlas teams about this and they both using [EnsureSuccessStatusCode](https://docs.microsoft.com/en-us/uwp/api/windows.web.http.httpresponsemessage.issuccessstatuscode?view=winrt-22000#property-value) which accepts any response in the 200 - 299 range, so this will not be a breaking change

3. Also added E2E tests for drain mode with a cancellation token sample

This PR has been tested with a private site extension in a private stamp

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [x] Otherwise: Documentation issue linked to PR
        - [PR to update drain docs](https://dev.azure.com/msazure/One/_git/AAPT-Antares-Docs/pullrequest/5359725)
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

