### PR TITLE
Add support to send configuration for the new Durable Functions storage providers (Netherite and Microsoft SQL) to ScaleController

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -35,6 +35,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         private const string DurableTaskV2StorageOptions = "storageProvider";
         private const string DurableTaskV2StorageConnectionName = "connectionStringName";
         private const string DurableTask = "durableTask";
+        private const string StorageProviderType = "storageProviderType";
+        private const string NetheriteStorageConnectionName = "netheriteStorageConnectionName";
+        private const string NetheriteEventHubsConnectionName = "netheriteEventHubsConnectionName";
 
         // 45 alphanumeric characters gives us a buffer in our table/queue/blob container names.
         private const int MaxTaskHubNameSize = 45;
@@ -477,6 +480,21 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 {
                     trigger[Connection] = durableTaskConfig.Connection;
                 }
+
+                if (durableTaskConfig.StorageType != null)
+                {
+                    trigger[StorageProviderType] = durableTaskConfig.StorageType;
+                }
+
+                if (durableTaskConfig.NetheriteStorageConnectionName != null)
+                {
+                    trigger[NetheriteStorageConnectionName] = durableTaskConfig.NetheriteStorageConnectionName;
+                }
+
+                if (durableTaskConfig.NetheriteEventHubsConnectionName != null)
+                {
+                    trigger[NetheriteEventHubsConnectionName] = durableTaskConfig.NetheriteEventHubsConnectionName;
+                }
             }
             return trigger;
         }
@@ -587,7 +605,24 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
                 if (durableHostConfig.TryGetValue(DurableTaskV2StorageOptions, StringComparison.OrdinalIgnoreCase, out JToken storageOptions) && (storageOptions as JObject) != null)
                 {
-                    if (((JObject)storageOptions).TryGetValue(DurableTaskV2StorageConnectionName, StringComparison.OrdinalIgnoreCase, out nameValue) && nameValue != null)
+                    if (((JObject)storageOptions).TryGetValue("type", StringComparison.OrdinalIgnoreCase, out JToken typeValue) && typeValue != null)
+                    {
+                        config.StorageType = typeValue.ToString();
+
+                        if (string.Equals(config.StorageType, "Netherite", StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (((JObject)storageOptions).TryGetValue("StorageConnectionName", StringComparison.OrdinalIgnoreCase, out JToken storageConnectionName) && storageConnectionName != null)
+                            {
+                                config.NetheriteStorageConnectionName = storageConnectionName.ToString();
+                            }
+
+                            if (((JObject)storageOptions).TryGetValue("EventHubsConnectionName", StringComparison.OrdinalIgnoreCase, out JToken eventHubsConnectionName) && eventHubsConnectionName != null)
+                            {
+                                config.NetheriteEventHubsConnectionName = eventHubsConnectionName.ToString();
+                            }
+                        }
+                    }
+                    else if (((JObject)storageOptions).TryGetValue(DurableTaskV2StorageConnectionName, StringComparison.OrdinalIgnoreCase, out nameValue) && nameValue != null)
                     {
                         config.Connection = nameValue.ToString();
                     }
@@ -716,6 +751,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             public string HubName { get; set; }
 
             public string Connection { get; set; }
+
+            public string StorageType { get; set; }
+
+            public string NetheriteStorageConnectionName { get; set; }
+
+            public string NetheriteEventHubsConnectionName { get; set; }
 
             public bool HasValues()
             {


### PR DESCRIPTION
This PR adds support to send Durable Functions storage provider specific information (from host.json) to the Scale Controller to properly scale the new Durable Functions storage providers under a consumption plan. The new storage providers are Netherite and Microsoft SQL. For the Netherite backend, the ScaleController needs information about the storage connection string and event hubs connection string. For the Microsoft SQL backend, the ScaleController needs information about the SQL connection string, the maxConcurrentActivityFunctions value, and the maxConcurrentActivityFunctions value.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)