### PR TITLE
V3 - Conditional based profiles for workers

### DIFF
--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -29,6 +29,7 @@ using Microsoft.Azure.WebJobs.Script.Scale;
 using Microsoft.Azure.WebJobs.Script.StorageProvider;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Http;
+using Microsoft.Azure.WebJobs.Script.Workers.Profiles;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -295,6 +296,10 @@ namespace Microsoft.Azure.WebJobs.Script
 
                 services.AddSingleton<IFileLoggingStatusManager, FileLoggingStatusManager>();
 
+                services.AddSingleton<IWorkerProfileManager, WorkerProfileManager>();
+
+                services.AddSingleton<IWorkerProfileConditionProvider, WorkerProfileConditionProvider>();
+
                 if (!applicationHostOptions.HasParentScope)
                 {
                     AddCommonServices(services);
@@ -346,6 +351,8 @@ namespace Microsoft.Azure.WebJobs.Script
             services.TryAddSingleton<IWorkerConsoleLogSource, WorkerConsoleLogSource>();
             services.AddSingleton<IWorkerProcessFactory, DefaultWorkerProcessFactory>();
             services.AddSingleton<IRpcWorkerProcessFactory, RpcWorkerProcessFactory>();
+            services.AddSingleton<IWorkerProfileManager, WorkerProfileManager>();
+            services.AddSingleton<IWorkerProfileConditionProvider, WorkerProfileConditionProvider>();
             services.TryAddSingleton<IWebHostRpcWorkerChannelManager, WebHostRpcWorkerChannelManager>();
             services.TryAddSingleton<IDebugManager, DebugManager>();
             services.TryAddSingleton<IDebugStateProvider, DebugStateProvider>();

--- a/src/WebJobs.Script/Workers/Profiles/EnvironmentCondition.cs
+++ b/src/WebJobs.Script/Workers/Profiles/EnvironmentCondition.cs
@@ -1,0 +1,82 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Text.RegularExpressions;
+using Microsoft.Azure.WebJobs.Script.Workers.Profiles;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.Workers
+{
+    /// <summary>
+    /// An implementation of an <see cref="IWorkerProfileCondition"/> that checks if
+    /// environment variables match the expected output
+    /// </summary>
+    public class EnvironmentCondition : IWorkerProfileCondition
+    {
+        private readonly ILogger _logger;
+        private readonly IEnvironment _environment;
+        private readonly string _name;
+        private readonly string _expression;
+        private Regex _regex;
+
+        internal EnvironmentCondition(ILogger logger, IEnvironment environment, WorkerProfileConditionDescriptor descriptor)
+        {
+            if (descriptor is null)
+            {
+                throw new ArgumentNullException(nameof(descriptor));
+            }
+
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _environment = environment ?? throw new ArgumentNullException(nameof(environment));
+
+            descriptor.Properties.TryGetValue(WorkerConstants.WorkerDescriptionProfileConditionName, out _name);
+            descriptor.Properties.TryGetValue(WorkerConstants.WorkerDescriptionProfileConditionExpression, out _expression);
+
+            Validate();
+        }
+
+        public string Name => _name;
+
+        public string Expression => _expression;
+
+        /// <inheritdoc />
+        public bool Evaluate()
+        {
+            string value = _environment.GetEnvironmentVariable(Name);
+
+            if (string.IsNullOrEmpty(value))
+            {
+                return false;
+            }
+
+            _logger.LogDebug($"Evaluating EnvironmentCondition with value '{value}' and expression '{Expression}'");
+
+            return _regex.IsMatch(value);
+        }
+
+        // Validates if condition parametrs meet expected values, fail if they don't
+        private void Validate()
+        {
+            if (string.IsNullOrEmpty(Name))
+            {
+                throw new ValidationException($"EnvironmentCondition {nameof(Name)} cannot be empty.");
+            }
+
+            if (string.IsNullOrEmpty(Expression))
+            {
+                throw new ValidationException($"EnvironmentCondition {nameof(Expression)} cannot be empty.");
+            }
+
+            try
+            {
+                _regex = new Regex(Expression);
+            }
+            catch
+            {
+                throw new ValidationException($"EnvironmentCondition {nameof(Expression)} must be a valid regular expression.");
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script/Workers/Profiles/FalseCondition.cs
+++ b/src/WebJobs.Script/Workers/Profiles/FalseCondition.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script.Workers
+{
+    /// <summary>
+    /// An implementation of an <see cref="IWorkerProfileCondition"/> that always evaluates to false.
+    /// This condition is used to disable a profile when condition providers fail to resolve conditions.
+    /// </summary>
+    public class FalseCondition : IWorkerProfileCondition
+    {
+        public bool Evaluate()
+        {
+            return false;
+        }
+    }
+}

--- a/src/WebJobs.Script/Workers/Profiles/HostPropertyCondition.cs
+++ b/src/WebJobs.Script/Workers/Profiles/HostPropertyCondition.cs
@@ -1,0 +1,104 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Workers.Profiles;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.Workers
+{
+    /// <summary>
+    /// An implementation of an <see cref="IWorkerProfileCondition"/> that checks if different host properties
+    /// such as Sku, Platform, HostVersion match the expected output
+    /// </summary>
+    public class HostPropertyCondition : IWorkerProfileCondition
+    {
+        private readonly ILogger _logger;
+        private readonly ISystemRuntimeInformation _systemRuntimeInformation;
+        private readonly string _name;
+        private readonly string _expression;
+        private Regex _regex;
+
+        public HostPropertyCondition(ILogger logger, ISystemRuntimeInformation systemRuntimeInformation, WorkerProfileConditionDescriptor descriptor)
+        {
+            if (descriptor is null)
+            {
+                throw new ArgumentNullException(nameof(descriptor));
+            }
+
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _systemRuntimeInformation = systemRuntimeInformation ?? throw new ArgumentNullException(nameof(systemRuntimeInformation));
+
+            descriptor.Properties.TryGetValue(WorkerConstants.WorkerDescriptionProfileConditionName, out _name);
+            descriptor.Properties.TryGetValue(WorkerConstants.WorkerDescriptionProfileConditionExpression, out _expression);
+
+            Validate();
+        }
+
+        public enum HostProperty
+        {
+            Sku,
+            Platform,
+            HostVersion
+        }
+
+        public string Name => _name;
+
+        public string Expression => _expression;
+
+        /// <inheritdoc />
+        public bool Evaluate()
+        {
+            var hostPropertyName = Enum.Parse(typeof(HostProperty), Name, true);
+
+            string value = hostPropertyName switch
+            {
+                HostProperty.Sku => ScriptSettingsManager.Instance.GetSetting(EnvironmentSettingNames.AzureWebsiteSku),
+                HostProperty.Platform => _systemRuntimeInformation.GetOSPlatform().ToString(),
+                HostProperty.HostVersion => ScriptHost.Version,
+                _ => null
+            };
+
+            if (string.IsNullOrEmpty(value))
+            {
+                return false;
+            }
+
+            _logger.LogDebug($"Evaluating HostPropertyCondition with value: {value} and expression {Expression}");
+
+            return _regex.IsMatch(value);
+        }
+
+        // Validates if condition parametrs meet expected values, fail if they don't
+        private void Validate()
+        {
+            if (string.IsNullOrEmpty(Name))
+            {
+               throw new ValidationException($"HostPropertyCondition {nameof(Name)} cannot be empty.");
+            }
+
+            if (!Enum.GetNames(typeof(HostProperty)).Any(x => x.ToLower().Contains(Name.ToLower())))
+            {
+               throw new ValidationException($"HostPropertyCondition {nameof(Name)} is not a valid host property name.");
+            }
+
+            if (string.IsNullOrEmpty(Expression))
+            {
+               throw new ValidationException($"HostPropertyCondition {nameof(Expression)} cannot be empty.");
+            }
+
+            try
+            {
+                _regex = new Regex(Expression);
+            }
+            catch
+            {
+              throw new ValidationException($"HostPropertyCondition {nameof(Expression)} must be a valid regular expression.");
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script/Workers/Profiles/IWorkerProfileCondition.cs
+++ b/src/WebJobs.Script/Workers/Profiles/IWorkerProfileCondition.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script.Workers
+{
+    /// <summary>
+    /// Interface for different types of profile conditions
+    /// </summary>
+    public interface IWorkerProfileCondition
+    {
+        /// <summary>
+        /// Check if different condition type meet their criteria
+        /// </summary>
+        bool Evaluate();
+    }
+}

--- a/src/WebJobs.Script/Workers/Profiles/IWorkerProfileConditionProvider.cs
+++ b/src/WebJobs.Script/Workers/Profiles/IWorkerProfileConditionProvider.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script.Workers.Profiles
+{
+    /// <summary>
+    /// Interface to manage different profile condition providers
+    /// </summary>
+    internal interface IWorkerProfileConditionProvider
+    {
+        /// <summary>
+        /// Factory method to create a profile condition
+        /// </summary>
+        bool TryCreateCondition(WorkerProfileConditionDescriptor descriptor, out IWorkerProfileCondition condition);
+    }
+}

--- a/src/WebJobs.Script/Workers/Profiles/IWorkerProfileManager.cs
+++ b/src/WebJobs.Script/Workers/Profiles/IWorkerProfileManager.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Script.Workers.Profiles;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+
+namespace Microsoft.Azure.WebJobs.Script.Workers
+{
+    /// <summary>
+    /// Interface to regulate profile operations through the profile manager
+    /// </summary>
+    public interface IWorkerProfileManager
+    {
+        /// <summary>
+        /// Creates profile condition using different condition descriptor properties
+        /// </summary>
+        bool TryCreateWorkerProfileCondition(WorkerProfileConditionDescriptor conditionDescriptor, out IWorkerProfileCondition condition);
+
+        /// <summary>
+        /// Set the different profiles for a given worker runtime language
+        /// </summary>
+        void SetWorkerDescriptionProfiles(List<WorkerDescriptionProfile> workerDescriptionProfiles, string language);
+
+        /// <summary>
+        /// Load a profile that meets it's conditions
+        /// </summary>
+        void LoadWorkerDescriptionFromProfiles(RpcWorkerDescription defaultWorkerDescription, out RpcWorkerDescription workerDescription);
+
+        /// <summary>
+        /// Verify if the current profile's conditions have changed
+        /// </summary>
+        bool IsCorrectProfileLoaded(string workerRuntime);
+    }
+}

--- a/src/WebJobs.Script/Workers/Profiles/WorkerDescriptionProfile.cs
+++ b/src/WebJobs.Script/Workers/Profiles/WorkerDescriptionProfile.cs
@@ -1,0 +1,96 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+
+namespace Microsoft.Azure.WebJobs.Script.Workers
+{
+    /// <summary>
+    /// Class that holds data of a profile
+    /// </summary>
+    public class WorkerDescriptionProfile
+    {
+        public WorkerDescriptionProfile(string name, List<IWorkerProfileCondition> conditions, RpcWorkerDescription profileDescription)
+        {
+            Name = name;
+            Conditions = conditions;
+            ProfileDescription = profileDescription;
+            ProfileId = Guid.NewGuid().ToString();
+            Validate();
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the profile.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the conditions which must be met for the profile to be used.
+        /// </summary>
+        public List<IWorkerProfileCondition> Conditions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the worker description for the profile
+        /// </summary>
+        public RpcWorkerDescription ProfileDescription { get; set; }
+
+        public string ProfileId { get; }
+
+        private void Validate()
+        {
+            if (string.IsNullOrEmpty(Name))
+            {
+                throw new ValidationException($"WorkerDescriptionProfile {nameof(Name)} cannot be empty");
+            }
+
+            if (Conditions == null || Conditions.Count < 1)
+            {
+                throw new ValidationException($"WorkerDescriptionProfile {nameof(Conditions)} cannot be empty");
+            }
+
+            if (ProfileDescription == null)
+            {
+                throw new ValidationException($"WorkerDescriptionProfile {nameof(ProfileDescription)} cannot be null");
+            }
+        }
+
+        public bool EvaluateConditions()
+        {
+            foreach (var condition in Conditions)
+            {
+                if (!condition.Evaluate())
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Overrides the worker description parameters to that available in the profile
+        /// </summary>
+        public RpcWorkerDescription ApplyProfile(RpcWorkerDescription workerDescription)
+        {
+            workerDescription.Arguments = UseProfileOrDefault(ProfileDescription.Arguments, workerDescription.Arguments);
+            workerDescription.DefaultExecutablePath = UseProfileOrDefault(ProfileDescription.DefaultExecutablePath, workerDescription.DefaultExecutablePath);
+            workerDescription.DefaultWorkerPath = UseProfileOrDefault(ProfileDescription.DefaultWorkerPath, workerDescription.DefaultWorkerPath);
+            workerDescription.Extensions = UseProfileOrDefault(ProfileDescription.Extensions, workerDescription.Extensions) as List<string>;
+            workerDescription.Language = UseProfileOrDefault(ProfileDescription.Language, workerDescription.Language);
+            workerDescription.WorkerDirectory = UseProfileOrDefault(ProfileDescription.WorkerDirectory, workerDescription.WorkerDirectory);
+            return workerDescription;
+        }
+
+        private string UseProfileOrDefault(string profileParameter, string defaultParameter)
+        {
+            return string.IsNullOrEmpty(profileParameter) ? defaultParameter : profileParameter;
+        }
+
+        private IList<string> UseProfileOrDefault(IList<string> profileParameter, IList<string> defaultParameter)
+        {
+            return profileParameter != null && profileParameter.Count > 0 ? profileParameter : defaultParameter;
+        }
+    }
+}

--- a/src/WebJobs.Script/Workers/Profiles/WorkerProfileConditionDescriptor.cs
+++ b/src/WebJobs.Script/Workers/Profiles/WorkerProfileConditionDescriptor.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Script.Workers.Profiles
+{
+    public sealed class WorkerProfileConditionDescriptor
+    {
+        [JsonExtensionData]
+#pragma warning disable CS0649 // The value is assigned by the serializer
+        private IDictionary<string, JToken> _extensionData;
+#pragma warning restore CS0649
+
+        private IDictionary<string, string> _properties;
+
+        [JsonProperty(Required = Required.Always, PropertyName = WorkerConstants.WorkerDescriptionProfileConditionType)]
+        public string Type { get; set; }
+
+        public IDictionary<string, string> Properties
+        {
+            get
+            {
+                if (_properties == null)
+                {
+                    _properties = _extensionData?.ToDictionary(kv => kv.Key, kv => kv.Value.ToString()) ?? new Dictionary<string, string>();
+                }
+
+                return _properties;
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script/Workers/Profiles/WorkerProfileConditionProvider.cs
+++ b/src/WebJobs.Script/Workers/Profiles/WorkerProfileConditionProvider.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Script.Workers.Profiles;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.Workers
+{
+    internal sealed class WorkerProfileConditionProvider : IWorkerProfileConditionProvider
+    {
+        private readonly ILogger<WorkerProfileConditionProvider> _logger;
+        private readonly IEnvironment _environment;
+
+        public WorkerProfileConditionProvider(ILogger<WorkerProfileConditionProvider> logger, IEnvironment environment)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _environment = environment ?? throw new ArgumentNullException(nameof(environment));
+        }
+
+        /// <inheritdoc />
+        public bool TryCreateCondition(WorkerProfileConditionDescriptor descriptor, out IWorkerProfileCondition condition)
+        {
+            condition = descriptor.Type switch
+            {
+                WorkerConstants.WorkerDescriptionProfileHostPropertyCondition => new HostPropertyCondition(_logger, SystemRuntimeInformation.Instance, descriptor),
+                WorkerConstants.WorkerDescriptionProfileEnvironmentCondition => new EnvironmentCondition(_logger, _environment, descriptor),
+                _ => null
+            };
+
+            return condition != null;
+        }
+    }
+}

--- a/src/WebJobs.Script/Workers/Profiles/WorkerProfileDescriptor.cs
+++ b/src/WebJobs.Script/Workers/Profiles/WorkerProfileDescriptor.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+
+namespace Microsoft.Azure.WebJobs.Script.Workers.Profiles
+{
+    public sealed class WorkerProfileDescriptor
+    {
+        public string ProfileName { get; set; }
+
+        public RpcWorkerDescription Description { get; set; }
+
+        public IList<WorkerProfileConditionDescriptor> Conditions { get; set; }
+    }
+}

--- a/src/WebJobs.Script/Workers/Profiles/WorkerProfileManager.cs
+++ b/src/WebJobs.Script/Workers/Profiles/WorkerProfileManager.cs
@@ -1,0 +1,95 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Script.Workers.Profiles;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.Workers
+{
+    /// <summary>
+    /// The default profile manager that manages profiles from language workers
+    /// </summary>
+    internal class WorkerProfileManager : IWorkerProfileManager
+    {
+        private readonly ILogger _logger;
+        private readonly IEnumerable<IWorkerProfileConditionProvider> _conditionProviders;
+        private Dictionary<string, List<WorkerDescriptionProfile>> _profiles;
+        private string _activeProfile;
+
+        public WorkerProfileManager(ILogger<WorkerProfileManager> logger, IEnumerable<IWorkerProfileConditionProvider> conditionProviders)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _conditionProviders = conditionProviders ?? throw new ArgumentNullException(nameof(conditionProviders));
+            _profiles = new Dictionary<string, List<WorkerDescriptionProfile>>();
+            _activeProfile = string.Empty;
+        }
+
+        /// <inheritdoc />
+        public void SetWorkerDescriptionProfiles(List<WorkerDescriptionProfile> workerDescriptionProfiles, string language)
+        {
+            _profiles[language] = workerDescriptionProfiles;
+        }
+
+        // Evaluate profile conditions for a language
+        private bool GetEvaluatedProfile(string language, out WorkerDescriptionProfile evaluatedProfile)
+        {
+            if (_profiles.TryGetValue(language, out List<WorkerDescriptionProfile> profiles))
+            {
+                foreach (var profile in profiles)
+                {
+                    if (profile.EvaluateConditions())
+                    {
+                        evaluatedProfile = profile;
+                        return true;
+                    }
+                }
+            }
+            evaluatedProfile = null;
+            return false;
+        }
+
+        /// <inheritdoc />
+        public void LoadWorkerDescriptionFromProfiles(RpcWorkerDescription defaultWorkerDescription, out RpcWorkerDescription workerDescription)
+        {
+            if (GetEvaluatedProfile(defaultWorkerDescription.Language, out WorkerDescriptionProfile profile))
+            {
+                _logger?.LogInformation($"Worker initialized with profile - {profile.Name}, Profile ID {profile.ProfileId} from worker config.");
+                _activeProfile = profile.ProfileId;
+                workerDescription = profile.ApplyProfile(defaultWorkerDescription);
+                return;
+            }
+            workerDescription = defaultWorkerDescription;
+        }
+
+        /// <inheritdoc />
+        public bool TryCreateWorkerProfileCondition(WorkerProfileConditionDescriptor conditionDescriptor, out IWorkerProfileCondition condition)
+        {
+            foreach (var provider in _conditionProviders)
+            {
+                if (provider.TryCreateCondition(conditionDescriptor, out condition))
+                {
+                    return true;
+                }
+            }
+
+            _logger.LogInformation("Unable to create profile condition for condition type '{conditionType}'", conditionDescriptor.Type);
+
+            condition = null;
+            return false;
+        }
+
+        /// <inheritdoc />
+        public bool IsCorrectProfileLoaded(string workerRuntime)
+        {
+            var profileId = string.Empty;
+            if (GetEvaluatedProfile(workerRuntime, out WorkerDescriptionProfile profile))
+            {
+               profileId = profile.ProfileId;
+            }
+            return _activeProfile.Equals(profileId);
+        }
+    }
+}

--- a/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -26,13 +26,21 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         private readonly ILoggerFactory _loggerFactory = null;
         private readonly IRpcWorkerChannelFactory _rpcWorkerChannelFactory;
         private readonly IMetricsLogger _metricsLogger;
+        private readonly IWorkerProfileManager _profileManager;
         private string _workerRuntime;
         private Action _shutdownStandbyWorkerChannels;
         private IConfiguration _config;
 
         private ConcurrentDictionary<string, Dictionary<string, TaskCompletionSource<IRpcWorkerChannel>>> _workerChannels = new ConcurrentDictionary<string, Dictionary<string, TaskCompletionSource<IRpcWorkerChannel>>>(StringComparer.OrdinalIgnoreCase);
 
-        public WebHostRpcWorkerChannelManager(IScriptEventManager eventManager, IEnvironment environment, ILoggerFactory loggerFactory, IRpcWorkerChannelFactory rpcWorkerChannelFactory, IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, IMetricsLogger metricsLogger, IOptionsMonitor<LanguageWorkerOptions> languageWorkerOptions, IConfiguration config)
+        public WebHostRpcWorkerChannelManager(IScriptEventManager eventManager,
+                                              IEnvironment environment,
+                                              ILoggerFactory loggerFactory,
+                                              IRpcWorkerChannelFactory rpcWorkerChannelFactory,
+                                              IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions,
+                                              IMetricsLogger metricsLogger, IOptionsMonitor<LanguageWorkerOptions> languageWorkerOptions,
+                                              IConfiguration config,
+                                              IWorkerProfileManager profileManager)
         {
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
             _eventManager = eventManager;
@@ -43,6 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             _applicationHostOptions = applicationHostOptions;
             _lanuageworkerOptions = languageWorkerOptions;
             _config = config ?? throw new ArgumentNullException(nameof(config));
+            _profileManager = profileManager ?? throw new ArgumentNullException(nameof(profileManager));
 
             _shutdownStandbyWorkerChannels = ScheduleShutdownStandbyChannels;
             _shutdownStandbyWorkerChannels = _shutdownStandbyWorkerChannels.Debounce(milliseconds: 5000);
@@ -137,6 +146,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 // Restart worker process if custom languageWorkers:[runtime]:arguments are passed in
                 var workerArguments = _config.GetSection($"{RpcWorkerConstants.LanguageWorkersSectionName}:{workerRuntime}:{WorkerConstants.WorkerDescriptionArguments}").Value;
                 if (!string.IsNullOrEmpty(workerArguments))
+                {
+                    return false;
+                }
+
+                // If a profile evaluates to true and was not previously loaded, restart worker process
+                if (!_profileManager.IsCorrectProfileLoaded(workerRuntime))
                 {
                     return false;
                 }

--- a/src/WebJobs.Script/Workers/RuntimeInformation/SystemRuntimeInformation.cs
+++ b/src/WebJobs.Script/Workers/RuntimeInformation/SystemRuntimeInformation.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Azure.WebJobs.Script.Workers
+{
+    public class SystemRuntimeInformation : ISystemRuntimeInformation
+    {
+        private static OSPlatform? _platform;
+        private static Lazy<SystemRuntimeInformation> _runtimeInformationInstance = new Lazy<SystemRuntimeInformation>(() => new SystemRuntimeInformation());
+
+        public static ISystemRuntimeInformation Instance => _runtimeInformationInstance.Value;
+
+        public Architecture GetOSArchitecture()
+        {
+            return RuntimeInformation.OSArchitecture;
+        }
+
+        public OSPlatform GetOSPlatform()
+        {
+            if (_platform == null)
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    _platform = OSPlatform.Windows;
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    _platform = OSPlatform.OSX;
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    _platform = OSPlatform.Linux;
+                }
+            }
+
+            return _platform.Value;
+        }
+    }
+}

--- a/src/WebJobs.Script/Workers/WorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/WorkerConstants.cs
@@ -29,6 +29,13 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
 
         // Profiles
         public const string WorkerDescriptionProfiles = "profiles";
+        public const string WorkerDescriptionProfileName = "profileName";
+        public const string WorkerDescriptionProfileConditions = "conditions";
+        public const string WorkerDescriptionProfileConditionType = "conditionType";
+        public const string WorkerDescriptionProfileEnvironmentCondition = "environment";
+        public const string WorkerDescriptionProfileHostPropertyCondition = "hostProperty";
+        public const string WorkerDescriptionProfileConditionName = "conditionName";
+        public const string WorkerDescriptionProfileConditionExpression = "conditionExpression";
         public const string WorkerDescriptionAppServiceEnvProfileName = "appServiceEnvironment";
 
         // Logs

--- a/test/WebJobs.Script.Tests.Shared/TestLogger.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestLogger.cs
@@ -10,6 +10,12 @@ using Microsoft.Extensions.Logging;
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public class TestLogger<T> : TestLogger, ILogger<T>
+    {
+        public TestLogger() : base(typeof(T).Name) { }
+    }
+
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class TestLogger : ILogger
     {
         private readonly object _syncLock = new object();

--- a/test/WebJobs.Script.Tests/Configuration/LanguageWorkerOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/LanguageWorkerOptionsSetupTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -18,16 +19,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         [InlineData("node")]
         public void LanguageWorkerOptions_Expected_ListOfConfigs(string workerRuntime)
         {
+            var runtimeInfo = new TestSystemRuntimeInformation();
             var testEnvironment = new TestEnvironment();
             var configurationBuilder = new ConfigurationBuilder()
                 .Add(new ScriptEnvironmentVariablesConfigurationSource());
+
+            var profileConditionProvider = new WorkerProfileConditionProvider(new TestLogger<WorkerProfileConditionProvider>(), testEnvironment);
+            var profileConditionManager = new WorkerProfileManager(new TestLogger<WorkerProfileManager>(), new[] { profileConditionProvider });
 
             var configuration = configurationBuilder.Build();
             if (!string.IsNullOrEmpty(workerRuntime))
             {
                 testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, workerRuntime);
             }
-            LanguageWorkerOptionsSetup setup = new LanguageWorkerOptionsSetup(configuration, NullLoggerFactory.Instance, testEnvironment, new TestMetricsLogger());
+            LanguageWorkerOptionsSetup setup = new LanguageWorkerOptionsSetup(configuration, NullLoggerFactory.Instance, testEnvironment, profileConditionManager, new TestMetricsLogger());
             LanguageWorkerOptions options = new LanguageWorkerOptions();
             setup.Configure(options);
             if (string.IsNullOrEmpty(workerRuntime))

--- a/test/WebJobs.Script.Tests/Workers/Profiles/EnvironmentConditionTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Profiles/EnvironmentConditionTests.cs
@@ -1,0 +1,74 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.Azure.WebJobs.Script.Tests;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Workers.Profiles
+{
+    public class EnvironmentConditionTests
+    {
+        private TestEnvironment _testEnvironment = new TestEnvironment();
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", "")]
+        [InlineData("", null)]
+        [InlineData(null, "")]
+        [InlineData("APPLICATIONINSIGHTS_ENABLE_AGENT", null)]
+        [InlineData("APPLICATIONINSIGHTS_ENABLE_AGENT", "")]
+        [InlineData(null, "true")]
+        [InlineData("", "true")]
+        public void EnvironmentConditionTest_ThrowsValidationException(string name, string expression)
+        {
+            var testLogger = new TestLogger("test");
+            var descriptor = new WorkerProfileConditionDescriptor();
+            descriptor.Type = WorkerConstants.WorkerDescriptionProfileEnvironmentCondition;
+
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = name;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = expression;
+
+            Assert.Throws<ValidationException>(() => new EnvironmentCondition(testLogger, _testEnvironment, descriptor));
+        }
+
+        [Theory]
+        [InlineData("APPLICATIONINSIGHTS_ENABLE_AGENT", "true", "true")]
+        [InlineData("APPLICATIONINSIGHTS_ENABLE_AGENT", "^((?!true).)*$", "false")]
+        public void EnvironmentConditionTest_EvaluateTrue(string name, string testExpression, string environmentSetting)
+        {
+            _testEnvironment.SetEnvironmentVariable(name, environmentSetting);
+
+            var testLogger = new TestLogger("test");
+
+            var descriptor = new WorkerProfileConditionDescriptor();
+            descriptor.Type = WorkerConstants.WorkerDescriptionProfileEnvironmentCondition;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = name;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = testExpression;
+
+            var environmentCondition = new EnvironmentCondition(testLogger, _testEnvironment, descriptor);
+
+            Assert.True(environmentCondition.Evaluate());
+        }
+
+        [Theory]
+        [InlineData("APPLICATIONINSIGHTS_ENABLE_AGENT", "true", "false")]
+        [InlineData("APPLICATIONINSIGHTS_ENABLE_AGENT", "^((?!true).)*$", "true")]
+        public void EnvironmentConditionTest_EvaluateFalse(string name, string testExpression, string environmentSetting)
+        {
+            _testEnvironment.SetEnvironmentVariable(name, environmentSetting);
+
+            var testLogger = new TestLogger("test");
+
+            var descriptor = new WorkerProfileConditionDescriptor();
+            descriptor.Type = WorkerConstants.WorkerDescriptionProfileEnvironmentCondition;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = name;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = testExpression;
+
+            var environmentCondition = new EnvironmentCondition(testLogger, _testEnvironment, descriptor);
+
+            Assert.False(environmentCondition.Evaluate(), "Expression evaluates to false");
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Workers/Profiles/FalseConditionTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Profiles/FalseConditionTests.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Workers.Profiles
+{
+    public class FalseConditionTests
+    {
+        [Fact]
+        public void FalseCondition_EvaluesFalse()
+        {
+            var falseCondition = new FalseCondition();
+            Assert.False(falseCondition.Evaluate(), "False condition must always return false");
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Workers/Profiles/HostPropertyConditionTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Profiles/HostPropertyConditionTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.ComponentModel.DataAnnotations;
+using Microsoft.Azure.WebJobs.Script.Tests;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Workers.Profiles
+{
+    public class HostPropertyConditionTests
+    {
+        private TestSystemRuntimeInformation _testSystemRuntimeInfo = new TestSystemRuntimeInformation();
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", "")]
+        [InlineData("", null)]
+        [InlineData(null, "")]
+        [InlineData("sku", null)]
+        [InlineData("Platform", "")]
+        [InlineData("HostVersion", null)]
+        [InlineData("APPLICATIONINSIGHTS_ENABLE_AGENT", "")]
+        [InlineData(null, "true")]
+        [InlineData("", "true")]
+        public void HostPropertyConditionTest_ThrowsValidationException(string name, string expression)
+        {
+            var testLogger = new TestLogger("test");
+            var descriptor = new WorkerProfileConditionDescriptor();
+            descriptor.Type = WorkerConstants.WorkerDescriptionProfileHostPropertyCondition;
+
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = name;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = expression;
+
+            Assert.Throws<ValidationException>(() => new HostPropertyCondition(testLogger, _testSystemRuntimeInfo, descriptor));
+        }
+
+        [Theory]
+        //[InlineData("sku", "Dynamic")] TODO: Add test case
+        [InlineData("platForm", "LINUX")]
+        [InlineData("HostVersion", "3.*")]
+        public void HostPropertyConditionTest_EvaluateTrue(string name, string testExpression)
+        {
+            var testLogger = new TestLogger("test");
+
+            var descriptor = new WorkerProfileConditionDescriptor();
+            descriptor.Type = WorkerConstants.WorkerDescriptionProfileHostPropertyCondition;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = name;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = testExpression;
+
+            var hostPropertyCondition = new HostPropertyCondition(testLogger, _testSystemRuntimeInfo, descriptor);
+
+            Assert.True(hostPropertyCondition.Evaluate());
+        }
+
+        [Theory]
+        //[InlineData("sku", "Dynamic")] TODO: Add test case
+        [InlineData("platForm", "Windows")]
+        [InlineData("HostVersion", "-1")]
+        public void HostPropertyConditionTest_EvaluateFalse(string name, string testExpression)
+        {
+            var testLogger = new TestLogger("test");
+
+            var descriptor = new WorkerProfileConditionDescriptor();
+            descriptor.Type = WorkerConstants.WorkerDescriptionProfileHostPropertyCondition;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = name;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = testExpression;
+
+            var hostPropertyCondition = new HostPropertyCondition(testLogger, _testSystemRuntimeInfo, descriptor);
+
+            Assert.False(hostPropertyCondition.Evaluate(), "Expression evaluates to false");
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Workers/Profiles/ProfilesTestUtilities.cs
+++ b/test/WebJobs.Script.Tests/Workers/Profiles/ProfilesTestUtilities.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Azure.WebJobs.Script.Workers.Profiles;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles
+{
+    public class ProfilesTestUtilities
+    {
+        public static JObject GetTestWorkerProfileCondition(string type = WorkerConstants.WorkerDescriptionProfileHostPropertyCondition, string name = "hostVersion", string expression = "3.*")
+        {
+            var condition = new JObject();
+            condition[WorkerConstants.WorkerDescriptionProfileConditionType] = type;
+            condition[WorkerConstants.WorkerDescriptionProfileConditionName] = name;
+            condition[WorkerConstants.WorkerDescriptionProfileConditionExpression] = expression;
+            return condition;
+        }
+
+        public static WorkerProfileConditionDescriptor GetTestWorkerProfileConditionDescriptor(string type, string name, string expression)
+        {
+            var condition = GetTestWorkerProfileCondition(type, name, expression);
+            return condition.ToObject<WorkerProfileConditionDescriptor>();
+        }
+
+        public static EnvironmentCondition GetTestEnvironmentCondition(TestLogger logger, TestEnvironment testEnvironment, string name, string expression)
+        {
+            var descriptor = new WorkerProfileConditionDescriptor();
+            descriptor.Type = WorkerConstants.WorkerDescriptionProfileEnvironmentCondition;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = name;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = expression;
+
+            return new EnvironmentCondition(logger, testEnvironment, descriptor);
+        }
+
+        public static HostPropertyCondition GetTestHostPropertyCondition(TestLogger logger, TestSystemRuntimeInformation testSystemRuntimeInfo, string name, string expression)
+        {
+            var descriptor = new WorkerProfileConditionDescriptor();
+            descriptor.Type = WorkerConstants.WorkerDescriptionProfileHostPropertyCondition;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = name;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = expression;
+
+            return new HostPropertyCondition(logger, testSystemRuntimeInfo, descriptor);
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Workers/Profiles/WorkerDescriptionProfileTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Profiles/WorkerDescriptionProfileTests.cs
@@ -1,0 +1,120 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.Azure.WebJobs.Script.Tests;
+using Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles;
+using Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Workers.Profiles
+{
+    public class WorkerDescriptionProfileTests
+    {
+        private static TestEnvironment _testEnvironment = new TestEnvironment();
+        private static TestSystemRuntimeInformation _testSystemRuntimeInfo = new TestSystemRuntimeInformation();
+        private static TestLogger _testLogger = new TestLogger("test");
+
+        private static string[] argumentList = new string[] { "-TestArg=1" };
+
+        [Theory]
+        [MemberData(nameof(WorkerDescriptionProfileExceptionData))]
+        public void WorkerDescriptionProfile_ThrowsValidationException(string name, List<IWorkerProfileCondition> coditions, RpcWorkerDescription workerDescription)
+        {
+            Assert.Throws<ValidationException>(() => new WorkerDescriptionProfile(name, coditions, workerDescription));
+        }
+
+        public static IEnumerable<object[]> WorkerDescriptionProfileExceptionData()
+        {
+            var description = RpcWorkerConfigTestUtilities.GetTestDefaultWorkerDescription("java", argumentList);
+
+            var validConditionsList = new List<IWorkerProfileCondition>();
+            validConditionsList.Add(ProfilesTestUtilities.GetTestEnvironmentCondition(_testLogger, _testEnvironment, "APPLICATIONINSIGHTS_ENABLE_AGENT", "true"));
+            validConditionsList.Add(ProfilesTestUtilities.GetTestHostPropertyCondition(_testLogger, _testSystemRuntimeInfo, "hostversion", "3.*"));
+
+            yield return new object[] { null, validConditionsList,  description };
+            yield return new object[] { string.Empty, validConditionsList, description };
+            yield return new object[] { "profileName", new List<IWorkerProfileCondition>(0), description };
+            yield return new object[] { "profileName", null, description };
+            yield return new object[] { "profileName", new List<IWorkerProfileCondition>(1), description };
+        }
+
+        [Theory]
+        [MemberData(nameof(WorkerDescriptionProfileData))]
+        public void WorkerDescriptionProfile_ApplyProfile(string name, List<IWorkerProfileCondition> coditions, RpcWorkerDescription workerDescription)
+        {
+            _testEnvironment.SetEnvironmentVariable("APPLICATIONINSIGHTS_ENABLE_AGENT", "true");
+            var defaultDescription = RpcWorkerConfigTestUtilities.GetTestDefaultWorkerDescription("java", new string[] { "-DefaultArgs" });
+
+            var workerDescriptionProfile = new WorkerDescriptionProfile(name, coditions, workerDescription);
+            defaultDescription = workerDescriptionProfile.ApplyProfile(defaultDescription);
+
+            Assert.Equal(defaultDescription.Arguments[0], argumentList[0]);
+            Assert.NotEqual(defaultDescription.Arguments[0], "-DefaultArgs");
+        }
+
+        public static IEnumerable<object[]> WorkerDescriptionProfileData()
+        {
+            var description = RpcWorkerConfigTestUtilities.GetTestDefaultWorkerDescription("java", argumentList);
+
+            var validConditionsList = new List<IWorkerProfileCondition>();
+            validConditionsList.Add(ProfilesTestUtilities.GetTestEnvironmentCondition(_testLogger, _testEnvironment, "APPLICATIONINSIGHTS_ENABLE_AGENT", "true"));
+            yield return new object[] { "profileName", validConditionsList, description };
+
+            validConditionsList.Add(ProfilesTestUtilities.GetTestHostPropertyCondition(_testLogger, _testSystemRuntimeInfo, "hostversion", "3.*"));
+            yield return new object[] { "profileName", validConditionsList, description };
+        }
+
+        [Theory]
+        [MemberData(nameof(WorkerDescriptionProfileInvalidData))]
+        public void WorkerDescriptionProfile_DoNotApplyProfile(string name, List<IWorkerProfileCondition> coditions, RpcWorkerDescription workerDescription)
+        {
+            _testEnvironment.SetEnvironmentVariable("APPLICATIONINSIGHTS_ENABLE_AGENT", "false");
+            var defaultDescription = RpcWorkerConfigTestUtilities.GetTestDefaultWorkerDescription("java", new string[] { "-DefaultArgs" });
+
+            var workerDescriptionProfile = new WorkerDescriptionProfile(name, coditions, workerDescription);
+            defaultDescription = workerDescriptionProfile.ApplyProfile(defaultDescription);
+
+            Assert.NotNull(defaultDescription.Arguments[0]);
+            Assert.Equal(defaultDescription.Arguments[0], "-DefaultArgs");
+        }
+
+        public static IEnumerable<object[]> WorkerDescriptionProfileInvalidData()
+        {
+            var description = RpcWorkerConfigTestUtilities.GetTestDefaultWorkerDescription("java", new string[] { });
+
+            var validConditionsList = new List<IWorkerProfileCondition>();
+            validConditionsList.Add(ProfilesTestUtilities.GetTestEnvironmentCondition(_testLogger, _testEnvironment, "APPLICATIONINSIGHTS_ENABLE_AGENT", "true"));
+            yield return new object[] { "profileName", validConditionsList, description };
+
+            validConditionsList.Add(ProfilesTestUtilities.GetTestHostPropertyCondition(_testLogger, _testSystemRuntimeInfo, "hostversion", "3.*"));
+            yield return new object[] { "profileName", validConditionsList, description };
+        }
+
+        [Fact]
+        public void WorkerDescriptionProfile_EvaluateConditions()
+        {
+            var description = RpcWorkerConfigTestUtilities.GetTestDefaultWorkerDescription("java", argumentList);
+
+            var conditions = new List<IWorkerProfileCondition>();
+            conditions.Add(ProfilesTestUtilities.GetTestEnvironmentCondition(_testLogger, _testEnvironment, "APPLICATIONINSIGHTS_ENABLE_AGENT", "true"));
+
+            var workerDescriptionProfile = new WorkerDescriptionProfile("profileName", conditions, description);
+            Assert.False(workerDescriptionProfile.EvaluateConditions());
+
+            _testEnvironment.SetEnvironmentVariable("APPLICATIONINSIGHTS_ENABLE_AGENT", "true");
+            Assert.True(workerDescriptionProfile.EvaluateConditions());
+
+            conditions.Add(ProfilesTestUtilities.GetTestHostPropertyCondition(_testLogger, _testSystemRuntimeInfo, "hostversion", "3.*"));
+            workerDescriptionProfile = new WorkerDescriptionProfile("profileName", conditions, description);
+            Assert.True(workerDescriptionProfile.EvaluateConditions());
+
+            conditions.Add(ProfilesTestUtilities.GetTestHostPropertyCondition(_testLogger, _testSystemRuntimeInfo, "platform", "windows"));
+            workerDescriptionProfile = new WorkerDescriptionProfile("profileName", conditions, description);
+
+            Assert.False(workerDescriptionProfile.EvaluateConditions());
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Workers/Profiles/WorkerProfileConditionDescriptorTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Profiles/WorkerProfileConditionDescriptorTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Workers.Profiles
+{
+    public class WorkerProfileConditionDescriptorTests
+    {
+        [Fact]
+        public void ConditionDescriptor_ConvertsJObject()
+        {
+            var conditionJObject = new JObject();
+            conditionJObject[WorkerConstants.WorkerDescriptionProfileConditionName] = WorkerConstants.WorkerDescriptionProfileConditionName;
+            conditionJObject[WorkerConstants.WorkerDescriptionProfileConditionExpression] = WorkerConstants.WorkerDescriptionProfileConditionExpression;
+
+            Assert.Throws<JsonSerializationException>(() => conditionJObject.ToObject<WorkerProfileConditionDescriptor>());
+
+            conditionJObject[WorkerConstants.WorkerDescriptionProfileConditionType] = WorkerConstants.WorkerDescriptionProfileEnvironmentCondition;
+
+            var conditionDescriptor = conditionJObject.ToObject<WorkerProfileConditionDescriptor>();
+            conditionDescriptor.Properties.TryGetValue(WorkerConstants.WorkerDescriptionProfileConditionName, out string conditionDescriptorName);
+            conditionDescriptor.Properties.TryGetValue(WorkerConstants.WorkerDescriptionProfileConditionExpression, out string conditionDescriptorExpression);
+
+            Assert.Equal(WorkerConstants.WorkerDescriptionProfileConditionName, conditionDescriptorName);
+            Assert.Equal(WorkerConstants.WorkerDescriptionProfileConditionExpression, conditionDescriptorExpression);
+            Assert.Equal(WorkerConstants.WorkerDescriptionProfileEnvironmentCondition, conditionDescriptor.Type);
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
@@ -17,12 +17,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 {
     public class RpcWorkerConfigFactoryTests : IDisposable
     {
+        private readonly WorkerProfileManager _profileManager;
         private TestSystemRuntimeInformation _testSysRuntimeInfo = new TestSystemRuntimeInformation();
         private TestEnvironment _testEnvironment;
 
         public RpcWorkerConfigFactoryTests()
         {
             _testEnvironment = new TestEnvironment();
+
+            var profileConditionProvider = new WorkerProfileConditionProvider(new TestLogger<WorkerProfileConditionProvider>(), _testEnvironment);
+            _profileManager = new WorkerProfileManager(new TestLogger<WorkerProfileManager>(), new[] { profileConditionProvider });
         }
 
         public void Dispose()
@@ -36,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var expectedWorkersDir = Path.Combine(Path.GetDirectoryName(new Uri(typeof(RpcWorkerConfigFactory).Assembly.CodeBase).LocalPath), RpcWorkerConstants.DefaultWorkersDirectoryName);
             var config = new ConfigurationBuilder().Build();
             var testLogger = new TestLogger("test");
-            var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger());
+            var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _profileManager, _testEnvironment, new TestMetricsLogger());
             Assert.Equal(expectedWorkersDir, configFactory.WorkersDirPath);
         }
 
@@ -69,7 +73,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                    })
                    .Build();
             var testLogger = new TestLogger("test");
-            var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger());
+            var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _profileManager, _testEnvironment, new TestMetricsLogger());
             Assert.Equal(expectedWorkersDir, configFactory.WorkersDirPath);
         }
 
@@ -85,7 +89,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var config = configBuilder.Build();
             var scriptSettingsManager = new ScriptSettingsManager(config);
             var testLogger = new TestLogger("test");
-            var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger());
+            var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _profileManager, _testEnvironment, new TestMetricsLogger());
             Assert.Equal(expectedWorkersDir, configFactory.WorkersDirPath);
         }
 
@@ -96,7 +100,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var config = configBuilder.Build();
             var scriptSettingsManager = new ScriptSettingsManager(config);
             var testLogger = new TestLogger("test");
-            var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger());
+            var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _profileManager, _testEnvironment, new TestMetricsLogger());
             var workerConfigs = configFactory.GetConfigs();
             var javaPath = workerConfigs.Where(c => c.Description.Language.Equals("java", StringComparison.OrdinalIgnoreCase)).FirstOrDefault().Description.DefaultExecutablePath;
             Assert.DoesNotContain(@"%JAVA_HOME%", javaPath);
@@ -117,7 +121,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var testLogger = new TestLogger("test");
             using (var variables = new TestScopedSettings(scriptSettingsManager, testEnvVariables))
             {
-                var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger());
+                var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _profileManager, _testEnvironment, new TestMetricsLogger());
                 var workerConfigs = configFactory.GetConfigs();
                 var pythonWorkerConfig = workerConfigs.Where(w => w.Description.Language.Equals("python", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
                 var powershellWorkerConfig = workerConfigs.Where(w => w.Description.Language.Equals("powershell", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
@@ -139,7 +143,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var config = configBuilder.Build();
             var scriptSettingsManager = new ScriptSettingsManager(config);
             var testLogger = new TestLogger("test");
-            var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, testEnvironment, new TestMetricsLogger());
+            var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _profileManager, testEnvironment, new TestMetricsLogger());
             var workerConfigs = configFactory.GetConfigs();
             var powershellWorkerConfig = workerConfigs.Where(w => w.Description.Language.Equals("powershell", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
             Assert.Equal(1, workerConfigs.Count);
@@ -166,7 +170,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             }
             var config = new ConfigurationBuilder().Build();
             var testLogger = new TestLogger("test");
-            RpcWorkerConfigFactory rpcWorkerConfigFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger());
+            RpcWorkerConfigFactory rpcWorkerConfigFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _profileManager, _testEnvironment, new TestMetricsLogger());
             _testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, workerRuntime);
             Assert.Equal(expectedResult, rpcWorkerConfigFactory.ShouldAddWorkerConfig(workerLanguage));
         }
@@ -196,7 +200,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             }
             var config = new ConfigurationBuilder().Build();
             var testLogger = new TestLogger("test");
-            RpcWorkerConfigFactory rpcWorkerConfigFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger());
+            RpcWorkerConfigFactory rpcWorkerConfigFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _profileManager, _testEnvironment, new TestMetricsLogger());
             var result = rpcWorkerConfigFactory.GetWorkerProcessCount(workerConfig);
             if (defaultWorkerConfig)
             {
@@ -240,7 +244,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             var config = new ConfigurationBuilder().Build();
             var testLogger = new TestLogger("test");
-            RpcWorkerConfigFactory rpcWorkerConfigFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger());
+            RpcWorkerConfigFactory rpcWorkerConfigFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _profileManager, _testEnvironment, new TestMetricsLogger());
             var resultEx1 = Assert.Throws<ArgumentOutOfRangeException>(() => rpcWorkerConfigFactory.GetWorkerProcessCount(workerConfig));
             Assert.Contains("ProcessCount must be greater than 0", resultEx1.Message);
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTestUtilities.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTestUtilities.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Newtonsoft.Json.Linq;
@@ -17,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         public const string HttpWorkerExe = "httpServer.exe";
         public const string TestDefaultExecutablePath = "testWorkerPath";
 
-        public static JObject GetTestWorkerConfig(string language, string[] arguments, bool invalid, string profileName, bool emptyWorkerPath = false)
+        public static JObject GetTestWorkerConfig(string language, string[] arguments, bool invalid, string profileName, bool invalidProfile, bool emptyWorkerPath = false)
         {
             WorkerDescription description = GetTestDefaultWorkerDescription(language, arguments);
 
@@ -31,8 +32,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                     DefaultExecutablePath = "myFooPath",
                 };
 
-                JObject profiles = new JObject();
-                profiles[profileName] = JObject.FromObject(appSvcDescription);
+                var profiles = new JArray();
+                var profile = new JObject();
+                var conditions = new JArray();
+                profile[WorkerConstants.WorkerDescriptionProfileName] = "profileName";
+                if (invalidProfile)
+                {
+                    conditions.Add(ProfilesTestUtilities.GetTestWorkerProfileCondition(WorkerConstants.WorkerDescriptionProfileHostPropertyCondition, "hostVersion", "-1"));
+                }
+                conditions.Add(ProfilesTestUtilities.GetTestWorkerProfileCondition());
+                profile[WorkerConstants.WorkerDescriptionProfileConditions] = conditions;
+                profile[WorkerConstants.WorkerDescription] = JObject.FromObject(appSvcDescription);
+                profiles.Add(profile);
                 config[WorkerConstants.WorkerDescriptionProfiles] = profiles;
             }
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
@@ -24,13 +24,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         private static string customRootPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         private static string testLanguagePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         private static string testLanguage = "testLanguage";
-
         private readonly TestSystemRuntimeInformation _testSysRuntimeInfo = new TestSystemRuntimeInformation();
         private readonly TestEnvironment _testEnvironment;
+        private readonly WorkerProfileManager _profileManager;
 
         public RpcWorkerConfigTests()
         {
             _testEnvironment = new TestEnvironment();
+
+            var profileConditionProvider = new WorkerProfileConditionProvider(new TestLogger<WorkerProfileConditionProvider>(), _testEnvironment);
+            _profileManager = new WorkerProfileManager(new TestLogger<WorkerProfileManager>(), new[] { profileConditionProvider });
         }
 
         public static IEnumerable<object[]> InvalidWorkerDescriptions
@@ -112,7 +115,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         [Fact]
         public void ReadWorkerProviderFromConfig_EmptyWorkerPath()
         {
-            var configs = new List<TestRpcWorkerConfig>() { MakeTestConfig(testLanguage, new string[0], false, string.Empty, true) };
+            var configs = new List<TestRpcWorkerConfig>() { MakeTestConfig(testLanguage, new string[0], false, string.Empty, false, true) };
             TestMetricsLogger testMetricsLogger = new TestMetricsLogger();
 
             var workerConfigs = TestReadWorkerProviderFromConfig(configs, new TestLogger(testLanguage), testMetricsLogger);
@@ -202,7 +205,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         public void ReadWorkerProviderFromConfig_AddProfile_ReturnsDefaultDescription()
         {
             var expectedArguments = new string[] { "-v", "verbose" };
-            var configs = new List<TestRpcWorkerConfig>() { MakeTestConfig(testLanguage, expectedArguments, false, "TestProfile") };
+            var configs = new List<TestRpcWorkerConfig>() { MakeTestConfig(testLanguage, expectedArguments, false, "TestProfile", true) };
             var testLogger = new TestLogger(testLanguage);
             TestMetricsLogger testMetricsLogger = new TestMetricsLogger();
 
@@ -682,7 +685,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
                 var scriptHostOptions = new ScriptJobHostOptions();
                 var scriptSettingsManager = new ScriptSettingsManager(config);
-                var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, testMetricsLogger);
+                var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _profileManager, _testEnvironment, testMetricsLogger);
                 if (appSvcEnv)
                 {
                     var testEnvVariables = new Dictionary<string, string>
@@ -721,9 +724,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             return config;
         }
 
-        private static TestRpcWorkerConfig MakeTestConfig(string language, string[] arguments, bool invalid = false, string addAppSvcProfile = "", bool emptyWorkerPath = false)
+        private static TestRpcWorkerConfig MakeTestConfig(string language, string[] arguments, bool invalid = false, string addAppSvcProfile = "", bool invalidProfile = false, bool emptyWorkerPath = false)
         {
-            string json = RpcWorkerConfigTestUtilities.GetTestWorkerConfig(language, arguments, invalid, addAppSvcProfile, emptyWorkerPath).ToString();
+            string json = RpcWorkerConfigTestUtilities.GetTestWorkerConfig(language, arguments, invalid, addAppSvcProfile, invalidProfile, emptyWorkerPath).ToString();
             return new TestRpcWorkerConfig()
             {
                 Json = json,

--- a/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
@@ -34,6 +34,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         private readonly Mock<IWorkerProcess> _rpcWorkerProcess;
         private readonly TestLogger _testLogger;
         private readonly IConfiguration _emptyConfig;
+        private readonly TestSystemRuntimeInformation _testSysRuntimeInfo = new TestSystemRuntimeInformation();
+        private readonly WorkerProfileManager _profileManager;
 
         private WebHostRpcWorkerChannelManager _rpcWorkerChannelManager;
 
@@ -71,7 +73,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _testLogger = new TestLogger("WebHostLanguageWorkerChannelManagerTests");
             _rpcWorkerChannelFactory = new TestRpcWorkerChannelFactory(_eventManager, _testLogger, _scriptRootPath);
             _emptyConfig = new ConfigurationBuilder().Build();
-            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, new TestMetricsLogger(), _workerOptionsMonitor, _emptyConfig);
+            var profileConditionProvider = new WorkerProfileConditionProvider(new TestLogger<WorkerProfileConditionProvider>(), _testEnvironment);
+            _profileManager = new WorkerProfileManager(new TestLogger<WorkerProfileManager>(), new[] { profileConditionProvider });
+            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, new TestMetricsLogger(), _workerOptionsMonitor, _emptyConfig, _profileManager);
         }
 
         [Fact]
@@ -92,7 +96,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         {
             var testMetricsLogger = new TestMetricsLogger();
             _testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, RpcWorkerConstants.JavaLanguageWorkerName);
-            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, testMetricsLogger, _workerOptionsMonitor, _emptyConfig);
+            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, testMetricsLogger, _workerOptionsMonitor, _emptyConfig, _profileManager);
 
             IRpcWorkerChannel javaWorkerChannel = CreateTestChannel(RpcWorkerConstants.JavaLanguageWorkerName);
 
@@ -113,7 +117,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         {
             var testMetricsLogger = new TestMetricsLogger();
             _testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, RpcWorkerConstants.DotNetLanguageWorkerName);
-            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, testMetricsLogger, _workerOptionsMonitor, _emptyConfig);
+            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, testMetricsLogger, _workerOptionsMonitor, _emptyConfig, _profileManager);
 
             IRpcWorkerChannel javaWorkerChannel = CreateTestChannel(RpcWorkerConstants.JavaLanguageWorkerName);
             IRpcWorkerChannel nodeWorkerChannel = CreateTestChannel(RpcWorkerConstants.NodeLanguageWorkerName);
@@ -152,7 +156,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         {
             var testMetricsLogger = new TestMetricsLogger();
             _testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, RpcWorkerConstants.NodeLanguageWorkerName);
-            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, testMetricsLogger, _workerOptionsMonitor, _emptyConfig);
+            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, testMetricsLogger, _workerOptionsMonitor, _emptyConfig, _profileManager);
 
             IRpcWorkerChannel javaWorkerChannel = CreateTestChannel(RpcWorkerConstants.JavaLanguageWorkerName);
 
@@ -175,7 +179,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, runtime);
             _optionsMonitor.CurrentValue.IsFileSystemReadOnly = true;
 
-            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, testMetricsLogger, _workerOptionsMonitor, _emptyConfig);
+            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, testMetricsLogger, _workerOptionsMonitor, _emptyConfig, _profileManager);
 
             IRpcWorkerChannel workerChannel = CreateTestChannel(languageWorkerName);
 
@@ -204,7 +208,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, RpcWorkerConstants.JavaLanguageWorkerName);
             _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteZipDeployment, "0");
 
-            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, testMetricsLogger, _workerOptionsMonitor, _emptyConfig);
+            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, testMetricsLogger, _workerOptionsMonitor, _emptyConfig, _profileManager);
 
             IRpcWorkerChannel javaWorkerChannel = CreateTestChannel(RpcWorkerConstants.JavaLanguageWorkerName);
 
