### PR TITLE
Discussion: Functions Host Throughput Performance Improvements & Opportunities

### DIFF
--- a/sample/CSharp/HttpTrigger/function.json
+++ b/sample/CSharp/HttpTrigger/function.json
@@ -2,6 +2,7 @@
     "bindings": [
         {
             "type": "httpTrigger",
+            "authLevel": "anonymous",
             "name": "req",
             "direction": "in",
             "methods": [ "get" ]

--- a/sample/CSharp/host.json
+++ b/sample/CSharp/host.json
@@ -10,16 +10,17 @@
     },
     "functionTimeout": "00:05:00",
     "logging": {
-        "fileLoggingMode": "always"        
+        "fileLoggingMode": "never",
+        "console": {
+            "isEnabled": false
+        }
     },
     "extensions": {
         "sendGrid": {
             "from": "Azure Functions <samples@functions.com>"
         },
         "http": {
-            "routePrefix": "api",
-            "maxConcurrentRequests": 5,
-            "maxOutstandingRequests": 30
+            "routePrefix": "api"
         },
         "queues": {
             "visibilityTimeout": "00:00:10",

--- a/src/WebJobs.Script.WebHost/Diagnostics/EtwEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/EtwEventGenerator.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public void LogFunctionTraceEvent(LogLevel level, string subscriptionId, string appName, string functionName, string eventName, string source, string details, string summary, string exceptionType, string exceptionMessage, string functionInvocationId, string hostInstanceId, string activityId, string runtimeSiteName, string slotName, DateTime eventTimeStamp)
         {
+            // TODO: String generated regardless of being enabled
             string formattedEventTimestamp = eventTimeStamp.ToString(EventTimestampFormat);
             using (FunctionsSystemLogsEventSource.SetActivityId(activityId))
             {

--- a/src/WebJobs.Script.WebHost/Diagnostics/EtwEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/EtwEventGenerator.cs
@@ -19,7 +19,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public void LogFunctionTraceEvent(LogLevel level, string subscriptionId, string appName, string functionName, string eventName, string source, string details, string summary, string exceptionType, string exceptionMessage, string functionInvocationId, string hostInstanceId, string activityId, string runtimeSiteName, string slotName, DateTime eventTimeStamp)
         {
-            // TODO: String generated regardless of being enabled
+            if (!FunctionsSystemLogsEventSource.Instance.IsEnabled())
+            {
+                return;
+            }
+
             string formattedEventTimestamp = eventTimeStamp.ToString(EventTimestampFormat);
             using (FunctionsSystemLogsEventSource.SetActivityId(activityId))
             {

--- a/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
@@ -178,12 +178,18 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
 
         public static void ExecutingHttpRequest(this ILogger logger, string mS_ActivityId, string httpMethod, string userAgent, string uri)
         {
-            _executingHttpRequest(logger, mS_ActivityId, httpMethod, userAgent, uri, null);
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                _executingHttpRequest(logger, mS_ActivityId, httpMethod, userAgent, uri, null);
+            }
         }
 
         public static void ExecutedHttpRequest(this ILogger logger, string mS_ActivityId, string identities, int statusCode, long duration)
         {
-            _executedHttpRequest(logger, mS_ActivityId, identities, statusCode, duration, null);
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                _executedHttpRequest(logger, mS_ActivityId, identities, statusCode, duration, null);
+            }
         }
 
         public static void ScriptHostServiceInitCanceledByRuntime(this ILogger logger)

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceFileLoggerFactory.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceFileLoggerFactory.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public virtual LinuxAppServiceFileLogger GetOrCreate(string category)
         {
-            return Loggers.GetOrAdd(category,
-                c => new Lazy<LinuxAppServiceFileLogger>(() => new LinuxAppServiceFileLogger(c, _logRootPath, new FileSystem()))).Value;
+            return Loggers.GetOrAdd(category, 
+                static (c, path) => new Lazy<LinuxAppServiceFileLogger>(() => new LinuxAppServiceFileLogger(c, path, new FileSystem())), _logRootPath).Value;
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceFileLoggerFactory.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceFileLoggerFactory.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         public virtual LinuxAppServiceFileLogger GetOrCreate(string category)
         {
             return Loggers.GetOrAdd(category,
-                c => new Lazy<LinuxAppServiceFileLogger>(() => new LinuxAppServiceFileLogger(category, _logRootPath, new FileSystem()))).Value;
+                c => new Lazy<LinuxAppServiceFileLogger>(() => new LinuxAppServiceFileLogger(c, _logRootPath, new FileSystem()))).Value;
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
@@ -498,12 +498,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                     executionTimespan = runningFunctionInfo.Duration.TotalMilliseconds;
                 }
 
+                // Don't allocate the GUID string twice, though we can probably optimize this further upstream.
+                var invocationId = runningFunctionInfo.InvocationId.ToString();
+
                 MetricsEventGenerator.LogFunctionExecutionEvent(
                     _executionId,
                     _appServiceOptions.AppName,
                     concurrency,
                     runningFunctionInfo.FunctionMetadata.Name,
-                    runningFunctionInfo.InvocationId.ToString(),
+                    invocationId,
                     executionStage.ToString(),
                     (long)executionTimespan,
                     runningFunctionInfo.Success);
@@ -512,7 +515,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 {
                     _metricsPublisher.AddFunctionExecutionActivity(
                         runningFunctionInfo.FunctionMetadata.Name,
-                        runningFunctionInfo.InvocationId.ToString(),
+                        invocationId,
                         concurrency,
                         executionStage.ToString(),
                         runningFunctionInfo.Success,

--- a/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
@@ -460,22 +460,27 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 // We only need to raise events here for functions that aren't completed.
                 // Events are raised immediately for completed functions elsewhere.
                 // Loop through and prune any completed runs
+                // Also collects the currently running functions in the same enumeration to minimize cost.
+                var running = new List<FunctionStartedEvent>();
                 foreach (var possiblyRunning in _runningFunctions)
                 {
                     if (possiblyRunning.Value.Completed)
                     {
                         _runningFunctions.TryRemove(possiblyRunning.Key, out _);
                     }
+                    else
+                    {
+                        running.Add(possiblyRunning.Value);
+                    }
                 }
 
-                // If not for the length, we could probably avoid this array allocation
-                var concurrency = _runningFunctions.Count;
+                var concurrency = running.Count;
 
                 // We calculate concurrency here based on count, since these events are raised
                 // on a background thread, so we want the actual count for this interval, not
                 // the current count.
                 var currentTime = DateTime.UtcNow;
-                foreach (var runningFunction in _runningFunctions.Values)
+                foreach (var runningFunction in running)
                 {
                     RaiseFunctionMetricEvent(runningFunction, concurrency, currentTime);
                 }

--- a/src/WebJobs.Script.WebHost/Extensions/IExternalScopeProviderExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Extensions/IExternalScopeProviderExtensions.cs
@@ -16,11 +16,36 @@ namespace Microsoft.Extensions.Logging
             {
                 if (scope is IEnumerable<KeyValuePair<string, object>> kvps)
                 {
-                    result = result ?? new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+                    result = result ?? new Dictionary<string, object>(16, StringComparer.OrdinalIgnoreCase);
 
                     foreach (var kvp in kvps)
                     {
                         result[kvp.Key] = kvp.Value;
+                    }
+                }
+            }, (object)null);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Gets a scope entry by iterating the existing scope, but without allocating a dictionary.
+        /// </summary>
+        public static object GetScopeEntry(this IExternalScopeProvider scopeProvider, string key)
+        {
+            // Track the result because we want to _last_ (most local scope), but can only iterate forward
+            object result = null;
+
+            scopeProvider.ForEachScope((scope, _) =>
+            {
+                if (scope is IEnumerable<KeyValuePair<string, object>> kvps)
+                {
+                    foreach (var kvp in kvps)
+                    {
+                        if (string.Equals(kvp.Key, key, StringComparison.OrdinalIgnoreCase))
+                        {
+                            result = kvp.Value;
+                        }
                     }
                 }
             }, (object)null);

--- a/src/WebJobs.Script.WebHost/Helpers/MediaTypeMap.cs
+++ b/src/WebJobs.Script.WebHost/Helpers/MediaTypeMap.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Helpers
         private static readonly MediaTypeMap _defaultInstance = new MediaTypeMap();
         private static readonly FileExtensionContentTypeProvider _mimeMapping = new FileExtensionContentTypeProvider();
         private readonly ConcurrentDictionary<string, MediaTypeHeaderValue> _mediatypeMap = CreateMediaTypeMap();
-        private readonly MediaTypeHeaderValue _defaultMediaType = MediaTypeHeaderValue.Parse("application/octet-stream");
+        private static readonly MediaTypeHeaderValue _defaultMediaType = MediaTypeHeaderValue.Parse("application/octet-stream");
 
         public static MediaTypeMap Default
         {
@@ -28,11 +28,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Helpers
             }
 
             return _mediatypeMap.GetOrAdd(fileExtension,
-                (extension) =>
+                static (extension) =>
                 {
                     try
                     {
-                        if (_mimeMapping.TryGetContentType(fileExtension, out string mediaTypeValue))
+                        if (_mimeMapping.TryGetContentType(extension, out string mediaTypeValue))
                         {
                             if (MediaTypeHeaderValue.TryParse(mediaTypeValue, out MediaTypeHeaderValue mediaType))
                             {

--- a/src/WebJobs.Script.WebHost/Middleware/SystemTraceMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/SystemTraceMiddleware.cs
@@ -29,15 +29,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
         {
             var requestId = SetRequestId(context.Request);
 
-            var sw = Stopwatch.StartNew();
+            var startTicks = Stopwatch.GetTimestamp();
             string userAgent = context.Request.GetHeaderValueOrDefault("User-Agent");
             _logger.ExecutingHttpRequest(requestId, context.Request.Method, userAgent, context.Request.Path);
 
             await _next.Invoke(context);
 
-            sw.Stop();
+            var elapsed = Utility.GetDuration(startTicks);
             string identities = GetIdentities(context);
-            _logger.ExecutedHttpRequest(requestId, identities, context.Response.StatusCode, sw.ElapsedMilliseconds);
+            _logger.ExecutedHttpRequest(requestId, identities, context.Response.StatusCode, (long)elapsed.TotalMilliseconds);
         }
 
         internal static string SetRequestId(HttpRequest request)

--- a/src/WebJobs.Script.WebHost/Models/FunctionMetrics.cs
+++ b/src/WebJobs.Script.WebHost/Models/FunctionMetrics.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
 {
-    public enum ExecutionStage
+    public enum ExecutionStage : byte
     {
         Started,
         InProgress,
@@ -12,11 +12,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
         Succeeded
     }
 
-    public class FunctionMetrics
+    public struct FunctionMetrics
     {
-        private string _functionName;
-        private ExecutionStage _executionStage;
-        private long _executionTimeInMS;
+        private readonly string _functionName;
+        private readonly ExecutionStage _executionStage;
+        private readonly long _executionTimeInMS;
 
         public FunctionMetrics(string functionName, ExecutionStage executionStage, long executionTimeInMS)
         {

--- a/src/WebJobs.Script.WebHost/Routing/ScriptRouteHandler.cs
+++ b/src/WebJobs.Script.WebHost/Routing/ScriptRouteHandler.cs
@@ -3,12 +3,17 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization.Policy;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Features;
 using Microsoft.Extensions.Logging;
 
@@ -19,15 +24,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
         private readonly IScriptJobHost _scriptHost;
         private readonly ILoggerFactory _loggerFactory;
         private readonly IEnvironment _environment;
+        private readonly IApplicationLifetime _applicationLifetime;
+        private readonly IPolicyEvaluator _policyEvaluator;
         private readonly bool _isWarmup;
         private static int _warmupExecuted;
         private readonly ConcurrentDictionary<string, FunctionDescriptor> _functionMap = new ConcurrentDictionary<string, FunctionDescriptor>(System.StringComparer.OrdinalIgnoreCase);
 
-        public ScriptRouteHandler(ILoggerFactory loggerFactory, IScriptJobHost scriptHost, IEnvironment environment, bool isWarmup = false)
+        public ScriptRouteHandler(ILoggerFactory loggerFactory, IScriptJobHost scriptHost, IEnvironment environment, IApplicationLifetime applicationLifetime, IPolicyEvaluator policyEvaluator, bool isWarmup = false)
         {
             _scriptHost = scriptHost;
             _loggerFactory = loggerFactory;
             _environment = environment;
+            _applicationLifetime = applicationLifetime;
+            _policyEvaluator = policyEvaluator;
             _isWarmup = isWarmup;
         }
 

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
@@ -750,7 +750,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         {
             // We're only serializing access to secrets per-function, not across all functions,
             // so we need to ensure we're using a single shared lock per-function.
-            return _functionSecretsLocks.GetOrAdd(functionName, k => new SemaphoreSlim(1, 1));
+            return _functionSecretsLocks.GetOrAdd(functionName, static k => new SemaphoreSlim(1, 1));
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -70,9 +70,9 @@
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.32" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.0-beta.1" />
     <PackageReference Include="Microsoft.Azure.WebSites.DataProtection" Version="2.1.91-alpha" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
+    <!-- <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    </PackageReference> -->
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -11,13 +11,13 @@
     <TieredCompilation>false</TieredCompilation>
     <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">
+  <!--<PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">
     <PublishReadyToRun>true</PublishReadyToRun>
     <PublishReadyToRunUseCrossgen2>true</PublishReadyToRunUseCrossgen2>
     <PublishReadyToRunComposite>true</PublishReadyToRunComposite>    
     <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
     <PublishReadyToRunShowWarnings>true</PublishReadyToRunShowWarnings> 
-  </PropertyGroup>  
+  </PropertyGroup>-->  
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -11,13 +11,13 @@
     <TieredCompilation>false</TieredCompilation>
     <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
-  <!--<PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">
     <PublishReadyToRun>true</PublishReadyToRun>
     <PublishReadyToRunUseCrossgen2>true</PublishReadyToRunUseCrossgen2>
     <PublishReadyToRunComposite>true</PublishReadyToRunComposite>    
     <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
     <PublishReadyToRunShowWarnings>true</PublishReadyToRunShowWarnings> 
-  </PropertyGroup>-->  
+  </PropertyGroup>  
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/WebJobs.Script/Description/FunctionDescriptor.cs
+++ b/src/WebJobs.Script/Description/FunctionDescriptor.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection.Emit;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Binding;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.Description
 {
@@ -25,7 +26,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             Collection<ParameterDescriptor> parameters,
             Collection<CustomAttributeBuilder> attributes,
             Collection<FunctionBinding> inputBindings,
-            Collection<FunctionBinding> outputBindings)
+            Collection<FunctionBinding> outputBindings,
+            ILoggerFactory loggerFactory)
         {
             Name = name;
             Invoker = invoker;
@@ -39,6 +41,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             TriggerBinding = InputBindings?.SingleOrDefault(p => p.Metadata.IsTrigger);
             HttpTriggerAttribute = GetTriggerAttributeOrNull<HttpTriggerAttribute>();
             LogCategory = LogCategories.CreateFunctionCategory(Name);
+            Logger = loggerFactory.CreateLogger(LogCategory);
         }
 
         public string Name { get; internal set; }
@@ -62,6 +65,8 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         public virtual HttpTriggerAttribute HttpTriggerAttribute { get; }
 
         public string LogCategory { get; }
+
+        public ILogger Logger { get; }
 
         private TAttribute GetTriggerAttributeOrNull<TAttribute>()
         {

--- a/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 Collection<CustomAttributeBuilder> methodAttributes = new Collection<CustomAttributeBuilder>();
                 Collection<ParameterDescriptor> parameters = await GetFunctionParametersAsync(invoker, functionMetadata, triggerMetadata, methodAttributes, inputBindings, outputBindings);
 
-                var functionDescriptor = new FunctionDescriptor(functionMetadata.Name, invoker, functionMetadata, parameters, methodAttributes, inputBindings, outputBindings);
+                var functionDescriptor = new FunctionDescriptor(functionMetadata.Name, invoker, functionMetadata, parameters, methodAttributes, inputBindings, outputBindings, Host.LoggerFactory);
 
                 return (true, functionDescriptor);
             }

--- a/src/WebJobs.Script/Description/FunctionInvokerBase.cs
+++ b/src/WebJobs.Script/Description/FunctionInvokerBase.cs
@@ -84,14 +84,34 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         private static FunctionInvocationContext GetContextFromParameters(object[] parameters, FunctionMetadata metadata)
         {
+            ExecutionContext functionExecutionContext = null;
+            Binder binder = null;
+            ILogger logger = null;
+
+            for (var i = 0; i < parameters.Length; i++)
+            {
+                switch (parameters[i])
+                {
+                    case ExecutionContext fc:
+                        functionExecutionContext ??= fc;
+                        break;
+                    case Binder b:
+                        binder = b;
+                        break;
+                    case ILogger l:
+                        logger = l;
+                        break;
+                }
+            }
+
             // We require the ExecutionContext, so this will throw if one is not found.
-            ExecutionContext functionExecutionContext = parameters.OfType<ExecutionContext>().First();
+            if (functionExecutionContext == null)
+            {
+                throw new ArgumentException("Function ExecutionContext was not found");
+            }
+
             functionExecutionContext.FunctionDirectory = metadata.FunctionDirectory;
             functionExecutionContext.FunctionName = metadata.Name;
-
-            // These may not be present, so null is okay.
-            Binder binder = parameters.OfType<Binder>().FirstOrDefault();
-            ILogger logger = parameters.OfType<ILogger>().FirstOrDefault();
 
             FunctionInvocationContext context = new FunctionInvocationContext
             {

--- a/src/WebJobs.Script/Diagnostics/FunctionFileLoggerProvider.cs
+++ b/src/WebJobs.Script/Diagnostics/FunctionFileLoggerProvider.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
             {
                 // Make sure that we return the same fileWriter if multiple loggers write to the same path. This happens
                 // with Function logs as Function.{FunctionName} and Function.{FunctionName}.User both go to the same file.
-                IFileWriter fileWriter = _fileWriterCache.GetOrAdd(filePath, (p) => _fileWriterFactory.Create(Path.Combine(_roogLogPath, filePath)));
+                IFileWriter fileWriter = _fileWriterCache.GetOrAdd(filePath, (path) => _fileWriterFactory.Create(Path.Combine(_roogLogPath, path)));
                 return new FileLogger(categoryName, fileWriter, _isFileLoggingEnabled, _isPrimary, LogType.Function, _scopeProvider);
             }
 

--- a/src/WebJobs.Script/Environment/SystemEnvironment.cs
+++ b/src/WebJobs.Script/Environment/SystemEnvironment.cs
@@ -2,33 +2,28 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Collections.Concurrent;
 
 namespace Microsoft.Azure.WebJobs.Script
 {
     public class SystemEnvironment : IEnvironment
     {
-        private static readonly Lazy<SystemEnvironment> _instance = new Lazy<SystemEnvironment>(CreateInstance);
+        private static readonly ConcurrentDictionary<string, string> _cache = new ConcurrentDictionary<string, string>();
 
         private SystemEnvironment()
         {
         }
 
-        public static SystemEnvironment Instance => _instance.Value;
-
-        private static SystemEnvironment CreateInstance()
-        {
-            return new SystemEnvironment();
-        }
+        public static SystemEnvironment Instance => new SystemEnvironment();
 
         public string GetEnvironmentVariable(string name)
         {
-            return Environment.GetEnvironmentVariable(name);
+            return _cache.GetOrAdd(name, static n => Environment.GetEnvironmentVariable(n));
         }
 
         public void SetEnvironmentVariable(string name, string value)
         {
+            _cache[name] = value;
             Environment.SetEnvironmentVariable(name, value);
         }
     }

--- a/src/WebJobs.Script/Extensions/ScriptLoggingBuilderExtensions.cs
+++ b/src/WebJobs.Script/Extensions/ScriptLoggingBuilderExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Extensions.Logging
 
         private static bool IsFiltered(string category)
         {
-            return _filteredCategoryCache.GetOrAdd(category, c => ScriptConstants.SystemLogCategoryPrefixes.Where(p => category.StartsWith(p)).Any());
+            return _filteredCategoryCache.GetOrAdd(category, static cat => ScriptConstants.SystemLogCategoryPrefixes.Any(p => cat.StartsWith(p)));
         }
 
         public static void AddConsoleIfEnabled(this ILoggingBuilder builder, HostBuilderContext context)

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -172,6 +172,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
         internal IExtensionBundleManager ExtensionBundleManager { get; }
 
+        public ILoggerFactory LoggerFactory => _loggerFactory;
+
         public ILogger Logger { get; internal set; }
 
         public ScriptJobHostOptions ScriptOptions { get; private set; }

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -506,9 +506,9 @@ namespace Microsoft.Azure.WebJobs.Script
 
             object scopeValue = null;
             if (scopeProps != null && scopeProps.Count > 0 &&
-                (scopeProps.TryGetValue("functionName", out scopeValue) ||
-                 scopeProps.TryGetValue(LogConstants.NameKey, out scopeValue) ||
-                 scopeProps.TryGetValue(ScopeKeys.FunctionName, out scopeValue)) && scopeValue != null)
+                (scopeProps.TryGetValue(ScopeKeys.FunctionName, out scopeValue) ||
+                 scopeProps.TryGetValue("functionName", out scopeValue) ||
+                 scopeProps.TryGetValue(LogConstants.NameKey, out scopeValue)) && scopeValue != null)
             {
                 functionName = scopeValue.ToString();
             }
@@ -518,9 +518,9 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public static bool IsFunctionName(KeyValuePair<string, object> p)
         {
-            return string.Equals(p.Key, "functionName", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(p.Key, LogConstants.NameKey, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(p.Key, ScopeKeys.FunctionName, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(p.Key, ScopeKeys.FunctionName, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(p.Key, "functionName", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(p.Key, LogConstants.NameKey, StringComparison.OrdinalIgnoreCase);
         }
 
         public static string GetValueFromScope(IDictionary<string, object> scopeProperties, string key)

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.Dynamic;
 using System.Globalization;
 using System.IO;
@@ -48,6 +49,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
         private static readonly string UTF8ByteOrderMark = Encoding.UTF8.GetString(Encoding.UTF8.GetPreamble());
         private static readonly FilteredExpandoObjectConverter _filteredExpandoObjectConverter = new FilteredExpandoObjectConverter();
+
+        private static readonly double TicksRatio = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
 
         private static List<string> dotNetLanguages = new List<string>() { DotNetScriptTypes.CSharp, DotNetScriptTypes.DotNetAssembly };
 
@@ -972,6 +975,15 @@ namespace Microsoft.Azure.WebJobs.Script
             {
                 return FunctionAppContentEditingState.NotAllowed;
             }
+        }
+
+        /// <summary>
+        /// Gets a timestamp given start ticks (from <see cref="Stopwatch.GetTimestamp"/>) without allocating a Stopwatch.
+        /// </summary>
+        public static TimeSpan GetDuration(long startTicks)
+        {
+            var tickDiff = Stopwatch.GetTimestamp() - startTicks;
+            return new TimeSpan((long)(TicksRatio * tickDiff));
         }
 
         private class FilteredExpandoObjectConverter : ExpandoObjectConverter

--- a/src/WebJobs.Script/Workers/SharedMemoryDataTransfer/SharedMemoryManager.cs
+++ b/src/WebJobs.Script/Workers/SharedMemoryDataTransfer/SharedMemoryManager.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer
 
         public void AddSharedMemoryMapForInvocation(string invocationId, string mapName)
         {
-            HashSet<string> sharedMemoryMaps = InvocationSharedMemoryMaps.GetOrAdd(invocationId, (key) => new HashSet<string>());
+            HashSet<string> sharedMemoryMaps = InvocationSharedMemoryMaps.GetOrAdd(invocationId, static (key) => new HashSet<string>());
             sharedMemoryMaps.Add(mapName);
         }
 

--- a/test/WebJobs.Script.Tests.Integration/Diagnostics/MetricsEventManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Diagnostics/MetricsEventManagerTests.cs
@@ -24,6 +24,7 @@ using Moq;
 using Moq.Protected;
 using Xunit;
 using Xunit.Sdk;
+using static Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.MetricsEventManager;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
@@ -129,7 +130,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _metricsLogger.LogEvent(eventName);
 
             Assert.Equal(1, _metricsEventManager.QueuedEvents.Count);
-            SystemMetricEvent evt = _metricsEventManager.QueuedEvents.Values.Single();
+            SystemMetricEvent evt = _metricsEventManager.QueuedEvents.Values.Single().Value;
             Assert.Equal(expectedEventName, evt.EventName);  // case is normalized to lower
             Assert.Equal(1, evt.Count);
             Assert.Equal(0, evt.Average);
@@ -151,7 +152,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Count = 1
             };
 
-            _metricsEventManager.QueuedEvents[initialEvent.EventName] = initialEvent;
+            _metricsEventManager.QueuedEvents[new EventKey(initialEvent.EventName, null)] = new Lazy<SystemMetricEvent>(() => initialEvent);
             Assert.Equal(1, _metricsEventManager.QueuedEvents.Count);
 
             for (int i = 0; i < 10; i++)
@@ -189,20 +190,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             Assert.Equal(3, _metricsEventManager.QueuedEvents.Count);
 
-            string key = MetricsEventManager.GetAggregateKey("Event1", "Function1");
-            var metricEvent = _metricsEventManager.QueuedEvents[key];
+            var key = new EventKey("Event1", "Function1");
+            var metricEvent = _metricsEventManager.QueuedEvents[key].Value;
             Assert.Equal(10, metricEvent.Count);
             Assert.Equal("event1", metricEvent.EventName);
             Assert.Equal("Function1", metricEvent.FunctionName);
 
-            key = MetricsEventManager.GetAggregateKey("Event1", "Function2");
-            metricEvent = _metricsEventManager.QueuedEvents[key];
+            key = new EventKey("Event1", "Function2");
+            metricEvent = _metricsEventManager.QueuedEvents[key].Value;
             Assert.Equal(5, metricEvent.Count);
             Assert.Equal("event1", metricEvent.EventName);
             Assert.Equal("Function2", metricEvent.FunctionName);
 
-            key = MetricsEventManager.GetAggregateKey("Event3");
-            metricEvent = _metricsEventManager.QueuedEvents[key];
+            key = new EventKey("Event3", null);
+            metricEvent = _metricsEventManager.QueuedEvents[key].Value;
             Assert.Equal(15, metricEvent.Count);
             Assert.Equal("event3", metricEvent.EventName);
             Assert.Null(metricEvent.FunctionName);
@@ -273,7 +274,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _metricsLogger.EndEvent(eventHandle);
             Assert.Equal(1, _metricsEventManager.QueuedEvents.Count);
 
-            SystemMetricEvent evt = _metricsEventManager.QueuedEvents.Values.Single();
+            SystemMetricEvent evt = _metricsEventManager.QueuedEvents.Values.Single().Value;
             Assert.Equal("event1", evt.EventName);
             Assert.Equal(1, evt.Count);
             Assert.True(evt.Maximum > 0);
@@ -290,7 +291,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
 
             Assert.Equal(1, _metricsEventManager.QueuedEvents.Count);
-            var evt = _metricsEventManager.QueuedEvents.Single().Value;
+            var evt = _metricsEventManager.QueuedEvents.Single().Value.Value;
             Assert.Equal("event1", evt.EventName);
             Assert.Equal(1, evt.Count);
         }
@@ -310,7 +311,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Count = 1
             };
 
-            _metricsEventManager.QueuedEvents[initialEvent.EventName] = initialEvent;
+            _metricsEventManager.QueuedEvents[new EventKey(initialEvent.EventName, null)] = new Lazy<SystemMetricEvent>(() => initialEvent);
             Assert.Equal(1, _metricsEventManager.QueuedEvents.Count);
 
             for (int i = 0; i < 10; i++)
@@ -362,20 +363,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             Assert.Equal(3, _metricsEventManager.QueuedEvents.Count);
 
-            string key = MetricsEventManager.GetAggregateKey("Event1", "Function1");
-            metricEvent = _metricsEventManager.QueuedEvents[key];
+            var key = new EventKey("Event1", "Function1");
+            metricEvent = _metricsEventManager.QueuedEvents[key].Value;
             Assert.Equal(10, metricEvent.Count);
             Assert.Equal("event1", metricEvent.EventName);
             Assert.Equal("Function1", metricEvent.FunctionName);
 
-            key = MetricsEventManager.GetAggregateKey("Event1", "Function2");
-            metricEvent = _metricsEventManager.QueuedEvents[key];
+            key = new EventKey("Event1", "Function2");
+            metricEvent = _metricsEventManager.QueuedEvents[key].Value;
             Assert.Equal(5, metricEvent.Count);
             Assert.Equal("event1", metricEvent.EventName);
             Assert.Equal("Function2", metricEvent.FunctionName);
 
-            key = MetricsEventManager.GetAggregateKey("Event2");
-            metricEvent = _metricsEventManager.QueuedEvents[key];
+            key = new EventKey("Event2", null);
+            metricEvent = _metricsEventManager.QueuedEvents[key].Value;
             Assert.Equal(15, metricEvent.Count);
             Assert.Equal("event2", metricEvent.EventName);
             Assert.Null(metricEvent.FunctionName);

--- a/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/FunctionGeneratorEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/FunctionGeneratorEndToEndTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.WebJobs.Script.Tests;
 using Xunit;
 
@@ -41,7 +42,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             // create the FunctionDefinition
             FunctionMetadata metadata = new FunctionMetadata();
             TestInvoker invoker = new TestInvoker();
-            FunctionDescriptor function = new FunctionDescriptor("TimerFunction", invoker, metadata, parameters, null, null, null);
+            LoggerFactory loggerFactory = new LoggerFactory();
+            FunctionDescriptor function = new FunctionDescriptor("TimerFunction", invoker, metadata, parameters, null, null, null, loggerFactory);
             Collection<FunctionDescriptor> functions = new Collection<FunctionDescriptor>();
             functions.Add(function);
 

--- a/test/WebJobs.Script.Tests/Controllers/Admin/FunctionsControllerTests.cs
+++ b/test/WebJobs.Script.Tests/Controllers/Admin/FunctionsControllerTests.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             string triggerParameterName = "testTrigger";
             string testInput = Guid.NewGuid().ToString();
             bool functionInvoked = false;
+            var loggerFactory = new LoggerFactory();
 
             var scriptHostMock = new Mock<IScriptJobHost>();
             scriptHostMock.Setup(p => p.CallAsync(It.IsAny<string>(), It.IsAny<IDictionary<string, object>>(), CancellationToken.None))
@@ -71,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     IsTrigger = true
                 }
             };
-            testFunctions.Add(new FunctionDescriptor(testFunctionName, null, null, parameters, null, null, null));
+            testFunctions.Add(new FunctionDescriptor(testFunctionName, null, null, parameters, null, null, null, loggerFactory));
 
             FunctionInvocation invocation = new FunctionInvocation
             {
@@ -84,7 +85,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var optionsWrapper = new OptionsWrapper<ScriptApplicationHostOptions>(applicationHostOptions);
             var functionsManagerMock = new Mock<IWebFunctionsManager>();
             var mockRouter = new Mock<IWebJobsRouter>();
-            var testController = new FunctionsController(functionsManagerMock.Object, mockRouter.Object, new LoggerFactory(), optionsWrapper);
+            var testController = new FunctionsController(functionsManagerMock.Object, mockRouter.Object, loggerFactory, optionsWrapper);
             IActionResult response = testController.Invoke(testFunctionName, invocation, scriptHostMock.Object);
             Assert.IsType<AcceptedResult>(response);
 

--- a/test/WebJobs.Script.Tests/Description/FunctionGeneratorTests.cs
+++ b/test/WebJobs.Script.Tests/Description/FunctionGeneratorTests.cs
@@ -28,7 +28,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             FunctionMetadata metadata = new FunctionMetadata();
             TestInvoker invoker = new TestInvoker();
-            FunctionDescriptor function = new FunctionDescriptor(functionName, invoker, metadata, parameters, null, null, null);
+            LoggerFactory loggerFactory = new LoggerFactory();
+            FunctionDescriptor function = new FunctionDescriptor(functionName, invoker, metadata, parameters, null, null, null, loggerFactory);
             Collection<FunctionDescriptor> functions = new Collection<FunctionDescriptor>();
             functions.Add(function);
 
@@ -80,8 +81,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
 
             FunctionMetadata metadata = new FunctionMetadata();
+            LoggerFactory loggerFactory = new LoggerFactory();
             var invoker = new RealInvoker(userFunc);
-            FunctionDescriptor function = new FunctionDescriptor(functionName, invoker, metadata, parameters, null, null, null);
+            FunctionDescriptor function = new FunctionDescriptor(functionName, invoker, metadata, parameters, null, null, null, loggerFactory);
             Collection<FunctionDescriptor> functions = new Collection<FunctionDescriptor>();
             functions.Add(function);
 

--- a/test/WebJobs.Script.Tests/Middleware/HttpThrottleMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Middleware/HttpThrottleMiddlewareTests.cs
@@ -39,7 +39,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public HttpThrottleMiddlewareTests()
         {
-            _functionDescriptor = new FunctionDescriptor("Test", null, null, new Collection<ParameterDescriptor>(), null, null, null);
+            _loggerFactory = new LoggerFactory();
+            _functionDescriptor = new FunctionDescriptor("Test", null, null, new Collection<ParameterDescriptor>(), null, null, null, _loggerFactory);
             _scriptHost = new Mock<IScriptJobHost>(MockBehavior.Strict);
             _metricsLogger = new Mock<IMetricsLogger>(MockBehavior.Strict);
             _metricsLogger.Setup(p => p.LogEvent(MetricEventNames.FunctionInvokeThrottled, null, null)).Callback(() =>
@@ -51,7 +52,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var healthMonitorOptions = new HostHealthMonitorOptions();
             _performanceManager = new Mock<HostPerformanceManager>(MockBehavior.Strict, environment, new OptionsWrapper<HostHealthMonitorOptions>(healthMonitorOptions), mockServiceProvider.Object);
             _httpOptions = new HttpOptions();
-            _loggerFactory = new LoggerFactory();
             _loggerProvider = new TestLoggerProvider();
             _loggerFactory.AddProvider(_loggerProvider);
             RequestDelegate next = (ctxt) =>

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -798,7 +798,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Name = "SomeFunction",
                 ScriptFile = "D:\\home\\site\\wwwroot\\SomeFunction\\index.js"
             };
-            FunctionDescriptor function = new FunctionDescriptor("TimerFunction", new TestInvoker(), metadata, new Collection<ParameterDescriptor>(), null, null, null);
+            LoggerFactory loggerFactory = new LoggerFactory();
+            FunctionDescriptor function = new FunctionDescriptor("TimerFunction", new TestInvoker(), metadata, new Collection<ParameterDescriptor>(), null, null, null, loggerFactory);
             functions.Add(function);
             result = ScriptHost.TryGetFunctionFromException(functions, exception, out functionResult);
             Assert.False(result);
@@ -810,7 +811,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Name = "HttpTriggerNode",
                 ScriptFile = "D:\\home\\site\\wwwroot\\HttpTriggerNode\\index.js"
             };
-            function = new FunctionDescriptor("TimerFunction", new TestInvoker(), metadata, new Collection<ParameterDescriptor>(), null, null, null);
+            function = new FunctionDescriptor("TimerFunction", new TestInvoker(), metadata, new Collection<ParameterDescriptor>(), null, null, null, loggerFactory);
             functions.Add(function);
             result = ScriptHost.TryGetFunctionFromException(functions, exception, out functionResult);
             Assert.True(result);
@@ -1348,7 +1349,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             parameters.Add(new ParameterDescriptor("param1", typeof(string)));
             var metadata = new FunctionMetadata();
             var invoker = new TestInvoker();
-            var function = new FunctionDescriptor("TestFunction", invoker, metadata, parameters, null, null, null);
+            var loggerFactory = new LoggerFactory();
+            var function = new FunctionDescriptor("TestFunction", invoker, metadata, parameters, null, null, null, loggerFactory);
             scriptHost.Functions.Add(function);
 
             var errors = new Collection<string>();


### PR DESCRIPTION
This is a draft PR **for discussion and not meant to be merged**, think "issue with some code". I figured this was the easiest way to talk about areas we can improve throughput performance in the least spammy way possible.

## Proposals Summary
These diffs are *not* proposed PRs. They are pain points or opportunities identified in profiling and experimentation where I think we can improve performance. It's likely some are viable and some are not due to constraints I'm unaware of (so let's talk!). The hope is that some of these findings help in making us faster and spur new discussions on the remaining. 

#### Goals
- Optimize what we have, with equivalent functionality - not remove any functionality.
- Don't break any use cases we have today
- Make any improvements as small single-thing PRs, not one big batch

A lot of these I file under "papercuts". Except 1 very recent regression in the `4.x` branch (which @fabiocav and @brettsam are looking at already), there is no large single item affecting performance that I can see. However, there are many small items we can potentially improve that add up. I'm numbering these in lists below so that they're easy to refer to and talk about in discussions in a quick way.

It's worth breaking these down and testing each we consider viable, though each may be a small gain in itself. In aggregate I'm seeing 24-38% gains (depending on scenario) with our typical 2 and 4 core VMs for a hello world scenario. We need to test this in App Services yet (private stamp issues...) and the gains will be proportionately smaller when the function itself is more expensive.

These proposals are split across 3 repos and need discussion PRs for each (I'll update this as I create PRs)
- (**This PR**) https://github.com/Azure/azure-functions-host/
- ([#2794](https://github.com/Azure/azure-webjobs-sdk/pull/2794)) https://github.com/Azure/azure-webjobs-sdk
- ([#755](https://github.com/Azure/azure-webjobs-sdk-extensions/pull/755)) https://github.com/Azure/azure-webjobs-sdk-extensions

#### Optimizations for WebJobs Host

- [ ] 1. (Issue #8073 & WIP #7969) There is 1 medium/major regression in allocations from  which went live in 4.0 via [#7669](https://github.com/Azure/azure-functions-host/pull/7669) but have been behind a flag for ~14 months from [5176a5ea](https://github.com/Azure/azure-functions-host/commit/5176a5ea86861fde8ae15561d2413797eb10ed63). The last commit shows the use cases this was meant to resolve with transitive dependencies. Due to how DryIoc works, this is copying an immutable structure of service references on every call though, accounting for a large percentage of allocations.
   - Notes: @fabiocav and @brettsam are working on this already.
- [x] 2. (#7926) `IOptionsMonitor.CurrentValue` allocates on every call [due to the `_factory` capture in the lambda here](https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.Extensions.Options/src/OptionsMonitor.cs#L89). Instead of keeping a reference to the monitor and calling `.CurrentValue` often (which changes rarely, as I understand it - **TODO: question this assumption**), we can reference the actual value and subscribe for updates via `.OnChange` in the monitor, removing all of these allocations and overhead.
- [x] 3. (#7924) In `EtwEventGenerator` when it isn't enabled, we can avoid the `DateTime.ToString()` at the start of each activity. These strings account for ~4-5% of all allocations. If we zoom out, we can probably improve how we're passing values down through logging for `DateTime` and `Guid` specifically.
   - Open questions:
      -  Is this _always_ enabled in production? If so it's low priority but probably still worth doing. It's worth noting such a change dilutes inaccurate benchmarks though. If we could deal with less resolution (we're at 6 decimal places on `.ToString("O")`, we could lessen the allocations here, or serialize to stream potentially.
- [x] 4. (#7925) Misc captures especially in `.GetOrAdd()` for dictionaries - here are are specifically capturing context which means a lambda allocation per call, we can easily fix these items and with latest C# also add `static` to the lamda to prevent future occurences, e.g. `dict.GetOrAdd(binding, static (b) => something(b));`
- [x] 5. (#7942) We're allocating the JSON string for function metric data (via `.LogEvent()`) even though it's a rollup after the first event, which is also ~4-5% of all allocations. Given the limited cardinality of the data we can use a `ConcurrentDictionary` with a tuple or `readonly record struct` key to prevent re-allocating the string representation per call.
- [ ] 6. (#7936) `MetricsEventManager.QueuedEvents` uses a `ConcurrentDictinary<string, SystemMetricEvent>` but is allocating a string for the key on each lookup. Instead, we can use a `read-only record struct` (fastest hashing) for the lookup without an allocation.
- [ ] 7. (#7936) `MetricsEventManager.QueuedEvents` is also used in `.AddOrUpdate()` with 2 sets of opportunities to improve: We're capturing in the update lambda, but also locking under load in a `Monitor.Wait()`. Rather then doing this, we can change the structure slightly to only use `.GetOrAdd()` returning the object and _always_ updating the result. Using the `Lazy<T>` approach, we should not drop any metrics.
    - Notes: StyleCop breaks here due to an issue in the library, resolved in https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3401 - we'll need to upgrade StyleCop to not introduce sporadic build issues before applying this optimization.
- [ ] 8. (#7936) In the `FunctionActivityTracker` we have a `List<FunctionStartedEvent>` and locking around it to keep a running tally of all running functions (for periodic reporting). There's a lock on insert and periodically a lock while reporting which also prunes the list - this interaction creates contention under load. Since we already have a unique identifier per run (a `Guid`), we can use a `ConcurrentDictionary<Guid,FunctionStartedEvent>` and add/remove proactively rather than a large cull when logging to reduce lock contention.
    - Notes: per @mathewc, this was a problem area before and needs a history dig to assess further.
- [x] 9. (#8012) `ScriptLoggerFactory` calls `LoggerFactory.CreateLogger`, which has a `Monitor.Wait()` around the creation - so while we're not over-allocating we are stalling around loggers. We can create a `ConcurrentDictionary<string, ILogger>` here since they don't change. It's worth noting we're hitting this because we're calling the string name version of `CreateLogger`, where the generic version does not have this lock.
- [x] 10. (**Punted**) `SystemLogger` is the source of _most_ allocations, because although we're using structured logging we're also formatting it and allocating the string on the way out. This string is consumed by ETW, Linux, etc. The scope dictionary is allocated by `GetScopeDictionaryOrNull()` which we can change to an enumeration approach (or likely better: a broader think on how we might improve key/value), but it's non-trivial because `Utility.TryGetFunctionName` is in a project layer beneath the `IExternalScopeProvider` extensions.
    - Notes: this needs a larger think on improving, including version skew between libraries. If we want to change the `Dictionary` behavior, there are many questions, and this should be a thing we tackle by itself and not part of this papercut performance pass.
- [x] 11. (#7941) `Utility.TryGetFunctionName` is searching for 3 function names per call - this isn't terrible expensive in itself, but: is it for legacy or current? If we have `n` keys to look for, it would go into any key/value logging scope approach thinking.
- [x] 12. (#7938) `Dictionary` sizing: there are a hand full of spots we're allocating from resizes we can avoid.
- [ ] 13. There are a few places we're doing `.GetService<T>` per call when we can pass them in the constructor, if we can pass them once instead of live we can save lookup cost. Note that the measures for these were before number 1 above and need to be re-benchmarked solo since that's likely a compounding combination.
    - Open questions:
       -  Does this get from the correct scope? If global we're fine - if from the JobHsot we need to assess.
- [x] 14. (#7928) `HostAvailabilityCheckMiddleware` has a startup path and a runtime path. Since we're most often in the runtime path, we can elide the async/await state machine for the common case here with a local function and get a bit more performance out.
- [x] 15. (#7943) `SystemTraceMiddleware` is allocating a `Stopwatch` per call but we really only want the difference - we can shortcut without the reference allocation here via `.GetTimestamp()`.
- [ ] 16. (#7936) `FunctionMetrics` is a large allocation source under load but is a simple type - we can reduce overhead by using a `readonly struct` here.
- [ ] 17. (#7977) `loggerFactory.CreateLogger` is called many times for a function - but it's always the same logger so we could cache this somewhere like the `FunctionDescriptor`.
    - Open questions:
       - Are `FunctionDescriptors` re-created when a JobHost is? (It appears so via a fresh call through the `IFunctionIndexProvider`)
- [x] 18. (#7922) `FunctionInvokerBase` is allocating 3x `OfTypeIterator`s to grab a few specific binders - we can side-step this with a manual iteration.
- [x] 19. (#7937) `FunctionLoader` is currently using a `ReaderWriterLockSlim` for concurrency control of a single instance - instead we can `Interlocked.Exchange` the reference and save some critical section contention here.
- [x] 20. (**Punting**) `System.Environment` has an instance but doesn't have state, but more importantly we're using environmental variables a lot, and we can cache there.
     - Notes: this is worth benchmarking to re-evaluate, **but not doable in its current form dur to needing to observe sandbox changes**. One thought here is we could add code clarity and simplify configuration by having an Environmental variable -> `IOptionsMonitor<T>` that refreshed on some interval and triggered on `OnChange` when something shifted. This would eliminate a bunch of environmental variable calls spread across the codebase into a simpler structure. `AppServiceOptions` does similar things today on specialization as a reference - we could expand this class overall.

#### Other areas of interest

- `Guid`: We are parsing and `.ToString()`-ing GUIDs for logging and correlation in many places, we could probably keep a reference to both once and save a few per request.
- Logging scopes: This is a large source of overhead since we're allocating a `Dictionary<string, object>`, an execution context, and related bits at each `.BeginScope()`. Additionally, we're creating another `Dictionary<string, object>` and enumerator at the consumption site (via `.GetScopeDictionaryOrNull()`). I'm not sure how to crack this, but it feels like we can potentially find a better alternative for what's essentially key/value pairs in all cases. For example, if we had an `AsyncLocal<T>` with 1 dictionary perhaps. It's worth noting that most of the attributes are references to pre-allocated items like function descriptor components, with only a few (like start time) being per-request, so almost all of our overhead is not in the allocation of data but the structure we're conveying it over.
  - Notes: @mathewc already looked at this previously as well and if we can't change the structure there's indeed probably not much we can do, _can we change the structure?_ and keep compatibility is the primary question and that's a small investigation in itself.
- Strings: Though we're profiling on Windows predominately as that's where the tooling it the most mature (**TODO: Check assumption**), the Linux app service takes on far more allocations in the logging process due to additional formatting and normalization just before buffering (grep: `NormalizeString`).
  - TODO: Investigate if we could buffer structured log data and not allocate the string at all, instead formatting to the output stream (this may be bananapants).
- In building `StyleCop` has a race that fails around `record`...no clue there (that's why it's commented out in the branch), but something to be aware of in the `EventKey` optimization, something perhaps a newer version resolves.
- Sanitization: `SystemLogger` sanitizes a value (`formattedMessage = Sanitizer.Sanitize(formattedMessage);`) but doesn't use it during exception logging, this seems to be unintentional I just didn't want to forget it, so including here.
  - TODO: Look at history and propose.

#### Diff Notes
- Some of the changes are for benchmarking compatibility only (e.g. `samples/*` - please ignore)
- I'm not in love with passing the logger factory

I talked through most of the above with various people (thanks @mathewc @paulbatum and @fabiocav especially), and the next step is to start on the smaller and more straightforward PRs before moving to ones that require any discussion. If anyone has feedback of comments on any of the above proposals (presented here as code too), please add! I'm missing immense amounts of context and assume that I may have missed some edge cases which is why this discussion PR exists :)