### PR TITLE
Emitting metric to identify .NET applications not using R2R

### DIFF
--- a/src/WebJobs.Script.WebHost/AssemblyAnalysis/AssemblyAnalysisService.cs
+++ b/src/WebJobs.Script.WebHost/AssemblyAnalysis/AssemblyAnalysisService.cs
@@ -1,0 +1,159 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.PortableExecutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.AssemblyAnalyzer
+{
+    internal class AssemblyAnalysisService : IHostedService, IDisposable
+    {
+        private readonly IEnvironment _environment;
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly IOptionsMonitor<StandbyOptions> _standbyOptionsMonitor;
+        private readonly WebJobsScriptHostService _scriptHost;
+        private CancellationTokenSource _cancellationTokenSource;
+        private Task _analysisTask;
+        private bool _disposed;
+        private bool _analysisScheduled;
+
+        public AssemblyAnalysisService(IEnvironment environment, WebJobsScriptHostService scriptHost, ILoggerFactory loggerFactory, IOptionsMonitor<StandbyOptions> standbyOptionsMonitor)
+        {
+            _environment = environment;
+            _scriptHost = scriptHost;
+            _loggerFactory = loggerFactory;
+            _standbyOptionsMonitor = standbyOptionsMonitor;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            if (!_environment.IsCoreTools())
+            {
+                if (_standbyOptionsMonitor.CurrentValue.InStandbyMode)
+                {
+                    _standbyOptionsMonitor.OnChange(standbyOptions =>
+                    {
+                        if (!standbyOptions.InStandbyMode && !_analysisScheduled)
+                        {
+                            ScheduleAssemblyAnalysis();
+                        }
+                    });
+                }
+                else
+                {
+                    ScheduleAssemblyAnalysis();
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            _cancellationTokenSource?.Cancel();
+
+            if (_analysisTask != null && !_analysisTask.IsCompleted)
+            {
+                var logger = _loggerFactory.CreateLogger<AssemblyAnalysisService>();
+                logger.LogDebug("Assembly analysis service stopped before analysis completion. Waiting for cancellation.");
+
+                return _analysisTask;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private void ScheduleAssemblyAnalysis()
+        {
+            var jobHost = _scriptHost.GetService<IScriptJobHost>();
+            if (jobHost == null
+                || !jobHost.Functions.Any(f => f.Metadata.IsDirect()))
+            {
+                return;
+            }
+
+            _analysisScheduled = true;
+            _cancellationTokenSource = new CancellationTokenSource();
+
+            _analysisTask = Task.Delay(TimeSpan.FromMinutes(1), _cancellationTokenSource.Token)
+               .ContinueWith(t => AnalyzeFunctionAssemblies());
+        }
+
+        private void AnalyzeFunctionAssemblies()
+        {
+            var jobHost = _scriptHost.GetService<IScriptJobHost>();
+
+            if (jobHost == null
+                || _cancellationTokenSource.IsCancellationRequested)
+            {
+                return;
+            }
+
+            var logger = _loggerFactory.CreateLogger<AssemblyAnalysisService>();
+            var assemblies = new HashSet<Assembly>();
+            var hasUnoptimizedAssemblies = false;
+
+            foreach (var item in jobHost.Functions)
+            {
+                if (_cancellationTokenSource.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                if (item.Metadata.Properties.TryGetValue(ScriptConstants.FunctionMetadataDirectTypeKey, out Type type)
+                    && !assemblies.Contains(type.Assembly))
+                {
+                    if (!IsReadyToRunOptimized(type.Assembly))
+                    {
+                        hasUnoptimizedAssemblies = true;
+                        logger.Log(LogLevel.Debug, "Detected unoptimized function assemblies.");
+
+                        break;
+                    }
+
+                    assemblies.Add(type.Assembly);
+                }
+            }
+
+            if (!hasUnoptimizedAssemblies)
+            {
+                logger.Log(LogLevel.Debug, "All function assemblies optimized.");
+            }
+        }
+
+        private static bool IsReadyToRunOptimized(Assembly assembly)
+        {
+            try
+            {
+                using (var stream = File.OpenRead(assembly.Location))
+                using (var peFile = new PEReader(stream))
+                {
+                    return peFile.PEHeaders.CorHeader?.ManagedNativeHeaderDirectory.Size != 0;
+                }
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _cancellationTokenSource?.Dispose();
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -159,6 +159,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddSingleton<WebJobsScriptHostService>();
             services.AddSingleton<IHostedService>(s => s.GetRequiredService<WebJobsScriptHostService>());
 
+            // Performs function assembly analysis to generete log use of unoptimized assemblies.
+            services.AddSingleton<IHostedService, AssemblyAnalyzer.AssemblyAnalysisService>();
+
             // Handles shutdown of services that need to happen after StopAsync() of all services of type IHostedService are complete.
             // Order is important.
             // All other IHostedService injections need to go before this.

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -189,5 +189,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public static readonly long DefaultMaxRequestBodySize = 104857600;
 
         public static readonly ImmutableArray<string> SystemLogCategoryPrefixes = ImmutableArray.Create("Microsoft.Azure.WebJobs.", "Function.", "Worker.", "Host.");
+
+        public static readonly string FunctionMetadataDirectTypeKey = "DirectType";
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

This change adds logic to perform analysis of function assemblies to identify whether they have been R2R optimized. This enables us to emit telemetry that will power Risk Alerts and other notifications to provide guidance to .NET Function Apps not using R2R

No tests checked in as part of this change, but I ran through validation with a number of scenarios and wanted to get this in to give @safihamid a chance to look and make sure we can get this in the next release. I'll follow up with additional tests.

resolves #7901 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

