### PR TITLE
Additional attributes for worker AI agent

### DIFF
--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Azure.WebJobs.Script
 {
     internal static class EnvironmentExtensions
     {
-        // For testing
+        private static bool? isApplicationInsightsAgentEnabled;
+
         internal static string BaseDirectory { get; set; }
 
         public static string GetEnvironmentVariableOrDefault(this IEnvironment environment, string name, string defaultValue)
@@ -507,6 +508,22 @@ namespace Microsoft.Azure.WebJobs.Script
                 placeholderRuntimeSet.Add(workerRuntime);
             }
             return placeholderRuntimeSet;
+        }
+
+        public static bool IsApplicationInsightsAgentEnabled(this IEnvironment environment)
+        {
+            // cache the value of the environment variable
+            if (isApplicationInsightsAgentEnabled.HasValue)
+            {
+                return isApplicationInsightsAgentEnabled.Value;
+            }
+            else if (!environment.IsPlaceholderModeEnabled())
+            {
+                bool.TryParse(environment.GetEnvironmentVariable(AppInsightsAgent), out bool isEnabled);
+                isApplicationInsightsAgentEnabled = isEnabled;
+                return isApplicationInsightsAgentEnabled.Value;
+            }
+            return false;
         }
     }
 }

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AppInsightsInstrumentationKey = "APPINSIGHTS_INSTRUMENTATIONKEY";
         public const string AppInsightsConnectionString = "APPLICATIONINSIGHTS_CONNECTION_STRING";
         public const string AppInsightsQuickPulseAuthApiKey = "APPINSIGHTS_QUICKPULSEAUTHAPIKEY";
+        public const string AppInsightsAgent = "APPLICATIONINSIGHTS_ENABLE_AGENT";
         public const string FunctionsExtensionVersion = "FUNCTIONS_EXTENSION_VERSION";
         public const string FunctionWorkerRuntime = "FUNCTIONS_WORKER_RUNTIME";
         public const string ContainerName = "CONTAINER_NAME";

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string LogPropertyIsSystemLogKey = "MS_IsSystemLog";
         public const string LogPropertyFunctionInvocationIdKey = "MS_FunctionInvocationId";
         public const string LogPropertyHostInstanceIdKey = "HostInstanceId";
+        public const string LogPropertyProcessIdKey = "ProcessId";
         public const string LogPropertyActivityIdKey = "MS_ActivityId";
 
         public const string TraceSourceSecretManagement = "SecretManagement";

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -3,11 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
@@ -36,6 +38,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         private readonly string _workerId = "testWorkerId";
         private readonly string _scriptRootPath = "c:\testdir";
         private readonly IScriptEventManager _eventManager = new ScriptEventManager();
+        private readonly Mock<IScriptEventManager> _eventManagerMock = new Mock<IScriptEventManager>();
         private readonly TestMetricsLogger _metricsLogger = new TestMetricsLogger();
         private readonly Mock<IWorkerConsoleLogSource> _mockConsoleLogger = new Mock<IWorkerConsoleLogSource>();
         private readonly Mock<FunctionRpc.FunctionRpcBase> _mockFunctionRpcService = new Mock<FunctionRpc.FunctionRpcBase>();
@@ -52,6 +55,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         private readonly IFunctionDataCache _functionDataCache;
         private readonly IOptions<WorkerConcurrencyOptions> _workerConcurrencyOptions;
         private GrpcWorkerChannel _workerChannel;
+        private GrpcWorkerChannel _workerChannelwithMockEventManager;
 
         public GrpcWorkerChannelTests()
         {
@@ -104,6 +108,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                _sharedMemoryManager,
                _functionDataCache,
                _workerConcurrencyOptions);
+
+            _eventManagerMock.Setup(proxy => proxy.Publish(It.IsAny<OutboundGrpcEvent>())).Verifiable();
+            _workerChannelwithMockEventManager = new GrpcWorkerChannel(
+               _workerId,
+               _eventManagerMock.Object,
+               _testWorkerConfig,
+               _mockrpcWorkerProcess.Object,
+               _logger,
+               _metricsLogger,
+               0,
+               _testEnvironment,
+               _hostOptionsMonitor,
+               _sharedMemoryManager,
+               _functionDataCache,
+               _workerConcurrencyOptions);
+
+            _testEnvironment.SetEnvironmentVariable("APPLICATIONINSIGHTS_ENABLE_AGENT", "true");
         }
 
         public void Dispose()
@@ -730,6 +751,42 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.True(latencyHistory.Count() == 0);
         }
 
