### PR TITLE
Introduce the admin/host/config API

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,6 +3,7 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Add admin/host/config API (#7394)
 
 **Release sprint:** Sprint 118
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+118%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+118%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -395,5 +395,21 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
             return NotFound();
         }
+
+        [HttpGet]
+        [Route("admin/host/config")]
+        [Authorize(Policy = PolicyNames.AdminAuthLevelOrInternal)]
+        [RequiresRunningHost]
+        public IActionResult GetConfig([FromServices] IScriptHostManager scriptHostManager)
+        {
+            if (Utility.TryGetHostService(scriptHostManager, out IHostOptionsProvider provider))
+            {
+                return Ok(provider.GetOptions().ToString());
+            }
+            else
+            {
+                return StatusCode(StatusCodes.Status503ServiceUnavailable);
+            }
+        }
     }
 }

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -72,7 +72,7 @@
     <PackageReference Include="Microsoft.Azure.AppService.Middleware.Functions" Version="1.4.13" />
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
     <PackageReference Include="Microsoft.Azure.Storage.File" Version="11.1.7" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33-11904" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33-11908" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.0-beta.1" />
     <PackageReference Include="Microsoft.Azure.WebSites.DataProtection" Version="2.1.91-alpha" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.15.1" />

--- a/src/WebJobs.Script/Extensions/JObjectExtensions.cs
+++ b/src/WebJobs.Script/Extensions/JObjectExtensions.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Script.Extensions
+{
+    public static class JObjectExtensions
+    {
+        public static JObject ToCamelCase(this JObject obj)
+        {
+            var camelObj = new JObject();
+            foreach (var property in obj.Properties())
+            {
+                string camelCaseName = property.Name.CamelCaseString();
+                if (camelCaseName != null)
+                {
+                    camelObj[camelCaseName] = property.Value.ToCamelCaseJToken();
+                }
+            }
+            return camelObj;
+        }
+
+        public static string CamelCaseString(this string str)
+        {
+            if (str != null)
+            {
+                if (str.Length < 1)
+                {
+                    return str.ToLower();
+                }
+                else
+                {
+                    return str.Substring(0, 1).ToLower() + str[1..];
+                }
+            }
+            return str;
+        }
+
+        private static JToken ToCamelCaseJToken(this JToken obj)
+        {
+            switch (obj.Type)
+            {
+                case JTokenType.Object:
+                    return ((JObject)obj).ToCamelCase();
+                case JTokenType.Array:
+                    return new JArray(((JArray)obj).Select(x => x.ToCamelCaseJToken()));
+                default:
+                    return obj.DeepClone();
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script/HostOptionsProvider.cs
+++ b/src/WebJobs.Script/HostOptionsProvider.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Azure.WebJobs.Host.Scale;
+using Microsoft.Azure.WebJobs.Hosting;
+using Microsoft.Azure.WebJobs.Script.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+
+namespace Microsoft.Azure.WebJobs.Script
+{
+    public class HostOptionsProvider : IHostOptionsProvider
+    {
+        private readonly JsonSerializer _serializer = JsonSerializer.Create(new JsonSerializerSettings
+        {
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+        });
+
+        private readonly IEnumerable<IExtensionOptionsProvider> _extensionOptionsProviders;
+        private readonly ILogger<HostOptionsProvider> _logger;
+        private readonly IOptionsMonitor<ConcurrencyOptions> _concurrencyOptions;
+
+        public HostOptionsProvider(IEnumerable<IExtensionOptionsProvider> extensionOptionsProviders, IOptionsMonitor<ConcurrencyOptions> concurrencyOptions, ILogger<HostOptionsProvider> logger)
+        {
+            _extensionOptionsProviders = extensionOptionsProviders;
+            _logger = logger;
+            _concurrencyOptions = concurrencyOptions;
+        }
+
+        public JObject GetOptions()
+        {
+            var payload = new JObject();
+            var extensions = new JObject();
+            var extensionOptions = GetExtensionOptions();
+            foreach (var extension in extensionOptions)
+            {
+                extensions.Add(extension.Key, extension.Value);
+            }
+            if (extensionOptions.Count != 0)
+            {
+                payload.Add("extensions", extensions);
+            }
+
+            var concurrency = GetConcurrencyOptions();
+            payload.Add("concurrency", concurrency);
+            return payload;
+        }
+
+        private Dictionary<string, JObject> GetExtensionOptions()
+        {
+            Dictionary<string, JObject> result = new Dictionary<string, JObject>();
+            foreach (IExtensionOptionsProvider extensionOptionsProvider in _extensionOptionsProviders)
+            {
+                var options = extensionOptionsProvider.GetOptions();
+                if (typeof(IOptionsFormatter).IsAssignableFrom(options.GetType()))
+                {
+                    var optionsFormatter = (IOptionsFormatter)options;
+                    string sectionName = extensionOptionsProvider?.ExtensionInfo?.ConfigurationSectionName?.CamelCaseString();
+                    result.Add(sectionName, JObject.Parse(optionsFormatter.Format()).ToCamelCase());
+                }
+            }
+
+            return result;
+        }
+
+        private JObject GetConcurrencyOptions()
+        {
+            var concurrencyOptions = _concurrencyOptions.CurrentValue;
+            return JObject.FromObject(concurrencyOptions, _serializer);
+        }
+    }
+}

--- a/src/WebJobs.Script/IHostOptionsProvider.cs
+++ b/src/WebJobs.Script/IHostOptionsProvider.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Script
+{
+    public interface IHostOptionsProvider
+    {
+        JObject GetOptions();
+    }
+}

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -307,6 +307,8 @@ namespace Microsoft.Azure.WebJobs.Script
                     services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, FunctionsScaleMonitorService>());
                 }
                 services.TryAddSingleton<FunctionsScaleManager>();
+
+                services.AddSingleton<IHostOptionsProvider, HostOptionsProvider>();
             });
 
             RegisterFileProvisioningService(builder);

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="Azure.Core" Version="1.19.0" />
     <PackageReference Include="Azure.Identity" Version="1.4.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.9.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33-11904" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33-11908" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.20.0" />

