### PR TITLE
Performance: Avoid locking in ScriptLoggerFactory

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/ScriptLoggerFactory.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/ScriptLoggerFactory.cs
@@ -52,6 +52,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         public void Dispose()
         {
             _factory.Dispose();
+            // We also clear the cache here so that any future callers will hit a HostDisposedException as expected
+            _loggerCache.Clear();
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/ScriptLoggerFactory.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/ScriptLoggerFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -11,6 +12,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
     public class ScriptLoggerFactory : ILoggerFactory
     {
         private readonly LoggerFactory _factory;
+        private readonly ConcurrentDictionary<string, ILogger> _loggerCache = new ConcurrentDictionary<string, ILogger>();
 
         public ScriptLoggerFactory(IEnumerable<ILoggerProvider> providers, IOptionsMonitor<LoggerFilterOptions> filterOption)
         {
@@ -31,7 +33,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         {
             try
             {
-                return _factory.CreateLogger(categoryName);
+                // To avoid the lock contention in factory.CreateLogger, cache the result
+                // This is safe because:
+                // a) The factory isn't changing in this instance anyway
+                // b) This singleton gets re-created with every new JobHost as it exists in the child service scope
+                if (_loggerCache.TryGetValue(categoryName, out var result))
+                {
+                    return result;
+                }
+                return _loggerCache[categoryName] = _factory.CreateLogger(categoryName);
             }
             catch (ObjectDisposedException ex)
             {


### PR DESCRIPTION
Part of #7908. Under load, we hit a contention point inside `ILoggerFactory.CreateLogger()` ([critical section here](https://github.com/dotnet/runtime/blob/823ec6914c2ea5f9e99bc261c6247e4d78fa1cfd/src/libraries/Microsoft.Extensions.Logging/src/LoggerFactory.cs#L126-L141)). We can avoid that by caching the loggers on this factory and not diving into the lock.

It should be safe because we're both inside the job host services (so get re-created with every new host) and it's based on the _factory we're caching a ref to anyway (added comments to this effect inline).

### Issue describing the changes in this PR

Resolves part oof #7908

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

#### Crank comparison
| application                             | dev-sw-1    | slf-1       |         |
| --------------------------------------- | ----------- | ----------- | ------- |
| CPU Usage (%)                           |           7 |           7 |   0.00% |
| Cores usage (%)                         |         201 |         201 |   0.00% |
| Working Set (MB)                        |         364 |         385 |  +5.77% |
| Private Memory (MB)                     |       1,102 |       1,152 |  +4.54% |
| Build Time (ms)                         |      17,373 |      20,490 | +17.94% |
| Start Time (ms)                         |       4,768 |       4,768 |   0.00% |
| Published Size (KB)                     |     674,686 |     674,686 |   0.00% |
| .NET Core SDK Version                   |     6.0.101 |     6.0.101 |         |
| Max CPU Usage (%)                       |          99 |          99 |   0.00% |
| Max Working Set (MB)                    |         379 |         403 |  +6.33% |
| Max GC Heap Size (MB)                   |         185 |         105 | -43.24% |
| Size of committed memory by the GC (MB) |         191 |         215 | +12.57% |
| Max Number of Gen 0 GCs / sec           |       14.00 |       13.00 |  -7.14% |
| Max Number of Gen 1 GCs / sec           |        5.00 |        5.00 |   0.00% |
| Max Number of Gen 2 GCs / sec           |        1.00 |        1.00 |   0.00% |
| Max Time in GC (%)                      |        7.00 |        6.00 | -14.29% |
| Max Gen 0 Size (B)                      |  38,895,824 |  40,443,552 |  +3.98% |
| Max Gen 1 Size (B)                      |  10,841,312 |  12,644,720 | +16.63% |
| Max Gen 2 Size (B)                      |  28,461,904 |  30,502,608 |  +7.17% |
| Max LOH Size (B)                        |   8,830,720 |  10,763,632 | +21.89% |
| Max Allocation Rate (B/sec)             | 335,214,208 | 337,072,112 |  +0.55% |
| Max GC Heap Fragmentation               |          70 |          72 |  +2.39% |
| # of Assemblies Loaded                  |         201 |         201 |   0.00% |
| Max Exceptions (#/s)                    |         249 |         261 |  +4.82% |
| Max Lock Contention (#/s)               |         127 |          81 | -36.22% |
| Max ThreadPool Threads Count            |          30 |          27 | -10.00% |
| Max ThreadPool Queue Length             |          94 |          93 |  -1.06% |
| Max ThreadPool Items (#/s)              |      36,332 |      36,515 |  +0.50% |
| Max Active Timers                       |          86 |          94 |  +9.30% |
| IL Jitted (B)                           |   1,054,476 |   1,055,591 |  +0.11% |
| Methods Jitted                          |      10,881 |      10,891 |  +0.09% |
| Avg Allocation Rate (B/sec)             | 297,712,948 | 305,483,571 |  +2.61% |
| 90th Allocation Rate (B/sec)            | 329,426,128 | 334,592,488 |  +1.57% |


| load                   | dev-sw-1 | slf-1   |        |
| ---------------------- | -------- | ------- | ------ |
| CPU Usage (%)          |        1 |       1 |  0.00% |
| Cores usage (%)        |       37 |      37 |  0.00% |
| Working Set (MB)       |       37 |      38 | +2.70% |
| Private Memory (MB)    |      357 |     357 |  0.00% |
| Start Time (ms)        |        0 |       0 |        |
| First Request (ms)     |      340 |     338 | -0.59% |
| Requests/sec           |    8,055 |   8,157 | +1.27% |
| Requests               |  484,085 | 490,084 | +1.24% |
| Mean latency (ms)      |    13.92 |   13.45 | -3.38% |
| Max latency (ms)       |   198.99 |  200.77 | +0.89% |
| Bad responses          |        0 |       0 |        |
| Socket errors          |        0 |       0 |        |
| Read throughput (MB/s) |     1.24 |    1.25 | +0.81% |
| Latency 50th (ms)      |    10.04 |    9.95 | -0.90% |
| Latency 75th (ms)      |    15.90 |   15.51 | -2.45% |
| Latency 90th (ms)      |    28.15 |   26.56 | -5.65% |
| Latency 99th (ms)      |    64.70 |   58.75 | -9.20% |
