### PR TITLE
Update Linux File Logger Frequency to support Elastic Premium Scaling

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceFileLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceFileLogger.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             {
                 try
                 {
-                    if (_logFileDirectory.Contains("exec") ) 
+                    if (_logFileDirectory.Contains("exec"))
                     {
                         _currentBatch.Add($"InternalProcessLogQueue found executions size {_currentBatch.Count} at time {DateTime.UtcNow} ");
                     }

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceFileLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceFileLogger.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             {
                 await InternalProcessLogQueue();
                 await Task.Delay(TimeSpan.FromSeconds(StartingFlushFrequencySeconds), _cancellationTokenSource.Token).ContinueWith(task => { });
-                if (StartingFlushFrequencySeconds < MaxFlushFrequencySeconds) 
+                if ( StartingFlushFrequencySeconds < MaxFlushFrequencySeconds)
                 {
                     StartingFlushFrequencySeconds++;
                 }
@@ -111,7 +111,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             {
                 try
                 {
-                    if (_logFileDirectory.Contains("exec")){
+                    if (_logFileDirectory.Contains("exec") ) 
+                    {
                         _currentBatch.Add($"InternalProcessLogQueue found executions size {_currentBatch.Count} at time {DateTime.UtcNow} ");
                     }
                     await WriteLogs(_currentBatch);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

This is a PR to change the host in a way that should speed up scaling time for Elastic Premium on Linux.  To scale the worker, the Function Execution log file must be populated and reported to the DataService. Prior to this change, the file logger always had a 30 second delay between buffer flushes. 

This change implements a backoff delay so that file logging begins with a 1 second delay between flushes the increments each iteration until it hits the maximum delay (30 seconds).  The 1 second delay helps to quickly populate log sources on initialization.  The current change affects all file loggers. Log categories other than execution logs are not as time sensitive. 

DO NOT MERGE

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
