### PR TITLE
Fixed the ExtensionsMetadataGenerator project build on the Unix system

### DIFF
--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.csproj
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.csproj
@@ -31,7 +31,8 @@
   </ItemGroup>
 
   <Target Name="UpdateRuntimeAssemblies" BeforeTargets="Build">
-    <Exec Command="powershell.exe –command .\updateruntimeassemblies.ps1" />
+    <Exec Command="pwsh ./updateruntimeassemblies.ps1" Condition=" '$(OS)' == 'Unix' "/>
+    <Exec Command="powershell.exe –command .\updateruntimeassemblies.ps1" Condition=" '$(OS)' == 'Windows_NT' "/>
   </Target>
   
   <Target Name="PackReferenceAssemblies">

--- a/tools/ExtensionsMetadataGenerator/test/ExtensionsMetadataGeneratorTests/ExtensionsMetadataGeneratorTests.csproj
+++ b/tools/ExtensionsMetadataGenerator/test/ExtensionsMetadataGeneratorTests/ExtensionsMetadataGeneratorTests.csproj
@@ -19,7 +19,9 @@
   </ItemGroup>
 
   <Target Name="UpdateRuntimeAssemblies" BeforeTargets="Build">
-    <Exec Command="powershell.exe –command .\..\..\src\ExtensionsMetadataGenerator\updateruntimeassemblies.ps1" />
+    <Exec Command="pwsh ./../../src/ExtensionsMetadataGenerator/updateruntimeassemblies.ps1" Condition=" '$(OS)' == 'Unix' "/>
+    <Exec Command="powershell.exe –command .\..\..\src\ExtensionsMetadataGenerator\updateruntimeassemblies.ps1" Condition=" '$(OS)' == 'Windows_NT' "/>
+
     <Copy SourceFiles="runtimeassemblies.txt" DestinationFolder="$(OutputPath)" />
   </Target>
   


### PR DESCRIPTION
Clone of PR #8100

----------------------

On a Unix system, we need to use the `pwsh` command instead of `powershell.exe`. Therefore, to solve this problem, it suffices to add conditions to the `Exec` and execute one of two command based on the OS.

### Issue describing the changes in this PR

resolves [#8093](https://github.com/Azure/azure-functions-host/pull/8093)

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

