### PR TITLE
Remove BindingData from DataType and update BindingMetadata

### DIFF
--- a/src/WebJobs.Script.Abstractions/Description/Binding/BindingMetadata.cs
+++ b/src/WebJobs.Script.Abstractions/Description/Binding/BindingMetadata.cs
@@ -24,7 +24,16 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         [JsonConstructor]
         private BindingMetadata(Dictionary<string, object> properties)
         {
-            Properties = new Dictionary<string, object>(properties, StringComparer.OrdinalIgnoreCase);
+            if (properties is null)
+            {
+                Properties = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            }
+            else
+            {
+                Properties = properties.Count > 0
+                                ? new Dictionary<string, object>(properties, StringComparer.OrdinalIgnoreCase)
+                                : properties;
+            }
         }
 
         /// <summary>

--- a/src/WebJobs.Script.Abstractions/Description/Binding/BindingMetadata.cs
+++ b/src/WebJobs.Script.Abstractions/Description/Binding/BindingMetadata.cs
@@ -87,7 +87,10 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             string bindingDirectionValue = (string)raw["direction"];
             string connection = (string)raw["connection"];
             string bindingType = (string)raw["type"];
-            var properties = raw["properties"].ToObject<IDictionary<string, object>>();
+            var properties = raw["properties"] != null
+                                ? raw["properties"].ToObject<IDictionary<string, object>>()
+                                : new Dictionary<string, object>();
+
             BindingDirection bindingDirection = default(BindingDirection);
 
             if (!string.IsNullOrEmpty(bindingDirectionValue) &&

--- a/src/WebJobs.Script.Abstractions/Description/Binding/BindingMetadata.cs
+++ b/src/WebJobs.Script.Abstractions/Description/Binding/BindingMetadata.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -87,9 +88,9 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             string bindingDirectionValue = (string)raw["direction"];
             string connection = (string)raw["connection"];
             string bindingType = (string)raw["type"];
-            var properties = raw["properties"] != null
-                                ? raw["properties"].ToObject<IDictionary<string, object>>()
-                                : new Dictionary<string, object>();
+            IDictionary<string, object> properties = raw.TryGetValue("properties", StringComparison.OrdinalIgnoreCase, out JToken value)
+                            ? new Dictionary<string, object>(value.ToObject<IDictionary<string, object>>(), StringComparer.OrdinalIgnoreCase)
+                            : ImmutableDictionary<string, object>.Empty;
 
             BindingDirection bindingDirection = default(BindingDirection);
 

--- a/src/WebJobs.Script.Abstractions/Description/Binding/BindingMetadata.cs
+++ b/src/WebJobs.Script.Abstractions/Description/Binding/BindingMetadata.cs
@@ -18,6 +18,11 @@ namespace Microsoft.Azure.WebJobs.Script.Description
     {
         private const string _systemReturnParameterBindingName = "$return";
 
+        public BindingMetadata()
+        {
+            Properties = new Dictionary<string, object>();
+        }
+
         /// <summary>
         /// Gets or sets the name of the binding.
         /// </summary>
@@ -39,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         /// <summary>
         /// Gets or sets the binding properties.
         /// </summary>
-        public IDictionary<string, object> Properties { get; set; }
+        public IDictionary<string, object> Properties { get; private set; }
 
         /// <summary>
         /// Gets or sets the direction of the binding.
@@ -88,9 +93,6 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             string bindingDirectionValue = (string)raw["direction"];
             string connection = (string)raw["connection"];
             string bindingType = (string)raw["type"];
-            IDictionary<string, object> properties = raw.TryGetValue("properties", StringComparison.OrdinalIgnoreCase, out JToken value)
-                            ? new Dictionary<string, object>(value.ToObject<IDictionary<string, object>>(), StringComparer.OrdinalIgnoreCase)
-                            : ImmutableDictionary<string, object>.Empty;
 
             BindingDirection bindingDirection = default(BindingDirection);
 
@@ -105,7 +107,11 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             bindingMetadata.Direction = bindingDirection;
             bindingMetadata.Connection = connection;
             bindingMetadata.Raw = raw;
-            bindingMetadata.Properties = properties;
+
+            if (raw.TryGetValue("properties", StringComparison.OrdinalIgnoreCase, out JToken value))
+            {
+                bindingMetadata.Properties = new Dictionary<string, object>(value.ToObject<IDictionary<string, object>>(), StringComparer.OrdinalIgnoreCase);
+            }
 
             return bindingMetadata;
         }

--- a/src/WebJobs.Script.Abstractions/Description/Binding/BindingMetadata.cs
+++ b/src/WebJobs.Script.Abstractions/Description/Binding/BindingMetadata.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         public BindingMetadata()
         {
-            Properties = new Dictionary<string, object>();
+            Properties = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/src/WebJobs.Script.Abstractions/Description/Binding/BindingMetadata.cs
+++ b/src/WebJobs.Script.Abstractions/Description/Binding/BindingMetadata.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -33,6 +34,11 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         /// Gets or sets the type of the binding.
         /// </summary>
         public string Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the binding properties.
+        /// </summary>
+        public IDictionary<string, object> Properties { get; set; }
 
         /// <summary>
         /// Gets or sets the direction of the binding.
@@ -81,6 +87,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             string bindingDirectionValue = (string)raw["direction"];
             string connection = (string)raw["connection"];
             string bindingType = (string)raw["type"];
+            var properties = raw["properties"].ToObject<IDictionary<string, object>>();
             BindingDirection bindingDirection = default(BindingDirection);
 
             if (!string.IsNullOrEmpty(bindingDirectionValue) &&
@@ -94,6 +101,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             bindingMetadata.Direction = bindingDirection;
             bindingMetadata.Connection = connection;
             bindingMetadata.Raw = raw;
+            bindingMetadata.Properties = properties;
 
             return bindingMetadata;
         }

--- a/src/WebJobs.Script.Abstractions/Description/Binding/BindingMetadata.cs
+++ b/src/WebJobs.Script.Abstractions/Description/Binding/BindingMetadata.cs
@@ -17,7 +17,9 @@ namespace Microsoft.Azure.WebJobs.Script.Description
     {
         private const string _systemReturnParameterBindingName = "$return";
 
-        public BindingMetadata() : this(new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)) { }
+        public BindingMetadata() : this(new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase))
+        {
+        }
 
         [JsonConstructor]
         private BindingMetadata(Dictionary<string, object> properties)
@@ -110,10 +112,10 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 if (!string.IsNullOrEmpty(bindingDirectionValue) &&
                     !Enum.TryParse<BindingDirection>(bindingDirectionValue, true, out BindingDirection bindingDirection))
                 {
-                    throw new FormatException(string.Format(CultureInfo.InvariantCulture, "'{0}' is not a valid binding direction.", bindingDirectionValue));
+                    throw new FormatException(string.Format(CultureInfo.InvariantCulture, "'{0}' is not a valid binding direction.", bindingDirectionValue), ex);
                 }
 
-                throw ex;
+                throw;
             }
         }
     }

