### PR TITLE
Fix: Exception logging .LogError() calls

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/BashCommandHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/BashCommandHandler.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
             }
             catch (Exception e)
             {
-                _logger.LogError("Error running bash", e);
+                _logger.LogError(e, "Error running bash");
             }
 
             return (string.Empty, string.Empty, -1);

--- a/src/WebJobs.Script/Scale/HostPerformanceManager.cs
+++ b/src/WebJobs.Script/Scale/HostPerformanceManager.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.WebJobs.Script.Scale
                 }
                 catch (JsonReaderException ex)
                 {
-                    logger.LogError($"Failed to deserialize application performance counters. JSON Content: \"{json}\"", ex);
+                    logger.LogError(ex, "Failed to deserialize application performance counters. JSON Content: \"{json}\"", json);
                 }
             }
 


### PR DESCRIPTION
This was something I noticed looking through, we have a few instances of `.LogError()` inadvertently using the `(string message, params object[] args)` overload. These aren't actually logging the exception, just passing it (unused) into the formatting - quick fix PR!

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
