### PR TITLE
Revert Node.js worker verison to 3.4.0

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <MajorVersion>4</MajorVersion>
     <MinorVersion>12</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <PatchVersion>2</PatchVersion>
     <BuildNumber Condition="'$(BuildNumber)' == '' ">0</BuildNumber>
     <PreviewVersion></PreviewVersion>        
     

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -56,7 +56,7 @@
 
     <!-- Workers -->
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.4.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.4.0" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" Version="4.0.2045" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" Version="4.0.2258" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="5.0.0-beta.2-10879" />

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.0" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.11.2" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.4.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.5-11874" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.4.0" />
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Cherry pick of the commit in this PR: https://github.com/Azure/azure-functions-host/pull/8793

Mitigation to address https://github.com/Azure/azure-functions-nodejs-worker/issues/630
