### PR TITLE
Removing binding direction from event name when emitting binding metric to logs.

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/FunctionInstanceLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/FunctionInstanceLogger.cs
@@ -83,9 +83,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             {
                 string eventName = _bindingMetricEventNames.GetOrAdd(binding, static (b) =>
                 {
-                    return b.IsTrigger ?
-                        string.Format(MetricEventNames.FunctionBindingTypeFormat, b.Type) :
-                        string.Format(MetricEventNames.FunctionBindingTypeDirectionFormat, b.Type, b.Direction);
+                    return string.Format(MetricEventNames.FunctionBindingTypeFormat, b.Type);
                 });
                 _metrics.LogEvent(eventName, metadata.Name);
             }

--- a/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
@@ -48,7 +48,6 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
         // function level events
         public const string FunctionInvokeLatency = "function.invoke.latency";
         public const string FunctionBindingTypeFormat = "function.binding.{0}";
-        public const string FunctionBindingTypeDirectionFormat = "function.binding.{0}.{1}";
         public const string FunctionCompileLatencyByLanguageFormat = "function.compile.{0}.latency";
         public const string FunctionInvokeThrottled = "function.invoke.throttled";
         public const string FunctionUserLog = "function.userlog";

--- a/test/WebJobs.Script.Tests/Diagnostics/FunctionInstanceLoggerTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/FunctionInstanceLoggerTests.cs
@@ -30,24 +30,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
                 Name = "TestFunction"
             };
             metadata.Bindings.Add(new BindingMetadata { Type = "httpTrigger" });
-            metadata.Bindings.Add(new BindingMetadata { Type = "blob", Direction = BindingDirection.In });
             metadata.Bindings.Add(new BindingMetadata { Type = "blob", Direction = BindingDirection.Out });
-            metadata.Bindings.Add(new BindingMetadata { Type = "table", Direction = BindingDirection.In });
             metadata.Bindings.Add(new BindingMetadata { Type = "table", Direction = BindingDirection.In });
             var invokeLatencyEvent = _functionInstanceLogger.LogInvocationMetrics(metadata);
 
             Assert.Equal($"{MetricEventNames.FunctionInvokeLatency}_testfunction", (string)invokeLatencyEvent);
 
-            Assert.Equal(5, _metrics.LoggedEvents.Count());
+            Assert.Equal(3, _metrics.LoggedEvents.Count());
             Assert.Contains("function.binding.httptrigger_testfunction", _metrics.LoggedEvents);
-            Assert.Contains("function.binding.blob.in_testfunction", _metrics.LoggedEvents);
-            Assert.Contains("function.binding.blob.out_testfunction", _metrics.LoggedEvents);
-            Assert.Contains("function.binding.table.in_testfunction", _metrics.LoggedEvents);
-            Assert.Contains("function.binding.table.in_testfunction", _metrics.LoggedEvents);
+            Assert.Contains("function.binding.blob_testfunction", _metrics.LoggedEvents);
+            Assert.Contains("function.binding.table_testfunction", _metrics.LoggedEvents);
 
             // log the events once more
             invokeLatencyEvent = _functionInstanceLogger.LogInvocationMetrics(metadata);
-            Assert.Equal(10, _metrics.LoggedEvents.Count());
+            Assert.Equal(6, _metrics.LoggedEvents.Count());
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Diagnostics/FunctionInstanceLoggerTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/FunctionInstanceLoggerTests.cs
@@ -30,20 +30,26 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
                 Name = "TestFunction"
             };
             metadata.Bindings.Add(new BindingMetadata { Type = "httpTrigger" });
+            metadata.Bindings.Add(new BindingMetadata { Type = "blob", Direction = BindingDirection.In });
             metadata.Bindings.Add(new BindingMetadata { Type = "blob", Direction = BindingDirection.Out });
+            metadata.Bindings.Add(new BindingMetadata { Type = "table", Direction = BindingDirection.In });
             metadata.Bindings.Add(new BindingMetadata { Type = "table", Direction = BindingDirection.In });
             var invokeLatencyEvent = _functionInstanceLogger.LogInvocationMetrics(metadata);
 
             Assert.Equal($"{MetricEventNames.FunctionInvokeLatency}_testfunction", (string)invokeLatencyEvent);
 
-            Assert.Equal(3, _metrics.LoggedEvents.Count());
+            Assert.Equal(5, _metrics.LoggedEvents.Count());
             Assert.Contains("function.binding.httptrigger_testfunction", _metrics.LoggedEvents);
-            Assert.Contains("function.binding.blob_testfunction", _metrics.LoggedEvents);
-            Assert.Contains("function.binding.table_testfunction", _metrics.LoggedEvents);
+            Assert.Equal(1, _metrics.LoggedEvents.Count(x => x == "function.binding.httptrigger_testfunction"));
+
+            // for non-trigger bindings, event name does not include direction.
+            // So log entries for input and output binding will have same event name.
+            Assert.Equal(2, _metrics.LoggedEvents.Count(x => x == "function.binding.blob_testfunction"));
+            Assert.Equal(2, _metrics.LoggedEvents.Count(x => x == "function.binding.table_testfunction"));
 
             // log the events once more
             invokeLatencyEvent = _functionInstanceLogger.LogInvocationMetrics(metadata);
-            Assert.Equal(6, _metrics.LoggedEvents.Count());
+            Assert.Equal(10, _metrics.LoggedEvents.Count());
         }
     }
 }


### PR DESCRIPTION
Currently, for in-proc function apps, only trigger bindings were included in the function meta data. So, no other bindings (out/return) are being logged to the functions metrics logs. This is being fixed with this PR: [Include all bindings when generating function metadata](https://github.com/Azure/azure-functions-vs-build-sdk/pull/542)

As part of fixing this issue, we have decided to remove the binding direction value ("in" or "out") from the event name when emitting this to the functions metrics logs since we cannot reliably get this value.