### PR TITLE
Add functions ext version into building log

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
@@ -90,11 +90,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
                 new EventId(512, nameof(Restarted)),
                 "Host restarted.");
 
-        private static readonly Action<ILogger, bool, bool, Guid, Exception> _building =
-            LoggerMessage.Define<bool, bool, Guid>(
+        private static readonly Action<ILogger, string, bool, bool, Guid, Exception> _building =
+            LoggerMessage.Define<string, bool, bool, Guid>(
                 LogLevel.Information,
                 new EventId(513, nameof(Building)),
-                "Building host: startup suppressed: '{skipHostStartup}', configuration suppressed: '{skipHostJsonConfiguration}', startup operation id: '{operationId}'");
+                "Building host: version spec: {functionsExtensionVersion}, startup suppressed: '{skipHostStartup}', configuration suppressed: '{skipHostJsonConfiguration}', startup operation id: '{operationId}'");
 
         private static readonly Action<ILogger, Guid, Exception> _startupOperationWasCanceled =
             LoggerMessage.Define<Guid>(
@@ -264,9 +264,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
             _restarted(logger, null);
         }
 
-        public static void Building(this ILogger logger, bool skipHostStartup, bool skipHostJsonConfiguration, Guid operationId)
+        public static void Building(this ILogger logger, string functionExtensionVersion, bool skipHostStartup, bool skipHostJsonConfiguration, Guid operationId)
         {
-            _building(logger, skipHostStartup, skipHostJsonConfiguration, operationId, null);
+            _building(logger, functionExtensionVersion, skipHostStartup, skipHostJsonConfiguration, operationId, null);
         }
 
         public static void StartupOperationWasCanceled(this ILogger logger, Guid operationId)

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -269,7 +269,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 // If we're in a non-transient error state or offline, skip host initialization
                 bool skipJobHostStartup = isOffline || hasNonTransientErrors;
                 bool skipHostJsonConfiguration = startupMode == JobHostStartupMode.HandlingConfigurationParsingError;
-                _logger.Building(skipJobHostStartup, skipHostJsonConfiguration, activeOperation.Id);
+                string functionsExtensionVersion = _environment.GetFunctionsExtensionVersion();
+                _logger.Building(functionsExtensionVersion, skipJobHostStartup, skipHostJsonConfiguration, activeOperation.Id);
 
                 using (_metricsLogger.LatencyEvent(MetricEventNames.ScriptHostManagerBuildScriptHost))
                 {

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -584,5 +584,14 @@ namespace Microsoft.Azure.WebJobs.Script
             isMultiLanguageEnabled = null;
             isApplicationInsightsAgentEnabled = null;
         }
+
+        /// <summary>
+        /// Gets a value indicated in the variable FUNCTIONS_EXTENSION_VERSION
+        /// </summary>
+        /// <returns>Value of FUNCTIONS_EXTENSION_VERSION variable</returns>
+        public static string GetFunctionsExtensionVersion(this IEnvironment environment)
+        {
+            return environment.GetEnvironmentVariableOrDefault(FunctionsExtensionVersion, string.Empty);
+        }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebJobsStartupEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebJobsStartupEndToEndTests.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
         public async Task ExternalStartup_InvalidOverwrite_StopsHost()
         {
             _envVars["Cron"] = "* * * * * *";
+            _envVars[EnvironmentSettingNames.FunctionsExtensionVersion] = "~4";
 
             // We need different fixture setup for each test.
             var fixture = new CSharpPrecompiledEndToEndTestFixture(_projectName, _envVars); // Startup.cs will change this.
@@ -66,8 +67,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
 
                 // Check that one startup began successfully, then the restart was suppressed.
                 var logMessages = fixture.Host.GetWebHostLogMessages();
-                Assert.Single(logMessages, p => p.FormattedMessage != null && p.FormattedMessage.Contains("Building host: startup suppressed: 'True'"));
-                Assert.Single(logMessages, p => p.FormattedMessage != null && p.FormattedMessage.Contains("Building host: startup suppressed: 'False'"));
+                Assert.Single(logMessages, p => p.FormattedMessage != null && p.FormattedMessage.Contains("Building host: version spec: ~4, startup suppressed: 'True'"));
+                Assert.Single(logMessages, p => p.FormattedMessage != null && p.FormattedMessage.Contains("Building host: version spec: ~4, startup suppressed: 'False'"));
             }
             finally
             {

--- a/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
@@ -230,6 +230,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
         }
 
         [Theory]
+        [InlineData("~1", "~1")]
+        [InlineData("~2", "~2")]
+        [InlineData("~3", "~3")]
+        [InlineData("~4", "~4")]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        public void Returns_FunctionsExtensionVersion(string functionsExtensionVersion, string functionsExtensionVersionExpected)
+        {
+            var enviroment = new TestEnvironment();
+            enviroment.SetEnvironmentVariable(FunctionsExtensionVersion, functionsExtensionVersion);
+            Assert.Equal(functionsExtensionVersionExpected, enviroment.GetFunctionsExtensionVersion());
+        }
+
+        [Theory]
         [InlineData(RpcWorkerConstants.PowerShellLanguageWorkerName, true, false, true)]
         [InlineData(RpcWorkerConstants.PowerShellLanguageWorkerName, false, true, true)]
         [InlineData(RpcWorkerConstants.PowerShellLanguageWorkerName, false, false, true)]


### PR DESCRIPTION
In the host building process, ensure we log the extension version early to ensure we always have a log for it. This branch is based on the PR https://github.com/Azure/azure-functions-host/pull/8593 which was based on a fork. To get full CI to run, I'm pulling this into a branch to get it in.

Resolves #8511

### Pull request checklist

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Backported to v3 via https://github.com/Azure/azure-functions-host/pull/8707
* [X] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [X] I have added all required tests (Unit tests, E2E tests)
