### PR TITLE
V3 - Placeholder for worker directory path in RpcWorkerDescription arguments

### DIFF
--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -130,6 +130,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     if (ShouldAddWorkerConfig(workerDescription.Language))
                     {
                         workerDescription.FormatWorkerPathIfNeeded(_systemRuntimeInformation, _environment, _logger);
+                        workerDescription.FormatArgumentsIfNeeded(_logger);
                         workerDescription.ThrowIfFileNotExists(workerDescription.DefaultWorkerPath, nameof(workerDescription.DefaultWorkerPath));
                         workerDescription.ExpandEnvironmentVariables();
 

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public const string OSPlaceholder = "{os}";
         public const string ArchitecturePlaceholder = "{architecture}";
         public const string RuntimeVersionPlaceholder = "%" + FunctionWorkerRuntimeVersionSettingName + "%";
+        public const string WorkerDirectoryPath = "{workerDirectoryPath}";
 
         // Rpc message length
         public const int DefaultMaxMessageLengthBytes = int.MaxValue;

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
@@ -203,6 +203,24 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                              .Replace(RpcWorkerConstants.RuntimeVersionPlaceholder, DefaultRuntimeVersion);
         }
 
+        internal void FormatArgumentsIfNeeded(ILogger logger)
+        {
+            if (Arguments?.Any() == false)
+            {
+                return;
+            }
+
+            for (int i = 0; i < Arguments.Count; i++)
+            {
+                if (!string.IsNullOrEmpty(Arguments[i]))
+                {
+                    Arguments[i] = Arguments[i].Replace(RpcWorkerConstants.WorkerDirectoryPath, WorkerDirectory);
+                }
+            }
+
+            logger.LogDebug($"Worker description arguments after formatting: {Arguments}");
+        }
+
         internal bool ShouldFormatWorkerPath(string workerPath)
         {
             if (string.IsNullOrEmpty(workerPath))

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
@@ -615,6 +615,58 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.Equal("3.7", workerDescription.DefaultRuntimeVersion);
         }
 
+        public static IEnumerable<object[]> RpcWorkerDescriptionArgumentsWithPlaceholder()
+        {
+            yield return new object[] { "D:/Code/Host/workers/java", new List<string> { RpcWorkerConstants.WorkerDirectoryPath } };
+            yield return new object[] { "/java", new List<string> { string.Concat("/path/version/", RpcWorkerConstants.WorkerDirectoryPath) } };
+            yield return new object[] { "/", new List<string> { string.Concat("version/", RpcWorkerConstants.WorkerDirectoryPath) } };
+        }
+
+        [Theory]
+        [MemberData(nameof(RpcWorkerDescriptionArgumentsWithPlaceholder))]
+        public void LanguageWorker_FormatArguments_ReplacePlaceholder(string workerDirectory, List<string> arguments)
+        {
+            RpcWorkerDescription workerDescription = new RpcWorkerDescription()
+            {
+                Arguments = arguments,
+                DefaultExecutablePath = "python",
+                WorkerDirectory = workerDirectory,
+                Language = "python"
+            };
+            workerDescription.FormatArgumentsIfNeeded(new TestLogger(testLanguage));
+
+            for (int i = 0; i < arguments.Count; i++)
+            {
+                Assert.Contains(workerDirectory, workerDescription.Arguments[i]);
+            }
+        }
+
+        public static IEnumerable<object[]> RpcWorkerDescriptionArgumentsWithoutPlaceholder()
+        {
+            yield return new object[] { "D:/Code/Host/workers/java", new List<string> { } };
+            yield return new object[] { "D:/Code/Host/workers/", new List<string> { string.Empty, null } };
+            yield return new object[] { "/worker/path", new List<string> { string.Empty, null, "/path/version/" } };
+        }
+
+        [Theory]
+        [MemberData(nameof(RpcWorkerDescriptionArgumentsWithoutPlaceholder))]
+        public void LanguageWorker_FormatArguments_DoNotReplacePlaceholder(string workerDirectory, List<string> arguments)
+        {
+            RpcWorkerDescription workerDescription = new RpcWorkerDescription()
+            {
+                Arguments = arguments,
+                DefaultExecutablePath = "python",
+                WorkerDirectory = workerDirectory,
+                Language = "python"
+            };
+            workerDescription.FormatArgumentsIfNeeded(new TestLogger(testLanguage));
+
+            for (int i = 0; i < arguments.Count; i++)
+            {
+                Assert.DoesNotContain(workerDirectory, workerDescription.Arguments[i]);
+            }
+        }
+
         private IEnumerable<RpcWorkerConfig> TestReadWorkerProviderFromConfig(IEnumerable<TestRpcWorkerConfig> configs, ILogger testLogger, TestMetricsLogger testMetricsLogger, string language = null, Dictionary<string, string> keyValuePairs = null, bool appSvcEnv = false)
         {
             Mock<IEnvironment> mockEnvironment = new Mock<IEnvironment>();


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
Language workers can access the worker directory path using the {workerDirectoryPath} placeholder in the worker config arguments.
This will help in using the worker directory path in worker.config.json to refer to worker specific files such as java agent jar

resolves #8450

The Java worker team is working on a prototype where an Application Insights (AI) agent is deployed along side the Java worker
to handle telemetry and logging to AI. Depending on the SKU and environment variables, the AI agent should be used. 
Profiles will be used to add arguments required to enable the agent. The arguments must refer to the worker directory path, which will be obtained using this environment variable.

Profiles Design doc: https://dev.azure.com/msazure/One/_git/AAPT-Antares-Docs/pullrequest/5715621?_a=files

Sample `worker.config.json` with profiles 
``` json 
{
  "description": { ... }, // this will always be the default worker configuration
  "profiles": [
    {
      "profileName": "profile1",
      "conditions": [
        { "conditionType": "environment", "conditionName": "APP_SETTING_NAME", "conditionExpression": "app_setting_value" }
      ],
      "description": {
        "arguments": ["-DmyNewArg -javaagent='{workerDirectoryPath}/agent/applicationinsights-agent.jar' "]
      }
    }
  ]
}
```

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
