### PR TITLE
[Linux Consumption]HostId generation should be cloud specific

### DIFF
--- a/src/WebJobs.Script/CloudConstants.cs
+++ b/src/WebJobs.Script/CloudConstants.cs
@@ -5,6 +5,8 @@ namespace Microsoft.Azure.WebJobs.Script
 {
     public static class CloudConstants
     {
+        public const string AzureCloudName = "Azure";
+
         public const string AzureStorageSuffix = "core.windows.net";
         public const string BlackforestStorageSuffix = "core.cloudapi.de";
         public const string FairfaxStorageSuffix = "core.usgovcloudapi.net";
@@ -17,5 +19,12 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string MooncakeVaultSuffix = ".vault.azure.cn";
         public const string FairfaxVaultSuffix = ".vault.usgovcloudapi.net";
         public const string BlackforestVaultSuffix = ".vault.microsoftazure.de";
+
+        public const string AzureDnsSuffixWithDotPrefix = ".azurewebsites.net";
+        public const string BlackforestDnsSuffixWithDotPrefix = ".azurewebsites.de";
+        public const string FairfaxDnsSuffixWithDotPrefix = ".azurewebsites.us";
+        public const string MooncakeDnsSuffixWithDotPrefix = ".chinacloudsites.cn";
+        public const string USNatDnsSuffixWithDotPrefix = ".appservice.eaglex.ic.gov";
+        public const string USSecDnsSuffixWithDotPrefix = ".appservice.microsoft.scloud";
     }
 }

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -470,7 +470,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 || string.IsNullOrEmpty(environment.GetEnvironmentVariable(MeshInitURI));
         }
 
-        public static CloudName GetCloudName(this IEnvironment environment)
+        public static CloudName GetCloudName(this IEnvironment environment, bool throwOnError = false)
         {
             var cloudName = environment.GetEnvironmentVariable(EnvironmentSettingNames.CloudName);
             if (Enum.TryParse(cloudName, true, out CloudName cloud))
@@ -478,6 +478,10 @@ namespace Microsoft.Azure.WebJobs.Script
                 return cloud;
             }
 
+            if (throwOnError)
+            {
+                throw new ArgumentException(nameof(GetCloudName), cloudName);
+            }
             return CloudName.Azure;
         }
 
@@ -499,6 +503,28 @@ namespace Microsoft.Azure.WebJobs.Script
                     return CloudConstants.USSecStorageSuffix;
                 default:
                     return CloudConstants.AzureStorageSuffix;
+            }
+        }
+
+        public static string GetDnsSuffixWithDotPrefix(this IEnvironment environment)
+        {
+            var cloudName = GetCloudName(environment, true);
+            switch (cloudName)
+            {
+                case CloudName.Azure:
+                    return CloudConstants.AzureDnsSuffixWithDotPrefix;
+                case CloudName.Blackforest:
+                    return CloudConstants.BlackforestDnsSuffixWithDotPrefix;
+                case CloudName.Fairfax:
+                    return CloudConstants.FairfaxDnsSuffixWithDotPrefix;
+                case CloudName.Mooncake:
+                    return CloudConstants.MooncakeDnsSuffixWithDotPrefix;
+                case CloudName.USNat:
+                    return CloudConstants.USNatDnsSuffixWithDotPrefix;
+                case CloudName.USSec:
+                    return CloudConstants.USSecDnsSuffixWithDotPrefix;
+                default:
+                    throw new ArgumentException(nameof(GetDnsSuffixWithDotPrefix), cloudName.ToString());
             }
         }
 

--- a/src/WebJobs.Script/Host/ScriptHostIdProvider.cs
+++ b/src/WebJobs.Script/Host/ScriptHostIdProvider.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.WebJobs.Script
             {
                 // The hostid is derived from the hostname for Linux consumption.
                 string hostName = environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName);
-                hostId = hostName?.Replace(".azurewebsites.net", string.Empty);
+                hostId = hostName?.Replace(environment.GetDnsSuffixWithDotPrefix(), string.Empty);
             }
             else
             {

--- a/src/WebJobs.Script/HostNameProvider.cs
+++ b/src/WebJobs.Script/HostNameProvider.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Script
                         string websiteName = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName);
                         if (!string.IsNullOrEmpty(websiteName))
                         {
-                            _hostName = $"{websiteName}.azurewebsites.net";
+                            _hostName = $"{websiteName}{_environment.GetDnsSuffixWithDotPrefix()}";
                         }
                     }
                 }

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Linux.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Linux.cs
@@ -47,7 +47,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 { EnvironmentSettingNames.AzureWebsiteSku, "Dynamic" },
                 { EnvironmentSettingNames.AzureWebsiteZipDeployment, null },
                 { EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagEnableProxies },
