### PR TITLE
Adding a new logger for tooling console log entries from language workers so that they are always logged as Informational

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/SystemLoggerProvider.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/SystemLoggerProvider.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         private bool IsUserLogCategory(string categoryName)
         {
-            return LogCategories.IsFunctionUserCategory(categoryName) || categoryName.Equals(WorkerConstants.FunctionConsoleLogCategoryName, StringComparison.OrdinalIgnoreCase);
+            return LogCategories.IsFunctionUserCategory(categoryName) || categoryName.Equals(WorkerConstants.ConsoleLogCategoryName, StringComparison.OrdinalIgnoreCase);
         }
 
         public void Dispose()

--- a/src/WebJobs.Script/Extensions/ScriptLoggingBuilderExtensions.cs
+++ b/src/WebJobs.Script/Extensions/ScriptLoggingBuilderExtensions.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Configuration;
+using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
@@ -65,7 +66,10 @@ namespace Microsoft.Extensions.Logging
 
             if (enableConsole)
             {
-                builder.AddConsole();
+                builder.AddConsole()
+                       // Tooling console json log entries are meant to be used by IDEs / Debuggers.
+                       // Users are not supposed to set the log level for this category via host.JSON logging settings.
+                       .AddFilter(WorkerConstants.FunctionToolingConsoleJsonCategoryName, LogLevel.Information);
             }
         }
     }

--- a/src/WebJobs.Script/Extensions/ScriptLoggingBuilderExtensions.cs
+++ b/src/WebJobs.Script/Extensions/ScriptLoggingBuilderExtensions.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Extensions.Logging
                 builder.AddConsole()
                        // Tooling console json log entries are meant to be used by IDEs / Debuggers.
                        // Users are not supposed to set the log level for this category via host.JSON logging settings.
-                       .AddFilter(WorkerConstants.FunctionToolingConsoleJsonCategoryName, LogLevel.Information);
+                       .AddFilter(WorkerConstants.ToolingConsoleLogCategoryName, LogLevel.Information);
             }
         }
     }

--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcessUtilities.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcessUtilities.cs
@@ -38,5 +38,15 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         {
             return Regex.Replace(msg, WorkerConstants.LanguageWorkerConsoleLogPrefix, string.Empty, RegexOptions.IgnoreCase);
         }
+
+        public static bool IsToolingConsoleJsonLogEntry(ConsoleLog consoleLog)
+        {
+            return consoleLog.Message.StartsWith(WorkerConstants.ToolingConsoleJsonLogEntryPrefix, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static string RemoveToolingConsoleJsonLogPrefix(string msg)
+        {
+            return Regex.Replace(msg, WorkerConstants.ToolingConsoleJsonLogEntryPrefix, string.Empty, RegexOptions.IgnoreCase);
+        }
     }
 }

--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcessUtilities.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcessUtilities.cs
@@ -41,12 +41,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
 
         public static bool IsToolingConsoleJsonLogEntry(ConsoleLog consoleLog)
         {
-            return consoleLog.Message.StartsWith(WorkerConstants.ToolingConsoleJsonLogEntryPrefix, StringComparison.OrdinalIgnoreCase);
+            return consoleLog.Message.StartsWith(WorkerConstants.ToolingConsoleLogPrefix, StringComparison.OrdinalIgnoreCase);
         }
 
         public static string RemoveToolingConsoleJsonLogPrefix(string msg)
         {
-            return Regex.Replace(msg, WorkerConstants.ToolingConsoleJsonLogEntryPrefix, string.Empty, RegexOptions.IgnoreCase);
+            return Regex.Replace(msg, WorkerConstants.ToolingConsoleLogPrefix, string.Empty, RegexOptions.IgnoreCase);
         }
     }
 }

