### PR TITLE
Bump C# language version to 8.0

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -2,7 +2,7 @@
   <Import Project=".\package.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <MajorVersion>3</MajorVersion>
     <MinorVersion>5</MinorVersion>
     <PatchVersion>0</PatchVersion>

--- a/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
+++ b/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     RpcDataType.None => null,
                     RpcDataType.String => typedData.String,
                     RpcDataType.Json => JsonConvert.DeserializeObject(typedData.Json, _datetimeSerializerSettings),
-                    RpcDataType.Bytes or RpcDataType.Stream => typedData.Bytes.ToByteArray(),
+                    var type when type == RpcDataType.Bytes || type == RpcDataType.Stream => typedData.Bytes.ToByteArray(),
                     RpcDataType.Http => GrpcMessageExtensionUtilities.ConvertFromHttpMessageToExpando(typedData.Http),
                     RpcDataType.Int => typedData.Int,
                     RpcDataType.Double => typedData.Double,


### PR DESCRIPTION
dotnet 3.1 supports C# 8.0, and given we have v8.0 language changes in the v4 dev branch this should make it easier to backport