### PR TITLE
Add support for index.cjs files

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -8,3 +8,4 @@
 **Release sprint:** Sprint 118
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+118%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+118%22+label%3Afeature+is%3Aclosed) ]
 
+- Added support for "index.cjs" files

--- a/release_notes.md
+++ b/release_notes.md
@@ -7,4 +7,3 @@
 
 **Release sprint:** Sprint 118
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+118%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+118%22+label%3Afeature+is%3Aclosed) ]
--

--- a/release_notes.md
+++ b/release_notes.md
@@ -7,3 +7,4 @@
 
 **Release sprint:** Sprint 118
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+118%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+118%22+label%3Afeature+is%3Aclosed) ]
+-

--- a/release_notes.md
+++ b/release_notes.md
@@ -7,3 +7,4 @@
 
 **Release sprint:** Sprint 118
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+118%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+118%22+label%3Afeature+is%3Aclosed) ]
+

--- a/release_notes.md
+++ b/release_notes.md
@@ -7,5 +7,3 @@
 
 **Release sprint:** Sprint 118
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+118%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+118%22+label%3Afeature+is%3Aclosed) ]
-
-- Added support for "index.cjs" files

--- a/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
@@ -241,6 +241,7 @@ namespace Microsoft.Azure.WebJobs.Script
                         fileSystem.Path.GetFileNameWithoutExtension(p).ToLowerInvariant() == "run" ||
                         fileSystem.Path.GetFileName(p).ToLowerInvariant() == "index.js" ||
                         fileSystem.Path.GetFileName(p).ToLowerInvariant() == "index.mjs" ||
+                        fileSystem.Path.GetFileName(p).ToLowerInvariant() == "index.cjs" ||
                         fileSystem.Path.GetFileName(p).ToLowerInvariant() == "__init__.py");
                 }
             }

--- a/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
@@ -315,6 +315,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [InlineData("run.csx")]
         [InlineData("run.py")]
         [InlineData("index.js")]
+        [InlineData("index.cjs")]
+        [InlineData("index.mjs")]
         [InlineData("test.dll")]
         public void ScriptFile_Emtpy_Returns_True(string scriptFile)
         {

--- a/test/WebJobs.Script.Tests/HostFunctionMetadataProviderTests.cs
+++ b/test/WebJobs.Script.Tests/HostFunctionMetadataProviderTests.cs
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 { @"c:\functions\test.txt", new MockFileData(string.Empty) }
             };
             var fileSystem = new MockFileSystem(files);
-
+            
             string scriptFile = HostFunctionMetadataProvider.DeterminePrimaryScriptFile(scriptFileProperty, @"c:\functions", fileSystem);
             Assert.Equal(expectedScriptFilePath, scriptFile);
         }

--- a/test/WebJobs.Script.Tests/HostFunctionMetadataProviderTests.cs
+++ b/test/WebJobs.Script.Tests/HostFunctionMetadataProviderTests.cs
@@ -206,12 +206,29 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 { @"c:\functions\run.js", new MockFileData(string.Empty) },
                 { @"c:\functions\index.js", new MockFileData(string.Empty) },
+                { @"c:\functions\index.mjs", new MockFileData(string.Empty) },
+                { @"c:\functions\index.cjs", new MockFileData(string.Empty) },
                 { @"c:\functions\test.txt", new MockFileData(string.Empty) }
             };
             var fileSystem = new MockFileSystem(files);
 
             string scriptFile = HostFunctionMetadataProvider.DeterminePrimaryScriptFile(string.Empty, @"c:\functions", fileSystem);
             Assert.Equal(@"c:\functions\run.js", scriptFile);
+        }
+
+        [Fact]
+        public void DeterminePrimaryScriptFile_MultipleFiles_IndexJsTrumpsMjsAndCjs()
+        {
+            var files = new Dictionary<string, MockFileData>
+            {
+                { @"c:\functions\index.js", new MockFileData(string.Empty) },
+                { @"c:\functions\index.mjs", new MockFileData(string.Empty) },
+                { @"c:\functions\index.cjs", new MockFileData(string.Empty) }
+            };
+            var fileSystem = new MockFileSystem(files);
+
+            string scriptFile = HostFunctionMetadataProvider.DeterminePrimaryScriptFile(string.Empty, @"c:\functions", fileSystem);
+            Assert.Equal(@"c:\functions\index.js", scriptFile);
         }
 
         [Theory]

--- a/test/WebJobs.Script.Tests/HostFunctionMetadataProviderTests.cs
+++ b/test/WebJobs.Script.Tests/HostFunctionMetadataProviderTests.cs
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 { @"c:\functions\test.txt", new MockFileData(string.Empty) }
             };
             var fileSystem = new MockFileSystem(files);
-            
+
             string scriptFile = HostFunctionMetadataProvider.DeterminePrimaryScriptFile(scriptFileProperty, @"c:\functions", fileSystem);
             Assert.Equal(expectedScriptFilePath, scriptFile);
         }


### PR DESCRIPTION
Auto-detects "index.cjs" files as primary for node functions. Implementes #8213 

### Issues describing the changes in this PR

This is related to [this issue](https://github.com/Azure/azure-functions-nodejs-worker/issues/531) in the node worker, which includes adding support for ".cjs" files.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR
* [x] I have added all required tests (Unit tests, E2E tests)