--- a/src/WebJobs.Script/Workers/WorkerConsoleLogService.cs
+++ b/src/WebJobs.Script/Workers/WorkerConsoleLogService.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
     internal class WorkerConsoleLogService : IHostedService, IDisposable
     {
         private readonly ILogger _logger;
+        private readonly Lazy<ILogger> _toolingConsoleJsonLoggerLazy;
         private readonly IWorkerConsoleLogSource _source;
         private readonly CancellationTokenSource _cts = new CancellationTokenSource();
         private Task _processingTask;
@@ -27,12 +28,14 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
 
             _source = consoleLogSource ?? throw new ArgumentNullException(nameof(consoleLogSource));
             _logger = loggerFactory.CreateLogger(WorkerConstants.FunctionConsoleLogCategoryName);
+            _toolingConsoleJsonLoggerLazy = new Lazy<ILogger>(() => loggerFactory.CreateLogger(WorkerConstants.FunctionToolingConsoleJsonCategoryName), isThreadSafe: true);
         }
 
-        internal WorkerConsoleLogService(ILogger logger, IWorkerConsoleLogSource consoleLogSource)
+        internal WorkerConsoleLogService(ILogger logger, Lazy<ILogger> toolingConsoleJsonLoggerLazy, IWorkerConsoleLogSource consoleLogSource)
         {
             _source = consoleLogSource ?? throw new ArgumentNullException(nameof(consoleLogSource));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _toolingConsoleJsonLoggerLazy = toolingConsoleJsonLoggerLazy;
         }
 
         public Task StartAsync(CancellationToken cancellationToken)
@@ -59,7 +62,16 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
                 while (await source.OutputAvailableAsync(_cts.Token))
                 {
                     var consoleLog = await source.ReceiveAsync();
-                    _logger.Log(consoleLog.Level, consoleLog.Message);
+
+                    if (WorkerProcessUtilities.IsToolingConsoleJsonLogEntry(consoleLog))
+                    {
+                        _toolingConsoleJsonLoggerLazy.Value.Log(consoleLog.Level,
+                            WorkerProcessUtilities.RemoveToolingConsoleJsonLogPrefix(consoleLog.Message));
+                    }
+                    else
+                    {
+                        _logger.Log(consoleLog.Level, consoleLog.Message);
+                    }
                 }
             }
             catch (OperationCanceledException)

--- a/src/WebJobs.Script/Workers/WorkerConsoleLogService.cs
+++ b/src/WebJobs.Script/Workers/WorkerConsoleLogService.cs
@@ -27,8 +27,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             }
 
             _source = consoleLogSource ?? throw new ArgumentNullException(nameof(consoleLogSource));
-            _logger = loggerFactory.CreateLogger(WorkerConstants.FunctionConsoleLogCategoryName);
-            _toolingConsoleJsonLoggerLazy = new Lazy<ILogger>(() => loggerFactory.CreateLogger(WorkerConstants.FunctionToolingConsoleJsonCategoryName), isThreadSafe: true);
+            _logger = loggerFactory.CreateLogger(WorkerConstants.ConsoleLogCategoryName);
+            _toolingConsoleJsonLoggerLazy = new Lazy<ILogger>(() => loggerFactory.CreateLogger(WorkerConstants.ToolingConsoleLogCategoryName), isThreadSafe: true);
         }
 
         internal WorkerConsoleLogService(ILogger logger, Lazy<ILogger> toolingConsoleJsonLoggerLazy, IWorkerConsoleLogSource consoleLogSource)

--- a/src/WebJobs.Script/Workers/WorkerConsoleLogService.cs
+++ b/src/WebJobs.Script/Workers/WorkerConsoleLogService.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         {
             _source = consoleLogSource ?? throw new ArgumentNullException(nameof(consoleLogSource));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _toolingConsoleJsonLoggerLazy = toolingConsoleJsonLoggerLazy;
+            _toolingConsoleJsonLoggerLazy = toolingConsoleJsonLoggerLazy ?? throw new ArgumentNullException(nameof(toolingConsoleJsonLoggerLazy));
         }
 
         public Task StartAsync(CancellationToken cancellationToken)

--- a/src/WebJobs.Script/Workers/WorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/WorkerConstants.cs
@@ -33,18 +33,18 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
 
         // Logs
         public const string LanguageWorkerConsoleLogPrefix = "LanguageWorkerConsoleLog";
-        public const string FunctionConsoleLogCategoryName = "Host.Function.Console";
+        public const string ConsoleLogCategoryName = "Host.Function.Console";
 
         /// <summary>
         /// The log category to be used for logging Tooling log entries emitted from language workers.
         /// </summary>
