### PR TITLE
Performance: ArgumentNullException: ThrowIfNull inlining & Cleanup

### DIFF
--- a/src/WebJobs.Script.WebHost/DependencyInjection/DependencyValidator/ExpectedDependencyBuilder.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/DependencyValidator/ExpectedDependencyBuilder.cs
@@ -28,10 +28,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
 
         public void Expect<TService>(string typeName, ServiceLifetime lifetime = ServiceLifetime.Singleton)
         {
-            if (typeName == null)
-            {
-                throw new ArgumentNullException(nameof(typeName));
-            }
+            ArgumentNullException.ThrowIfNull(typeName, nameof(typeName));
 
             ServiceMatch match = ServiceMatch.CreateMatch<TService>();
             AddNewMatch<TService>(match);
@@ -52,10 +49,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
 
         public void Expect<TService, TPeerType>(string typeName, ServiceLifetime lifetime = ServiceLifetime.Singleton)
         {
-            if (typeName == null)
-            {
-                throw new ArgumentNullException(nameof(typeName));
-            }
+            ArgumentNullException.ThrowIfNull(typeName, nameof(typeName));
 
             ServiceMatch match = ServiceMatch.CreateMatch<TService>();
             AddNewMatch<TService>(match);

--- a/src/WebJobs.Script.WebHost/DependencyInjection/DependencyValidator/ExpectedDependencyBuilder.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/DependencyValidator/ExpectedDependencyBuilder.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
 
         public void Expect<TService>(string typeName, ServiceLifetime lifetime = ServiceLifetime.Singleton)
         {
-            ArgumentNullException.ThrowIfNull(typeName, nameof(typeName));
+            ArgumentNullException.ThrowIfNull(typeName);
 
             ServiceMatch match = ServiceMatch.CreateMatch<TService>();
             AddNewMatch<TService>(match);
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
 
         public void Expect<TService, TPeerType>(string typeName, ServiceLifetime lifetime = ServiceLifetime.Singleton)
         {
-            ArgumentNullException.ThrowIfNull(typeName, nameof(typeName));
+            ArgumentNullException.ThrowIfNull(typeName);
 
             ServiceMatch match = ServiceMatch.CreateMatch<TService>();
             AddNewMatch<TService>(match);

--- a/src/WebJobs.Script.WebHost/DependencyInjection/DependencyValidator/ServiceMatch.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/DependencyValidator/ServiceMatch.cs
@@ -77,10 +77,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
 
         public void Add<TPeerType>(string typeName, ServiceLifetime lifetime)
         {
-            if (typeName == null)
-            {
-                throw new ArgumentNullException(nameof(typeName));
-            }
+            ArgumentNullException.ThrowIfNull(typeName, nameof(typeName));
 
             Type peerType = typeof(TPeerType);
             Add(peerType, typeName, lifetime);
@@ -88,10 +85,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
 
         public void Add(string typeName, ServiceLifetime lifetime)
         {
-            if (typeName == null)
-            {
-                throw new ArgumentNullException(nameof(typeName));
-            }
+            ArgumentNullException.ThrowIfNull(typeName, nameof(typeName));
 
             Add(ServiceType, typeName, lifetime);
         }
@@ -153,10 +147,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
 
         public IEnumerable<InvalidServiceDescriptor> FindInvalidServices(IServiceCollection services)
         {
-            if (services == null)
-            {
-                throw new ArgumentNullException(nameof(services));
-            }
+            ArgumentNullException.ThrowIfNull(services, nameof(services));
 
             IEnumerable<ServiceDescriptor> registered = services.Where(p => p.ServiceType == ServiceType);
 

--- a/src/WebJobs.Script.WebHost/DependencyInjection/DependencyValidator/ServiceMatch.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/DependencyValidator/ServiceMatch.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
 
         public void Add<TPeerType>(string typeName, ServiceLifetime lifetime)
         {
-            ArgumentNullException.ThrowIfNull(typeName, nameof(typeName));
+            ArgumentNullException.ThrowIfNull(typeName);
 
             Type peerType = typeof(TPeerType);
             Add(peerType, typeName, lifetime);
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
 
         public void Add(string typeName, ServiceLifetime lifetime)
         {
-            ArgumentNullException.ThrowIfNull(typeName, nameof(typeName));
+            ArgumentNullException.ThrowIfNull(typeName);
 
             Add(ServiceType, typeName, lifetime);
         }
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
 
         public IEnumerable<InvalidServiceDescriptor> FindInvalidServices(IServiceCollection services)
         {
-            ArgumentNullException.ThrowIfNull(services, nameof(services));
+            ArgumentNullException.ThrowIfNull(services);
 
             IEnumerable<ServiceDescriptor> registered = services.Where(p => p.ServiceType == ServiceType);
 

--- a/src/WebJobs.Script.WebHost/DependencyInjection/JobHostServiceProvider.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/JobHostServiceProvider.cs
@@ -31,10 +31,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
 
         public JobHostServiceProvider(IServiceCollection descriptors, IServiceProvider rootProvider, IServiceScopeFactory rootScopeFactory)
         {
-            if (descriptors == null)
-            {
-                throw new ArgumentNullException(nameof(descriptors));
-            }
+            ArgumentNullException.ThrowIfNull(descriptors, nameof(descriptors));
 
             _rootProvider = rootProvider ?? throw new ArgumentNullException(nameof(rootProvider));
             _rootScopeFactory = rootScopeFactory ?? throw new ArgumentNullException(nameof(rootScopeFactory));

--- a/src/WebJobs.Script.WebHost/DependencyInjection/JobHostServiceProvider.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/JobHostServiceProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
 
         public JobHostServiceProvider(IServiceCollection descriptors, IServiceProvider rootProvider, IServiceScopeFactory rootScopeFactory)
         {
-            ArgumentNullException.ThrowIfNull(descriptors, nameof(descriptors));
+            ArgumentNullException.ThrowIfNull(descriptors);
 
             _rootProvider = rootProvider ?? throw new ArgumentNullException(nameof(rootProvider));
             _rootScopeFactory = rootScopeFactory ?? throw new ArgumentNullException(nameof(rootScopeFactory));

--- a/src/WebJobs.Script.WebHost/DependencyInjection/WebHostServiceProvider.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/WebHostServiceProvider.cs
@@ -24,10 +24,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
 
         public WebHostServiceProvider(IServiceCollection descriptors)
         {
-            if (descriptors == null)
-            {
-                throw new ArgumentNullException(nameof(descriptors));
-            }
+            ArgumentNullException.ThrowIfNull(descriptors, nameof(descriptors));
 
             // preferInterpretation will be set to true to significanly improve cold start in consumption mode
             // it will be set to false for premium and appservice plans to make sure throughput is not impacted

--- a/src/WebJobs.Script.WebHost/DependencyInjection/WebHostServiceProvider.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/WebHostServiceProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
 
         public WebHostServiceProvider(IServiceCollection descriptors)
         {
-            ArgumentNullException.ThrowIfNull(descriptors, nameof(descriptors));
+            ArgumentNullException.ThrowIfNull(descriptors);
 
             // preferInterpretation will be set to true to significanly improve cold start in consumption mode
             // it will be set to false for premium and appservice plans to make sure throughput is not impacted

--- a/src/WebJobs.Script.WebHost/Diagnostics/FunctionInstanceLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/FunctionInstanceLogger.cs
@@ -30,8 +30,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             ILoggerFactory loggerFactory)
             : this(metadataManager, metrics)
         {
-            ArgumentNullException.ThrowIfNull(configuration, nameof(configuration));
-            ArgumentNullException.ThrowIfNull(loggerFactory, nameof(loggerFactory));
+            ArgumentNullException.ThrowIfNull(configuration);
+            ArgumentNullException.ThrowIfNull(loggerFactory);
 
             string accountConnectionString = configuration.GetWebJobsConnectionString(ConnectionStringNames.Dashboard);
             if (accountConnectionString != null)

--- a/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public object BeginEvent(string eventName, string functionName = null, string data = null)
         {
-            ArgumentNullException.ThrowIfNull(eventName, nameof(eventName));
+            ArgumentNullException.ThrowIfNull(eventName);
 
             return new SystemMetricEvent
             {
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public void EndEvent(object eventHandle)
         {
-            ArgumentNullException.ThrowIfNull(eventHandle, nameof(eventHandle));
+            ArgumentNullException.ThrowIfNull(eventHandle);
 
             SystemMetricEvent evt = eventHandle as SystemMetricEvent;
             if (evt != null)
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public void LogEvent(string eventName, string functionName = null, string data = null)
         {
-            ArgumentNullException.ThrowIfNull(eventName, nameof(eventName));
+            ArgumentNullException.ThrowIfNull(eventName);
 
             eventName = Sanitizer.Sanitize(eventName);
 
@@ -253,7 +253,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         protected internal virtual void WriteMetricEvents(SystemMetricEvent[] metricEvents)
         {
-            ArgumentNullException.ThrowIfNull(metricEvents, nameof(metricEvents));
+            ArgumentNullException.ThrowIfNull(metricEvents);
 
             AppServiceOptions currentAppServiceOptions = _appServiceOptions;
             foreach (SystemMetricEvent metricEvent in metricEvents)

--- a/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
@@ -57,10 +57,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public object BeginEvent(string eventName, string functionName = null, string data = null)
         {
-            if (string.IsNullOrEmpty(eventName))
-            {
-                throw new ArgumentNullException(nameof(eventName));
-            }
+            ArgumentNullException.ThrowIfNull(eventName, nameof(eventName));
 
             return new SystemMetricEvent
             {
@@ -74,10 +71,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public void EndEvent(object eventHandle)
         {
-            if (eventHandle == null)
-            {
-                throw new ArgumentNullException(nameof(eventHandle));
-            }
+            ArgumentNullException.ThrowIfNull(eventHandle, nameof(eventHandle));
 
             SystemMetricEvent evt = eventHandle as SystemMetricEvent;
             if (evt != null)
@@ -123,10 +117,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public void LogEvent(string eventName, string functionName = null, string data = null)
         {
-            if (string.IsNullOrEmpty(eventName))
-            {
-                throw new ArgumentNullException(nameof(eventName));
-            }
+            ArgumentNullException.ThrowIfNull(eventName, nameof(eventName));
 
             eventName = Sanitizer.Sanitize(eventName);
 
@@ -262,10 +253,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         protected internal virtual void WriteMetricEvents(SystemMetricEvent[] metricEvents)
         {
-            if (metricEvents == null)
-            {
-                throw new ArgumentNullException(nameof(metricEvents));
-            }
+            ArgumentNullException.ThrowIfNull(metricEvents, nameof(metricEvents));
 
             AppServiceOptions currentAppServiceOptions = _appServiceOptions;
             foreach (SystemMetricEvent metricEvent in metricEvents)

--- a/src/WebJobs.Script.WebHost/Features/FunctionExecutionFeature.cs
+++ b/src/WebJobs.Script.WebHost/Features/FunctionExecutionFeature.cs
@@ -26,7 +26,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Features
 
         public FunctionExecutionFeature(IScriptJobHost host, FunctionDescriptor descriptor, IEnvironment environment, ILoggerFactory loggerFactory)
         {
-            _host = host ?? throw new ArgumentNullException(nameof(host));
+            ArgumentNullException.ThrowIfNull(host, nameof(host));
+            _host = host;
             _descriptor = descriptor;
             _environment = environment;
             _logger = loggerFactory.CreateLogger(ScriptConstants.LogCategoryHostMetrics);

--- a/src/WebJobs.Script.WebHost/Features/FunctionExecutionFeature.cs
+++ b/src/WebJobs.Script.WebHost/Features/FunctionExecutionFeature.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Features
 
         public FunctionExecutionFeature(IScriptJobHost host, FunctionDescriptor descriptor, IEnvironment environment, ILoggerFactory loggerFactory)
         {
-            ArgumentNullException.ThrowIfNull(host, nameof(host));
+            ArgumentNullException.ThrowIfNull(host);
             _host = host;
             _descriptor = descriptor;
             _environment = environment;

--- a/src/WebJobs.Script.WebHost/FunctionsSyncService.cs
+++ b/src/WebJobs.Script.WebHost/FunctionsSyncService.cs
@@ -26,10 +26,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         public FunctionsSyncService(ILoggerFactory loggerFactory, IScriptHostManager scriptHostManager, IPrimaryHostStateProvider primaryHostStateProvider, IFunctionsSyncManager functionsSyncManager)
         {
-            if (loggerFactory == null)
-            {
-                throw new ArgumentNullException(nameof(loggerFactory));
-            }
+            ArgumentNullException.ThrowIfNull(loggerFactory, nameof(loggerFactory));
 
             DueTime = 30 * 1000;
             _scriptHostManager = scriptHostManager;

--- a/src/WebJobs.Script.WebHost/FunctionsSyncService.cs
+++ b/src/WebJobs.Script.WebHost/FunctionsSyncService.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         public FunctionsSyncService(ILoggerFactory loggerFactory, IScriptHostManager scriptHostManager, IPrimaryHostStateProvider primaryHostStateProvider, IFunctionsSyncManager functionsSyncManager)
         {
-            ArgumentNullException.ThrowIfNull(loggerFactory, nameof(loggerFactory));
+            ArgumentNullException.ThrowIfNull(loggerFactory);
 
             DueTime = 30 * 1000;
             _scriptHostManager = scriptHostManager;

--- a/src/WebJobs.Script.WebHost/Helpers/MediaTypeMap.cs
+++ b/src/WebJobs.Script.WebHost/Helpers/MediaTypeMap.cs
@@ -22,10 +22,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Helpers
 
         public MediaTypeHeaderValue GetMediaType(string fileExtension)
         {
-            if (fileExtension == null)
-            {
-                throw new ArgumentNullException(nameof(fileExtension));
-            }
+            ArgumentNullException.ThrowIfNull(fileExtension, nameof(fileExtension));
 
             return _mediatypeMap.GetOrAdd(fileExtension,
                 (extension) =>

--- a/src/WebJobs.Script.WebHost/Helpers/MediaTypeMap.cs
+++ b/src/WebJobs.Script.WebHost/Helpers/MediaTypeMap.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Helpers
 
         public MediaTypeHeaderValue GetMediaType(string fileExtension)
         {
-            ArgumentNullException.ThrowIfNull(fileExtension, nameof(fileExtension));
+            ArgumentNullException.ThrowIfNull(fileExtension);
 
             return _mediatypeMap.GetOrAdd(fileExtension,
                 (extension) =>

--- a/src/WebJobs.Script.WebHost/Management/VirtualFileSystem.cs
+++ b/src/WebJobs.Script.WebHost/Management/VirtualFileSystem.cs
@@ -224,10 +224,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
         protected virtual Task<HttpResponseMessage> CreateDirectoryGetResponse(HttpRequest request, DirectoryInfoBase info, string localFilePath)
         {
-            if (info == null)
-            {
-                throw new ArgumentNullException(nameof(info));
-            }
+            ArgumentNullException.ThrowIfNull(info, nameof(info));
 
             try
             {
@@ -484,10 +481,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         /// </summary>
         protected static Stream GetFileReadStream(string localFilePath)
         {
-            if (localFilePath == null)
-            {
-                throw new ArgumentNullException(nameof(localFilePath));
-            }
+            ArgumentNullException.ThrowIfNull(localFilePath, nameof(localFilePath));
 
             // Open file exclusively for read-sharing
             return FileUtility.Instance.File.Open(localFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
@@ -498,10 +492,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         /// </summary>
         protected static Stream GetFileWriteStream(string localFilePath, bool fileExists)
         {
-            if (localFilePath == null)
-            {
-                throw new ArgumentNullException(nameof(localFilePath));
-            }
+            ArgumentNullException.ThrowIfNull(localFilePath, nameof(localFilePath));
 
             // Create path if item doesn't already exist
             if (!fileExists)
@@ -518,10 +509,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         /// </summary>
         private static Stream GetFileDeleteStream(FileInfoBase file)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
+            ArgumentNullException.ThrowIfNull(file, nameof(file));
 
             // Open file exclusively for delete sharing only
             return file.Open(FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
@@ -532,10 +520,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         /// </summary>
         private static Microsoft.Net.Http.Headers.EntityTagHeaderValue CreateEntityTag(FileSystemInfoBase sysInfo)
         {
-            if (sysInfo == null)
-            {
-                throw new ArgumentNullException(nameof(sysInfo));
-            }
+            ArgumentNullException.ThrowIfNull(sysInfo, nameof(sysInfo));
 
             var etag = BitConverter.GetBytes(sysInfo.LastWriteTimeUtc.Ticks);
 

--- a/src/WebJobs.Script.WebHost/Management/VirtualFileSystem.cs
+++ b/src/WebJobs.Script.WebHost/Management/VirtualFileSystem.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
         protected virtual Task<HttpResponseMessage> CreateDirectoryGetResponse(HttpRequest request, DirectoryInfoBase info, string localFilePath)
         {
-            ArgumentNullException.ThrowIfNull(info, nameof(info));
+            ArgumentNullException.ThrowIfNull(info);
 
             try
             {
@@ -481,7 +481,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         /// </summary>
         protected static Stream GetFileReadStream(string localFilePath)
         {
-            ArgumentNullException.ThrowIfNull(localFilePath, nameof(localFilePath));
+            ArgumentNullException.ThrowIfNull(localFilePath);
 
             // Open file exclusively for read-sharing
             return FileUtility.Instance.File.Open(localFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
@@ -492,7 +492,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         /// </summary>
         protected static Stream GetFileWriteStream(string localFilePath, bool fileExists)
         {
-            ArgumentNullException.ThrowIfNull(localFilePath, nameof(localFilePath));
+            ArgumentNullException.ThrowIfNull(localFilePath);
 
             // Create path if item doesn't already exist
             if (!fileExists)
@@ -509,7 +509,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         /// </summary>
         private static Stream GetFileDeleteStream(FileInfoBase file)
         {
-            ArgumentNullException.ThrowIfNull(file, nameof(file));
+            ArgumentNullException.ThrowIfNull(file);
 
             // Open file exclusively for delete sharing only
             return file.Open(FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
@@ -520,7 +520,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         /// </summary>
         private static Microsoft.Net.Http.Headers.EntityTagHeaderValue CreateEntityTag(FileSystemInfoBase sysInfo)
         {
-            ArgumentNullException.ThrowIfNull(sysInfo, nameof(sysInfo));
+            ArgumentNullException.ThrowIfNull(sysInfo);
 
             var etag = BitConverter.GetBytes(sysInfo.LastWriteTimeUtc.Ticks);
 

--- a/src/WebJobs.Script.WebHost/Models/ApiModelUtility.cs
+++ b/src/WebJobs.Script.WebHost/Models/ApiModelUtility.cs
@@ -38,15 +38,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
 
         public static Link CreateLink(HttpRequest request, Uri resourceUri, string relation)
         {
-            if (resourceUri == null)
-            {
-                throw new ArgumentNullException(nameof(resourceUri));
-            }
-
-            if (relation == null)
-            {
-                throw new ArgumentNullException(nameof(relation));
-            }
+            ArgumentNullException.ThrowIfNull(resourceUri, nameof(resourceUri));
+            ArgumentNullException.ThrowIfNull(relation, nameof(relation));
 
             return new Link
             {

--- a/src/WebJobs.Script.WebHost/Models/ApiModelUtility.cs
+++ b/src/WebJobs.Script.WebHost/Models/ApiModelUtility.cs
@@ -38,8 +38,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
 
         public static Link CreateLink(HttpRequest request, Uri resourceUri, string relation)
         {
-            ArgumentNullException.ThrowIfNull(resourceUri, nameof(resourceUri));
-            ArgumentNullException.ThrowIfNull(relation, nameof(relation));
+            ArgumentNullException.ThrowIfNull(resourceUri);
+            ArgumentNullException.ThrowIfNull(relation);
 
             return new Link
             {

--- a/src/WebJobs.Script.WebHost/Models/FileCallbackResult.cs
+++ b/src/WebJobs.Script.WebHost/Models/FileCallbackResult.cs
@@ -39,10 +39,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
         public FileCallbackResult(MediaTypeHeaderValue contentType, Func<Stream, ActionContext, Task> callback)
             : base(contentType?.ToString())
         {
-            if (callback == null)
-            {
-                throw new ArgumentNullException(nameof(callback));
-            }
+            ArgumentNullException.ThrowIfNull(callback, nameof(callback));
 
             Callback = callback;
         }
@@ -59,10 +56,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
 
             set
             {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
+                ArgumentNullException.ThrowIfNull(value, nameof(value));
 
                 _callback = value;
             }
@@ -71,10 +65,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
         /// <inheritdoc />
         public override Task ExecuteResultAsync(ActionContext context)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context, nameof(context));
 
             var executor = new FileCallbackResultExecutor(context.HttpContext.RequestServices.GetRequiredService<ILoggerFactory>());
             return executor.ExecuteAsync(context, this);

--- a/src/WebJobs.Script.WebHost/Models/FileCallbackResult.cs
+++ b/src/WebJobs.Script.WebHost/Models/FileCallbackResult.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
         public FileCallbackResult(MediaTypeHeaderValue contentType, Func<Stream, ActionContext, Task> callback)
             : base(contentType?.ToString())
         {
-            ArgumentNullException.ThrowIfNull(callback, nameof(callback));
+            ArgumentNullException.ThrowIfNull(callback);
 
             Callback = callback;
         }
@@ -56,8 +56,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
 
             set
             {
-                ArgumentNullException.ThrowIfNull(value, nameof(value));
-
+                ArgumentNullException.ThrowIfNull(value);
                 _callback = value;
             }
         }
@@ -65,7 +64,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
         /// <inheritdoc />
         public override Task ExecuteResultAsync(ActionContext context)
         {
-            ArgumentNullException.ThrowIfNull(context, nameof(context));
+            ArgumentNullException.ThrowIfNull(context);
 
             var executor = new FileCallbackResultExecutor(context.HttpContext.RequestServices.GetRequiredService<ILoggerFactory>());
             return executor.ExecuteAsync(context, this);

--- a/src/WebJobs.Script.WebHost/Scale/TableStorageScaleMetricsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Scale/TableStorageScaleMetricsRepository.cs
@@ -396,10 +396,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         private static bool IsNotFoundTableNotFound(StorageException exception)
         {
-            if (exception == null)
-            {
-                throw new ArgumentNullException(nameof(exception));
-            }
+            ArgumentNullException.ThrowIfNull(exception, nameof(exception));
 
             var result = exception.RequestInformation;
             if (result == null)

--- a/src/WebJobs.Script.WebHost/Scale/TableStorageScaleMetricsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Scale/TableStorageScaleMetricsRepository.cs
@@ -396,7 +396,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         private static bool IsNotFoundTableNotFound(StorageException exception)
         {
-            ArgumentNullException.ThrowIfNull(exception, nameof(exception));
+            ArgumentNullException.ThrowIfNull(exception);
 
             var result = exception.RequestInformation;
             if (result == null)

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/BaseSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/BaseSecretsRepository.cs
@@ -23,14 +23,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         public BaseSecretsRepository(string secretsSentinelFilePath, ILogger logger, IEnvironment environment)
         {
-            if (secretsSentinelFilePath == null)
-            {
-                throw new ArgumentNullException(nameof(secretsSentinelFilePath));
-            }
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
+            ArgumentNullException.ThrowIfNull(secretsSentinelFilePath, nameof(secretsSentinelFilePath));
+            ArgumentNullException.ThrowIfNull(logger, nameof(logger));
 
             _secretsSentinelFilePath = secretsSentinelFilePath;
             Logger = logger;

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/BaseSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/BaseSecretsRepository.cs
@@ -23,8 +23,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         public BaseSecretsRepository(string secretsSentinelFilePath, ILogger logger, IEnvironment environment)
         {
-            ArgumentNullException.ThrowIfNull(secretsSentinelFilePath, nameof(secretsSentinelFilePath));
-            ArgumentNullException.ThrowIfNull(logger, nameof(logger));
+            ArgumentNullException.ThrowIfNull(secretsSentinelFilePath);
+            ArgumentNullException.ThrowIfNull(logger);
 
             _secretsSentinelFilePath = secretsSentinelFilePath;
             Logger = logger;

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/BlobStorageSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/BlobStorageSecretsRepository.cs
@@ -29,18 +29,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         public BlobStorageSecretsRepository(string secretSentinelDirectoryPath, string accountConnection, string siteSlotName, ILogger logger, IEnvironment environment, IAzureBlobStorageProvider azureBlobStorageProvider)
             : base(secretSentinelDirectoryPath, logger, environment)
         {
-            if (secretSentinelDirectoryPath == null)
-            {
-                throw new ArgumentNullException(nameof(secretSentinelDirectoryPath));
-            }
-            if (accountConnection == null)
-            {
-                throw new ArgumentNullException(nameof(accountConnection));
-            }
-            if (siteSlotName == null)
-            {
-                throw new ArgumentNullException(nameof(siteSlotName));
-            }
+            ArgumentNullException.ThrowIfNull(secretSentinelDirectoryPath, nameof(secretSentinelDirectoryPath));
+            ArgumentNullException.ThrowIfNull(accountConnection, nameof(accountConnection));
+            ArgumentNullException.ThrowIfNull(siteSlotName, nameof(siteSlotName));
 
             _secretsBlobPath = siteSlotName.ToLowerInvariant();
             _hostSecretsBlobPath = string.Format("{0}/{1}", _secretsBlobPath, ScriptConstants.HostMetadataFileName);
@@ -110,10 +101,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         public override async Task WriteAsync(ScriptSecretsType type, string functionName, ScriptSecrets secrets)
         {
-            if (secrets == null)
-            {
-                throw new ArgumentNullException(nameof(secrets));
-            }
+            ArgumentNullException.ThrowIfNull(secrets, nameof(secrets));
 
             string blobPath = GetSecretsBlobPath(type, functionName);
             try
@@ -132,10 +120,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         public override async Task WriteSnapshotAsync(ScriptSecretsType type, string functionName, ScriptSecrets secrets)
         {
-            if (secrets == null)
-            {
-                throw new ArgumentNullException(nameof(secrets));
-            }
+            ArgumentNullException.ThrowIfNull(secrets, nameof(secrets));
 
             string blobPath = GetSecretsBlobPath(type, functionName);
             blobPath = SecretsUtility.GetNonDecryptableName(blobPath);

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/BlobStorageSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/BlobStorageSecretsRepository.cs
@@ -29,9 +29,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         public BlobStorageSecretsRepository(string secretSentinelDirectoryPath, string accountConnection, string siteSlotName, ILogger logger, IEnvironment environment, IAzureBlobStorageProvider azureBlobStorageProvider)
             : base(secretSentinelDirectoryPath, logger, environment)
         {
-            ArgumentNullException.ThrowIfNull(secretSentinelDirectoryPath, nameof(secretSentinelDirectoryPath));
-            ArgumentNullException.ThrowIfNull(accountConnection, nameof(accountConnection));
-            ArgumentNullException.ThrowIfNull(siteSlotName, nameof(siteSlotName));
+            ArgumentNullException.ThrowIfNull(secretSentinelDirectoryPath);
+            ArgumentNullException.ThrowIfNull(accountConnection);
+            ArgumentNullException.ThrowIfNull(siteSlotName);
 
             _secretsBlobPath = siteSlotName.ToLowerInvariant();
             _hostSecretsBlobPath = string.Format("{0}/{1}", _secretsBlobPath, ScriptConstants.HostMetadataFileName);
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         public override async Task WriteAsync(ScriptSecretsType type, string functionName, ScriptSecrets secrets)
         {
-            ArgumentNullException.ThrowIfNull(secrets, nameof(secrets));
+            ArgumentNullException.ThrowIfNull(secrets);
 
             string blobPath = GetSecretsBlobPath(type, functionName);
             try
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         public override async Task WriteSnapshotAsync(ScriptSecretsType type, string functionName, ScriptSecrets secrets)
         {
-            ArgumentNullException.ThrowIfNull(secrets, nameof(secrets));
+            ArgumentNullException.ThrowIfNull(secrets);
 
             string blobPath = GetSecretsBlobPath(type, functionName);
             blobPath = SecretsUtility.GetNonDecryptableName(blobPath);

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/DefaultSecretManagerProvider.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/DefaultSecretManagerProvider.cs
@@ -31,10 +31,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         public DefaultSecretManagerProvider(IOptionsMonitor<ScriptApplicationHostOptions> options, IHostIdProvider hostIdProvider,
             IConfiguration configuration, IEnvironment environment, ILoggerFactory loggerFactory, IMetricsLogger metricsLogger, HostNameProvider hostNameProvider, StartupContextProvider startupContextProvider, IAzureBlobStorageProvider azureBlobStorageProvider)
         {
-            if (loggerFactory == null)
-            {
-                throw new ArgumentNullException(nameof(loggerFactory));
-            }
+            ArgumentNullException.ThrowIfNull(loggerFactory, nameof(loggerFactory));
 
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _hostIdProvider = hostIdProvider ?? throw new ArgumentNullException(nameof(hostIdProvider));

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/DefaultSecretManagerProvider.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/DefaultSecretManagerProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         public DefaultSecretManagerProvider(IOptionsMonitor<ScriptApplicationHostOptions> options, IHostIdProvider hostIdProvider,
             IConfiguration configuration, IEnvironment environment, ILoggerFactory loggerFactory, IMetricsLogger metricsLogger, HostNameProvider hostNameProvider, StartupContextProvider startupContextProvider, IAzureBlobStorageProvider azureBlobStorageProvider)
         {
-            ArgumentNullException.ThrowIfNull(loggerFactory, nameof(loggerFactory));
+            ArgumentNullException.ThrowIfNull(loggerFactory);
 
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _hostIdProvider = hostIdProvider ?? throw new ArgumentNullException(nameof(hostIdProvider));

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/FileSystemSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/FileSystemSecretsRepository.cs
@@ -24,10 +24,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         public FileSystemSecretsRepository(string secretsPath, ILogger logger, IEnvironment environment) : base(secretsPath, logger, environment)
         {
-            if (secretsPath == null)
-            {
-                throw new ArgumentNullException(nameof(secretsPath));
-            }
+            ArgumentNullException.ThrowIfNull(secretsPath, nameof(secretsPath));
 
             _secretsPath = secretsPath;
             _hostSecretsPath = Path.Combine(_secretsPath, ScriptConstants.HostMetadataFileName);

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/FileSystemSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/FileSystemSecretsRepository.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         public FileSystemSecretsRepository(string secretsPath, ILogger logger, IEnvironment environment) : base(secretsPath, logger, environment)
         {
-            ArgumentNullException.ThrowIfNull(secretsPath, nameof(secretsPath));
+            ArgumentNullException.ThrowIfNull(secretsPath);
 
             _secretsPath = secretsPath;
             _hostSecretsPath = Path.Combine(_secretsPath, ScriptConstants.HostMetadataFileName);

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/KubernetesSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/KubernetesSecretsRepository.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         {
             if (type == ScriptSecretsType.Function && string.IsNullOrEmpty(functionName))
             {
-                throw new ArgumentNullException($"{nameof(functionName)} cannot be null or empty with {nameof(type)} = {nameof(ScriptSecretsType.Function)}");
+                throw new ArgumentNullException(nameof(functionName), $"{nameof(functionName)} cannot be null or empty with {nameof(type)} = {nameof(ScriptSecretsType.Function)}");
             }
 
             functionName = functionName?.ToLowerInvariant();
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
             if (type == ScriptSecretsType.Function && string.IsNullOrEmpty(functionName))
             {
-                throw new ArgumentNullException($"{nameof(functionName)} cannot be null or empty with {nameof(type)} = {nameof(ScriptSecretsType.Function)}");
+                throw new ArgumentNullException(nameof(functionName), $"{nameof(functionName)} cannot be null or empty with {nameof(type)} = {nameof(ScriptSecretsType.Function)}");
             }
 
             functionName = functionName?.ToLowerInvariant();

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -62,10 +62,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             HostPerformanceManager hostPerformanceManager, IOptions<HostHealthMonitorOptions> healthMonitorOptions,
             IMetricsLogger metricsLogger, IApplicationLifetime applicationLifetime, IConfiguration config)
         {
-            if (loggerFactory == null)
-            {
-                throw new ArgumentNullException(nameof(loggerFactory));
-            }
+            ArgumentNullException.ThrowIfNull(loggerFactory, nameof(loggerFactory));
 
             // This will no-op if already initialized.
             InitializeApplicationInsightsRequestTracking();

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             HostPerformanceManager hostPerformanceManager, IOptions<HostHealthMonitorOptions> healthMonitorOptions,
             IMetricsLogger metricsLogger, IApplicationLifetime applicationLifetime, IConfiguration config)
         {
-            ArgumentNullException.ThrowIfNull(loggerFactory, nameof(loggerFactory));
+            ArgumentNullException.ThrowIfNull(loggerFactory);
 
             // This will no-op if already initialized.
             InitializeApplicationInsightsRequestTracking();

--- a/src/WebJobs.Script/Binding/Manual/ManualTriggerAttributeBindingProvider.cs
+++ b/src/WebJobs.Script/Binding/Manual/ManualTriggerAttributeBindingProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
         {
             if (context == null)
             {
-                throw new ArgumentNullException("context");
+                throw new ArgumentNullException(nameof(context));
             }
 
             ParameterInfo parameter = context.Parameter;
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
             {
                 if (context == null)
                 {
-                    throw new ArgumentNullException("context");
+                    throw new ArgumentNullException(nameof(context));
                 }
 
                 return Task.FromResult<IListener>(new NullListener());

--- a/src/WebJobs.Script/Binding/ValueBinder.cs
+++ b/src/WebJobs.Script/Binding/ValueBinder.cs
@@ -65,11 +65,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Bindings
         {
             if (parameter == null)
             {
-                throw new ArgumentNullException("parameter");
+                throw new ArgumentNullException(nameof(parameter));
             }
             if (types == null)
             {
-                throw new ArgumentNullException("types");
+                throw new ArgumentNullException(nameof(types));
             }
 
             if (parameter.IsOut)

--- a/src/WebJobs.Script/Description/DotNet/DotNetFunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/DotNet/DotNetFunctionDescriptorProvider.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         {
             if (functionMetadata == null)
             {
-                throw new ArgumentNullException("functionMetadata");
+                throw new ArgumentNullException(nameof(functionMetadata));
             }
 
             // We can only handle script types supported by the current compilation service factory
@@ -85,19 +85,19 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         {
             if (functionInvoker == null)
             {
-                throw new ArgumentNullException("functionInvoker");
+                throw new ArgumentNullException(nameof(functionInvoker));
             }
             if (functionMetadata == null)
             {
-                throw new ArgumentNullException("functionMetadata");
+                throw new ArgumentNullException(nameof(functionMetadata));
             }
             if (triggerMetadata == null)
             {
-                throw new ArgumentNullException("triggerMetadata");
+                throw new ArgumentNullException(nameof(triggerMetadata));
             }
             if (methodAttributes == null)
             {
-                throw new ArgumentNullException("methodAttributes");
+                throw new ArgumentNullException(nameof(methodAttributes));
             }
 
             var dotNetInvoker = functionInvoker as DotNetFunctionInvoker;

--- a/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
@@ -93,19 +93,19 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         {
             if (functionInvoker == null)
             {
-                throw new ArgumentNullException("functionInvoker");
+                throw new ArgumentNullException(nameof(functionInvoker));
             }
             if (functionMetadata == null)
             {
-                throw new ArgumentNullException("functionMetadata");
+                throw new ArgumentNullException(nameof(functionMetadata));
             }
             if (triggerMetadata == null)
             {
-                throw new ArgumentNullException("triggerMetadata");
+                throw new ArgumentNullException(nameof(triggerMetadata));
             }
             if (methodAttributes == null)
             {
-                throw new ArgumentNullException("methodAttributes");
+                throw new ArgumentNullException(nameof(methodAttributes));
             }
 
             ApplyMethodLevelAttributes(functionMetadata, triggerMetadata, methodAttributes);
@@ -245,7 +245,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         {
             if (trigger == null)
             {
-                throw new ArgumentNullException("trigger");
+                throw new ArgumentNullException(nameof(trigger));
             }
 
             if (triggerParameterType == null)

--- a/src/WebJobs.Script/Description/FunctionGenerator.cs
+++ b/src/WebJobs.Script/Description/FunctionGenerator.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         {
             if (functions == null)
             {
-                throw new ArgumentNullException("functions");
+                throw new ArgumentNullException(nameof(functions));
             }
 
             AssemblyName assemblyName = new AssemblyName(functionAssemblyName);

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -846,7 +846,7 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             if (exception == null)
             {
-                throw new ArgumentNullException("exception");
+                throw new ArgumentNullException(nameof(exception));
             }
 
             // Note: We do not log to ILogger here as any error has already been logged.

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -48,10 +48,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public static Task WaitOneAsync(this WaitHandle waitHandle)
         {
-            if (waitHandle == null)
-            {
-                throw new ArgumentNullException("waitHandle");
-            }
+            ArgumentNullException.ThrowIfNull(waitHandle, nameof(waitHandle));
 
             var tcs = new TaskCompletionSource<bool>();
             var rwh = ThreadPool.RegisterWaitForSingleObject(waitHandle,

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public static Task WaitOneAsync(this WaitHandle waitHandle)
         {
-            ArgumentNullException.ThrowIfNull(waitHandle, nameof(waitHandle));
+            ArgumentNullException.ThrowIfNull(waitHandle);
 
             var tcs = new TaskCompletionSource<bool>();
             var rwh = ThreadPool.RegisterWaitForSingleObject(waitHandle,

--- a/test/WebJobs.Script.Tests/TestUtils.cs
+++ b/test/WebJobs.Script.Tests/TestUtils.cs
@@ -91,10 +91,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 return true;
             }
 
-            if (stream1 == null || stream2 == null)
-            {
-                throw new ArgumentNullException(stream1 == null ? "stream1" : "stream2");
-            }
+            ArgumentNullException.ThrowIfNull(stream1, nameof(stream1));
+            ArgumentNullException.ThrowIfNull(stream2, nameof(stream2));
 
             if (stream1.Length != stream2.Length)
             {

--- a/test/WebJobs.Script.Tests/TestUtils.cs
+++ b/test/WebJobs.Script.Tests/TestUtils.cs
@@ -91,8 +91,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 return true;
             }
 
-            ArgumentNullException.ThrowIfNull(stream1, nameof(stream1));
-            ArgumentNullException.ThrowIfNull(stream2, nameof(stream2));
+            ArgumentNullException.ThrowIfNull(stream1);
+            ArgumentNullException.ThrowIfNull(stream2);
 
             if (stream1.Length != stream2.Length)
             {


### PR DESCRIPTION
Extension of discussions around #7908. This is a (very minor) performance improvement available in .NET 6 to allow JIT inlining in some paths that couldn't be before, due to the presence of a `throw`. When a method contains a `throw` directly, it cannot be inlined. Generally, this won't be a huge percentage win in a web app, but it all adds up.

Note: there are more places in bindings that could benefit more, but I'm not sure what the customer dependency story on WebJobs.Script is and if we can readily add a `net6.0` TFM there - needs input and so I didn't change it beyond cleanup here. If we're okay adding a `net6.0` build for WebJobs.Script - we can get a likely get a bit more out of inlining on some hot binding paths.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

Benchmarking old vs. new (2 core Linux) - this was the median of 3x 5 minute runs but still, I expect the wins to be slightly over-stated here.

| application                             | exp-lin-2-baseline | exp-lin-2-exp |         |
| --------------------------------------- | ------------------ | ------------- | ------- |
| CPU Usage (%)                           |                  7 |             7 |   0.00% |
| Cores usage (%)                         |                201 |           201 |   0.00% |
| Working Set (MB)                        |                387 |           379 |  -2.07% |
| Private Memory (MB)                     |              1,209 |         1,207 |  -0.17% |
| Build Time (ms)                         |             17,206 |        18,726 |  +8.83% |
| Start Time (ms)                         |              6,892 |         6,840 |  -0.75% |
| Published Size (KB)                     |            674,603 |       674,602 |  -0.00% |
| .NET Core SDK Version                   |            6.0.100 |       6.0.100 |         |
| Max CPU Usage (%)                       |                100 |           100 |   0.00% |
| Max Working Set (MB)                    |                405 |           396 |  -2.22% |
| Max GC Heap Size (MB)                   |                154 |           136 | -11.69% |
| Size of committed memory by the GC (MB) |                202 |           194 |  -3.96% |
| Max Number of Gen 0 GCs / sec           |               7.00 |         11.00 | +57.14% |
| Max Number of Gen 1 GCs / sec           |               3.00 |          3.00 |   0.00% |
| Max Number of Gen 2 GCs / sec           |               2.00 |          1.00 | -50.00% |
| Max Time in GC (%)                      |               7.00 |          7.00 |   0.00% |
| Max Gen 0 Size (B)                      |         93,547,448 |   101,799,152 |  +8.82% |
| Max Gen 1 Size (B)                      |         14,140,984 |    17,950,184 | +26.94% |
| Max Gen 2 Size (B)                      |         49,181,024 |    53,466,608 |  +8.71% |
| Max LOH Size (B)                        |          8,010,448 |     8,141,576 |  +1.64% |
| Max Allocation Rate (B/sec)             |        333,588,552 |   340,979,992 |  +2.22% |
| Max GC Heap Fragmentation               |                 80 |            80 |  -0.03% |
| # of Assemblies Loaded                  |                212 |           212 |   0.00% |
| Max Exceptions (#/s)                    |                281 |           264 |  -6.05% |
| Max Lock Contention (#/s)               |                116 |           132 | +13.79% |
| Max ThreadPool Threads Count            |                 32 |            32 |   0.00% |
| Max ThreadPool Queue Length             |                 95 |            95 |   0.00% |
| Max ThreadPool Items (#/s)              |             34,081 |        34,367 |  +0.84% |
| Max Active Timers                       |                100 |           106 |  +6.00% |
| IL Jitted (B)                           |          1,246,571 |     1,245,818 |  -0.06% |
| Methods Jitted                          |             12,924 |        12,914 |  -0.08% |


| load                   | exp-lin-2-baseline | exp-lin-2-exp |         |
| ---------------------- | ------------------ | ------------- | ------- |
| CPU Usage (%)          |                  1 |             1 |   0.00% |
| Cores usage (%)        |                 35 |            36 |  +2.86% |
| Working Set (MB)       |                 37 |            37 |   0.00% |
| Private Memory (MB)    |                357 |           357 |   0.00% |
| Start Time (ms)        |                  0 |             0 |         |
| First Request (ms)     |                329 |           328 |  -0.30% |
| Requests/sec           |              7,547 |         7,632 |  +1.13% |
| Requests               |          2,264,753 |     2,290,401 |  +1.13% |
| Mean latency (ms)      |              14.53 |         14.20 |  -2.27% |
| Max latency (ms)       |             323.35 |        224.72 | -30.50% |
| Bad responses          |                  0 |             0 |         |
| Socket errors          |                  0 |             0 |         |
| Read throughput (MB/s) |               1.16 |          1.17 |  +0.86% |
| Latency 50th (ms)      |              10.79 |         10.70 |  -0.83% |
| Latency 75th (ms)      |              16.74 |         16.35 |  -2.33% |
| Latency 90th (ms)      |              28.45 |         27.57 |  -3.09% |
| Latency 99th (ms)      |              63.91 |         60.25 |  -5.73% |