### PR TITLE
Do not throw when dotnet-isolated app deployed without payload

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,4 +7,3 @@
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+125%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+125%22+label%3Afeature+is%3Aclosed) ]
 - Fix the bug where debugging of dotnet isolated function apps hangs in visual studio (#8596)
 - Host does not throw anymore for dotnet-isolated app without deployed payload (#8311)
-- 

--- a/release_notes.md
+++ b/release_notes.md
@@ -5,3 +5,4 @@
 - Update Python Worker Version to [4.4.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.4.0)
 **Release sprint:** Sprint 125
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+125%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+125%22+label%3Afeature+is%3Aclosed) ]
+- Host does not throw anymore for dotnet-isolated app without deployed payload (#8311)

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -277,8 +277,16 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
             var workerConfig = _workerConfigs.Where(c => c.Description.Language.Equals(_workerRuntime, StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault();
 
+            // For dotnet isolated workerConfig is populated by reading workerconfig.json from the deployed payload
+            var isDotnetIsolatedApp = string.Equals(_workerRuntime, RpcWorkerConstants.DotNetIsolatedLanguageWorkerName, StringComparison.InvariantCultureIgnoreCase);
+            var isDotNetIsolatedAppWithoutPayload = isDotnetIsolatedApp && workerConfig == null;
+
+            _logger.LogInformation($"isDotnetIsolatedApp: {isDotnetIsolatedApp}, isDotNetIsolatedAppWithoutPayload:{isDotNetIsolatedAppWithoutPayload}");
+
             // We are skipping this check for multi-language environments because they use multiple workers and thus doesn't honor 'FUNCTIONS_WORKER_RUNTIME'
-            if ((workerConfig == null && (functions == null || functions.Count() == 0)) && !_environment.IsMultiLanguageRuntimeEnvironment())
+            if ((workerConfig == null && (functions == null || functions.Count() == 0))
+                && !_environment.IsMultiLanguageRuntimeEnvironment()
+                && !isDotNetIsolatedAppWithoutPayload)
             {
                 // Only throw if workerConfig is null AND some functions have been found.
                 // With .NET out-of-proc, worker config comes from functions.

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -277,13 +277,14 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
             var workerConfig = _workerConfigs.Where(c => c.Description.Language.Equals(_workerRuntime, StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault();
 
-            // For dotnet isolated workerConfig is populated by reading workerconfig.json from the deployed payload
-            var isDotnetIsolatedApp = string.Equals(_workerRuntime, RpcWorkerConstants.DotNetIsolatedLanguageWorkerName, StringComparison.InvariantCultureIgnoreCase);
-            var isDotNetIsolatedAppWithoutPayload = isDotnetIsolatedApp && workerConfig == null;
-
-            _logger.LogInformation($"isDotnetIsolatedApp: {isDotnetIsolatedApp}, isDotNetIsolatedAppWithoutPayload:{isDotNetIsolatedAppWithoutPayload}");
+            // For other OOP workers, workerconfigs are present inside "workers" folder of host bin directory and is used to populate "_workerConfigs".
+            // For dotnet-isolated _workerConfigs is populated by reading workerconfig.json from the deployed payload(customer function app code).
+            // So if workerConfig is null and worker runtime is dotnet-isolated, that means isolated function code was not deployed yet.
+            var isDotNetIsolatedAppWithoutPayload = string.Equals(_workerRuntime, RpcWorkerConstants.DotNetIsolatedLanguageWorkerName, StringComparison.InvariantCultureIgnoreCase)
+                                                    && workerConfig == null;
 
             // We are skipping this check for multi-language environments because they use multiple workers and thus doesn't honor 'FUNCTIONS_WORKER_RUNTIME'
+            // Also, skip if dotnet-isoalted app without payload as it is a valid case to exist.
             if ((workerConfig == null && (functions == null || functions.Count() == 0))
                 && !_environment.IsMultiLanguageRuntimeEnvironment()
                 && !isDotNetIsolatedAppWithoutPayload)

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                                                     && workerConfig == null;
 
             // We are skipping this check for multi-language environments because they use multiple workers and thus doesn't honor 'FUNCTIONS_WORKER_RUNTIME'
-            // Also, skip if dotnet-isoalted app without payload as it is a valid case to exist.
+            // Also, skip if dotnet-isolated app without payload as it is a valid case to exist.
             if ((workerConfig == null && (functions == null || functions.Count() == 0))
                 && !_environment.IsMultiLanguageRuntimeEnvironment()
                 && !isDotNetIsolatedAppWithoutPayload)

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         // This will override the default directories.
         public const string FunctionsUnixSharedMemoryDirectories = "FUNCTIONS_UNIX_SHARED_MEMORY_DIRECTORIES";
         public const string DotNetLanguageWorkerName = "dotnet";
+        public const string DotNetIsolatedLanguageWorkerName = "dotnet-isolated";
         public const string NodeLanguageWorkerName = "node";
         public const string JavaLanguageWorkerName = "java";
         public const string PowerShellLanguageWorkerName = "powershell";

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
@@ -331,6 +331,27 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
+        public async Task InitializeAsync_Throws_When_Worker_Config_not_found()
+        {
+            // Our GetTestFunctionDispatcher return a dispatcher with 2 worker configs loaded(java, node)
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(runtime: "python");
+
+            Func<Task> task = () => functionDispatcher.InitializeAsync(new List<FunctionMetadata>());
+
+            InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(task);
+            Assert.Equal("WorkerConfig for runtime: python not found", exception.Message);
+        }
+
+        [Fact]
+        public async Task InitializeAsync_DoesNotThrow_ForDotNetIsolatedWithoutDeployedPayload()
+        {
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(runtime: RpcWorkerConstants.DotNetIsolatedLanguageWorkerName);
+
+            // Should not throw for dotnet-isolated runtime.
+            await functionDispatcher.InitializeAsync(new List<FunctionMetadata>());
+        }
+
+        [Fact]
         public async Task FunctionDispatcherState_Default_NoFunctions()
         {
             RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(runtime: RpcWorkerConstants.NodeLanguageWorkerName);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #8311

Currently, when a new function app is created and `FUNCTIONS_WORKER_RUNTIME` app setting is set to `dotnet-isolated` host will throw an exception as shown in #8311 

For all other OOP language workers, the host code includes a "workers" folder inside which we have workerconfig.json for each of the worker implementations. Host code[ reads these files](https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs#L90) to populate the _workerConfig collection from which we will [get the workerConfig for the current app](https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs#L278). For dotnet-isolated, we do not follow this approach. Instead the workerconfig.json is included in the customer's deployed payload(the isolated function app binaries). In this PR, I am adding an additional check to determine whether we are dealing with a dotnet-isolated app without deployed payload and then skips the code path which throws the exception.

I tested this version of host by deploying this as a private site extension and verified the fix is working.
1. Portal was not showing the "worker config not found" error.
2. Deploying a dotnet isolated app to this function app worked fine.


Note: For dotnet-isolated apps, the workerconfig.json includes the worker executable name(Ex: `MyApp.dll`) and we do not know what that would be, so we cannot ship this config with the host like other worker implementations.


### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)


