### PR TITLE
Update ToRpc method to replace async with Task for perf improvement

### DIFF
--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -674,6 +674,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     {
                         if (rpcLog.Exception != null)
                         {
+                            // TODO fix RpcException catch all https://github.com/Azure/azure-functions-dotnet-worker/issues/370
                             var exception = new Workers.Rpc.RpcException(rpcLog.Message, rpcLog.Exception.Message, rpcLog.Exception.StackTrace);
                             context.Logger.Log(logLevel, new EventId(0, rpcLog.EventId), rpcLog.Message, exception, (state, exc) => state);
                         }

--- a/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
+++ b/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
@@ -38,21 +38,25 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     _ => throw new InvalidOperationException($"Unknown RpcDataType: {typedData.DataCase}")
             };
 
-        public static Task<TypedData> ToRpc(this object value, ILogger logger, GrpcCapabilities capabilities) =>
-            value switch
+        public static Task<TypedData> ToRpc(this object value, ILogger logger, GrpcCapabilities capabilities)
+        {
+            TypedData typedData = value switch
             {
-                null => Task.FromResult(new TypedData()),
-                byte[] arr => Task.FromResult(new TypedData() { Bytes = ByteString.CopyFrom(arr) }),
-                JObject jobj => Task.FromResult(new TypedData() { Json = jobj.ToString(Formatting.None) }),
-                string str => Task.FromResult(new TypedData() { String = str }),
-                double dbl => Task.FromResult(new TypedData() { Double = dbl }),
-                HttpRequest request => request.ToRpcHttp(logger, capabilities),
-                byte[][] arrBytes when IsTypedDataCollectionSupported(capabilities) => Task.FromResult(arrBytes.ToRpcByteArray()),
-                string[] arrStr when IsTypedDataCollectionSupported(capabilities) => Task.FromResult(arrStr.ToRpcStringArray()),
-                double[] arrDouble when IsTypedDataCollectionSupported(capabilities) => Task.FromResult(arrDouble.ToRpcDoubleArray()),
-                long[] arrLong when IsTypedDataCollectionSupported(capabilities) => Task.FromResult(arrLong.ToRpcLongArray()),
-                _ => Task.FromResult(value.ToRpcDefault()),
+                null => new TypedData(),
+                byte[] arr => new TypedData() { Bytes = ByteString.CopyFrom(arr) },
+                JObject jobj => new TypedData() { Json = jobj.ToString(Formatting.None) },
+                string str => new TypedData() { String = str },
+                double dbl => new TypedData() { Double = dbl },
+                HttpRequest request => request.ToRpcHttp(logger, capabilities).Result,
+                byte[][] arrBytes when IsTypedDataCollectionSupported(capabilities) => arrBytes.ToRpcByteArray(),
+                string[] arrStr when IsTypedDataCollectionSupported(capabilities) => arrStr.ToRpcStringArray(),
+                double[] arrDouble when IsTypedDataCollectionSupported(capabilities) => arrDouble.ToRpcDoubleArray(),
+                long[] arrLong when IsTypedDataCollectionSupported(capabilities) => arrLong.ToRpcLongArray(),
+                _ => value.ToRpcDefault(),
             };
+
+            return Task.FromResult(typedData);
+        }
 
         internal static async Task<TypedData> ToRpcHttp(this HttpRequest request, ILogger logger, GrpcCapabilities capabilities)
         {

--- a/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
+++ b/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
@@ -38,24 +38,28 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     _ => throw new InvalidOperationException($"Unknown RpcDataType: {typedData.DataCase}")
             };
 
