### PR TITLE
Temporarily bring back `DisableAspNetCoreGrpc` feature flag

### DIFF
--- a/src/WebJobs.Script.Grpc/GrpcServiceCollectionsExtensions.cs
+++ b/src/WebJobs.Script.Grpc/GrpcServiceCollectionsExtensions.cs
@@ -17,6 +17,15 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
             services.AddSingleton<IRpcServer, AspNetCoreGrpcServer>();
 
+            if (FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableAspNetCoreGrpc))
+            {
+                services.AddSingleton<IRpcServer, GrpcServer>();
+            }
+            else
+            {
+                services.AddSingleton<IRpcServer, AspNetCoreGrpcServer>();
+            }
+
             return services;
         }
     }

--- a/src/WebJobs.Script.Grpc/Server/GrpcServer.cs
+++ b/src/WebJobs.Script.Grpc/Server/GrpcServer.cs
@@ -1,0 +1,75 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.Grpc
+{
+    public class GrpcServer : IRpcServer, IDisposable
+    {
+        private readonly ILogger<GrpcServer> _logger;
+        private int _shutdown = 0;
+        private Server _server;
+        private bool _disposed = false;
+        public const int MaxMessageLengthBytes = int.MaxValue;
+
+        public GrpcServer(FunctionRpc.FunctionRpcBase serviceImpl, ILogger<GrpcServer> logger)
+        {
+            ChannelOption maxReceiveMessageLength = new ChannelOption(ChannelOptions.MaxReceiveMessageLength, MaxMessageLengthBytes);
+            ChannelOption maxSendMessageLength = new ChannelOption(ChannelOptions.MaxSendMessageLength, MaxMessageLengthBytes);
+            ChannelOption[] grpcChannelOptions = { maxReceiveMessageLength, maxSendMessageLength };
+            _server = new Server(grpcChannelOptions)
+            {
+                Services = { FunctionRpc.BindService(serviceImpl) },
+                Ports = { new ServerPort("127.0.0.1", ServerPort.PickUnused, ServerCredentials.Insecure) }
+            };
+            _logger = logger;
+        }
+
+        public Uri Uri => new Uri($"http://127.0.0.1:{_server.Ports.First().BoundPort}");
+
+        public Task StartAsync()
+        {
+            _server.Start();
+            _logger.LogDebug($"Started {nameof(GrpcServer)} on {Uri}.");
+            return Task.CompletedTask;
+        }
+
+        public Task ShutdownAsync()
+        {
+            // The Grpc server will throw if it is shutdown multiple times.
+            if (Interlocked.CompareExchange(ref _shutdown, 1, 0) == 0)
+            {
+                return _server.ShutdownAsync();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task KillAsync() => _server.KillAsync();
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    ShutdownAsync();
+                }
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+    }
+}

--- a/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
+++ b/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
@@ -18,9 +18,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.39.0" />
+    <PackageReference Include="Grpc.Core" Version="2.32.0" />
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>
@@ -30,8 +31,8 @@
   <ItemGroup>
     <ProjectReference Include="..\WebJobs.Script\WebJobs.Script.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
-     <Protobuf Include=".\azure-functions-language-worker-protobuf\src\proto\**\*.proto" GrpcServices="server" ProtoRoot=".\azure-functions-language-worker-protobuf\src\proto" />
+    <Protobuf Include=".\azure-functions-language-worker-protobuf\src\proto\**\*.proto" GrpcServices="server" ProtoRoot=".\azure-functions-language-worker-protobuf\src\proto" />
   </ItemGroup>
 </Project>

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -107,6 +107,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FeatureFlagEnableDiagnosticEventLogging = "EnableDiagnosticEventLogging";
         public const string FeatureFlagDisableMergedWebHostScriptHostConfiguration = "DisableMergedConfiguration";
         public const string FeatureFlagEnableWorkerIndexing = "EnableWorkerIndexing";
+        public const string FeatureFlagDisableAspNetCoreGrpc = "DisableAspNetCoreGrpc";
 
         public const string AdminJwtValidAudienceFormat = "https://{0}.azurewebsites.net/azurefunctions";
         public const string AdminJwtValidIssuerFormat = "https://{0}.scm.azurewebsites.net";


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Part of #8001, temporality bringing back the feature flag to disable AspNetCoreGrpc whilst I investigate the cold start root cause.

Marking as draft to confirm with @fabiocav & @brettsam if this is okay to do?

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

