### PR TITLE
Return 500 instead of 403 when writing secrets to storage fails

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,6 +3,7 @@
 - My change description (#PR)
 -->
 - Update Python Worker Version to [4.1.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.1.0)
+- Return 500 instead of 403 when writing secrets to storage fails (#8362)
 - Updated Java Worker Version to [2.2.3](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.2.3)
 - Updated Node.js Worker Version to [3.3.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.3.0)
 - Add Include minimum durable payload to sync trigger (#8292)

--- a/src/WebJobs.Script.WebHost/Controllers/KeysController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/KeysController.cs
@@ -218,6 +218,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                     return StatusCode(StatusCodes.Status409Conflict);
                 case OperationResult.Forbidden:
                     return StatusCode(StatusCodes.Status403Forbidden);
+                case OperationResult.Error:
+                    return StatusCode(StatusCodes.Status500InternalServerError);
                 default:
                     return StatusCode(StatusCodes.Status500InternalServerError);
             }

--- a/src/WebJobs.Script.WebHost/Controllers/KeysController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/KeysController.cs
@@ -216,10 +216,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                     return NotFound();
                 case OperationResult.Conflict:
                     return StatusCode(StatusCodes.Status409Conflict);
-                case OperationResult.Forbidden:
-                    return StatusCode(StatusCodes.Status403Forbidden);
-                case OperationResult.Error:
-                    return StatusCode(StatusCodes.Status500InternalServerError);
                 default:
                     return StatusCode(StatusCodes.Status500InternalServerError);
             }

--- a/src/WebJobs.Script.WebHost/OperationResult.cs
+++ b/src/WebJobs.Script.WebHost/OperationResult.cs
@@ -10,8 +10,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         Created,
         Updated,
         NotFound,
-        Conflict,
-        Forbidden,
-        Error
+        Conflict
     }
 }

--- a/src/WebJobs.Script.WebHost/OperationResult.cs
+++ b/src/WebJobs.Script.WebHost/OperationResult.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         Updated,
         NotFound,
         Conflict,
-        Forbidden
+        Forbidden,
+        Error
     }
 }

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
@@ -329,10 +329,19 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 return secrets;
             }, secretsFactory).ContinueWith(t =>
             {
-                if (t.IsFaulted && t.Exception.InnerException is RequestFailedException)
+                if (t.IsFaulted)
                 {
-                    result = OperationResult.Forbidden;
+                    _logger.LogError("Error adding or updating secrets", t.Exception.InnerException);
+
+                    result = OperationResult.Error;
+
+                    if (t.Exception.InnerException is RequestFailedException)
+                    {
+                        result = OperationResult.Forbidden;
+                    }
                 }
+
+                return result;
             });
 
             return new KeyOperationResult(secret, result);

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
@@ -328,24 +328,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 }
 
                 return secrets;
-            }, secretsFactory).ContinueWith(t =>
-            {
-                if (t.IsFaulted)
-                {
-                    _logger.LogError("Error adding or updating secrets", t.Exception.InnerException);
-
-                    result = OperationResult.Error;
-
-                    var exception = t.Exception.InnerException as RequestFailedException;
-
-                    if (exception?.Status == (int)HttpStatusCode.Forbidden)
-                    {
-                        result = OperationResult.Forbidden;
-                    }
-                }
-
-                return result;
-            });
+            }, secretsFactory);
 
             return new KeyOperationResult(secret, result);
         }

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
@@ -337,7 +338,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                     if (t.Exception.InnerException is RequestFailedException)
                     {
-                        result = OperationResult.Forbidden;
+                        var exception = t.Exception.InnerException as RequestFailedException;
+                        if (exception.Status == (int)HttpStatusCode.Forbidden)
+                        {
+                            result = OperationResult.Forbidden;
+                        }
                     }
                 }
 

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
@@ -336,13 +336,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                     result = OperationResult.Error;
 
