### PR TITLE
Performance: eliminate ETW date strings when disabled

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/EtwEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/EtwEventGenerator.cs
@@ -19,6 +19,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public void LogFunctionTraceEvent(LogLevel level, string subscriptionId, string appName, string functionName, string eventName, string source, string details, string summary, string exceptionType, string exceptionMessage, string functionInvocationId, string hostInstanceId, string activityId, string runtimeSiteName, string slotName, DateTime eventTimeStamp)
         {
+            if (!FunctionsSystemLogsEventSource.Instance.IsEnabled())
+            {
+                return;
+            }
+
             string formattedEventTimestamp = eventTimeStamp.ToString(EventTimestampFormat);
             using (FunctionsSystemLogsEventSource.SetActivityId(activityId))
             {


### PR DESCRIPTION
Part of #7908. I'm not sure for which cases this is disabled, but for any scenario where it's not activated in (which may be zero in production, to be fair), this accounts for roughly 5% of allocations from the `DateTime.ToString("O")` immediately below.

### Issue describing the changes in this PR

Resolves a component of #7908

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

(switching to internal branch - migration of #7919)