### PR TITLE
Adding ability to allow worker to send Function load responses in batch

### DIFF
--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -295,7 +295,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                         .Subscribe((msg) => LoadResponse(msg.Message.FunctionLoadResponse), HandleWorkerFunctionLoadError));
 
                     _functionLoadTimeout = functionTimeout.Value > _functionLoadTimeout ? functionTimeout.Value : _functionLoadTimeout;
-                    _eventSubscriptions.Add(_inboundWorkerEvents.Where(msg => msg.MessageType == MsgType.FunctionLoadResponse)
+                    _eventSubscriptions.Add(_inboundWorkerEvents.Where(msg => msg.MessageType == MsgType.FunctionLoadResponseCollection)
                         .Timeout(_functionLoadTimeout)
                         .Take(_functions.Count())
                         .Subscribe((msg) => LoadResponse(msg.Message.FunctionLoadResponseCollection), HandleWorkerFunctionLoadError));
@@ -305,7 +305,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     _eventSubscriptions.Add(_inboundWorkerEvents.Where(msg => msg.MessageType == MsgType.FunctionLoadResponse)
                         .Subscribe((msg) => LoadResponse(msg.Message.FunctionLoadResponse), HandleWorkerFunctionLoadError));
 
-                    _eventSubscriptions.Add(_inboundWorkerEvents.Where(msg => msg.MessageType == MsgType.FunctionLoadResponse)
+                    _eventSubscriptions.Add(_inboundWorkerEvents.Where(msg => msg.MessageType == MsgType.FunctionLoadResponseCollection)
                         .Subscribe((msg) => LoadResponse(msg.Message.FunctionLoadResponseCollection), HandleWorkerFunctionLoadError));
                 }
 
@@ -468,6 +468,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
         internal void LoadResponse(FunctionLoadResponseCollection loadResponseCollection)
         {
+            _workerChannelLogger.LogDebug("Received FunctionLoadResponseCollection with number of functions: '{count}'.", loadResponseCollection.FunctionLoadResponses.Count);
+
             foreach (FunctionLoadResponse loadResponse in loadResponseCollection.FunctionLoadResponses)
             {
                 LoadResponse(loadResponse);

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -294,7 +294,6 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                         .Take(_functions.Count())
                         .Subscribe((msg) => LoadResponse(msg.Message.FunctionLoadResponse), HandleWorkerFunctionLoadError));
 
-                    _functionLoadTimeout = functionTimeout.Value > _functionLoadTimeout ? functionTimeout.Value : _functionLoadTimeout;
                     _eventSubscriptions.Add(_inboundWorkerEvents.Where(msg => msg.MessageType == MsgType.FunctionLoadResponseCollection)
                         .Timeout(_functionLoadTimeout)
                         .Take(_functions.Count())

--- a/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
+++ b/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
@@ -82,6 +82,8 @@ message StreamingMessage {
 
     // Host sends required metadata to worker to load functions
     FunctionLoadRequestCollection function_load_request_collection = 31;
+    // Host gets the list of load responses
+    FunctionLoadResponseCollection function_load_response_collection = 32;
   }
 }
 
@@ -238,6 +240,11 @@ message FunctionLoadRequest {
 
   // A flag indicating if managed dependency is enabled or not
   bool managed_dependency_enabled = 3;
+}
+
+// Host gets the list of load responses
+message FunctionLoadResponseCollection {
+  repeated FunctionLoadResponse function_load_responses = 1;
 }
 
 // Worker tells host result of reload

--- a/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
+++ b/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
@@ -82,7 +82,8 @@ message StreamingMessage {
 
     // Host sends required metadata to worker to load functions
     FunctionLoadRequestCollection function_load_request_collection = 31;
-    // Host gets the list of load responses
+
+    // Host gets the list of function load responses
     FunctionLoadResponseCollection function_load_response_collection = 32;
   }
 }
@@ -230,6 +231,11 @@ message FunctionLoadRequestCollection {
   repeated FunctionLoadRequest function_load_requests = 1;
 }
 
+// Host gets the list of function load responses
+message FunctionLoadResponseCollection {
+  repeated FunctionLoadResponse function_load_responses = 1;
+}
+
 // Load request of a single Function
 message FunctionLoadRequest {
   // unique function identifier (avoid name collisions, facilitate reload case)
@@ -240,11 +246,6 @@ message FunctionLoadRequest {
 
   // A flag indicating if managed dependency is enabled or not
   bool managed_dependency_enabled = 3;
-}
-
-// Host gets the list of load responses
-message FunctionLoadResponseCollection {
-  repeated FunctionLoadResponse function_load_responses = 1;
 }
 
 // Worker tells host result of reload

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -488,12 +488,30 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
+        public void ReceivesInboundEvent_Failed_FunctionLoadResponses()
+        {
+            var functionMetadatas = GetTestFunctionsList("node");
+            _workerChannel.SetupFunctionInvocationBuffers(functionMetadatas);
+            _workerChannel.SendFunctionLoadRequests(null, TimeSpan.FromMinutes(1));
+            _testFunctionRpcService.PublishFunctionLoadResponsesEvent(
+                            new List<string>() { "TestFunctionId1", "TestFunctionId2" },
+                            new StatusResult() { Status = StatusResult.Types.Status.Failure });
+            var traces = _logger.GetLogMessages();
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Setting up FunctionInvocationBuffer for function: 'js1' with functionId: 'TestFunctionId1'")));
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Setting up FunctionInvocationBuffer for function: 'js2' with functionId: 'TestFunctionId2'")));
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Worker failed to load function: 'js1' with function id: 'TestFunctionId1'.")));
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Worker failed to load function: 'js2' with function id: 'TestFunctionId2'.")));
+        }
+
+        [Fact]
         public void ReceivesInboundEvent_FunctionLoadResponses()
         {
             var functionMetadatas = GetTestFunctionsList("node");
             _workerChannel.SetupFunctionInvocationBuffers(functionMetadatas);
-            _workerChannel.SendFunctionLoadRequests(null, TimeSpan.FromMinutes(5));
-            _testFunctionRpcService.PublishFunctionLoadResponsesEvent(new List<string>() { "TestFunctionId1", "TestFunctionId2" });
+            _workerChannel.SendFunctionLoadRequests(null, TimeSpan.FromMinutes(1));
+            _testFunctionRpcService.PublishFunctionLoadResponsesEvent(
+                            new List<string>() { "TestFunctionId1", "TestFunctionId2" },
+                            new StatusResult() { Status = StatusResult.Types.Status.Success });
             var traces = _logger.GetLogMessages();
             Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Setting up FunctionInvocationBuffer for function: 'js1' with functionId: 'TestFunctionId1'")));
             Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Setting up FunctionInvocationBuffer for function: 'js2' with functionId: 'TestFunctionId2'")));

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -488,6 +488,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
+        public void ReceivesInboundEvent_FunctionLoadResponses()
+        {
+            var functionMetadatas = GetTestFunctionsList("node");
+            _workerChannel.SetupFunctionInvocationBuffers(functionMetadatas);
+            _workerChannel.SendFunctionLoadRequests(null, TimeSpan.FromMinutes(5));
+            _testFunctionRpcService.PublishFunctionLoadResponsesEvent(new List<string>() { "TestFunctionId1", "TestFunctionId2" });
+            var traces = _logger.GetLogMessages();
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Setting up FunctionInvocationBuffer for function: 'js1' with functionId: 'TestFunctionId1'")));
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Setting up FunctionInvocationBuffer for function: 'js2' with functionId: 'TestFunctionId2'")));
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, string.Format("Received FunctionLoadResponseCollection with number of functions: '{0}'.", functionMetadatas.ToList().Count))));
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Received FunctionLoadResponse for function: 'js1' with functionId: 'TestFunctionId1'.")));
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Received FunctionLoadResponse for function: 'js2' with functionId: 'TestFunctionId2'.")));
+        }
+
+        [Fact]
         public void ReceivesInboundEvent_Successful_FunctionMetadataResponse()
         {
             var functionMetadata = GetTestFunctionsList("python");

--- a/test/WebJobs.Script.Tests/Workers/Rpc/TestFunctionRpcService.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/TestFunctionRpcService.cs
@@ -62,13 +62,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _eventManager.Publish(new InboundGrpcEvent(_workerId, responseMessage));
         }
 
