### PR TITLE
Performance: GetScopeDictionaryOrNull() - prevent a resize in the common path

### DIFF
--- a/src/WebJobs.Script.WebHost/Extensions/IExternalScopeProviderExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Extensions/IExternalScopeProviderExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Extensions.Logging
             {
                 if (scope is IEnumerable<KeyValuePair<string, object>> kvps)
                 {
-                    result = result ?? new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+                    result = result ?? new Dictionary<string, object>(16, StringComparer.OrdinalIgnoreCase);
 
                     foreach (var kvp in kvps)
                     {


### PR DESCRIPTION
Part of #7908. In every function call, we eat some allocations and cost from a dictionary resize when the logging dictionary is fetched in `SystemLogger`. By sizing appropriately (16 ensures we won't grow in the 99% case, but we could lower it to save a few more bytes), we can eliminate the resize and only have the construction cost of adding members left.

There are more of these happening, but over in the SDK project, so separate PRs there.

### Issue describing the changes in this PR

Resolves a component of #7908

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