-                    if (t.Exception.InnerException is RequestFailedException)
+                    var exception = t.Exception.InnerException as RequestFailedException;
+
+                    if (exception?.Status == (int)HttpStatusCode.Forbidden)
                     {
-                        var exception = t.Exception.InnerException as RequestFailedException;
-                        if (exception.Status == (int)HttpStatusCode.Forbidden)
-                        {
-                            result = OperationResult.Forbidden;
-                        }
+                        result = OperationResult.Forbidden;
                     }
                 }
 

--- a/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
@@ -6,9 +6,11 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
@@ -522,7 +524,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
         }
 
         [Fact]
-        public async Task AddOrUpdateFunctionSecret_Handles_Error()
+        public async Task AddOrUpdateFunctionSecret_Handles_InternalSeverError()
         {
             using (var directory = new TempDirectory())
             {
@@ -530,7 +532,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
 
                 KeyOperationResult result;
 
-                ISecretsRepository repository = new TestSecretsRepository(false, true);
+                ISecretsRepository repository = new TestSecretsRepository(false, true, HttpStatusCode.InternalServerError);
                 using (var secretManager = CreateSecretManager(directory.Path, simulateWriteConversion: false, secretsRepository: repository))
                 {
                     result = await secretManager.AddOrUpdateFunctionSecretAsync("function-key-3", "9876", "TestFunction", ScriptSecretsType.Function);
@@ -538,6 +540,27 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
 
                 var logs = _loggerProvider.GetAllLogMessages();
                 Assert.Equal(OperationResult.Error, result.Result);
+                Assert.True(logs.Any(p => string.Equals(p.FormattedMessage, "Error adding or updating secrets", StringComparison.OrdinalIgnoreCase)));
+            }
+        }
+
+        [Fact]
+        public async Task AddOrUpdateFunctionSecret_Handles_RequestForbiddenError()
+        {
+            using (var directory = new TempDirectory())
+            {
+                CreateTestSecrets(directory.Path);
+
+                KeyOperationResult result;
+
+                ISecretsRepository repository = new TestSecretsRepository(false, true, HttpStatusCode.Forbidden);
+                using (var secretManager = CreateSecretManager(directory.Path, simulateWriteConversion: false, secretsRepository: repository))
+                {
+                    result = await secretManager.AddOrUpdateFunctionSecretAsync("function-key-3", "9876", "TestFunction", ScriptSecretsType.Function);
+                }
+
+                var logs = _loggerProvider.GetAllLogMessages();
+                Assert.Equal(OperationResult.Forbidden, result.Result);
                 Assert.True(logs.Any(p => string.Equals(p.FormattedMessage, "Error adding or updating secrets", StringComparison.OrdinalIgnoreCase)));
             }
         }
@@ -1260,16 +1283,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             private Random _rand = new Random();
             private bool _enforceSerialWrites = false;
             private bool _forceWriteErrors = false;
+            private HttpStatusCode _httpstaus;
 
             public TestSecretsRepository(bool enforceSerialWrites)
             {
                 _enforceSerialWrites = enforceSerialWrites;
             }
 
-            public TestSecretsRepository(bool enforceSerialWrites, bool forceWriteErrors)
+            public TestSecretsRepository(bool enforceSerialWrites, bool forceWriteErrors, HttpStatusCode httpstaus = HttpStatusCode.InternalServerError)
                 : this(enforceSerialWrites)
             {
                 _forceWriteErrors = forceWriteErrors;
+                _httpstaus = httpstaus;
             }
 
             public event EventHandler<SecretsChangedEventArgs> SecretsChanged;
@@ -1312,7 +1337,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             {
                 if (_forceWriteErrors)
                 {
-                    throw new Exception();
+                    throw new RequestFailedException((int)_httpstaus, "Error");
                 }
 
                 if (_enforceSerialWrites && _writeCount > 1)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #7591

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [x] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #8361
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
