### PR TITLE
Updating RID resolution. Removing use of Microsoft.DotNet.PlatformAbstractions

### DIFF
--- a/src/WebJobs.Script/Description/DotNet/DependencyHelper.cs
+++ b/src/WebJobs.Script/Description/DotNet/DependencyHelper.cs
@@ -9,7 +9,6 @@ using System.Runtime.InteropServices;
 using Microsoft.Azure.WebJobs.Script.ExtensionRequirements;
 using Microsoft.Extensions.DependencyModel;
 using Newtonsoft.Json.Linq;
-using static Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment;
 
 namespace Microsoft.Azure.WebJobs.Script.Description
 {
@@ -17,6 +16,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
     {
         private const string AssemblyNamePrefix = "assembly:";
         private static readonly Lazy<Dictionary<string, string[]>> _ridGraph = new Lazy<Dictionary<string, string[]>>(BuildRuntimesGraph);
+        private static string _runtimeIdentifier;
 
         private static Dictionary<string, string[]> BuildRuntimesGraph()
         {
@@ -204,5 +204,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
             return isSharedAssembly;
         }
+
+        private static string GetRuntimeIdentifier() => _runtimeIdentifier ??= AppContext.GetData("RUNTIME_IDENTIFIER") as string ?? "unknown";
     }
 }


### PR DESCRIPTION
This change removes the dependency on `RuntimeEnvironment` as `Microsoft.DotNet.PlatformAbstractions` has been deprecated and the RID resolution implementation in `RuntimeEnvironment` returns invalid values under some conditions (e.g., invalid osx RIDs in recent MacOS versions)

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
