### PR TITLE
Parse and log WorkerMetadata information

### DIFF
--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -258,9 +258,10 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
             if (_initMessage.WorkerMetadata != null)
             {
-                _initMessage.WorkerMetadata = ParseWorkerMetadata(_initMessage.WorkerMetadata);
-                _metricsLogger.LogEvent(MetricEventNames.WorkerMetadata, functionName: null, _initMessage.WorkerMetadata.ToString());
-                _workerChannelLogger.LogDebug($"Worker metadata: {_initMessage.WorkerMetadata}");
+                _initMessage.ParseWorkerMetadata(_workerConfig);
+                var workerMetadata = _initMessage.WorkerMetadata.ToString();
+                _metricsLogger.LogEvent(MetricEventNames.WorkerMetadata, functionName: null, workerMetadata);
+                _workerChannelLogger.LogDebug($"Worker metadata: {workerMetadata}");
             }
 
             if (_initMessage.Result.IsFailure(out Exception exc))
@@ -281,15 +282,6 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             }
 
             _workerInitTask.SetResult(true);
-        }
-
-        private WorkerMetadata ParseWorkerMetadata(WorkerMetadata workerMetadata)
-        {
-            workerMetadata.RuntimeName = string.IsNullOrEmpty(workerMetadata.RuntimeName)
-                                            ? _workerConfig.Description.Language : workerMetadata.RuntimeName;
-            workerMetadata.RuntimeVersion = string.IsNullOrEmpty(workerMetadata.RuntimeVersion)
-                                            ? _workerConfig.Description.DefaultRuntimeVersion : workerMetadata.RuntimeVersion;
-            return workerMetadata;
         }
 
         public void SetupFunctionInvocationBuffers(IEnumerable<FunctionMetadata> functions)

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -254,13 +254,9 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
             _workerChannelLogger.LogDebug("Received WorkerInitResponse. Worker process initialized");
             _initMessage = initEvent.Message.WorkerInitResponse;
+            _workerChannelLogger.LogDebug($"Worker capabilities: {_initMessage.Capabilities}");
 
             ParseAndLogWorkerMetadata();
-
-            using (_workerChannelLogger.BeginScope(_initMessage.WorkerMetadata))
-            {
-                _workerChannelLogger.LogDebug($"Worker capabilities: {_initMessage.Capabilities}");
-            }
 
             if (_initMessage.Result.IsFailure(out Exception exc))
             {
@@ -282,7 +278,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             _workerInitTask.SetResult(true);
         }
 
