### PR TITLE
Set environment variable to indicate an application started from placeholder mode

### DIFF
--- a/src/WebJobs.Script.WebHost/Standby/StandbyManager.cs
+++ b/src/WebJobs.Script.WebHost/Standby/StandbyManager.cs
@@ -166,6 +166,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     {
                         await CreateStandbyWarmupFunctions();
 
+                        // Flag to indicate a function was initialized from placeholder mode
+                        _environment.SetEnvironmentVariable(EnvironmentSettingNames.InitializedFromPlaceholder, "true");
+
                         // start a background timer to identify when specialization happens
                         // specialization usually happens via an http request (e.g. scale controller
                         // ping) but this timer is started as well to handle cases where we

--- a/src/WebJobs.Script.WebHost/Standby/StandbyManager.cs
+++ b/src/WebJobs.Script.WebHost/Standby/StandbyManager.cs
@@ -164,10 +164,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 {
                     try
                     {
-                        await CreateStandbyWarmupFunctions();
-
                         // Flag to indicate a function was initialized from placeholder mode
-                        _environment.SetEnvironmentVariable(EnvironmentSettingNames.InitializedFromPlaceholder, "true");
+                        _environment.SetEnvironmentVariable(EnvironmentSettingNames.InitializedFromPlaceholder, bool.TrueString);
+
+                        await CreateStandbyWarmupFunctions();
 
                         // start a background timer to identify when specialization happens
                         // specialization usually happens via an http request (e.g. scale controller

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AzureWebsiteSku = "WEBSITE_SKU";
         public const string RemoteDebuggingPort = "REMOTEDEBUGGINGPORT";
         public const string AzureWebsitePlaceholderMode = "WEBSITE_PLACEHOLDER_MODE";
+        public const string InitializedFromPlaceholder = "INITIALIZED_FROM_PLACEHOLDER";
         public const string AzureWebsiteHomePath = "HOME";
         public const string AzureWebJobsScriptRoot = "AzureWebJobsScriptRoot";
         public const string CompilationReleaseMode = "AzureWebJobsDotNetReleaseCompilation";

--- a/src/WebJobs.Script/Workers/Profiles/EnvironmentCondition.cs
+++ b/src/WebJobs.Script/Workers/Profiles/EnvironmentCondition.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             return _regex.IsMatch(value);
         }
 
-        // Validates if condition parametrs meet expected values, fail if they don't
+        // Validates if condition parameters meet expected values, fail if they don't
         private void Validate()
         {
             if (string.IsNullOrEmpty(Name))

--- a/test/WebJobs.Script.Tests/StandbyManagerTests.cs
+++ b/test/WebJobs.Script.Tests/StandbyManagerTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
@@ -131,7 +132,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             await manager.InitializeAsync().ContinueWith(t => { }); // Ignore errors.
 
             // Ensure InitializedFromPlaceholder environment variable is set to true
-            Assert.Equal("true", _testEnvironment.GetEnvironmentVariable(EnvironmentSettingNames.InitializedFromPlaceholder));
+            Assert.Equal(bool.TrueString, _testEnvironment.GetEnvironmentVariable(EnvironmentSettingNames.InitializedFromPlaceholder));
         }
 
         private bool AreExpectedMetricsGenerated(TestMetricsLogger metricsLogger)

--- a/test/WebJobs.Script.Tests/StandbyManagerTests.cs
+++ b/test/WebJobs.Script.Tests/StandbyManagerTests.cs
@@ -120,6 +120,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.True(metricsLogger.EventsBegan.Contains(MetricEventNames.SpecializationStandbyManagerInitialize) && metricsLogger.EventsEnded.Contains(MetricEventNames.SpecializationStandbyManagerInitialize));
         }
 
+        [Fact]
+        public async Task Specialize_StandbyManagerInitialize_SetsInitializedFromPlaceholderFlag()
+        {
+            TestMetricsLogger metricsLogger = new TestMetricsLogger();
+            _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName, "placeholder.azurewebsites.net");
+
+            var hostNameProvider = new HostNameProvider(_testEnvironment);
+            var manager = new StandbyManager(_mockHostManager.Object, _mockLanguageWorkerChannelManager.Object, _mockConfiguration.Object, _mockWebHostEnvironment.Object, _testEnvironment, _mockOptionsMonitor.Object, NullLogger<StandbyManager>.Instance, hostNameProvider, _mockApplicationLifetime.Object, metricsLogger);
+            await manager.InitializeAsync().ContinueWith(t => { }); // Ignore errors.
+
+            // Ensure InitializedFromPlaceholder environment variable is set to true
+            Assert.Equal("true", _testEnvironment.GetEnvironmentVariable(EnvironmentSettingNames.InitializedFromPlaceholder));
+        }
+
         private bool AreExpectedMetricsGenerated(TestMetricsLogger metricsLogger)
         {
             return metricsLogger.EventsBegan.Contains(MetricEventNames.SpecializationSpecializeHost) && metricsLogger.EventsEnded.Contains(MetricEventNames.SpecializationSpecializeHost)

--- a/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
@@ -113,9 +113,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             // add general post startup validations here
             mockEventManager.Verify(_ => _.Publish(It.IsAny<HostStartEvent>()), Times.Once());
-
-            // InitializedFromPlaceholder should not be set if we don't specialize
-            Assert.Empty(Environment.GetEnvironmentVariable(EnvironmentSettingNames.InitializedFromPlaceholder));
         }
 
         [Fact]
@@ -183,9 +180,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var logMessages = _webHostLoggerProvider.GetAllLogMessages().Where(m => m.FormattedMessage.Contains("Restarting host."));
             Assert.Equal(2, logMessages.Count());
-
-            // InitializedFromPlaceholder should be set after specialization
-            Assert.Equal("true", Environment.GetEnvironmentVariable(EnvironmentSettingNames.InitializedFromPlaceholder));
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
@@ -113,6 +113,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             // add general post startup validations here
             mockEventManager.Verify(_ => _.Publish(It.IsAny<HostStartEvent>()), Times.Once());
+
+            // InitializedFromPlaceholder should not be set if we don't specialize
+            Assert.Empty(Environment.GetEnvironmentVariable(EnvironmentSettingNames.InitializedFromPlaceholder));
         }
 
         [Fact]
@@ -180,6 +183,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var logMessages = _webHostLoggerProvider.GetAllLogMessages().Where(m => m.FormattedMessage.Contains("Restarting host."));
             Assert.Equal(2, logMessages.Count());
+
+            // InitializedFromPlaceholder should be set after specialization
+            Assert.Equal("true", Environment.GetEnvironmentVariable(EnvironmentSettingNames.InitializedFromPlaceholder));
         }
 
         [Fact]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #8638 

New environment variable `INITIALIZED_FROM_PLACEHOLDER` to indicate that a function app was started from placeholder mode.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
