### PR TITLE
Include empty entries when building InvocationRequest payload for OOP workers

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -9,6 +9,7 @@
 - Updated Java Worker Version to [2.4.0](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.4.0)
 - Update PowerShell Worker 7.0 to 4.0.2255 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2255)
 - Update PowerShell Worker 7.2 to 4.0.2258 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2258)
+- Adding support to conditionally include empty entries from trigger payload when sending to OOP workers. ([#8499](https://github.com/Azure/azure-functions-host/issues/8499))
 
 **Release sprint:** Sprint 128
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+128%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+128%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
+++ b/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
@@ -54,7 +54,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     string str => new TypedData() { String = str },
                     double dbl => new TypedData() { Double = dbl },
                     byte[][] arrBytes when IsTypedDataCollectionSupported(capabilities) => arrBytes.ToRpcByteArray(),
-                    string[] arrStr when IsTypedDataCollectionSupported(capabilities) => arrStr.ToRpcStringArray(),
+                    string[] arrStr when IsTypedDataCollectionSupported(capabilities) => arrStr.ToRpcStringArray(
+                                                            ShouldIncludeEmptyEntriesInMessagePayload(capabilities)),
                     double[] arrDouble when IsTypedDataCollectionSupported(capabilities) => arrDouble.ToRpcDoubleArray(),
                     long[] arrLong when IsTypedDataCollectionSupported(capabilities) => arrLong.ToRpcLongArray(),
                     _ => value.ToRpcDefault(),
@@ -203,7 +204,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     rawBodyString = await request.ReadAsStringAsync();
                     try
                     {
-                        // REVIEW: We are json deserializing this to a JObject only to serialze
+                        // REVIEW: We are json deserializing this to a JObject only to serialize
                         // it back to string below. Why?
                         body = JsonConvert.DeserializeObject(rawBodyString);
                     }
@@ -273,16 +274,25 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             return typedData;
         }
 
-        internal static TypedData ToRpcStringArray(this string[] arrString)
+        internal static TypedData ToRpcStringArray(this string[] arrString, bool includeEmptyEntries)
         {
             TypedData typedData = new TypedData();
             CollectionString collectionString = new CollectionString();
             foreach (string element in arrString)
             {
-                if (!string.IsNullOrEmpty(element))
+                // Don't add null entries.("Add" method below will throw)
+                if (element is null)
                 {
-                    collectionString.String.Add(element);
+                    continue;
                 }
+
+                // Empty string entries are okay to add based on includeEmptyEntries param value.
+                if (element == string.Empty && !includeEmptyEntries)
+                {
+                    continue;
+                }
+
+                collectionString.String.Add(element);
             }
             typedData.CollectionString = collectionString;
 
@@ -313,6 +323,11 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             typedData.CollectionSint64 = collectionLong;
 
             return typedData;
+        }
+
+        private static bool ShouldIncludeEmptyEntriesInMessagePayload(GrpcCapabilities capabilities)
+        {
+            return !string.IsNullOrWhiteSpace(capabilities.GetCapabilityState(RpcWorkerConstants.IncludeEmptyEntriesInMessagePayload));
         }
 
         private static bool IsRawBodyBytesRequested(GrpcCapabilities capabilities)

--- a/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
+++ b/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
@@ -54,7 +54,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     string str => new TypedData() { String = str },
                     double dbl => new TypedData() { Double = dbl },
                     byte[][] arrBytes when IsTypedDataCollectionSupported(capabilities) => arrBytes.ToRpcByteArray(),
-                    string[] arrStr when IsTypedDataCollectionSupported(capabilities) => arrStr.ToRpcStringArray(),
+                    string[] arrStr when IsTypedDataCollectionSupported(capabilities) => arrStr.ToRpcStringArray(
+                                                            ShouldIncludeEmptyEntriesInMessagePayload(capabilities)),
                     double[] arrDouble when IsTypedDataCollectionSupported(capabilities) => arrDouble.ToRpcDoubleArray(),
                     long[] arrLong when IsTypedDataCollectionSupported(capabilities) => arrLong.ToRpcLongArray(),
                     _ => value.ToRpcDefault(),
@@ -273,17 +274,25 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             return typedData;
         }
 