-                { "AzureWebEncryptionKey", "0F75CA46E7EBDD39E4CA6B074D1F9A5972B849A55F91A248" }
+                { "AzureWebEncryptionKey", "0F75CA46E7EBDD39E4CA6B074D1F9A5972B849A55F91A248" },
+                { EnvironmentSettingNames.CloudName, CloudConstants.AzureCloudName }
             };
 
             var environment = new TestEnvironment(vars);

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Windows.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Windows.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 { EnvironmentSettingNames.AzureWebsiteHomePath, null },
                 { "AzureWebEncryptionKey", "0F75CA46E7EBDD39E4CA6B074D1F9A5972B849A55F91A248" },
                 { EnvironmentSettingNames.AzureWebsiteRunFromPackage, null },
+                { EnvironmentSettingNames.CloudName, CloudConstants.AzureCloudName },
              };
         }
 

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -816,6 +816,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             _hostNameProvider.Reset();
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)).Returns(siteName);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName)).Returns(hostName);
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.CloudName)).Returns(CloudConstants.AzureCloudName);
 
             var httpRequest = _functionsSyncManager.BuildSetTriggersRequest();
             Assert.Equal(expectedSyncTriggersUri, httpRequest.RequestUri.AbsoluteUri);

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
@@ -129,6 +129,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 Environment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName, _functionsWorkerRuntimeVersion);
             }
+            Environment.SetEnvironmentVariable(EnvironmentSettingNames.CloudName, CloudConstants.AzureCloudName);
 
             FunctionsSyncManagerMock = new Mock<IFunctionsSyncManager>(MockBehavior.Strict);
             FunctionsSyncManagerMock.Setup(p => p.TrySyncTriggersAsync(It.IsAny<bool>())).ReturnsAsync(new SyncTriggersResult { Success = true });

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SWAEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SWAEndToEndTests.cs
@@ -106,7 +106,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                     { "AzureWebEncryptionKey", testKey },
                     { EnvironmentSettingNames.WebSiteAuthEncryptionKey, testKey },
                     { "AzureWebJobsStorage", null },
-                    { EnvironmentSettingNames.AzureWebsiteName, "testsite" }
+                    { EnvironmentSettingNames.AzureWebsiteName, "testsite" },
+                    {EnvironmentSettingNames.CloudName, "Azure"}
                 };
                 _scopedEnvironment = new TestScopedEnvironmentVariable(settings);
             }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
@@ -1130,6 +1130,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                 environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, "e777fde04dea4eb931d5e5f06e65b4fdf5b375aed60af41dd7b491cf5792e01b");
                 environment.SetEnvironmentVariable(EnvironmentSettingNames.AntaresPlatformVersionWindows, "89.0.7.73");
                 environment.SetEnvironmentVariable(EnvironmentSettingNames.AntaresComputerName, "RD281878FCB8E7");
+                environment.SetEnvironmentVariable(EnvironmentSettingNames.CloudName, CloudConstants.AzureCloudName);
 
                 services.AddSingleton<IEnvironment>(_ => environment);
             }

--- a/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
+++ b/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
@@ -150,20 +150,36 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
-        [InlineData("Azure", CloudName.Azure)]
-        [InlineData("azuRe", CloudName.Azure)]
-        [InlineData("", CloudName.Azure)]
-        [InlineData(null, CloudName.Azure)]
-        [InlineData("Blackforest", CloudName.Blackforest)]
-        [InlineData("Fairfax", CloudName.Fairfax)]
-        [InlineData("Mooncake", CloudName.Mooncake)]
-        [InlineData("USNat", CloudName.USNat)]
-        [InlineData("USSec", CloudName.USSec)]
-        public void GetCloudName_Returns_RightCloud(string cloudNameSetting, CloudName cloudName)
+        [InlineData("Azure", CloudName.Azure, true, false)]
+        [InlineData("Azure", CloudName.Azure, false, false)]
+        [InlineData("azuRe", CloudName.Azure, true, false)]
+        [InlineData("azuRe", CloudName.Azure, false, false)]
+        [InlineData("", CloudName.Azure, true, true)]
+        [InlineData("", CloudName.Azure, false, false)]
+        [InlineData(null, CloudName.Azure, true, true)]
+        [InlineData(null, CloudName.Azure, false, false)]
+        [InlineData("Blackforest", CloudName.Blackforest, true, false)]
+        [InlineData("Blackforest", CloudName.Blackforest, false, false)]
+        [InlineData("Fairfax", CloudName.Fairfax, true, false)]
+        [InlineData("Fairfax", CloudName.Fairfax, false, false)]
+        [InlineData("Mooncake", CloudName.Mooncake, true, false)]
+        [InlineData("Mooncake", CloudName.Mooncake, false, false)]
+        [InlineData("USNat", CloudName.USNat, true, false)]
+        [InlineData("USNat", CloudName.USNat, false, false)]
+        [InlineData("USSec", CloudName.USSec, true, false)]
+        [InlineData("USSec", CloudName.USSec, false, false)]
+        public void GetCloudName_Returns_RightCloud(string cloudNameSetting, CloudName cloudName, bool throwOnError, bool exceptionExpected)
         {
             var testEnvironment = new TestEnvironment();
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.CloudName, cloudNameSetting);
-            Assert.Equal(cloudName, testEnvironment.GetCloudName());
+            if (exceptionExpected)
+            {
+                Assert.Throws<ArgumentException>(() => testEnvironment.GetCloudName(throwOnError));
+            }
+            else
+            {
+                Assert.Equal(cloudName, testEnvironment.GetCloudName(throwOnError));
+            }
         }
 
         [Theory]