-        public static Task<TypedData> ToRpc(this object value, ILogger logger, GrpcCapabilities capabilities)
+        public static ValueTask<TypedData> ToRpc(this object value, ILogger logger, GrpcCapabilities capabilities)
         {
-            TypedData typedData = value switch
+            if (value is HttpRequest request)
             {
-                null => new TypedData(),
-                byte[] arr => new TypedData() { Bytes = ByteString.CopyFrom(arr) },
-                JObject jobj => new TypedData() { Json = jobj.ToString(Formatting.None) },
-                string str => new TypedData() { String = str },
-                double dbl => new TypedData() { Double = dbl },
-                HttpRequest request => request.ToRpcHttp(logger, capabilities).Result,
-                byte[][] arrBytes when IsTypedDataCollectionSupported(capabilities) => arrBytes.ToRpcByteArray(),
-                string[] arrStr when IsTypedDataCollectionSupported(capabilities) => arrStr.ToRpcStringArray(),
-                double[] arrDouble when IsTypedDataCollectionSupported(capabilities) => arrDouble.ToRpcDoubleArray(),
-                long[] arrLong when IsTypedDataCollectionSupported(capabilities) => arrLong.ToRpcLongArray(),
-                _ => value.ToRpcDefault(),
-            };
-
-            return Task.FromResult(typedData);
+                return new ValueTask<TypedData>(request.ToRpcHttp(logger, capabilities));
+            }
+            else
+            {
+                return ValueTask.FromResult(value switch
+                {
+                    null => new TypedData(),
+                    byte[] arr => new TypedData() { Bytes = ByteString.CopyFrom(arr) },
+                    JObject jobj => new TypedData() { Json = jobj.ToString(Formatting.None) },
+                    string str => new TypedData() { String = str },
+                    double dbl => new TypedData() { Double = dbl },
+                    byte[][] arrBytes when IsTypedDataCollectionSupported(capabilities) => arrBytes.ToRpcByteArray(),
+                    string[] arrStr when IsTypedDataCollectionSupported(capabilities) => arrStr.ToRpcStringArray(),
+                    double[] arrDouble when IsTypedDataCollectionSupported(capabilities) => arrDouble.ToRpcDoubleArray(),
+                    long[] arrLong when IsTypedDataCollectionSupported(capabilities) => arrLong.ToRpcLongArray(),
+                    _ => value.ToRpcDefault(),
+                });
+            }
         }
 
         internal static async Task<TypedData> ToRpcHttp(this HttpRequest request, ILogger logger, GrpcCapabilities capabilities)

--- a/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
+++ b/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
@@ -38,20 +38,20 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     _ => throw new InvalidOperationException($"Unknown RpcDataType: {typedData.DataCase}")
             };
 
-        public static async Task<TypedData> ToRpc(this object value, ILogger logger, GrpcCapabilities capabilities) =>
+        public static Task<TypedData> ToRpc(this object value, ILogger logger, GrpcCapabilities capabilities) =>
             value switch
             {
-                null => new TypedData(),
-                byte[] arr => new TypedData() { Bytes = ByteString.CopyFrom(arr) },
-                JObject jobj => new TypedData() { Json = jobj.ToString(Formatting.None) },
-                string str => new TypedData() { String = str },
-                double dbl => new TypedData() { Double = dbl },
-                HttpRequest request => await request.ToRpcHttp(logger, capabilities),
-                byte[][] arrBytes when IsTypedDataCollectionSupported(capabilities) => arrBytes.ToRpcByteArray(),
-                string[] arrStr when IsTypedDataCollectionSupported(capabilities) => arrStr.ToRpcStringArray(),
-                double[] arrDouble when IsTypedDataCollectionSupported(capabilities) => arrDouble.ToRpcDoubleArray(),
-                long[] arrLong when IsTypedDataCollectionSupported(capabilities) => arrLong.ToRpcLongArray(),
-                _ => value.ToRpcDefault(),
+                null => Task.FromResult(new TypedData()),
+                byte[] arr => Task.FromResult(new TypedData() { Bytes = ByteString.CopyFrom(arr) }),
+                JObject jobj => Task.FromResult(new TypedData() { Json = jobj.ToString(Formatting.None) }),
+                string str => Task.FromResult(new TypedData() { String = str }),
+                double dbl => Task.FromResult(new TypedData() { Double = dbl }),
+                HttpRequest request => request.ToRpcHttp(logger, capabilities),
+                byte[][] arrBytes when IsTypedDataCollectionSupported(capabilities) => Task.FromResult(arrBytes.ToRpcByteArray()),
+                string[] arrStr when IsTypedDataCollectionSupported(capabilities) => Task.FromResult(arrStr.ToRpcStringArray()),
+                double[] arrDouble when IsTypedDataCollectionSupported(capabilities) => Task.FromResult(arrDouble.ToRpcDoubleArray()),
+                long[] arrLong when IsTypedDataCollectionSupported(capabilities) => Task.FromResult(arrLong.ToRpcLongArray()),
+                _ => Task.FromResult(value.ToRpcDefault()),
             };
 
         internal static async Task<TypedData> ToRpcHttp(this HttpRequest request, ILogger logger, GrpcCapabilities capabilities)


