### PR TITLE
Performance: optimize order of SystemLogger.IsEnabled

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/SystemLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/SystemLogger.cs
@@ -49,12 +49,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public bool IsEnabled(LogLevel logLevel)
         {
-            if (_debugStateProvider.InDiagnosticMode)
-            {
-                // when in diagnostic mode, we log everything
-                return true;
-            }
-            return logLevel >= _logLevel;
+            // When in diagnostic mode, we log everything, but that has a .UtcNow check,
+            // so first see if we even need to make that assessment.
+            return logLevel >= _logLevel || _debugStateProvider.InDiagnosticMode;
         }
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)


### PR DESCRIPTION
The `InDiagnosticMode` check isn't super cheap because it's a `UtcNow` fetch (not free) against a file timestamp (mostly cached/cheap) on every call times 2. For all the cases we're above the log level _anyway_ (perhaps *always* true?), don't bother doing this extra check.

On the diagnostic mode in general - I think we could rig it to a timer set to re-evaluate in 15 minutes or 3 hours past the last event (if not already passed) rather than be a comparison operator on every call and maintain the existing functionality much cheaper but I'd like to discuss that before just PRing it.

This one's a papercut - small but simple wins (0.16% local profiling).

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

#### Crank comparison
| application                             | dev2-1      | systemlogger-2 |         |
| --------------------------------------- | ----------- | -------------- | ------- |
| CPU Usage (%)                           |           7 |              7 |   0.00% |
| Cores usage (%)                         |         202 |            200 |  -0.99% |
| Working Set (MB)                        |         308 |            360 | +16.88% |
| Private Memory (MB)                     |       1,133 |          1,157 |  +2.12% |
| Build Time (ms)                         |      17,993 |         17,858 |  -0.75% |
| Start Time (ms)                         |       4,778 |          4,796 |  +0.38% |
| Published Size (KB)                     |     674,687 |        674,686 |  -0.00% |
| .NET Core SDK Version                   |     6.0.101 |        6.0.101 |         |
| Max CPU Usage (%)                       |          99 |             99 |   0.00% |
| Max Working Set (MB)                    |         322 |            376 | +16.77% |
| Max GC Heap Size (MB)                   |         128 |            121 |  -5.47% |
| Size of committed memory by the GC (MB) |         134 |            189 | +41.04% |
| Max Number of Gen 0 GCs / sec           |       13.00 |          11.00 | -15.38% |
| Max Number of Gen 1 GCs / sec           |        6.00 |           5.00 | -16.67% |
| Max Number of Gen 2 GCs / sec           |        1.00 |           1.00 |   0.00% |
| Max Time in GC (%)                      |        6.00 |           7.00 | +16.67% |
| Max Gen 0 Size (B)                      |  55,366,672 |     34,370,416 | -37.92% |
| Max Gen 1 Size (B)                      |   9,674,736 |     11,739,120 | +21.34% |
| Max Gen 2 Size (B)                      |  26,395,496 |     28,849,776 |  +9.30% |
| Max LOH Size (B)                        |   9,321,280 |     10,239,064 |  +9.85% |
| Max Allocation Rate (B/sec)             | 333,640,760 |    337,730,824 |  +1.23% |
| Max GC Heap Fragmentation               |          77 |             66 | -13.76% |
| # of Assemblies Loaded                  |         201 |            201 |   0.00% |
| Max Exceptions (#/s)                    |         279 |            261 |  -6.45% |
| Max Lock Contention (#/s)               |         114 |            101 | -11.40% |
| Max ThreadPool Threads Count            |          32 |             29 |  -9.38% |
| Max ThreadPool Queue Length             |          95 |             95 |   0.00% |
| Max ThreadPool Items (#/s)              |      36,150 |         36,496 |  +0.96% |
| Max Active Timers                       |          98 |             85 | -13.27% |
| IL Jitted (B)                           |   1,054,878 |      1,054,218 |  -0.06% |
| Methods Jitted                          |      10,887 |         10,878 |  -0.08% |
| Avg Allocation Rate (B/sec)             | 302,116,391 |    308,517,135 |  +2.12% |
| 90th Allocation Rate (B/sec)            | 331,095,488 |    334,344,664 |  +0.98% |


| load                   | dev2-1  | systemlogger-2 |        |
| ---------------------- | ------- | -------------- | ------ |
| CPU Usage (%)          |       1 |              1 |  0.00% |
| Cores usage (%)        |      36 |             38 | +5.56% |
| Working Set (MB)       |      37 |             37 |  0.00% |
| Private Memory (MB)    |     357 |            357 |  0.00% |
| Start Time (ms)        |       0 |              0 |        |
| First Request (ms)     |     350 |            341 | -2.57% |
| Requests/sec           |   8,072 |          8,130 | +0.72% |
| Requests               | 485,103 |        488,383 | +0.68% |
| Mean latency (ms)      |   13.95 |          13.69 | -1.86% |
| Max latency (ms)       |  179.16 |         165.97 | -7.36% |
| Bad responses          |       0 |              0 |        |
| Socket errors          |       0 |              0 |        |
| Read throughput (MB/s) |    1.24 |           1.25 | +0.81% |
| Latency 50th (ms)      |   10.02 |           9.96 | -0.60% |
| Latency 75th (ms)      |   15.93 |          15.77 | -1.00% |
| Latency 90th (ms)      |   28.37 |          27.63 | -2.61% |
| Latency 99th (ms)      |   65.38 |          63.07 | -3.53% |