### PR TITLE
Hotfix v3 - Include FunctionExecutionCount feature flag in 3.15.0

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
@@ -68,8 +69,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         {
             var logger = _loggerFactory.GetOrCreate(FunctionsExecutionEventsCategory);
             string currentUtcTime = DateTime.UtcNow.ToString();
-            string log = string.Join(",", executionId, siteName, concurrency.ToString(), functionName, invocationId, executionStage, executionTimeSpan.ToString(), success.ToString(), currentUtcTime);
-            WriteEvent(logger, log);
+            if (FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableLinuxEPExecutionCount))
+            {
+                string log = string.Join(",", executionId, siteName, concurrency.ToString(), functionName, invocationId, executionStage, executionTimeSpan.ToString(), success.ToString(), currentUtcTime);
+                WriteEvent(logger, log);
+            }
+            else
+            {
+                WriteEvent(logger, currentUtcTime);
+            }
         }
 
         private static void WriteEvent(LinuxAppServiceFileLogger logger, string evt)

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -120,6 +120,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FeatureFlagDisableAspNetCoreGrpc = "DisableAspNetCoreGrpc";
         public const string FeatureFlagEnableWorkerIndexing = "EnableWorkerIndexing";
         public const string FeatureFlagEnableMultiLanguageWorker = "EnableMultiLanguageWorker";
+        public const string FeatureFlagEnableLinuxEPExecutionCount = "EnableLinuxFEC";
 
         public const string AdminJwtValidAudienceFormat = "https://{0}.azurewebsites.net/azurefunctions";
         public const string AdminJwtValidIssuerFormat = "https://{0}.scm.azurewebsites.net";

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxAppServiceEventGeneratorTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxAppServiceEventGeneratorTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
+using static Microsoft.Azure.WebJobs.Script.ScriptConstants;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 {
@@ -178,28 +179,47 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         [Theory]
         [MemberData(nameof(LinuxEventGeneratorTestData.GetFunctionExecutionEvents), MemberType = typeof(LinuxEventGeneratorTestData))]
         public void ParseFunctionExecutionEvents(string executionId, string siteName, int concurrency, string functionName, string invocationId,
-            string executionStage, long executionTimeSpan, bool success)
+            string executionStage, long executionTimeSpan, bool success, bool featureFlagEnabled)
         {
-            _generator.LogFunctionExecutionEvent(executionId, siteName, concurrency, functionName, invocationId, executionStage, executionTimeSpan, success);
-            string evt = _loggers[LinuxEventGenerator.FunctionsExecutionEventsCategory].Events.Single();
+            TestScopedEnvironmentVariable featureFlags = null;
+            try
+            {
+                if (featureFlagEnabled)
+                {
+                    featureFlags = new TestScopedEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, FeatureFlagEnableLinuxEPExecutionCount);
+                }
+                _generator.LogFunctionExecutionEvent(executionId, siteName, concurrency, functionName, invocationId, executionStage, executionTimeSpan, success);
+                string evt = _loggers[LinuxEventGenerator.FunctionsExecutionEventsCategory].Events.Single();
 
-            Regex regex = new Regex(LinuxAppServiceEventGenerator.ExecutionEventRegex);
-            var match = regex.Match(evt);
+                if (featureFlagEnabled)
+                {
+                    Regex regex = new Regex(LinuxAppServiceEventGenerator.ExecutionEventRegex);
+                    var match = regex.Match(evt);
 
-            Assert.True(match.Success);
-            Assert.Equal(10, match.Groups.Count);
+                    Assert.True(match.Success);
+                    Assert.Equal(10, match.Groups.Count);
 
-            var groupMatches = match.Groups.Cast<Group>().Select(p => p.Value).Skip(1).ToArray();
-            Assert.Collection(groupMatches,
-                p => Assert.Equal(executionId, p),
-                p => Assert.Equal(siteName, p),
-                p => Assert.Equal(concurrency.ToString(), p),
-                p => Assert.Equal(functionName, p),
-                p => Assert.Equal(invocationId, p),
-                p => Assert.Equal(executionStage, p),
-                p => Assert.Equal(executionTimeSpan.ToString(), p),
-                p => Assert.True(Convert.ToBoolean(p)),
-                p => Assert.True(DateTime.TryParse(p, out DateTime dt)));
+                    var groupMatches = match.Groups.Cast<Group>().Select(p => p.Value).Skip(1).ToArray();
+                    Assert.Collection(groupMatches,
+                        p => Assert.Equal(executionId, p),
+                        p => Assert.Equal(siteName, p),
+                        p => Assert.Equal(concurrency.ToString(), p),
+                        p => Assert.Equal(functionName, p),
+                        p => Assert.Equal(invocationId, p),
+                        p => Assert.Equal(executionStage, p),
+                        p => Assert.Equal(executionTimeSpan.ToString(), p),
+                        p => Assert.True(Convert.ToBoolean(p)),
+                        p => Assert.True(DateTime.TryParse(p, out DateTime dt)));
+                }
+                else
+                {
+                    Assert.True(DateTime.TryParse(evt, out DateTime dt));
+                }
+            }
+            finally
+            {
+                featureFlags?.Dispose();
+            }
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxEventGeneratorTestData.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxEventGeneratorTestData.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 
         public static IEnumerable<object[]> GetFunctionExecutionEvents()
         {
-            yield return new object[] { "testexecution", "testSite", 1, "testFunction", "testInvocation", "testStage", 1, true };
+            yield return new object[] { "testexecution", "testSite", 1, "testFunction", "testInvocation", "testStage", 1, true, true };
+            yield return new object[] { "testexecution", "testSite", 1, "testFunction", "testInvocation", "testStage", 1, true, false };
         }
     }
 }


### PR DESCRIPTION
Includes 1182b02c038996edb63f21fe746e88ca9bcedb1e in version 3.15.0 to bring it up to date with prior hotfix version .
Updates host version to 3.15.1