### PR TITLE
Adding support for admin API isolation

### DIFF
--- a/sample/CSharp/HttpTrigger-AdminLevel/function.json
+++ b/sample/CSharp/HttpTrigger-AdminLevel/function.json
@@ -1,0 +1,16 @@
+{
+  "bindings": [
+    {
+      "type": "httpTrigger",
+      "name": "req",
+      "direction": "in",
+      "methods": [ "get" ],
+      "authLevel": "admin"
+    },
+    {
+      "type": "http",
+      "name": "$return",
+      "direction": "out"
+    }
+  ]
+}

--- a/sample/CSharp/HttpTrigger-AdminLevel/run.csx
+++ b/sample/CSharp/HttpTrigger-AdminLevel/run.csx
@@ -1,0 +1,15 @@
+﻿using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
+
+public static IActionResult Run(HttpRequest req, TraceWriter log)
+{
+    log.Info("C# HTTP trigger function processed a request.");
+
+    if (req.Query.TryGetValue("name", out StringValues value))
+    {
+        return new OkObjectResult($"Hello {value.ToString()}");
+    }
+
+    return new BadRequestObjectResult("Please pass a name on the query string or in the request body");
+}

--- a/src/WebJobs.Script.WebHost/Middleware/VirtualFileSystemMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/VirtualFileSystemMiddleware.cs
@@ -104,6 +104,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
             var authorizationPolicyProvider = context.RequestServices.GetRequiredService<IAuthorizationPolicyProvider>();
             var policyEvaluator = context.RequestServices.GetRequiredService<IPolicyEvaluator>();
 
+            if (!AuthorizationOptionsExtensions.CheckPlatformInternal(context, allowAppServiceInternal: false))
+            {
+                return false;
+            }
+
             var policy = await authorizationPolicyProvider.GetPolicyAsync(PolicyNames.AdminAuthLevel);
             var authenticateResult = await policyEvaluator.AuthenticateAsync(policy, context);
 

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -46,6 +46,11 @@ namespace Microsoft.Azure.WebJobs.Script
             return environment.GetEnvironmentVariable(FunctionsRuntimeScaleMonitoringEnabled) == "1";
         }
 
+        public static bool IsAdminIsolationEnabled(this IEnvironment environment)
+        {
+            return environment.GetEnvironmentVariable(FunctionsAdminIsolationEnabled) == "1";
+        }
+
         public static bool IsEasyAuthEnabled(this IEnvironment environment)
         {
             bool.TryParse(environment.GetEnvironmentVariable(EasyAuthEnabled), out bool isEasyAuthEnabled);

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AzureFilesContentShare = "WEBSITE_CONTENTSHARE";
         public const string AzureWebsiteRuntimeSiteName = "WEBSITE_DEPLOYMENT_ID";
         public const string FunctionsRuntimeScaleMonitoringEnabled = "FUNCTIONS_RUNTIME_SCALE_MONITORING_ENABLED";
+        public const string FunctionsAdminIsolationEnabled = "FUNCTIONS_ADMIN_ISOLATION_ENABLED";
         public const string AzureWebsiteStartupContextCache = "WEBSITE_FUNCTIONS_STARTUPCONTEXT_CACHE";
         public const string AzureWebJobsFeatureFlags = "AzureWebJobsFeatureFlags";
         public const string CloudName = "WEBSITE_CLOUD_NAME";

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -94,6 +94,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AntaresColdStartHeaderName = "X-MS-COLDSTART";
         public const string SiteTokenHeaderName = "x-ms-site-restricted-token";
         public const string EasyAuthIdentityHeader = "x-ms-client-principal";
+        public const string AntaresPlatformInternal = "x-ms-platform-internal";
         public const string AzureVersionHeader = "x-ms-version";
         public const string XIdentityHeader = "X-IDENTITY-HEADER";
         public const string DynamicSku = "Dynamic";

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -171,6 +171,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             HttpClient = _testServer.CreateClient();
             HttpClient.Timeout = TimeSpan.FromMinutes(5);
 
+            var environment = _testServer.Services.GetService<IEnvironment>();
+            if (environment.IsAppService())
+            {
+                // host is configured to simulate an AppService environment
+                // all normal requests will go through the Antares FrontEnd and receive this header
+                HttpClient.DefaultRequestHeaders.Add(ScriptConstants.AntaresLogIdHeaderName, "xyz");
+            }
+
             var manager = _testServer.Host.Services.GetService<IScriptHostManager>();
             _hostService = manager as WebJobsScriptHostService;
 
@@ -207,6 +215,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public string ScriptPath => _hostOptions.ScriptPath;
 
         public HttpClient HttpClient { get; private set; }
+
+        /// <summary>
+        /// Create a new HttpClient without default test configuration.
+        /// </summary>
+        public HttpClient CreateHttpClient()
+        {
+            var httpClient = _testServer.CreateClient();
+            httpClient.Timeout = TimeSpan.FromMinutes(5);
+
+            return httpClient;
+        }
 
         public async Task<string> GetMasterKeyAsync()
         {

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
@@ -14,6 +14,7 @@ using Microsoft.Azure.WebJobs.Script.BindingExtensions;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.ExtensionBundle;
 using Microsoft.Azure.WebJobs.Script.Models;
+using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
@@ -316,6 +317,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var logs = Host.GetScriptHostLogMessages();
             var errors = logs.Where(x => x.Level == Microsoft.Extensions.Logging.LogLevel.Error).ToList();
             Assert.True(errors.Count > 0);
+        }
+
+        public async Task AddMasterKey(HttpRequestMessage request)
+        {
+            var masterKey = await Host.GetMasterKeyAsync();
+            request.Headers.Add(AuthenticationLevelHandler.FunctionsKeyHeaderName, masterKey);
         }
 
         private class TestExtensionBundleManager : IExtensionBundleManager

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
@@ -86,6 +86,75 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         }
 
         [Theory]
