### PR TITLE
Reset cached secrets on SyncTriggers (#7698)

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -106,6 +106,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             {
                 await _syncSemaphore.WaitAsync();
 
+                PrepareSyncTriggers();
+
                 var hashBlobClient = await GetHashBlobAsync();
                 if (isBackgroundSync && hashBlobClient == null && !_environment.IsKubernetesManagedHosting())
                 {
@@ -158,6 +160,31 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// SyncTriggers is performed whenever deployments or other changes are made to the application.
+        /// There are some operations we want to perform whenever this happens.
+        /// </summary>
+        private void PrepareSyncTriggers()
+        {
+            // We clear cache to ensure that secrets are reloaded. This is important because secrets are part
+            // of the StartupContext payload (see StartupContextProvider) and that payload comes from the
+            // SyncTriggers operation. So there's a chicken and egg situation here. Consider the following scenario:
+            //   - app is using blob storage for keys
+            //   - a SyncTriggers operation has happened previously and the StartupContext has key info
+            //   - app instances initialize keys from StartupContext (keys aren't loaded from storage)
+            //   - user updates the app to use a new storage account
+            //   - a SyncTriggers operation is performed
+            //   - the app initializes from StartupContext, and **previous old key info is loaded**
+            //   - the SyncTriggers operation uses this old key info, so trigger cache is never updated with new key info
+            //   - Portal/ARM APIs will continue to show old key info.
+            // By clearing cache, we ensure that this host instance reloads keys when they're requested, and the SyncTriggers
+            // operation will contain current keys.
+            if (_secretManagerProvider.SecretsEnabled)
+            {
+                _secretManagerProvider.Current.ClearCache();
+            }
         }
 
         internal static bool IsSyncTriggersEnvironment(IScriptWebHostEnvironment webHostEnvironment, IEnvironment environment)
@@ -316,45 +343,48 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 }
             }
 
-            // Add functions secrets to the payload
-            // Only secret types we own/control can we cache directly
-            // Encryption is handled by Antares before storage
-            var secretsStorageType = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsSecretStorageType);
-            if (string.IsNullOrEmpty(secretsStorageType) ||
-                string.Compare(secretsStorageType, "files", StringComparison.OrdinalIgnoreCase) == 0 ||
-                string.Compare(secretsStorageType, "blob", StringComparison.OrdinalIgnoreCase) == 0)
+            if (_secretManagerProvider.SecretsEnabled)
             {
-                var functionAppSecrets = new FunctionAppSecrets();
-
-                // add host secrets
-                var hostSecretsInfo = await _secretManagerProvider.Current.GetHostSecretsAsync();
-                functionAppSecrets.Host = new FunctionAppSecrets.HostSecrets
+                // Add functions secrets to the payload
+                // Only secret types we own/control can we cache directly
+                // Encryption is handled by Antares before storage
+                var secretsStorageType = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsSecretStorageType);
+                if (string.IsNullOrEmpty(secretsStorageType) ||
+                    string.Compare(secretsStorageType, "files", StringComparison.OrdinalIgnoreCase) == 0 ||
+                    string.Compare(secretsStorageType, "blob", StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    Master = hostSecretsInfo.MasterKey,
-                    Function = hostSecretsInfo.FunctionKeys,
-                    System = hostSecretsInfo.SystemKeys
-                };
+                    var functionAppSecrets = new FunctionAppSecrets();
 
-                // add function secrets
-                var httpFunctions = functionsMetadata.Where(p => p.InputBindings.Any(q => q.IsTrigger && string.Compare(q.Type, "httptrigger", StringComparison.OrdinalIgnoreCase) == 0)).Select(p => p.Name).ToArray();
-                functionAppSecrets.Function = new FunctionAppSecrets.FunctionSecrets[httpFunctions.Length];
-                for (int i = 0; i < httpFunctions.Length; i++)
-                {
-                    var currFunctionName = httpFunctions[i];
-                    var currSecrets = await _secretManagerProvider.Current.GetFunctionSecretsAsync(currFunctionName);
-                    functionAppSecrets.Function[i] = new FunctionAppSecrets.FunctionSecrets
+                    // add host secrets
+                    var hostSecretsInfo = await _secretManagerProvider.Current.GetHostSecretsAsync();
+                    functionAppSecrets.Host = new FunctionAppSecrets.HostSecrets
                     {
-                        Name = currFunctionName,
-                        Secrets = currSecrets
+                        Master = hostSecretsInfo.MasterKey,
+                        Function = hostSecretsInfo.FunctionKeys,
+                        System = hostSecretsInfo.SystemKeys
                     };
-                }
 
-                result.Add("secrets", JObject.FromObject(functionAppSecrets));
-            }
-            else
-            {
-                // TODO: handle other external key storage types
-                // like KeyVault when the feature comes online
+                    // add function secrets
+                    var httpFunctions = functionsMetadata.Where(p => p.InputBindings.Any(q => q.IsTrigger && string.Compare(q.Type, "httptrigger", StringComparison.OrdinalIgnoreCase) == 0)).Select(p => p.Name).ToArray();
+                    functionAppSecrets.Function = new FunctionAppSecrets.FunctionSecrets[httpFunctions.Length];
+                    for (int i = 0; i < httpFunctions.Length; i++)
+                    {
+                        var currFunctionName = httpFunctions[i];
+                        var currSecrets = await _secretManagerProvider.Current.GetFunctionSecretsAsync(currFunctionName);
+                        functionAppSecrets.Function[i] = new FunctionAppSecrets.FunctionSecrets
+                        {
+                            Name = currFunctionName,
+                            Secrets = currSecrets
+                        };
+                    }
+
+                    result.Add("secrets", JObject.FromObject(functionAppSecrets));
+                }
+                else
+                {
+                    // TODO: handle other external key storage types
+                    // like KeyVault when the feature comes online
+                }
             }
 
             string json = JsonConvert.SerializeObject(result);

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/DefaultSecretManagerProvider.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/DefaultSecretManagerProvider.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         private readonly StartupContextProvider _startupContextProvider;
         private readonly IAzureBlobStorageProvider _azureBlobStorageProvider;
         private Lazy<ISecretManager> _secretManagerLazy;
