### PR TITLE
No longer need to remove node grpc binaries in v4

### DIFF
--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -100,14 +100,6 @@ function CleanOutput([string] $rootPath) {
     Write-Host "  Removing python worker"
     Remove-Item -Recurse -Force "$rootPath\workers\python" -ErrorAction SilentlyContinue
 
-    Write-Host "  Removing non-win32 node grpc binaries"
-    Get-ChildItem "$rootPath\workers\node\grpc\src\node\extension_binary" -ErrorAction SilentlyContinue | 
-    Foreach-Object {
-        if (-Not ($_.FullName -Match "win32")) {
-            Remove-Item -Recurse -Force $_.FullName
-        }
-    }
-
     $keepRuntimes = @('win', 'win-x86', 'win10-x86', 'win-x64', 'win10-x64')
     Write-Host "  Removing all powershell runtimes except $keepRuntimes"
     Get-ChildItem "$rootPath\workers\powershell" -Directory -ErrorAction SilentlyContinue |


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Related to https://github.com/Azure/azure-functions-host/pull/8305, but this PR is much less important

The node worker in v4 of the host uses "grpc-js", a newer pure-javascript version of the old "grpc" package that was built in C++ and had a bunch of native binaries (PR here: https://github.com/Azure/azure-functions-nodejs-worker/pull/417). Thus we can remove this clean-up logic specific to the old package.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)