+        [Trait(TestTraits.Group, TestTraits.AdminIsolationTests)]
+        [InlineData("admin/host/status", true, true, false, false, true, HttpStatusCode.Forbidden)]
+        [InlineData("admin/host/status", true, true, true, false, false, HttpStatusCode.Unauthorized)]
+        [InlineData("admin/host/status", true, true, true, true, true, HttpStatusCode.OK)]
+        [InlineData("admin/host/status", true, false, false, false, true, HttpStatusCode.OK)]
+        [InlineData("admin/host/status", true, false, false, true, true, HttpStatusCode.OK)]
+        [InlineData("admin/host/status", true, true, true, false, true, HttpStatusCode.OK)]
+        [InlineData("admin/host/status", false, true, false, true, true, HttpStatusCode.Forbidden)]
+        [InlineData("admin/host/extensionBundle/v1/templates", true, true, false, true, false, HttpStatusCode.Unauthorized)]
+        [InlineData("admin/host/extensionBundle/v1/templates", true, true, true, false, true, HttpStatusCode.NotFound)]
+        [InlineData("admin/host/extensionBundle/v1/templates", true, false, false, false, true, HttpStatusCode.NotFound)]
+        [InlineData("admin/host/extensionBundle/v1/templates", true, true, false, true, true, HttpStatusCode.Forbidden)]
+        [InlineData("admin/vfs/host.json", true, true, true, false, true, HttpStatusCode.OK)]
+        [InlineData("admin/vfs/host.json", true, true, false, false, true, HttpStatusCode.Unauthorized)]
+        [InlineData("admin/vfs/host.json", true, true, true, false, false, HttpStatusCode.Unauthorized)]
+        public async Task AdminIsolation_ReturnsExpectedStatus(string uri, bool isAppService, bool enableIsolation, bool isPlatformInternal, bool bypassFE, bool addAuthKey, HttpStatusCode expectedStatus)
+        {
+            var environment = this._fixture.Host.WebHostServices.GetService<IEnvironment>();
+            string websiteInstanceId = environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId);
+
+            try
+            {
+                if (enableIsolation)
+                {
+                    environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionsAdminIsolationEnabled, "1");
+                    Assert.True(environment.IsAdminIsolationEnabled());
+                }
+
+                if (!isAppService)
+                {
+                    environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, null);
+                    Assert.False(environment.IsAppService());
+                }
+                else
+                {
+                    Assert.True(environment.IsAppService());
+                }
+
+                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
+                
+                if (addAuthKey)
+                {
+                    await this._fixture.AddMasterKey(request);
+                }
+
+                if (isPlatformInternal)
+                {
+                    request.Headers.Add(ScriptConstants.AntaresPlatformInternal, "True");
+                }
+
+                if (!bypassFE)
+                {
+                    request.Headers.Add(ScriptConstants.AntaresLogIdHeaderName, Guid.NewGuid().ToString());
+                }
+
+                using (var httpClient = _fixture.Host.CreateHttpClient())
+                {
+                    HttpResponseMessage response = await httpClient.SendAsync(request);
+                    Assert.Equal(expectedStatus, response.StatusCode);
+                }
+            }
+            finally
+            {
+                environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionsAdminIsolationEnabled, null);
+                environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, websiteInstanceId);
+            }
+        }
+
+        [Theory]
         [InlineData("GET")]
         [InlineData("POST")]
         public async Task HostPing_Succeeds(string method)
