### PR TITLE
[pack] make channel lookups case-insensitive

### DIFF
--- a/src/WebJobs.Script/Workers/Rpc/JobHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/JobHostRpcWorkerChannelManager.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
     {
         private readonly object _getChannelLock = new object();
         private readonly ILogger _logger;
-        private ConcurrentDictionary<string, IRpcWorkerChannelDictionary> _channels = new ConcurrentDictionary<string, IRpcWorkerChannelDictionary>();
+        private ConcurrentDictionary<string, IRpcWorkerChannelDictionary> _channels = new ConcurrentDictionary<string, IRpcWorkerChannelDictionary>(StringComparer.OrdinalIgnoreCase);
 
         public JobHostRpcWorkerChannelManager(ILoggerFactory loggerFactory)
         {

--- a/test/WebJobs.Script.Tests/Workers/Rpc/JobHostRpcWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/JobHostRpcWorkerChannelManagerTests.cs
@@ -204,6 +204,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.True(_jobHostRpcWorkerChannelManager.GetChannels("powershell").Contains(_workerChannelPs2.Object), "Job Manager doesn't contains 'ps2'");
             Assert.Equal(1, _jobHostRpcWorkerChannelManager.GetChannels("node").Count());
             Assert.True(_jobHostRpcWorkerChannelManager.GetChannels("node").Contains(_workerChannelJs1.Object), "Job Manager doesn't contains 'js2'");
+
+            // test case insensitivity
+            Assert.Equal(1, _jobHostRpcWorkerChannelManager.GetChannels("Java").Count());
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
@@ -86,6 +86,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.NotNull(initializedChannel);
             Assert.Equal(javaWorkerChannel.Id, initializedChannel.Id);
             Assert.Equal(_rpcWorkerChannelManager.GetChannels(RpcWorkerConstants.JavaLanguageWorkerName).Count(), 2);
+
+            // test case insensitivity
+            Assert.Equal(_rpcWorkerChannelManager.GetChannels("Java").Count(), 2);
         }
 
         [Fact]
@@ -299,7 +302,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>
                 {
-                   [$"{RpcWorkerConstants.LanguageWorkersSectionName}:{languageWorkerName}:{WorkerConstants.WorkerDescriptionArguments}"] = argument
+                    [$"{RpcWorkerConstants.LanguageWorkersSectionName}:{languageWorkerName}:{WorkerConstants.WorkerDescriptionArguments}"] = argument
                 })
                 .Build();
             _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, testMetricsLogger, _workerOptionsMonitor, config);


### PR DESCRIPTION
Worker channels were stored in a dictionary with case-sensitive keys, meaning that mismatches between `FUNCTIONS_WORKER_RUNTIME` and the worker config's `language` value would cause the exception `Did not find any initialized language workers`.