### PR TITLE
Ensure child worker processes are monitored after specialization

### DIFF
--- a/src/WebJobs.Script.WebHost/Configuration/ScriptApplicationHostOptionsSetup.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/ScriptApplicationHostOptionsSetup.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
                 options.IsStandbyConfiguration = true;
             }
 
-            options.IsFileSystemReadOnly = IsZipDeployment(out bool isScmRunFromPackage);
+            options.IsFileSystemReadOnly |= IsZipDeployment(out bool isScmRunFromPackage);
             options.IsScmRunFromPackage = isScmRunFromPackage;
         }
 

--- a/src/WebJobs.Script/Eventing/EventSources.cs
+++ b/src/WebJobs.Script/Eventing/EventSources.cs
@@ -16,5 +16,6 @@ namespace Microsoft.Azure.WebJobs.Script.Eventing
         public const string Worker = "Worker";
         public const string WorkerProcess = "WorkerProcess";
         public const string HttpWorker = "HttpWorker";
+        public const string Host = "Host";
     }
 }

--- a/src/WebJobs.Script/Eventing/Host/HostStartEvent.cs
+++ b/src/WebJobs.Script/Eventing/Host/HostStartEvent.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script.Eventing
+{
+    public class HostStartEvent : ScriptEvent
+    {
+        public HostStartEvent()
+            : base(nameof(HostStartEvent), EventSources.Host)
+        {
+        }
+    }
+}

--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcess.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcess.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Azure.WebJobs.Logging;
@@ -24,10 +25,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         private readonly IMetricsLogger _metricsLogger;
         private readonly int processExitTimeoutInMilliseconds = 1000;
         private readonly IServiceProvider _serviceProvider;
+        private readonly IDisposable _eventSubscription;
 
-        private Process _process;
         private bool _useStdErrorStreamForErrorsOnly;
         private Queue<string> _processStdErrDataQueue = new Queue<string>(3);
+        private IHostProcessMonitor _processMonitor;
+        private object _syncLock = new object();
 
         internal WorkerProcess(IScriptEventManager eventManager, IProcessRegistry processRegistry, ILogger workerProcessLogger, IWorkerConsoleLogSource consoleLogSource, IMetricsLogger metricsLogger, IServiceProvider serviceProvider, bool useStdErrStreamForErrorsOnly = false)
         {
@@ -38,13 +41,20 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             _metricsLogger = metricsLogger;
             _useStdErrorStreamForErrorsOnly = useStdErrStreamForErrorsOnly;
             _serviceProvider = serviceProvider;
+
+            // We subscribe to host start events so we can handle the restart that occurs
+            // on host specialization.
+            _eventSubscription = _eventManager.OfType<HostStartEvent>().Subscribe(OnHostStart);
         }
 
         protected bool Disposing { get; private set; }
 
-        public int Id => _process.Id;
+        public int Id => Process.Id;
 
         internal Queue<string> ProcessStdErrDataQueue => _processStdErrDataQueue;
+
+        // for testing
+        internal Process Process { get; set; }
 
         internal abstract Process CreateWorkerProcess();
 