### PR DESCRIPTION
Address perf suggestion made here: https://github.com/Azure/azure-functions-host/pull/7956#discussion_r765016129

Task:

|                Method |        Mean |      Error |     StdDev |      Median |         Min |         Max |  Gen 0 |  Gen 1 | Allocated |
|---------------------- |------------:|-----------:|-----------:|------------:|------------:|------------:|-------:|-------:|----------:|
|            ToRpc_Null |    55.41 ns |   1.067 ns |   0.946 ns |    55.35 ns |    54.41 ns |    58.15 ns | 0.0132 |      - |     112 B |
|       ToRpc_ByteArray |   309.94 ns |   8.163 ns |   8.017 ns |   312.00 ns |   290.63 ns |   318.10 ns | 0.2599 | 0.0013 |   2,168 B |
|          ToRpc_String |    59.23 ns |   1.589 ns |   1.766 ns |    59.08 ns |    56.40 ns |    62.90 ns | 0.0134 |      - |     112 B |
|          ToRpc_Double |    68.86 ns |   2.274 ns |   2.618 ns |    69.28 ns |    63.97 ns |    73.78 ns | 0.0191 |      - |     160 B |
| ToRpc_ByteJaggedArray |   922.35 ns |  15.014 ns |  14.044 ns |   919.40 ns |   899.25 ns |   945.49 ns | 0.0189 |      - |     176 B |
|     ToRpc_StringArray |   146.08 ns |   2.213 ns |   1.962 ns |   146.19 ns |   142.84 ns |   148.87 ns | 0.0315 |      - |     264 B |
|     ToRpc_DoubleArray | 7,021.36 ns | 130.503 ns | 115.688 ns | 7,032.74 ns | 6,867.80 ns | 7,254.16 ns | 1.9842 | 0.0559 |  16,688 B |
|       ToRpc_LongArray | 6,922.54 ns | 308.668 ns | 316.979 ns | 6,898.93 ns | 6,457.40 ns | 7,401.79 ns | 1.9754 | 0.0534 |  16,688 B |
|         ToRpc_JObject |   299.41 ns |   8.027 ns |   9.244 ns |   299.05 ns |   281.76 ns |   315.15 ns | 0.0817 |      - |     688 B |


ValueTask:

|                Method |        Mean |      Error |     StdDev |      Median |         Min |         Max |  Gen 0 |  Gen 1 | Allocated |
|---------------------- |------------:|-----------:|-----------:|------------:|------------:|------------:|-------:|-------:|----------:|
|            ToRpc_Null |    32.94 ns |   0.793 ns |   0.814 ns |    32.79 ns |    31.39 ns |    34.74 ns | 0.0047 |      - |      40 B |
|       ToRpc_ByteArray |   288.57 ns |  24.520 ns |  28.237 ns |   282.38 ns |   252.67 ns |   333.24 ns | 0.2514 | 0.0011 |   2,096 B |
|          ToRpc_String |    40.91 ns |   0.831 ns |   0.924 ns |    40.55 ns |    39.84 ns |    43.28 ns | 0.0047 |      - |      40 B |
|          ToRpc_Double |    61.85 ns |   0.954 ns |   0.845 ns |    61.73 ns |    60.68 ns |    63.54 ns | 0.0103 |      - |      88 B |
| ToRpc_ByteJaggedArray |   884.16 ns |  13.116 ns |  11.627 ns |   884.60 ns |   870.53 ns |   911.26 ns | 0.0105 |      - |     104 B |
|     ToRpc_StringArray |   135.89 ns |   5.468 ns |   6.297 ns |   134.12 ns |   127.91 ns |   147.78 ns | 0.0227 |      - |     192 B |
|     ToRpc_DoubleArray | 7,111.88 ns | 295.261 ns | 328.182 ns | 7,033.78 ns | 6,412.81 ns | 7,560.57 ns | 1.9507 | 0.0433 |  16,616 B |
|       ToRpc_LongArray | 7,003.11 ns | 257.936 ns | 297.039 ns | 7,025.62 ns | 6,360.74 ns | 7,505.29 ns | 1.9701 | 0.0518 |  16,616 B |
|         ToRpc_JObject |   282.96 ns |   4.168 ns |   3.695 ns |   283.39 ns |   272.31 ns |   287.12 ns | 0.0734 |      - |     616 B |
