### PR TITLE
TestHelper: fix WaitForBlobAsync null ref

### DIFF
--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -138,7 +138,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 return exists;
             },
             pollingInterval: 500,
-            userMessageCallback: () => sb.ToString() + Environment.NewLine + userMessageCallback());
+            userMessageCallback: () =>
+            {
+                if (userMessageCallback != null)
+                {
+                    sb.AppendLine().Append(userMessageCallback());
+                }
+                return sb.ToString();
+            });
         }
 
         public static void ClearFunctionLogs(string functionName)


### PR DESCRIPTION
This only errored in the timeout case without a debugger attached (but is failing on many CI runs). We're not passing a `userMessageCallback` in which means `userMessageCallback()` will null ref, like this:
```
[xUnit.net 00:01:10.82]     Microsoft.Azure.WebJobs.Script.Tests.EndToEnd.CSharpEndToEndTests.QueueTriggerToBlob [FAIL]
  Failed Microsoft.Azure.WebJobs.Script.Tests.EndToEnd.CSharpEndToEndTests.QueueTriggerToBlob [1 m]
  Error Message:
   System.NullReferenceException : Object reference not set to an instance of an object.
  Stack Trace:
     at Microsoft.Azure.WebJobs.Script.Tests.TestHelpers.<>c__DisplayClass12_0.<WaitForBlobAsync>b__1() in /_/test/WebJobs.Script.Tests.Shared/TestHelpers.cs:line 141
   at Microsoft.Azure.WebJobs.Script.Tests.TestHelpers.Await(Func`1 condition, Int32 timeout, Int32 pollingInterval, Boolean throwWhenDebugging, Func`1 userMessageCallback) in /_/test/WebJobs.Script.Tests.Shared/TestHelpers.cs:line 113
   at Microsoft.Azure.WebJobs.Script.Tests.TestHelpers.WaitForBlobAsync(CloudBlockBlob blob, Func`1 userMessageCallback) in /_/test/WebJobs.Script.Tests.Shared/TestHelpers.cs:line 134
   at Microsoft.Azure.WebJobs.Script.Tests.TestHelpers.WaitForBlobAndGetStringAsync(CloudBlockBlob blob, Func`1 userMessageCallback) in /_/test/WebJobs.Script.Tests.Shared/TestHelpers.cs:line 122
   at Microsoft.Azure.WebJobs.Script.Tests.EndToEndTestsBase`1.QueueTriggerToBlobTest() in /_/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestsBase.cs:line 168
   at Microsoft.Azure.WebJobs.Script.Tests.EndToEnd.CSharpEndToEndTests.QueueTriggerToBlob() in /_/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpEndToEndTests.cs:line 47
--- End of stack trace from previous location ---
```

This fixes the case and should behave as intended. I think we'll still timeout and fail the actual test because it's still a failure, but we'll see the actual fail instead of the current null ref exception while reporting the timeout.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)