### PR TITLE
Fix: gRPC server disposal null ref if never started

### DIFF
--- a/src/WebJobs.Script.Grpc/Server/AspNetCoreGrpcServer.cs
+++ b/src/WebJobs.Script.Grpc/Server/AspNetCoreGrpcServer.cs
@@ -60,10 +60,11 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         {
             if (!_disposed)
             {
-                if (disposing)
+                var temp = _grpcHost;
+                if (disposing && temp != null)
                 {
-                    await _grpcHost.StopAsync();
-                    _grpcHost.Dispose();
+                    await temp.StopAsync();
+                    temp.Dispose();
                 }
                 _disposed = true;
             }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/AspNetCoreGrpcServerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/AspNetCoreGrpcServerTests.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Grpc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
+{
+    public class AspNetCoreGrpcServerTests
+    {
+        [Fact]
+        public void CleanDisposal()
+        {
+            var server = new AspNetCoreGrpcServer(new TestScriptEventManager(), NullLogger<AspNetCoreGrpcServer>.Instance);
+            server.Dispose();
+        }
+
+        [Fact]
+        public async Task CleanDisposalAsync()
+        {
+            var server = new AspNetCoreGrpcServer(new TestScriptEventManager(), NullLogger<AspNetCoreGrpcServer>.Instance);
+            await server.DisposeAsync();
+        }
+    }
+}


### PR DESCRIPTION
Found by accident while investigating #7969. Overall: if we don't start the gRPC server then we get some null ref action when we go to dispose it.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

I'm not sure on the backport front - @brettsam?