+        [Fact]
+        public async Task SendInvocationRequest_ValidateTraceContext()
+        {
+            ScriptInvocationContext scriptInvocationContext = GetTestScriptInvocationContext(Guid.NewGuid(), null);
+            await _workerChannelwithMockEventManager.SendInvocationRequest(scriptInvocationContext);
+
+            _eventManagerMock.Verify(proxy => proxy.Publish(It.Is<OutboundGrpcEvent>(
+                grpcEvent => grpcEvent.Message.InvocationRequest.TraceContext.Attributes.ContainsKey(ScriptConstants.LogPropertyProcessIdKey)
+                && grpcEvent.Message.InvocationRequest.TraceContext.Attributes.ContainsKey(ScriptConstants.LogPropertyHostInstanceIdKey)
+                && grpcEvent.Message.InvocationRequest.TraceContext.Attributes.ContainsKey(LogConstants.CategoryNameKey)
+                && grpcEvent.Message.InvocationRequest.TraceContext.Attributes[LogConstants.CategoryNameKey].Equals("testcat1")
+                && grpcEvent.Message.InvocationRequest.TraceContext.Attributes.Count == 3)));
+        }
+
+        [Fact]
+        public async Task SendInvocationRequest_ValidateTraceContext_SessionId()
+        {
+            string sessionId = "sessionId1234";
+            Activity activity = new Activity("testActivity");
+            activity.AddBaggage(ScriptConstants.LiveLogsSessionAIKey, sessionId);
+            activity.Start();
+            ScriptInvocationContext scriptInvocationContext = GetTestScriptInvocationContext(Guid.NewGuid(), null);
+            await _workerChannelwithMockEventManager.SendInvocationRequest(scriptInvocationContext);
+            activity.Stop();
+            _eventManagerMock.Verify(p => p.Publish(It.Is<OutboundGrpcEvent>(grpcEvent => ValidateInvocationRequest(grpcEvent, sessionId))));
+        }
+
+        private bool ValidateInvocationRequest(OutboundGrpcEvent grpcEvent, string sessionId)
+        {
+            bool b = grpcEvent.Message.InvocationRequest.TraceContext.Attributes[ScriptConstants.LiveLogsSessionAIKey].Equals(sessionId)
+                && grpcEvent.Message.InvocationRequest.TraceContext.Attributes.ContainsKey(LogConstants.CategoryNameKey)
+                && grpcEvent.Message.InvocationRequest.TraceContext.Attributes[LogConstants.CategoryNameKey].Equals("testcat1")
+                && grpcEvent.Message.InvocationRequest.TraceContext.Attributes.Count == 4;
+            return b;
+        }
+
         private IEnumerable<FunctionMetadata> GetTestFunctionsList(string runtime)
         {
             var metadata1 = new FunctionMetadata()
@@ -739,7 +796,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             };
 
             metadata1.SetFunctionId("TestFunctionId1");
-
+            metadata1.Properties.Add(LogConstants.CategoryNameKey, "testcat1");
+            metadata1.Properties.Add(ScriptConstants.LogPropertyHostInstanceIdKey, "testhostId1");
             var metadata2 = new FunctionMetadata()
             {
                 Language = runtime,
@@ -747,7 +805,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             };
 
             metadata2.SetFunctionId("TestFunctionId2");
-
+            metadata2.Properties.Add(LogConstants.CategoryNameKey, "testcat2");
+            metadata2.Properties.Add(ScriptConstants.LogPropertyHostInstanceIdKey, "testhostId2");
             return new List<FunctionMetadata>()
             {
                 metadata1,

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
@@ -644,7 +644,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             var functions = GetTestFunctionsList(RpcWorkerConstants.JavaLanguageWorkerName);
             await functionDispatcher.FinishInitialization(functions);
-            Assert.Equal(functions.Count(), 2);
             foreach (var item in functions)
             {
                 Assert.Equal(item.Properties.Count, 2);

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
@@ -635,6 +636,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.Equal(expectedProcessCount, functionDispatcher.JobHostLanguageWorkerChannelManager.GetChannels().Count());
         }
 
+        [Fact]
+        public async Task FunctionDispatcher_AdditionalAttributes()
+        {
+            int expectedProcessCount = 3;
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount, false, runtime: RpcWorkerConstants.JavaLanguageWorkerName, workerIndexing: true);
+
+            var functions = GetTestFunctionsList(RpcWorkerConstants.JavaLanguageWorkerName);
+            await functionDispatcher.FinishInitialization(functions);
+            Assert.Equal(functions.Count(), 2);
+            foreach (var item in functions)
+            {
+                Assert.Equal(item.Properties.Count, 2);
+                Assert.True(item.Properties.ContainsKey(LogConstants.CategoryNameKey) &&
+                    item.Properties.ContainsKey(ScriptConstants.LogPropertyHostInstanceIdKey));
+            }
+        }
+
         [Theory]
         [InlineData("node", "node", false, true, true)]
         [InlineData("node", "node", true, false, true)]
@@ -719,6 +737,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _javaTestChannel = new TestRpcWorkerChannel(Guid.NewGuid().ToString(), "java", eventManager, _testLogger, false);
             var optionsMonitor = TestHelpers.CreateOptionsMonitor(workerConfigOptions);
 
+            testEnv.SetEnvironmentVariable("APPLICATIONINSIGHTS_ENABLE_AGENT", "true");
             return new RpcFunctionInvocationDispatcher(scriptOptions,
                 metricsLogger.Object,
                 testEnv,


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Java worker team is working on a solution to run AI agent along with the worker. The agent is going to send logs to AI instead of sending it back to the host. This PR includes the changes to pass on additional context to the worker that must to be included in the logs.

- HostInstanceId
- ProcessId (Worker processId)
- Category
- AzFuncLiveLogsSessionId

APPLICATIONINSIGHTS_ENABLE_AGENT=true, enable app insights logging from agent
APPLICATIONINSIGHTS_ENABLE_AGENT=false, disable app insights logging from agent

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)