### PR TITLE
(Not for Merge!) HtmlParser: Speed Suggestions

### DIFF
--- a/sample/CSharpBenchmark/HttpHtmlParserAnon/function.json
+++ b/sample/CSharpBenchmark/HttpHtmlParserAnon/function.json
@@ -1,0 +1,16 @@
+{
+    "bindings": [
+        {
+            "type": "httpTrigger",
+            "authLevel": "anonymous",
+            "name": "req",
+            "direction": "in",
+            "methods": [ "get", "post" ]
+        },
+        {
+            "type": "http",
+            "name": "$return",
+            "direction": "out"
+        }
+    ]
+}

--- a/sample/CSharpBenchmark/HttpHtmlParserAnon/function.proj
+++ b/sample/CSharpBenchmark/HttpHtmlParserAnon/function.proj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="HtmlAgilityPack" Version="1.11.42" />
+    </ItemGroup>
+</Project>

--- a/sample/CSharpBenchmark/HttpHtmlParserAnon/run.csx
+++ b/sample/CSharpBenchmark/HttpHtmlParserAnon/run.csx
@@ -1,0 +1,19 @@
+﻿using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using HtmlAgilityPack;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
+
+public static async Task<IActionResult> Run(HttpRequest req, ILogger log)
+{
+    string content = await new StreamReader(req.Body).ReadToEndAsync();
+    var html = new HtmlDocument();
+    html.LoadHtml(content);
+    var root = html.DocumentNode;
+    var nodes = root.Descendants();
+    var totalNodes = nodes.Count();
+
+    return (ActionResult)new OkObjectResult($"{totalNodes} parsed!");
+}

--- a/sample/CSharpBenchmark/HttpHtmlParserAnonNew/function.json
+++ b/sample/CSharpBenchmark/HttpHtmlParserAnonNew/function.json
@@ -1,0 +1,16 @@
+{
+    "bindings": [
+        {
+            "type": "httpTrigger",
+            "authLevel": "anonymous",
+            "name": "req",
+            "direction": "in",
+            "methods": [ "get", "post" ]
+        },
+        {
+            "type": "http",
+            "name": "$return",
+            "direction": "out"
+        }
+    ]
+}

--- a/sample/CSharpBenchmark/HttpHtmlParserAnonNew/function.proj
+++ b/sample/CSharpBenchmark/HttpHtmlParserAnonNew/function.proj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="HtmlAgilityPack" Version="1.11.42" />
+    </ItemGroup>
+</Project>

--- a/sample/CSharpBenchmark/HttpHtmlParserAnonNew/run.csx
+++ b/sample/CSharpBenchmark/HttpHtmlParserAnonNew/run.csx
@@ -1,0 +1,20 @@
+﻿using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using HtmlAgilityPack;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
+
+// Note: Requires AzureWebJobsFeatureFlags=AllowSynchronousIO for env variables
+public static async Task<IActionResult> Run(HttpRequest req)
+{
+    var html = new HtmlDocument();
+    html.Load(req.Body);
+    var root = html.DocumentNode;
+    var nodes = root.Descendants();
+    var totalNodes = nodes.Count();
+
+    return (ActionResult)new OkObjectResult($"{totalNodes} parsed!");
+}

--- a/sample/Samples.csproj
+++ b/sample/Samples.csproj
@@ -2,4 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="CSharpBenchmark\HttpHtmlParserAnonNew\function.proj" />
+    <None Include="CSharpBenchmark\HttpHtmlParserAnon\function.proj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
The stream load of HTMLParser allows a parse run to begin before the full incoming stream is read. This isn't a big savings on the allocation front (it allocates about 3MB per parse) but it's a decent time savings in the ~18-20% range. Note: since HtmlAgilityPack doesn't have an async stream read overlap, `AllowSynchronousIO` has to be enabled.

Throwing this up as a demo, if viable we can upstream - either way we should add the HtmlParser baseline into the benchmarks repo (not both versions as in this commit, though - whichever we go with).

Benchmark results between the current and stream load variants of HTML parser:

### Baseline (`HttpHtmlParserAnon`)
```lua
➜ .\bombard.exe -k -l -c 100 -d 60s "http://localhost:5000/api/HttpHtmlParserAnon" -m POST -f "raw.html" -H "Content-Type: text/html"
Bombarding http://localhost:5000/api/HttpHtmlParserAnon for 1m0s using 100 connection(s)

Statistics        Avg      Stdev        Max
  Reqs/sec      1418.30    1021.10   10483.52
  Latency       73.70ms    35.21ms   387.76ms
  Latency Distribution
     50%    51.12ms
     75%   101.26ms
     90%   141.18ms
     95%   158.42ms
     99%   205.49ms
  HTTP codes:
    1xx - 0, 2xx - 81460, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    96.99MB/s

Statistics        Avg      Stdev        Max
  Reqs/sec      1441.01    1069.44   16520.65
  Latency       72.58ms    34.19ms   334.96ms
  Latency Distribution
     50%    50.00ms
     75%   100.83ms
     90%   139.90ms
     95%   156.02ms
     99%   206.98ms
  HTTP codes:
    1xx - 0, 2xx - 82725, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    98.48MB/s

Statistics        Avg      Stdev        Max
  Reqs/sec      1437.30    1125.08   20914.25
  Latency       73.17ms    35.05ms   412.27ms
  Latency Distribution
     50%    49.92ms
     75%   101.41ms
     90%   142.71ms
     95%   158.01ms
     99%   208.02ms
  HTTP codes:
    1xx - 0, 2xx - 82046, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    97.68MB/s
```

### html.Load (`HttpHtmlParserAnonNew`);
```lua
➜ .\bombard.exe -k -l -c 100 -d 60s "http://localhost:5000/api/HttpHtmlParserAnonNew" -m POST -f "raw.html" -H "Content-Type: text/html"
Bombarding http://localhost:5000/api/HttpHtmlParserAnonNew for 1m0s using 100 connection(s)

Statistics        Avg      Stdev        Max
  Reqs/sec      1685.78     885.01    5501.38
  Latency       60.14ms    24.39ms   355.66ms
  Latency Distribution
     50%    51.00ms
     75%    65.00ms
     90%    88.05ms
     95%   109.06ms
     99%   178.71ms
  HTTP codes:
    1xx - 0, 2xx - 99743, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:   118.91MB/s

Statistics        Avg      Stdev        Max
  Reqs/sec      1693.36     899.72    8576.33
  Latency       59.96ms    25.85ms   424.00ms
  Latency Distribution
     50%    50.34ms
     75%    64.21ms
     90%    88.72ms
     95%   110.30ms
     99%   175.38ms
  HTTP codes:
    1xx - 0, 2xx - 100046, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:   119.26MB/s

Statistics        Avg      Stdev        Max
  Reqs/sec      1699.45     940.78   19507.80
  Latency       59.77ms    24.00ms   457.91ms
  Latency Distribution
     50%    51.00ms
     75%    64.30ms
     90%    86.66ms
     95%   106.72ms
     99%   177.57ms
  HTTP codes:
    1xx - 0, 2xx - 100398, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:   119.65MB/s
```

cc @vrdmr @paulbatum @anirudhgarg for eyes - happy to discuss but wanted to toss this up! I'm not sure if enable synchronous IO is "something the average user would do", but if I was doing this...it's what I'd jump to given the options. If this is out of scope, no worries - just thought a PR was the easiest way to demo here.