### PR TITLE
Adding Microsoft.Security.Utilities to runtime assemblies rules

### DIFF
--- a/src/WebJobs.Script/runtimeassemblies.json
+++ b/src/WebJobs.Script/runtimeassemblies.json
@@ -1496,6 +1496,10 @@
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
+      "name": "Microsoft.Security.Utilities",
+      "resolutionPolicy": "private"
+    },
+    {
       "name": "System.ValueTuple",
       "resolutionPolicy": "minorMatchOrLower"
     },


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Follow up update to #8171

@mathewc @brettsam @michaelcfanning this ensures the new dependency is scoped to the host only.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)


