### PR TITLE
4.2.1 Hotfix - Change Java Worker Version Number

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <MajorVersion>4</MajorVersion>
     <MinorVersion>2</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <BuildNumber Condition="'$(BuildNumber)' == '' ">0</BuildNumber>
     <PreviewVersion></PreviewVersion>        
     

--- a/build/install-dotnet.yml
+++ b/build/install-dotnet.yml
@@ -7,4 +7,5 @@ steps:
       Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -OutFile 'dotnet-install.ps1'
       # Official release versions can be found at: https://dotnet.microsoft.com/download/dotnet/6.0
       # Newer versions can be found at: https://github.com/dotnet/installer#installers-and-binaries
+      ./dotnet-install.ps1 -InstallDir 'C:\Program Files\dotnet' -Verbose -Channel 2.1
       ./dotnet-install.ps1 -InstallDir 'C:\Program Files\dotnet' -Verbose -Channel 6.0

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,7 +4,7 @@
 -->
 - Update Python Worker Version to [4.0.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.0.0)
 - Fixing race during language worker start (#7979)
-- Updated Java Worker Version to [2.2.1-SNAPSHOT](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.2.1-SNAPSHOT)
+- Updated Java Worker Version to [2.1.0-SNAPSHOT](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.1.0-SNAPSHOT)
 - Updated Node.js Worker Version to [3.1.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.1.0)
 
 **Release sprint:** Sprint 113

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -55,7 +55,7 @@
     </PackageReference>
 
     <!-- Workers -->
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.2.1-SNAPSHOT" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.1.0-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" Version="4.0.1570" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" Version="4.0.1567" />

--- a/test/TestFunctions/TestFunctions.csproj
+++ b/test/TestFunctions/TestFunctions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -44,7 +44,7 @@
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.5-11874" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.2.1-SNAPSHOT" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.1.0-SNAPSHOT" />
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.2.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />


### PR DESCRIPTION
Regressing Java worker version to 2.1.0-SNAPSHOT to fix  2.2.0-SNAPSHOT bug.
https://github.com/Azure/azure-functions-java-worker/releases/tag/2.1.0-SNAPSHOT

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information