### PR TITLE
Performance: String papercuts

### DIFF
--- a/src/WebJobs.Script.WebHost/Configuration/WebScriptHostConfigurationSource.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/WebScriptHostConfigurationSource.cs
@@ -56,9 +56,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
                 {
                     // Local hosting or Linux container scenarios
                     Data[WebHostScriptPathProperty] = GetOrDefault(EnvironmentSettingNames.AzureWebJobsScriptRoot, Environment.CurrentDirectory);
-                    Data[LogPathProperty] = GetOrDefault(EnvironmentSettingNames.FunctionsLogPath, Path.Combine(Path.GetTempPath(), @"Functions"));
+                    Data[LogPathProperty] = GetOrDefault(EnvironmentSettingNames.FunctionsLogPath, Path.Combine(Path.GetTempPath(), "Functions"));
                     Data[SecretsPathProperty] = GetOrDefault(EnvironmentSettingNames.FunctionsSecretsPath, Path.Combine(AppContext.BaseDirectory, "Secrets"));
-                    Data[TestDataPathProperty] = GetOrDefault(EnvironmentSettingNames.FunctionsTestDataPath, Path.Combine(Path.GetTempPath(), @"FunctionsData"));
+                    Data[TestDataPathProperty] = GetOrDefault(EnvironmentSettingNames.FunctionsTestDataPath, Path.Combine(Path.GetTempPath(), "FunctionsData"));
                 }
 
                 string GetOrDefault(string variableName, string @default)

--- a/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerActivityPublisher.cs
+++ b/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerActivityPublisher.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
             }
             catch (Exception exc) when (!exc.IsFatal())
             {
-                _logger.LogError(exc, $"{nameof(FlushFunctionExecutionActivities)}");
+                _logger.LogError(exc, nameof(FlushFunctionExecutionActivities));
             }
         }
 
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
             }
             catch (Exception e)
             {
-                _logger.LogError(e, $"{nameof(SetTimerInterval)}");
+                _logger.LogError(e, nameof(SetTimerInterval));
             }
         }
 

--- a/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/FunctionsController.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                 // if we don't have any errors registered, make sure the function exists
                 // before returning empty errors
                 var result = await _functionsManager.GetFunctionsMetadata();
-                var function = result.FirstOrDefault(p => p.Name.ToLowerInvariant() == name.ToLowerInvariant());
+                var function = result.FirstOrDefault(p => string.Equals(p.Name, name, System.StringComparison.InvariantCultureIgnoreCase));
                 if (function == null)
                 {
                     return NotFound();

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
@@ -19,11 +19,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             _hostNameProvider = hostNameProvider ?? throw new ArgumentNullException(nameof(hostNameProvider));
         }
 
-        public static string TraceEventRegex { get; } = $"(?<Level>[0-6]),(?<SubscriptionId>[^,]*),(?<HostName>[^,]*),(?<AppName>[^,]*),(?<FunctionName>[^,]*),(?<EventName>[^,]*),(?<Source>[^,]*),\"(?<Details>.*)\",\"(?<Summary>.*)\",(?<HostVersion>[^,]*),(?<EventTimestamp>[^,]+),(?<ExceptionType>[^,]*),\"(?<ExceptionMessage>.*)\",(?<FunctionInvocationId>[^,]*),(?<HostInstanceId>[^,]*),(?<ActivityId>[^,\"]*)";
+        public static string TraceEventRegex { get; } = "(?<Level>[0-6]),(?<SubscriptionId>[^,]*),(?<HostName>[^,]*),(?<AppName>[^,]*),(?<FunctionName>[^,]*),(?<EventName>[^,]*),(?<Source>[^,]*),\"(?<Details>.*)\",\"(?<Summary>.*)\",(?<HostVersion>[^,]*),(?<EventTimestamp>[^,]+),(?<ExceptionType>[^,]*),\"(?<ExceptionMessage>.*)\",(?<FunctionInvocationId>[^,]*),(?<HostInstanceId>[^,]*),(?<ActivityId>[^,\"]*)";
 
-        public static string MetricEventRegex { get; } = $"(?<SubscriptionId>[^,]*),(?<AppName>[^,]*),(?<FunctionName>[^,]*),(?<EventName>[^,]*),(?<Average>\\d*),(?<Min>\\d*),(?<Max>\\d*),(?<Count>\\d*),(?<HostVersion>[^,]*),(?<EventTimestamp>[^,]+),(?<Details>[^,\"]*)";
+        public static string MetricEventRegex { get; } = "(?<SubscriptionId>[^,]*),(?<AppName>[^,]*),(?<FunctionName>[^,]*),(?<EventName>[^,]*),(?<Average>\\d*),(?<Min>\\d*),(?<Max>\\d*),(?<Count>\\d*),(?<HostVersion>[^,]*),(?<EventTimestamp>[^,]+),(?<Details>[^,\"]*)";
 