+        private Lazy<bool> _secretsEnabledLazy;
 
         public DefaultSecretManagerProvider(IOptionsMonitor<ScriptApplicationHostOptions> options, IHostIdProvider hostIdProvider,
             IConfiguration configuration, IEnvironment environment, ILoggerFactory loggerFactory, IMetricsLogger metricsLogger, HostNameProvider hostNameProvider, StartupContextProvider startupContextProvider, IAzureBlobStorageProvider azureBlobStorageProvider)
@@ -45,6 +46,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             _loggerFactory = loggerFactory;
             _metricsLogger = metricsLogger ?? throw new ArgumentNullException(nameof(metricsLogger));
             _secretManagerLazy = new Lazy<ISecretManager>(Create);
+            _secretsEnabledLazy = new Lazy<bool>(GetSecretsEnabled);
 
             // When these options change (due to specialization), we need to reset the secret manager.
             options.OnChange(_ => ResetSecretManager());
@@ -52,68 +54,139 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             _azureBlobStorageProvider = azureBlobStorageProvider ?? throw new ArgumentNullException(nameof(azureBlobStorageProvider));
         }
 
+        public bool SecretsEnabled
+        {
+            get
+            {
+                if (_secretManagerLazy.IsValueCreated)
+                {
+                    return true;
+                }
+                return _secretsEnabledLazy.Value;
+            }
+        }
+
         public ISecretManager Current => _secretManagerLazy.Value;
 
