### PR TITLE
HOTFIXv3 - Introduce feature flag to Execution Logger. Opt-in for FunctionExecutionCount 

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
@@ -69,12 +69,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         {
             var logger = _loggerFactory.GetOrCreate(FunctionsExecutionEventsCategory);
             string currentUtcTime = DateTime.UtcNow.ToString();
-            string log = currentUtcTime;
             if (FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableLinuxEPExecutionCount))
             {
                 log = string.Join(",", executionId, siteName, concurrency.ToString(), functionName, invocationId, executionStage, executionTimeSpan.ToString(), success.ToString(), currentUtcTime);
+                WriteEvent(logger, log);
             }
-            WriteEvent(logger, log);
+            else
+            {
+                WriteEvent(logger, currentUtcTime);
+            }
         }
 
         private static void WriteEvent(LinuxAppServiceFileLogger logger, string evt)

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
@@ -68,7 +68,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         {
             var logger = _loggerFactory.GetOrCreate(FunctionsExecutionEventsCategory);
             string currentUtcTime = DateTime.UtcNow.ToString();
-            string log = string.Join(",", executionId, siteName, concurrency.ToString(), functionName, invocationId, executionStage, executionTimeSpan.ToString(), success.ToString(), currentUtcTime);
+            if (FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableLinuxEPExecutionCount)) 
+            {
+                string log = string.Join(",", executionId, siteName, concurrency.ToString(), functionName, invocationId, executionStage, executionTimeSpan.ToString(), success.ToString(), currentUtcTime);
+            }
+            else 
+            {
+                string log = currentUtcTime;
+            }
             WriteEvent(logger, log);
         }
 

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             string currentUtcTime = DateTime.UtcNow.ToString();
             if (FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableLinuxEPExecutionCount))
             {
-                log = string.Join(",", executionId, siteName, concurrency.ToString(), functionName, invocationId, executionStage, executionTimeSpan.ToString(), success.ToString(), currentUtcTime);
+                string log = string.Join(",", executionId, siteName, concurrency.ToString(), functionName, invocationId, executionStage, executionTimeSpan.ToString(), success.ToString(), currentUtcTime);
                 WriteEvent(logger, log);
             }
             else

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Extensions.Logging;
 using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 {
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             string log = currentUtcTime;
             if (FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableLinuxEPExecutionCount))
             {
-                string log = string.Join(",", executionId, siteName, concurrency.ToString(), functionName, invocationId, executionStage, executionTimeSpan.ToString(), success.ToString(), currentUtcTime);
+                log = string.Join(",", executionId, siteName, concurrency.ToString(), functionName, invocationId, executionStage, executionTimeSpan.ToString(), success.ToString(), currentUtcTime);
             }
             WriteEvent(logger, log);
         }

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Extensions.Logging;
+using Microsoft.Azure.WebJobs.Script.Config;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 {
@@ -68,13 +69,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         {
             var logger = _loggerFactory.GetOrCreate(FunctionsExecutionEventsCategory);
             string currentUtcTime = DateTime.UtcNow.ToString();
-            if (FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableLinuxEPExecutionCount)) 
+            string log = currentUtcTime;
+            if (FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableLinuxEPExecutionCount))
             {
                 string log = string.Join(",", executionId, siteName, concurrency.ToString(), functionName, invocationId, executionStage, executionTimeSpan.ToString(), success.ToString(), currentUtcTime);
-            }
-            else 
-            {
-                string log = currentUtcTime;
             }
             WriteEvent(logger, log);
         }

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -120,6 +120,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FeatureFlagDisableAspNetCoreGrpc = "DisableAspNetCoreGrpc";
         public const string FeatureFlagEnableWorkerIndexing = "EnableWorkerIndexing";
         public const string FeatureFlagEnableMultiLanguageWorker = "EnableMultiLanguageWorker";
