### PR TITLE
Performance: WebHostServiceProvider: remove unused bits

### DIFF
--- a/src/WebJobs.Script.WebHost/DependencyInjection/WebHostServiceProvider.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/WebHostServiceProvider.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
     {
         private static readonly Rules _defaultContainerRules;
         private readonly Container _container;
-        private ScopedResolver _currentResolver;
 
         static WebHostServiceProvider()
         {
@@ -37,8 +36,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
             _container.Populate(descriptors);
             _container.UseInstance<IServiceProvider>(this);
             _container.UseInstance<IServiceScopeFactory>(this);
-
-            _currentResolver = new ScopedResolver(_container);
         }
 
         public object GetService(Type serviceType)


### PR DESCRIPTION
This appears to just be leftover after the last usages were removed in 52e1911f173df3be030da75b261e5ec21b6f6a0c - noticed it digging into DI performance a bit. Ultimately, this is just 1 allocation and not that impactful, but for code clarity sake too I figured let's clean it up real quick.

There are other areas where we're resolving more services for constructors then we're using (again just leftovers over history), going to look at those next.

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
