### PR TITLE
Removing the UT

### DIFF
--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
@@ -636,22 +636,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.Equal(expectedProcessCount, functionDispatcher.JobHostLanguageWorkerChannelManager.GetChannels().Count());
         }
 
-        [Fact]
-        public async Task FunctionDispatcher_AdditionalAttributes()
-        {
-            int expectedProcessCount = 3;
-            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount, false, runtime: RpcWorkerConstants.JavaLanguageWorkerName, workerIndexing: true);
-
-            var functions = GetTestFunctionsList(RpcWorkerConstants.JavaLanguageWorkerName);
-            await functionDispatcher.FinishInitialization(functions);
-            foreach (var item in functions)
-            {
-                Assert.Equal(item.Properties.Count, 2);
-                Assert.True(item.Properties.ContainsKey(LogConstants.CategoryNameKey) &&
-                    item.Properties.ContainsKey(ScriptConstants.LogPropertyHostInstanceIdKey));
-            }
-        }
-
         [Theory]
         [InlineData("node", "node", false, true, true)]
         [InlineData("node", "node", true, false, true)]


### PR DESCRIPTION
Removing the UT as it depends on the environment variable. The value is cached and if the sequence is not correct, test will fail.

### Issue describing the changes in this PR

resolves #[Fix flaky unit test](https://github.com/Azure/azure-functions-host/issues/8444)

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
