### PR TITLE
Adding SecretGenerator utility

### DIFF
--- a/src/WebJobs.Script.WebHost/Security/SecretGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Security/SecretGenerator.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Security.Utilities;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Security
+{
+    /// <summary>
+    /// Generates identifiable secret values for use as Azure Functions keys.
+    /// </summary>
+    public static class SecretGenerator
+    {
+        public const string AzureFunctionsSignature = "AzFu";
+
+        // Seeds (passed to the Marvin checksum algorithm) for grouping
+        // Azure Functions Host keys. See references from unit tests for
+        // information on how these seeds were generated/are versioned.
+        public const ulong MasterKeySeed = 0x4d61737465723030;
+        public const ulong SystemKeySeed = 0x53797374656d3030;
+        public const ulong FunctionKeySeed = 0x46756e6374693030;
+
+        public static string GenerateMasterKeyValue()
+        {
+            return GenerateIdentifiableSecret(MasterKeySeed);
+        }
+
+        public static string GenerateFunctionKeyValue()
+        {
+            return GenerateIdentifiableSecret(FunctionKeySeed);
+        }
+
+        public static string GenerateSystemKeyValue()
+        {
+            return GenerateIdentifiableSecret(SystemKeySeed);
+        }
+
+        internal static string GenerateIdentifiableSecret(ulong seed)
+        {
+            // Return a generated secret with a completely URL-safe base64-encoding
+            // alphabet, 'a-zA-Z0-9' as well as '-' and '_'. We preserve the trailing
+            // equal sign padding in the token in order to improve the ability to
+            // match against the general token format (with performing a checksum
+            // validation. This is safe in Azure Functions utilization because a
+            // token will only appear in a URL as a query string parameter, where
+            // equal signs do not require encoding.
+            return IdentifiableSecrets.GenerateUrlSafeBase64Key(seed, 40, AzureFunctionsSignature, elidePadding: false);
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/WebHooks/DefaultScriptWebHookProvider.cs
+++ b/src/WebJobs.Script.WebHost/WebHooks/DefaultScriptWebHookProvider.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security;
 using HttpHandler = Microsoft.Azure.WebJobs.IAsyncConverter<System.Net.Http.HttpRequestMessage, System.Net.Http.HttpResponseMessage>;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
@@ -77,7 +78,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             if (!hostSecrets.SystemKeys.TryGetValue(keyName, out keyValue))
             {
                 // if the requested secret doesn't exist, create it on demand
-                keyValue = SecretManager.GenerateSystemKeyValue();
+                keyValue = SecretGenerator.GenerateSystemKeyValue();
                 await secretManager.AddOrUpdateFunctionSecretAsync(keyName, keyValue, HostKeyScopes.SystemKeys, ScriptSecretsType.Host);
             }
 

--- a/test/WebJobs.Script.Tests/DefaultScriptWebHookProviderTests.cs
+++ b/test/WebJobs.Script.Tests/DefaultScriptWebHookProviderTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Script.Tests.Security;
 using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security;
 using Microsoft.Extensions.Logging;
 using Microsoft.Security.Utilities;
 using Microsoft.WebJobs.Script.Tests;
@@ -80,8 +81,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var url = webHookProvider.GetUrl(configProvider);
             Assert.Equal($"{TestUrlRoot}{secretValue}", url.ToString());
             Assert.True(IdentifiableSecrets.ValidateBase64Key(secretValue,
-                                                              SecretManager.SystemKeySeed,
-                                                              SecretManager.AzureFunctionsSignature,
+                                                              SecretGenerator.SystemKeySeed,
+                                                              SecretGenerator.AzureFunctionsSignature,
                                                               encodeForUrl: true));
         }
 

--- a/test/WebJobs.Script.Tests/Security/SecretGeneratorTests.cs
+++ b/test/WebJobs.Script.Tests/Security/SecretGeneratorTests.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Text;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.Security.Utilities;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Security
+{
+    public class SecretGeneratorTests
+    {
+        [Fact]
+        public void GenerateIdentifiableSecret_HonorsSeed()
+        {
+            ulong seed = uint.MaxValue;
+            string secret = SecretGenerator.GenerateIdentifiableSecret(uint.MaxValue);
+            ValidateSecret(secret, seed);
+        }
+
+        [Fact]
+        public void GenerateMasterKeyValue_GeneratesCorrectSecret()
+        {
+            // This is how the preliminary system key seed was generated.
+            // "Master01" can be used as the next string literal if this seed
+            // is versioned. The bytes are reversed in an attempt to retain a
+            // common prefix (left-hand data value) for the the seed if changed.
+            ulong expectedSeed = BitConverter.ToUInt64(Encoding.ASCII.GetBytes("Master00").Reverse().ToArray());
+            Assert.Equal(expectedSeed, SecretGenerator.MasterKeySeed);
+
+            string secret = SecretGenerator.GenerateMasterKeyValue();
+            ValidateSecret(secret, SecretGenerator.MasterKeySeed);
+        }
+
+        [Fact]
+        public void GenerateSystemKeyValue_GeneratesCorrectSecret()
+        {
+            // This is how the preliminary system key seed was generated.
+            // "System01" can be used as the next string literal if this seed
+            // is versioned. The bytes are reversed in an attempt to retain a
+            // common prefix (left-hand data value) for the the seed if changed.
+            ulong expectedSeed = BitConverter.ToUInt64(Encoding.ASCII.GetBytes("System00").Reverse().ToArray());
+            Assert.Equal(expectedSeed, SecretGenerator.SystemKeySeed);
+
+            string secret = SecretGenerator.GenerateSystemKeyValue();
+            ValidateSecret(secret, SecretGenerator.SystemKeySeed);
+        }
+
+        [Fact]
+        public void GenerateFunctionKeyValue_GeneratesCorrectSecret()
+        {
+            // This is how the preliminary system key seed was generated.
+            // "Functi01" can be used as the next string literal if this seed
+            // is versioned. The bytes are reversed in an attempt to retain a
+            // common prefix (left-hand data value) for the the seed if changed.
+            ulong expectedSeed = BitConverter.ToUInt64(Encoding.ASCII.GetBytes("Functi00").Reverse().ToArray());
+            Assert.Equal(expectedSeed, SecretGenerator.FunctionKeySeed);
+
+            string secret = SecretGenerator.GenerateFunctionKeyValue();
+            ValidateSecret(secret, SecretGenerator.FunctionKeySeed);
+        }
+
+        internal static void ValidateSecret(string secret, ulong seed)
+        {
+            Assert.True(IdentifiableSecrets.ValidateBase64Key(secret,
+                                                              seed,
+                                                              SecretGenerator.AzureFunctionsSignature,
+                                                              encodeForUrl: true));
+
+            // Strictly speaking, these tests shouldn't be required, failure
+            // would indicate a bug in the Microsoft.Security.Utilities API itself
+            // Still, this is a new dependency, so we'll do some sanity checking.
+
+            // Azure Function secrets are base64-encoded using a URL friendly character set.
+            // These tokens therefore never include the '+' or '/' characters.
+            Assert.False(secret.Contains('+'));
+            Assert.False(secret.Contains('/'));
+
+            // All Azure function keys are 40 bytes in length, 56 base64-encoded chars.
+            Assert.True(secret.Length == 56);
+            Assert.True(Base64UrlEncoder.DecodeBytes(secret).Length == 40);
+
+            ulong[] testSeeds = new[]
+            {
+                uint.MinValue, uint.MaxValue, SecretGenerator.SystemKeySeed,
+                SecretGenerator.MasterKeySeed, SecretGenerator.FunctionKeySeed,
+            };
+
+            // Verify that validation fails for incorrect seed values.
+            foreach (ulong testSeed in testSeeds)
+            {
+                if (testSeed == seed)
+                {
+                    // We looked at this one already.
+                    continue;
+                }
+
+                Assert.False(IdentifiableSecrets.ValidateBase64Key(secret,
+                                                                  testSeed,
+                                                                  SecretGenerator.AzureFunctionsSignature,
+                                                                  encodeForUrl: true));
+            }
+
+            // Validate that validation fails for an incorrect signature.
+            Assert.False(IdentifiableSecrets.ValidateBase64Key(secret,
+                                                  seed,
+                                                  "XXXX",
+                                                  encodeForUrl: true));
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.Http;
@@ -18,8 +17,6 @@ using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 using Microsoft.Azure.WebJobs.Script.WebHost.Properties;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security;
 using Microsoft.Extensions.Logging;
-using Microsoft.IdentityModel.Tokens;
-using Microsoft.Security.Utilities;
 using Microsoft.WebJobs.Script.Tests;
 using Moq;
 using Newtonsoft.Json;
@@ -58,56 +55,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
         }
 
         [Fact]
-        public void SecretManager_GenerateIdentifiableSecret_HonorsSeed()
-        {
-            ulong seed = uint.MaxValue;
-            string secret = SecretManager.GenerateIdentifiableSecret(uint.MaxValue);
-            ValidateSecret(secret, seed);
-        }
-
-        [Fact]
-        public void SecretManager_GeneratesMasterKeysWithCorrectSeed()
-        {
-            // This is how the preliminary system key seed was generated.
-            // "Master01" can be used as the next string literal if this seed
-            // is versioned. The bytes are reversed in an attempt to retain a
-            // common prefix (left-hand data value) for the the seed if changed.
-            ulong expectedSeed = BitConverter.ToUInt64(Encoding.ASCII.GetBytes("Master00").Reverse().ToArray());
-            Assert.Equal(expectedSeed, SecretManager.MasterKeySeed);
-
-            string secret = SecretManager.GenerateMasterKeyValue();
-            ValidateSecret(secret, SecretManager.MasterKeySeed);
-        }
-
-        [Fact]
-        public void SecretManager_GeneratesSystemKeyValuesWithCorrectSeed()
-        {
-            // This is how the preliminary system key seed was generated.
-            // "System01" can be used as the next string literal if this seed
-            // is versioned. The bytes are reversed in an attempt to retain a
-            // common prefix (left-hand data value) for the the seed if changed.
-            ulong expectedSeed = BitConverter.ToUInt64(Encoding.ASCII.GetBytes("System00").Reverse().ToArray());
-            Assert.Equal(expectedSeed, SecretManager.SystemKeySeed);
-
-            string secret = SecretManager.GenerateSystemKeyValue();
-            ValidateSecret(secret, SecretManager.SystemKeySeed);
-        }
-
-        [Fact]
-        public void SecretManager_GeneratesFunctionKeysWithCorrectSeed()
-        {
-            // This is how the preliminary system key seed was generated.
-            // "Functi01" can be used as the next string literal if this seed
-            // is versioned. The bytes are reversed in an attempt to retain a
-            // common prefix (left-hand data value) for the the seed if changed.
-            ulong expectedSeed = BitConverter.ToUInt64(Encoding.ASCII.GetBytes("Functi00").Reverse().ToArray());
-            Assert.Equal(expectedSeed, SecretManager.FunctionKeySeed);
-
-            string secret = SecretManager.GenerateFunctionKeyValue();
-            ValidateSecret(secret, SecretManager.FunctionKeySeed);
-        }
-
-        [Fact]
         public async Task SecretManager_NewlyGeneratedKeysAreIdentifiable()
         {
             using (var directory = new TempDirectory())
@@ -132,7 +79,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             // generated secret value, as a clue that actual encryption is simulated in
             // the test case.
             string normalizedKey = NormalizeKey(hostSecrets.MasterKey);
-            ValidateSecret(normalizedKey, SecretManager.MasterKeySeed);
+            SecretGeneratorTests.ValidateSecret(normalizedKey, SecretGenerator.MasterKeySeed);
 
             // Create host secrets if missing knob does not allocate a system
             // key. The system key creation/validation test is done in the
@@ -142,7 +89,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             foreach (string key in hostSecrets.FunctionKeys.Values)
             {
                 normalizedKey = NormalizeKey(key);
-                ValidateSecret(normalizedKey, SecretManager.FunctionKeySeed);
+                SecretGeneratorTests.ValidateSecret(normalizedKey, SecretGenerator.FunctionKeySeed);
             }
 
             return true;
@@ -152,54 +99,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
         {
             // Elide the '!' appended to secrets which are simulated as encrypted.
             return key.StartsWith("!") ? key.Substring(1) : key;
-        }
-
-        private static void ValidateSecret(string secret, ulong seed)
-        {
-            Assert.True(IdentifiableSecrets.ValidateBase64Key(secret,
-                                                              seed,
-                                                              SecretManager.AzureFunctionsSignature,
-                                                              encodeForUrl: true));
-
-            // Strictly speaking, these tests shouldn't be required, failure
-            // would indicate a bug in the Microsoft.Security.Utilities API itself
-            // Still, this is a new dependency, so we'll do some sanity checking.
-
-            // Azure Function secrets are base64-encoded using a URL friendly character set.
-            // These tokens therefore never include the '+' or '/' characters.
-            Assert.False(secret.Contains('+'));
-            Assert.False(secret.Contains('/'));
-
-            // All Azure function keys are 40 bytes in length, 56 base64-encoded chars.
-            Assert.True(secret.Length == 56);
-            Assert.True(Base64UrlEncoder.DecodeBytes(secret).Length == 40);
-
-            ulong[] testSeeds = new[]
-            {
-                uint.MinValue, uint.MaxValue, SecretManager.SystemKeySeed,
-                SecretManager.MasterKeySeed, SecretManager.FunctionKeySeed,
-            };
-
-            // Verify that validation fails for incorrect seed values.
-            foreach (ulong testSeed in testSeeds)
-            {
-                if (testSeed == seed)
-                {
-                    // We looked at this one already.
-                    continue;
-                }
-
-                Assert.False(IdentifiableSecrets.ValidateBase64Key(secret,
-                                                                  testSeed,
-                                                                  SecretManager.AzureFunctionsSignature,
-                                                                  encodeForUrl: true));
-            }
-
-            // Validate that validation fails for an incorrect signature.
-            Assert.False(IdentifiableSecrets.ValidateBase64Key(secret,
-                                                  seed,
-                                                  "XXXX",
-                                                  encodeForUrl: true));
         }
 
         [Fact]
@@ -513,7 +412,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                 Assert.Equal(1, testRepository.FunctionSecrets.Count);
                 var functionSecrets = (FunctionSecrets)testRepository.FunctionSecrets[testFunctionName];
                 string defaultKeyValue = functionSecrets.Keys.Where(p => p.Name == "default").Single().Value;
-                ValidateSecret(defaultKeyValue, SecretManager.FunctionKeySeed);
+                SecretGeneratorTests.ValidateSecret(defaultKeyValue, SecretGenerator.FunctionKeySeed);
                 Assert.True(tasks.Select(p => p.Result).All(t => t["default"] == defaultKeyValue));
             }
         }


### PR DESCRIPTION
Exposing a public helper utility so the same identifiable secrets logic can be shared between Functions Host and CLI (see https://github.com/Azure/azure-functions-core-tools/issues/2944).

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