@@ -52,35 +62,31 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         {
             using (_metricsLogger.LatencyEvent(MetricEventNames.ProcessStart))
             {
-                _process = CreateWorkerProcess();
+                Process = CreateWorkerProcess();
                 try
                 {
-                    _process.ErrorDataReceived += (sender, e) => OnErrorDataReceived(sender, e);
-                    _process.OutputDataReceived += (sender, e) => OnOutputDataReceived(sender, e);
-                    _process.Exited += (sender, e) => OnProcessExited(sender, e);
-                    _process.EnableRaisingEvents = true;
+                    Process.ErrorDataReceived += (sender, e) => OnErrorDataReceived(sender, e);
+                    Process.OutputDataReceived += (sender, e) => OnOutputDataReceived(sender, e);
+                    Process.Exited += (sender, e) => OnProcessExited(sender, e);
+                    Process.EnableRaisingEvents = true;
 
-                    _workerProcessLogger?.LogDebug($"Starting worker process with FileName:{_process.StartInfo.FileName} WorkingDirectory:{_process.StartInfo.WorkingDirectory} Arguments:{_process.StartInfo.Arguments}");
-                    _process.Start();
-                    _workerProcessLogger?.LogDebug($"{_process.StartInfo.FileName} process with Id={_process.Id} started");
+                    _workerProcessLogger?.LogDebug($"Starting worker process with FileName:{Process.StartInfo.FileName} WorkingDirectory:{Process.StartInfo.WorkingDirectory} Arguments:{Process.StartInfo.Arguments}");
+                    Process.Start();
+                    _workerProcessLogger?.LogDebug($"{Process.StartInfo.FileName} process with Id={Process.Id} started");
 
-                    _process.BeginErrorReadLine();
-                    _process.BeginOutputReadLine();
+                    Process.BeginErrorReadLine();
+                    Process.BeginOutputReadLine();
 
                     // Register process only after it starts
-                    _processRegistry?.Register(_process);
+                    _processRegistry?.Register(Process);
 
-                    var processMonitor = _serviceProvider.GetScriptHostServiceOrNull<IHostProcessMonitor>();
-                    if (processMonitor != null)
-                    {
-                        processMonitor.RegisterChildProcess(_process);
-                    }
+                    RegisterWithProcessMonitor();
 
                     return Task.CompletedTask;
                 }
                 catch (Exception ex)
                 {
-                    _workerProcessLogger.LogError(ex, $"Failed to start Worker Channel. Process fileName: {_process.StartInfo.FileName}");
+                    _workerProcessLogger.LogError(ex, $"Failed to start Worker Channel. Process fileName: {Process.StartInfo.FileName}");
                     return Task.FromException(ex);
                 }
             }
@@ -139,20 +145,20 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
 
             try
             {
-                if (_process.ExitCode == WorkerConstants.SuccessExitCode)
+                if (Process.ExitCode == WorkerConstants.SuccessExitCode)
                 {
-                    _process.WaitForExit();
-                    _process.Close();
+                    Process.WaitForExit();
+                    Process.Close();
                 }
-                else if (_process.ExitCode == WorkerConstants.IntentionalRestartExitCode)
+                else if (Process.ExitCode == WorkerConstants.IntentionalRestartExitCode)
                 {
                     HandleWorkerProcessRestart();
                 }
                 else
                 {
-                    var processExitEx = new WorkerProcessExitException($"{_process.StartInfo.FileName} exited with code {_process.ExitCode}\n {exceptionMessage}");
-                    processExitEx.ExitCode = _process.ExitCode;
-                    processExitEx.Pid = _process.Id;
+                    var processExitEx = new WorkerProcessExitException($"{Process.StartInfo.FileName} exited with code {Process.ExitCode}\n {exceptionMessage}");
+                    processExitEx.ExitCode = Process.ExitCode;
+                    processExitEx.Pid = Process.Id;
                     HandleWorkerProcessExitError(processExitEx);
                 }
             }
@@ -163,11 +169,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             }
             finally
             {
-                var processMonitor = _serviceProvider.GetScriptHostServiceOrNull<IHostProcessMonitor>();
-                if (processMonitor != null)
-                {
-                    processMonitor.UnregisterChildProcess(_process);
-                }
+                UnregisterFromProcessMonitor();
             }
         }
 
