### PR TITLE
Performance: Eliminate string allocation for LatencyEvent

### DIFF
--- a/src/WebJobs.Script/Extensions/IMetricsLoggerExtensions.cs
+++ b/src/WebJobs.Script/Extensions/IMetricsLoggerExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
             public DisposableEvent(string eventName, string functionName, IMetricsLogger metricsLogger)
             {
-                _metricEvent = metricsLogger.BeginEvent(eventName, functionName, $"{{\"IsStopwatchHighResolution:\" {Stopwatch.IsHighResolution}}}");
+                _metricEvent = metricsLogger.BeginEvent(eventName, functionName, Stopwatch.IsHighResolution ? @"{""IsStopwatchHighResolution"": True}" : @"{""IsStopwatchHighResolution"": False}");
                 _metricsLogger = metricsLogger;
             }
 


### PR DESCRIPTION
This eliminates a string we allocate each time but is easily removed. Importantly though, this might break an existing query by correcting the JSON - needs eyes to see if this would be the case. I'm not sure who to ask on usage here and if there's a reason to maintain the incorrect format, but happy to amend if so!

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)