### PR TITLE
Include minimum durable payload to sync trigger

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,6 +4,7 @@
 -->
 - Updated Java Worker Version to [2.2.3](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.2.3)
 - Updated Node.js Worker Version to [3.3.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.3.0)
+- Add admin/host/config API (#7394)
 
 **Release sprint:** Sprint 118
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+118%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+118%22+label%3Afeature+is%3Aclosed) ]

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,7 +4,7 @@
 -->
 - Updated Java Worker Version to [2.2.3](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.2.3)
 - Updated Node.js Worker Version to [3.3.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.3.0)
-- Add admin/host/config API (#7394)
+- Add Include minimum durable payload to sync trigger (#8292)
 
 **Release sprint:** Sprint 118
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+118%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+118%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         private const string DurableTaskV1StorageConnectionName = "azureStorageConnectionStringName";
         private const string DurableTaskV2StorageOptions = "storageProvider";
         private const string DurableTaskV2StorageConnectionName = "connectionStringName";
+        private const string DurableTaskV2MaxConcurrentActivityFunctions = "maxConcurrentActivityFunctions";
+        private const string DurableTaskV2MaxConcurrentOrchestratorFunctions = "maxConcurrentOrchestratorFunctions";
         private const string DurableTask = "durableTask";
 
         // 45 alphanumeric characters gives us a buffer in our table/queue/blob container names.
@@ -477,6 +479,21 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 {
                     trigger[Connection] = durableTaskConfig.Connection;
                 }
+
+                if (durableTaskConfig.StorageProvider != null)
+                {
+                    trigger[DurableTaskV2StorageOptions] = durableTaskConfig.StorageProvider;
+                }
+
+                if (durableTaskConfig.MaxConcurrentOrchestratorFunctions != 0)
+                {
+                    trigger[DurableTaskV2MaxConcurrentOrchestratorFunctions] = durableTaskConfig.MaxConcurrentOrchestratorFunctions;
+                }
+
+                if (durableTaskConfig.MaxConcurrentActivityFunctions != 0)
+                {
+                    trigger[DurableTaskV2MaxConcurrentActivityFunctions] = durableTaskConfig.MaxConcurrentActivityFunctions;
+                }
             }
             return trigger;
         }
@@ -591,6 +608,18 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                     {
                         config.Connection = nameValue.ToString();
                     }
+
+                    config.StorageProvider = storageOptions;
+                }
+
+                if (durableHostConfig.TryGetValue(DurableTaskV2MaxConcurrentOrchestratorFunctions, StringComparison.OrdinalIgnoreCase, out JToken maxConcurrentOrchestratorFunctions) && maxConcurrentOrchestratorFunctions != null)
+                {
+                    config.MaxConcurrentOrchestratorFunctions = int.Parse(maxConcurrentOrchestratorFunctions.ToString());
+                }
+
+                if (durableHostConfig.TryGetValue(DurableTaskV2MaxConcurrentActivityFunctions, StringComparison.OrdinalIgnoreCase, out JToken maxConcurrentActivityFunctions) && maxConcurrentActivityFunctions != null)
+                {
+                    config.MaxConcurrentActivityFunctions = int.Parse(maxConcurrentActivityFunctions.ToString());
                 }
             }
 
@@ -717,9 +746,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
             public string Connection { get; set; }
 
+            public JToken StorageProvider { get; set; }
+
+            public int MaxConcurrentActivityFunctions { get; set; }
+
+            public int MaxConcurrentOrchestratorFunctions { get; set; }
+
             public bool HasValues()
             {
-                return this.HubName != null || this.Connection != null;
+                return this.HubName != null || this.Connection != null || this.StorageProvider != null || this.MaxConcurrentOrchestratorFunctions != 0 || this.MaxConcurrentOrchestratorFunctions != 0;
             }
         }
     }

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -368,7 +368,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 Assert.Equal(1, _mockHttpHandler.RequestCount);
                 var result = JObject.Parse(_contentBuilder.ToString());
                 var triggers = result["triggers"];
-                Assert.Equal(GetExpectedSyncTriggersPayload(), triggers.ToString(Formatting.None));
+                Assert.Equal(GetExpectedSyncTriggersPayload(durableVersion: "V1"), triggers.ToString(Formatting.None));
 
                 string hash = string.Empty;
                 var downloadResponse = await hashBlob.DownloadAsync();
