### PR TITLE
processing logs from language worker distribute agent 

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/EtwEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/EtwEventGenerator.cs
@@ -87,5 +87,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                     break;
             }
         }
+
+        public void LogAppInsightDistributeTracingEvent(LogLevel level, string summary)
+        {
+        }
     }
 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/IEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/IEventGenerator.cs
@@ -19,5 +19,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         void LogFunctionExecutionEvent(string executionId, string siteName, int concurrency, string functionName, string invocationId, string executionStage, long executionTimeSpan, bool success);
 
         void LogAzureMonitorDiagnosticLogEvent(LogLevel level, string resourceId, string operationName, string category, string regionName, string properties);
+
+        void LogAppInsightDistributeTracingEvent(LogLevel level, string summary);
     }
 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/KubernetesEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/KubernetesEventGenerator.cs
@@ -106,5 +106,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         {
             Console.WriteLine(evt);
         }
+
+        public override void LogAppInsightDistributeTracingEvent(LogLevel level, string summary)
+        {
+        }
     }
 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
@@ -89,5 +89,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             // Pipe the unhandled exception to stdout as part of docker logs.
             Console.WriteLine($"Unhandled exception on {DateTime.UtcNow}: {e?.ToString()}");
         }
+
+        public override void LogAppInsightDistributeTracingEvent(LogLevel level, string summary)
+        {
+        }
     }
 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxContainerEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxContainerEventGenerator.cs
@@ -142,5 +142,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 slotName: SystemEnvironment.Instance.GetSlotName() ?? string.Empty,
                 eventTimestamp: DateTime.UtcNow);
         }
+
+        public override void LogAppInsightDistributeTracingEvent(LogLevel level, string summary)
+        {
+            _writeEvent(summary);
+        }
     }
 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxEventGenerator.cs
@@ -85,5 +85,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public abstract void LogAzureMonitorDiagnosticLogEvent(LogLevel level, string resourceId, string operationName,
             string category, string regionName, string properties);
+
+        public abstract void LogAppInsightDistributeTracingEvent(LogLevel level, string summary);
     }
 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/SystemLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/SystemLogger.cs
@@ -132,6 +132,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             // Note: we must be sure to default any null values to empty string
             // otherwise the ETW event will fail to be persisted (silently)
             string summary = formattedMessage ?? string.Empty;
+
+            if (!string.IsNullOrEmpty(summary) && summary.StartsWith(ScriptConstants.AppInsightsLogPrefix))
+            {
+                _eventGenerator.LogAppInsightDistributeTracingEvent(logLevel, summary);
+                return;
+            }
+
             string eventName = !string.IsNullOrEmpty(eventId.Name) ? eventId.Name : stateEventName ?? string.Empty;
             string activityId = stateActivityId ?? string.Empty;
             var options = _appServiceOptions;

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string HstsMiddlewareRequestDelegate = "MS_HstsMiddlewareRequestDelegate";
         public const string CorsMiddlewareRequestDelegate = "MS_CorsMiddlewareRequestDelegate";
         public const string EasyAuthMiddlewareRequestDelegate = "MS_EasyAuthMiddlewareRequestDelegate";
+        public const string AppInsightsLogPrefix = "MS_APPLICATION_INSIGHTS_LOGS";
 
         public const string LegacyPlaceholderTemplateSiteName = "FunctionsPlaceholderTemplateSite";
 

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string HstsMiddlewareRequestDelegate = "MS_HstsMiddlewareRequestDelegate";
         public const string CorsMiddlewareRequestDelegate = "MS_CorsMiddlewareRequestDelegate";
         public const string EasyAuthMiddlewareRequestDelegate = "MS_EasyAuthMiddlewareRequestDelegate";
-        public const string AppInsightsLogPrefix = "MS_APPLICATION_INSIGHTS_LOGS";
+        public const string AppInsightsLogPrefix = " MS_APPLICATION_INSIGHTS_LOGS";
 
         public const string LegacyPlaceholderTemplateSiteName = "FunctionsPlaceholderTemplateSite";
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This PR add logic for processing formatting the logs coming from language worker distribute agent:
1. logs from the agent is already well formatted, so on host end we just check for the agent prefix and log out entire "summary" which is well formatted agent log. 
2. currently only has implementation for linux consumption, will check the workability to have the implementation for windows/linux other skus. 

