### PR TITLE
Adds Metric Logging support for GRPC workers

### DIFF
--- a/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
+++ b/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
@@ -24,59 +24,35 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
     {
         private static readonly JsonSerializerSettings _datetimeSerializerSettings = new JsonSerializerSettings { DateParseHandling = DateParseHandling.None };
 
-        public static object ToObject(this TypedData typedData)
-        {
-            switch (typedData.DataCase)
+        public static object ToObject(this TypedData typedData) =>
+            typedData.DataCase switch
             {
-                case RpcDataType.None:
-                    return null;
-                case RpcDataType.String:
-                    return typedData.String;
-                case RpcDataType.Json:
-                    return JsonConvert.DeserializeObject(typedData.Json, _datetimeSerializerSettings);
-                case RpcDataType.Bytes:
-                case RpcDataType.Stream:
-                    return typedData.Bytes.ToByteArray();
-                case RpcDataType.Http:
-                    return GrpcMessageExtensionUtilities.ConvertFromHttpMessageToExpando(typedData.Http);
-                case RpcDataType.Int:
-                    return typedData.Int;
-                case RpcDataType.Double:
-                    return typedData.Double;
-                default:
+                    RpcDataType.None => null,
+                    RpcDataType.String => typedData.String,
+                    RpcDataType.Json => JsonConvert.DeserializeObject(typedData.Json, _datetimeSerializerSettings),
+                    RpcDataType.Bytes or RpcDataType.Stream => typedData.Bytes.ToByteArray(),
+                    RpcDataType.Http => GrpcMessageExtensionUtilities.ConvertFromHttpMessageToExpando(typedData.Http),
+                    RpcDataType.Int => typedData.Int,
+                    RpcDataType.Double => typedData.Double,
                     // TODO better exception
-                    throw new InvalidOperationException($"Unknown RpcDataType: {typedData.DataCase}");
-            }
-        }
+                    _ => throw new InvalidOperationException($"Unknown RpcDataType: {typedData.DataCase}")
+            };
 
-        public static async Task<TypedData> ToRpc(this object value, ILogger logger, GrpcCapabilities capabilities)
-        {
-            switch (value)
+        public static async Task<TypedData> ToRpc(this object value, ILogger logger, GrpcCapabilities capabilities) =>
+            value switch
             {
-                case null:
-                    return new TypedData();
-                case byte[] arr:
-                    return new TypedData() { Bytes = ByteString.CopyFrom(arr) };
-                case JObject jobj:
-                    return new TypedData() { Json = jobj.ToString(Formatting.None) };
-                case string str:
-                    return new TypedData() { String = str };
-                case double dbl:
-                    return new TypedData() { Double = dbl };
-                case HttpRequest request:
-                    return await request.ToRpcHttp(logger, capabilities);
-                case byte[][] arrBytes when IsTypedDataCollectionSupported(capabilities):
-                    return arrBytes.ToRpcByteArray();
-                case string[] arrStr when IsTypedDataCollectionSupported(capabilities):
-                    return arrStr.ToRpcStringArray();
-                case double[] arrDouble when IsTypedDataCollectionSupported(capabilities):
-                    return arrDouble.ToRpcDoubleArray();
-                case long[] arrLong when IsTypedDataCollectionSupported(capabilities):
-                    return arrLong.ToRpcLongArray();
-                default:
-                    return value.ToRpcDefault();
-            }
-        }
+                null => new TypedData(),
+                byte[] arr => new TypedData() { Bytes = ByteString.CopyFrom(arr) },
+                JObject jobj => new TypedData() { Json = jobj.ToString(Formatting.None) },
+                string str => new TypedData() { String = str },
+                double dbl => new TypedData() { Double = dbl },
+                HttpRequest request => await request.ToRpcHttp(logger, capabilities),
+                byte[][] arrBytes when IsTypedDataCollectionSupported(capabilities) => arrBytes.ToRpcByteArray(),
+                string[] arrStr when IsTypedDataCollectionSupported(capabilities) => arrStr.ToRpcStringArray(),
+                double[] arrDouble when IsTypedDataCollectionSupported(capabilities) => arrDouble.ToRpcDoubleArray(),
+                long[] arrLong when IsTypedDataCollectionSupported(capabilities) => arrLong.ToRpcLongArray(),
+                _ => value.ToRpcDefault(),
+            };
 
         internal static async Task<TypedData> ToRpcHttp(this HttpRequest request, ILogger logger, GrpcCapabilities capabilities)
         {

--- a/test/WebJobs.Script.Tests/Extensions/InboundGrpcEventExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/InboundGrpcEventExtensionsTests.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Theory]
         [InlineData(RpcLogCategory.System)]
         [InlineData(RpcLogCategory.User)]
+        [InlineData(RpcLogCategory.CustomMetric)]
         public void TestLogCategories(RpcLogCategory categoryToTest)
         {
             InboundGrpcEvent inboundEvent = new InboundGrpcEvent(Guid.NewGuid().ToString(), new Grpc.Messages.StreamingMessage


### PR DESCRIPTION
- [ Branch transferred from here: #7593 ]

Host-level fix to support gRPC logging of custom metric types

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

For https://github.com/Azure/azure-functions-dotnet-worker/issues/543

This adds `RpcMetric` as a gRPC message type + support to log it to ILogger in such a way that it shows in Application Insights logs as a custom metric. This provides functionality similar to what we had in in-proc languages by simply using the `.LogMetric()` ILogger extension method.

This PR encompasses the necessary changes required to complete https://github.com/Azure/azure-functions-dotnet-worker/issues/543

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

After completion, https://github.com/Azure/azure-functions-dotnet-worker/pull/548 should be completed to fully implement this functionality.
