### PR TITLE
Performance: eliminate PathString implicit conversion

### DIFF
--- a/src/WebJobs.Script.WebHost/Middleware/VirtualFileSystemMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/VirtualFileSystemMiddleware.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
     public class VirtualFileSystemMiddleware : IMiddleware
     {
         private readonly VirtualFileSystem _vfs;
+        private static readonly PathString _pathRoot = new PathString("/admin/vfs");
 
         public VirtualFileSystemMiddleware(VirtualFileSystem vfs)
         {
@@ -30,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
         /// <returns>IsVirtualFileSystemRequest</returns>
         public static bool IsVirtualFileSystemRequest(HttpContext context)
         {
-            return context.Request.Path.StartsWithSegments("/admin/vfs");
+            return context.Request.Path.StartsWithSegments(_pathRoot);
         }
 
         public async Task InvokeAsync(HttpContext context, RequestDelegate requestDelegate)

--- a/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs
+++ b/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs
@@ -21,14 +21,17 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
 {
     public static class HttpRequestExtensions
     {
+        private static readonly PathString _adminRoot = new PathString("/admin");
+        private static readonly PathString _adminDownloadRequestRoot = new PathString("/admin/functions/download");
+
         public static bool IsAdminRequest(this HttpRequest request)
         {
-            return request.Path.StartsWithSegments("/admin");
+            return request.Path.StartsWithSegments(_adminRoot);
         }
 
         public static bool IsAdminDownloadRequest(this HttpRequest request)
         {
-            return request.Path.StartsWithSegments("/admin/functions/download");
+            return request.Path.StartsWithSegments(_adminDownloadRequestRoot);
         }
 
         public static TValue GetRequestPropertyOrDefault<TValue>(this HttpRequest request, string key)
@@ -58,12 +61,7 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
 
         public static string GetHeaderValueOrDefault(this HttpRequest request, string headerName)
         {
-            StringValues values;
-            if (request.Headers.TryGetValue(headerName, out values))
-            {
-                return values.First();
-            }
-            return null;
+            return request.Headers.TryGetValue(headerName, out var values) ? values[0] : null;
         }
 
         public static TValue GetItemOrDefault<TValue>(this HttpRequest request, string key)


### PR DESCRIPTION
This is minor but we do it every time - eliminate the implicit op to PathString on the comparisons for every request that never change. Very small papercut but happens on every request and makes a small difference.

Also in here is a neighboring `GetHeaderValueOrDefault` papercut via the `.IsAdminDownloadRequest` check every request - we can eliminate the LINQ overhead and go much faster on that extension.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

#### Crank comparison
| application                             | dev2-1      | pathstring-1 |         |
| --------------------------------------- | ----------- | ------------ | ------- |
| CPU Usage (%)                           |           7 |            7 |   0.00% |
| Cores usage (%)                         |         202 |          201 |  -0.50% |
| Working Set (MB)                        |         308 |          374 | +21.43% |
| Private Memory (MB)                     |       1,133 |        1,158 |  +2.21% |
| Build Time (ms)                         |      17,993 |       16,030 | -10.91% |
| Start Time (ms)                         |       4,778 |        4,825 |  +0.98% |
| Published Size (KB)                     |     674,687 |      674,686 |  -0.00% |
| .NET Core SDK Version                   |     6.0.101 |      6.0.101 |         |
| Max CPU Usage (%)                       |          99 |           99 |   0.00% |
| Max Working Set (MB)                    |         322 |          390 | +21.12% |
| Max GC Heap Size (MB)                   |         128 |          146 | +14.06% |
| Size of committed memory by the GC (MB) |         134 |          202 | +50.75% |
| Max Number of Gen 0 GCs / sec           |       13.00 |        13.00 |   0.00% |
| Max Number of Gen 1 GCs / sec           |        6.00 |         5.00 | -16.67% |
| Max Number of Gen 2 GCs / sec           |        1.00 |         1.00 |   0.00% |
| Max Time in GC (%)                      |        6.00 |         8.00 | +33.33% |
| Max Gen 0 Size (B)                      |  55,366,672 |   44,565,448 | -19.51% |
| Max Gen 1 Size (B)                      |   9,674,736 |   13,055,800 | +34.95% |
| Max Gen 2 Size (B)                      |  26,395,496 |   23,897,128 |  -9.47% |
| Max LOH Size (B)                        |   9,321,280 |    8,796,992 |  -5.62% |
| Max Allocation Rate (B/sec)             | 333,640,760 |  344,309,400 |  +3.20% |
| Max GC Heap Fragmentation               |          77 |           66 | -13.30% |
| # of Assemblies Loaded                  |         201 |          201 |   0.00% |
| Max Exceptions (#/s)                    |         279 |          264 |  -5.38% |
| Max Lock Contention (#/s)               |         114 |          116 |  +1.75% |
| Max ThreadPool Threads Count            |          32 |           32 |   0.00% |
| Max ThreadPool Queue Length             |          95 |           91 |  -4.21% |
| Max ThreadPool Items (#/s)              |      36,150 |       36,801 |  +1.80% |
| Max Active Timers                       |          98 |           86 | -12.24% |
| IL Jitted (B)                           |   1,054,878 |    1,054,863 |  -0.00% |
| Methods Jitted                          |      10,887 |       10,888 |  +0.01% |
| Avg Allocation Rate (B/sec)             | 302,116,391 |  299,905,524 |  -0.73% |
| 90th Allocation Rate (B/sec)            | 331,095,488 |  333,756,808 |  +0.80% |


| load                   | dev2-1  | pathstring-1 |        |
| ---------------------- | ------- | ------------ | ------ |
| CPU Usage (%)          |       1 |            1 |  0.00% |
| Cores usage (%)        |      36 |           36 |  0.00% |
| Working Set (MB)       |      37 |           37 |  0.00% |
| Private Memory (MB)    |     357 |          357 |  0.00% |
| Start Time (ms)        |       0 |            0 |        |
| First Request (ms)     |     350 |          340 | -2.86% |
| Requests/sec           |   8,072 |        8,101 | +0.37% |
| Requests               | 485,103 |      486,795 | +0.35% |
| Mean latency (ms)      |   13.95 |        13.77 | -1.29% |
| Max latency (ms)       |  179.16 |       181.16 | +1.12% |
| Bad responses          |       0 |            0 |        |
| Socket errors          |       0 |            0 |        |
| Read throughput (MB/s) |    1.24 |         1.24 |  0.00% |
| Latency 50th (ms)      |   10.02 |        10.00 | -0.20% |
| Latency 75th (ms)      |   15.93 |        15.62 | -1.95% |
| Latency 90th (ms)      |   28.37 |        27.45 | -3.24% |
| Latency 99th (ms)      |   65.38 |        63.92 | -2.23% |
