### PR TITLE
Updating end to end test to consume cancellation token with drain mode

### DIFF
--- a/sample/CSharp/HttpTrigger-Cancellation/run.csx
+++ b/sample/CSharp/HttpTrigger-Cancellation/run.csx
@@ -6,21 +6,7 @@ using Microsoft.Extensions.Primitives;
 public static async Task<IActionResult> Run(HttpRequest req, ILogger log, CancellationToken token)
 {
     log.LogInformation("C# HTTP trigger cancellation function processing a request.");
-
-    try
-    {
-        await Task.Delay(10000, token);
-        log.LogInformation("Function invocation successful.");
-        return new OkResult();
-
-    }
-    catch (OperationCanceledException)
-    {
-        log.LogInformation("Function invocation cancelled.");
-        return new NotFoundResult();
-    }
-    catch (Exception e)
-    {
-        return new StatusCodeResult(500);
-    }
+    await Task.Delay(10000, token);
+    log.LogInformation("Function invocation successful.");
+    return new OkResult();
 }

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -67,7 +67,7 @@
     <PackageReference Include="Microsoft.Azure.AppService.Middleware.Functions" Version="1.4.10" />
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
     <PackageReference Include="Microsoft.Azure.Storage.File" Version="11.1.7" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.32" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33-11904" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.0-beta.1" />
     <PackageReference Include="Microsoft.Azure.WebSites.DataProtection" Version="2.1.91-alpha" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="Azure.Core" Version="1.19.0" />
     <PackageReference Include="Azure.Identity" Version="1.4.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.9.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.32" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33-11904" />
 	<PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.0-beta.1" />
 	<PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0">

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/DrainModeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/DrainModeEndToEndTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 
             // Call function with cancellation token handler
             response = await SamplesTestHelpers.InvokeHttpTrigger(this, "HttpTrigger-Cancellation");
-            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
     }
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-webjobs-sdk/pull/2821

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