@@ -234,11 +303,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         [Fact]
         public async Task SyncTriggers_InternalAuth_Succeeds()
         {
-            using (new TestScopedSettings(_settingsManager, EnvironmentSettingNames.AzureWebsiteInstanceId, "testinstance"))
+            using (var httpClient = _fixture.Host.CreateHttpClient())
             {
                 string uri = "admin/host/synctriggers";
                 HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
-                HttpResponseMessage response = await _fixture.Host.HttpClient.SendAsync(request);
+                HttpResponseMessage response = await httpClient.SendAsync(request);
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             }
         }
@@ -266,17 +335,27 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         public async Task HostLog_Anonymous_Fails()
         {
             var request = new HttpRequestMessage(HttpMethod.Post, "admin/host/log");
-            request.Headers.Add(ScriptConstants.AntaresLogIdHeaderName, "xyz");
             request.Content = new StringContent("[]");
             request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
             var response = await _fixture.Host.HttpClient.SendAsync(request);
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
 
-            request = new HttpRequestMessage(HttpMethod.Post, "admin/host/log");
-            request.Content = new StringContent("[]");
-            request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-            response = await _fixture.Host.HttpClient.SendAsync(request);
-            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        [Fact]
+        public async Task HostLog_PlatformInternal_Succeeds()
+        {
+            var environment = _fixture.Host.JobHostServices.GetService<IEnvironment>();
+            Assert.True(environment.IsAppService());
+
+            using (var httpClient = _fixture.Host.CreateHttpClient())
+            {
+                // no x-arr-log-id header makes this request platform internal
+                var request = new HttpRequestMessage(HttpMethod.Post, "admin/host/log");
+                request.Content = new StringContent("[]");
+                request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+                var response = await httpClient.SendAsync(request);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            }
         }
 
         [Fact]
@@ -512,7 +591,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             var response = await _fixture.Host.HttpClient.SendAsync(request);
             var metadata = (await response.Content.ReadAsAsync<IEnumerable<FunctionMetadataResponse>>()).ToArray();
 
-            Assert.Equal(17, metadata.Length);
+            Assert.Equal(18, metadata.Length);
             var function = metadata.Single(p => p.Name == "HttpTrigger-CustomRoute");
             Assert.Equal("https://somewebsite.azurewebsites.net/api/csharp/products/{category:alpha?}/{id:int?}/{extra?}", function.InvokeUrlTemplate.ToString());
 
@@ -524,7 +603,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         public async Task Home_Get_Succeeds()
         {
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, string.Empty);
-
             HttpResponseMessage response = await _fixture.Host.HttpClient.SendAsync(request);
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
@@ -544,15 +622,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         [Fact]
         public async Task Home_Get_InAzureEnvironment_AsInternalRequest_ReturnsNoContent()
         {
-            // Pings to the site root should not return the homepage content if they are internal requests.
-            // This test sets a website instance Id which means that we'll go down the IsAzureEnvironment = true codepath
-            // but the sent request does NOT include an X-ARR-LOG-ID header. This indicates the request was internal.
+            var environment = _fixture.Host.JobHostServices.GetService<IEnvironment>();
+            Assert.True(environment.IsAppService());
 
-            using (new TestScopedSettings(_settingsManager, EnvironmentSettingNames.AzureWebsiteInstanceId, "123"))
+            // Pings to the site root should not return the homepage content if they are internal requests.
+            // The sent request does NOT include an X-ARR-LOG-ID header. This indicates the request was internal.
+            using (var httpClient = _fixture.Host.CreateHttpClient())
             {
                 HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, string.Empty);
-
-                HttpResponseMessage response = await _fixture.Host.HttpClient.SendAsync(request);
+                HttpResponseMessage response = await httpClient.SendAsync(request);
                 Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
             }
         }
