### PR TITLE
Do not upload V2SiteExtension .Does not exist

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -275,8 +275,6 @@ jobs:
     displayName: 'Delete CodeSignSummary files'
     inputs:
       contents: '**\CodeSignSummary-*.md'
-  - publish: $(Build.ArtifactStagingDirectory)\V2SiteExtension
-    artifact: V2SiteExtension
   - publish: $(Build.ArtifactStagingDirectory)\SiteExtension
     artifact: SiteExtension
   - publish: $(Build.ArtifactStagingDirectory)\ZippedPatchSiteExtension


### PR DESCRIPTION
Commit # 30e42d3929f6a7cfa1b86c65a2b8d638d6c5e13b deleted building V2 Site Extension. Fixing pipeline- delete upload step for V2 Site extension