-        public const string FunctionToolingConsoleJsonCategoryName = "Host.Function.ToolingConsoleJson";
+        public const string ToolingConsoleLogCategoryName = "Host.Function.ToolingConsoleLog";
 
         /// <summary>
         /// The prefix used by language workers when sending a tooling data log entry via Console.WriteLine.
         /// Tooling data log entries are meant to be used by IDEs / Debuggers.
         /// </summary>
-        public const string ToolingConsoleJsonLogEntryPrefix = "azfuncjsonlog:";
+        public const string ToolingConsoleLogPrefix = "azfuncjsonlog:";
 
         // Thresholds
         public const int WorkerRestartErrorIntervalThresholdInMinutes = 30;

--- a/src/WebJobs.Script/Workers/WorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/WorkerConstants.cs
@@ -35,6 +35,17 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         public const string LanguageWorkerConsoleLogPrefix = "LanguageWorkerConsoleLog";
         public const string FunctionConsoleLogCategoryName = "Host.Function.Console";
 
+        /// <summary>
+        /// The log category to be used for logging Tooling log entries emitted from language workers.
+        /// </summary>
+        public const string FunctionToolingConsoleJsonCategoryName = "Host.Function.ToolingConsoleJson";
+
+        /// <summary>
+        /// The prefix used by language workers when sending a tooling data log entry via Console.WriteLine.
+        /// Tooling data log entries are meant to be used by IDEs / Debuggers.
+        /// </summary>
+        public const string ToolingConsoleJsonLogEntryPrefix = "azfuncjsonlog:";
+
         // Thresholds
         public const int WorkerRestartErrorIntervalThresholdInMinutes = 30;
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpEndToEndTests.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             IEnumerable<FunctionTraceEvent> allLogs = Fixture.EventGenerator.GetFunctionTraceEvents();
             Assert.False(allLogs.Any(l => l.Summary.Contains("From ")));
             Assert.False(allLogs.Any(l => l.Source.EndsWith(".User")));
-            Assert.False(allLogs.Any(l => l.Source == WorkerConstants.FunctionConsoleLogCategoryName));
+            Assert.False(allLogs.Any(l => l.Source == WorkerConstants.ConsoleLogCategoryName));
             Assert.NotEmpty(allLogs);
         }
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/NodeEndToEndTests.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             await TestHelpers.Await(() =>
             {
                 userLogs = Fixture.Host.GetScriptHostLogMessages(userCategory).Select(p => p.FormattedMessage).ToList();
-                consoleLog = Fixture.Host.GetScriptHostLogMessages(WorkerConstants.FunctionConsoleLogCategoryName).Select(p => p.FormattedMessage).SingleOrDefault();
+                consoleLog = Fixture.Host.GetScriptHostLogMessages(WorkerConstants.ConsoleLogCategoryName).Select(p => p.FormattedMessage).SingleOrDefault();
                 return userLogs.Count == 11 && consoleLog != null;
             }, userMessageCallback: Fixture.Host.GetLog);
 
@@ -232,7 +232,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.False(allLogs.Any(l => l.Summary.Contains("loglevel")));
             Assert.False(allLogs.Any(l => l.Summary.Contains("after done")));
             Assert.False(allLogs.Any(l => l.Source.EndsWith(".User")));
-            Assert.False(allLogs.Any(l => l.Source == WorkerConstants.FunctionConsoleLogCategoryName));
+            Assert.False(allLogs.Any(l => l.Source == WorkerConstants.ConsoleLogCategoryName));
             Assert.NotEmpty(allLogs);
         }
 

--- a/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
 
         public WorkerConsoleLogServiceTests()
         {
-            _toolingConsoleTestLogger = new TestLogger("Host.Function.ToolingConsole");
+            _toolingConsoleTestLogger = new TestLogger("Host.Function.ToolingConsoleLog");
             _toolingConsoleJsonLoggerLazy = new Lazy<ILogger>(() => _toolingConsoleTestLogger, true);
         }
 
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             var message = allLogs.FirstOrDefault(l => l.FormattedMessage.Contains(msg));
             Assert.NotNull(message);
             Assert.DoesNotContain(WorkerConstants.LanguageWorkerConsoleLogPrefix, message.FormattedMessage);