+        public const string FeatureFlagEnableLinuxEPExecutionCount = "EnableLinuxFEC";
 
         public const string AdminJwtValidAudienceFormat = "https://{0}.azurewebsites.net/azurefunctions";
         public const string AdminJwtValidIssuerFormat = "https://{0}.scm.azurewebsites.net";

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxAppServiceEventGeneratorTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxAppServiceEventGeneratorTests.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Microsoft.Azure.WebJobs.Script.Tests.Workers;
+//using Microsoft.Azure.WebJobs.Script.Tests.Workers;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.Logging;
@@ -37,9 +37,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
                 [LinuxEventGenerator.FunctionsMetricsCategory] =
                     new MockLinuxAppServiceFileLogger(LinuxEventGenerator.FunctionsMetricsCategory, string.Empty, null),
                 [LinuxEventGenerator.FunctionsDetailsCategory] =
-                    new MockLinuxAppServiceFileLogger(LinuxEventGenerator.FunctionsDetailsCategory, string.Empty, null),
-                [LinuxEventGenerator.FunctionsExecutionEventsCategory] =
-                    new MockLinuxAppServiceFileLogger(LinuxEventGenerator.FunctionsExecutionEventsCategory, string.Empty, null)
+                    new MockLinuxAppServiceFileLogger(LinuxEventGenerator.FunctionsDetailsCategory, string.Empty, null)
+                // [LinuxEventGenerator.FunctionsExecutionEventsCategory] =
+                //     new MockLinuxAppServiceFileLogger(LinuxEventGenerator.FunctionsExecutionEventsCategory, string.Empty, null)
             };
 
             var loggerFactoryMock = new Mock<LinuxAppServiceFileLoggerFactory>(MockBehavior.Strict);
@@ -175,31 +175,31 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
                 p => Assert.True(DateTime.TryParse(p, out DateTime dt)));
         }
 
-        [Theory]
-        [MemberData(nameof(LinuxEventGeneratorTestData.GetFunctionExecutionEvents), MemberType = typeof(LinuxEventGeneratorTestData))]
-        public void ParseFunctionExecutionEvents(string executionId, string siteName, int concurrency, string functionName, string invocationId,
-            string executionStage, long executionTimeSpan, bool success)
-        {
-            _generator.LogFunctionExecutionEvent(executionId, siteName, concurrency, functionName, invocationId, executionStage, executionTimeSpan, success);
-            string evt = _loggers[LinuxEventGenerator.FunctionsExecutionEventsCategory].Events.Single();
+        // [Theory]
+        // [MemberData(nameof(LinuxEventGeneratorTestData.GetFunctionExecutionEvents), MemberType = typeof(LinuxEventGeneratorTestData))]
+        // public void ParseFunctionExecutionEvents(string executionId, string siteName, int concurrency, string functionName, string invocationId,
+        //     string executionStage, long executionTimeSpan, bool success)
+        // {
+        //     _generator.LogFunctionExecutionEvent(executionId, siteName, concurrency, functionName, invocationId, executionStage, executionTimeSpan, success);
+        //     string evt = _loggers[LinuxEventGenerator.FunctionsExecutionEventsCategory].Events.Single();
 
-            Regex regex = new Regex(LinuxAppServiceEventGenerator.ExecutionEventRegex);
-            var match = regex.Match(evt);
+        //     Regex regex = new Regex(LinuxAppServiceEventGenerator.ExecutionEventRegex);
+        //     var match = regex.Match(evt);
 
-            Assert.True(match.Success);
-            Assert.Equal(10, match.Groups.Count);
+        //     Assert.True(match.Success);
+        //     Assert.Equal(10, match.Groups.Count);
 
-            var groupMatches = match.Groups.Cast<Group>().Select(p => p.Value).Skip(1).ToArray();
-            Assert.Collection(groupMatches,
-                p => Assert.Equal(executionId, p),
-                p => Assert.Equal(siteName, p),
-                p => Assert.Equal(concurrency.ToString(), p),
-                p => Assert.Equal(functionName, p),
-                p => Assert.Equal(invocationId, p),
-                p => Assert.Equal(executionStage, p),
-                p => Assert.Equal(executionTimeSpan.ToString(), p),
-                p => Assert.True(Convert.ToBoolean(p)),
-                p => Assert.True(DateTime.TryParse(p, out DateTime dt)));
-        }
+        //     var groupMatches = match.Groups.Cast<Group>().Select(p => p.Value).Skip(1).ToArray();
+        //     Assert.Collection(groupMatches,
+        //         p => Assert.Equal(executionId, p),
+        //         p => Assert.Equal(siteName, p),
+        //         p => Assert.Equal(concurrency.ToString(), p),
+        //         p => Assert.Equal(functionName, p),
+        //         p => Assert.Equal(invocationId, p),
+        //         p => Assert.Equal(executionStage, p),
+        //         p => Assert.Equal(executionTimeSpan.ToString(), p),
+        //         p => Assert.True(Convert.ToBoolean(p)),
+        //         p => Assert.True(DateTime.TryParse(p, out DateTime dt)));
+        // }
     }
 }

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxAppServiceEventGeneratorTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxAppServiceEventGeneratorTests.cs
@@ -5,12 +5,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-//using Microsoft.Azure.WebJobs.Script.Tests.Workers;
+using Microsoft.Azure.WebJobs.Script.Tests.Workers;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
+using static Microsoft.Azure.WebJobs.Script.ScriptConstants;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 {
@@ -37,9 +38,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
                 [LinuxEventGenerator.FunctionsMetricsCategory] =
                     new MockLinuxAppServiceFileLogger(LinuxEventGenerator.FunctionsMetricsCategory, string.Empty, null),
                 [LinuxEventGenerator.FunctionsDetailsCategory] =
-                    new MockLinuxAppServiceFileLogger(LinuxEventGenerator.FunctionsDetailsCategory, string.Empty, null)
-                // [LinuxEventGenerator.FunctionsExecutionEventsCategory] =
-                //     new MockLinuxAppServiceFileLogger(LinuxEventGenerator.FunctionsExecutionEventsCategory, string.Empty, null)
+                    new MockLinuxAppServiceFileLogger(LinuxEventGenerator.FunctionsDetailsCategory, string.Empty, null),
+                [LinuxEventGenerator.FunctionsExecutionEventsCategory] =
+                    new MockLinuxAppServiceFileLogger(LinuxEventGenerator.FunctionsExecutionEventsCategory, string.Empty, null)
             };
 
             var loggerFactoryMock = new Mock<LinuxAppServiceFileLoggerFactory>(MockBehavior.Strict);
