### PR TITLE
Sync host with Protobuf - removing retry_options and config_source

### DIFF
--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -525,8 +525,6 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     {
                         Metadata = functionMetadata,
                         Bindings = bindings,
-                        RetryOptions = metadata.RetryOptions,
-                        ConfigurationSource = metadata.ConfigSource,
                         UseDefaultMetadataIndexing = functionMetadataResponse.UseDefaultMetadataIndexing
                     });
                 }

--- a/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
+++ b/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
@@ -274,12 +274,6 @@ message RpcFunctionMetadata {
   // Raw binding info
   repeated string raw_bindings = 10;
 
-  // Retry Options: string representation of JObject retry options (maxRetryCount, intervals, etc.)
-  string retry_options = 11;
-
-  // Configuration Source: string representation of JToken configuration source property in function metadata
-  string config_source = 12;
-
   // unique function identifier (avoid name collisions, facilitate reload case)
   string function_id = 13;
 


### PR DESCRIPTION
Host protobuf file has extra fields as compared to Protobuf repo. Removing those fields to bring them in sync.
Discussion - https://github.com/Azure/azure-functions-host/issues/7849