### PR TITLE
Add BindingData to DataType

### DIFF
--- a/src/WebJobs.Script.Abstractions/Description/Binding/DataType.cs
+++ b/src/WebJobs.Script.Abstractions/Description/Binding/DataType.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         Undefined,
         String,
         Binary,
-        Stream
+        Stream,
+        BindingData
     }
 }

--- a/src/WebJobs.Script.Abstractions/WebJobs.Script.Abstractions.csproj
+++ b/src/WebJobs.Script.Abstractions/WebJobs.Script.Abstractions.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.0.3-preview</Version>
+    <Version>1.0.4-preview</Version>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">1</BuildNumber>
     <MajorMinorProductVersion>1.0</MajorMinorProductVersion>
     <AssemblyVersion>$(MajorMinorProductVersion).0.0</AssemblyVersion>


### PR DESCRIPTION
Part of https://github.com/Azure/azure-functions-dotnet-worker/issues/1081

Adding BindingData to `DataType` to support new SDK-binding reference types