-        private void ResetSecretManager() => Interlocked.Exchange(ref _secretManagerLazy, new Lazy<ISecretManager>(Create));
+        private void ResetSecretManager()
+        {
+            Interlocked.Exchange(ref _secretsEnabledLazy, new Lazy<bool>(GetSecretsEnabled));
+            Interlocked.Exchange(ref _secretManagerLazy, new Lazy<ISecretManager>(Create));
+        }
 
         private ISecretManager Create() => new SecretManager(CreateSecretsRepository(), _loggerFactory.CreateLogger<SecretManager>(), _metricsLogger, _hostNameProvider, _startupContextProvider);
 
         internal ISecretsRepository CreateSecretsRepository()
         {
-            ISecretsRepository repository;
+            ISecretsRepository repository = null;
 
+            if (TryGetSecretsRepositoryType(out Type repositoryType))
+            {
+                if (repositoryType == typeof(FileSystemSecretsRepository))
+                {
+                    repository = new FileSystemSecretsRepository(_options.CurrentValue.SecretsPath, _loggerFactory.CreateLogger<FileSystemSecretsRepository>(), _environment);
+                }
+                else if (repositoryType == typeof(KeyVaultSecretsRepository))
+                {
+                    string azureWebJobsSecretStorageKeyVaultUri = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsSecretStorageKeyVaultUri);
+                    string azureWebJobsSecretStorageKeyVaultClientId = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsSecretStorageKeyVaultClientId);
+                    string azureWebJobsSecretStorageKeyVaultClientSecret = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsSecretStorageKeyVaultClientSecret);
+                    string azureWebJobsSecretStorageKeyVaultTenantId = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsSecretStorageKeyVaultTenantId);
+
+                    var keyVaultLogger = _loggerFactory.CreateLogger<KeyVaultSecretsRepository>();
+
+                    return new KeyVaultSecretsRepository(Path.Combine(_options.CurrentValue.SecretsPath, "Sentinels"), azureWebJobsSecretStorageKeyVaultUri, azureWebJobsSecretStorageKeyVaultClientId,
+                                                                        azureWebJobsSecretStorageKeyVaultClientSecret, azureWebJobsSecretStorageKeyVaultTenantId, keyVaultLogger, _environment);
+                }
+                else if (repositoryType == typeof(KubernetesSecretsRepository))
+                {
+                    repository = new KubernetesSecretsRepository(_environment, new SimpleKubernetesClient(_environment, _loggerFactory.CreateLogger<SimpleKubernetesClient>()));
+                }
+                else if (repositoryType == typeof(BlobStorageSasSecretsRepository))
+                {
+                    string secretStorageSas = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsSecretStorageSas);
+                    string siteSlotName = _environment.GetAzureWebsiteUniqueSlotName() ?? _hostIdProvider.GetHostIdAsync(CancellationToken.None).GetAwaiter().GetResult();
+                    repository = new BlobStorageSasSecretsRepository(Path.Combine(_options.CurrentValue.SecretsPath, "Sentinels"),
+                                                                        secretStorageSas,
+                                                                        siteSlotName,
+                                                                        _loggerFactory.CreateLogger<BlobStorageSasSecretsRepository>(),
+                                                                        _environment,
+                                                                        _azureBlobStorageProvider);
+                }
+                else if (repositoryType == typeof(BlobStorageSecretsRepository))
+                {
+                    string siteSlotName = _environment.GetAzureWebsiteUniqueSlotName() ?? _hostIdProvider.GetHostIdAsync(CancellationToken.None).GetAwaiter().GetResult();
+                    repository = new BlobStorageSecretsRepository(Path.Combine(_options.CurrentValue.SecretsPath, "Sentinels"),
+                                                                    ConnectionStringNames.Storage,
+                                                                    siteSlotName,
+                                                                    _loggerFactory.CreateLogger<BlobStorageSecretsRepository>(),
+                                                                    _environment,
+                                                                    _azureBlobStorageProvider);
+                }
+            }
+
+            if (repository == null)
+            {
+                throw new InvalidOperationException($"Secret initialization from Blob storage failed due to missing both an Azure Storage connection string and a SAS connection uri. " +
+                        $"For Blob Storage, please provide at least one of these. If you intend to use files for secrets, add an App Setting key '{EnvironmentSettingNames.AzureWebJobsSecretStorageType}' with value '{FileStorage}'.");
+            }
+
+            ILogger logger = _loggerFactory.CreateLogger<DefaultSecretManagerProvider>();
+            logger.LogInformation("Resolved secret storage provider {provider}", repository.Name);
+
+            return repository;
+        }
+
+        /// <summary>
+        /// Determines the repository Type to use based on configured settings.
+        /// </summary>
+        /// <remarks>
+        /// For scenarios where the app isn't configured for key storage (e.g. no AzureWebJobsSecretStorageType explicitly configured,
+        /// no storage connection string for default blob storage, etc.). Note that it's still possible for the creation of the repository
+        /// to fail due to invalid values. This method just does preliminary config checks to determine the Type.
+        /// </remarks>
+        /// <param name="repositoryType">The repository Type or null.</param>
+        /// <returns>True if a Type was determined, false otherwise.</returns>
+        internal bool TryGetSecretsRepositoryType(out Type repositoryType)
+        {
             string secretStorageType = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsSecretStorageType);
             string secretStorageSas = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsSecretStorageSas);
 
             if (secretStorageType != null && secretStorageType.Equals(FileStorage, StringComparison.OrdinalIgnoreCase))
             {
-                repository = new FileSystemSecretsRepository(_options.CurrentValue.SecretsPath, _loggerFactory.CreateLogger<FileSystemSecretsRepository>(), _environment);
+                repositoryType = typeof(FileSystemSecretsRepository);
+                return true;
             }
             else if (secretStorageType != null && secretStorageType.Equals("keyvault", StringComparison.OrdinalIgnoreCase))
             {
-                string azureWebJobsSecretStorageKeyVaultUri = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsSecretStorageKeyVaultUri);
-                string azureWebJobsSecretStorageKeyVaultClientId = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsSecretStorageKeyVaultClientId);
-                string azureWebJobsSecretStorageKeyVaultClientSecret = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsSecretStorageKeyVaultClientSecret);
-                string azureWebJobsSecretStorageKeyVaultTenantId = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsSecretStorageKeyVaultTenantId);
-
-                var keyVaultLogger = _loggerFactory.CreateLogger<KeyVaultSecretsRepository>();
-
-                return new KeyVaultSecretsRepository(Path.Combine(_options.CurrentValue.SecretsPath, "Sentinels"), azureWebJobsSecretStorageKeyVaultUri, azureWebJobsSecretStorageKeyVaultClientId,
-                                                                    azureWebJobsSecretStorageKeyVaultClientSecret, azureWebJobsSecretStorageKeyVaultTenantId, keyVaultLogger, _environment);
+                repositoryType = typeof(KeyVaultSecretsRepository);
+                return true;
             }
             else if (secretStorageType != null && secretStorageType.Equals("kubernetes", StringComparison.OrdinalIgnoreCase))
             {
-                repository = new KubernetesSecretsRepository(_environment, new SimpleKubernetesClient(_environment, _loggerFactory.CreateLogger<SimpleKubernetesClient>()));
+                repositoryType = typeof(KubernetesSecretsRepository);
+                return true;
             }
             else if (secretStorageSas != null)
             {
-                string siteSlotName = _environment.GetAzureWebsiteUniqueSlotName() ?? _hostIdProvider.GetHostIdAsync(CancellationToken.None).GetAwaiter().GetResult();
-                repository = new BlobStorageSasSecretsRepository(Path.Combine(_options.CurrentValue.SecretsPath, "Sentinels"),
-                                                                 secretStorageSas,
-                                                                 siteSlotName,
-                                                                 _loggerFactory.CreateLogger<BlobStorageSasSecretsRepository>(),
-                                                                 _environment,
-                                                                 _azureBlobStorageProvider);
+                repositoryType = typeof(BlobStorageSasSecretsRepository);
+                return true;
             }
             else if (_azureBlobStorageProvider.TryCreateHostingBlobContainerClient(out _))
             {
-                string siteSlotName = _environment.GetAzureWebsiteUniqueSlotName() ?? _hostIdProvider.GetHostIdAsync(CancellationToken.None).GetAwaiter().GetResult();
-                repository = new BlobStorageSecretsRepository(Path.Combine(_options.CurrentValue.SecretsPath, "Sentinels"),
-                                                              ConnectionStringNames.Storage,
-                                                              siteSlotName,
-                                                              _loggerFactory.CreateLogger<BlobStorageSecretsRepository>(),
-                                                              _environment,
-                                                              _azureBlobStorageProvider);
+                repositoryType = typeof(BlobStorageSecretsRepository);
+                return true;
             }
             else
             {
-                throw new InvalidOperationException($"Secret initialization from Blob storage failed due to missing both an Azure Storage connection string and a SAS connection uri. " +
-                    $"For Blob Storage, please provide at least one of these. If you intend to use files for secrets, add an App Setting key '{EnvironmentSettingNames.AzureWebJobsSecretStorageType}' with value '{FileStorage}'.");
+                repositoryType = null;
+                return false;
             }
