### PR TITLE
Performance: Memorize FunctionInstanceLogger data format strings

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/FunctionInstanceLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/FunctionInstanceLogger.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         private readonly IMetricsLogger _metrics;
         private readonly IFunctionMetadataManager _metadataManager;
+        private ConcurrentDictionary<(string, string, bool, bool), string> _eventDataCache = new ConcurrentDictionary<(string, string, bool, bool), string>();
         private ConcurrentDictionary<BindingMetadata, string> _bindingMetricEventNames = new ConcurrentDictionary<BindingMetadata, string>();
 
         public FunctionInstanceLogger(
@@ -103,7 +104,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             var function = startedEvent.FunctionMetadata;
             string eventName = success ? MetricEventNames.FunctionInvokeSucceeded : MetricEventNames.FunctionInvokeFailed;
             string functionName = function != null ? function.Name : string.Empty;
-            string data = string.Format(Microsoft.Azure.WebJobs.Script.Properties.Resources.FunctionInvocationMetricsData, startedEvent.FunctionMetadata.Language, functionName, success, Stopwatch.IsHighResolution);
+
+            // This has low cadinality but we allocate the string every call (even though ironically it's often not used due to rollups)
+            // It's cheaper to cache and lookup rather than generate and pay for GC here.
+            // Note: this would be faster with a readonly record struct key, but StyleCop is angry with it until an upcoming 1.2.x beta release
+            var key = (startedEvent.FunctionMetadata.Language, functionName, success, Stopwatch.IsHighResolution);
+            if (!_eventDataCache.TryGetValue(key, out var data))
+            {
+                data = string.Format(Microsoft.Azure.WebJobs.Script.Properties.Resources.FunctionInvocationMetricsData, startedEvent.FunctionMetadata.Language, functionName, success, Stopwatch.IsHighResolution);
+                _eventDataCache[key] = data;
+            }
             _metrics.LogEvent(eventName, startedEvent.FunctionName, data);
 
             startedEvent.Data = data;


### PR DESCRIPTION
Part of #7908. Today we format a string per call but the number of permutations of these strings is pretty low - we can cache/lookup and do better than the GC cost here with a lookup (in the 1-3% range depending on load).

This can be a bit faster by moving to a `readonly record struct` key (due to faster hashing by ~33%), but since StyleCop is broken with that - it'll need to wait on a 1.2.x upgrade. Let's get the win now and improve it more later.

### Issue describing the changes in this PR

Resolves a component of #7908

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

I'm not concerned with the supserset of memory usage here since the cardinality should be pretty finite, but is this a valid assumption? It warrants checking by those with more context to make sure that's correct.