@@ -196,6 +212,30 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var testEnvironment = new TestEnvironment();
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.CloudName, cloudNameSetting);
             Assert.Equal(suffix, testEnvironment.GetVaultSuffix());
+        }
+
+        [Theory]
+        [InlineData("Azure", CloudConstants.AzureDnsSuffixWithDotPrefix, false)]
+        [InlineData("azuRe", CloudConstants.AzureDnsSuffixWithDotPrefix, false)]
+        [InlineData("", CloudConstants.AzureVaultSuffix, true)]
+        [InlineData(null, CloudConstants.AzureVaultSuffix, true)]
+        [InlineData("Blackforest", CloudConstants.BlackforestDnsSuffixWithDotPrefix, false)]
+        [InlineData("Fairfax", CloudConstants.FairfaxDnsSuffixWithDotPrefix, false)]
+        [InlineData("Mooncake", CloudConstants.MooncakeDnsSuffixWithDotPrefix, false)]
+        [InlineData("USNAT", CloudConstants.USNatDnsSuffixWithDotPrefix, false)]
+        [InlineData("UsSec", CloudConstants.USSecDnsSuffixWithDotPrefix, false)]
+        public void GetDnsSuffix_Returns_Suffix_Based_On_CloudType(string cloudNameSetting, string suffix, bool throwsException)
+        {
+            var testEnvironment = new TestEnvironment();
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.CloudName, cloudNameSetting);
+            if (throwsException)
+            {
+                Assert.Throws<ArgumentException>(() => testEnvironment.GetDnsSuffixWithDotPrefix());
+            }
+            else
+            {
+                Assert.Equal(suffix, testEnvironment.GetDnsSuffixWithDotPrefix());
+            }
         }
 
         [Theory]

--- a/test/WebJobs.Script.Tests/HostNameProviderTests.cs
+++ b/test/WebJobs.Script.Tests/HostNameProviderTests.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Extensions.Logging;
 using Microsoft.WebJobs.Script.Tests;
 using Moq;
@@ -39,9 +35,27 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [InlineData("", "", "")]
         public void GetValue_ReturnsExpectedResult(string hostName, string siteName, string expected)
         {
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.CloudName)).Returns("Azure");
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName)).Returns(hostName);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)).Returns(siteName);
 
+            Assert.Equal(expected, _hostNameProvider.Value);
+        }
+
+        [Theory]
+        [InlineData("Azure", "test", "test.azurewebsites.net")]
+        [InlineData("fairfax", "test", "test.azurewebsites.us")]
+        [InlineData("blackforest", "test", "test.azurewebsites.de")]
+        [InlineData("MoonCake", "test", "test.chinacloudsites.cn")]
+        [InlineData("USNat", "test", "test.appservice.eaglex.ic.gov")]
+        [InlineData("USSEC", "test", "test.appservice.microsoft.scloud")]
+        public void ReturnsHostNameFromSiteNameBasedOnCloud(string cloud, string siteName, string expected)
+        {
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.CloudName))
+                .Returns(cloud);
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName))
+                .Returns((string)null);
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)).Returns(siteName);
             Assert.Equal(expected, _hostNameProvider.Value);
         }
 

--- a/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
@@ -180,6 +180,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         {
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName)).Returns(hostName);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)).Returns(siteName);
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.CloudName)).Returns(CloudConstants.AzureCloudName);
             Assert.Equal(expected, _webFunctionsManager.GetBaseUrl());
         }
 


### PR DESCRIPTION
Logic doesnt account for non-Azure clouds resulting in failures across different scenarios.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-host/issues/8788

### Pull request checklist

* [ X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [X ] Otherwise: Backport tracked by issue/PR  (https://github.com/Azure/azure-functions-host/issues/8788)
* [ X] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