@@ -692,6 +770,47 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             request.Content = new StringContent(jo.ToString());
             request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
             return await _fixture.Host.HttpClient.SendAsync(request);
+        }
+
+        [Fact]
+        [Trait(TestTraits.Group, TestTraits.AdminIsolationTests)]
+        public async Task HttpTrigger_AdminLevel_AdminIsolationEnabled_Succeeds()
+        {
+            var environment = this._fixture.Host.WebHostServices.GetService<IEnvironment>();
+
+            var vars = new Dictionary<string, string>
+            {
+                { RpcWorkerConstants.FunctionWorkerRuntimeSettingName, RpcWorkerConstants.DotNetLanguageWorkerName},
+                { EnvironmentSettingNames.FunctionsAdminIsolationEnabled, "1" }
+            };
+            using (_fixture.Host.WebHostServices.CreateScopedEnvironment(vars))
+            {
+                Assert.True(environment.IsAdminIsolationEnabled());
+                Assert.True(environment.IsAppService());
+
+                // verify admin isolation checks don't apply to customer admin level functions,
+                // only our admin APIs.
+
+                // no key presented
+                string uri = $"api/httptrigger-adminlevel?name=Mathew";
+                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
+                HttpResponseMessage response = await _fixture.Host.HttpClient.SendAsync(request);
+                Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+
+                // function level key when admin is required
+                request = new HttpRequestMessage(HttpMethod.Get, uri);
+                string key = await _fixture.Host.GetFunctionSecretAsync("httptrigger-adminlevel");
+                request.Headers.Add(AuthenticationLevelHandler.FunctionsKeyHeaderName, key);
+                response = await _fixture.Host.HttpClient.SendAsync(request);
+                Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+
+                // required master key supplied
+                request = new HttpRequestMessage(HttpMethod.Get, uri);
+                key = await _fixture.Host.GetMasterKeyAsync();
+                request.Headers.Add(AuthenticationLevelHandler.FunctionsKeyHeaderName, key);
+                response = await _fixture.Host.HttpClient.SendAsync(request);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            }
         }
 
         [Fact]
@@ -985,6 +1104,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                     o.Functions = new[]
                     {
                         "HttpTrigger",
+                        "HttpTrigger-AdminLevel",
                         "HttpTrigger-Compat",
                         "HttpTrigger-CustomRoute",
                         "HttpTrigger-POCO",

--- a/test/WebJobs.Script.Tests.Shared/TestTraits.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestTraits.cs
@@ -45,5 +45,10 @@ namespace Microsoft.WebJobs.Script.Tests
         /// These are Linux container environment specific tests.
         /// </summary>
         public const string ContainerInstanceTests = "ContainerInstanceTests";
+
+        /// <summary>
+        /// Tests for the AdminIsolation feature.
+        /// </summary>
+        public const string AdminIsolationTests = "AdminIsolationTests";
     }
 }

--- a/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.WebJobs.Script.Tests;
 using Xunit;
 using static Microsoft.Azure.WebJobs.Script.EnvironmentSettingNames;
 