-        public static string DetailsEventRegex { get; } = $"(?<AppName>[^,]*),(?<FunctionName>[^,]*),\"(?<InputBindings>.*)\",\"(?<OutputBindings>.*)\",(?<ScriptType>[^,]*),(?<IsDisabled>[0|1])";
+        public static string DetailsEventRegex { get; } = "(?<AppName>[^,]*),(?<FunctionName>[^,]*),\"(?<InputBindings>.*)\",\"(?<OutputBindings>.*)\",(?<ScriptType>[^,]*),(?<IsDisabled>[0|1])";
 
         public static string AzureMonitorEventRegex { get; } = $"{ScriptConstants.LinuxAzureMonitorEventStreamName} (?<Level>[0-6]),(?<ResourceId>[^,]*),(?<OperationName>[^,]*),(?<Category>[^,]*),(?<RegionName>[^,]*),\"(?<Properties>[^,]*)\",(?<EventTimestamp>[^,]+)";
 

--- a/src/WebJobs.Script.WebHost/Extensions/FunctionMetadataExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Extensions/FunctionMetadataExtensions.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Extensions
 
         internal static Uri GetFunctionInvokeUrlTemplate(string baseUrl, FunctionMetadata functionMetadata, string routePrefix)
         {
-            var httpBinding = functionMetadata.InputBindings.FirstOrDefault(p => string.Compare(p.Type, "httpTrigger", StringComparison.OrdinalIgnoreCase) == 0);
+            var httpBinding = functionMetadata.InputBindings.FirstOrDefault(p => string.Equals(p.Type, "httpTrigger", StringComparison.OrdinalIgnoreCase));
 
             if (httpBinding != null)
             {

--- a/src/WebJobs.Script.WebHost/FileMonitoringService.cs
+++ b/src/WebJobs.Script.WebHost/FileMonitoringService.cs
@@ -281,7 +281,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             {
                 changeDescription = "Watched directory";
             }
-            else if (string.Compare(fileName, ScriptConstants.AppOfflineFileName, StringComparison.OrdinalIgnoreCase) == 0)
+            else if (string.Equals(fileName, ScriptConstants.AppOfflineFileName, StringComparison.OrdinalIgnoreCase))
             {
                 // app_offline.htm has changed
                 // when app_offline.htm is created, we trigger
@@ -316,7 +316,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 }
 
                 TraceFileChangeRestart(changeDescription, e.ChangeType.ToString(), e.FullPath, shutdown);
-                ScheduleRestartAsync(shutdown).ContinueWith(t => _logger.LogError($"Error restarting host (full shutdown: {shutdown})", t.Exception),
+                ScheduleRestartAsync(shutdown).ContinueWith(t => _logger.LogError(t.Exception, $"Error restarting host (full shutdown: {shutdown})"),
                     TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted);
             }
         }

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -350,8 +350,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 // Encryption is handled by Antares before storage
                 var secretsStorageType = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsSecretStorageType);
                 if (string.IsNullOrEmpty(secretsStorageType) ||
-                    string.Compare(secretsStorageType, "files", StringComparison.OrdinalIgnoreCase) == 0 ||
-                    string.Compare(secretsStorageType, "blob", StringComparison.OrdinalIgnoreCase) == 0)
+                    string.Equals(secretsStorageType, "files", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(secretsStorageType, "blob", StringComparison.OrdinalIgnoreCase))
                 {
                     var functionAppSecrets = new FunctionAppSecrets();
 
@@ -365,7 +365,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                     };
 
                     // add function secrets
