### PR TITLE
Hotfix 4.8.1-Fix for dotnet-isolated function app debugging hang issue

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <MajorVersion>4</MajorVersion>
     <MinorVersion>8</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <BuildNumber Condition="'$(BuildNumber)' == '' ">0</BuildNumber>
     <PreviewVersion></PreviewVersion>        
     

--- a/release_notes.md
+++ b/release_notes.md
@@ -2,7 +2,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-- Update Python Worker Version to [4.4.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.4.0)
-**Release sprint:** Sprint 125
-[ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+125%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+125%22+label%3Afeature+is%3Aclosed) ]
 - Fix the bug where debugging of dotnet isolated function apps hangs in visual studio (#8596)

--- a/release_notes.md
+++ b/release_notes.md
@@ -2,8 +2,7 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-
-- Updated Java Worker Version to [2.3.1](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.3.1)
-
-**Release sprint:** Sprint 123
-[ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+123%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+123%22+label%3Afeature+is%3Aclosed) ]
+- Update Python Worker Version to [4.4.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.4.0)
+**Release sprint:** Sprint 125
+[ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+125%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+125%22+label%3Afeature+is%3Aclosed) ]
+- Fix the bug where debugging of dotnet isolated function apps hangs in visual studio (#8596)

--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcessUtilities.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcessUtilities.cs
@@ -43,10 +43,5 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         {
             return consoleLog.Message.StartsWith(WorkerConstants.ToolingConsoleLogPrefix, StringComparison.OrdinalIgnoreCase);
         }
-
-        public static string RemoveToolingConsoleJsonLogPrefix(string msg)
-        {
-            return Regex.Replace(msg, WorkerConstants.ToolingConsoleLogPrefix, string.Empty, RegexOptions.IgnoreCase);
-        }
     }
 }

--- a/src/WebJobs.Script/Workers/WorkerConsoleLogService.cs
+++ b/src/WebJobs.Script/Workers/WorkerConsoleLogService.cs
@@ -65,8 +65,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
 
                     if (WorkerProcessUtilities.IsToolingConsoleJsonLogEntry(consoleLog))
                     {
-                        _toolingConsoleJsonLoggerLazy.Value.Log(consoleLog.Level,
-                            WorkerProcessUtilities.RemoveToolingConsoleJsonLogPrefix(consoleLog.Message));
+                        // log with the message prefix as coretools expects it.
+                        _toolingConsoleJsonLoggerLazy.Value.Log(consoleLog.Level, consoleLog.Message);
                     }
                     else
                     {

--- a/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             workerProcess.ParseErrorMessageAndLog("LanguageWorkerConsoleLog[Test Worker Message No keyword]");
             workerProcess.ParseErrorMessageAndLog("LanguageWorkerConsoleLog[Test Worker Error Message]");
             workerProcess.ParseErrorMessageAndLog("LanguageWorkerConsoleLog[Test Worker Warning Message]");
-            workerProcess.ParseErrorMessageAndLog("azfuncjsonlog:Azure Functions .NET Worker (PID: 4) initialized in debug mode.");
+            workerProcess.ParseErrorMessageAndLog("azfuncjsonlog:{ 'name':'dotnet-worker-startup', 'workerProcessId' : 321 }");
 
             // Act
             _ = _workerConsoleLogService.ProcessLogs().ContinueWith(t => { });
@@ -73,14 +73,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             {
                 VerifyLogLevel(userLogs, "Test Message No keyword", LogLevel.Error);
                 VerifyLogLevel(systemLogs, "[Test Worker Message No keyword]", LogLevel.Error);
-                VerifyLogLevel(toolingConsoleLogs, "Azure Functions .NET Worker (PID: 4) initialized in debug mode.", LogLevel.Error);
+                VerifyLogLevel(toolingConsoleLogs, "azfuncjsonlog:{ 'name':'dotnet-worker-startup', 'workerProcessId' : 321 }", LogLevel.Error);
             }
             else
             {
                 VerifyLogLevel(userLogs, "Test Message No keyword", LogLevel.Information);
                 VerifyLogLevel(systemLogs, "[Test Worker Message No keyword]", LogLevel.Information);
-                VerifyLogLevel(toolingConsoleLogs, "Azure Functions .NET Worker (PID: 4) initialized in debug mode.", LogLevel.Information);
+                VerifyLogLevel(toolingConsoleLogs, "azfuncjsonlog:{ 'name':'dotnet-worker-startup', 'workerProcessId' : 321 }", LogLevel.Information);
             }
+
+            Assert.True(toolingConsoleLogs.All(l => l.FormattedMessage.StartsWith(WorkerConstants.ToolingConsoleLogPrefix)));
         }
 
         private static void VerifyLogLevel(IList<LogMessage> allLogs, string msg, LogLevel expectedLevel)
@@ -88,7 +90,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             var message = allLogs.FirstOrDefault(l => l.FormattedMessage.Contains(msg));
             Assert.NotNull(message);
             Assert.DoesNotContain(WorkerConstants.LanguageWorkerConsoleLogPrefix, message.FormattedMessage);
-            Assert.DoesNotContain(WorkerConstants.ToolingConsoleLogPrefix, message.FormattedMessage);
             Assert.Equal(expectedLevel, message.Level);
         }
     }


### PR DESCRIPTION
Cherry picking fix from below PR on top of [4.8.0 tag](https://github.com/Azure/azure-functions-host/releases/tag/v4.8.0)

[Fix for dotnet-isolated function app debugging hang issue](https://github.com/Azure/azure-functions-host/pull/8596)

Bumped up the version to 4.8.1