### PR TITLE
Add hex exit code to message when worker fails

### DIFF
--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcess.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcess.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
                 }
                 else
                 {
-                    var processExitEx = new WorkerProcessExitException($"{Process.StartInfo.FileName} exited with code {Process.ExitCode}", new Exception(exceptionMessage));
+                    var processExitEx = new WorkerProcessExitException($"{Process.StartInfo.FileName} exited with code {Process.ExitCode} (0x{Process.ExitCode.ToString("X")})", new Exception(exceptionMessage));
                     processExitEx.ExitCode = Process.ExitCode;
                     processExitEx.Pid = Process.Id;
                     HandleWorkerProcessExitError(processExitEx);


### PR DESCRIPTION
We sometimes gets issues and CRIs like [this](https://github.com/Azure/azure-functions-nodejs-worker/issues/556) where the node process exits, but the integer exit code (`-1073741819`) doesn't come up with many results on google. By contrast, the hex version (`0xC0000005`) usually has a lot more results, including docs like [this](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/596a1078-e883-4972-9bbc-49e60bebca55).

## Previous message

> node exited with code -1073741819

## New message

> node exited with code -1073741819 (0xC0000005)

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Not entirely sure this needs to be backported, although I supposed it could help supportability so might be worth it. Let's see what people think in the first place
* [x] I have added all required tests (Unit tests, E2E tests)