### PR TITLE
Figure out FUNCTIONS_WORKER_RUNTIME from function app content if Environment variable FUNCTIONS_WORKER_RUNTIME is not set

### DIFF
--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -633,11 +633,16 @@ namespace Microsoft.Azure.WebJobs.Script
 
         internal static string GetWorkerRuntime(IEnumerable<FunctionMetadata> functions, IEnvironment environment = null)
         {
-            var workerRuntime = environment != null ? environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime) : null;
+            string workerRuntime = null;
 
-            if (!string.IsNullOrEmpty(workerRuntime))
+            if (environment != null)
             {
-                return workerRuntime;
+                workerRuntime = environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime);
+
+                if (!string.IsNullOrEmpty(workerRuntime))
+                {
+                    return workerRuntime;
+                }
             }
 
             if (functions != null && IsSingleLanguage(functions, null))

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -631,9 +631,16 @@ namespace Microsoft.Azure.WebJobs.Script
             return ContainsFunctionWithWorkerRuntime(filteredFunctions, workerRuntime);
         }
 
-        internal static string GetWorkerRuntime(IEnumerable<FunctionMetadata> functions)
+        internal static string GetWorkerRuntime(IEnumerable<FunctionMetadata> functions, IEnvironment environment = null)
         {
-            if (IsSingleLanguage(functions, null))
+            var workerRuntime = environment != null ? environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime) : null;
+
+            if (!string.IsNullOrEmpty(workerRuntime))
+            {
+                return workerRuntime;
+            }
+
+            if (functions != null && IsSingleLanguage(functions, null))
             {
                 var filteredFunctions = functions?.Where(f => !f.IsCodeless());
                 string functionLanguage = filteredFunctions.FirstOrDefault()?.Language;

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -218,7 +218,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             }
 
             _workerRuntime = _workerRuntime ?? _environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime);
-            _workerRuntime = _workerRuntime ?? Utility.GetWorkerRuntime(functions);
+
+            if (functions != null)
+            {
+                _workerRuntime = _workerRuntime ?? Utility.GetWorkerRuntime(functions);
+            }
 
             if (string.IsNullOrEmpty(_workerRuntime) || _workerRuntime.Equals(RpcWorkerConstants.DotNetLanguageWorkerName, StringComparison.InvariantCultureIgnoreCase))
             {

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -217,12 +217,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 return;
             }
 
-            _workerRuntime = _workerRuntime ?? _environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime);
-
-            if (functions != null)
-            {
-                _workerRuntime = _workerRuntime ?? Utility.GetWorkerRuntime(functions);
-            }
+            _workerRuntime = _workerRuntime ?? Utility.GetWorkerRuntime(functions, _environment);
 
             if (string.IsNullOrEmpty(_workerRuntime) || _workerRuntime.Equals(RpcWorkerConstants.DotNetLanguageWorkerName, StringComparison.InvariantCultureIgnoreCase))
             {

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -218,6 +218,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             }
 
             _workerRuntime = _workerRuntime ?? _environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime);
+            _workerRuntime = _workerRuntime ?? Utility.GetWorkerRuntime(functions);
+
             if (string.IsNullOrEmpty(_workerRuntime) || _workerRuntime.Equals(RpcWorkerConstants.DotNetLanguageWorkerName, StringComparison.InvariantCultureIgnoreCase))
             {
                 // Shutdown any placeholder channels for empty function apps or dotnet function apps.

--- a/test/WebJobs.Script.Tests/UtilityTests.cs
+++ b/test/WebJobs.Script.Tests/UtilityTests.cs
@@ -596,6 +596,27 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
+        [InlineData(null)]
+        [InlineData("java")]
+        public void GetWorkerRuntimeTests(string workerRuntime)
+        {
+            FunctionMetadata func1 = new FunctionMetadata()
+            {
+                Name = "func1",
+                Language = workerRuntime
+            };
+
+            IEnumerable<FunctionMetadata> functionMetadatas = new List<FunctionMetadata>
+            {
+                 func1
+            };
+
+            var testEnv = new TestEnvironment();
+            testEnv.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, workerRuntime);
+            Assert.True(Utility.GetWorkerRuntime(functionMetadatas, testEnv) == workerRuntime);
+        }
+
+        [Theory]
         [InlineData("node", "java")]
         [InlineData("java", "node")]
         [InlineData("python", "")]

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
@@ -314,7 +314,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             mockLanguageWorkerChannelManager.Verify(m => m.ShutdownChannelsAsync(), Times.Once);
         }
 