@@ -175,31 +176,50 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
                 p => Assert.True(DateTime.TryParse(p, out DateTime dt)));
         }
 
-        // [Theory]
-        // [MemberData(nameof(LinuxEventGeneratorTestData.GetFunctionExecutionEvents), MemberType = typeof(LinuxEventGeneratorTestData))]
-        // public void ParseFunctionExecutionEvents(string executionId, string siteName, int concurrency, string functionName, string invocationId,
-        //     string executionStage, long executionTimeSpan, bool success)
-        // {
-        //     _generator.LogFunctionExecutionEvent(executionId, siteName, concurrency, functionName, invocationId, executionStage, executionTimeSpan, success);
-        //     string evt = _loggers[LinuxEventGenerator.FunctionsExecutionEventsCategory].Events.Single();
+        [Theory]
+        [MemberData(nameof(LinuxEventGeneratorTestData.GetFunctionExecutionEvents), MemberType = typeof(LinuxEventGeneratorTestData))]
+        public void ParseFunctionExecutionEvents(string executionId, string siteName, int concurrency, string functionName, string invocationId,
+            string executionStage, long executionTimeSpan, bool success, bool featureFlagEnabled)
+        {
+            TestScopedEnvironmentVariable featureFlags = null;
+            try
+            {
+                if (featureFlagEnabled)
+                {
+                    featureFlags = new TestScopedEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, FeatureFlagEnableLinuxEPExecutionCount);
+                }
+                _generator.LogFunctionExecutionEvent(executionId, siteName, concurrency, functionName, invocationId, executionStage, executionTimeSpan, success);
+                string evt = _loggers[LinuxEventGenerator.FunctionsExecutionEventsCategory].Events.Single();
 
-        //     Regex regex = new Regex(LinuxAppServiceEventGenerator.ExecutionEventRegex);
-        //     var match = regex.Match(evt);
+                if (featureFlagEnabled)
+                {
+                    Regex regex = new Regex(LinuxAppServiceEventGenerator.ExecutionEventRegex);
+                    var match = regex.Match(evt);
 
-        //     Assert.True(match.Success);
-        //     Assert.Equal(10, match.Groups.Count);
+                    Assert.True(match.Success);
+                    Assert.Equal(10, match.Groups.Count);
 
-        //     var groupMatches = match.Groups.Cast<Group>().Select(p => p.Value).Skip(1).ToArray();
-        //     Assert.Collection(groupMatches,
-        //         p => Assert.Equal(executionId, p),
-        //         p => Assert.Equal(siteName, p),
-        //         p => Assert.Equal(concurrency.ToString(), p),
-        //         p => Assert.Equal(functionName, p),
-        //         p => Assert.Equal(invocationId, p),
-        //         p => Assert.Equal(executionStage, p),
-        //         p => Assert.Equal(executionTimeSpan.ToString(), p),
-        //         p => Assert.True(Convert.ToBoolean(p)),
-        //         p => Assert.True(DateTime.TryParse(p, out DateTime dt)));
-        // }
+                    var groupMatches = match.Groups.Cast<Group>().Select(p => p.Value).Skip(1).ToArray();
+                    Assert.Collection(groupMatches,
+                        p => Assert.Equal(executionId, p),
+                        p => Assert.Equal(siteName, p),
+                        p => Assert.Equal(concurrency.ToString(), p),
+                        p => Assert.Equal(functionName, p),
+                        p => Assert.Equal(invocationId, p),
+                        p => Assert.Equal(executionStage, p),
+                        p => Assert.Equal(executionTimeSpan.ToString(), p),
+                        p => Assert.True(Convert.ToBoolean(p)),
+                        p => Assert.True(DateTime.TryParse(p, out DateTime dt)));
+                }
+                else
+                {
+                    Assert.True(DateTime.TryParse(evt, out DateTime dt));
+                }
+            }
+            finally
+            {
+                featureFlags?.Dispose();
+            }
+        }
     }
 }

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxEventGeneratorTestData.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxEventGeneratorTestData.cs
@@ -33,9 +33,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             yield return new object[] { LogLevel.Information, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty };
         }
 