-        public void PublishFunctionLoadResponsesEvent(List<string> functionIds)
+        public void PublishFunctionLoadResponsesEvent(List<string> functionIds, StatusResult statusResult)
         {
-            StatusResult statusResult = new StatusResult()
-            {
-                Status = StatusResult.Types.Status.Success
-            };
-
             FunctionLoadResponseCollection functionLoadResponseCollection = new FunctionLoadResponseCollection();
 
             foreach (string functionId in functionIds)

--- a/test/WebJobs.Script.Tests/Workers/Rpc/TestFunctionRpcService.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/TestFunctionRpcService.cs
@@ -62,6 +62,33 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _eventManager.Publish(new InboundGrpcEvent(_workerId, responseMessage));
         }
 
+        public void PublishFunctionLoadResponsesEvent(List<string> functionIds)
+        {
+            StatusResult statusResult = new StatusResult()
+            {
+                Status = StatusResult.Types.Status.Success
+            };
+
+            FunctionLoadResponseCollection functionLoadResponseCollection = new FunctionLoadResponseCollection();
+
+            foreach (string functionId in functionIds)
+            {
+                FunctionLoadResponse functionLoadResponse = new FunctionLoadResponse()
+                {
+                    FunctionId = functionId,
+                    Result = statusResult
+                };
+
+                functionLoadResponseCollection.FunctionLoadResponses.Add(functionLoadResponse);
+            }
+
+            StreamingMessage responseMessage = new StreamingMessage()
+            {
+                FunctionLoadResponseCollection = functionLoadResponseCollection
+            };
+            _eventManager.Publish(new InboundGrpcEvent(_workerId, responseMessage));
+        }
+
         public void PublishFunctionEnvironmentReloadResponseEvent()
         {
             FunctionEnvironmentReloadResponse relaodEnvResponse = GetTestFunctionEnvReloadResponse();


### PR DESCRIPTION
resolves #8082

Adding ability to allow worker to send Function load responses in batch. Worker can choose to send load responses one by one using _FunctionLoadResponse_ field or in batch using _FunctionLoadResponseCollection_ field.