### PR TITLE
Reverting powershell worker version

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,7 +7,6 @@
 - Update Node.js Worker Version to [3.5.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.5.0)
 - Host support for out-of-proc cancellation tokens ([#2153](https://github.com/Azure/azure-functions-host/issues/2152))
 - Updated Java Worker Version to [2.4.0](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.4.0)
-- Update PowerShell Worker 7.0 to 4.0.2255 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2255)
 - Update PowerShell Worker 7.2 to 4.0.2258 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2258)
 - Adding support to conditionally include empty entries from trigger payload when sending to OOP workers. ([#8499](https://github.com/Azure/azure-functions-host/issues/8499))
 

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -57,7 +57,7 @@
     <!-- Workers -->
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.4.0" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.5.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" Version="4.0.2255" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" Version="4.0.2045" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" Version="4.0.2258" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="5.0.0-beta.2-10879" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />


### PR DESCRIPTION
Re-creating https://github.com/Azure/azure-functions-host/pull/8692.

Reverts https://github.com/Azure/azure-functions-host/pull/8671 due to this regression: https://github.com/Azure/azure-functions-powershell-worker/issues/851

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)