### PR TITLE
improving test resiliency

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -398,7 +398,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 string token = GenerateAdminJwtToken();
                 request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             }
-            
+
             HttpResponseMessage response = await HttpClient.SendAsync(request);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadAsAsync<HostStatus>();
@@ -441,7 +441,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
         }
 
-        private async Task<bool> IsHostStarted()
+        public async Task<bool> IsHostStarted()
         {
             HostStatus status = await GetHostStatusAsync();
             return status.State == $"{ScriptHostState.Running}" || status.State == $"{ScriptHostState.Error}";

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node.cs
@@ -388,7 +388,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                 {
                     o.Functions = new[]
                     {
-                        "HttpTrigger"
+                        "EventHubTrigger",
+                        "HttpTrigger",
+                        "HttpTrigger-CustomRoute-Get",
+                        "HttpTrigger-Disabled",
+                        "HttpTrigger-Identities",
+                        "ManualTrigger",
+                        "proxyroute"
                     };
                 });
             }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node.cs
@@ -13,13 +13,13 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.Storage.Blob;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Models;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.WebJobs.Script.Tests;
-using Microsoft.Azure.Storage.Blob;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -242,7 +242,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         [Fact(Skip = "http://github.com/Azure/azure-functions-host/issues/2812")]
         public async Task HttpTrigger_CustomRoute_Post_ReturnsExpectedResponse()
         {
-
             string id = Guid.NewGuid().ToString();
             string functionKey = await _fixture.Host.GetFunctionSecretAsync("HttpTrigger-CustomRoute-Post");
             string uri = $"api/node/products/housewares/{id}?code={functionKey}";
@@ -311,6 +310,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             response = await _fixture.Host.HttpClient.SendAsync(request);
             timestamp = response.Headers.GetValues("Shared-Module").First();
             Assert.Equal(initialTimestamp, timestamp);
+
+            // Prevent errors when host is disposed during startup.
+            await TestHelpers.Await(_fixture.Host.IsHostStarted, userMessageCallback: _fixture.Host.GetLog);
         }
 
         [Fact]
@@ -386,13 +388,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                 {
                     o.Functions = new[]
                     {
-                        "EventHubTrigger",
-                        "HttpTrigger",
-                        "HttpTrigger-CustomRoute-Get",
-                        "HttpTrigger-Disabled",
-                        "HttpTrigger-Identities",
-                        "ManualTrigger",
-                        "proxyroute"
+                        "HttpTrigger"
                     };
                 });
             }


### PR DESCRIPTION
We have a test (`SharedDirectory_ReloadsOnFileChange`) that reloads a javascript file and then confirms that the host has picked up the change by pinging the site via http and checking a header. As soon as it finds the header, the test passes, and the fixture is free to dispose the host.

This test runs fine, however, http endpoints are available to be routed to customer code before the host is fully running (this helps with cold start). This means that this test has the chance to start a host, then dispose it mid-startup.

Ideally, this would work smoothly and everything would properly skip steps if shutdown happened mid-startup, etc. But that's not the case.

When this test fails, we can see exceptions thrown from some HostedServices, and after the host has been disposed, the FileSystemWatcher (a HostedService) still starts up -- this part I don't quite understand, but it's StartAsync is being called --  and begins watching for "*". But the services that are called upon files being changed are already disposed... which results in the ObjectDisposedExcpetion we were constantly seeing with these tests. In this case, those file changes are the files that are being deleted as the test fixture disposes itself. If the host throws an unhandled exception during this, it crashes the test harness, resulting in the failure we have been seeing.

The perfect fix is to make sure that the host is resilient to immediate start/stop calls. But that will be a lot of work and not really benefit anything in production as it's not really a scenario there. The fix here is to slow down this one test and ensure it doesn't pass until it has allowed the host to hit its "running" state, thus allowing for a smooth shutdown later by the fixture.

Fun times.