### PR TITLE
Include FunctionActivityStatus in DrainModeStatus

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -154,7 +154,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
                 DrainModeStatus status = new DrainModeStatus()
                 {
-                    State = state
+                    State = state,
+                    OutstandingInvocations = functionActivityStatus.OutstandingInvocations,
+                    OutstandingRetries = functionActivityStatus.OutstandingRetries
                 };
 
                 string message = $"Drain Status: {JsonConvert.SerializeObject(state, Formatting.Indented)}, Activity Status: {JsonConvert.SerializeObject(functionActivityStatus, Formatting.Indented)}";

--- a/src/WebJobs.Script.WebHost/Models/DrainModeStatus.cs
+++ b/src/WebJobs.Script.WebHost/Models/DrainModeStatus.cs
@@ -11,5 +11,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
         [JsonProperty("state")]
         [JsonConverter(typeof(StringEnumConverter))]
         public DrainModeState State { get; set; }
+
+        [JsonProperty("outstandingInvocations")]
+        public int OutstandingInvocations { get; set; }
+
+        [JsonProperty("outstandingRetries")]
+        public int OutstandingRetries { get; set; }
     }
 }

--- a/test/WebJobs.Script.Tests/Controllers/Admin/HostControllerTests.cs
+++ b/test/WebJobs.Script.Tests/Controllers/Admin/HostControllerTests.cs
@@ -256,9 +256,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             serviceProviderMock.Setup(x => x.GetService(typeof(IFunctionActivityStatusProvider))).Returns(functionActivityStatusProvider.Object);
             serviceProviderMock.Setup(x => x.GetService(typeof(IDrainModeManager))).Returns(drainModeManager.Object);
             drainModeManager.Setup(x => x.IsDrainModeEnabled).Returns(expectedState != DrainModeState.Disabled);
-
             var result = (OkObjectResult)_hostController.DrainStatus(scriptHostManagerMock.Object);
-            Assert.Equal(expectedState, (result.Value as DrainModeStatus).State);
+            var resultStatus = result.Value as DrainModeStatus;
+            Assert.Equal(expectedState, resultStatus.State);
+            Assert.Equal(outstandingRetries, resultStatus.OutstandingRetries);
+            Assert.Equal(outstandingInvocations, resultStatus.OutstandingInvocations);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Controllers/Admin/HostControllerTests.cs
+++ b/test/WebJobs.Script.Tests/Controllers/Admin/HostControllerTests.cs
@@ -242,6 +242,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [InlineData(2, 0, DrainModeState.InProgress)]
         [InlineData(0, 10, DrainModeState.InProgress)]
         [InlineData(5, 1, DrainModeState.InProgress)]
+        [InlineData(20, 30, DrainModeState.Disabled)]
         public void GetDrainStatus_HostRunning_ReturnsExpected(int outstandingRetries, int outstandingInvocations, DrainModeState expectedState)
         {
             var scriptHostManagerMock = new Mock<IScriptHostManager>(MockBehavior.Strict);


### PR DESCRIPTION
Include Outstanding Invocations count in DrainMode Status. This will allow Scale Controller to pick worker with least number of invocations for Scaling-in