### PR TITLE
adding logs to shutdown path

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -694,15 +694,23 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         /// <param name="instance">The <see cref="IHost"/> instance to remove</param>
         private async Task Orphan(IHost instance, CancellationToken cancellationToken = default)
         {
+            if (instance == null)
+            {
+                _logger.LogDebug("Cannot stop or dispose a null host instance.");
+                return;
+            }
+
             var isStandbyHost = false;
+            string hostInstanceId = "unknown";
             try
             {
-                var scriptHost = (ScriptHost)instance?.Services.GetService<ScriptHost>();
+                var scriptHost = instance.Services.GetService<ScriptHost>();
                 if (scriptHost != null)
                 {
                     scriptHost.HostInitializing -= OnHostInitializing;
                     scriptHost.HostInitialized -= OnHostInitialized;
                     isStandbyHost = scriptHost.IsStandbyHost;
+                    hostInstanceId = scriptHost.ScriptOptions.InstanceId;
                 }
             }
             catch (ObjectDisposedException)
@@ -712,45 +720,43 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
             try
             {
-                await (instance?.StopAsync(cancellationToken) ?? Task.CompletedTask);
+                await instance.StopAsync(cancellationToken);
             }
             catch (Exception ex) when (!ex.IsFatal())
             {
                 // some errors are expected here - e.g. in error/shutdown situations
                 // we might attempt to stop the host before it has fully started
+                _logger.LogError(ex, "Failed to stop host instance '{hostInstanceId}'.", hostInstanceId);
             }
             finally
             {
-                if (instance != null)
+                GetHostLogger(instance).LogDebug("Disposing ScriptHost: '{hostInstanceId}'", hostInstanceId);
+
+                if (isStandbyHost && !_scriptWebHostEnvironment.InStandbyMode)
                 {
-                    GetHostLogger(instance).LogDebug("Disposing ScriptHost.");
-
-                    if (isStandbyHost && !_scriptWebHostEnvironment.InStandbyMode)
+                    // For cold start reasons delay disposing script host if specializing out of placeholder mode
+                    Utility.ExecuteAfterColdStartDelay(_environment, () =>
                     {
-                        // For cold start reasons delay disposing script host if specializing out of placeholder mode
-                        Utility.ExecuteAfterColdStartDelay(_environment, () =>
+                        try
                         {
-                            try
-                            {
-                                GetHostLogger(instance).LogDebug("Starting Standby ScriptHost dispose");
-                                instance.Dispose();
-                                _logger.LogDebug("Standby ScriptHost disposed");
-                            }
-                            catch (Exception e)
-                            {
-                                _logger.LogError(e, "Failed to dispose Standby ScriptHost instance");
-                                throw;
-                            }
-                        }, cancellationToken);
+                            GetHostLogger(instance).LogDebug("Starting Standby ScriptHost dispose");
+                            instance.Dispose();
+                            _logger.LogDebug("Standby ScriptHost disposed");
+                        }
+                        catch (Exception e)
+                        {
+                            _logger.LogError(e, "Failed to dispose Standby ScriptHost instance");
+                            throw;
+                        }
+                    }, cancellationToken);
 
-                        _logger.LogDebug("Standby ScriptHost marked for disposal");
-                    }
-                    else
-                    {
-                        DisposeDependencyTrackingModule(instance);
-                        instance.Dispose();
-                        _logger.LogDebug("ScriptHost disposed");
-                    }
+                    _logger.LogDebug("Standby ScriptHost marked for disposal");
+                }
+                else
+                {
+                    DisposeDependencyTrackingModule(instance);
+                    instance.Dispose();
+                    _logger.LogDebug("ScriptHost disposed: '{hostInstanceId}'", hostInstanceId);
                 }
             }
         }

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -730,6 +730,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
             finally
             {
+                GetHostLogger(instance).LogDebug("Disposing ScriptHost.");
+
                 if (isStandbyHost && !_scriptWebHostEnvironment.InStandbyMode)
                 {
                     // For cold start reasons delay disposing script host if specializing out of placeholder mode

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -730,8 +730,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
             finally
             {
-                GetHostLogger(instance).LogDebug("Disposing ScriptHost: '{hostInstanceId}'", hostInstanceId);
-
                 if (isStandbyHost && !_scriptWebHostEnvironment.InStandbyMode)
                 {
                     // For cold start reasons delay disposing script host if specializing out of placeholder mode
@@ -756,7 +754,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 {
                     DisposeDependencyTrackingModule(instance);
                     instance.Dispose();
-                    _logger.LogDebug("ScriptHost disposed: '{hostInstanceId}'", hostInstanceId);
+                    _logger.LogDebug("ScriptHost disposed");
                 }
             }
         }

--- a/src/WebJobs.Script/Diagnostics/Extensions/ScriptHostLoggerExtension.cs
+++ b/src/WebJobs.Script/Diagnostics/Extensions/ScriptHostLoggerExtension.cs
@@ -94,6 +94,30 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
            new EventId(414, nameof(AddingDescriptorProviderForHttpWorker)),
            "Adding Function descriptor provider for HttpWorker.");
 
+        private static readonly Action<ILogger, string, Exception> _stoppingScriptHost =
+            LoggerMessage.Define<string>(
+            LogLevel.Debug,
+            new EventId(415, nameof(StoppingScriptHost)),
+            "Stopping ScriptHost instance '{hostInstanceId}'.");
+
+        private static readonly Action<ILogger, string, Exception> _stoppedScriptHost =
+          LoggerMessage.Define<string>(
+          LogLevel.Debug,
+          new EventId(416, nameof(StoppedScriptHost)),
+          "Stopped ScriptHost instance '{hostInstanceId}'.");
+
+        private static readonly Action<ILogger, string, Exception> _disposingScriptHost =
+          LoggerMessage.Define<string>(
+          LogLevel.Debug,
+          new EventId(417, nameof(DisposingScriptHost)),
+          "Disposing ScriptHost instance '{hostInstanceId}'.");
+
+        private static readonly Action<ILogger, string, Exception> _disposedScriptHost =
+          LoggerMessage.Define<string>(
+          LogLevel.Debug,
+          new EventId(418, nameof(DisposedScriptHost)),
+          "Disposed ScriptHost instance '{hostInstanceId}'.");
+
         public static void HostIdIsSet(this ILogger logger)
         {
             _hostIdIsSet(logger, null);
@@ -170,6 +194,26 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
         public static void ScriptHostStarted(this ILogger logger, long ms)
         {
             _scriptHostStarted(logger, ms, null);
+        }
+
+        public static void StoppingScriptHost(this ILogger logger, string hostInstanceId)
+        {
+            _stoppingScriptHost(logger, hostInstanceId, null);
+        }
+
+        public static void StoppedScriptHost(this ILogger logger, string hostInstanceId)
+        {
+            _stoppedScriptHost(logger, hostInstanceId, null);
+        }
+
+        public static void DisposingScriptHost(this ILogger logger, string hostInstanceId)
+        {
+            _disposingScriptHost(logger, hostInstanceId, null);
+        }
+
+        public static void DisposedScriptHost(this ILogger logger, string hostInstanceId)
+        {
+            _disposedScriptHost(logger, hostInstanceId, null);
         }
     }
 }

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -962,8 +962,17 @@ namespace Microsoft.Azure.WebJobs.Script
             _logger.ScriptHostStarted((long)_stopwatch.GetElapsedTime().TotalMilliseconds);
         }
 
+        protected override async Task StopAsyncCore(CancellationToken cancellationToken)
+        {
+            _logger.StoppingScriptHost(ScriptOptions.InstanceId);
+            await base.StopAsyncCore(cancellationToken);
+            _logger.StoppedScriptHost(ScriptOptions.InstanceId);
+        }
+
         protected override void Dispose(bool disposing)
         {
+            _logger.DisposingScriptHost(ScriptOptions.InstanceId);
+
             if (disposing)
             {
                 foreach (var subscription in _eventSubscriptions)
@@ -990,6 +999,8 @@ namespace Microsoft.Azure.WebJobs.Script
             // dispose base last to ensure that errors there don't
             // cause us to not dispose ourselves
             base.Dispose(disposing);
+
+            _logger.DisposedScriptHost(ScriptOptions.InstanceId);
         }
     }
 }


### PR DESCRIPTION
While investigating https://github.com/Azure/azure-webjobs-sdk/issues/2823, it became clear that we have some blind spots during shutdown. For example, some scenarios seem to completely skip the call to `StopAsync()` and immediately dispose of the listeners. I'm adding some additional logging to see if we can catch this and possibly address it.