### PR TITLE
Use appropriate log level for worker console logs for v3

### DIFF
--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcess.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcess.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             };
             if (WorkerProcessUtilities.IsConsoleLog(msg))
             {
-                _workerProcessLogger?.LogDebug(WorkerProcessUtilities.RemoveLogPrefix(msg));
+                _workerProcessLogger?.Log(level, WorkerProcessUtilities.RemoveLogPrefix(msg));
             }
             else
             {

--- a/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
@@ -17,7 +17,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
     {
         private IScriptEventManager _eventManager;
         private IProcessRegistry _processRegistry;
-        private TestLogger _testLogger = new TestLogger("test");
+        private TestLogger _testUserLogger = new TestLogger("Host.Function.Console");
+        private TestLogger _testSystemLogger = new TestLogger("Worker.rpcWorkerProcess");
         private WorkerConsoleLogService _workerConsoleLogService;
         private WorkerConsoleLogSource _workerConsoleLogSource;
         private Mock<IServiceProvider> _serviceProviderMock;
@@ -30,9 +31,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             _workerConsoleLogSource = new WorkerConsoleLogSource();
             _eventManager = new ScriptEventManager();
             _processRegistry = new EmptyProcessRegistry();
-            _workerConsoleLogService = new WorkerConsoleLogService(_testLogger, _workerConsoleLogSource);
+            _workerConsoleLogService = new WorkerConsoleLogService(_testUserLogger, _workerConsoleLogSource);
             _serviceProviderMock = new Mock<IServiceProvider>(MockBehavior.Strict);
-            WorkerProcess workerProcess = new TestWorkerProcess(_eventManager, _processRegistry, _testLogger, _workerConsoleLogSource, null, _serviceProviderMock.Object, useStdErrForErroLogsOnly);
+            WorkerProcess workerProcess = new TestWorkerProcess(_eventManager, _processRegistry, _testSystemLogger, _workerConsoleLogSource, null, _serviceProviderMock.Object, useStdErrForErroLogsOnly);
             workerProcess.ParseErrorMessageAndLog("Test Message No keyword");
             workerProcess.ParseErrorMessageAndLog("Test Error Message");
             workerProcess.ParseErrorMessageAndLog("Test Warning Message");
@@ -42,21 +43,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
 
             _ = _workerConsoleLogService.ProcessLogs().ContinueWith(t => { });
             await _workerConsoleLogService.StopAsync(System.Threading.CancellationToken.None);
-            var allLogs = _testLogger.GetLogMessages();
-            Assert.True(allLogs.Count == 6);
-            VerifyLogLevel(allLogs, "Test Error Message", LogLevel.Error);
-            VerifyLogLevel(allLogs, "[Test Worker Error Message]", LogLevel.Error);
-            VerifyLogLevel(allLogs, "Test Warning Message", LogLevel.Warning);
-            VerifyLogLevel(allLogs, "[Test Worker Warning Message]", LogLevel.Warning);
+            var userLogs = _testUserLogger.GetLogMessages();
+            var systemLogs = _testSystemLogger.GetLogMessages();
+            Assert.True(userLogs.Count == 3);
+            Assert.True(systemLogs.Count == 3);
+            VerifyLogLevel(userLogs, "Test Error Message", LogLevel.Error);
+            VerifyLogLevel(systemLogs, "[Test Worker Error Message]", LogLevel.Error);
+            VerifyLogLevel(userLogs, "Test Warning Message", LogLevel.Warning);
+            VerifyLogLevel(systemLogs, "[Test Worker Warning Message]", LogLevel.Warning);
             if (useStdErrForErroLogsOnly)
             {
-                VerifyLogLevel(allLogs, "Test Message No keyword", LogLevel.Error);
-                VerifyLogLevel(allLogs, "[Test Worker Message No keyword]", LogLevel.Error);
+                VerifyLogLevel(userLogs, "Test Message No keyword", LogLevel.Error);
+                VerifyLogLevel(systemLogs, "[Test Worker Message No keyword]", LogLevel.Error);
             }
             else
             {
-                VerifyLogLevel(allLogs, "Test Message No keyword", LogLevel.Information);
-                VerifyLogLevel(allLogs, "[Test Worker Message No keyword]", LogLevel.Information);
+                VerifyLogLevel(userLogs, "Test Message No keyword", LogLevel.Information);
+                VerifyLogLevel(systemLogs, "[Test Worker Message No keyword]", LogLevel.Information);
             }
         }
 

--- a/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
@@ -58,7 +58,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
                 VerifyLogLevel(allLogs, "Test Message No keyword", LogLevel.Information);
                 VerifyLogLevel(allLogs, "[Test Worker Message No keyword]", LogLevel.Information);
             }
-
         }
 
         private static void VerifyLogLevel(IList<LogMessage> allLogs, string msg, LogLevel expectedLevel)

--- a/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
@@ -36,25 +36,29 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             workerProcess.ParseErrorMessageAndLog("Test Message No keyword");
             workerProcess.ParseErrorMessageAndLog("Test Error Message");
             workerProcess.ParseErrorMessageAndLog("Test Warning Message");
-
-            workerProcess.BuildAndLogConsoleLog("LanguageWorkerConsoleLog[Test worker log]", LogLevel.Information);
+            workerProcess.ParseErrorMessageAndLog("LanguageWorkerConsoleLog[Test Worker Message No keyword]");
+            workerProcess.ParseErrorMessageAndLog("LanguageWorkerConsoleLog[Test Worker Error Message]");
+            workerProcess.ParseErrorMessageAndLog("LanguageWorkerConsoleLog[Test Worker Warning Message]");
 
             _ = _workerConsoleLogService.ProcessLogs().ContinueWith(t => { });
             await _workerConsoleLogService.StopAsync(System.Threading.CancellationToken.None);
             var allLogs = _testLogger.GetLogMessages();
-            Assert.True(allLogs.Count == 4);
+            Assert.True(allLogs.Count == 6);
             VerifyLogLevel(allLogs, "Test Error Message", LogLevel.Error);
+            VerifyLogLevel(allLogs, "[Test Worker Error Message]", LogLevel.Error);
             VerifyLogLevel(allLogs, "Test Warning Message", LogLevel.Warning);
+            VerifyLogLevel(allLogs, "[Test Worker Warning Message]", LogLevel.Warning);
             if (useStdErrForErroLogsOnly)
             {
                 VerifyLogLevel(allLogs, "Test Message No keyword", LogLevel.Error);
+                VerifyLogLevel(allLogs, "[Test Worker Message No keyword]", LogLevel.Error);
             }
             else
             {
                 VerifyLogLevel(allLogs, "Test Message No keyword", LogLevel.Information);
+                VerifyLogLevel(allLogs, "[Test Worker Message No keyword]", LogLevel.Information);
             }
 
-            VerifyLogLevel(allLogs, "[Test worker log]", LogLevel.Debug);
         }
 
         private static void VerifyLogLevel(IList<LogMessage> allLogs, string msg, LogLevel expectedLevel)


### PR DESCRIPTION
Currently, worker console logs are always categorized as "Debug" even though they can contain useful warnings or errors. For example, the Node.js worker displays warnings/errors when validating the Node.js version prior to initializing the rpc channel.

This may be a regression caused by https://github.com/Azure/azure-functions-host/pull/6576. That PR doesn't mention anything about changing log level, so I'm pretty sure it was unintentional, but cc @pragnagopa @AnatoliB to confirm

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)