### PR TITLE
Adding Additional logging before throwing WorkerConfig for runtime: {workerRunTime} not found

### DIFF
--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -196,8 +196,6 @@ namespace Microsoft.Azure.WebJobs.Script
 
         private void LoadCustomProviderFunctions(List<FunctionMetadata> functionMetadataList)
         {
-            _logger.FunctionMetadataProviderParsingFunctions();
-
             // We always want to get the most updated function providers in case this list was changed.
             IEnumerable<IFunctionProvider> functionProviders = _serviceProvider?.GetService<IEnumerable<IFunctionProvider>>();
 
@@ -209,6 +207,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
         private void AddMetadataFromCustomProviders(IEnumerable<IFunctionProvider> functionProviders, List<FunctionMetadata> functionMetadataList)
         {
+            _logger.FunctionMetadataProviderParsingFunctions();
+
             var functionProviderTasks = new List<Task<ImmutableArray<FunctionMetadata>>>();
             foreach (var functionProvider in functionProviders)
             {

--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -196,6 +196,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
         private void LoadCustomProviderFunctions(List<FunctionMetadata> functionMetadataList)
         {
+            _logger.FunctionMetadataProviderParsingFunctions();
+
             // We always want to get the most updated function providers in case this list was changed.
             IEnumerable<IFunctionProvider> functionProviders = _serviceProvider?.GetService<IEnumerable<IFunctionProvider>>();
 
@@ -217,6 +219,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
             // This is used to make sure no duplicates are registered
             var distinctFunctionNames = new HashSet<string>(functionMetadataList.Select(m => m.Name));
+
+            _logger.FunctionMetadataProviderFunctionFound(functionMetadataListArray.Length);
 
             foreach (var metadataArray in functionMetadataListArray)
             {

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -233,6 +233,10 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             {
                 // Only throw if workerConfig is null AND some functions have been found.
                 // With .NET out-of-proc, worker config comes from functions.
+
+                var allLanguageNamesFromWorkerConfigs = string.Join(",", _workerConfigs.Select(c => c.Description.Language));
+                _logger.LogDebug($"Languages present in WorkerConfig: {allLanguageNamesFromWorkerConfigs}");
+
                 throw new InvalidOperationException($"WorkerConfig for runtime: {_workerRuntime} not found");
             }
 


### PR DESCRIPTION
We have a few dotnet-isolated customers complaining lately about running into "WorkerConfig for runtime: dotnet-isolated not found" issue. When this happens host won't start at all. This is happening only for linux deployment only and is transient when deploying from VS publish feature.  I was able to repro this issue with VS publish but appears to be transient. Deploying via core tools works for me and other customers.

[Issue 1](https://github.com/Azure/azure-functions-dotnet-worker/issues/821), [Issue 2](https://github.com/Azure/azure-functions-dotnet-worker/issues/810)

I [looked at the code which throws this exception](https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs#L232). We throw when we have 0 functions and workerConfig is null. Looking at the logs for a failed app, I see entries saying 0 functions found. During debugging locally, I noticed that we try to load functions metadata from [HostFunctionMetaDataProvider](https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs#L23) and then from[ Custom providers](https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/Host/FunctionMetadataManager.cs#L197) (IFunctionProvider implementations, In the case of dotnet isolated app, this should be the one returning the functions). But we do not log the function count we receive from the custom providers. So it is unclear to us it is the [isolated worker implementation of IFunctionProvider ](https://github.com/Azure/azure-functions-dotnet-worker/blob/main/sdk/FunctionMetadataLoaderExtension/JsonFunctionProvider.cs#L12)returning 0 functions.

In this PR I am adding additional logging before we throw the "WorkerConfig for runtime: dotnet-isolated not found" exception and logging function count when using custom providers.