### PR TITLE
Rev Azure.Core to 1.25 to compensate for dependabot side-effects

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Dependencies needed for Storage Providers -->
-    <PackageReference Include="Azure.Core" Version="1.19.0" />
+    <PackageReference Include="Azure.Core" Version="1.25.0" />
     <PackageReference Include="Azure.Identity" Version="1.4.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />

--- a/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
+++ b/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
@@ -6,7 +6,7 @@
   "compilationOptions": {},
   "targets": {
     ".NETCoreApp,Version=v6.0": {
-      "Microsoft.Azure.WebJobs.Script.WebHost/4.9.0": {
+      "Microsoft.Azure.WebJobs.Script.WebHost/4.12.0": {
         "dependencies": {
           "Azure.Identity": "1.4.1",
           "Azure.Security.KeyVault.Secrets": "4.2.0",
@@ -20,12 +20,12 @@
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "6.0.0",
           "Microsoft.Azure.AppService.Middleware.Functions": "1.4.17",
           "Microsoft.Azure.Cosmos.Table": "1.0.8",
-          "Microsoft.Azure.Functions.PythonWorker": "4.3.0",
+          "Microsoft.Azure.Functions.PythonWorker": "4.7.0",
           "Microsoft.Azure.Storage.File": "11.1.7",
-          "Microsoft.Azure.WebJobs": "3.0.34-11938",
-          "Microsoft.Azure.WebJobs.Host.Storage": "5.0.0-beta.2-11938",
-          "Microsoft.Azure.WebJobs.Script": "4.9.0",
-          "Microsoft.Azure.WebJobs.Script.Grpc": "4.9.0",
+          "Microsoft.Azure.WebJobs": "3.0.34-11957",
+          "Microsoft.Azure.WebJobs.Host.Storage": "5.0.0-beta.2-11957",
+          "Microsoft.Azure.WebJobs.Script": "4.12.0",
+          "Microsoft.Azure.WebJobs.Script.Grpc": "4.12.0",
           "Microsoft.Azure.WebSites.DataProtection": "2.1.91-alpha",
           "Microsoft.IdentityModel.Tokens": "6.21.0",
           "Microsoft.Security.Utilities": "1.3.0",
@@ -38,12 +38,10 @@
           "Microsoft.Azure.WebJobs.Script.WebHost.dll": {}
         }
       },
-      "Azure.Core/1.19.0": {
+      "Azure.Core/1.25.0": {
         "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
-          "System.Buffers": "4.5.1",
+          "Microsoft.Bcl.AsyncInterfaces": "1.1.1",
           "System.Diagnostics.DiagnosticSource": "6.0.0",
-          "System.Memory": "4.5.4",
           "System.Memory.Data": "1.0.2",
           "System.Numerics.Vectors": "4.5.0",
           "System.Text.Encodings.Web": "6.0.0",
@@ -52,14 +50,14 @@
         },
         "runtime": {
           "lib/net5.0/Azure.Core.dll": {
-            "assemblyVersion": "1.19.0.0",
-            "fileVersion": "1.1900.21.45105"
+            "assemblyVersion": "1.25.0.0",
+            "fileVersion": "1.2500.22.33004"
           }
         }
       },
       "Azure.Identity/1.4.1": {
         "dependencies": {
-          "Azure.Core": "1.19.0",
+          "Azure.Core": "1.25.0",
           "Microsoft.Identity.Client": "4.30.1",
           "Microsoft.Identity.Client.Extensions.Msal": "2.18.4",
           "System.Memory": "4.5.4",
@@ -76,7 +74,7 @@
       },
       "Azure.Security.KeyVault.Secrets/4.2.0": {
         "dependencies": {
-          "Azure.Core": "1.19.0",
+          "Azure.Core": "1.25.0",
           "System.Memory": "4.5.4",
           "System.Text.Json": "6.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4"
@@ -88,26 +86,27 @@
           }
         }
       },
-      "Azure.Storage.Blobs/12.9.0": {
+      "Azure.Storage.Blobs/12.13.0": {
         "dependencies": {
-          "Azure.Storage.Common": "12.8.0",
+          "Azure.Storage.Common": "12.12.0",
           "System.Text.Json": "6.0.0"
         },
         "runtime": {
-          "lib/netstandard2.0/Azure.Storage.Blobs.dll": {
-            "assemblyVersion": "12.9.0.0",
-            "fileVersion": "12.900.21.30804"
+          "lib/netstandard2.1/Azure.Storage.Blobs.dll": {
+            "assemblyVersion": "12.13.0.0",
+            "fileVersion": "12.1300.22.35704"
           }
         }
       },
-      "Azure.Storage.Common/12.8.0": {
+      "Azure.Storage.Common/12.12.0": {
         "dependencies": {
-          "Azure.Core": "1.19.0"
+          "Azure.Core": "1.25.0",
+          "System.IO.Hashing": "6.0.0"
         },
         "runtime": {
           "lib/netstandard2.0/Azure.Storage.Common.dll": {
-            "assemblyVersion": "12.8.0.0",
-            "fileVersion": "12.800.21.30804"
+            "assemblyVersion": "12.12.0.0",
+            "fileVersion": "12.1200.22.35704"
           }
         }
       },
@@ -420,7 +419,7 @@
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
           "Microsoft.Extensions.FileProviders.Abstractions": "6.0.0",
           "Microsoft.Net.Http.Headers": "2.2.0",
-          "System.Buffers": "4.5.1"
+          "System.Buffers": "4.5.0"
         }
       },
       "Microsoft.AspNetCore.Http.Features/2.2.0": {
@@ -611,11 +610,11 @@
           }
         }
       },
-      "Microsoft.Azure.Functions.JavaWorker/2.3.1": {},
-      "Microsoft.Azure.Functions.NodeJsWorker/3.4.0": {},
-      "Microsoft.Azure.Functions.PowerShellWorker.PS7.0/4.0.2045": {},
-      "Microsoft.Azure.Functions.PowerShellWorker.PS7.2/4.0.2040": {},
-      "Microsoft.Azure.Functions.PythonWorker/4.3.0": {},
+      "Microsoft.Azure.Functions.JavaWorker/2.4.0": {},
+      "Microsoft.Azure.Functions.NodeJsWorker/3.5.0": {},
+      "Microsoft.Azure.Functions.PowerShellWorker.PS7.0/4.0.2302": {},
+      "Microsoft.Azure.Functions.PowerShellWorker.PS7.2/4.0.2304": {},
+      "Microsoft.Azure.Functions.PythonWorker/4.7.0": {},
       "Microsoft.Azure.KeyVault.Core/2.0.4": {
         "dependencies": {
           "System.Runtime": "4.3.0",
@@ -653,9 +652,9 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs/3.0.34-11938": {
+      "Microsoft.Azure.WebJobs/3.0.34-11957": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Core": "3.0.34-11938",
+          "Microsoft.Azure.WebJobs.Core": "3.0.34-11957",
           "Microsoft.Extensions.Configuration": "6.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "6.0.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "2.1.1",
@@ -675,7 +674,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Core/3.0.34-11938": {
+      "Microsoft.Azure.WebJobs.Core/3.0.34-11957": {
         "dependencies": {
           "System.ComponentModel.Annotations": "4.4.0",
           "System.Diagnostics.TraceSource": "4.3.0"
@@ -687,9 +686,9 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Extensions/5.0.0-beta.2-10871": {
+      "Microsoft.Azure.WebJobs.Extensions/5.0.0-beta.2-10879": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.34-11938",
+          "Microsoft.Azure.WebJobs": "3.0.34-11957",
           "NCrontab.Signed": "3.3.2"
         },
         "runtime": {
@@ -706,7 +705,7 @@
           "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.2.0",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
           "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.Azure.WebJobs": "3.0.34-11938"
+          "Microsoft.Azure.WebJobs": "3.0.34-11957"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Http.dll": {
@@ -717,9 +716,9 @@
       },
       "Microsoft.Azure.WebJobs.Extensions.Timers.Storage/1.0.0-beta.1": {
         "dependencies": {
-          "Azure.Storage.Blobs": "12.9.0",
-          "Microsoft.Azure.WebJobs.Extensions": "5.0.0-beta.2-10871",
-          "Microsoft.Azure.WebJobs.Host.Storage": "5.0.0-beta.2-11938"
+          "Azure.Storage.Blobs": "12.13.0",
+          "Microsoft.Azure.WebJobs.Extensions": "5.0.0-beta.2-10879",
+          "Microsoft.Azure.WebJobs.Host.Storage": "5.0.0-beta.2-11957"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Timers.Storage.dll": {
@@ -728,10 +727,10 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Host.Storage/5.0.0-beta.2-11938": {
+      "Microsoft.Azure.WebJobs.Host.Storage/5.0.0-beta.2-11957": {
         "dependencies": {
-          "Azure.Storage.Blobs": "12.9.0",
-          "Microsoft.Azure.WebJobs": "3.0.34-11938",
+          "Azure.Storage.Blobs": "12.13.0",
+          "Microsoft.Azure.WebJobs": "3.0.34-11957",
           "Microsoft.Extensions.Azure": "1.1.1"
         },
         "runtime": {
@@ -741,7 +740,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Logging.ApplicationInsights/3.0.34-11938": {
+      "Microsoft.Azure.WebJobs.Logging.ApplicationInsights/3.0.34-11957": {
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.20.0",
           "Microsoft.ApplicationInsights.AspNetCore": "2.20.0",
@@ -752,7 +751,7 @@
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.20.0",
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.Azure.WebJobs": "3.0.34-11938",
+          "Microsoft.Azure.WebJobs": "3.0.34-11957",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
           "System.Diagnostics.TraceSource": "4.3.0",
           "System.Threading": "4.3.0",
@@ -790,11 +789,11 @@
           }
         }
       },
-      "Microsoft.Bcl.AsyncInterfaces/1.0.0": {
+      "Microsoft.Bcl.AsyncInterfaces/1.1.1": {
         "runtime": {
           "lib/netstandard2.1/Microsoft.Bcl.AsyncInterfaces.dll": {
             "assemblyVersion": "1.0.0.0",
-            "fileVersion": "4.700.19.46214"
+            "fileVersion": "4.700.20.21406"
           }
         }
       },
@@ -1038,7 +1037,7 @@
       },
       "Microsoft.Extensions.Azure/1.1.1": {
         "dependencies": {
-          "Azure.Core": "1.19.0",
+          "Azure.Core": "1.25.0",
           "Azure.Identity": "1.4.1",
           "Microsoft.Extensions.Configuration.Abstractions": "6.0.0",
           "Microsoft.Extensions.Configuration.Binder": "6.0.0",
@@ -1311,7 +1310,7 @@
       "Microsoft.Net.Http.Headers/2.2.0": {
         "dependencies": {
           "Microsoft.Extensions.Primitives": "6.0.0",
-          "System.Buffers": "4.5.1"
+          "System.Buffers": "4.5.0"
         }
       },
       "Microsoft.NETCore.Platforms/3.1.0": {},
@@ -1679,7 +1678,7 @@
           "System.Runtime": "4.3.0"
         }
       },
-      "System.Buffers/4.5.1": {},
+      "System.Buffers/4.5.0": {},
       "System.Collections/4.3.0": {
         "dependencies": {
           "Microsoft.NETCore.Platforms": "3.1.0",
@@ -1922,6 +1921,14 @@
       "System.IO.FileSystem.Primitives/4.3.0": {
         "dependencies": {
           "System.Runtime": "4.3.0"
+        }
+      },
+      "System.IO.Hashing/6.0.0": {
+        "runtime": {
+          "lib/net6.0/System.IO.Hashing.dll": {
+            "assemblyVersion": "6.0.0.0",
+            "fileVersion": "6.0.21.52210"
+          }
         }
       },
       "System.Linq/4.3.0": {
@@ -2499,6 +2506,7 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
+      "System.Threading.Channels/6.0.0": {},
       "System.Threading.Overlapped/4.0.1": {
         "dependencies": {
           "Microsoft.NETCore.Platforms": "3.1.0",
@@ -2546,27 +2554,27 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Script/4.9.0": {
+      "Microsoft.Azure.WebJobs.Script/4.12.0": {
         "dependencies": {
-          "Azure.Core": "1.19.0",
+          "Azure.Core": "1.25.0",
           "Azure.Identity": "1.4.1",
-          "Azure.Storage.Blobs": "12.9.0",
+          "Azure.Storage.Blobs": "12.13.0",
           "Microsoft.ApplicationInsights": "2.20.0",
           "Microsoft.ApplicationInsights.AspNetCore": "2.20.0",
           "Microsoft.ApplicationInsights.DependencyCollector": "2.20.0",
           "Microsoft.ApplicationInsights.WindowsServer": "2.20.0",
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.20.0",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
-          "Microsoft.Azure.Functions.JavaWorker": "2.3.1",
-          "Microsoft.Azure.Functions.NodeJsWorker": "3.4.0",
-          "Microsoft.Azure.Functions.PowerShellWorker.PS7.0": "4.0.2045",
-          "Microsoft.Azure.Functions.PowerShellWorker.PS7.2": "4.0.2040",
-          "Microsoft.Azure.WebJobs": "3.0.34-11938",
-          "Microsoft.Azure.WebJobs.Extensions": "5.0.0-beta.2-10871",
+          "Microsoft.Azure.Functions.JavaWorker": "2.4.0",
+          "Microsoft.Azure.Functions.NodeJsWorker": "3.5.0",
+          "Microsoft.Azure.Functions.PowerShellWorker.PS7.0": "4.0.2302",
+          "Microsoft.Azure.Functions.PowerShellWorker.PS7.2": "4.0.2304",
+          "Microsoft.Azure.WebJobs": "3.0.34-11957",
+          "Microsoft.Azure.WebJobs.Extensions": "5.0.0-beta.2-10879",
           "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.0",
           "Microsoft.Azure.WebJobs.Extensions.Timers.Storage": "1.0.0-beta.1",
-          "Microsoft.Azure.WebJobs.Host.Storage": "5.0.0-beta.2-11938",
-          "Microsoft.Azure.WebJobs.Logging.ApplicationInsights": "3.0.34-11938",
+          "Microsoft.Azure.WebJobs.Host.Storage": "5.0.0-beta.2-11957",
+          "Microsoft.Azure.WebJobs.Logging.ApplicationInsights": "3.0.34-11957",
           "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.3-preview",
           "Microsoft.CodeAnalysis.CSharp.Scripting": "3.3.1",
           "Microsoft.Extensions.Azure": "1.1.1",
@@ -2583,7 +2591,7 @@
           "Microsoft.Azure.WebJobs.Script.dll": {}
         }
       },
-      "Microsoft.Azure.WebJobs.Script.Grpc/4.9.0": {
+      "Microsoft.Azure.WebJobs.Script.Grpc/4.12.0": {
         "dependencies": {
           "Grpc.AspNetCore": "2.39.0",
           "Microsoft.ApplicationInsights": "2.20.0",
@@ -2591,8 +2599,9 @@
           "Microsoft.ApplicationInsights.DependencyCollector": "2.20.0",
           "Microsoft.ApplicationInsights.WindowsServer": "2.20.0",
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.20.0",
-          "Microsoft.Azure.WebJobs.Script": "4.9.0",
-          "System.IO.FileSystem.Primitives": "4.3.0"
+          "Microsoft.Azure.WebJobs.Script": "4.12.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Threading.Channels": "6.0.0"
         },
         "runtime": {
           "Microsoft.Azure.WebJobs.Script.Grpc.dll": {}
@@ -2601,17 +2610,17 @@
     }
   },
   "libraries": {
-    "Microsoft.Azure.WebJobs.Script.WebHost/4.9.0": {
+    "Microsoft.Azure.WebJobs.Script.WebHost/4.12.0": {
       "type": "project",
       "serviceable": false,
       "sha512": ""
     },
-    "Azure.Core/1.19.0": {
+    "Azure.Core/1.25.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-lcDjG635DPE4fU5tqSueVMmzrx0QrIfPuY0+y6evHN5GanQ0GB+/4nuMHMmoNPwEow6OUPkJu4cZQxfHJQXPdA==",
-      "path": "azure.core/1.19.0",
-      "hashPath": "azure.core.1.19.0.nupkg.sha512"
+      "sha512": "sha512-X8Dd4sAggS84KScWIjEbFAdt2U1KDolQopTPoHVubG2y3CM54f9l6asVrP5Uy384NWXjsspPYaJgz5xHc+KvTA==",
+      "path": "azure.core/1.25.0",
+      "hashPath": "azure.core.1.25.0.nupkg.sha512"
     },
     "Azure.Identity/1.4.1": {
       "type": "package",
@@ -2627,19 +2636,19 @@
       "path": "azure.security.keyvault.secrets/4.2.0",
       "hashPath": "azure.security.keyvault.secrets.4.2.0.nupkg.sha512"
     },
-    "Azure.Storage.Blobs/12.9.0": {
+    "Azure.Storage.Blobs/12.13.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-nVjRfa0+/xJguoP/4F2tSk4OMAixO3QE2azG+RcbdcoZVVrEF7eVNlpsJoDSWwFBM7qiVc6+O7hwji3JjXmdrA==",
-      "path": "azure.storage.blobs/12.9.0",
-      "hashPath": "azure.storage.blobs.12.9.0.nupkg.sha512"
+      "sha512": "sha512-h5ZxRwmS/U1NOFwd+MuHJe4To1hEPu/yeBIKS1cbAHTDc+7RBZEjPf1VFeUZsIIuHvU/AzXtcRaph9BHuPRNMQ==",
+      "path": "azure.storage.blobs/12.13.0",
+      "hashPath": "azure.storage.blobs.12.13.0.nupkg.sha512"
     },
-    "Azure.Storage.Common/12.8.0": {
+    "Azure.Storage.Common/12.12.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-2nR+kp1UfF+Ib3JHJkFf1VcVkx98ESIXoxUQ751uZ+fPtABAvA4C5JKuwLhksLVfnVMaljQRGS1BhHjrrUoz9g==",
-      "path": "azure.storage.common/12.8.0",
-      "hashPath": "azure.storage.common.12.8.0.nupkg.sha512"
+      "sha512": "sha512-Ms0XsZ/D9Pcudfbqj+rWeCkhx/ITEq8isY0jkor9JFmDAEHsItFa2XrWkzP3vmJU6EsXQrk4snH63HkW/Jksvg==",
+      "path": "azure.storage.common/12.12.0",
+      "hashPath": "azure.storage.common.12.12.0.nupkg.sha512"
     },
     "Google.Protobuf/3.15.8": {
       "type": "package",
@@ -2970,40 +2979,40 @@
       "path": "microsoft.azure.documentdb.core/2.11.2",
       "hashPath": "microsoft.azure.documentdb.core.2.11.2.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.JavaWorker/2.3.1": {
+    "Microsoft.Azure.Functions.JavaWorker/2.4.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-phtVkMzn8kxajit8yak7WR2IqjvkyUHF04kbgChbzGBsZTho1mnaI+zvMrVVZO094LUGkOCErt3+nofH3PNzWg==",
-      "path": "microsoft.azure.functions.javaworker/2.3.1",
-      "hashPath": "microsoft.azure.functions.javaworker.2.3.1.nupkg.sha512"
+      "sha512": "sha512-zo26921bvBegp9jth6QX85eMWR4Orb5T5xK98ueXsTd/H4fhc8cBfUqEr0pXE0bzm/T6y+PtY/DYrkyqtz1IPA==",
+      "path": "microsoft.azure.functions.javaworker/2.4.0",
+      "hashPath": "microsoft.azure.functions.javaworker.2.4.0.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.NodeJsWorker/3.4.0": {
+    "Microsoft.Azure.Functions.NodeJsWorker/3.5.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-uzQmwUXcx58BhtumbAH9asPyZAFF6bwSOEqVS8C7PDM/B52PNe1yguGMDBQVHohp7JoKIcWWQJLqJb46QvoL3w==",
-      "path": "microsoft.azure.functions.nodejsworker/3.4.0",
-      "hashPath": "microsoft.azure.functions.nodejsworker.3.4.0.nupkg.sha512"
+      "sha512": "sha512-k96v8BQP9zuFfHoowak7ibwZEcPDfnWhbYD+X9TeFFb0rhcY37fJHMCWNPyyurkV70cCtaVa5KgSM1nyBOLyzA==",
+      "path": "microsoft.azure.functions.nodejsworker/3.5.0",
+      "hashPath": "microsoft.azure.functions.nodejsworker.3.5.0.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.PowerShellWorker.PS7.0/4.0.2045": {
+    "Microsoft.Azure.Functions.PowerShellWorker.PS7.0/4.0.2302": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ErJlaw4ACpZ/6xtv7rCWi38EWtpPQpqlbf9o6XcfIlJiEMdBvq4pX+fHfvPtk7pbb/Z3v3BSdWlwcHBBsioK/g==",
-      "path": "microsoft.azure.functions.powershellworker.ps7.0/4.0.2045",
-      "hashPath": "microsoft.azure.functions.powershellworker.ps7.0.4.0.2045.nupkg.sha512"
+      "sha512": "sha512-kDYQTNhdblE2uwOjlnKwfvhDk753S+JIQcxBxlDhntO8eaof1xuZQsRfNW9ZMNC4x7Q4fctXRxr7bQA0OZ7vRA==",
+      "path": "microsoft.azure.functions.powershellworker.ps7.0/4.0.2302",
+      "hashPath": "microsoft.azure.functions.powershellworker.ps7.0.4.0.2302.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.PowerShellWorker.PS7.2/4.0.2040": {
+    "Microsoft.Azure.Functions.PowerShellWorker.PS7.2/4.0.2304": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-g3EvrIqDH7NTSUn2ZbcQFfFhCDi2Io4HsKSOywiFRR1tHt+SE80uZ6clgxNoOstfTdzckZfJiB99qF9wGSfPPA==",
-      "path": "microsoft.azure.functions.powershellworker.ps7.2/4.0.2040",
-      "hashPath": "microsoft.azure.functions.powershellworker.ps7.2.4.0.2040.nupkg.sha512"
+      "sha512": "sha512-IEfRdhLx+tDX06DW5dTR3t4OmKpCI5WlGdhsm/it9Nd7Xnu4HfaxLyr8++fOXHJYRNwoBx+ofqVzYPGhBEkPXQ==",
+      "path": "microsoft.azure.functions.powershellworker.ps7.2/4.0.2304",
+      "hashPath": "microsoft.azure.functions.powershellworker.ps7.2.4.0.2304.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.PythonWorker/4.3.0": {
+    "Microsoft.Azure.Functions.PythonWorker/4.7.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-M48lr0lPi1QtrUhoVwzqdvt9SOjpP7dofKH3mprSW5vWGhBrFx0iLVbujZ6VQpynGQPjLCoeY9v4fEamgQz/ng==",
-      "path": "microsoft.azure.functions.pythonworker/4.3.0",
-      "hashPath": "microsoft.azure.functions.pythonworker.4.3.0.nupkg.sha512"
+      "sha512": "sha512-F3BMg9g7AX7Avpe48pTa8aarFpzxaV2iBKzIkvOWtAYYmmYJKWEKecNLpefpVPxzr6pmcUd48ejrR2mtdmG5Ig==",
+      "path": "microsoft.azure.functions.pythonworker/4.7.0",
+      "hashPath": "microsoft.azure.functions.pythonworker.4.7.0.nupkg.sha512"
     },
     "Microsoft.Azure.KeyVault.Core/2.0.4": {
       "type": "package",
@@ -3026,26 +3035,26 @@
       "path": "microsoft.azure.storage.file/11.1.7",
       "hashPath": "microsoft.azure.storage.file.11.1.7.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs/3.0.34-11938": {
+    "Microsoft.Azure.WebJobs/3.0.34-11957": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-7OKcP6h5p5Qmlnsef+ZFlokyCCLhjpGqGhgw72gl9tZmjxCfCEQFhtW+WwoLybzLhrAgSI3sq+l7uOnGWW0KNw==",
-      "path": "microsoft.azure.webjobs/3.0.34-11938",
-      "hashPath": "microsoft.azure.webjobs.3.0.34-11938.nupkg.sha512"
+      "sha512": "sha512-sCGFa3yWGvRP3PybuaRTlUDcoWQdmwZBzFnc7D92B1aC6ZbN2eshZx9YJoMH/B0sTBkqD+kQw45VHtFLwF+SYA==",
+      "path": "microsoft.azure.webjobs/3.0.34-11957",
+      "hashPath": "microsoft.azure.webjobs.3.0.34-11957.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Core/3.0.34-11938": {
+    "Microsoft.Azure.WebJobs.Core/3.0.34-11957": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-ycbRY4HWxsG/yQgbjOqty9mLgApfev8XF58aF1YB7xRG4mPsmju6FsvWtE8Ftb0wsKvoSqjRfgleE/NqluAMzA==",
-      "path": "microsoft.azure.webjobs.core/3.0.34-11938",
-      "hashPath": "microsoft.azure.webjobs.core.3.0.34-11938.nupkg.sha512"
+      "sha512": "sha512-5xbzwPPX2lMqFy8L1BsTwwDAF4syRUtd/DxqLaziWb9sypgXLzjrFN/kpOM8MEHALYzXHlh/sOzzJiVK6ulIGQ==",
+      "path": "microsoft.azure.webjobs.core/3.0.34-11957",
+      "hashPath": "microsoft.azure.webjobs.core.3.0.34-11957.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Extensions/5.0.0-beta.2-10871": {
+    "Microsoft.Azure.WebJobs.Extensions/5.0.0-beta.2-10879": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-4KiAcvr1vY+hnS1xa6ujgKcMXRJZ3+DFPyCO84w4yK1PHHNBauiJy23Z25ZcpzKVYdxA3ZC9zlE/PL5FwZJx5g==",
-      "path": "microsoft.azure.webjobs.extensions/5.0.0-beta.2-10871",
-      "hashPath": "microsoft.azure.webjobs.extensions.5.0.0-beta.2-10871.nupkg.sha512"
+      "sha512": "sha512-oaGjQ3qTaLAo/f+J3hPY3IKmn7tXPYlx0cTmxmIfvSdxI2qncwClNe1ya9j9zv7+loPGsS2hjhjgOSSZLkKb9Q==",
+      "path": "microsoft.azure.webjobs.extensions/5.0.0-beta.2-10879",
+      "hashPath": "microsoft.azure.webjobs.extensions.5.0.0-beta.2-10879.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions.Http/3.2.0": {
       "type": "package",
@@ -3061,19 +3070,19 @@
       "path": "microsoft.azure.webjobs.extensions.timers.storage/1.0.0-beta.1",
       "hashPath": "microsoft.azure.webjobs.extensions.timers.storage.1.0.0-beta.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Host.Storage/5.0.0-beta.2-11938": {
+    "Microsoft.Azure.WebJobs.Host.Storage/5.0.0-beta.2-11957": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-O78u4PEgh3MAZ4gRmb/UbGo2Vo3Sb8ErN5hk2GtoJpRyzHyH/H/iOZWygg/V9q/8NWdr/amc0bF/c+ut1CM8LA==",
-      "path": "microsoft.azure.webjobs.host.storage/5.0.0-beta.2-11938",
-      "hashPath": "microsoft.azure.webjobs.host.storage.5.0.0-beta.2-11938.nupkg.sha512"
+      "sha512": "sha512-Oq0rRfl/MPfyUW0Tdue3osfXZxiKxMltSfF+rB2VurYHAlw1cHXuX9diMd8nCyYSjUFYkVi/mRS3lYJK9jdzqA==",
+      "path": "microsoft.azure.webjobs.host.storage/5.0.0-beta.2-11957",
+      "hashPath": "microsoft.azure.webjobs.host.storage.5.0.0-beta.2-11957.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Logging.ApplicationInsights/3.0.34-11938": {
+    "Microsoft.Azure.WebJobs.Logging.ApplicationInsights/3.0.34-11957": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-8MU629bGmATg808Pb8Q0JtAEriVUjFlI1GWAb9D2QGMdN8nqjnJS0uWPUdPwNz4eCJCv+8bOyN3TNPvWl6fJ6Q==",
-      "path": "microsoft.azure.webjobs.logging.applicationinsights/3.0.34-11938",
-      "hashPath": "microsoft.azure.webjobs.logging.applicationinsights.3.0.34-11938.nupkg.sha512"
+      "sha512": "sha512-8SuCRJe5CKht1agGAKGZEL6CqlmJ0RfQy3HMckKJXg6APLCmh7DR3lxNcIe5KNbQklTv5nyeGGEjokRijF/55w==",
+      "path": "microsoft.azure.webjobs.logging.applicationinsights/3.0.34-11957",
+      "hashPath": "microsoft.azure.webjobs.logging.applicationinsights.3.0.34-11957.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Script.Abstractions/1.0.3-preview": {
       "type": "package",
@@ -3089,12 +3098,12 @@
       "path": "microsoft.azure.websites.dataprotection/2.1.91-alpha",
       "hashPath": "microsoft.azure.websites.dataprotection.2.1.91-alpha.nupkg.sha512"
     },
-    "Microsoft.Bcl.AsyncInterfaces/1.0.0": {
+    "Microsoft.Bcl.AsyncInterfaces/1.1.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-K63Y4hORbBcKLWH5wnKgzyn7TOfYzevIEwIedQHBIkmkEBA9SCqgvom+XTuE+fAFGvINGkhFItaZ2dvMGdT5iw==",
-      "path": "microsoft.bcl.asyncinterfaces/1.0.0",
-      "hashPath": "microsoft.bcl.asyncinterfaces.1.0.0.nupkg.sha512"
+      "sha512": "sha512-yuvf07qFWFqtK3P/MRkEKLhn5r2UbSpVueRziSqj0yJQIKFwG1pq9mOayK3zE5qZCTs0CbrwL9M6R8VwqyGy2w==",
+      "path": "microsoft.bcl.asyncinterfaces/1.1.1",
+      "hashPath": "microsoft.bcl.asyncinterfaces.1.1.1.nupkg.sha512"
     },
     "Microsoft.Build.Tasks.Git/1.0.0": {
       "type": "package",
@@ -3705,12 +3714,12 @@
       "path": "system.appcontext/4.1.0",
       "hashPath": "system.appcontext.4.1.0.nupkg.sha512"
     },
-    "System.Buffers/4.5.1": {
+    "System.Buffers/4.5.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg==",
-      "path": "system.buffers/4.5.1",
-      "hashPath": "system.buffers.4.5.1.nupkg.sha512"
+      "sha512": "sha512-pL2ChpaRRWI/p4LXyy4RgeWlYF2sgfj/pnVMvBqwNFr5cXg7CXNnWZWxrOONLg8VGdFB8oB+EG2Qw4MLgTOe+A==",
+      "path": "system.buffers/4.5.0",
+      "hashPath": "system.buffers.4.5.0.nupkg.sha512"
     },
     "System.Collections/4.3.0": {
       "type": "package",
@@ -3886,6 +3895,13 @@
       "sha512": "sha512-6QOb2XFLch7bEc4lIcJH49nJN2HV+OC3fHDgsLVsBVBk3Y4hFAnOBGzJ2lUu7CyDDFo9IBWkSsnbkT6IBwwiMw==",
       "path": "system.io.filesystem.primitives/4.3.0",
       "hashPath": "system.io.filesystem.primitives.4.3.0.nupkg.sha512"
+    },
+    "System.IO.Hashing/6.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Rfm2jYCaUeGysFEZjDe7j1R4x6Z6BzumS/vUT5a1AA/AWJuGX71PoGB0RmpyX3VmrGqVnAwtfMn39OHR8Y/5+g==",
+      "path": "system.io.hashing/6.0.0",
+      "hashPath": "system.io.hashing.6.0.0.nupkg.sha512"
     },
     "System.Linq/4.3.0": {
       "type": "package",
@@ -4279,6 +4295,13 @@
       "path": "system.threading/4.3.0",
       "hashPath": "system.threading.4.3.0.nupkg.sha512"
     },
+    "System.Threading.Channels/6.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-TY8/9+tI0mNaUMgntOxxaq2ndTkdXqLSxvPmas7XEqOlv9lQtB7wLjYGd756lOaO7Dvb5r/WXhluM+0Xe87v5Q==",
+      "path": "system.threading.channels/6.0.0",
+      "hashPath": "system.threading.channels.6.0.0.nupkg.sha512"
+    },
     "System.Threading.Overlapped/4.0.1": {
       "type": "package",
       "serviceable": true,
@@ -4328,12 +4351,12 @@
       "path": "system.windows.extensions/4.7.0",
       "hashPath": "system.windows.extensions.4.7.0.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Script/4.9.0": {
+    "Microsoft.Azure.WebJobs.Script/4.12.0": {
       "type": "project",
       "serviceable": false,
       "sha512": ""
     },
-    "Microsoft.Azure.WebJobs.Script.Grpc/4.9.0": {
+    "Microsoft.Azure.WebJobs.Script.Grpc/4.12.0": {
       "type": "project",
       "serviceable": false,
       "sha512": ""


### PR DESCRIPTION
Change:

1. rev Azure.Core to 1.25.0
2. copy current deps.json

NOTE I HAVE NO IDEA ON THE CORRECT PROCESS FOR THE "2"; I'm just winging it here; but: the test passes, yay?

Background:

In https://github.com/Azure/azure-functions-host/commit/7458ff70be685f2a38cfd05a2ae11dc1fef3870f (yesterday), Azure.Storage.Blobs was updated from 12.9.0 to 12.13.0

[Azure.Storage.Blobs 12.9.0](https://www.nuget.org/packages/Azure.Storage.Blobs/12.9.0#dependencies-body-tab) => [Azure.Storage.Common 12.8.0](https://www.nuget.org/packages/Azure.Storage.Common/12.8.0#dependencies-body-tab) => Azure.Core 1.15.0

However:

[Azure.Storage.Blobs 12.13.0](https://www.nuget.org/packages/Azure.Storage.Blobs/12.13.0#dependencies-body-tab) => [Azure.Storage.Common 12.12.0](https://www.nuget.org/packages/Azure.Storage.Common/12.12.0#dependencies-body-tab) => Azure.Core 1.25.0

WebJobs.Script *was* taking Azure.Core 1.19.0 (1.19.0 satisfies >= 1.15.0), but with this dependabot bump, this is no longer usable (1.19.0 does not satisfy >= 1.25.0), and thus dev is unbuildable:

![image](https://user-images.githubusercontent.com/17328/190126144-08b943c9-72e4-4327-8e95-a9b69697764b.png)

This includes blocking all PRs etc, due to CI failures.