-            Assert.DoesNotContain(WorkerConstants.ToolingConsoleJsonLogEntryPrefix, message.FormattedMessage);
+            Assert.DoesNotContain(WorkerConstants.ToolingConsoleLogPrefix, message.FormattedMessage);
             Assert.Equal(expectedLevel, message.Level);
         }
     }

--- a/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
@@ -15,10 +15,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
 {
     public class WorkerConsoleLogServiceTests
     {
+        private static TestLogger toolingConsoleTestLogger = new TestLogger("Host.Function.ToolingConsole");
         private IScriptEventManager _eventManager;
         private IProcessRegistry _processRegistry;
         private TestLogger _testUserLogger = new TestLogger("Host.Function.Console");
         private TestLogger _testSystemLogger = new TestLogger("Worker.rpcWorkerProcess");
+        private Lazy<ILogger> _toolingConsoleJsonLoggerLazy = new Lazy<ILogger>(() => toolingConsoleTestLogger);
         private WorkerConsoleLogService _workerConsoleLogService;
         private WorkerConsoleLogSource _workerConsoleLogSource;
         private Mock<IServiceProvider> _serviceProviderMock;
@@ -32,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             _workerConsoleLogSource = new WorkerConsoleLogSource();
             _eventManager = new ScriptEventManager();
             _processRegistry = new EmptyProcessRegistry();
-            _workerConsoleLogService = new WorkerConsoleLogService(_testUserLogger, _workerConsoleLogSource);
+            _workerConsoleLogService = new WorkerConsoleLogService(_testUserLogger, _toolingConsoleJsonLoggerLazy, _workerConsoleLogSource);
             _serviceProviderMock = new Mock<IServiceProvider>(MockBehavior.Strict);
 
             WorkerProcess workerProcess = new TestWorkerProcess(_eventManager, _processRegistry, _testSystemLogger, _workerConsoleLogSource, null, _serviceProviderMock.Object, useStdErrForErrorLogsOnly);
@@ -42,16 +44,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             workerProcess.ParseErrorMessageAndLog("LanguageWorkerConsoleLog[Test Worker Message No keyword]");
             workerProcess.ParseErrorMessageAndLog("LanguageWorkerConsoleLog[Test Worker Error Message]");
             workerProcess.ParseErrorMessageAndLog("LanguageWorkerConsoleLog[Test Worker Warning Message]");
+            workerProcess.ParseErrorMessageAndLog("azfuncjsonlog:Azure Functions .NET Worker (PID: 4) initialized in debug mode.");
 
             // Act
             _ = _workerConsoleLogService.ProcessLogs().ContinueWith(t => { });
             await _workerConsoleLogService.StopAsync(System.Threading.CancellationToken.None);
             var userLogs = _testUserLogger.GetLogMessages();
             var systemLogs = _testSystemLogger.GetLogMessages();
+            var toolingConsoleLogs = toolingConsoleTestLogger.GetLogMessages();
 
             // Assert
-            Assert.True(userLogs.Count == 3);
-            Assert.True(systemLogs.Count == 3);
+            Assert.Equal(3, userLogs.Count);
+            Assert.Equal(3, systemLogs.Count);
+            Assert.Equal(1, toolingConsoleLogs.Count);
 
             VerifyLogLevel(userLogs, "Test Error Message", LogLevel.Error);
             VerifyLogLevel(systemLogs, "[Test Worker Error Message]", LogLevel.Error);
@@ -62,19 +67,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             {
                 VerifyLogLevel(userLogs, "Test Message No keyword", LogLevel.Error);
                 VerifyLogLevel(systemLogs, "[Test Worker Message No keyword]", LogLevel.Error);
+                VerifyLogLevel(toolingConsoleLogs, "Azure Functions .NET Worker (PID: 4) initialized in debug mode.", LogLevel.Error);
             }
             else
             {
                 VerifyLogLevel(userLogs, "Test Message No keyword", LogLevel.Information);
                 VerifyLogLevel(systemLogs, "[Test Worker Message No keyword]", LogLevel.Information);
+                VerifyLogLevel(toolingConsoleLogs, "Azure Functions .NET Worker (PID: 4) initialized in debug mode.", LogLevel.Information);
             }
         }
 
         private static void VerifyLogLevel(IList<LogMessage> allLogs, string msg, LogLevel expectedLevel)
         {
-            var message = allLogs.Where(l => l.FormattedMessage.Contains(msg)).FirstOrDefault();
+            var message = allLogs.FirstOrDefault(l => l.FormattedMessage.Contains(msg));
             Assert.NotNull(message);
             Assert.DoesNotContain(WorkerConstants.LanguageWorkerConsoleLogPrefix, message.FormattedMessage);
+            Assert.DoesNotContain(WorkerConstants.ToolingConsoleJsonLogEntryPrefix, message.FormattedMessage);
             Assert.Equal(expectedLevel, message.Level);
         }
     }