-        /*
         [Fact]
         public async Task ShutdownChannels_NullFunctions()
         {
@@ -327,7 +326,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             await Task.Delay(6000);
             mockLanguageWorkerChannelManager.Verify(m => m.ShutdownChannelsAsync(), Times.Once);
         }
-        */
 
         [Fact]
         public async Task ShutdownChannels_DotNetFunctions()

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
@@ -126,29 +126,39 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.Equal(expectedProcessCount, initializedChannelsCount);
         }
 
-        [Fact]
-        public async Task WorkerRuntime_Setting_ChannelInitializationState_Succeeds()
+        [Theory]
+        [InlineData(null)]
+        [InlineData(RpcWorkerConstants.JavaLanguageWorkerName)]
+        public async Task WorkerRuntime_Setting_ChannelInitializationState_Succeeds(string workerRuntime)
         {
             _testLoggerProvider.ClearAllLogMessages();
-            int expectedProcessCount = 3;
-            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount, false, runtime: RpcWorkerConstants.JavaLanguageWorkerName, workerIndexing: true);
-
-            var testEnv = new TestEnvironment();
-            testEnv.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, null);
+            int expectedProcessCount = 1;
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount, false, runtime: workerRuntime, workerIndexing: true);
 
             // create channels and ensure that they aren't ready for invocation requests yet
             await functionDispatcher.InitializeAsync(new List<FunctionMetadata>());
-            int createdChannelsCount = await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount, false);
-            Assert.Equal(expectedProcessCount, createdChannelsCount);
 
-            IEnumerable<IRpcWorkerChannel> channels = await functionDispatcher.GetInitializedWorkerChannelsAsync();
-            Assert.Equal(0, channels.Count());
+            if (!string.IsNullOrEmpty(workerRuntime))
+            {
+                int createdChannelsCount = await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount, false);
+                Assert.Equal(expectedProcessCount, createdChannelsCount);
 
-            // set up invocation buffers, send load requests, and ensure that the channels are now set up for invocation requests
-            var functions = GetTestFunctionsList(RpcWorkerConstants.JavaLanguageWorkerName);
-            await functionDispatcher.FinishInitialization(functions);
-            int initializedChannelsCount = await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount, true);
-            Assert.Equal(expectedProcessCount, initializedChannelsCount);
+                IEnumerable<IRpcWorkerChannel> channels = await functionDispatcher.GetInitializedWorkerChannelsAsync();
+                Assert.Equal(0, channels.Count());
+
+                // set up invocation buffers, send load requests, and ensure that the channels are now set up for invocation requests
+                var functions = GetTestFunctionsList(RpcWorkerConstants.JavaLanguageWorkerName);
+                await functionDispatcher.FinishInitialization(functions);
+                int initializedChannelsCount = await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount, true);
+                Assert.Equal(expectedProcessCount, initializedChannelsCount);
+            }
+            else
+            {
+                foreach (var currChannel in functionDispatcher.JobHostLanguageWorkerChannelManager.GetChannels())
+                {
+                    Assert.True(((TestRpcWorkerChannel)currChannel).ExecutionContexts.Count == 0);
+                }
+            }
         }
 
         [Fact]


### PR DESCRIPTION
### Issue describing the changes in this PR

One of the previous changes causing the language worker channel to get shutdown if worker runtime setting is not present in Environment setting - https://github.com/Azure/azure-functions-host/commit/7e52075f6377530ddc0970e38cff1625816f2bed#diff-5a241b8ff64ccf9edb3fc0cc63256d99705ba2ffa011019fa8371d16d86b6cd6L208-L209

Fixing issue by allowing it to read runtime from files.