--- a/src/WebJobs.Script.Abstractions/Description/Binding/DataType.cs
+++ b/src/WebJobs.Script.Abstractions/Description/Binding/DataType.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         Undefined,
         String,
         Binary,
-        Stream,
-        ModelBindingData
+        Stream
     }
 }

--- a/src/WebJobs.Script.Abstractions/Description/Binding/DataType.cs
+++ b/src/WebJobs.Script.Abstractions/Description/Binding/DataType.cs
@@ -12,6 +12,6 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         String,
         Binary,
         Stream,
-        BindingData
+        ModelBindingData
     }
 }

--- a/test/WebJobs.Script.Tests/Abstractions/BindingMetadataTests.cs
+++ b/test/WebJobs.Script.Tests/Abstractions/BindingMetadataTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public class BindingMetadataTests
+    {
+        [Fact]
+        public void BindingMetadata_Create_TriggerBinding_Success()
+        {
+            JObject triggerBinding = JObject.Parse("{\"name\":\"book\",\"direction\":\"In\",\"type\":\"blobTrigger\",\"blobPath\":\"expression-trigger\",\"connection\":\"AzureWebJobsStorage\",\"properties\":{\"supportsDeferredBinding\":false}}");
+            var result = BindingMetadata.Create(triggerBinding);
+
+            Assert.Equal("book", result.Name);
+            Assert.Equal("blobTrigger", result.Type);
+            Assert.Equal("AzureWebJobsStorage", result.Connection);
+            Assert.Equal(triggerBinding, result.Raw);
+            Assert.Equal(BindingDirection.In, result.Direction);
+            Assert.True(result.Properties.TryGetValue("SupportsDeferredBinding", out bool supportsDeferredBinding));
+            Assert.False(supportsDeferredBinding);
+            Assert.True(result.IsTrigger);
+            Assert.False(result.IsReturn);
+        }
+
+        [Fact]
+        public void BindingMetadata_Create_InputBinding_Success()
+        {
+            JObject inputBinding = JObject.Parse("{\"name\":\"myBlob\",\"direction\":\"In\",\"type\":\"blob\",\"blobPath\":\"input-container//hello.txt\",\"connection\":\"AzureWebJobsStorage\",\"properties\":{\"supportsDeferredBinding\":true}}");
+            var result = BindingMetadata.Create(inputBinding);
+
+            Assert.Equal("myBlob", result.Name);
+            Assert.Equal("blob", result.Type);
+            Assert.Equal("AzureWebJobsStorage", result.Connection);
+            Assert.Equal(inputBinding, result.Raw);
+            Assert.Equal(BindingDirection.In, result.Direction);
+            Assert.True(result.Properties.TryGetValue("SupportsDeferredBinding", out bool supportsDeferredBinding));
+            Assert.True(supportsDeferredBinding);
+            Assert.False(result.IsTrigger);
+            Assert.False(result.IsReturn);
+        }
+
+        [Fact]
+        public void BindingMetadata_Create_OutputBinding_Success()
+        {
+            JObject outputBinding = JObject.Parse("{\"name\":\"$return\",\"direction\":\"Out\",\"type\":\"blob\",\"blobPath\":\"output-container//output.txt\",\"connection\":\"AzureWebJobsStorage\",\"properties\":{}}");
+            var result = BindingMetadata.Create(outputBinding);
+
+            Assert.Equal("$return", result.Name);
+            Assert.Equal("blob", result.Type);
+            Assert.Equal("AzureWebJobsStorage", result.Connection);
+            Assert.Equal(outputBinding, result.Raw);
+            Assert.Equal(BindingDirection.Out, result.Direction);
+            Assert.Empty(result.Properties);
+            Assert.False(result.IsTrigger);
+            Assert.True(result.IsReturn);
+        }
+
+        [Fact]
+        public void BindingMetadata_Create_InvalidDirectionFormat_Throws()
+        {
+            JObject outputBinding = JObject.Parse("{\"name\":\"$return\",\"direction\":\"hi\",\"type\":\"blob\",\"blobPath\":\"output-container//output.txt\",\"connection\":\"AzureWebJobsStorage\",\"properties\":{}}");
+            Action act = () => BindingMetadata.Create(outputBinding);
+            FormatException exception = Assert.Throws<FormatException>(act);
+            Assert.Equal("'hi' is not a valid binding direction.", exception.Message);
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Abstractions/BindingMetadataTests.cs
+++ b/test/WebJobs.Script.Tests/Abstractions/BindingMetadataTests.cs
@@ -61,7 +61,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-
         public void BindingMetadata_Create_NullJObject_Throws()
         {
             Action act = () => BindingMetadata.Create(null);

--- a/test/WebJobs.Script.Tests/Abstractions/BindingMetadataTests.cs
+++ b/test/WebJobs.Script.Tests/Abstractions/BindingMetadataTests.cs
@@ -61,6 +61,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+
+        public void BindingMetadata_Create_NullJObject_Throws()
+        {
+            Action act = () => BindingMetadata.Create(null);
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(act);
+            Assert.Equal("Value cannot be null. (Parameter 'raw')", exception.Message);
+        }
+
+        [Fact]
         public void BindingMetadata_Create_InvalidDirectionFormat_Throws()
         {
             JObject outputBinding = JObject.Parse("{\"name\":\"$return\",\"direction\":\"hi\",\"type\":\"blob\",\"blobPath\":\"output-container//output.txt\",\"connection\":\"AzureWebJobsStorage\",\"properties\":{}}");

--- a/test/WebJobs.Script.Tests/Abstractions/BindingMetadataTests.cs
+++ b/test/WebJobs.Script.Tests/Abstractions/BindingMetadataTests.cs
@@ -76,5 +76,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             FormatException exception = Assert.Throws<FormatException>(act);
             Assert.Equal("'hi' is not a valid binding direction.", exception.Message);
         }
+
+        [Fact]
+        public void BindingMetadata_Create_PropertiesIsNull_CreatesEmptyDict()
+        {
+            JObject inputBinding = JObject.Parse("{\"name\":\"myBlob\",\"direction\":\"In\",\"type\":\"blob\",\"blobPath\":\"input-container//hello.txt\",\"connection\":\"AzureWebJobsStorage\"}");
+            var result = BindingMetadata.Create(inputBinding);
+            Assert.Empty(result.Properties);
+        }
     }
 }

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -74,6 +74,7 @@
     <ProjectReference Include="..\..\src\WebJobs.Script.WebHost\WebJobs.Script.WebHost.csproj" />
     <ProjectReference Include="..\..\src\WebJobs.Script\WebJobs.Script.csproj" />
     <ProjectReference Include="..\..\src\WebJobs.Script.Grpc\WebJobs.Script.Grpc.csproj" />
+    <ProjectReference Include="..\..\src\WebJobs.Script.Abstractions\WebJobs.Script.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- We're no longer using the DataType for sdk-type bindings, so the PR is removing the unused enum value "BindingData".

- Update BindingMetadata to include `Properties` prop. In the protobuf, the [Binding info was updated](https://github.com/Azure/azure-functions-language-worker-protobuf/blob/27a28ca180e6a34b8aea3349e3ffe46d2ff36ce7/src/proto/FunctionRpc.proto#L524-L525) to include a `Properties` map. We need to reflect this change by updating out representation of that message here.