### PR TITLE
Fix for dotnet-isolated function app debugging hang issue

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,3 +5,4 @@
 - Update Python Worker Version to [4.4.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.4.0)
 **Release sprint:** Sprint 125
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+125%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+125%22+label%3Afeature+is%3Aclosed) ]
+- Fix the bug where debugging of dotnet isolated function apps hangs in visual studio (#8596)

--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcessUtilities.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcessUtilities.cs
@@ -43,10 +43,5 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         {
             return consoleLog.Message.StartsWith(WorkerConstants.ToolingConsoleLogPrefix, StringComparison.OrdinalIgnoreCase);
         }
-
-        public static string RemoveToolingConsoleJsonLogPrefix(string msg)
-        {
-            return Regex.Replace(msg, WorkerConstants.ToolingConsoleLogPrefix, string.Empty, RegexOptions.IgnoreCase);
-        }
     }
 }

--- a/src/WebJobs.Script/Workers/WorkerConsoleLogService.cs
+++ b/src/WebJobs.Script/Workers/WorkerConsoleLogService.cs
@@ -65,8 +65,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
 
                     if (WorkerProcessUtilities.IsToolingConsoleJsonLogEntry(consoleLog))
                     {
-                        _toolingConsoleJsonLoggerLazy.Value.Log(consoleLog.Level,
-                            WorkerProcessUtilities.RemoveToolingConsoleJsonLogPrefix(consoleLog.Message));
+                        _toolingConsoleJsonLoggerLazy.Value.Log(consoleLog.Level, consoleLog.Message);
                     }
                     else
                     {

--- a/src/WebJobs.Script/Workers/WorkerConsoleLogService.cs
+++ b/src/WebJobs.Script/Workers/WorkerConsoleLogService.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
 
                     if (WorkerProcessUtilities.IsToolingConsoleJsonLogEntry(consoleLog))
                     {
+                        // log with the message prefix as coretools expects it.
                         _toolingConsoleJsonLoggerLazy.Value.Log(consoleLog.Level, consoleLog.Message);
                     }
                     else

--- a/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
@@ -73,13 +73,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             {
                 VerifyLogLevel(userLogs, "Test Message No keyword", LogLevel.Error);
                 VerifyLogLevel(systemLogs, "[Test Worker Message No keyword]", LogLevel.Error);
-                VerifyLogLevel(toolingConsoleLogs, "Azure Functions .NET Worker (PID: 4) initialized in debug mode.", LogLevel.Error);
+                VerifyLogLevel(toolingConsoleLogs, "azfuncjsonlog:Azure Functions .NET Worker (PID: 4) initialized in debug mode.", LogLevel.Error);
             }
             else
             {
                 VerifyLogLevel(userLogs, "Test Message No keyword", LogLevel.Information);
                 VerifyLogLevel(systemLogs, "[Test Worker Message No keyword]", LogLevel.Information);
-                VerifyLogLevel(toolingConsoleLogs, "Azure Functions .NET Worker (PID: 4) initialized in debug mode.", LogLevel.Information);
+                VerifyLogLevel(toolingConsoleLogs, "azfuncjsonlog:Azure Functions .NET Worker (PID: 4) initialized in debug mode.", LogLevel.Information);
             }
         }
 
@@ -88,7 +88,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             var message = allLogs.FirstOrDefault(l => l.FormattedMessage.Contains(msg));
             Assert.NotNull(message);
             Assert.DoesNotContain(WorkerConstants.LanguageWorkerConsoleLogPrefix, message.FormattedMessage);
-            Assert.DoesNotContain(WorkerConstants.ToolingConsoleLogPrefix, message.FormattedMessage);
             Assert.Equal(expectedLevel, message.Level);
         }
     }

--- a/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             workerProcess.ParseErrorMessageAndLog("LanguageWorkerConsoleLog[Test Worker Message No keyword]");
             workerProcess.ParseErrorMessageAndLog("LanguageWorkerConsoleLog[Test Worker Error Message]");
             workerProcess.ParseErrorMessageAndLog("LanguageWorkerConsoleLog[Test Worker Warning Message]");
-            workerProcess.ParseErrorMessageAndLog("azfuncjsonlog:Azure Functions .NET Worker (PID: 4) initialized in debug mode.");
+            workerProcess.ParseErrorMessageAndLog("azfuncjsonlog:{ 'name':'dotnet-worker-startup', 'workerProcessId' : 321 }");
 
             // Act
             _ = _workerConsoleLogService.ProcessLogs().ContinueWith(t => { });
@@ -73,14 +73,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             {
                 VerifyLogLevel(userLogs, "Test Message No keyword", LogLevel.Error);
                 VerifyLogLevel(systemLogs, "[Test Worker Message No keyword]", LogLevel.Error);
-                VerifyLogLevel(toolingConsoleLogs, "azfuncjsonlog:Azure Functions .NET Worker (PID: 4) initialized in debug mode.", LogLevel.Error);
+                VerifyLogLevel(toolingConsoleLogs, "azfuncjsonlog:{ 'name':'dotnet-worker-startup', 'workerProcessId' : 321 }", LogLevel.Error);
             }
             else
             {
                 VerifyLogLevel(userLogs, "Test Message No keyword", LogLevel.Information);
                 VerifyLogLevel(systemLogs, "[Test Worker Message No keyword]", LogLevel.Information);
-                VerifyLogLevel(toolingConsoleLogs, "azfuncjsonlog:Azure Functions .NET Worker (PID: 4) initialized in debug mode.", LogLevel.Information);
+                VerifyLogLevel(toolingConsoleLogs, "azfuncjsonlog:{ 'name':'dotnet-worker-startup', 'workerProcessId' : 321 }", LogLevel.Information);
             }
+
+            Assert.True(toolingConsoleLogs.All(l => l.FormattedMessage.StartsWith(WorkerConstants.ToolingConsoleLogPrefix)));
         }
 
         private static void VerifyLogLevel(IList<LogMessage> allLogs, string msg, LogLevel expectedLevel)


### PR DESCRIPTION
This is a follow up PR to fix the bug introduced in #8435 

**Context:**
In #8435, I added code to log the tooling log messages using a new logger for which the log level is always set to Informational. My PR had a bug where I was stripping out the special prefix(`azfuncjsonlog:`)of the log messages before sending it to the logger. This caused core-tools to not handle this messages properly. 

**Impact of this bug:**
Visual studio debugging for dotnet-isolated functions apps will hang. 

**Fix:**
In this PR, I deleted the code which stripped the prefix so that the message is sent as it is to the logger. Now [coretools will handle messages with this prefix as expected](https://github.com/Azure/azure-functions-core-tools/blob/v4.x/src/Azure.Functions.Cli/Diagnostics/ColoredConsoleLogger.cs#L104). 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)


### Validation

1. Created a new version of "Microsoft.Azure.WebJobs.Script.WebHost" nuget package with the host changes.
2. Consumed that nuget version in CoreTools (Azure.Functions.CLI)
3. Copied the build output of the Azure.Functions.CLI project and replaced it in the "cli_x64" of the release used by VS in local computer.
4. Verified debugging works.
5. Also verified the temporary file which VS uses (to which Coretools will write the message which include the process id).
