### PR TITLE
fixing build numbering for releases

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <MajorVersion>4</MajorVersion>
     <MinorVersion>1</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <BuildNumber Condition="'$(BuildNumber)' == '' ">0</BuildNumber>
     <PreviewVersion></PreviewVersion>        
     

--- a/build/initialize-pipeline.ps1
+++ b/build/initialize-pipeline.ps1
@@ -1,4 +1,5 @@
 $buildReason = $env:BUILD_REASON
+$sourceBranch = $env:BUILD_SOURCEBRANCH
 
 if ($buildReason -eq "PullRequest") {
   # parse PR title to see if we should pack this
@@ -11,8 +12,13 @@ if ($buildReason -eq "PullRequest") {
   }
 }
 
-$buildNumber = $env:buildNumber
-Write-Host "BuildNumber: '$buildNumber'"
+$buildNumber = ""
+
+if(($buildReason -eq "PullRequest") -or !($sourceBranch.ToLower().Contains("release")))
+{
+  $buildNumber = $env:buildNumber
+  Write-Host "BuildNumber: '$buildNumber'"
+}
 
 Import-Module $PSScriptRoot\Get-AzureFunctionsVersion -Force
 $version = Get-AzureFunctionsVersion $buildNumber $buildNumber

--- a/build/initialize-pipeline.ps1
+++ b/build/initialize-pipeline.ps1
@@ -1,6 +1,9 @@
 $buildReason = $env:BUILD_REASON
 $sourceBranch = $env:BUILD_SOURCEBRANCH
 
+Write-Host "BUILD_REASON: '$buildReason'"
+Write-Host "BUILD_SOURCEBRANCH: '$sourceBranch'"
+
 if ($buildReason -eq "PullRequest") {
   # parse PR title to see if we should pack this
   $response = Invoke-RestMethod api.github.com/repos/$env:BUILD_REPOSITORY_ID/pulls/$env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER
@@ -14,7 +17,7 @@ if ($buildReason -eq "PullRequest") {
 
 $buildNumber = ""
 
-if(($buildReason -eq "PullRequest") -or !($sourceBranch.ToLower().Contains("release")))
+if(($buildReason -eq "PullRequest") -or !($sourceBranch.ToLower().Contains("release/4.")))
 {
   $buildNumber = $env:buildNumber
   Write-Host "BuildNumber: '$buildNumber'"


### PR DESCRIPTION
For releases (those in the `release/...` branch), we are not supposed to append the build version to the build number. This affects tags and the automated release. The behavior was already built into the powershell module, but I wasn't correctly calling it in this situation.