+        }
 
-            ILogger logger = _loggerFactory.CreateLogger<DefaultSecretManagerProvider>();
-            logger.LogInformation("Resolved secret storage provider {provider}", repository.Name);
-            return repository;
+        internal bool GetSecretsEnabled()
+        {
+            return TryGetSecretsRepositoryType(out _);
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/ISecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/ISecretManager.cs
@@ -68,5 +68,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         /// <param name="rootScriptPath">The root function directory.</param>
         /// <param name="logger">The ILogger to log to.</param>
         Task PurgeOldSecretsAsync(string rootScriptPath, ILogger logger);
+
+        /// <summary>
+        /// If secrets have been loaded and cached, clear all cached secrets so they'll
+        /// be reloaded next time they're requested.
+        /// </summary>
+        void ClearCache();
     }
 }

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/ISecretManagerProvider.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/ISecretManagerProvider.cs
@@ -5,6 +5,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 {
     public interface ISecretManagerProvider
     {
+        /// <summary>
+        /// Gets a value indicating whether we're configured to use secrets.
+        /// </summary>
+        bool SecretsEnabled { get; }
+
+        /// <summary>
+        /// Gets or creates the <see cref="ISecretManager"./>
+        /// </summary>
         ISecretManager Current { get; }
     }
 }

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
@@ -651,6 +651,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
         }
 