@@ -234,7 +238,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, RpcWorkerConstants.JavaLanguageWorkerName);
             _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteZipDeployment, "1");
 
-            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, testMetricsLogger, _workerOptionsMonitor, _emptyConfig);
+            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, testMetricsLogger, _workerOptionsMonitor, _emptyConfig, _profileManager);
 
             IRpcWorkerChannel javaWorkerChannel = CreateTestChannel(RpcWorkerConstants.JavaLanguageWorkerName);
 
@@ -268,7 +272,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             // This is an invalid setting configuration, but just to show that run from zip is NOT set
             _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteZipDeployment, "0");
 
-            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, testMetricsLogger, _workerOptionsMonitor, _emptyConfig);
+            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, testMetricsLogger, _workerOptionsMonitor, _emptyConfig, _profileManager);
 
             IRpcWorkerChannel workerChannel = CreateTestChannel(languageWorkerName);
 
@@ -301,7 +305,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                    [$"{RpcWorkerConstants.LanguageWorkersSectionName}:{languageWorkerName}:{WorkerConstants.WorkerDescriptionArguments}"] = argument
                 })
                 .Build();
-            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, testMetricsLogger, _workerOptionsMonitor, config);
+            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, testMetricsLogger, _workerOptionsMonitor, config, _profileManager);
 
             IRpcWorkerChannel workerChannel = CreateTestChannel(languageWorkerName);
 
