### PR TITLE
Introduce minimum Durable host.json payload on SyncTrigger

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,6 +4,7 @@
 - My change description (#PR)
 -->
 - Add admin/host/config API (#7394)
+- Add Durable Functions minimm host.json payload to SyncTrigger(#8188)
 
 **Release sprint:** Sprint 118
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+118%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+118%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -335,7 +335,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             JObject extensionsPayload = null;
             extensionsPayload = _environment.IsKubernetesManagedHosting() ? 
                 await GetHostJsonExtensionsForKubernetesAsync(_applicationHostOptions, _logger) : 
-                await GetHostJsonExtensionsAsync(_applicationHostOptions, _logger);
+                await GetHostJsonExtensionsForDurableAsync(_applicationHostOptions, _logger);
 
             if (extensionsPayload != null)
             {
@@ -408,7 +408,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             };
         }
 
-        internal static async Task<JObject> GetHostJsonExtensionsAsync(IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, ILogger logger)
+        internal static async Task<JObject> GetHostJsonExtensionsForDurableAsync(IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, ILogger logger)
         {
             var hostOptions = applicationHostOptions.CurrentValue.ToHostOptions();
             string hostJsonPath = Path.Combine(hostOptions.RootScriptPath, ScriptConstants.HostMetadataFileName);

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -333,7 +333,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             result.Add("functions", new JArray(functionDetails.Select(p => JObject.FromObject(p))));
 
             JObject extensionsPayload = null;
-            extensionsPayload = _environment.IsKubernetesManagedHosting() ? await GetHostJsonExtensionsForKubernetesAsync(_applicationHostOptions, _logger) : await GetHostJsonExtensionsAsync(_applicationHostOptions, _logger);
+            extensionsPayload = _environment.IsKubernetesManagedHosting() ? 
+                await GetHostJsonExtensionsForKubernetesAsync(_applicationHostOptions, _logger) : 
+                await GetHostJsonExtensionsAsync(_applicationHostOptions, _logger);
 
             if (extensionsPayload != null)
             {

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -332,15 +332,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             var functionDetails = await WebFunctionsManager.GetFunctionMetadataResponse(listableFunctions, hostOptions, _hostNameProvider);
             result.Add("functions", new JArray(functionDetails.Select(p => JObject.FromObject(p))));
 
-            // TEMP: refactor this code to properly add extensions in all scenario(#7394)
-            // Add the host.json extensions to the payload
-            if (_environment.IsKubernetesManagedHosting())
+            JObject extensionsPayload = null;
+            extensionsPayload = _environment.IsKubernetesManagedHosting() ? await GetHostJsonExtensionsForKubernetesAsync(_applicationHostOptions, _logger) : await GetHostJsonExtensionsAsync(_applicationHostOptions, _logger);
+
+            if (extensionsPayload != null)
             {
-                JObject extensionsPayload = await GetHostJsonExtensionsAsync(_applicationHostOptions, _logger);
-                if (extensionsPayload != null)
-                {
-                    result.Add("extensions", extensionsPayload);
-                }
+                result.Add("extensions", extensionsPayload);
             }
 
             if (_secretManagerProvider.SecretsEnabled)
@@ -410,6 +407,67 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         }
 
         internal static async Task<JObject> GetHostJsonExtensionsAsync(IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, ILogger logger)
+        {
+            var hostOptions = applicationHostOptions.CurrentValue.ToHostOptions();
+            string hostJsonPath = Path.Combine(hostOptions.RootScriptPath, ScriptConstants.HostMetadataFileName);
+            if (FileUtility.FileExists(hostJsonPath))
+            {
+                try
+                {
+                    var hostJson = JObject.Parse(await FileUtility.ReadAsync(hostJsonPath));
+
+                    var extensions = new JObject();
+                    var durableTask = new JObject();
+
+                    // Filter the minimum Durable Functions Payload
+                    string sectionPrefix = "extensions.durableTask.";
+                    string hubNamePropertyName = "hubName";
+                    string storageProviderPropertyName = "storageProvider";
+                    string maxConcurrentActivityFunctionsPropertyName = "maxConcurrentActivityFunctions";
+                    string maxConcurrentOrchestratorFunctionsPropertyName = "maxConcurrentOrchestratorFunctions";
+
+                    var hubName = hostJson.SelectToken($"{sectionPrefix}{hubNamePropertyName}");
+                    var storageProvider = hostJson.SelectToken($"{sectionPrefix}{storageProviderPropertyName}");
+                    var maxConcurrentActivityFunctions = hostJson.SelectToken($"{sectionPrefix}{maxConcurrentActivityFunctionsPropertyName}");
+                    var maxConcurrentOrchestratorFunctions = hostJson.SelectToken($"{sectionPrefix}{maxConcurrentOrchestratorFunctionsPropertyName}");
+
+                    if (hubName != null)
+                    {
+                        durableTask.Add(hubNamePropertyName, hubName);
+                    }
+
+                    if (storageProvider != null)
+                    {
+                        durableTask.Add(storageProviderPropertyName, storageProvider);
+                    }
+
+                    if (maxConcurrentActivityFunctions != null)
+                    {
+                        durableTask.Add(maxConcurrentActivityFunctionsPropertyName, maxConcurrentActivityFunctions);
+                    }
+
+                    if (maxConcurrentOrchestratorFunctions != null)
+                    {
+                        durableTask.Add(maxConcurrentOrchestratorFunctionsPropertyName, maxConcurrentOrchestratorFunctions);
+                    }
+
+                    if (durableTask.Count != 0)
+                    {
+                        extensions.Add("durableTask", durableTask);
+                        return extensions;
+                    }
+                }
+                catch (JsonException ex)
+                {
+                    logger.LogWarning($"Unable to parse host configuration file '{hostJsonPath}'. : {ex}");
+                    return null;
+                }
+            }
+
+            return null;
+        }
+
+        internal static async Task<JObject> GetHostJsonExtensionsForKubernetesAsync(IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, ILogger logger)
         {
             var hostOptions = applicationHostOptions.CurrentValue.ToHostOptions();
             string hostJsonPath = Path.Combine(hostOptions.RootScriptPath, ScriptConstants.HostMetadataFileName);

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -333,8 +333,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             result.Add("functions", new JArray(functionDetails.Select(p => JObject.FromObject(p))));
 
             JObject extensionsPayload = null;
-            extensionsPayload = _environment.IsKubernetesManagedHosting() ? 
-                await GetHostJsonExtensionsForKubernetesAsync(_applicationHostOptions, _logger) : 
+            extensionsPayload = _environment.IsKubernetesManagedHosting() ?
+                await GetHostJsonExtensionsForKubernetesAsync(_applicationHostOptions, _logger) :
                 await GetHostJsonExtensionsForDurableAsync(_applicationHostOptions, _logger);
 
             if (extensionsPayload != null)

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -785,9 +785,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 { "extensions", extensionsConfig }
             };
             hostJsonContent = hostJsonContent ?? defaultHostConfig.ToString();
-            var testHostJsonStream = new MemoryStream(Encoding.UTF8.GetBytes(hostJsonContent));
-            testHostJsonStream.Position = 0;
-            fileBase.Setup(f => f.Open(Path.Combine(rootPath, @"host.json"), It.IsAny<FileMode>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>())).Returns(testHostJsonStream);
+
+            fileBase.Setup(f => f.Open(Path.Combine(rootPath, @"host.json"), It.IsAny<FileMode>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>())).Returns(() =>
+            {
+                var testHostJsonStream = new MemoryStream(Encoding.UTF8.GetBytes(hostJsonContent));
+                testHostJsonStream.Position = 0;
+                return testHostJsonStream;
+            });
 
             if (extensionsJsonContent != null)
             {

--- a/test/WebJobs.Script.Tests/Managment/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Managment/FunctionsSyncManagerTests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             try
             {
                 var context = await SetupTestContextAsync(hostJsonContents, skipWriteFile);
-                var json = await FunctionsSyncManager.GetHostJsonExtensionsAsync(context.Options, context.Logger);
+                var json = await FunctionsSyncManager.GetHostJsonExtensionsForDurableAsync(context.Options, context.Logger);
                 if (isNull)
                 {
                     Assert.Null(json);

--- a/test/WebJobs.Script.Tests/Managment/Payloads/DurableWithStorageProviderPayload.json
+++ b/test/WebJobs.Script.Tests/Managment/Payloads/DurableWithStorageProviderPayload.json
@@ -1,0 +1,14 @@
+{
+  "version": "2.0",
+  "extensions": {
+    "durableTask": {
+      "storageProvider": {
+        "type": "mssql",
+        "connectionStringName": "SQLDB_Connection",
+        "taskEventLockTimeout": "00:02:00",
+        "createDatabaseIfNotExists": true
+      },
+      "maxConcurrentOrchestratorFunctions": 10
+    }
+  }
+}

--- a/test/WebJobs.Script.Tests/Managment/Payloads/DurableWithoutStorageProviderPayload.json
+++ b/test/WebJobs.Script.Tests/Managment/Payloads/DurableWithoutStorageProviderPayload.json
@@ -1,0 +1,9 @@
+{
+  "version": "2.0",
+  "extensions": {
+    "durableTask": {
+      "hubName": "UpdatedTaskHubName",
+      "maxConcurrentActivityFunctions": 12
+    }
+  }
+}

--- a/test/WebJobs.Script.Tests/Managment/Payloads/MultipleExtensionsWithDurablePayload.json
+++ b/test/WebJobs.Script.Tests/Managment/Payloads/MultipleExtensionsWithDurablePayload.json
@@ -1,0 +1,37 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[2.*, 3.0.0)"
+
+  },
+  "extensions": {
+    "durableTask": {
+      "hubName": "UpdatedTaskHubName",
+      "storageProvider": {
+        "type": "mssql",
+        "connectionStringName": "SQLDB_Connection",
+        "taskEventLockTimeout": "00:02:00",
+        "createDatabaseIfNotExists": true
+      },
+      "maxConcurrentActivityFunctions": 12,
+      "maxConcurrentOrchestratorFunctions": 10
+    },
+    "queues": {
+      "maxPollingInterval": "00:00:30",
+      "visibilityTimeout": "00:01:00",
+      "batchSize": 16,
+      "maxDequeueCount": 5,
+      "newBatchThreshold": 8,
+      "messageEncoding": "base64"
+    }
+  }
+}

--- a/test/WebJobs.Script.Tests/Managment/Payloads/NoExtensionSection.json
+++ b/test/WebJobs.Script.Tests/Managment/Payloads/NoExtensionSection.json
@@ -1,0 +1,16 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[2.*, 3.0.0)"
+
+  }
+}

--- a/test/WebJobs.Script.Tests/Managment/Payloads/NonDurableExtensionPayload.json
+++ b/test/WebJobs.Script.Tests/Managment/Payloads/NonDurableExtensionPayload.json
@@ -1,0 +1,26 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[2.*, 3.0.0)"
+
+  },
+  "extensions": {
+    "queues": {
+      "maxPollingInterval": "00:00:30",
+      "visibilityTimeout": "00:01:00",
+      "batchSize": 16,
+      "maxDequeueCount": 5,
+      "newBatchThreshold": 8,
+      "messageEncoding": "base64"
+    }
+  }
+}

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -103,13 +103,19 @@
     <None Update="Description\DotNet\TestFiles\PackageReferences\ProjectWithMismatchedLock\MismatchedProjectDependencies\project.assets.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="Managment\Payloads\ExpectedConcurrencyPayload.json">