+        public void ClearCache()
+        {
+            _authorizationCache.Clear();
+            _hostSecrets = null;
+            _functionSecrets.Clear();
+        }
+
         private async Task<string> AnalyzeSnapshots(string[] secretBackups)
         {
             string analyzeResult = string.Empty;

--- a/test/WebJobs.Script.Tests.Integration/Security/SecretManagerProviderTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Security/SecretManagerProviderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Threading;
 using Microsoft.Azure.WebJobs.Host.Executors;
@@ -60,6 +61,29 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
 
             Assert.Same(manager1, manager2);
             Assert.NotSame(manager1, manager3);
+        }
+
+        [Fact]
+        public void TryGetSecretsRepositoryType_ReturnsExpectedValue()
+        {
+            bool result = _provider.TryGetSecretsRepositoryType(out Type repositoryType);
+            Assert.True(result);
+            Assert.Equal(typeof(BlobStorageSecretsRepository), repositoryType);
+        }
+
+        [Fact]
+        public void SecretsEnabled_ReturnsExpectedValue()
+        {
+            Assert.True(_provider.SecretsEnabled);
+
+            // we'll return a cached value here
+            Assert.True(_provider.SecretsEnabled);
+
+            // force creation of the manager
+            Assert.NotNull(_provider.Current);
+
+            // will short circuit here
+            Assert.True(_provider.SecretsEnabled);
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Shared/TestSecretManager.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestSecretManager.cs
@@ -90,6 +90,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             };
         }
 
+        public void ClearCache()
+        {
+        }
+
         public async Task<(string, AuthorizationLevel)> GetAuthorizationLevelOrNullAsync(string key, string functionName = null)
         {
             return await SecretManager.GetAuthorizationLevelAsync(this, key, functionName);

--- a/test/WebJobs.Script.Tests.Shared/TestSecretManagerProvider.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestSecretManagerProvider.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _secretManager = secretManager;
         }
 
+        public bool SecretsEnabled => true;
+
         public ISecretManager Current => _secretManager ?? new SecretManager();
     }
 }


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-functions-host/issues/7698. In addition, the changes here pave the way for addressing https://github.com/Azure/azure-functions-host/issues/5922 because a guard pattern is introduced for secret manager creation. I've improved the current state of things here for that issue a bit in this PR already by checking before accessing SecretManager in FunctionsSyncManager.

I'll be backporting this to 3.x as well.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport PR https://github.com/Azure/azure-functions-host/pull/7947
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