@@ -327,7 +331,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionsV2CompatibilityModeKey, "true");
             _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionsExtensionVersion, "~3");
 
-            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, testMetricsLogger, _workerOptionsMonitor, _emptyConfig);
+            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, testMetricsLogger, _workerOptionsMonitor, _emptyConfig, _profileManager);
 
             IRpcWorkerChannel workerChannel = CreateTestChannel(languageWorkerName);
 
@@ -402,7 +406,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         public async Task InitializeLanguageWorkerChannel_ThrowsOnProcessStartup()
         {
             var rpcWorkerChannelFactory = new TestRpcWorkerChannelFactory(_eventManager, null, _scriptRootPath, throwOnProcessStartUp: true);
-            var rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, rpcWorkerChannelFactory, _optionsMonitor, new TestMetricsLogger(), _workerOptionsMonitor, _emptyConfig);
+            var rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, rpcWorkerChannelFactory, _optionsMonitor, new TestMetricsLogger(), _workerOptionsMonitor, _emptyConfig, _profileManager);
             var rpcWorkerChannel = await rpcWorkerChannelManager.InitializeLanguageWorkerChannel("test", _scriptRootPath);
             var ex = await Assert.ThrowsAsync<AggregateException>(async () => await rpcWorkerChannelManager.GetChannelAsync("test"));
             Assert.Contains("Process startup failed", ex.InnerException.Message);