Info about the whole work flow:
1. For Application insight distribute agent, we are moving out of dependency on Antares to have agent embedded in java language worker. App insight agent will start when worker is started by host, it will be the same child process as java worker. It starts by command as below when we start Java worker:
```-javaagent:D:/code/azfs/ai/test-jars/withPrefix/applicationinsights-agent-3.2.11-SNAPSHOT.jar```
in short, it will be same process as java worker. 
2. Application insight team has two tables for logging info from agent in kusto as `WebAppsAppInsightsExtension` and `WebAppsAppInsightsExtensionLinux` for Windows and Linux function app. Those two tables are used to check any issues happen inside agent, ex. a potential bug in the agent. 
3. We are trying to populate those logs for application insight agent to the right kusto tables. For now the agent print out its logs into stdout, which is the same stdout as java worker since they are same process, and host as the parent process of java worker/agent can access all logs from worker stdout, and in side host it's processing and formatting the logs from worker stdout and generate right format logs send to Antares, which later will populate those well formatted logs in to Kusto table. 
4. For now all logs coming from java worker's stdout are formatted with a prefix `MS_FUNCTION_LOGS`, example as below
```
MS_FUNCTION_LOGS 4,,,,,Worker.rpcWorkerProcess.java.2ff1cf8b-a083-4e8d-9fec-0623fc781d98,"","[INFO] {Application.main}: Azure Functions Java Worker  version [ 2.2.2-SNAPSHOT]",4.3.1.1,2022-04-20T18:53:20.8612065Z,,"",,,,AWESOME_ID,,,,
```
this also happens to logs from app insight distributing agent below is an example
```
MS_FUNCTION_LOGS 4,,,,,Worker.rpcWorkerProcess.java.65678990-73f5-4154-b942-eb2b9f6b1e9c,""," MS_APPLICATION_INSIGHTS_LOGS 1651163685218,INFO,com.microsoft.applicationinsights.agent,'ApplicationInsights Java Agent 3.2.11-SNAPSHOT started successfully (PID 71)',null,null,null,3.2.11-SNAPSHOT,unknown,java MS_APPLICATION_INSIGHTS_LOGS 1651163685219,INFO,com.microsoft.applicationinsights.agent,'Java version: 11.0.12, vendor: Microsoft, home: /usr/lib/jvm/msft-11-x64',null,null,null,3.2.11-SNAPSHOT,unknown,java MS_APPLICATION_INSIGHTS_LOGS 1651163685219,INFO,com.microsoft.applicationinsights.agent,'Detected running on a read-only file system. Status json file won't be created. If this is unexpected, please check that process has write access to the directory: /home/LogFiles/ApplicationInsights/status',null,null,null,3.2.11-SNAPSHOT,unknown,java[INFO] {Application.main}: Azure Functions Java Worker  version [ 2.2.3]",4.4.0.1,2022-04-28T16:34:45.2821204Z,,"",,,,AWESOME_ID,,,,
```
we can see all pre formatted agent logs got formatted again by host into host summary column in host log and this will be populated to FunctionsLogs table as 
![image](https://user-images.githubusercontent.com/89094811/165847368-3174567e-fef1-4483-914b-36a7b1d60d02.png)
this is not want we want, we want the log from the agent to be printed to a new line in host console so it can be taken care by Antares correctly to populate to the right kusto table. If the app insight distribute agent logs are printed console in a new line then the  [diagnostic service](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Netcore?path=/src/Seabreeze/FunctionsAgents/PackageRoot/FunctionsDiagnosticsService/Config/Settings.xml&version=GBu/kaibocai/log-support-ai&line=32&lineEnd=33&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents) can take care of it properly using the regex match. The good news the regex match is already aligned with app insight agent log format. 

5. This PR is checking the summary coming from worker and if the summary already contains a prefix used only for app insight distributing agent then it should not go to the same flow as MS_FUNCTION_LOGS, instead it should be handle separately in order to be printed in a new line on host console [here](https://github.com/Azure/azure-functions-host/blob/4e80242c0299b89c36ef5213b5796156d02b7503/src/WebJobs.Script.WebHost/Diagnostics/SystemLogger.cs#L102). It helps to print the logs from agent to a new line instead of squashing it into summary column in functionslogs, so it later can be take care of by diagnostic service mentioned in 4 to populate right entry in right kusto table. Below has a right example how the logs form agent looks like in a new line in host console
![image](https://user-images.githubusercontent.com/89094811/165848836-99cbfe95-3263-482a-ad9a-adff7bc098f7.png)


### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
