### PR TITLE
Performance: HostAvailabilityCheckMiddleware: elide async when possible

### DIFF
--- a/src/WebJobs.Script.WebHost/Middleware/HostAvailabilityCheckMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/HostAvailabilityCheckMiddleware.cs
@@ -27,43 +27,48 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
 
         public Task Invoke(HttpContext httpContext)
         {
-            // Slow path with async/await for spin-up only
-            static async Task InvokeAwaited(HttpContext context, RequestDelegate next, ILogger<HostAvailabilityCheckMiddleware> logger, IScriptHostManager scriptHostManager)
-            {
-                using (Logger.VerifyingHostAvailabilityScope(logger, context.TraceIdentifier))
-                {
-                    Logger.InitiatingHostAvailabilityCheck(logger);
-
-                    bool hostReady = await scriptHostManager.DelayUntilHostReady();
-                    if (!hostReady)
-                    {
-                        Logger.HostUnavailableAfterCheck(logger);
-
-                        context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
-                        await context.Response.WriteAsync("Function host is not running.");
-
-                        return;
-                    }
-
-                    Logger.HostAvailabilityCheckSucceeded(logger);
-                }
-
-                await next.Invoke(context);
-            }
-
             if (_scriptHostManager.State != ScriptHostState.Offline)
             {
                 if (!_scriptHostManager.CanInvoke())
                 {
-                    return InvokeAwaited(httpContext, _next, _logger, _scriptHostManager);
+                    // If we're not ready, take the slower/more expensive route and await being ready
+                    return InvokeAwaitingHost(httpContext, _next, _logger, _scriptHostManager);
                 }
 
+                // But if we are ready, bypass the awaiting cost and go right to the next middleware
                 return _next.Invoke(httpContext);
             }
             else
             {
                 return httpContext.SetOfflineResponseAsync(_applicationHostOptions.CurrentValue.ScriptPath);
             }
+        }
+
+        /// <summary>
+        /// Slow path, for when the host isn't initialized and we need to wait.
+        /// In this more rare case, we'll allocate the async/await state machine because it's necessary overhead.
+        /// </summary>
+        private static async Task InvokeAwaitingHost(HttpContext context, RequestDelegate next, ILogger<HostAvailabilityCheckMiddleware> logger, IScriptHostManager scriptHostManager)
+        {
+            using (Logger.VerifyingHostAvailabilityScope(logger, context.TraceIdentifier))
+            {
+                Logger.InitiatingHostAvailabilityCheck(logger);
+
+                bool hostReady = await scriptHostManager.DelayUntilHostReady();
+                if (!hostReady)
+                {
+                    Logger.HostUnavailableAfterCheck(logger);
+
+                    context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                    await context.Response.WriteAsync("Function host is not running.");
+
+                    return;
+                }
+
+                Logger.HostAvailabilityCheckSucceeded(logger);
+            }
+
+            await next.Invoke(context);
         }
     }
 }


### PR DESCRIPTION
Part of #7908. The common case path through `HostAvailabiltyCheckMiddleware` _that we care about_ is when the host is ready and serving traffic - until then its impact is of minimal concern (and we indeed need to await availability anyway).

This change elides the async/await and state machine overhead in the common case once the host is ready using the local function pattern. If preferred we could make this another method - no preference at all, whatever the team is most comfortable with maintaining here.

### Issue describing the changes in this PR

Resolves a component of #7908

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional PR information

Reminder to review this with whitespace off for a much easier time!
