### PR TITLE
Update vscode for dev

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,8 @@
       },
       "env": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "AZURE_FUNCTIONS_ENVIRONMENT": "Development"
+        "AZURE_FUNCTIONS_ENVIRONMENT": "Development",
+        "AzureWebJobsSecretStorageType": "Files"
       },
       "sourceFileMap": {
         "/Views": "${workspaceFolder}/Views"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}


### PR DESCRIPTION
In general we do want to ignore `.vscode`, but we should have the basic tasks and config needed for a more seamless dev experience. These changes should make it so that users who clone the repo for the first time can just open VS Code and press F5 to run  and debug the host without any additional configuration.