-                    var httpFunctions = functionsMetadata.Where(p => p.InputBindings.Any(q => q.IsTrigger && string.Compare(q.Type, "httptrigger", StringComparison.OrdinalIgnoreCase) == 0)).Select(p => p.Name).ToArray();
+                    var httpFunctions = functionsMetadata.Where(p => p.InputBindings.Any(q => q.IsTrigger && string.Equals(q.Type, "httptrigger", StringComparison.OrdinalIgnoreCase))).Select(p => p.Name).ToArray();
                     functionAppSecrets.Function = new FunctionAppSecrets.FunctionSecrets[httpFunctions.Length];
                     for (int i = 0; i < httpFunctions.Length; i++)
                     {
@@ -687,7 +687,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
                 if (response.IsSuccessStatusCode)
                 {
-                    _logger.LogDebug($"SyncTriggers call succeeded.");
+                    _logger.LogDebug("SyncTriggers call succeeded.");
                     return (true, null);
                 }
                 else

--- a/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             }
             else
             {
-                _logger.LogError($"Missing ZipUrl and AzureFiles config. Continue with empty root.");
+                _logger.LogError("Missing ZipUrl and AzureFiles config. Continue with empty root.");
                 return null;
             }
         }
@@ -272,7 +272,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             }
             catch (Exception e)
             {
-                _logger.LogError(e, $"{nameof(ValidateAzureFilesContext)}");
+                _logger.LogError(e, nameof(ValidateAzureFilesContext));
                 return e.Message;
             }
         }

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
                 string bundlePath = Path.Combine(targetPath, "worker-bundle");
                 if (Directory.Exists(bundlePath))
                 {
-                    _logger.LogInformation($"Python worker bundle detected");
+                    _logger.LogInformation("Python worker bundle detected");
                 }
 
                 return true;

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/UnZipHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/UnZipHandler.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
             {
                 _logger.LogDebug($"Extracting files to '{scriptPath}'");
                 ZipFile.ExtractToDirectory(filePath, scriptPath, overwriteFiles: true);
-                _logger.LogDebug($"Zip extraction complete");
+                _logger.LogDebug("Zip extraction complete");
             }
         }
     }

--- a/src/WebJobs.Script.WebHost/Management/MeshServiceClient.cs
+++ b/src/WebJobs.Script.WebHost/Management/MeshServiceClient.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             }
             catch (Exception e)
             {
-                _logger.LogError(e, $"{nameof(PublishContainerActivity)}");
+                _logger.LogError(e, nameof(PublishContainerActivity));
             }
         }
 

--- a/src/WebJobs.Script.WebHost/Management/VirtualFileSystem.cs
+++ b/src/WebJobs.Script.WebHost/Management/VirtualFileSystem.cs
@@ -525,12 +525,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             var etag = BitConverter.GetBytes(sysInfo.LastWriteTimeUtc.Ticks);
 
             var result = new StringBuilder(2 + (etag.Length * 2));
-            result.Append("\"");
+            result.Append('"');
             foreach (byte b in etag)
             {
                 result.AppendFormat("{0:x2}", b);
             }
-            result.Append("\"");
+            result.Append('"');
             return new Microsoft.Net.Http.Headers.EntityTagHeaderValue(result.ToString());
         }
 

--- a/src/WebJobs.Script.WebHost/Middleware/SystemTraceMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/SystemTraceMiddleware.cs
@@ -65,14 +65,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
                     var claim = identity.Claims.FirstOrDefault(p => p.Type == SecurityConstants.AuthLevelClaimType);
                     if (claim != null)
                     {
-                        sbIdentity.AppendFormat(":{0}", claim.Value);
+                        sbIdentity.Append(':');
+                        sbIdentity.Append(claim.Value);
                     }
 
                     sbIdentities.Append(sbIdentity);
                 }
 
-                sbIdentities.Insert(0, "(");
-                sbIdentities.Append(")");
+                sbIdentities.Insert(0, '(');
+                sbIdentities.Append(')');
 
                 return sbIdentities.ToString();
             }

--- a/src/WebJobs.Script.WebHost/PreJIT/JitTraceRuntime.cs
+++ b/src/WebJobs.Script.WebHost/PreJIT/JitTraceRuntime.cs
@@ -20,11 +20,7 @@ namespace Microsoft.Diagnostics.JitTrace
 
         private static void LogOnFailure(string failure)
         {
-            var log = LogFailure;
-            if (log != null)
-            {
-                log(failure);
-            }
+            LogFailure?.Invoke(failure);
         }
 
         /// <summary>