-        internal static TypedData ToRpcStringArray(this string[] arrString)
+        internal static TypedData ToRpcStringArray(this string[] arrString, bool includeEmptyEntries)
         {
             TypedData typedData = new TypedData();
             CollectionString collectionString = new CollectionString();
             foreach (string element in arrString)
             {
-                // Don't add null entries, but empty string is valid.
-                if (element != null)
+                // Don't add null entries.("Add" method below will throw)
+                if (element is null)
                 {
-                    collectionString.String.Add(element);
+                    continue;
                 }
+
+                // Empty string entries are okay to add based on includeEmptyEntries param value.
+                if (element == string.Empty && !includeEmptyEntries)
+                {
+                    continue;
+                }
+
+                collectionString.String.Add(element);
             }
             typedData.CollectionString = collectionString;
 
@@ -314,6 +323,11 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             typedData.CollectionSint64 = collectionLong;
 
             return typedData;
+        }
+
+        private static bool ShouldIncludeEmptyEntriesInMessagePayload(GrpcCapabilities capabilities)
+        {
+            return !string.IsNullOrWhiteSpace(capabilities.GetCapabilityState(RpcWorkerConstants.IncludeEmptyEntriesInMessagePayload));
         }
 
         private static bool IsRawBodyBytesRequested(GrpcCapabilities capabilities)

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
@@ -55,6 +55,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public const string HandlesWorkerTerminateMessage = "HandlesWorkerTerminateMessage";
         public const string HandlesInvocationCancelMessage = "HandlesInvocationCancelMessage";
 
+        /// <summary>
+        /// Indicates whether empty entries in the trigger message should be included when sending RpcInvocation data to OOP workers.
+        /// </summary>
+        public const string IncludeEmptyEntriesInMessagePayload = "IncludeEmptyEntriesInMessagePayload";
+
         // Host Capabilities
         public const string V2Compatable = "V2Compatable";
 

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
@@ -55,11 +55,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public const string HandlesWorkerTerminateMessage = "HandlesWorkerTerminateMessage";
         public const string HandlesInvocationCancelMessage = "HandlesInvocationCancelMessage";
 
