### PR TITLE
[DRAFT] Add missing line to pull worker arguments from workerdescription

### DIFF
--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -121,6 +121,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     // Check if any appsettings are provided for that langauge
                     var languageSection = _config.GetSection($"{RpcWorkerConstants.LanguageWorkersSectionName}:{workerDescription.Language}");
                     workerDescription.Arguments = workerDescription.Arguments ?? new List<string>();
+                    workerDescription.WorkerArguments = workerDescription.WorkerArguments ?? new List<string>();
                     GetWorkerDescriptionFromAppSettings(workerDescription, languageSection);
                     AddArgumentsFromAppSettings(workerDescription, languageSection);
 

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -141,6 +141,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                             WorkerPath = workerDescription.DefaultWorkerPath
                         };
                         arguments.ExecutableArguments.AddRange(workerDescription.Arguments);
+                        arguments.WorkerArguments.AddRange(workerDescription.WorkerArguments);
                         var rpcWorkerConfig = new RpcWorkerConfig()
                         {
                             Description = workerDescription,

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -214,6 +214,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             {
                 ((List<string>)workerDescription.Arguments).AddRange(Regex.Split(argumentsSection.Value, @"\s+"));
             }
+
+            var workerArgumentsSection = languageSection.GetSection($"{WorkerConstants.WorkerDescriptionWorkerArguments}");
+            if (workerArgumentsSection.Value != null)
+            {
+                ((List<string>)workerDescription.WorkerArguments).AddRange(Regex.Split(workerArgumentsSection.Value, @"\s+"));
+            }
         }
 
         internal bool ShouldAddWorkerConfig(string workerDescriptionLanguage)

--- a/src/WebJobs.Script/Workers/WorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/WorkerConstants.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         public const string WorkerDescription = "description";
         public const string ProcessCount = "processOptions";
         public const string WorkerDescriptionArguments = "arguments";
+        public const string WorkerDescriptionWorkerArguments = "workerArguments";
         public const string WorkerDescriptionDefaultRuntimeVersion = "defaultRuntimeVersion";
 
         // Profiles

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
@@ -253,5 +253,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var resultEx3 = Assert.Throws<ArgumentOutOfRangeException>(() => rpcWorkerConfigFactory.GetWorkerProcessCount(workerConfig));
             Assert.Contains("The TimeSpan must not be negative", resultEx3.Message);
         }
+
+        [Fact]
+        public void AddProvider_AddsExecutableAndWorkerArgumentsToRpcWorkerConfigs()
+        {
+            var configBuilder = ScriptSettingsManager.CreateDefaultConfigurationBuilder();
+            var config = configBuilder.Build();
+            var testLogger = new TestLogger("test");
+            var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger());
+            var workerConfigs = configFactory.GetConfigs();
+            foreach (var resultConfig in workerConfigs)
+            {
+                Assert.NotNull(resultConfig.Arguments);
+                Assert.NotNull(resultConfig.Arguments.ExecutableArguments);
+                Assert.NotNull(resultConfig.Arguments.WorkerArguments);
+            }
+        }
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
@@ -110,6 +110,26 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
+        public void ReadWorkerProviderFromConfig_WorkerArgumentsFromSettings()
+        {
+            var configs = new List<TestRpcWorkerConfig>() { MakeTestConfig(testLanguage, new string[0]) };
+            // Creates temp directory w/ worker.config.json and runs ReadWorkerProviderFromConfig
+            Dictionary<string, string> keyValuePairs = new Dictionary<string, string>
+            {
+                [$"{RpcWorkerConstants.LanguageWorkersSectionName}:{testLanguage}:{WorkerConstants.WorkerDescriptionWorkerArguments}"] = "--inspect=5689  --no-deprecation"
+            };
+            TestMetricsLogger testMetricsLogger = new TestMetricsLogger();
+            var workerConfigs = TestReadWorkerProviderFromConfig(configs, new TestLogger(testLanguage), testMetricsLogger, null, keyValuePairs);
+            AreRequiredMetricsEmitted(testMetricsLogger);
+            Assert.Single(workerConfigs);
+            Assert.Equal(Path.Combine(rootPath, testLanguage, $"{RpcWorkerConfigTestUtilities.TestWorkerPathInWorkerConfig}.{testLanguage}"), workerConfigs.Single().Description.DefaultWorkerPath);
+            RpcWorkerConfig worker = workerConfigs.FirstOrDefault();
+            Assert.True(worker.Description.WorkerArguments.Count == 2);
+            Assert.True(worker.Description.WorkerArguments.Contains("--inspect=5689"));
+            Assert.True(worker.Description.WorkerArguments.Contains("--no-deprecation"));
+        }
+
+        [Fact]
         public void ReadWorkerProviderFromConfig_EmptyWorkerPath()
         {
             var configs = new List<TestRpcWorkerConfig>() { MakeTestConfig(testLanguage, new string[0], false, string.Empty, true) };


### PR DESCRIPTION
### Issue describing the changes in this PR

When building the command line arguments [here](https://github.com/Azure/azure-functions-host/blob/855f0b55fffc77b5b5376e396caa17d555ef8e42/src/WebJobs.Script/Workers/ProcessManagement/DefaultWorkerProcessFactory.cs#L83), DefaultWorkerProcessFactory takes both "executableArguments" and "workerArguments". 

Example of how these arguments would be built in a string: 

`dotnet [executable arguments] pathToApp [workerArguments]`

I need to add some worker arguments after `dotnet path\to\app` for perf improvements for stein. Example:

`dotnet "C:\path\to\app\bin\Debug\net6.0\FunctionApp.dll" [steinArgs] --host 127.0.0.1 --port 60439 --workerId c1795c88-ad3e-42be-b1ae-5e10e42fa1dd --requestId db527921-322f-4838-913c-e7652e28f7d1 --grpcMaxMessageLength 2147483647}`

However, **it seems that "workerArguments" aren't being passed all the way through to DefaultWorkerProcessFactory.** This PR adds the one-line change needed to do that ... you can see the line above my change where executableArguments were added, so I'm assuming workerArguments was just forgotten at this step? 

Another reason I believe it's a bug is that HttpWorker adds both executableArguments and workerArguments to its config as seen [here](https://github.com/Azure/azure-functions-host/blob/855f0b55fffc77b5b5376e396caa17d555ef8e42/src/WebJobs.Script/Workers/Http/Configuration/HttpWorkerOptionsSetup.cs#L111).

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
