### PR TITLE
Hotfix v4 - Include FunctionExecutionCount feature flag in 4.12.0

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <MajorVersion>4</MajorVersion>
     <MinorVersion>12</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
     <BuildNumber Condition="'$(BuildNumber)' == '' ">0</BuildNumber>
     <PreviewVersion></PreviewVersion>        
     

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
@@ -68,8 +69,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         {
             var logger = _loggerFactory.GetOrCreate(FunctionsExecutionEventsCategory);
             string currentUtcTime = DateTime.UtcNow.ToString();
-            string log = string.Join(",", executionId, siteName, concurrency.ToString(), functionName, invocationId, executionStage, executionTimeSpan.ToString(), success.ToString(), currentUtcTime);
-            WriteEvent(logger, log);
+            if (FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableLinuxEPExecutionCount))
+            {
+                string log = string.Join(",", executionId, siteName, concurrency.ToString(), functionName, invocationId, executionStage, executionTimeSpan.ToString(), success.ToString(), currentUtcTime);
+                WriteEvent(logger, log);
+            }
+            else
+            {
+                WriteEvent(logger, currentUtcTime);
+            }
         }
 
         private static void WriteEvent(LinuxAppServiceFileLogger logger, string evt)

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -113,6 +113,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FeatureFlagEnableWorkerIndexing = "EnableWorkerIndexing";
         public const string FeatureFlagEnableDebugTracing = "EnableDebugTracing";
         public const string FeatureFlagEnableMultiLanguageWorker = "EnableMultiLanguageWorker";
+        public const string FeatureFlagEnableLinuxEPExecutionCount = "EnableLinuxFEC";
 
         public const string AdminJwtValidAudienceFormat = "https://{0}.azurewebsites.net/azurefunctions";
         public const string AdminJwtValidIssuerFormat = "https://{0}.scm.azurewebsites.net";

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxAppServiceEventGeneratorTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxAppServiceEventGeneratorTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
+using static Microsoft.Azure.WebJobs.Script.ScriptConstants;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 {
@@ -178,28 +179,47 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         [Theory]
         [MemberData(nameof(LinuxEventGeneratorTestData.GetFunctionExecutionEvents), MemberType = typeof(LinuxEventGeneratorTestData))]
         public void ParseFunctionExecutionEvents(string executionId, string siteName, int concurrency, string functionName, string invocationId,
-            string executionStage, long executionTimeSpan, bool success)
+            string executionStage, long executionTimeSpan, bool success, bool featureFlagEnabled)
         {
-            _generator.LogFunctionExecutionEvent(executionId, siteName, concurrency, functionName, invocationId, executionStage, executionTimeSpan, success);
-            string evt = _loggers[LinuxEventGenerator.FunctionsExecutionEventsCategory].Events.Single();
+            TestScopedEnvironmentVariable featureFlags = null;
+            try
+            {
+                if (featureFlagEnabled)
+                {
+                    featureFlags = new TestScopedEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, FeatureFlagEnableLinuxEPExecutionCount);
+                }
+                _generator.LogFunctionExecutionEvent(executionId, siteName, concurrency, functionName, invocationId, executionStage, executionTimeSpan, success);
+                string evt = _loggers[LinuxEventGenerator.FunctionsExecutionEventsCategory].Events.Single();
 
-            Regex regex = new Regex(LinuxAppServiceEventGenerator.ExecutionEventRegex);
-            var match = regex.Match(evt);
+                if (featureFlagEnabled)
+                {
+                    Regex regex = new Regex(LinuxAppServiceEventGenerator.ExecutionEventRegex);
+                    var match = regex.Match(evt);
 
-            Assert.True(match.Success);
-            Assert.Equal(10, match.Groups.Count);
+                    Assert.True(match.Success);
+                    Assert.Equal(10, match.Groups.Count);
 
-            var groupMatches = match.Groups.Cast<Group>().Select(p => p.Value).Skip(1).ToArray();
-            Assert.Collection(groupMatches,
-                p => Assert.Equal(executionId, p),
-                p => Assert.Equal(siteName, p),
-                p => Assert.Equal(concurrency.ToString(), p),
-                p => Assert.Equal(functionName, p),
-                p => Assert.Equal(invocationId, p),
-                p => Assert.Equal(executionStage, p),
-                p => Assert.Equal(executionTimeSpan.ToString(), p),
-                p => Assert.True(Convert.ToBoolean(p)),
-                p => Assert.True(DateTime.TryParse(p, out DateTime dt)));
+                    var groupMatches = match.Groups.Cast<Group>().Select(p => p.Value).Skip(1).ToArray();
+                    Assert.Collection(groupMatches,
+                        p => Assert.Equal(executionId, p),
+                        p => Assert.Equal(siteName, p),
+                        p => Assert.Equal(concurrency.ToString(), p),
+                        p => Assert.Equal(functionName, p),
+                        p => Assert.Equal(invocationId, p),
+                        p => Assert.Equal(executionStage, p),
+                        p => Assert.Equal(executionTimeSpan.ToString(), p),
+                        p => Assert.True(Convert.ToBoolean(p)),
+                        p => Assert.True(DateTime.TryParse(p, out DateTime dt)));
+                }
+                else
+                {
+                    Assert.True(DateTime.TryParse(evt, out DateTime dt));
+                }
+            }
+            finally
+            {
+                featureFlags?.Dispose();
+            }
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxEventGeneratorTestData.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxEventGeneratorTestData.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 
         public static IEnumerable<object[]> GetFunctionExecutionEvents()
         {
-            yield return new object[] { "testexecution", "testSite", 1, "testFunction", "testInvocation", "testStage", 1, true };
+            yield return new object[] { "testexecution", "testSite", 1, "testFunction", "testInvocation", "testStage", 1, true, true };
+            yield return new object[] { "testexecution", "testSite", 1, "testFunction", "testInvocation", "testStage", 1, true, false };
         }
     }
 }


### PR DESCRIPTION
Hotfix to bring release 4.12.0 up to date with prior hotfix release 4.10.5 / 4.11.3.

This hotfix cherrypicks commit - 0bf51759a27d459d30cddd5f5cd17651a059ce4a from dev
Updates Host Version from 4.12.0 to 4.12.1