### PR TITLE
Performance: eliminate unintentional captures

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/FunctionInstanceLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/FunctionInstanceLogger.cs
@@ -80,11 +80,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             // log events for each of the binding types used
             foreach (var binding in metadata.Bindings)
             {
-                string eventName = _bindingMetricEventNames.GetOrAdd(binding, (existing) =>
+                string eventName = _bindingMetricEventNames.GetOrAdd(binding, static (b) =>
                 {
-                    return binding.IsTrigger ?
-                        string.Format(MetricEventNames.FunctionBindingTypeFormat, binding.Type) :
-                        string.Format(MetricEventNames.FunctionBindingTypeDirectionFormat, binding.Type, binding.Direction);
+                    return b.IsTrigger ?
+                        string.Format(MetricEventNames.FunctionBindingTypeFormat, b.Type) :
+                        string.Format(MetricEventNames.FunctionBindingTypeDirectionFormat, b.Type, b.Direction);
                 });
                 _metrics.LogEvent(eventName, metadata.Name);
             }

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceFileLoggerFactory.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceFileLoggerFactory.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         public virtual LinuxAppServiceFileLogger GetOrCreate(string category)
         {
             return Loggers.GetOrAdd(category,
-                c => new Lazy<LinuxAppServiceFileLogger>(() => new LinuxAppServiceFileLogger(category, _logRootPath, new FileSystem()))).Value;
+                static (c, path) => new Lazy<LinuxAppServiceFileLogger>(() => new LinuxAppServiceFileLogger(c, path, new FileSystem())), _logRootPath).Value;
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Helpers/MediaTypeMap.cs
+++ b/src/WebJobs.Script.WebHost/Helpers/MediaTypeMap.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Helpers
         private static readonly MediaTypeMap _defaultInstance = new MediaTypeMap();
         private static readonly FileExtensionContentTypeProvider _mimeMapping = new FileExtensionContentTypeProvider();
         private readonly ConcurrentDictionary<string, MediaTypeHeaderValue> _mediatypeMap = CreateMediaTypeMap();
-        private readonly MediaTypeHeaderValue _defaultMediaType = MediaTypeHeaderValue.Parse("application/octet-stream");
+        private static readonly MediaTypeHeaderValue _defaultMediaType = MediaTypeHeaderValue.Parse("application/octet-stream");
 
         public static MediaTypeMap Default
         {
@@ -28,11 +28,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Helpers
             }
 
             return _mediatypeMap.GetOrAdd(fileExtension,
-                (extension) =>
+                static (extension) =>
                 {
                     try
                     {
-                        if (_mimeMapping.TryGetContentType(fileExtension, out string mediaTypeValue))
+                        if (_mimeMapping.TryGetContentType(extension, out string mediaTypeValue))
                         {
                             if (MediaTypeHeaderValue.TryParse(mediaTypeValue, out MediaTypeHeaderValue mediaType))
                             {

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
@@ -743,7 +743,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         {
             // We're only serializing access to secrets per-function, not across all functions,
             // so we need to ensure we're using a single shared lock per-function.
-            return _functionSecretsLocks.GetOrAdd(functionName, k => new SemaphoreSlim(1, 1));
+            return _functionSecretsLocks.GetOrAdd(functionName, static k => new SemaphoreSlim(1, 1));
         }
     }
 }

--- a/src/WebJobs.Script/Diagnostics/FunctionFileLoggerProvider.cs
+++ b/src/WebJobs.Script/Diagnostics/FunctionFileLoggerProvider.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
             {
                 // Make sure that we return the same fileWriter if multiple loggers write to the same path. This happens
                 // with Function logs as Function.{FunctionName} and Function.{FunctionName}.User both go to the same file.
-                IFileWriter fileWriter = _fileWriterCache.GetOrAdd(filePath, (p) => _fileWriterFactory.Create(Path.Combine(_roogLogPath, filePath)));
+                IFileWriter fileWriter = _fileWriterCache.GetOrAdd(filePath, (path) => _fileWriterFactory.Create(Path.Combine(_roogLogPath, path)));
                 return new FileLogger(categoryName, fileWriter, _isFileLoggingEnabled, _isPrimary, LogType.Function, _scopeProvider);
             }
 

--- a/src/WebJobs.Script/Extensions/ScriptLoggingBuilderExtensions.cs
+++ b/src/WebJobs.Script/Extensions/ScriptLoggingBuilderExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Extensions.Logging
 
         private static bool IsFiltered(string category)
         {
-            return _filteredCategoryCache.GetOrAdd(category, c => ScriptConstants.SystemLogCategoryPrefixes.Where(p => category.StartsWith(p)).Any());
+            return _filteredCategoryCache.GetOrAdd(category, static cat => ScriptConstants.SystemLogCategoryPrefixes.Any(p => cat.StartsWith(p)));
         }
 
         public static void AddConsoleIfEnabled(this ILoggingBuilder builder, HostBuilderContext context)

--- a/src/WebJobs.Script/Workers/SharedMemoryDataTransfer/SharedMemoryManager.cs
+++ b/src/WebJobs.Script/Workers/SharedMemoryDataTransfer/SharedMemoryManager.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer
 
         public void AddSharedMemoryMapForInvocation(string invocationId, string mapName)
         {
-            HashSet<string> sharedMemoryMaps = InvocationSharedMemoryMaps.GetOrAdd(invocationId, (key) => new HashSet<string>());
+            HashSet<string> sharedMemoryMaps = InvocationSharedMemoryMaps.GetOrAdd(invocationId, static (key) => new HashSet<string>());
             sharedMemoryMaps.Add(mapName);
         }
 


### PR DESCRIPTION
Part of #7908 for unintentional captures - this removes unintentional captures resulting in an allocation per call on these areas as well as adding a `static` guard to prevent doing so by accident in the future.

### Issue describing the changes in this PR

Resolves a component of #7908

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

(Please double check the above - I'm guessing performance-only changes aren't something we note, but may in aggregate)