-        internal void ParseAndLogWorkerMetadata()
+        private void ParseAndLogWorkerMetadata()
         {
             if (_initMessage?.WorkerMetadata == null)
             {
@@ -294,7 +290,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             _initMessage.WorkerMetadata.RuntimeVersion = string.IsNullOrEmpty(_initMessage.WorkerMetadata.RuntimeVersion)
                                                         ? _workerConfig.Description.DefaultRuntimeVersion : _initMessage.WorkerMetadata.RuntimeVersion;
 
-            _metricsLogger.LogEvent(RpcWorkerConstants.WorkerMetadataMetricEvent, null, _initMessage.WorkerMetadata.ToString());
+            _metricsLogger.LogEvent(MetricEventNames.WorkerMetadata, null, _initMessage.WorkerMetadata.ToString());
+            _workerChannelLogger.LogDebug($"Worker metadata: {_initMessage.WorkerMetadata}");
         }
 
         public void SetupFunctionInvocationBuffers(IEnumerable<FunctionMetadata> functions)

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             _workerChannelLogger.LogDebug("Received WorkerInitResponse. Worker process initialized");
             _initMessage = initEvent.Message.WorkerInitResponse;
 
-            ParseWorkerMetadata();
+            ParseAndLogWorkerMetadata();
 
             using (_workerChannelLogger.BeginScope(_initMessage.WorkerMetadata))
             {
@@ -282,15 +282,19 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             _workerInitTask.SetResult(true);
         }
 
-        internal void ParseWorkerMetadata()
+        internal void ParseAndLogWorkerMetadata()
         {
             if (_initMessage?.WorkerMetadata == null)
             {
                 return;
             }
 
-            _initMessage.WorkerMetadata.RuntimeName = string.IsNullOrEmpty(_initMessage.WorkerMetadata.RuntimeName) ? _workerConfig.Description.Language : _initMessage.WorkerMetadata.RuntimeName;
-            _initMessage.WorkerMetadata.RuntimeVersion = string.IsNullOrEmpty(_initMessage.WorkerMetadata.RuntimeVersion) ? _workerConfig.Description.DefaultRuntimeVersion : _initMessage.WorkerMetadata.RuntimeVersion;
+            _initMessage.WorkerMetadata.RuntimeName = string.IsNullOrEmpty(_initMessage.WorkerMetadata.RuntimeName)
+                                                        ? _workerConfig.Description.Language : _initMessage.WorkerMetadata.RuntimeName;
+            _initMessage.WorkerMetadata.RuntimeVersion = string.IsNullOrEmpty(_initMessage.WorkerMetadata.RuntimeVersion)
+                                                        ? _workerConfig.Description.DefaultRuntimeVersion : _initMessage.WorkerMetadata.RuntimeVersion;
+
+            _metricsLogger.LogEvent(RpcWorkerConstants.WorkerMetadataMetricEvent, null, _initMessage.WorkerMetadata.ToString());
         }
 
         public void SetupFunctionInvocationBuffers(IEnumerable<FunctionMetadata> functions)

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
             if (_initMessage.WorkerMetadata != null)
             {
-                _initMessage.ParseWorkerMetadata(_workerConfig);
+                _initMessage.UpdateWorkerMetadata(_workerConfig);
                 var workerMetadata = _initMessage.WorkerMetadata.ToString();
                 _metricsLogger.LogEvent(MetricEventNames.WorkerMetadata, functionName: null, workerMetadata);
                 _workerChannelLogger.LogDebug($"Worker metadata: {workerMetadata}");

--- a/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageExtensionUtilities.cs
+++ b/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageExtensionUtilities.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             return new Tuple<string, string, CookieOptions>(cookie.Name, cookie.Value, cookieOptions);
         }
 
-        internal static void ParseWorkerMetadata(this WorkerInitResponse initResponse, RpcWorkerConfig workerConfig)
+        internal static void UpdateWorkerMetadata(this WorkerInitResponse initResponse, RpcWorkerConfig workerConfig)
         {
             initResponse.WorkerMetadata.RuntimeName = string.IsNullOrEmpty(initResponse.WorkerMetadata.RuntimeName)
                                             ? workerConfig.Description.Language : initResponse.WorkerMetadata.RuntimeName;

--- a/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageExtensionUtilities.cs
+++ b/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageExtensionUtilities.cs
@@ -7,6 +7,7 @@ using System.Dynamic;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 
 namespace Microsoft.Azure.WebJobs.Script.Grpc
 {
@@ -75,6 +76,14 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             }
 
             return new Tuple<string, string, CookieOptions>(cookie.Name, cookie.Value, cookieOptions);
+        }
+
+        internal static void ParseWorkerMetadata(this WorkerInitResponse initResponse, RpcWorkerConfig workerConfig)
+        {
+            initResponse.WorkerMetadata.RuntimeName = string.IsNullOrEmpty(initResponse.WorkerMetadata.RuntimeName)
+                                            ? workerConfig.Description.Language : initResponse.WorkerMetadata.RuntimeName;
+            initResponse.WorkerMetadata.RuntimeVersion = string.IsNullOrEmpty(initResponse.WorkerMetadata.RuntimeVersion)
+                                            ? workerConfig.Description.DefaultRuntimeVersion : initResponse.WorkerMetadata.RuntimeVersion;
         }
 
         private static SameSiteMode RpcSameSiteEnumConverter(RpcHttpCookie.Types.SameSite sameSite)

--- a/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
 
         // LanguageWorkerChannel events
         public const string FunctionLoadRequestResponse = "rpcworkerchannel.functionloadrequestresponse";
+        public const string WorkerMetadata = "rpcworkerchannel.workerinitresponse.workermetadata";
 
         // ScriptStartupTypeLocator events
         public const string ParseExtensions = "ScriptStartupTypeLocator.ParseExtensions";

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         // Rpc message length
         public const int DefaultMaxMessageLengthBytes = int.MaxValue;
 
-        // Capabilites
+        // Capabilities
         public const string RawHttpBodyBytes = "RawHttpBodyBytes";
         public const string TypedDataCollection = "TypedDataCollection";
         public const string RpcHttpBodyOnly = "RpcHttpBodyOnly";
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public const string FunctionDataCache = "FunctionDataCache";
         public const string AcceptsListOfFunctionLoadRequests = "AcceptsListOfFunctionLoadRequests";
 
-        // Host Capabilites
+        // Host Capabilities
         public const string V2Compatable = "V2Compatable";
 
         // dotnet executable file path components
@@ -63,5 +63,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public const string PythonThreadpoolThreadCount = "PYTHON_THREADPOOL_THREAD_COUNT";
         public const string PSWorkerInProcConcurrencyUpperBound = "PSWorkerInProcConcurrencyUpperBound";
         public const string DefaultConcurrencyLimit = "1000";
+
+        // Metric events
+        public const string WorkerMetadataMetricEvent = "WorkerMetadata";
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
@@ -63,8 +63,5 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public const string PythonThreadpoolThreadCount = "PYTHON_THREADPOOL_THREAD_COUNT";
         public const string PSWorkerInProcConcurrencyUpperBound = "PSWorkerInProcConcurrencyUpperBound";
         public const string DefaultConcurrencyLimit = "1000";
-
-        // Metric events
-        public const string WorkerMetadataMetricEvent = "WorkerMetadata";
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/TestFunctionRpcService.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/TestFunctionRpcService.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _eventManager.Publish(new InboundGrpcEvent(_workerId, responseMessage));
         }
 
-        public void PublishWorkerInitResponseEvent(IDictionary<string, string> capabilities = null)
+        public void PublishWorkerInitResponseEvent(IDictionary<string, string> capabilities = null, WorkerMetadata workerMetadata = null)
         {
             StatusResult statusResult = new StatusResult()
             {
@@ -87,6 +87,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             if (capabilities != null)
             {
                 initResponse.Capabilities.Add(capabilities);
+            }
+
+            if (workerMetadata != null)
+            {
+                initResponse.WorkerMetadata = workerMetadata;
             }
 
             StreamingMessage responseMessage = new StreamingMessage()


### PR DESCRIPTION
Logging WorkerMetadata information as a debug log and a metric event. Defaulting to information from worker config for language and runtime version

### Issue describing the changes in this PR

resolves #8452

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
 
### Testing

Metric shows up in FunctionMetrics table:

![Screen Shot 2022-06-17 at 3 00 20 PM](https://user-images.githubusercontent.com/2198905/174406975-95a2e4f9-f67f-40d3-b7f8-5014260c1c86.png)

Log shows up in FunctionLogs table:

![Screen Shot 2022-06-17 at 2 59 27 PM](https://user-images.githubusercontent.com/2198905/174406946-fac054a8-5415-42cd-8ed5-043f57e0c409.png)