### PR TITLE
Fix: race in RpcFunctionInvocationDispatcher

### DIFF
--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -573,7 +573,10 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 {
                     _logger.LogDebug("Disposing FunctionDispatcher");
                     _disposeToken.Cancel();
-                    _disposeToken.Dispose();
+                    // We're explicitly NOT disposing the token here, because if anything our Task.Delay() is waiting on it
+                    // Disposing here gives zero time to observe the cancel and is likely to yield an ObjectDisposeException in a race.
+                    // Since this is relatively rare, let the GC clean it up.
+                    //_disposeToken.Dispose();
                     _startWorkerProcessLock.Dispose();
                     _workerErrorSubscription.Dispose();
                     _workerRestartSubscription.Dispose();

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -527,6 +527,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 {
                     // Issue only one restart at a time.
                     await _startWorkerProcessLock.WaitAsync();
+                    // After waiting on the lock (which could take some time), make sure we're not in a disposed state trying to start things up
+                    if (_disposing || _disposed)
+                    {
+                        return;
+                    }
                     await InitializeJobhostLanguageWorkerChannelAsync(_languageWorkerErrors.Count);
                 }
                 finally


### PR DESCRIPTION
This is failing several test runs due to a race in the disposal/cancel and the Task.Delay() waiting on the same token. Since it's relatively rare, let's not create this situation and let the GC handle cleanup gracefully.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