@@ -97,11 +93,7 @@ namespace Microsoft.Diagnostics.JitTrace
                 try
                 {
                     methodString = jittraceStream.ReadLine();
-                    if (methodString == null)
-                    {
-                        break;
-                    }
-                    if (methodString.Trim() == string.Empty)
+                    if (string.IsNullOrWhiteSpace(methodString))
                     {
                         break;
                     }

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/BaseSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/BaseSecretsRepository.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             {
                 var args = new SecretsChangedEventArgs { SecretsType = ScriptSecretsType.Host };
 
-                if (string.Compare(Path.GetFileName(e.FullPath), ScriptConstants.HostMetadataFileName, StringComparison.OrdinalIgnoreCase) != 0)
+                if (!string.Equals(Path.GetFileName(e.FullPath), ScriptConstants.HostMetadataFileName, StringComparison.OrdinalIgnoreCase))
                 {
                     args.SecretsType = ScriptSecretsType.Function;
                     args.Name = Path.GetFileNameWithoutExtension(e.FullPath).ToLowerInvariant();

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/DefaultSecretManagerProvider.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/DefaultSecretManagerProvider.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
             if (repository == null)
             {
-                throw new InvalidOperationException($"Secret initialization from Blob storage failed due to missing both an Azure Storage connection string and a SAS connection uri. " +
+                throw new InvalidOperationException("Secret initialization from Blob storage failed due to missing both an Azure Storage connection string and a SAS connection uri. " +
                         $"For Blob Storage, please provide at least one of these. If you intend to use files for secrets, add an App Setting key '{EnvironmentSettingNames.AzureWebJobsSecretStorageType}' with value '{FileStorage}'.");
             }
 

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/FileSystemSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/FileSystemSecretsRepository.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                 foreach (var secretFile in secretsDirectory.GetFiles("*.json"))
                 {
-                    if (string.Compare(secretFile.Name, ScriptConstants.HostMetadataFileName, StringComparison.OrdinalIgnoreCase) == 0
+                    if (string.Equals(secretFile.Name, ScriptConstants.HostMetadataFileName, StringComparison.OrdinalIgnoreCase)
                         || secretFile.Name.Contains(ScriptConstants.Snapshot))
                     {
                         // the secrets directory contains the host secrets file in addition

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     HostSecrets hostSecrets;
                     try
                     {
-                        _logger.LogDebug($"Loading host secrets");
+                        _logger.LogDebug("Loading host secrets");
 
                         hostSecrets = await LoadSecretsAsync<HostSecrets>();
                         if (hostSecrets == null)

--- a/src/WebJobs.Script.WebHost/Standby/StandbyManager.cs
+++ b/src/WebJobs.Script.WebHost/Standby/StandbyManager.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 {
                     // if we fail during specialization for whatever reason
                     // this is fatal, so we shutdown
-                    _logger.LogError(t.Exception, $"Specialization failed. Shutting down.");
+                    _logger.LogError(t.Exception, "Specialization failed. Shutting down.");
                     _applicationLifetime.StopApplication();
                 }
                 latencyEvent.Dispose();
@@ -208,7 +208,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             content = FileUtility.ReadResourceString($"{ScriptConstants.ResourcePath}.Functions.{WarmUpConstants.FunctionName}.run.csx");
             File.WriteAllText(Path.Combine(functionPath, "run.csx"), content);
 
-            _logger.LogInformation($"StandbyMode placeholder function directory created");
+            _logger.LogInformation("StandbyMode placeholder function directory created");
         }
 
         private async void OnSpecializationTimerTick(object state)

--- a/src/WebJobs.Script.WebHost/WebHooks/DefaultScriptWebHookProvider.cs
+++ b/src/WebJobs.Script.WebHost/WebHooks/DefaultScriptWebHookProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             var handler = extension as HttpHandler;
             if (handler == null)
             {
-                throw new InvalidOperationException($"Extension must implement IAsyncConverter<HttpRequestMessage, HttpResponseMessage> in order to receive webhooks");
+                throw new InvalidOperationException("Extension must implement IAsyncConverter<HttpRequestMessage, HttpResponseMessage> in order to receive webhooks");
             }
 
             // use the config section moniker for the extension as the URL name

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -393,7 +393,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 }
                 else
                 {
-                    logger.LogDebug($"Will start a new host after delay.");
+                    logger.LogDebug("Will start a new host after delay.");
 
                     await Utility.DelayWithBackoffAsync(attemptCount, currentCancellationToken, min: TimeSpan.FromSeconds(1), max: TimeSpan.FromMinutes(2), logger: logger);
 


### PR DESCRIPTION
.NET 5-6 has some enhancements on string handling we can take advantage of...and just some cleanup along the way. I'd like to get analyzers running on these long-term, so cleaning up on the way to proposing such a thing to help us keep it optimized. These aren't going to be large needle moves on perf (some are zero, just tidy), only more things that add up.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