@@ -206,23 +208,70 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             // best effort process disposal
             try
             {
-                if (_process != null)
+                _eventSubscription?.Dispose();
+
+                if (Process != null)
                 {
-                    if (!_process.HasExited)
+                    if (!Process.HasExited)
                     {
-                        _process.Kill();
-                        if (!_process.WaitForExit(processExitTimeoutInMilliseconds))
+                        Process.Kill();
+                        if (!Process.WaitForExit(processExitTimeoutInMilliseconds))
                         {
                             _workerProcessLogger.LogWarning($"Worker process has not exited despite waiting for {processExitTimeoutInMilliseconds} ms");
                         }
                     }
-                    _process.Dispose();
+                    Process.Dispose();
                 }
             }
             catch (Exception exc)
             {
                 _workerProcessLogger?.LogDebug(exc, "Exception on worker disposal.");
                 //ignore
+            }
+        }
+
+        internal void OnHostStart(HostStartEvent evt)
+        {
+            if (!Disposing)
+            {
+                RegisterWithProcessMonitor();
+            }
+        }
+
+        /// <summary>
+        /// Ensures that our process is registered with <see cref="IHostProcessMonitor"/>.
+        /// </summary>
+        /// <remarks>
+        /// The goal is to ensure that all worker processes are registered with the monitor for the active host.
+        /// There are a few different cases to consider:
+        /// - Starting up in normal mode, we register on when the process is started.
+        /// - When a placeholder mode host is specialized, a new host will be started but the previously initialized
+        ///   worker process will remain running. We need to re-register with the new host.
+        /// - When the worker process dies and a new instance of this class is created.
+        /// </remarks>
+        internal void RegisterWithProcessMonitor()
+        {
+            var processMonitor = _serviceProvider.GetScriptHostServiceOrNull<IHostProcessMonitor>();
+            lock (_syncLock)
+            {
+                if (processMonitor != null && processMonitor != _processMonitor && Process != null)
+                {
+                    processMonitor.RegisterChildProcess(Process);
+                    _processMonitor = processMonitor;
+                }
+            }
+        }
+
+        internal void UnregisterFromProcessMonitor()
+        {
+            lock (_syncLock)
+            {
+                if (_processMonitor != null && Process != null)
+                {
+                    // if we've registered our process with the monitor, unregister
+                    _processMonitor.UnregisterChildProcess(Process);
+                    _processMonitor = null;
+                }
             }
         }
     }