+    <None Update="Managment\Payloads\DurableWithoutStorageProviderPayload.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="Managment\Payloads\ExpectedHostJsonPayload.json">
+    <None Update="Managment\Payloads\DurableWithStorageProviderPayload.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="Managment\Payloads\ExpectedHttpExtensionsPayload.json">
+    <None Update="Managment\Payloads\MultipleExtensionsWithDurablePayload.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Managment\Payloads\NoExtensionSection.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Managment\Payloads\NonDurableExtensionPayload.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="Microsoft.Azure.WebJobs.Script.WebHost.deps.json">


### PR DESCRIPTION
This PR introduce add SyncTriggerPayload to add minimum Durable Functions Payload. 
We include following section only. `hubName`, `storageProvider`, `maxConcurrentActivityFunctions`, `maxConcurrentOrchestratorFunctions`. 

```
  "extensions": {
    "durableTask": {
      "hubName": "UpdatedTaskHubName",
      "storageProvider": {
        "type": "mssql",
        "connectionStringName": "SQLDB_Connection",
        "taskEventLockTimeout": "00:02:00",
        "createDatabaseIfNotExists": true
      },
      "maxConcurrentActivityFunctions": 12,
      "maxConcurrentOrchestratorFunctions": 10
    },
```

### Issue describing the changes in this PR

resolves [Refactor the SyncTrigger extensions payload to make it generic](https://github.com/Azure/azure-functions-host/issues/7394)

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR   I'll update the backport PR after review has been done.
    * [x] I have added all required tests (Unit tests, E2E tests)

Could you review this? @cgillum @mathewc 
CC: @pragnagopa 