### PR TITLE
updating webjobs AppInsights package

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -64,7 +64,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Timers.Storage" Version="1.0.0-beta.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.Abstractions" Version="1.0.3-preview" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.34-11957" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.34" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.3.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />

--- a/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
+++ b/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
@@ -23,7 +23,7 @@
           "Microsoft.Azure.Cosmos.Table": "1.0.8",
           "Microsoft.Azure.Functions.PythonWorker": "4.8.0",
           "Microsoft.Azure.Storage.File": "11.1.7",
-          "Microsoft.Azure.WebJobs": "3.0.34-11957",
+          "Microsoft.Azure.WebJobs": "3.0.34-11969",
           "Microsoft.Azure.WebJobs.Host.Storage": "5.0.0-beta.2-11957",
           "Microsoft.Azure.WebJobs.Script": "4.14.0",
           "Microsoft.Azure.WebJobs.Script.Grpc": "4.14.0",
@@ -280,14 +280,16 @@
           }
         }
       },
-      "Microsoft.ApplicationInsights.SnapshotCollector/1.3.7.5": {
+      "Microsoft.ApplicationInsights.SnapshotCollector/1.4.3": {
         "dependencies": {
-          "Microsoft.ApplicationInsights.AspNetCore": "2.21.0"
+          "Microsoft.ApplicationInsights": "2.21.0",
+          "Microsoft.Extensions.Options": "6.0.0",
+          "System.IO.FileSystem.AccessControl": "4.7.0"
         },
         "runtime": {
-          "lib/netcoreapp3.0/Microsoft.ApplicationInsights.SnapshotCollector.dll": {
-            "assemblyVersion": "1.3.7.5",
-            "fileVersion": "1.3.7.5"
+          "lib/netstandard2.0/Microsoft.ApplicationInsights.SnapshotCollector.dll": {
+            "assemblyVersion": "1.4.3.0",
+            "fileVersion": "1.4.3.0"
           }
         }
       },
@@ -856,9 +858,9 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs/3.0.34-11957": {
+      "Microsoft.Azure.WebJobs/3.0.34-11969": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Core": "3.0.34-11957",
+          "Microsoft.Azure.WebJobs.Core": "3.0.34-11969",
           "Microsoft.Extensions.Configuration": "6.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "6.0.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "2.1.1",
@@ -878,7 +880,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Core/3.0.34-11957": {
+      "Microsoft.Azure.WebJobs.Core/3.0.34-11969": {
         "dependencies": {
           "System.ComponentModel.Annotations": "4.5.0",
           "System.Diagnostics.TraceSource": "4.3.0"
@@ -892,7 +894,7 @@
       },
       "Microsoft.Azure.WebJobs.Extensions/5.0.0-beta.2-10879": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.34-11957",
+          "Microsoft.Azure.WebJobs": "3.0.34-11969",
           "NCrontab.Signed": "3.3.2"
         },
         "runtime": {
@@ -909,7 +911,7 @@
           "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.2.0",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
           "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.Azure.WebJobs": "3.0.34-11957"
+          "Microsoft.Azure.WebJobs": "3.0.34-11969"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Http.dll": {
@@ -934,7 +936,7 @@
       "Microsoft.Azure.WebJobs.Host.Storage/5.0.0-beta.2-11957": {
         "dependencies": {
           "Azure.Storage.Blobs": "12.13.0",
-          "Microsoft.Azure.WebJobs": "3.0.34-11957",
+          "Microsoft.Azure.WebJobs": "3.0.34-11969",
           "Microsoft.Extensions.Azure": "1.1.1"
         },
         "runtime": {
@@ -944,18 +946,18 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Logging.ApplicationInsights/3.0.34-11957": {
+      "Microsoft.Azure.WebJobs.Logging.ApplicationInsights/3.0.34": {
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.21.0",
           "Microsoft.ApplicationInsights.AspNetCore": "2.21.0",
           "Microsoft.ApplicationInsights.DependencyCollector": "2.21.0",
           "Microsoft.ApplicationInsights.PerfCounterCollector": "2.21.0",
-          "Microsoft.ApplicationInsights.SnapshotCollector": "1.3.7.5",
+          "Microsoft.ApplicationInsights.SnapshotCollector": "1.4.3",
           "Microsoft.ApplicationInsights.WindowsServer": "2.21.0",
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.Azure.WebJobs": "3.0.34-11957",
+          "Microsoft.Azure.WebJobs": "3.0.34-11969",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
           "System.Diagnostics.TraceSource": "4.3.0",
           "System.Threading": "4.3.0",
@@ -2905,12 +2907,12 @@
           "Microsoft.Azure.Functions.NodeJsWorker": "3.5.1",
           "Microsoft.Azure.Functions.PowerShellWorker.PS7.0": "4.0.2302",
           "Microsoft.Azure.Functions.PowerShellWorker.PS7.2": "4.0.2304",
-          "Microsoft.Azure.WebJobs": "3.0.34-11957",
+          "Microsoft.Azure.WebJobs": "3.0.34-11969",
           "Microsoft.Azure.WebJobs.Extensions": "5.0.0-beta.2-10879",
           "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.0",
           "Microsoft.Azure.WebJobs.Extensions.Timers.Storage": "1.0.0-beta.1",
           "Microsoft.Azure.WebJobs.Host.Storage": "5.0.0-beta.2-11957",
-          "Microsoft.Azure.WebJobs.Logging.ApplicationInsights": "3.0.34-11957",
+          "Microsoft.Azure.WebJobs.Logging.ApplicationInsights": "3.0.34",
           "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.3-preview",
           "Microsoft.CodeAnalysis.CSharp.Scripting": "3.3.1",
           "Microsoft.Extensions.Azure": "1.1.1",
@@ -3092,12 +3094,12 @@
       "path": "microsoft.applicationinsights.perfcountercollector/2.21.0",
       "hashPath": "microsoft.applicationinsights.perfcountercollector.2.21.0.nupkg.sha512"
     },
-    "Microsoft.ApplicationInsights.SnapshotCollector/1.3.7.5": {
+    "Microsoft.ApplicationInsights.SnapshotCollector/1.4.3": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-r40NFCxNaDYINciQw2YMI+oKONd0rThvPT9h2XbDSBNca9dlPc1hBN4c4XLTYNSPvyBXb0/GXLO7BsPUQft7gg==",
-      "path": "microsoft.applicationinsights.snapshotcollector/1.3.7.5",
-      "hashPath": "microsoft.applicationinsights.snapshotcollector.1.3.7.5.nupkg.sha512"
+      "sha512": "sha512-PgfOT8G3SNoBKBEJZlDtjx0bm+hrY4XzPYmpHmksIqRKgSr9/QFlpQvMh2/LAQ+8o1BeubG4oYZRTTZPspYSOw==",
+      "path": "microsoft.applicationinsights.snapshotcollector/1.4.3",
+      "hashPath": "microsoft.applicationinsights.snapshotcollector.1.4.3.nupkg.sha512"
     },
     "Microsoft.ApplicationInsights.WindowsServer/2.21.0": {
       "type": "package",
@@ -3533,19 +3535,19 @@
       "path": "microsoft.azure.storage.file/11.1.7",
       "hashPath": "microsoft.azure.storage.file.11.1.7.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs/3.0.34-11957": {
+    "Microsoft.Azure.WebJobs/3.0.34-11969": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-sCGFa3yWGvRP3PybuaRTlUDcoWQdmwZBzFnc7D92B1aC6ZbN2eshZx9YJoMH/B0sTBkqD+kQw45VHtFLwF+SYA==",
-      "path": "microsoft.azure.webjobs/3.0.34-11957",
-      "hashPath": "microsoft.azure.webjobs.3.0.34-11957.nupkg.sha512"
+      "sha512": "sha512-2MVgn3T5OOk9+moCLnMWCxAh4GBfxHOzvZW0ItCAPGvmvjD0huJu2dl1bTfSX9Rt0l9nUE6FlpiuzdFIDHKU2Q==",
+      "path": "microsoft.azure.webjobs/3.0.34-11969",
+      "hashPath": "microsoft.azure.webjobs.3.0.34-11969.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Core/3.0.34-11957": {
+    "Microsoft.Azure.WebJobs.Core/3.0.34-11969": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-5xbzwPPX2lMqFy8L1BsTwwDAF4syRUtd/DxqLaziWb9sypgXLzjrFN/kpOM8MEHALYzXHlh/sOzzJiVK6ulIGQ==",
-      "path": "microsoft.azure.webjobs.core/3.0.34-11957",
-      "hashPath": "microsoft.azure.webjobs.core.3.0.34-11957.nupkg.sha512"
+      "sha512": "sha512-O22wN8DnbgZmFMnXfT9UxhrCeBeG3VrtrH+q4TD6z0Q6+IwprKVRI1THHGgGY2jbtggPU2Or1MYgD9Mo/KqwMQ==",
+      "path": "microsoft.azure.webjobs.core/3.0.34-11969",
+      "hashPath": "microsoft.azure.webjobs.core.3.0.34-11969.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions/5.0.0-beta.2-10879": {
       "type": "package",
@@ -3575,12 +3577,12 @@
       "path": "microsoft.azure.webjobs.host.storage/5.0.0-beta.2-11957",
       "hashPath": "microsoft.azure.webjobs.host.storage.5.0.0-beta.2-11957.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Logging.ApplicationInsights/3.0.34-11957": {
+    "Microsoft.Azure.WebJobs.Logging.ApplicationInsights/3.0.34": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-8SuCRJe5CKht1agGAKGZEL6CqlmJ0RfQy3HMckKJXg6APLCmh7DR3lxNcIe5KNbQklTv5nyeGGEjokRijF/55w==",
-      "path": "microsoft.azure.webjobs.logging.applicationinsights/3.0.34-11957",
-      "hashPath": "microsoft.azure.webjobs.logging.applicationinsights.3.0.34-11957.nupkg.sha512"
+      "sha512": "sha512-MDArWUT5n3NKWU28W79xCSvYkCue6av/rtJ3S8K0xFJRyVEf/Nuekacz2gVC60ymonDFAZq8JoWxCrahXXQKjA==",
+      "path": "microsoft.azure.webjobs.logging.applicationinsights/3.0.34",
+      "hashPath": "microsoft.azure.webjobs.logging.applicationinsights.3.0.34.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Script.Abstractions/1.0.3-preview": {
       "type": "package",


### PR DESCRIPTION
See https://github.com/Azure/azure-webjobs-sdk/pull/2916.

There are some Service Bus transaction tracking updates in App Insights 2.21.0. Even though Functions has updated to reference this directly, there are WebJobs customers that also want this update. There's an easy workaround for WebJobs (directly reference App Insights 2.21.0 from your project), but it's not obvious to everyone.

So I've bumped the reference in the WebJobs package and want to release it. But in order to release a WebJobs package, we first need to take it to production in Functions. 

So this is the first step -- once it's released everywhere in Functions Prod, we can move it to nuget.org.