### PR DESCRIPTION
resolves #8184

Design doc: https://dev.azure.com/msazure/One/_git/AAPT-Antares-Docs/pullrequest/5715621?_a=files

### Issue describing the changes in this PR
Profiles enable workers to change how the worker is configured based on certain conditions, for example a worker may want to configure
itself differently for a consumption application vs a dedicated application. The profiles will be defined in the `worker.config.json` file
and will essentially override the default worker description based on a set of conditions.

The Java worker team is working on a prototype where an Application Insights (AI) agent is deployed along side the Java worker
to handle telemetry and logging to AI. Depending on the SKU and environment variables, the AI agent should be used. 
Profiles will be used to add arguments required to enable the agent. 

Sample `worker.config.json` with profiles 
``` json 
{
  "description": { ... }, // this will always be the default worker configuration
  "profiles": [
    {
      "profileName": "profile1",
      "conditions": [
        { "conditionType": "environment", "conditionName": "APP_SETTING_NAME", "conditionExpression": "app_setting_value" }
      ],
      "description": {
        "arguments": ["-DmyNewArg"]
      }
    },
    {
      "profileName": "profile2",
      "conditions": [
        { "conditionType": "hostProperty", "conditionName": "sku", "conditionExpression": "consumption" }
      ],
      "description": {
        "defaultWorkerPath": "",
        "arguments": []
      }
    }
  ]
}
```


### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] I have added all required tests (Unit tests, E2E tests)