### PR TITLE
Revert "Upgrade PowerShellWorker 7 to 3.0.2262"

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,4 +5,3 @@
 
 **Release sprint:** Sprint 128
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+128%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+128%22+label%3Afeature+is%3Aclosed) ]
-- Update PowerShell Worker to 3.0.2262 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v3.0.2262)

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="1.11.0" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="2.1.3" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS6" Version="3.0.1761" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.2262" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7" Version="3.0.2046" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.34-11957" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.5-10880" />


### PR DESCRIPTION
Reverts Azure/azure-functions-host#8671 due to this regression: https://github.com/Azure/azure-functions-powershell-worker/issues/851