-        /// <summary>
-        /// Indicates whether empty entries in the trigger message should be included when sending RpcInvocation data to OOP workers.
-        /// </summary>
-        public const string IncludeEmptyEntriesInMessagePayload = "IncludeEmptyEntriesInMessagePayload";
-
         // Host Capabilities
         public const string V2Compatable = "V2Compatable";
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcMessageConversionExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcMessageConversionExtensionsTests.cs
@@ -486,6 +486,41 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
+        public async Task ToRpc_Collection_String_IgnoreEmptyEntries_When_Capability_Is_Not_Present()
+        {
+            var logger = MockNullLoggerFactory.CreateLogger();
+            var capabilities = new GrpcCapabilities(logger);
+            capabilities.UpdateCapabilities(new MapField<string, string>
+                {
+                    { RpcWorkerConstants.TypedDataCollection, bool.TrueString },
+                });
+
+            string[] arrString = { "element1", string.Empty, "element_2" };
+            TypedData actual = await arrString.ToRpc(logger, capabilities);
+
+            var expected = new RepeatedField<string> { "element1", "element_2" };
+            Assert.Equal(expected, actual.CollectionString.String);
+        }
+
+        [Fact]
+        public async Task ToRpc_Collection_String_IncludeEmptyEntries_When_Capability_Is_Present()
+        {
+            var logger = MockNullLoggerFactory.CreateLogger();
+            var capabilities = new GrpcCapabilities(logger);
+            capabilities.UpdateCapabilities(new MapField<string, string>
+                {
+                    { RpcWorkerConstants.TypedDataCollection, bool.TrueString },
+                    { RpcWorkerConstants.IncludeEmptyEntriesInMessagePayload, bool.TrueString }
+                });
+
+            string[] arrString = { "element1", string.Empty, "element_2", null };
+            TypedData actual = await arrString.ToRpc(logger, capabilities);
+
+            var expected = new RepeatedField<string> { "element1", string.Empty, "element_2" }; // null entry should be still skipped
+            Assert.Equal(expected, actual.CollectionString.String);
+        }
+
+        [Fact]
         public async Task ToRpc_Collection_Long_With_Capabilities_Value()
         {
             var logger = MockNullLoggerFactory.CreateLogger();

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcMessageConversionExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcMessageConversionExtensionsTests.cs
@@ -486,13 +486,31 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
-        public async Task ToRpc_Collection_String_IncludeEmptyEntries_for_TypedDataCollection()
+        public async Task ToRpc_Collection_String_IgnoreEmptyEntries_When_Capability_Is_Not_Present()
         {
             var logger = MockNullLoggerFactory.CreateLogger();
             var capabilities = new GrpcCapabilities(logger);
             capabilities.UpdateCapabilities(new MapField<string, string>
                 {
-                    { RpcWorkerConstants.TypedDataCollection, bool.TrueString }
+                    { RpcWorkerConstants.TypedDataCollection, bool.TrueString },
+                });
+
+            string[] arrString = { "element1", string.Empty, "element_2" };
+            TypedData actual = await arrString.ToRpc(logger, capabilities);
+
+            var expected = new RepeatedField<string> { "element1", "element_2" };
+            Assert.Equal(expected, actual.CollectionString.String);
+        }
+
+        [Fact]
+        public async Task ToRpc_Collection_String_IncludeEmptyEntries_When_Capability_Is_Present()
+        {
+            var logger = MockNullLoggerFactory.CreateLogger();
+            var capabilities = new GrpcCapabilities(logger);
+            capabilities.UpdateCapabilities(new MapField<string, string>
+                {
+                    { RpcWorkerConstants.TypedDataCollection, bool.TrueString },
+                    { RpcWorkerConstants.IncludeEmptyEntriesInMessagePayload, bool.TrueString }
                 });
 
             string[] arrString = { "element1", string.Empty, "element_2", null };

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcMessageConversionExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcMessageConversionExtensionsTests.cs
@@ -486,31 +486,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
-        public async Task ToRpc_Collection_String_IgnoreEmptyEntries_When_Capability_Is_Not_Present()
+        public async Task ToRpc_Collection_String_IncludeEmptyEntries_for_TypedDataCollection()
         {
             var logger = MockNullLoggerFactory.CreateLogger();
             var capabilities = new GrpcCapabilities(logger);
             capabilities.UpdateCapabilities(new MapField<string, string>
                 {
-                    { RpcWorkerConstants.TypedDataCollection, bool.TrueString },
-                });
-
-            string[] arrString = { "element1", string.Empty, "element_2" };
-            TypedData actual = await arrString.ToRpc(logger, capabilities);
-
-            var expected = new RepeatedField<string> { "element1", "element_2" };
-            Assert.Equal(expected, actual.CollectionString.String);
-        }
-
-        [Fact]
-        public async Task ToRpc_Collection_String_IncludeEmptyEntries_When_Capability_Is_Present()
-        {
-            var logger = MockNullLoggerFactory.CreateLogger();
-            var capabilities = new GrpcCapabilities(logger);
-            capabilities.UpdateCapabilities(new MapField<string, string>
-                {
-                    { RpcWorkerConstants.TypedDataCollection, bool.TrueString },
-                    { RpcWorkerConstants.IncludeEmptyEntriesInMessagePayload, bool.TrueString }
+                    { RpcWorkerConstants.TypedDataCollection, bool.TrueString }
                 });
 
             string[] arrString = { "element1", string.Empty, "element_2", null };


### PR DESCRIPTION
Fixes #8499 

The current behavior is to skip entries which are null or empty. This causes issues like  [this](https://github.com/Azure/azure-functions-dotnet-worker/issues/876). So we decided to introduce a new capability called `IncludeEmptyEntriesInMessagePayload` which language workers can advertise and if it is present, we will include the empty entries (empty, not null) in the array we create for the message payload.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by same issue. I will add once this change is in v4.
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
Please refer #8499 which has details about the current behavior and problems caused by that.