@@ -12,7 +13,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
     public class EnvironmentExtensionsTests
     {
         [Fact]
-        public void GetEffectiveCoresCount_RetrunsExpectedResult()
+        public void GetEffectiveCoresCount_ReturnsExpectedResult()
         {
             TestEnvironment env = new TestEnvironment();
             Assert.Equal(Environment.ProcessorCount, EnvironmentExtensions.GetEffectiveCoresCount(env));
@@ -25,6 +26,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
             env.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, ScriptConstants.DynamicSku);
             env.SetEnvironmentVariable(EnvironmentSettingNames.RoleInstanceId, "dw0SmallDedicatedWebWorkerRole_hr0HostRole-0-VM-1");
             Assert.Equal(Environment.ProcessorCount, EnvironmentExtensions.GetEffectiveCoresCount(env));
+        }
+
+        [Fact]
+        [Trait(TestTraits.Group, TestTraits.AdminIsolationTests)]
+        public void IsAdminIsolationEnabled_ReturnsExpectedResult()
+        {
+            TestEnvironment env = new TestEnvironment();
+            Assert.False(EnvironmentExtensions.IsAdminIsolationEnabled(env));
+
+            env.SetEnvironmentVariable(EnvironmentSettingNames.FunctionsAdminIsolationEnabled, "0");
+            Assert.False(EnvironmentExtensions.IsAdminIsolationEnabled(env));
+
+            env.SetEnvironmentVariable(EnvironmentSettingNames.FunctionsAdminIsolationEnabled, "1");
+            Assert.True(EnvironmentExtensions.IsAdminIsolationEnabled(env));
         }
 
         [Theory]

--- a/test/WebJobs.Script.Tests/Extensions/HttpRequestExtensionsTest.cs
+++ b/test/WebJobs.Script.Tests/Extensions/HttpRequestExtensionsTest.cs
@@ -13,12 +13,61 @@ using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Azure.WebJobs.Script.Extensions;
 using Microsoft.Azure.WebJobs.Script.Tests.HttpWorker;
 using Microsoft.WebJobs.Script.Tests;
+using Moq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
 {
     public class HttpRequestExtensionsTest
     {
+        [Fact]
+        [Trait(TestTraits.Group, TestTraits.AdminIsolationTests)]
+        public void IsPlatformInternalRequest_ReturnsExpectedResult()
+        {
+            // not running under Azure
+            TestEnvironment testEnvironment = new TestEnvironment();
+            var request = HttpTestHelpers.CreateHttpRequest("GET", "http://foobar");
+            Assert.False(request.IsPlatformInternalRequest(testEnvironment));
+
+            // running under Azure
+            var vars = new Dictionary<string, string>
+            {
+                { EnvironmentSettingNames.AzureWebsiteInstanceId, "123" }
+            };
+            using (var env = new TestScopedEnvironmentVariable(vars))
+            {
+                var environment = SystemEnvironment.Instance;
+                Assert.True(environment.IsAppService());
+
+                var headers = new HeaderDictionary();
+                request = HttpTestHelpers.CreateHttpRequest("GET", "http://foobar", headers);
+                Assert.False(request.IsPlatformInternalRequest(testEnvironment));
+
+                headers.Clear();
+                headers.Add(ScriptConstants.AntaresPlatformInternal, "False");
+                request = HttpTestHelpers.CreateHttpRequest("GET", "http://foobar", headers);
+                Assert.False(request.IsPlatformInternalRequest(environment));
+
+                headers.Clear();
+                headers.Add(ScriptConstants.AntaresPlatformInternal, "True");
+                request = HttpTestHelpers.CreateHttpRequest("GET", "http://foobar", headers);
+                Assert.True(request.IsPlatformInternalRequest(environment));
+
+                headers.Clear();
+                headers.Add(ScriptConstants.AntaresPlatformInternal, "true");
+                request = HttpTestHelpers.CreateHttpRequest("GET", "http://foobar", headers);
+                Assert.True(request.IsPlatformInternalRequest(environment));
+
+                headers.Clear();
+                headers.Add(ScriptConstants.AntaresPlatformInternal, "True");
+                request = HttpTestHelpers.CreateHttpRequest("GET", "http://foobar", headers);
+                var servicesMock = new Mock<IServiceProvider>();
+                servicesMock.Setup(s => s.GetService(typeof(IEnvironment))).Returns(environment);
+                request.HttpContext.RequestServices = servicesMock.Object;
+                Assert.True(request.IsPlatformInternalRequest());
+            }
+        }
+
         [Fact]
         public void IsAppServiceInternalRequest_ReturnsExpectedResult()
         {


### PR DESCRIPTION
See PR for Antares Platform work [here](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Websites/pullrequest/6191577).

Resolves https://github.com/Azure/azure-functions-host/issues/8142.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] These changes will be backported to v3, tracked by the same work item https://github.com/Azure/azure-functions-host/issues/8142
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