@@ -434,7 +434,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 Assert.Equal(1, _mockHttpHandler.RequestCount);
                 var result = JObject.Parse(_contentBuilder.ToString());
                 var triggers = result["triggers"];
-                Assert.Equal(GetExpectedSyncTriggersPayload(), triggers.ToString(Formatting.None));
+                Assert.Equal(GetExpectedSyncTriggersPayload(durableVersion: "V1"), triggers.ToString(Formatting.None));
                 bool hashBlobExists = await hashBlob.ExistsAsync();
                 Assert.False(hashBlobExists);
 

--- a/test/WebJobs.Script.Tests.Integration/Management/Payload/DurableHasHubNameAndOrchestrationConfigPayload.json
+++ b/test/WebJobs.Script.Tests.Integration/Management/Payload/DurableHasHubNameAndOrchestrationConfigPayload.json
@@ -1,0 +1,29 @@
+[
+  {
+    "authLevel": "anonymous",
+    "type": "httpTrigger",
+    "direction": "in",
+    "name": "req",
+    "functionName": "function1"
+  },
+  {
+    "name": "myQueueItem",
+    "type": "orchestrationTrigger",
+    "direction": "in",
+    "queueName": "myqueue-items",
+    "connection": "",
+    "functionName": "function2",
+    "taskHubName": "DurableTask",
+    "maxConcurrentOrchestratorFunctions": 10
+  },
+  {
+    "name": "myQueueItem",
+    "type": "activityTrigger",
+    "direction": "in",
+    "queueName": "myqueue-items",
+    "connection": "",
+    "functionName": "function3",
+    "taskHubName": "DurableTask",
+    "maxConcurrentOrchestratorFunctions": 10
+  }
+]

--- a/test/WebJobs.Script.Tests.Integration/Management/Payload/DurableHasStorageAndActivityConfigPayload.json
+++ b/test/WebJobs.Script.Tests.Integration/Management/Payload/DurableHasStorageAndActivityConfigPayload.json
@@ -1,0 +1,41 @@
+[
+  {
+    "authLevel": "anonymous",
+    "type": "httpTrigger",
+    "direction": "in",
+    "name": "req",
+    "functionName": "function1"
+  },
+  {
+    "name": "myQueueItem",
+    "type": "orchestrationTrigger",
+    "direction": "in",
+    "queueName": "myqueue-items",
+    "connection": "SQLDB_Connection",
+    "functionName": "function2",
+    "taskHubName": "TestHubValue",
+    "storageProvider": {
+      "type": "mssql",
+      "connectionStringName": "SQLDB_Connection",
+      "taskEventLockTimeout": "00:02:00",
+      "createDatabaseIfNotExists": true
+    },
+    "maxConcurrentActivityFunctions": 12
+  },
+  {
+    "name": "myQueueItem",
+    "type": "activityTrigger",
+    "direction": "in",
+    "queueName": "myqueue-items",
+    "connection": "SQLDB_Connection",
+    "functionName": "function3",
+    "taskHubName": "TestHubValue",
+    "storageProvider": {
+      "type": "mssql",
+      "connectionStringName": "SQLDB_Connection",
+      "taskEventLockTimeout": "00:02:00",
+      "createDatabaseIfNotExists": true
+    },
+    "maxConcurrentActivityFunctions": 12
+  }
+]

--- a/test/WebJobs.Script.Tests.Integration/Management/Payload/DurableMsSQLProviderPayload.json
+++ b/test/WebJobs.Script.Tests.Integration/Management/Payload/DurableMsSQLProviderPayload.json
@@ -1,0 +1,43 @@
+[
+  {
+    "authLevel": "anonymous",
+    "type": "httpTrigger",
+    "direction": "in",
+    "name": "req",
+    "functionName": "function1"
+  },
+  {
+    "name": "myQueueItem",
+    "type": "orchestrationTrigger",
+    "direction": "in",
+    "queueName": "myqueue-items",
+    "connection": "SQLDB_Connection",
+    "functionName": "function2",
+    "taskHubName": "DurableTask",
+    "storageProvider": {
+      "type": "mssql",
+      "connectionStringName": "SQLDB_Connection",
+      "taskEventLockTimeout": "00:02:00",
+      "createDatabaseIfNotExists": true
+    },
+    "maxConcurrentOrchestratorFunctions": 10,
+    "maxConcurrentActivityFunctions": 12
+  },
+  {
+    "name": "myQueueItem",
+    "type": "activityTrigger",
+    "direction": "in",
+    "queueName": "myqueue-items",
+    "connection": "SQLDB_Connection",
+    "functionName": "function3",
+    "taskHubName": "DurableTask",
+    "storageProvider": {
+      "type": "mssql",
+      "connectionStringName": "SQLDB_Connection",
+      "taskEventLockTimeout": "00:02:00",
+      "createDatabaseIfNotExists": true
+    },
+    "maxConcurrentOrchestratorFunctions": 10,
+    "maxConcurrentActivityFunctions": 12
+  }
+]

