### PR TITLE
Performance: Utility.TryGetFunctionName: search for current function key first

### DIFF
--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -506,9 +506,9 @@ namespace Microsoft.Azure.WebJobs.Script
 
             object scopeValue = null;
             if (scopeProps != null && scopeProps.Count > 0 &&
-                (scopeProps.TryGetValue("functionName", out scopeValue) ||
-                 scopeProps.TryGetValue(LogConstants.NameKey, out scopeValue) ||
-                 scopeProps.TryGetValue(ScopeKeys.FunctionName, out scopeValue)) && scopeValue != null)
+                (scopeProps.TryGetValue(ScopeKeys.FunctionName, out scopeValue) ||
+                 scopeProps.TryGetValue("functionName", out scopeValue) ||
+                 scopeProps.TryGetValue(LogConstants.NameKey, out scopeValue)) && scopeValue != null)
             {
                 functionName = scopeValue.ToString();
             }
@@ -518,9 +518,9 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public static bool IsFunctionName(KeyValuePair<string, object> p)
         {
-            return string.Equals(p.Key, "functionName", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(p.Key, LogConstants.NameKey, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(p.Key, ScopeKeys.FunctionName, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(p.Key, ScopeKeys.FunctionName, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(p.Key, "functionName", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(p.Key, LogConstants.NameKey, StringComparison.OrdinalIgnoreCase);
         }
 
         public static string GetValueFromScope(IDictionary<string, object> scopeProperties, string key)


### PR DESCRIPTION
Part of #7908. In talking with @mathewc and @paulbatum, we're not entirely sure the other keys are even needed - presumably they were at some point of compat along the way. Regardless, we don't have to take a risk here - we can optimize at least a little by moving the most common hit first and saving 2 lookups but still fallback if needed.

Note: the cleanup is still much better in the KeyValuePair case to execute because it's run in a loop to match (or miss) and we're doing an extra 2 case-insensitive searches per loop.

Are these fallbacks still needed for some case I can't find in the current solutions? (some extensibility point?)
### Issue describing the changes in this PR

Resolves a component of #7908

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)