### PR TITLE
Add function app dir to worker init request

### DIFF
--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -228,7 +228,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             return new WorkerInitRequest()
             {
                 HostVersion = ScriptHost.Version,
-                WorkerDirectory = _workerConfig.Description.WorkerDirectory
+                WorkerDirectory = _workerConfig.Description.WorkerDirectory,
+                FunctionAppDirectory = _applicationHostOptions.CurrentValue.ScriptPath
             };
         }
 

--- a/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
+++ b/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
@@ -113,6 +113,9 @@ message WorkerInitRequest {
 
   // Full path of worker.config.json location
   string worker_directory = 4;
+
+  // base directory for function app
+  string function_app_directory = 5;
 }
 
 // Worker responds with the result of initializing itself

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -225,8 +225,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         {
             WorkerInitRequest initRequest = _workerChannel.GetWorkerInitRequest();
             Assert.NotNull(initRequest.WorkerDirectory);
+            Assert.NotNull(initRequest.FunctionAppDirectory);
             Assert.NotNull(initRequest.HostVersion);
             Assert.Equal("testDir", initRequest.WorkerDirectory);
+            Assert.Equal(_scriptRootPath, initRequest.FunctionAppDirectory);
             Assert.Equal(ScriptHost.Version, initRequest.HostVersion);
         }
 


### PR DESCRIPTION
Updated protobuf subtree to tag [v1.5.5-protofile](https://github.com/Azure/azure-functions-language-worker-protobuf/releases/tag/v1.5.5-protofile)

### Issue describing the changes in this PR

This will help the Node.js worker address issues like https://github.com/Azure/azure-functions-nodejs-worker/issues/531 and https://github.com/Azure/azure-functions-nodejs-worker/issues/522 where we want to base our behavior on the user's package.json file.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)