### PR TITLE
Add reference to HostStatus in ARM API defined in App Services

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         [TypeFilter(typeof(EnableDebugModeFilter))]
         public async Task<IActionResult> GetHostStatus([FromServices] IScriptHostManager scriptHostManager, [FromServices] IHostIdProvider hostIdProvider, [FromServices] IServiceProvider serviceProvider = null)
         {
+            // When making changes to HostStatus, ensure that you update the HostStatus class in Antares as well: https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites?path=/src/Hosting/AdministrationService/Microsoft.Web.Hosting.Administration.Api/WebEntities/Kudu/HostStatus.cs
             var status = new HostStatus
             {
                 State = scriptHostManager.State.ToString(),

--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         [TypeFilter(typeof(EnableDebugModeFilter))]
         public async Task<IActionResult> GetHostStatus([FromServices] IScriptHostManager scriptHostManager, [FromServices] IHostIdProvider hostIdProvider, [FromServices] IServiceProvider serviceProvider = null)
         {
-            // When making changes to HostStatus, ensure that you update the HostStatus class in Antares as well: https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites?path=/src/Hosting/AdministrationService/Microsoft.Web.Hosting.Administration.Api/WebEntities/Kudu/HostStatus.cs
+            // When making changes to HostStatus, ensure that you update the HostStatus class in AAPT-Antares-Websites repo as well.
             var status = new HostStatus
             {
                 State = scriptHostManager.State.ToString(),


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Adding the link between HostStatus in functions host and ARM layer in Antares to ensure future updates to not miss updating the other location as well.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
