### PR TITLE
add auto detection for index.cjs files

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,3 +6,4 @@
 **Release sprint:** Sprint 118
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+<successiveSprint>%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+<successiveSprint>%22+label%3Afeature+is%3Aclosed) ]
 - Updated Node.js Worker Version to [2.1.3](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v2.1.3)
+- Added support for "index.cjs" files

--- a/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
@@ -241,7 +241,7 @@ namespace Microsoft.Azure.WebJobs.Script
                         fileSystem.Path.GetFileNameWithoutExtension(p).ToLowerInvariant() == "run" ||
                         fileSystem.Path.GetFileName(p).ToLowerInvariant() == "index.js" ||
                         fileSystem.Path.GetFileName(p).ToLowerInvariant() == "index.mjs" ||
-                        fileSystem.Path.GetFileName(p).ToLowerInvariant() == "index.cjs" || 
+                        fileSystem.Path.GetFileName(p).ToLowerInvariant() == "index.cjs" ||
                         fileSystem.Path.GetFileName(p).ToLowerInvariant() == "__init__.py");
                 }
             }

--- a/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
@@ -241,6 +241,7 @@ namespace Microsoft.Azure.WebJobs.Script
                         fileSystem.Path.GetFileNameWithoutExtension(p).ToLowerInvariant() == "run" ||
                         fileSystem.Path.GetFileName(p).ToLowerInvariant() == "index.js" ||
                         fileSystem.Path.GetFileName(p).ToLowerInvariant() == "index.mjs" ||
+                        fileSystem.Path.GetFileName(p).ToLowerInvariant() == "index.cjs" || 
                         fileSystem.Path.GetFileName(p).ToLowerInvariant() == "__init__.py");
                 }
             }

--- a/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
@@ -315,6 +315,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [InlineData("run.csx")]
         [InlineData("run.py")]
         [InlineData("index.js")]
+        [InlineData("index.cjs")]
+        [InlineData("index.mjs")]
         [InlineData("test.dll")]
         public void ScriptFile_Emtpy_Returns_True(string scriptFile)
         {

--- a/test/WebJobs.Script.Tests/HostFunctionMetadataProviderTests.cs
+++ b/test/WebJobs.Script.Tests/HostFunctionMetadataProviderTests.cs
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 { @"c:\functions\test.txt", new MockFileData(string.Empty) }
             };
             var fileSystem = new MockFileSystem(files);
-
+            
             string scriptFile = HostFunctionMetadataProvider.DeterminePrimaryScriptFile(scriptFileProperty, @"c:\functions", fileSystem);
             Assert.Equal(expectedScriptFilePath, scriptFile);
         }

--- a/test/WebJobs.Script.Tests/HostFunctionMetadataProviderTests.cs
+++ b/test/WebJobs.Script.Tests/HostFunctionMetadataProviderTests.cs
@@ -206,12 +206,29 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 { @"c:\functions\run.js", new MockFileData(string.Empty) },
                 { @"c:\functions\index.js", new MockFileData(string.Empty) },
+                { @"c:\functions\index.mjs", new MockFileData(string.Empty) },
+                { @"c:\functions\index.cjs", new MockFileData(string.Empty) },
                 { @"c:\functions\test.txt", new MockFileData(string.Empty) }
             };
             var fileSystem = new MockFileSystem(files);
 
             string scriptFile = HostFunctionMetadataProvider.DeterminePrimaryScriptFile(string.Empty, @"c:\functions", fileSystem);
             Assert.Equal(@"c:\functions\run.js", scriptFile);
+        }
+
+        [Fact]
+        public void DeterminePrimaryScriptFile_MultipleFiles_IndexJsTrumpsMjsAndCjs()
+        {
+            var files = new Dictionary<string, MockFileData>
+            {
+                { @"c:\functions\index.js", new MockFileData(string.Empty) },
+                { @"c:\functions\index.mjs", new MockFileData(string.Empty) },
+                { @"c:\functions\index.cjs", new MockFileData(string.Empty) }
+            };
+            var fileSystem = new MockFileSystem(files);
+
+            string scriptFile = HostFunctionMetadataProvider.DeterminePrimaryScriptFile(string.Empty, @"c:\functions", fileSystem);
+            Assert.Equal(@"c:\functions\index.js", scriptFile);
         }
 
         [Theory]

--- a/test/WebJobs.Script.Tests/HostFunctionMetadataProviderTests.cs
+++ b/test/WebJobs.Script.Tests/HostFunctionMetadataProviderTests.cs
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 { @"c:\functions\test.txt", new MockFileData(string.Empty) }
             };
             var fileSystem = new MockFileSystem(files);
-            
+
             string scriptFile = HostFunctionMetadataProvider.DeterminePrimaryScriptFile(scriptFileProperty, @"c:\functions", fileSystem);
             Assert.Equal(expectedScriptFilePath, scriptFile);
         }


### PR DESCRIPTION
Adds support for "index.cjs" files for node functions.

### Issue describing the changes in this PR

Backport of #8205. Related to [this issue](https://github.com/Azure/azure-functions-nodejs-worker/issues/531) in the node worker.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)