### PR TITLE
Add header when a sync trigger is background

### DIFF
--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -93,6 +93,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AntaresColdStartHeaderName = "X-MS-COLDSTART";
         public const string SiteTokenHeaderName = "x-ms-site-restricted-token";
         public const string EasyAuthIdentityHeader = "x-ms-client-principal";
+        public const string BackgroundSyncHeader = "x-ms-client-backgroundsync";
         public const string AzureVersionHeader = "x-ms-version";
         public const string XIdentityHeader = "X-IDENTITY-HEADER";
         public const string DynamicSku = "Dynamic";

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AntaresColdStartHeaderName = "X-MS-COLDSTART";
         public const string SiteTokenHeaderName = "x-ms-site-restricted-token";
         public const string EasyAuthIdentityHeader = "x-ms-client-principal";
-        public const string BackgroundSyncHeader = "x-ms-client-backgroundsync";
+        public const string BackgroundSyncHeader = "x-ms-functions-client-backgroundsync";
         public const string AzureVersionHeader = "x-ms-version";
         public const string XIdentityHeader = "X-IDENTITY-HEADER";
         public const string DynamicSku = "Dynamic";

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -415,6 +415,32 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             }
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task TrySyncTriggers_BackgroundSync_Contains_Header(bool isBackgroundSync)
+        {
+            using (var env = new TestScopedEnvironmentVariable(_vars))
+            {
+                var hashBlob = await _functionsSyncManager.GetHashBlobAsync();
+                if (hashBlob != null)
+                {
+                    await hashBlob.DeleteIfExistsAsync();
+                }
+
+                var syncResult = await _functionsSyncManager.TrySyncTriggersAsync(isBackgroundSync: isBackgroundSync);
+                Assert.True(syncResult.Success);
+                Assert.Null(syncResult.Error);
+                if (isBackgroundSync)
+                {
+                    Assert.Equal("true", _mockHttpHandler.LastRequest.Headers.GetValues(ScriptConstants.BackgroundSyncHeader).FirstOrDefault());
+                } else
+                {
+                    Assert.False(_mockHttpHandler.LastRequest.Headers.Contains(ScriptConstants.BackgroundSyncHeader));
+                }
+            }
+        }
+
         [Fact]
         public async Task TrySyncTriggers_BackgroundSync_SetTriggersFailure_HashNotUpdated()
         {


### PR DESCRIPTION
We'd like to avoid updating LastUpdate when the SyncTriggerPayload is background sync on our backend. 
So that we need a flag that distinguish if it is a background sync or not. 

### Issue describing the changes in this PR

resolves : internal workitem https://msazure.visualstudio.com/Antares/_workitems/edit/10210967/

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #issue_or_pr -> once this PR is approved, I'll backport to v3.
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