--- a/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
@@ -15,15 +15,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
 {
     public class WorkerConsoleLogServiceTests
     {
-        private static TestLogger toolingConsoleTestLogger = new TestLogger("Host.Function.ToolingConsole");
+        private TestLogger _toolingConsoleTestLogger;
         private IScriptEventManager _eventManager;
         private IProcessRegistry _processRegistry;
         private TestLogger _testUserLogger = new TestLogger("Host.Function.Console");
         private TestLogger _testSystemLogger = new TestLogger("Worker.rpcWorkerProcess");
-        private Lazy<ILogger> _toolingConsoleJsonLoggerLazy = new Lazy<ILogger>(() => toolingConsoleTestLogger);
+        private Lazy<ILogger> _toolingConsoleJsonLoggerLazy;
         private WorkerConsoleLogService _workerConsoleLogService;
         private WorkerConsoleLogSource _workerConsoleLogSource;
         private Mock<IServiceProvider> _serviceProviderMock;
+
+        public WorkerConsoleLogServiceTests()
+        {
+            _toolingConsoleTestLogger = new TestLogger("Host.Function.ToolingConsole");
+            _toolingConsoleJsonLoggerLazy = new Lazy<ILogger>(() => _toolingConsoleTestLogger, true);
+        }
 
         [Theory]
         [InlineData(false)]
@@ -51,7 +57,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             await _workerConsoleLogService.StopAsync(System.Threading.CancellationToken.None);
             var userLogs = _testUserLogger.GetLogMessages();
             var systemLogs = _testSystemLogger.GetLogMessages();
-            var toolingConsoleLogs = toolingConsoleTestLogger.GetLogMessages();
+            var toolingConsoleLogs = _toolingConsoleTestLogger.GetLogMessages();
 
             // Assert
             Assert.Equal(3, userLogs.Count);


### PR DESCRIPTION
Adding a new logger for tooling console log entries from language workers so that they are always logged as Informational irrespective of Host category level present in HOST.JSON

The dotnet language worker has a startup hook which emits some meta information about the language worker process (ex: processId). This information is emitted via [standard output using Console.WriteLine API](https://github.com/Azure/azure-functions-dotnet-worker/blob/main/src/DotNetWorker.Core/StartupHook.cs#L52). The Host reads this std output stream and log that information using ILogger. We have a console logger which will print this in the console when in development mode, which IDE/Debuggers may read (the processId) so that they can attach to the process.

When the `host.JSON` of dotnet isolated function app specify "Error" as the minimum log level for "Host" category, this information is not surfaced to console as ILogger will discard any log message with level below "Error". The tooling console log messages[ are sent as "Information" level](https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcess.cs#L127) one and thus being dropped.

The fix here in this PR is having a separate ILogger for the tooling related log messages coming from worker. We identify the tooling related messages by checking the existence of a special prefix(`azfuncjsonlog:`), and if detected, we will use the new logger for logging that message. This log level of this special logger is set to `Informational` in code (Customers/Users are not supposed to change this), so that the log level value of "Host" category is not impacting this log entries.

Relevant issue: https://github.com/Azure/azure-functions-dotnet-worker/issues/900