--- a/test/WebJobs.Script.Tests.Shared/TestScriptEventManager.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestScriptEventManager.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Script.Eventing;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public class TestScriptEventManager : IScriptEventManager
+    {
+        public void Publish(ScriptEvent scriptEvent)
+        {
+        }
+
+        public IDisposable Subscribe(IObserver<ScriptEvent> observer)
+        {
+            return null;
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Shared/WebJobs.Script.Tests.Shared.projitems
+++ b/test/WebJobs.Script.Tests.Shared/WebJobs.Script.Tests.Shared.projitems
@@ -29,6 +29,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)TestOptionsFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestOptionsMonitor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestScaleMonitor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestScriptEventManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestServiceCollectionExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestServiceProviderExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestTraits.cs" />

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerProcessTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerProcessTests.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
+using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
@@ -14,8 +16,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
     public class RpcWorkerProcessTests
     {
         private RpcWorkerProcess _rpcWorkerProcess;
-
         private Mock<IScriptEventManager> _eventManager;
+        private Mock<IHostProcessMonitor> _hostProcessMonitorMock;
 
         public RpcWorkerProcessTests()
         {
@@ -26,7 +28,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var languageWorkerConsoleLogSource = new Mock<IWorkerConsoleLogSource>();
             var testEnv = new TestEnvironment();
             var testWorkerConfigs = TestHelpers.GetTestWorkerConfigs();
+
+            _hostProcessMonitorMock = new Mock<IHostProcessMonitor>(MockBehavior.Strict);
+            var scriptHostManagerMock = new Mock<IScriptHostManager>(MockBehavior.Strict);
+            var scriptHostServiceProviderMock = scriptHostManagerMock.As<IServiceProvider>();
+            scriptHostServiceProviderMock.Setup(p => p.GetService(typeof(IHostProcessMonitor))).Returns(() => _hostProcessMonitorMock.Object);
+
             var serviceProviderMock = new Mock<IServiceProvider>(MockBehavior.Strict);
+            serviceProviderMock.Setup(p => p.GetService(typeof(IScriptHostManager))).Returns(scriptHostManagerMock.Object);
 
             _rpcWorkerProcess = new RpcWorkerProcess("node",
                 "testworkerId",
@@ -40,6 +49,78 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 languageWorkerConsoleLogSource.Object,
                 new TestMetricsLogger(),
                 serviceProviderMock.Object);
+        }
+
+        [Fact]
+        public void Constructor_RegistersHostStartedEvent()
+        {
+            Func<IObserver<ScriptEvent>, bool> validate = p =>
+            {
+                // validate the internal reactive ISink<HostStartEvent> implementation that
+                // results from the Subscribe extension method
+                Type eventType = p.GetType().GetInterfaces()[0].GetGenericArguments()[0];
+                return eventType == typeof(HostStartEvent);
+            };
+
+            _eventManager.Verify(_ => _.Subscribe(It.Is<IObserver<ScriptEvent>>(p => validate(p))), Times.Once());
+        }
+
+        [Fact]
+        public void OnHostStart_RegistersProcessWithMonitor()
+        {
+            Process process = Process.GetCurrentProcess();
+            _rpcWorkerProcess.Process = process;
+
+            _hostProcessMonitorMock.Setup(p => p.RegisterChildProcess(process));
+
+            HostStartEvent evt = new HostStartEvent();
+            _rpcWorkerProcess.OnHostStart(evt);
+            _hostProcessMonitorMock.Verify(p => p.RegisterChildProcess(process), Times.Once);
+        }
+
+        [Fact]
+        public void RegisterWithProcessMonitor_Succeeds()
+        {
+            Process process = Process.GetCurrentProcess();
+            _rpcWorkerProcess.Process = process;
+
+            _hostProcessMonitorMock.Setup(p => p.RegisterChildProcess(process));
+
+            _rpcWorkerProcess.RegisterWithProcessMonitor();
+            _hostProcessMonitorMock.Verify(p => p.RegisterChildProcess(process), Times.Once);
+
+            // registration is skipped if attempted again for the same monitor
+            _rpcWorkerProcess.RegisterWithProcessMonitor();
+            _hostProcessMonitorMock.Verify(p => p.RegisterChildProcess(process), Times.Once);
+
+            // if the monitor changes (e.g. due to a host restart)
+            // registration is performed
+            _hostProcessMonitorMock = new Mock<IHostProcessMonitor>(MockBehavior.Strict);
+            _hostProcessMonitorMock.Setup(p => p.RegisterChildProcess(process));
+            _rpcWorkerProcess.RegisterWithProcessMonitor();
+            _hostProcessMonitorMock.Verify(p => p.RegisterChildProcess(process), Times.Once);
+        }
+
+        [Fact]
+        public void UnregisterFromProcessMonitor_Succeeds()
+        {
+            Process process = Process.GetCurrentProcess();
+            _rpcWorkerProcess.Process = process;
+
+            _hostProcessMonitorMock.Setup(p => p.RegisterChildProcess(process));
+            _hostProcessMonitorMock.Setup(p => p.UnregisterChildProcess(process));
+
+            // not yet registered so noop
+            _rpcWorkerProcess.UnregisterFromProcessMonitor();
+            _hostProcessMonitorMock.Verify(p => p.UnregisterChildProcess(process), Times.Never);
+
+            _rpcWorkerProcess.RegisterWithProcessMonitor();
+            _rpcWorkerProcess.UnregisterFromProcessMonitor();
+            _hostProcessMonitorMock.Verify(p => p.UnregisterChildProcess(process), Times.Once);
+
+            // attempting to unregister again is a noop
+            _rpcWorkerProcess.UnregisterFromProcessMonitor();
+            _hostProcessMonitorMock.Verify(p => p.UnregisterChildProcess(process), Times.Once);
         }
 
         [Fact]


### PR DESCRIPTION
Currently, child worker processes are only registered for monitoring when the process is started. That's a problem if the host is started in placeholder mode and later specialized. In that case, the worker channels are NOT restarted, and the child processes are not registered for monitoring by the new specialized host instance.

For testing, I've configured my local functions host to start in placeholder mode. I can see that placeholder worker channels are used. After triggering specialization, I can see the worker channels are specialized. Previously before my fix, the newly restarted/specialized host wouldn't be monitoring the child processes, because the were only registered on process start before. Now the worker process instance handles the HostStartEvent and registers.

Caught this issue in production testing. For a Python Consumption app, after specialization only the main host process is being monitored, not the worker process. That impacts DynamicConcurrency - it's unable to make correct concurrency decisions because it doesn't have a full view of CPU usage. In previous rounds of testing, I was testing with private site extensions, with placeholders disabled.

Will send a PR backporting to v3 as well, once this one is signed off on.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Backport PR https://github.com/Azure/azure-functions-host/pull/7978
* [x] I have added all required tests (Unit tests, E2E tests)