### PR TITLE
[pack] [EMG] fixing infinite loop issue with typeforwarders

### DIFF
--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/ExtensionsMetadataGenerator.Console.csproj
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/ExtensionsMetadataGenerator.Console.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.11.1" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.4" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
   </ItemGroup>
 </Project>

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/ExtensionsMetadataGenerator.cs
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/ExtensionsMetadataGenerator.cs
@@ -186,7 +186,7 @@ namespace ExtensionsMetadataGenerator
 
         public class FunctionsAssemblyResolver : DefaultAssemblyResolver
         {
-            private static HashSet<string> _trustedPlatformAssemblies = GetTrustedPlatformAssemblies();
+            private static readonly HashSet<string> _trustedPlatformAssemblies = GetTrustedPlatformAssemblies();
 
             private static HashSet<string> GetTrustedPlatformAssemblies()
             {

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/ExtensionsMetadataGenerator.cs
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/ExtensionsMetadataGenerator.cs
@@ -190,13 +190,16 @@ namespace ExtensionsMetadataGenerator
 
             private static HashSet<string> GetTrustedPlatformAssemblies()
             {
-                var tpas = new HashSet<string>();
                 var data = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES");
-                foreach (var tpa in data.ToString().Split(";"))
+                var tpaArr = data.ToString().Split(Path.PathSeparator);
+                var tpaHash = new HashSet<string>(tpaArr.Length, StringComparer.OrdinalIgnoreCase);
+
+                foreach (var tpa in tpaArr)
                 {
-                    tpas.Add(tpa);
+                    tpaHash.Add(tpa);
                 }
-                return tpas;
+
+                return tpaHash;
             }
 
             public override AssemblyDefinition Resolve(AssemblyNameReference name)

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/ExtensionsMetadataGenerator.cs
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator.Console/ExtensionsMetadataGenerator.cs
@@ -207,7 +207,6 @@ namespace ExtensionsMetadataGenerator
                 // with type forwarders as well.
                 if (_trustedPlatformAssemblies.Contains(assemblyDef.MainModule.FileName))
                 {
-                    System.Console.WriteLine("TPA found: " + assemblyDef.FullName);
                     return null;
                 }
 

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.csproj
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" InitialTargets="UpdateRuntimeAssemblies">
   <Import Project="..\..\build\metadatagenerator.props" />
   <PropertyGroup>
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <AssemblyName>Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator</AssemblyName>
@@ -21,8 +21,8 @@
 
   <Target Name="BuildGeneratorConsole" Condition="'$(TargetFramework)' == 'netstandard2.0'" AfterTargets="Build">
     <MSBuild Projects="@(ConsoleProject)" Targets="Restore;Build" Properties="Configuration=$(Configuration);Platform=$(Platform);TargetFramework=netcoreapp2.0;OutputPath=$(MSBuildProjectDirectory)\$(OutputPath)\generator" />
-  </Target>    
-  
+  </Target>
+
   <ItemGroup>
     <Content Include="Targets\**\*">
       <Pack>true</Pack>
@@ -34,7 +34,7 @@
     <Exec Command="pwsh ./updateruntimeassemblies.ps1" Condition=" '$(OS)' == 'Unix' "/>
     <Exec Command="powershell.exe –command .\updateruntimeassemblies.ps1" Condition=" '$(OS)' == 'Windows_NT' "/>
   </Target>
-  
+
   <Target Name="PackReferenceAssemblies">
     <ItemGroup>
       <Content Include="$(OutputPath)\netstandard2.0\generator\*">
@@ -69,7 +69,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Runtime.Loader">
       <Version>4.3.0</Version>


### PR DESCRIPTION
It is rare, but some customers can hit an infinite loop with circular TypeForwarders. The issue in Cecil is here: https://github.com/jbevain/cecil/issues/706

This fix short-circuits our search for extensions if we hit a TPA as there's no need to go further. This breaks that circular logic as we don't keep searching for base types and assemblies once we make it this far.