### PR TITLE
moving BlobStorageSecretsRepository to use UploadAsync instead of OpenWriteAsync

### DIFF
--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/BlobStorageSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/BlobStorageSecretsRepository.cs
@@ -5,9 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
-using Azure.Storage.Blobs.Specialized;
 using Microsoft.Azure.WebJobs.Host.Storage;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions;
 using Microsoft.Extensions.Logging;
@@ -173,11 +173,22 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         private async Task WriteToBlobAsync(string blobPath, string secretsContent)
         {
-            BlockBlobClient secretBlobClient = Container.GetBlockBlobClient(blobPath);
-            using (StreamWriter writer = new StreamWriter(await secretBlobClient.OpenWriteAsync(true)))
+            BlobClient secretBlobClient = Container.GetBlobClient(blobPath);
+            BlobUploadOptions uploadOptions = new BlobUploadOptions();
+
+            if (await secretBlobClient.ExistsAsync())
             {
-                await writer.WriteAsync(secretsContent);
+                // Return a 412 if another write beats us to updating the file.
+                BlobProperties properties = await secretBlobClient.GetPropertiesAsync();
+                uploadOptions.Conditions = new BlobRequestConditions { IfMatch = properties.ETag };
             }
+            else
+            {
+                // Return a 409 if another write beats us to creating the file.
+                uploadOptions.Conditions = new BlobRequestConditions { IfNoneMatch = ETag.All };
+            }
+
+            await secretBlobClient.UploadAsync(BinaryData.FromString(secretsContent), uploadOptions);
         }
 
         protected virtual void LogErrorMessage(string operation, Exception exception)


### PR DESCRIPTION
Using `OpenWriteAsync` immediately clears the blob while blocks are written. This can lead to any reads of this blob seeing an empty file while a write is in progress. In this case, the SecretManager will believe, incorrectly, that there are no secrets and immediately regenerate them.

`UploadAsync` is an atomic operation, meaning that any reads will continue to see the last fully uploaded blob.

See here: https://github.com/Azure/azure-sdk-for-net/issues/29518