-        public static IEnumerable<object[]> GetFunctionExecutionEvents()
-        {
-            yield return new object[] { "testexecution", "testSite", 1, "testFunction", "testInvocation", "testStage", 1, true };
-        }
+        // public static IEnumerable<object[]> GetFunctionExecutionEvents()
+        // {
+        //     yield return new object[] { "testexecution", "testSite", 1, "testFunction", "testInvocation", "testStage", 1, true };
+        // }
     }
 }

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxEventGeneratorTestData.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxEventGeneratorTestData.cs
@@ -33,9 +33,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             yield return new object[] { LogLevel.Information, string.Empty, string.Empty, string.Empty, string.Empty, string.Empty };
         }
 
-        // public static IEnumerable<object[]> GetFunctionExecutionEvents()
-        // {
-        //     yield return new object[] { "testexecution", "testSite", 1, "testFunction", "testInvocation", "testStage", 1, true };
-        // }
+        public static IEnumerable<object[]> GetFunctionExecutionEvents()
+        {
+            yield return new object[] { "testexecution", "testSite", 1, "testFunction", "testInvocation", "testStage", 1, true, true };
+            yield return new object[] { "testexecution", "testSite", 1, "testFunction", "testInvocation", "testStage", 1, true, false };
+        }
     }
 }


### PR DESCRIPTION
Regression in latest host versions due to https://github.com/Azure/azure-functions-host/pull/8315. The number of execution emitted by high load functions overwhelms the metering service and causes Function Apps to fail with memory exceptions.

This PR introduced a feature flag to make FEC reporting optional until we are able to release a metering service fix targetting ANT100. For apps without high continuous load, they can enable FEC reporting.

Related ICMs:
https://portal.microsofticm.com/imp/v3/incidents/details/334835894/home
https://portal.microsofticm.com/imp/v3/incidents/details/333462646/home