### PR TITLE
Update DefaultMaxRequestBodySize

### DIFF
--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public static readonly ImmutableArray<string> AssemblyFileTypes = ImmutableArray.Create(".dll", ".exe");
         public static readonly string HostUserAgent = $"azure-functions-host/{ScriptHost.Version}";
         public static readonly NuGetVersion ExtensionBundleVersionTwo = new NuGetVersion("2.0.0");
-        public static readonly long DefaultMaxRequestBodySize = 104857600;
+        public static readonly long DefaultMaxRequestBodySize = 5242880000;
 
         public static readonly ImmutableArray<string> SystemLogCategoryPrefixes = ImmutableArray.Create("Microsoft.Azure.WebJobs.", "Function.", "Worker.", "Host.");
 


### PR DESCRIPTION
This is my request to update the DefaultMaxRequestBodySize to 5000 Mb. To make it easier to use azure functions as an in and out endpoint for large blob files.
I also thinks this is more consistent with the Maximum blob size via single write operation (via Put Blob).
Link: https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
