### PR TITLE
improve scoping of FunctionRpcService; remove call to CreateDefaultBu…

### DIFF
--- a/src/WebJobs.Script.Grpc/Server/AspNetCoreGrpcServer.cs
+++ b/src/WebJobs.Script.Grpc/Server/AspNetCoreGrpcServer.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.DependencyInjection;
@@ -22,10 +23,10 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         private bool _disposed = false;
         private IHost _grpcHost;
 
-        public AspNetCoreGrpcServer(IScriptEventManager scriptEventManager, ILogger<AspNetCoreGrpcServer> logger)
+        public AspNetCoreGrpcServer(FunctionRpc.FunctionRpcBase service, IScriptEventManager scriptEventManager, ILogger<AspNetCoreGrpcServer> logger)
         {
             int port = WorkerUtilities.GetUnusedTcpPort();
-            _grpcHostBuilder = AspNetCoreGrpcHostBuilder.CreateHostBuilder(scriptEventManager, port);
+            _grpcHostBuilder = AspNetCoreGrpcHostBuilder.CreateHostBuilder(service, scriptEventManager, port);
             _logger = logger;
             Uri = new Uri($"http://{WorkerConstants.HostName}:{port}");
         }

--- a/src/WebJobs.Script.Grpc/Server/Startup.cs
+++ b/src/WebJobs.Script.Grpc/Server/Startup.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -32,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
             app.UseEndpoints(endpoints =>
             {
-                endpoints.MapGrpcService<FunctionRpcService>();
+                endpoints.MapGrpcService<FunctionRpc.FunctionRpcBase>();
             });
         }
     }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/AspNetCoreGrpcServerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/AspNetCoreGrpcServerTests.cs
@@ -3,7 +3,9 @@
 
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Grpc;
+using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
@@ -13,14 +15,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         [Fact]
         public void CleanDisposal()
         {
-            var server = new AspNetCoreGrpcServer(new TestScriptEventManager(), NullLogger<AspNetCoreGrpcServer>.Instance);
+            var server = new AspNetCoreGrpcServer(new Mock<FunctionRpc.FunctionRpcBase>().Object, new TestScriptEventManager(), NullLogger<AspNetCoreGrpcServer>.Instance);
             server.Dispose();
         }
 
         [Fact]
         public async Task CleanDisposalAsync()
         {
-            var server = new AspNetCoreGrpcServer(new TestScriptEventManager(), NullLogger<AspNetCoreGrpcServer>.Instance);
+            var server = new AspNetCoreGrpcServer(new Mock<FunctionRpc.FunctionRpcBase>().Object, new TestScriptEventManager(), NullLogger<AspNetCoreGrpcServer>.Instance);
             await server.DisposeAsync();
         }
     }


### PR DESCRIPTION
1. Using the root-registered `FunctionRpcService` when running the `AspNetCoreGrpcService`. We were missing logs because the new inner Grpc host did not have all of the root loggers registered. By using this service from the root scope, the logger is automatically wired up as we expect.
2. Removing call to `CreateDefaultBuilder()` for the host running the `AspNetCoreGrpcService`. This was having cold start impact in single-core Linux instances, which we've attributed to the FileWatchers set up by the default builder.