--- a/test/WebJobs.Script.Tests.Integration/Management/Payload/EmptyDurablePayload.json
+++ b/test/WebJobs.Script.Tests.Integration/Management/Payload/EmptyDurablePayload.json
@@ -1,0 +1,27 @@
+[
+  {
+    "authLevel": "anonymous",
+    "type": "httpTrigger",
+    "direction": "in",
+    "name": "req",
+    "functionName": "function1"
+  },
+  {
+    "name": "myQueueItem",
+    "type": "orchestrationTrigger",
+    "direction": "in",
+    "queueName": "myqueue-items",
+    "connection": "",
+    "functionName": "function2",
+    "taskHubName": "TestHubValue"
+  },
+  {
+    "name": "myQueueItem",
+    "type": "activityTrigger",
+    "direction": "in",
+    "queueName": "myqueue-items",
+    "connection": "",
+    "functionName": "function3",
+    "taskHubName": "TestHubValue"
+  }
+]

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -102,6 +102,12 @@
     <None Include="ServiceBus\ServiceBusTriggerNodeEndToEndTests.cs" />
     <None Include="Twilio\TwilioEndToEndTestsBase.cs" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <Content Update="Management\Payload\DurableMsSQLProviderPayload.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
    
   <Import Project="..\..\build\GrpcTestFix.targets" />
   <Import Project="..\WebJobs.Script.Tests.Shared\WebJobs.Script.Tests.Shared.projitems" Label="Shared" />


### PR DESCRIPTION
Replace https://github.com/Azure/azure-functions-host/pull/8188 

This PR add SyncTriggerPayload for Durable Functions.  `triggers` section will be following.  The payload only includes the following sections of the `host.json` payload.  It doesn't include AppSettings and Default Value. If the section exists, it will included in the payload.  For more behavior, refer to the Integration testing Payload section.   

* `hubName`
* `storageProvider`  Durable Functions V2 only
* `maxConcurrentActivityFunctions` Durable Functions V2 only
* `maxConcurrentOrchestratorFunctions` Durable Functiosn V2 only

```json
[
  {
    "authLevel": "anonymous",
    "type": "httpTrigger",
    "direction": "in",
    "name": "req",
    "functionName": "function1"
  },
  {
    "name": "myQueueItem",
    "type": "orchestrationTrigger",
    "direction": "in",
    "queueName": "myqueue-items",
    "connection": "SQLDB_Connection",
    "functionName": "function2",
    "taskHubName": "DurableTask",
    "storageProvider": {
      "type": "mssql",
      "connectionStringName": "SQLDB_Connection",
      "taskEventLockTimeout": "00:02:00",
      "createDatabaseIfNotExists": true
    },
    "maxConcurrentOrchestratorFunctions": 10,
    "maxConcurrentActivityFunctions": 12
  },
  {
    "name": "myQueueItem",
    "type": "activityTrigger",
    "direction": "in",
    "queueName": "myqueue-items",
    "connection": "SQLDB_Connection",
    "functionName": "function3",
    "taskHubName": "DurableTask",
    "storageProvider": {
      "type": "mssql",
      "connectionStringName": "SQLDB_Connection",
      "taskEventLockTimeout": "00:02:00",
      "createDatabaseIfNotExists": true
    },
    "maxConcurrentOrchestratorFunctions": 10,
    "maxConcurrentActivityFunctions": 12
  }
]
```

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-host/issues/7394

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR [#8292 ](https://github.com/Azure/azure-functions-host/pull/8292)
* [x] I have added all required tests (Unit tests, E2E tests)

CC: @cgillum @bachuv @pragnagopa 