--- a/test/WebJobs.Script.Tests/HostsOptionsProviderTests.cs
+++ b/test/WebJobs.Script.Tests/HostsOptionsProviderTests.cs
@@ -1,0 +1,278 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Azure.WebJobs.Description;
+using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Azure.WebJobs.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public class HostsOptionsProviderTests
+    {
+        [Fact]
+        public void OverwriteWithAppSettings_Success()
+        {
+            var settings = new Dictionary<string, string>
+                {
+                    { "AzureFunctionsJobHost:extensions:test:config1", "test1" },
+                    { "AzureFunctionsJobHost:extensions:test:config2", "test2" }
+                };
+            var payload = GetHostOptionProviderPayload<TestExtensionConfigProvider, TestOptions>(settings);
+            Assert.Equal(ReadFixture("TestBasicBindings.json"), payload);
+        }
+
+        [Fact]
+        public void IrregularNamingConvention_Success()
+        {
+            var settings = new Dictionary<string, string>
+            {
+                { "AzureFunctionsJobHost:extensions:eventHubs:config1", "test1" },
+                { "AzureFunctionsJobHost:extensions:eventHubs:config2", "test2" }
+            };
+            var payload = GetHostOptionProviderPayload<TestEventHubConfigProvider, EventHubOptions>(settings);
+            Assert.Equal(ReadFixture("TestIrregularNamingBindings.json"), payload);
+        }
+
+        [Fact]
+        public void InCompliant_Extension_Without_ExtensionsAttribute_Success()
+        {
+            var settings = new Dictionary<string, string>
+                {
+                    { "AzureFunctionsJobHost:extensions:testNoExtensionAttributeConfigProvider:config1", "test1" },
+                    { "AzureFunctionsJobHost:extensions:testNoExtensionAttributeConfigProvider:config2", "test2" }
+                };
+
+            var payload = GetHostOptionProviderPayload<TestNoExtensionAttributeConfigProvider, TestOptions>(settings);
+            Assert.Equal(ReadFixture("TestWihtoutExtensionsAttributeBindings.json"), payload);
+        }
+
+        [Fact]
+        public void InCompliant_Extension_Without_IOptionFormatters_Ignored()
+        {
+            var settings = new Dictionary<string, string>
+                {
+                    { "AzureFunctionsJobHost:extensions:test:config1", "test1" },
+                    { "AzureFunctionsJobHost:extensions:test:config2", "test2" }
+                };
+            var payload = GetHostOptionProviderPayload<TestExtensionConfigProvider, TestNoIOptionsFormatterOptions>(settings);
+            Assert.Equal(ReadFixture("TestWihtoutIOptionsFormatter.json"), payload);
+        }
+
+        [Fact]
+        public void Multiple_Extensions_Works_Success()
+        {
+            var settings = new Dictionary<string, string>
+            {
+                { "AzureWebJobsConfigurationSection", "AzureFunctionsJobHost" },
+                { "AzureFunctionsJobHost:extensions:test:config1", "test1" },
+                { "AzureFunctionsJobHost:extensions:test:config2", "test2" },
+                { "AzureFunctionsJobHost:extensions:eventHubs:config1", "test0" },
+                { "AzureFunctionsJobHost:extensions:eventHubs:config2", "test2" }
+            };
+
+            var hostBuilder = new HostBuilder()
+            .ConfigureAppConfiguration(b =>
+            {
+                b.AddInMemoryCollection(settings);
+            })
+            .ConfigureDefaultTestHost(b =>
+            {
+                b.AddExtension<TestExtensionConfigProvider>()
+                .BindOptions<TestOptions>();
+                b.AddExtension<TestEventHubConfigProvider>()
+                .BindOptions<EventHubOptions>();
+            })
+            .ConfigureServices((context, services) =>
+            {
+                services.AddSingleton<IHostOptionsProvider, HostOptionsProvider>();
+            });
+
+            var host = hostBuilder.Build();
+            var provider = host.Services.GetService<IHostOptionsProvider>();
+            var payload = provider.GetOptions();
+            Assert.Equal(ReadFixture("TestMultipleBindings.json"), payload.ToString());
+        }
+
+        [Fact]
+        public void Multiple_Option_Resigered_Works_Success()
+        {
+            var settings = new Dictionary<string, string>
+            {
+                { "AzureWebJobsConfigurationSection", "AzureFunctionsJobHost" },
+                { "AzureFunctionsJobHost:extensions:test:config1", "test1" },
+                { "AzureFunctionsJobHost:extensions:test:config2", "test2" }
+            };
+
+            var hostBuilder = new HostBuilder()
+            .ConfigureAppConfiguration(b =>
+            {
+                b.AddInMemoryCollection(settings);
+            })
+            .ConfigureDefaultTestHost(b =>
+            {
+                // Bind Options called two times for the same Options.
+                b.AddExtension<TestExtensionConfigProvider>()
+                .BindOptions<TestOptions>()
+                .BindOptions<TestOptions>();
+            })
+            .ConfigureServices((context, services) =>
+            {
+                services.AddSingleton<IHostOptionsProvider, HostOptionsProvider>();
+            });
+
+            var host = hostBuilder.Build();
+            var provider = host.Services.GetService<IHostOptionsProvider>();
+            var payload = provider.GetOptions();
+            Assert.Equal(ReadFixture("TestBasicBindings.json"), payload.ToString());
+        }
+
+        [Fact]
+        public void ConcurrencyOption_Success()
+        {
+            var settings = new Dictionary<string, string>
+                {
+                    { "AzureFunctionsJobHost:concurrency:dynamicConcurrencyEnabled", "true" },
+                    { "AzureFunctionsJobHost:concurrency:maximumFunctionConcurrency", "20" },
+                };
+
+            var payload = GetHostOptionProviderPayload<TestExtensionConfigProvider, TestOptions>(settings);
+            Assert.Equal(ReadFixture("TestBasicConcurrency.json"), payload);
+        }
+
+        [Fact]
+        public void ConcurrencyOption_Default_Success()
+        {
+            var settings = new Dictionary<string, string>();
+            var payload = GetHostOptionProviderPayload<TestExtensionConfigProvider, TestOptions>(settings);
+            Assert.Equal(ReadFixture("TestDefaultConcurrency.json"), payload);
+        }
+
+        private string GetHostOptionProviderPayload<TExtension, TOptions>(Dictionary<string, string> settings) where TExtension : class, IExtensionConfigProvider where TOptions : class, new()
+        {
+            var host = SetupHostOptionProvider<TExtension, TOptions>(settings);
+            var provider = host.Services.GetService<IHostOptionsProvider>();
+            return provider.GetOptions().ToString();
+        }
+
+        private IHost SetupHostOptionProvider<TExtension, TOptions>(Dictionary<string, string> settings) where TExtension : class, IExtensionConfigProvider where TOptions : class, new()
+        {
+            settings["AzureWebJobsConfigurationSection"] = "AzureFunctionsJobHost";
+
+            var hostBuilder = new HostBuilder()
+            .ConfigureAppConfiguration(b =>
+            {
+                b.AddInMemoryCollection(settings);
+            })
+            .ConfigureDefaultTestHost(b =>
+            {
+                b.AddExtension<TExtension>()
+                .BindOptions<TOptions>();
+            })
+            .ConfigureServices((context, services) =>
+            {
+                services.AddSingleton<IHostOptionsProvider, HostOptionsProvider>();
+            });
+
+            return hostBuilder.Build();
+        }
+
+        public static string ReadFixture(string name)
+        {
+            var path = Path.Combine("TestFixture", "HostOptionsProviderTests", name);
+            return File.ReadAllText(path);
+        }
+
+        // class definition TestProvider
+        [Extension("Test")]
+        private class TestExtensionConfigProvider : IExtensionConfigProvider
+        {
+            public TestExtensionConfigProvider()
+            {
+            }
+
+            public void Initialize(ExtensionConfigContext context)
+            {
+            }
+        }
+
+        private class TestOptions : IOptionsFormatter
+        {
+            public string Config1 { get; set; } = "default";
+
+            public string Config2 { get; set; } = "default";
+
+            public string Config3 { get; set; } = "default";
+
+            public string Format()
+            {
+                return JObject.FromObject(this).ToString();
+            }
+        }
+
+        // class definition TestEventHubs
+        [Extension("EventHubs", configurationSection: "EventHubs")]
+        private class TestEventHubConfigProvider : IExtensionConfigProvider
+        {
+            public TestEventHubConfigProvider()
+            {
+            }
+
+            public void Initialize(ExtensionConfigContext context)
+            {
+            }
+        }
+
+        private class EventHubOptions : IOptionsFormatter
+        {
+            public string Config1 { get; set; } = "default";
+
+            public string Config2 { get; set; } = "default";
+
+            public string Config3 { get; set; } = "default";
+
+            public string Format()
+            {
+                return JObject.FromObject(this).ToString();
+            }
+        }
+
+        // Non compliant extension
+        // No Extension Section
+        private class TestNoExtensionAttributeConfigProvider : IExtensionConfigProvider
+        {
+            public TestNoExtensionAttributeConfigProvider()
+            {
+            }
+
+            public void Initialize(ExtensionConfigContext context)
+            {
+            }
+        }
+
+        // No IOptionsFormatter
+        private class TestNoIOptionsFormatterOptions
+        {
+            public string Config1 { get; set; } = "default";
+
+            public string Config2 { get; set; } = "default";
+
+            public string Config3 { get; set; } = "default";
+        }
+    }
+
+    public static class TestExtensions
+    {
+        public static IHostBuilder ConfigureDefaultTestHost(this IHostBuilder builder, Action<IWebJobsBuilder> configureWebJobs, params Type[] type)
+        {
+            return builder.ConfigureWebJobs(configureWebJobs);
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Managment/Payloads/ExpectedConcurrencyPayload.json
+++ b/test/WebJobs.Script.Tests/Managment/Payloads/ExpectedConcurrencyPayload.json
@@ -1,0 +1,6 @@
+{
+  "dynamicConcurrencyEnabled": true,
+  "maximumFunctionConcurrency": 500,
+  "cpuThreshold": 0.8,
+  "snapshotPersistenceEnabled": true
+} 

--- a/test/WebJobs.Script.Tests/Managment/Payloads/ExpectedHostJsonPayload.json
+++ b/test/WebJobs.Script.Tests/Managment/Payloads/ExpectedHostJsonPayload.json
@@ -1,0 +1,17 @@
+{
+  "extensions": {
+    "http": {
+      "dynamicThrottlesEnabled": false,
+      "enableChunkedRequestBinding": false,
+      "maxConcurrentRequests": -1,
+      "maxOutstandingRequests": -1,
+      "routePrefix": "api"
+    }
+  },
+  "concurrency": {
+    "dynamicConcurrencyEnabled": true,
+    "maximumFunctionConcurrency": 500,
+    "cpuThreshold": 0.8,
+    "snapshotPersistenceEnabled": true
+  }
+}

--- a/test/WebJobs.Script.Tests/Managment/Payloads/ExpectedHttpExtensionsPayload.json
+++ b/test/WebJobs.Script.Tests/Managment/Payloads/ExpectedHttpExtensionsPayload.json
@@ -1,0 +1,7 @@
+﻿{
+	"dynamicThrottlesEnabled": false,
+	"enableChunkedRequestBinding": false,
+	"maxConcurrentRequests": -1,
+	"maxOutstandingRequests": -1,
+	"routePrefix": "api"
+}

--- a/test/WebJobs.Script.Tests/TestFixture/HostOptionsProviderTests/TestBasicBindings.json
+++ b/test/WebJobs.Script.Tests/TestFixture/HostOptionsProviderTests/TestBasicBindings.json
@@ -1,0 +1,15 @@
+{
+  "extensions": {
+    "test": {
+      "config1": "test1",
+      "config2": "test2",
+      "config3": "default"
+    }
+  },
+  "concurrency": {
+    "dynamicConcurrencyEnabled": false,
+    "maximumFunctionConcurrency": 500,
+    "cpuThreshold": 0.8,
+    "snapshotPersistenceEnabled": true
+  }
+}

--- a/test/WebJobs.Script.Tests/TestFixture/HostOptionsProviderTests/TestBasicConcurrency.json
+++ b/test/WebJobs.Script.Tests/TestFixture/HostOptionsProviderTests/TestBasicConcurrency.json
@@ -1,0 +1,15 @@
+{
+  "extensions": {
+    "test": {
+      "config1": "default",
+      "config2": "default",
+      "config3": "default"
+    }
+  },
+  "concurrency": {
+    "dynamicConcurrencyEnabled": true,
+    "maximumFunctionConcurrency": 20,
+    "cpuThreshold": 0.8,
+    "snapshotPersistenceEnabled": true
+  }
+}

--- a/test/WebJobs.Script.Tests/TestFixture/HostOptionsProviderTests/TestDefaultConcurrency.json
+++ b/test/WebJobs.Script.Tests/TestFixture/HostOptionsProviderTests/TestDefaultConcurrency.json
@@ -1,0 +1,15 @@
+{
+  "extensions": {
+    "test": {
+      "config1": "default",
+      "config2": "default",
+      "config3": "default"
+    }
+  },
+  "concurrency": {
+    "dynamicConcurrencyEnabled": false,
+    "maximumFunctionConcurrency": 500,
+    "cpuThreshold": 0.8,
+    "snapshotPersistenceEnabled": true
+  }
+}

--- a/test/WebJobs.Script.Tests/TestFixture/HostOptionsProviderTests/TestIrregularNamingBindings.json
+++ b/test/WebJobs.Script.Tests/TestFixture/HostOptionsProviderTests/TestIrregularNamingBindings.json
@@ -1,0 +1,15 @@
+{
+  "extensions": {
+    "eventHubs": {
+      "config1": "test1",
+      "config2": "test2",
+      "config3": "default"
+    }
+  },
+  "concurrency": {
+    "dynamicConcurrencyEnabled": false,
+    "maximumFunctionConcurrency": 500,
+    "cpuThreshold": 0.8,
+    "snapshotPersistenceEnabled": true
+  }
+}

--- a/test/WebJobs.Script.Tests/TestFixture/HostOptionsProviderTests/TestMultipleBindings.json
+++ b/test/WebJobs.Script.Tests/TestFixture/HostOptionsProviderTests/TestMultipleBindings.json
@@ -1,0 +1,20 @@
+{
+  "extensions": {
+    "test": {
+      "config1": "test1",
+      "config2": "test2",
+      "config3": "default"
+    },
+    "eventHubs": {
+      "config1": "test0",
+      "config2": "test2",
+      "config3": "default"
+    }
+  },
+  "concurrency": {
+    "dynamicConcurrencyEnabled": false,
+    "maximumFunctionConcurrency": 500,
+    "cpuThreshold": 0.8,
+    "snapshotPersistenceEnabled": true
+  }
+}

--- a/test/WebJobs.Script.Tests/TestFixture/HostOptionsProviderTests/TestWihtoutExtensionsAttributeBindings.json
+++ b/test/WebJobs.Script.Tests/TestFixture/HostOptionsProviderTests/TestWihtoutExtensionsAttributeBindings.json
@@ -1,0 +1,15 @@
+{
+  "extensions": {
+    "testNoExtensionAttributeConfigProvider": {
+      "config1": "test1",
+      "config2": "test2",
+      "config3": "default"
+    }
+  },
+  "concurrency": {
+    "dynamicConcurrencyEnabled": false,
+    "maximumFunctionConcurrency": 500,
+    "cpuThreshold": 0.8,
+    "snapshotPersistenceEnabled": true
+  }
+}

--- a/test/WebJobs.Script.Tests/TestFixture/HostOptionsProviderTests/TestWihtoutIOptionsFormatter.json
+++ b/test/WebJobs.Script.Tests/TestFixture/HostOptionsProviderTests/TestWihtoutIOptionsFormatter.json
@@ -1,0 +1,8 @@
+{
+  "concurrency": {
+    "dynamicConcurrencyEnabled": false,
+    "maximumFunctionConcurrency": 500,
+    "cpuThreshold": 0.8,
+    "snapshotPersistenceEnabled": true
+  }
+}

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -103,7 +103,37 @@
     <None Update="Description\DotNet\TestFiles\PackageReferences\ProjectWithMismatchedLock\MismatchedProjectDependencies\project.assets.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Managment\Payloads\ExpectedConcurrencyPayload.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Managment\Payloads\ExpectedHostJsonPayload.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Managment\Payloads\ExpectedHttpExtensionsPayload.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Microsoft.Azure.WebJobs.Script.WebHost.deps.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TestFixture\HostOptionsProviderTests\TestBasicBindings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TestFixture\HostOptionsProviderTests\TestBasicConcurrency.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TestFixture\HostOptionsProviderTests\TestDefaultConcurrency.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TestFixture\HostOptionsProviderTests\TestIrregularNamingBindings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TestFixture\HostOptionsProviderTests\TestMultipleBindings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TestFixture\HostOptionsProviderTests\TestWihtoutExtensionsAttributeBindings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TestFixture\HostOptionsProviderTests\TestWihtoutIOptionsFormatter.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="Workers\Rpc\Resources\functions.png">


### PR DESCRIPTION
This Pull Request introduce a new API that provides `host.json` payload with support for `AppSettings` hydration and default value. 
The payload will provide `extensions` section and `concurrency` section. 

### Issue describing the changes in this PR

resolves [Refactor the SyncTrigger extensions payload to make it generic](https://github.com/Azure/azure-functions-host/issues/7394)

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR [#issue_or_pr](https://github.com/Azure/azure-functions-host/pull/8182)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This pull request requires WebJobsSDK change and update the SDK version for using this feature. 
* [Add ExtensionInfo to the DI system](https://github.com/Azure/azure-webjobs-sdk/pull/2832)
This pull request substitute the following pull request. Once this one is accepted, I'll close it.
* [Include Extension and Dynamic Concurrency in Sync Trigger Payload](https://github.com/Azure/azure-functions-host/pull/7863)

We talked offline, we decided to go this direction. 
* We don't include host.json information to SyncTrigger Payload. Instead we create a new API (this PR)
* The exception is durable functions. We include only a part of it.

### Spec

This API will return the following payload. To be supported this API, each extension should follow the convention. 
* The implementation class of `IExtensionConfigProvider` should have `Extensions` Attribute. 
* The option class should implement `IOptionsFormatter`. If it is not implemented, this API ignore the option.
* We return the `IOptionsFormatter.Format()` method result as the payload. 
 
#### Samples 
* [EventHubs V4 Provider](https://github.com/Azure/azure-functions-eventhubs-extension/blob/dev/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Config/EventHubExtensionConfigProvider.cs)
* [EventHubs V4 Option](https://github.com/Azure/azure-functions-eventhubs-extension/blob/dev/src/Microsoft.Azure.WebJobs.Extensions.EventHubs/Config/EventHubOptions.cs)

```csharp
    [Extension("EventHubs", configurationSection: "EventHubs")]
    internal class EventHubExtensionConfigProvider : IExtensionConfigProvider
```

```csharp
    public class EventHubOptions : IOptionsFormatter{
        public string Format()
        {       
                  :
        }    
    }
```
### Sample Default Payload 
Sample package versions.
```xml
<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.10" />
<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.5.1" />
<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventGrid" Version="2.1.0" />
<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.3.0" />
<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Kafka" Version="3.3.2" />
<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.RabbitMQ" Version="1.1.0" />
<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.SendGrid" Version="3.0.2" />
<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.0.0" />
<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.0" />
<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage.Blobs" Version="5.0.0" />
<PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage.Queues" Version="5.0.0" />
```

`GET admin/host/config`

NOTE: ServiceBus 5.0.0

```json
{
  "extensions": {
    "eventHubs": {
      "batchCheckpointFrequency": 1,
      "eventProcessorOptions": {
        "enableReceiverRuntimeMetric": false,
        "invokeProcessorAfterReceiveTimeout": false,
        "maxBatchSize": 10,
        "prefetchCount": 300,
        "receiveTimeout": "00:01:00"
      },
      "partitionManagerOptions": {
        "leaseDuration": "00:00:30",
        "renewInterval": "00:00:10"
      },
      "initialOffsetOptions": {
        "type": "",
        "enqueuedTimeUTC": ""
      }
    },
    "cosmosDB": {
      "connectionMode": null,
      "protocol": null,
      "leaseOptions": {
        "checkpointFrequency": {
          "explicitCheckpoint": false,
          "processedDocumentCount": null,
          "timeInterval": null
        },
        "feedPollDelay": "00:00:05",
        "isAutoCheckpointEnabled": true,
        "leaseAcquireInterval": "00:00:13",
        "leaseExpirationInterval": "00:01:00",
        "leasePrefix": null,
        "leaseRenewInterval": "00:00:17"
      }
    },
    "queues": {
      "batchSize": 16,
      "newBatchThreshold": 160,
      "maxPollingInterval": "00:01:00",
      "maxDequeueCount": 5,
      "visibilityTimeout": "00:00:00",
      "messageEncoding": "Base64"
    },
    "blobs": {
      "maxDegreeOfParallelism": 160
    },
    "durableTask": {
      "httpSettings": {
        "defaultAsyncRequestSleepTimeMilliseconds": 30000
      },
      "hubName": "TestHubName",
      "storageProvider": {},
      "tracing": {
        "traceInputsAndOutputs": false,
        "allowVerboseLinuxTelemetry": false,
        "traceReplayEvents": false,
        "distributedTracingEnabled": false,
        "distributedTracingProtocol": "HttpCorrelationProtocol"
      },
      "notifications": {
        "eventGrid": null
      },
      "maxConcurrentActivityFunctions": null,
      "maxConcurrentOrchestratorFunctions": null,
      "localRpcEndpointEnabled": null,
      "extendedSessionsEnabled": false,
      "extendedSessionIdleTimeoutInSeconds": 30,
      "maxOrchestrationActions": 100000,
      "overridableExistingInstanceStates": 1,
      "entityMessageReorderWindowInMinutes": 30,
      "useGracefulShutdown": false,
      "rollbackEntityOperationsOnExceptions": true,
      "useAppLease": true,
      "appLeaseOptions": {
        "renewInterval": "00:00:25",
        "acquireInterval": "00:05:00",
        "leaseInterval": "00:01:00"
      }
    },
    "kafka": {
      "maxBatchSize": 64,
      "autoCommitIntervalMs": 200,
      "metadataMaxAgeMs": 180000,
      "socketKeepaliveEnable": true,
      "subscriberIntervalInSeconds": 1,
      "executorChannelCapacity": 1,
      "channelFullRetryIntervalInMs": 50
    },
    "RabbitMQ": {
      "hostName": null,
      "queueName": null,
      "port": 0,
      "prefetchCount": 30
    },
    "serviceBus": {
      "clientRetryOptions": {
        "mode": "Exponential",
        "tryTimeout": "00:01:00",
        "delay": "00:00:00.8000000",
        "maxDelay": "00:01:00",
        "maxRetries": 3
      },
      "transportType": "AmqpTcp",
      "webProxy": "",
      "autoCompleteMessages": true,
      "prefetchCount": 0,
      "maxAutoLockRenewalDuration": "00:05:00",
      "maxConcurrentCalls": 320,
      "maxConcurrentSessions": 8,
      "maxMessageBatchSize": 1000,
      "sessionIdleTimeout": ""
    }
  },
  "concurrency": {
    "dynamicConcurrencyEnabled": false,
    "maximumFunctionConcurrency": 500,
    "cpuThreshold": 0.8,
    "snapshotPersistenceEnabled": true
  }
}
```

#### Service Bus 4.2.0
Servcie Bus Payload will be different between v4 and v5. 

```
    "serviceBus": {
      "prefetchCount": 0,
      "messageHandlerOptions": {
        "autoComplete": true,
        "maxAutoRenewDuration": "00:05:00",
        "maxConcurrentCalls": 320
      },
      "sessionHandlerOptions": {
        "autoComplete": true,
        "maxAutoRenewDuration": "00:05:00",
        "maxConcurrentSessions": 2000,
        "messageWaitTimeout": "00:01:00"
      },
      "batchOptions": {
        "maxMessageCount": 1000,
        "operationTimeout": "00:01:00",
        "autoComplete": true
      }
    }
```