### PR TITLE
Add legion host identifier

### DIFF
--- a/src/WebJobs.Script.WebHost/Configuration/CorsOptionsSetup.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/CorsOptionsSetup.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
 
         public void Configure(CorsOptions options)
         {
-            if (_env.IsLinuxConsumption())
+            if (_env.IsAnyLinuxConsumption())
             {
                 string[] allowedOrigins = _hostCorsOptions.Value.AllowedOrigins?.ToArray() ?? Array.Empty<string>();
                 var policyBuilder = new CorsPolicyBuilder(allowedOrigins);

--- a/src/WebJobs.Script.WebHost/Configuration/ScriptApplicationHostOptionsSetup.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/ScriptApplicationHostOptionsSetup.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
                 Utility.IsValidZipSetting(_environment.GetEnvironmentVariable(AzureWebsiteAltZipDeployment)) ||
                 Utility.IsValidZipSetting(_environment.GetEnvironmentVariable(AzureWebsiteRunFromPackage));
 
-            if (!_environment.IsLinuxConsumption())
+            if (!_environment.IsAnyLinuxConsumption())
             {
                 isScmRunFromPackage = false;
                 // This check is strong enough for SKUs other than Linux Consumption.

--- a/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerActivityPublisher.cs
+++ b/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerActivityPublisher.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
             IMeshServiceClient meshServiceClient, IEnvironment environment,
             ILogger<LinuxContainerActivityPublisher> logger, int flushIntervalMs = FlushIntervalMs, int initialFlushIntervalMs = InitialFlushIntervalMs)
         {
-            if (!environment.IsLinuxConsumption())
+            if (!environment.IsAnyLinuxConsumption())
             {
                 throw new NotSupportedException(
                     $"{nameof(LinuxContainerActivityPublisher)} is available in Linux consumption environment only");

--- a/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerInitializationHostService.cs
+++ b/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerInitializationHostService.cs
@@ -37,9 +37,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
             _cancellationToken = cancellationToken;
 
             // The service should be registered in Linux Consumption only, but do additional check here.
-            if (_environment.IsLinuxConsumption())
+            if (_environment.IsLinuxConsumptionOnAtlas())
             {
                 await ApplyStartContextIfPresent();
+            }
+            else if (_environment.IsLinuxConsumptionOnLegion())
+            {
+                _logger.LogInformation("Container has (re)started. Waiting for specialization");
             }
         }
 

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
             // Windows (Dedicated/Consumption)
             // Linux Consumption
-            if ((environment.IsWindowsAzureManagedHosting() || environment.IsLinuxConsumption()) &&
+            if ((environment.IsWindowsAzureManagedHosting() || environment.IsAnyLinuxConsumption()) &&
                 !environment.IsContainerReady())
             {
                 // container ready flag not set yet – site not fully specialized/initialized

--- a/src/WebJobs.Script.WebHost/Middleware/HostWarmupMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/HostWarmupMiddleware.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
             if (!_jitTraceHasRun)
             {
                 PreJitPrepare(WarmUpConstants.JitTraceFileName);
-                if (_environment.IsLinuxConsumption())
+                if (_environment.IsAnyLinuxConsumption())
                 {
                     PreJitPrepare(WarmUpConstants.LinuxJitTraceFileName);
                 }
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
         public static bool IsWarmUpRequest(HttpRequest request, bool inStandbyMode, IEnvironment environment)
         {
             return inStandbyMode
-                && ((environment.IsAppService() && request.IsAppServiceInternalRequest(environment)) || environment.IsLinuxConsumption())
+                && ((environment.IsAppService() && request.IsAppServiceInternalRequest(environment)) || environment.IsAnyLinuxConsumption())
                 && (request.Path.StartsWithSegments(_warmupRoutePath) || request.Path.StartsWithSegments(_warmupRouteAlternatePath));
         }
     }

--- a/src/WebJobs.Script.WebHost/Program.cs
+++ b/src/WebJobs.Script.WebHost/Program.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     config.Add(new WebScriptHostConfigurationSource
                     {
                         IsAppServiceEnvironment = SystemEnvironment.Instance.IsAppService(),
-                        IsLinuxContainerEnvironment = SystemEnvironment.Instance.IsLinuxConsumption(),
+                        IsLinuxContainerEnvironment = SystemEnvironment.Instance.IsAnyLinuxConsumption(),
                         IsLinuxAppServiceEnvironment = SystemEnvironment.Instance.IsLinuxAppService()
                     });
                 })
@@ -87,8 +87,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         /// </summary>
         private static void InitializeProcess()
         {
-            if (SystemEnvironment.Instance.IsLinuxConsumption())
+            if (SystemEnvironment.Instance.IsLinuxConsumptionOnAtlas())
             {
+                AppDomain.CurrentDomain.UnhandledException += CurrentDomainOnUnhandledExceptionInLinuxConsumption;
+            }
+            else if (SystemEnvironment.Instance.IsLinuxConsumptionOnLegion())
+            {
+                //todo: Replace with legion specific logger.
                 AppDomain.CurrentDomain.UnhandledException += CurrentDomainOnUnhandledExceptionInLinuxConsumption;
             }
             else if (SystemEnvironment.Instance.IsLinuxAppService())

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/DefaultKeyValueConverterFactory.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/DefaultKeyValueConverterFactory.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         private static bool IsEncryptionSupported()
         {
             return SystemEnvironment.Instance.IsAppService() ||
-                SystemEnvironment.Instance.IsLinuxConsumption() ||
+                SystemEnvironment.Instance.IsAnyLinuxConsumption() ||
                 SystemEnvironment.Instance.GetEnvironmentVariable(AzureWebsiteLocalEncryptionKey) != null;
         }
 

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -99,8 +99,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddSingleton<IEventGenerator>(p =>
             {
                 var environment = p.GetService<IEnvironment>();
-                if (environment.IsLinuxConsumption())
+                if (environment.IsLinuxConsumptionOnAtlas())
                 {
+                    return new LinuxContainerEventGenerator(environment);
+                }
+                else if (environment.IsLinuxConsumptionOnLegion())
+                {
+                    //todo: Replace with legion specific logger
                     return new LinuxContainerEventGenerator(environment);
                 }
                 else if (SystemEnvironment.Instance.IsLinuxAppService())
@@ -214,7 +219,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddSingleton<IHostedService>(s =>
             {
                 var environment = s.GetService<IEnvironment>();
-                if (environment.IsLinuxConsumption())
+                //todo: Replace with legion specific service
+                if (environment.IsAnyLinuxConsumption())
                 {
                     var instanceManager = s.GetService<IInstanceManager>();
                     var logger = s.GetService<ILogger<LinuxContainerInitializationHostService>>();
@@ -242,7 +248,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddSingleton<IMeshServiceClient>(s =>
             {
                 var environment = s.GetService<IEnvironment>();
-                if (environment.IsLinuxConsumption())
+                if (environment.IsAnyLinuxConsumption())
                 {
                     var httpClientFactory = s.GetService<IHttpClientFactory>();
                     var logger = s.GetService<ILogger<MeshServiceClient>>();
@@ -255,7 +261,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddSingleton<LinuxContainerActivityPublisher>(s =>
             {
                 var environment = s.GetService<IEnvironment>();
-                if (environment.IsLinuxConsumption())
+                if (environment.IsAnyLinuxConsumption())
                 {
                     var logger = s.GetService<ILogger<LinuxContainerActivityPublisher>>();
                     var meshInitServiceClient = s.GetService<IMeshServiceClient>();
@@ -269,7 +275,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddSingleton<IHostedService>(s =>
             {
                 var environment = s.GetService<IEnvironment>();
-                if (environment.IsLinuxConsumption())
+                if (environment.IsAnyLinuxConsumption())
                 {
                     return s.GetRequiredService<LinuxContainerActivityPublisher>();
                 }
@@ -280,7 +286,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddSingleton<ILinuxContainerActivityPublisher>(s =>
             {
                 var environment = s.GetService<IEnvironment>();
-                if (environment.IsLinuxConsumption())
+                if (environment.IsAnyLinuxConsumption())
                 {
                     return s.GetRequiredService<LinuxContainerActivityPublisher>();
                 }

--- a/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             builder.UseMiddleware<HttpRequestBodySizeMiddleware>();
             builder.UseMiddleware<SystemTraceMiddleware>();
             builder.UseMiddleware<HostnameFixupMiddleware>();
-            if (environment.IsLinuxConsumption() || environment.IsKubernetesManagedHosting())
+            if (environment.IsAnyLinuxConsumption() || environment.IsKubernetesManagedHosting())
             {
                 builder.UseMiddleware<EnvironmentReadyCheckMiddleware>();
             }

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     services.TryAddSingleton<IJobHostMiddlewarePipeline, DefaultMiddlewarePipeline>();
                     services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobHostHttpMiddleware, CustomHttpHeadersMiddleware>());
                     services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobHostHttpMiddleware, HstsConfigurationMiddleware>());
-                    if (environment.IsLinuxConsumption())
+                    if (environment.IsAnyLinuxConsumption())
                     {
                         services.AddSingleton<ICorsMiddlewareFactory, CorsMiddlewareFactory>();
                         services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobHostHttpMiddleware, JobHostCorsMiddleware>());

--- a/src/WebJobs.Script.WebHost/WebScriptHostHttpRoutesManager.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostHttpRoutesManager.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             WebJobsRouteBuilder routesBuilder = _router.CreateBuilder(new ScriptRouteHandler(_loggerFactory, host, _environment, false), _httpOptions.Value.RoutePrefix);
 
             WebJobsRouteBuilder warmupRouteBuilder = null;
-            if (!_environment.IsLinuxConsumption() && !_environment.IsWindowsConsumption())
+            if (!_environment.IsAnyLinuxConsumption() && !_environment.IsWindowsConsumption())
             {
                 warmupRouteBuilder = _router.CreateBuilder(new ScriptRouteHandler(_loggerFactory, host, _environment, isWarmup: true), routePrefix: "admin");
             }

--- a/src/WebJobs.Script/Config/ExtensionBundleConfigurationHelper.cs
+++ b/src/WebJobs.Script/Config/ExtensionBundleConfigurationHelper.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
 
                 string homeDirectory = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHomePath);
                 if ((_environment.IsAppService()
-                    || _environment.IsLinuxConsumption()
+                    || _environment.IsAnyLinuxConsumption()
                     || _environment.IsContainer())
                     && !string.IsNullOrEmpty(homeDirectory))
                 {
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
 
             var homeDirectory = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHomePath);
             if ((_environment.IsLinuxAppService()
-                || _environment.IsLinuxConsumption()
+                || _environment.IsAnyLinuxConsumption()
                 || _environment.IsContainer())
                 && !string.IsNullOrEmpty(homeDirectory))
             {

--- a/src/WebJobs.Script/Description/DotNet/Compilation/DotNetCompilationServiceFactory.cs
+++ b/src/WebJobs.Script/Description/DotNet/Compilation/DotNetCompilationServiceFactory.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                     string releaseModeSetting = SystemEnvironment.Instance.GetEnvironmentVariable(EnvironmentSettingNames.CompilationReleaseMode);
                     if (!bool.TryParse(releaseModeSetting, out bool releaseMode) &&
                         (SystemEnvironment.Instance.IsAppService() ||
-                        SystemEnvironment.Instance.IsLinuxConsumption()) &&
+                        SystemEnvironment.Instance.IsAnyLinuxConsumption()) &&
                         !SystemEnvironment.Instance.IsRemoteDebuggingEnabled())
                     {
                         // If the release mode setting is not set, we're running in Azure

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public static bool IsLinuxMetricsPublishingEnabled(this IEnvironment environment)
         {
-            return environment.IsLinuxConsumption() && string.IsNullOrEmpty(environment.GetEnvironmentVariable(ContainerStartContext));
+            return environment.IsLinuxConsumptionOnAtlas() && string.IsNullOrEmpty(environment.GetEnvironmentVariable(ContainerStartContext));
         }
 
         public static bool IsPlaceholderModeEnabled(this IEnvironment environment)
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <returns><see cref="true"/> if running in a Windows or Linux Consumption App Service app; otherwise, false.</returns>
         public static bool IsConsumptionSku(this IEnvironment environment)
         {
-            return IsWindowsConsumption(environment) || IsLinuxConsumption(environment);
+            return IsWindowsConsumption(environment) || IsAnyLinuxConsumption(environment);
         }
 
         /// <summary>
@@ -254,9 +254,23 @@ namespace Microsoft.Azure.WebJobs.Script
         /// </summary>
         /// <param name="environment">The environment to verify</param>
         /// <returns><see cref="true"/> if running in a Linux Consumption App Service app; otherwise, false.</returns>
-        public static bool IsLinuxConsumption(this IEnvironment environment)
+        public static bool IsAnyLinuxConsumption(this IEnvironment environment)
         {
-            return !environment.IsAppService() && !string.IsNullOrEmpty(environment.GetEnvironmentVariable(ContainerName));
+            return environment.IsLinuxConsumptionOnAtlas() || environment.IsLinuxConsumptionOnLegion();
+        }
+
+        public static bool IsLinuxConsumptionOnAtlas(this IEnvironment environment)
+        {
+            return !environment.IsAppService() &&
+                   !string.IsNullOrEmpty(environment.GetEnvironmentVariable(ContainerName)) &&
+                   string.IsNullOrEmpty(environment.GetEnvironmentVariable(LegionServiceHost));
+        }
+
+        public static bool IsLinuxConsumptionOnLegion(this IEnvironment environment)
+        {
+            return !environment.IsAppService() &&
+                   !string.IsNullOrEmpty(environment.GetEnvironmentVariable(ContainerName)) &&
+                   !string.IsNullOrEmpty(environment.GetEnvironmentVariable(LegionServiceHost));
         }
 
         /// <summary>
@@ -278,7 +292,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <returns><see cref="true"/> if running in a Linux Azure managed hosting environment; otherwise, false.</returns>
         public static bool IsLinuxAzureManagedHosting(this IEnvironment environment)
         {
-            return environment.IsLinuxConsumption() || environment.IsLinuxAppService();
+            return environment.IsAnyLinuxConsumption() || environment.IsLinuxAppService();
         }
 
         /// <summary>
@@ -369,7 +383,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// </summary>
         public static string GetInstanceId(this IEnvironment environment)
         {
-            if (environment.IsLinuxConsumption())
+            if (environment.IsAnyLinuxConsumption())
             {
                 return environment.GetEnvironmentVariableOrDefault(ContainerName, string.Empty);
             }

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FunctionsExtensionVersion = "FUNCTIONS_EXTENSION_VERSION";
         public const string FunctionWorkerRuntime = "FUNCTIONS_WORKER_RUNTIME";
         public const string ContainerName = "CONTAINER_NAME";
+        public const string LegionServiceHost = "LEGION_SERVICE_HOST";
         public const string WebSiteHomeStampName = "WEBSITE_HOME_STAMPNAME";
         public const string WebSiteStampDeploymentId = "WEBSITE_STAMP_DEPLOYMENT_ID";
         public const string WebSiteAuthEncryptionKey = "WEBSITE_AUTH_ENCRYPTION_KEY";

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
 
             if ((_environment.IsAppService()
                 || _environment.IsCoreTools()
-                || _environment.IsLinuxConsumption()
+                || _environment.IsAnyLinuxConsumption()
                 || _environment.IsContainer())
                 && (!bundleFound || _options.EnsureLatest))
             {

--- a/src/WebJobs.Script/Host/ScriptHostIdProvider.cs
+++ b/src/WebJobs.Script/Host/ScriptHostIdProvider.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.Script
                     hostId = uniqueSlotName;
                 }
             }
-            else if (environment.IsLinuxConsumption())
+            else if (environment.IsAnyLinuxConsumption())
             {
                 // The hostid is derived from the hostname for Linux consumption.
                 string hostName = environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName);

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.WebJobs.Script
                             // Validate the config for anything that needs the Scale Controller.
                             // Including Core Tools as a warning during development time.
                             if (environment.IsWindowsConsumption() ||
-                                environment.IsLinuxConsumption() ||
+                                environment.IsAnyLinuxConsumption() ||
                                 (environment.IsWindowsElasticPremium() && !environment.IsRuntimeScaleMonitoringEnabled()) ||
                                 environment.IsCoreTools())
                             {

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -982,7 +982,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public static FunctionAppContentEditingState GetFunctionAppContentEditingState(IEnvironment environment, IOptions<ScriptApplicationHostOptions> applicationHostOptions)
         {
             // For now, host can determine with certainty if contents are editable only for Linux Consumption apps. Return unknown for other SKUs.
-            if (!environment.IsLinuxConsumption())
+            if (!environment.IsAnyLinuxConsumption())
             {
                 return FunctionAppContentEditingState.Unknown;
             }

--- a/src/WebJobs.Script/Workers/Http/HttpWorkerProcess.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpWorkerProcess.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
             workerContext.EnvironmentVariables.Add(HttpWorkerConstants.CustomHandlerWorkerIdEnvVarName, _workerId);
             workerContext.EnvironmentVariables.Add(HttpWorkerConstants.FunctionAppRootVarName, _scriptRootPath);
             Process workerProcess = _processFactory.CreateWorkerProcess(workerContext);
-            if (_environment.IsLinuxConsumption())
+            if (_environment.IsAnyLinuxConsumption())
             {
                 AssignUserExecutePermissionsIfNotExists(workerProcess.StartInfo.FileName);
             }

--- a/test/WebJobs.Script.Tests.Integration/ContainerManagement/LinuxContainerInitializationHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ContainerManagement/LinuxContainerInitializationHostServiceTests.cs
@@ -46,7 +46,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ContainerManagement
         {
             _environment.SetEnvironmentVariable(ContainerName, null);
             _environment.SetEnvironmentVariable(AzureWebsiteInstanceId, null);
-            Assert.False(_environment.IsLinuxConsumption());
+            Assert.False(_environment.IsAnyLinuxConsumption());
+
+            var initializationHostService = new LinuxContainerInitializationHostService(_environment, _instanceManagerMock.Object, NullLogger<LinuxContainerInitializationHostService>.Instance, _startupContextProvider);
+            await initializationHostService.StartAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task Does_Not_Run_In_Linux_Container_On_Legion()
+        {
+            _environment.SetEnvironmentVariable(ContainerName, "abcd");
+            _environment.SetEnvironmentVariable(LegionServiceHost, "1");
+            Assert.True(_environment.IsAnyLinuxConsumption());
+            Assert.False(_environment.IsLinuxConsumptionOnAtlas());
+            Assert.True(_environment.IsLinuxConsumptionOnLegion());
 
             var initializationHostService = new LinuxContainerInitializationHostService(_environment, _instanceManagerMock.Object, NullLogger<LinuxContainerInitializationHostService>.Instance, _startupContextProvider);
             await initializationHostService.StartAsync(CancellationToken.None);

--- a/test/WebJobs.Script.Tests.Integration/Controllers/ControllerScenarioTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/ControllerScenarioTestFixture.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
                     config.Add(new WebScriptHostConfigurationSource
                     {
                         IsAppServiceEnvironment = SystemEnvironment.Instance.IsAppService(),
-                        IsLinuxContainerEnvironment = SystemEnvironment.Instance.IsLinuxConsumption()
+                        IsLinuxContainerEnvironment = SystemEnvironment.Instance.IsAnyLinuxConsumption()
                     });
                 })
                 .UseStartup<Startup>()

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Linux.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Linux.cs
@@ -51,7 +51,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var environment = new TestEnvironment(vars);
 
-            Assert.True(environment.IsLinuxConsumption());
+            Assert.True(environment.IsLinuxConsumptionOnAtlas());
+            Assert.False(environment.IsLinuxConsumptionOnLegion());
+            Assert.True(environment.IsAnyLinuxConsumption());
 
             await InitializeTestHostAsync("Linux", environment);
 

--- a/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
+++ b/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
@@ -213,23 +213,29 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
-        [InlineData("website-instance-id", "container-name", false)]
-        [InlineData("website-instance-id", "", false)]
-        [InlineData("website-instance-id", null, false)]
-        [InlineData("", "container-name", true)]
-        [InlineData(null, "container-name", true)]
-        [InlineData("", "", false)]
-        [InlineData(null, "", false)]
-        [InlineData("", null, false)]
-        [InlineData(null, null, false)]
-        public void Returns_IsLinuxConsumption(string websiteInstanceId, string containerName, bool isLinuxConsumption)
+        [InlineData("website-instance-id", "container-name", "1", false, false)]
+        [InlineData("website-instance-id", "container-name", "", false, false)]
+        [InlineData("website-instance-id", "", "", false, false)]
+        [InlineData("", "container-name", "1", false, true)]
+        [InlineData("", "container-name", "", true, false)]
+        [InlineData("", "container-name", "a", false, true)]
+        [InlineData(null, "container-name", "", true, false)]
+        [InlineData("", "", "", false, false)]
+        [InlineData(null, "", null, false, false)]
+        [InlineData("", null, null, false, false)]
+        [InlineData(null, null, null,  false, false)]
+        public void Returns_IsLinuxConsumption(string websiteInstanceId, string containerName, string legionServiceHost, bool isLinuxConsumptionOnAtlas, bool isLinuxConsumptionOnLegion)
         {
             var testEnvironment = new TestEnvironment();
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, websiteInstanceId);
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, containerName);
-            Assert.Equal(isLinuxConsumption, testEnvironment.IsLinuxConsumption());
-            Assert.Equal(isLinuxConsumption, testEnvironment.IsConsumptionSku());
-            Assert.Equal(isLinuxConsumption, testEnvironment.IsDynamicSku());
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.LegionServiceHost, legionServiceHost);
+            Assert.Equal(isLinuxConsumptionOnAtlas || isLinuxConsumptionOnLegion, testEnvironment.IsAnyLinuxConsumption());
+            Assert.Equal(isLinuxConsumptionOnAtlas, testEnvironment.IsLinuxConsumptionOnAtlas());
+            Assert.Equal(isLinuxConsumptionOnLegion, testEnvironment.IsLinuxConsumptionOnLegion());
+            Assert.Equal(isLinuxConsumptionOnAtlas || isLinuxConsumptionOnLegion, testEnvironment.IsConsumptionSku());
+            Assert.Equal(isLinuxConsumptionOnAtlas || isLinuxConsumptionOnLegion, testEnvironment.IsDynamicSku());
+            Assert.False(isLinuxConsumptionOnAtlas ? isLinuxConsumptionOnLegion : isLinuxConsumptionOnAtlas);
         }
 
         [Theory]

--- a/test/WebJobs.Script.Tests/Middleware/HostWarmupMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Middleware/HostWarmupMiddlewareTests.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Linq;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Azure.WebJobs.Script.WebHost;
-using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions;
 using Microsoft.Azure.WebJobs.Script.WebHost.Middleware;
 using Microsoft.Extensions.Logging;
 using Microsoft.WebJobs.Script.Tests;
@@ -54,7 +51,24 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
 
             request = HttpTestHelpers.CreateHttpRequest("POST", "http://azure.com/api/warmup");
             environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "TestContainer");
-            Assert.True(environment.IsLinuxConsumption());
+            Assert.True(environment.IsAnyLinuxConsumption());
+            Assert.True(environment.IsLinuxConsumptionOnAtlas());
+            Assert.False(environment.IsLinuxConsumptionOnLegion());
+            Assert.True(HostWarmupMiddleware.IsWarmUpRequest(request, hostEnvironment.InStandbyMode, environment));
+
+            // Reset environment
+            environment.Clear();
+            hostEnvironment = new ScriptWebHostEnvironment(environment);
+
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
+            Assert.False(HostWarmupMiddleware.IsWarmUpRequest(request, hostEnvironment.InStandbyMode, environment));
+
+            request = HttpTestHelpers.CreateHttpRequest("POST", "http://azure.com/api/warmup");
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "TestContainer");
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.LegionServiceHost, "1");
+            Assert.True(environment.IsAnyLinuxConsumption());
+            Assert.False(environment.IsLinuxConsumptionOnAtlas());
+            Assert.True(environment.IsLinuxConsumptionOnLegion());
             Assert.True(HostWarmupMiddleware.IsWarmUpRequest(request, hostEnvironment.InStandbyMode, environment));
         }
 


### PR DESCRIPTION
Subsequent PRs will customize different host services as required. Scope of this PR is to add a way to check if container is running on a Legion host.

<!-- Please provide all the information below.  -->

[### Issue describing the changes in this PR]
https://github.com/Azure/azure-functions-host/issues/8616

resolves #issue_for_this_pr

### Pull request checklist

* [X ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [X ] Otherwise: Backport tracked by issue/PR https://github.com/Azure/azure-functions-host/issues/8616
* [ X] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)