### PR TITLE
Samples: add a benchmarkable sample

### DIFF
--- a/sample/CSharpBenchmark/HttpTriggerAnon/function.json
+++ b/sample/CSharpBenchmark/HttpTriggerAnon/function.json
@@ -1,0 +1,16 @@
+{
+    "bindings": [
+        {
+            "type": "httpTrigger",
+            "authLevel": "anonymous",
+            "name": "req",
+            "direction": "in",
+            "methods": [ "get" ]
+        },
+        {
+            "type": "http",
+            "name": "$return",
+            "direction": "out"
+        }
+    ]
+}

--- a/sample/CSharpBenchmark/HttpTriggerAnon/run.csx
+++ b/sample/CSharpBenchmark/HttpTriggerAnon/run.csx
@@ -1,0 +1,15 @@
+﻿using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
+
+public static IActionResult Run(HttpRequest req, TraceWriter log)
+{
+    log.Info("C# HTTP trigger function processed a request.");
+
+    if (req.Query.TryGetValue("name", out StringValues value))
+    {
+        return new OkObjectResult($"Hello {value.ToString()}");
+    }
+
+    return new BadRequestObjectResult("Please pass a name on the query string or in the request body");
+}

--- a/sample/CSharpBenchmark/host.json
+++ b/sample/CSharpBenchmark/host.json
@@ -1,0 +1,27 @@
+{
+    "version": "2.0",
+    "watchDirectories": [ "Shared", "Test" ],
+    "healthMonitor": {
+        "enabled": true,
+        "healthCheckInterval": "00:00:10",
+        "healthCheckWindow": "00:02:00",
+        "healthCheckThreshold": 6,
+        "counterThreshold": 0.80
+    },
+    "functionTimeout": "00:05:00",
+    "logging": {
+        "fileLoggingMode": "never",
+        "console": {
+            "isEnabled": false
+        }
+    },
+    "extensions": {
+        "http": {
+            "routePrefix": "api"
+        },
+        "queues": {
+            "visibilityTimeout": "00:00:10",
+            "maxDequeueCount": 3
+        }
+    }
+}


### PR DESCRIPTION
This would allow us to run Crank benchmarks against the branch without modifications. Currently the `Samples/CSharp` path has throttling limiting throughput as well as authentication, which means effectively we can't pull the `dev` branch and benchmark it. Today to benchmark we need to mutate the baseline branch (removing or changing auth) and do the same to the proposed branch (so that it's not in the proposed PR), meaning we have 3 new branches to baseline 1 against `dev` every time...let's fix that!

It'd be better if we could test authentication with a known key so that we're invoking the authentication path as well, but I'm unsure how to do this (couldn't find it in docs). @fabiocav has ideas - but maybe this can go in as-is and we add the authenticated one beside it so we have benchmarks for both available as neighboring endpoints?

This would unblock me much more easily adding baseline vs. new benchmarks in performance PRs.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
