### PR TITLE
[pack] Fix publish variable not being recognized for patch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -266,7 +266,7 @@ jobs:
       if ((test-path $(Build.ArtifactStagingDirectory)\ZippedPatchSiteExtension))
       {
         Write-Host "Patched site extension detected."
-        Write-Host "##vso[task.setvariable variable=isPatchVersion;isOutput=true]true"
+        Write-Host "##vso[task.setvariable variable=isPatchVersion]true"
       }
     displayName: 'Set isPatchVersion'
   - publish: $(Build.ArtifactStagingDirectory)\ZippedPatchSiteExtension


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #8002

Turns out variables defined as part of the same job should not have `isOutput` set to true or the condition couldn't recognize it.

Sample build that produced the patched SiteExtension https://azfunc.visualstudio.com/Azure%20Functions/_build/results?buildId=45258&view=results

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
