### PR TITLE
[v3.x] Backport - Removing binding direction from event name when emitting binding metric to logs

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/FunctionInstanceLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/FunctionInstanceLogger.cs
@@ -133,9 +133,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             {
                 string eventName = _bindingMetricEventNames.GetOrAdd(binding, (existing) =>
                 {
-                    return binding.IsTrigger ?
-                        string.Format(MetricEventNames.FunctionBindingTypeFormat, binding.Type) :
-                        string.Format(MetricEventNames.FunctionBindingTypeDirectionFormat, binding.Type, binding.Direction);
+                    return string.Format(MetricEventNames.FunctionBindingTypeFormat, binding.Type);
                 });
                 _metrics.LogEvent(eventName, metadata.Name);
             }

--- a/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
@@ -48,7 +48,6 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
         // function level events
         public const string FunctionInvokeLatency = "function.invoke.latency";
         public const string FunctionBindingTypeFormat = "function.binding.{0}";
-        public const string FunctionBindingTypeDirectionFormat = "function.binding.{0}.{1}";
         public const string FunctionCompileLatencyByLanguageFormat = "function.compile.{0}.latency";
         public const string FunctionInvokeThrottled = "function.invoke.throttled";
         public const string FunctionUserLog = "function.userlog";

--- a/test/WebJobs.Script.Tests/Diagnostics/FunctionInstanceLoggerTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/FunctionInstanceLoggerTests.cs
@@ -40,10 +40,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 
             Assert.Equal(5, _metrics.LoggedEvents.Count());
             Assert.Contains("function.binding.httptrigger_testfunction", _metrics.LoggedEvents);
-            Assert.Contains("function.binding.blob.in_testfunction", _metrics.LoggedEvents);
-            Assert.Contains("function.binding.blob.out_testfunction", _metrics.LoggedEvents);
-            Assert.Contains("function.binding.table.in_testfunction", _metrics.LoggedEvents);
-            Assert.Contains("function.binding.table.in_testfunction", _metrics.LoggedEvents);
+            Assert.Equal(1, _metrics.LoggedEvents.Count(x => x == "function.binding.httptrigger_testfunction"));
+
+            // for non-trigger bindings, event name does not include direction.
+            // So log entries for input and output binding will have same event name.
+            Assert.Equal(2, _metrics.LoggedEvents.Count(x => x == "function.binding.blob_testfunction"));
+            Assert.Equal(2, _metrics.LoggedEvents.Count(x => x == "function.binding.table_testfunction"));
 
             // log the events once more
             invokeLatencyEvent = _functionInstanceLogger.LogInvocationMetrics(metadata);


### PR DESCRIPTION
Backport of the below PR to v3.x branch.

 - [Removing binding direction from event name when emitting binding metric to logs.](https://github.com/Azure/azure-functions-host/pull/8128)