### PR TITLE
Bump protobuf version to v1.5.9-protofile

### DIFF
--- a/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
+++ b/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
@@ -32,7 +32,8 @@ message StreamingMessage {
     WorkerInitRequest worker_init_request = 17;
     // Worker responds after initializing with its capabilities & status
     WorkerInitResponse worker_init_response = 16;
-    
+
+    // MESSAGE NOT USED
     // Worker periodically sends empty heartbeat message to host
     WorkerHeartbeat worker_heartbeat = 15;
 
@@ -120,7 +121,7 @@ message WorkerInitRequest {
 
 // Worker responds with the result of initializing itself
 message WorkerInitResponse {
-  // NOT USED
+  // PROPERTY NOT USED
   // TODO: Remove from protobuf during next breaking change release
   string worker_version = 1;
 
@@ -173,7 +174,7 @@ message StatusResult {
   repeated RpcLog logs = 3;
 }
 
-// NOT USED
+// MESSAGE NOT USED
 // TODO: Remove from protobuf during next breaking change release
 message WorkerHeartbeat {}
 
@@ -187,7 +188,7 @@ message WorkerTerminate {
 message FileChangeEventRequest {
   // Types of File change operations (See link for more info: https://msdn.microsoft.com/en-us/library/t6xf43e0(v=vs.110).aspx)
   enum Type {
-	  Unknown = 0;
+    Unknown = 0;
     Created = 1;
     Deleted = 2;
     Changed = 4;
@@ -369,14 +370,14 @@ message InvocationRequest {
 
 // Host sends ActivityId, traceStateString and Tags from host
 message RpcTraceContext {
-	// This corresponds to Activity.Current?.Id
-	string trace_parent = 1;
+  // This corresponds to Activity.Current?.Id
+  string trace_parent = 1;
 
-	// This corresponds to Activity.Current?.TraceStateString
-	string trace_state = 2;
+  // This corresponds to Activity.Current?.TraceStateString
+  string trace_state = 2;
 
-	// This corresponds to Activity.Current?.Tags
-	map<string, string> attributes = 3;
+  // This corresponds to Activity.Current?.Tags
+  map<string, string> attributes = 3;
 }
 
 // Host sends retry context for a function invocation
@@ -396,8 +397,8 @@ message InvocationCancel {
   // Unique id for invocation
   string invocation_id = 2;
 
-  // Time period before force shutdown
-  google.protobuf.Duration grace_period = 1; // could also use absolute time
+  // PROPERTY NOT USED
+  google.protobuf.Duration grace_period = 1;
 }
 
 // Worker responds with status of Invocation
@@ -429,6 +430,7 @@ message TypedData {
     CollectionString collection_string = 9;
     CollectionDouble collection_double = 10;
     CollectionSInt64 collection_sint64 = 11;
+    ModelBindingData model_binding_data = 12;
   }
 }
 
@@ -496,20 +498,20 @@ message ParameterBinding {
 
 // Used to describe a given binding on load
 message BindingInfo {
-    // Indicates whether it is an input or output binding (or a fancy inout binding)
-    enum Direction {
-      in = 0;
-      out = 1;
-      inout = 2;
-    }
+  // Indicates whether it is an input or output binding (or a fancy inout binding)
+  enum Direction {
+    in = 0;
+    out = 1;
+    inout = 2;
+  }
 
-    // Indicates the type of the data for the binding
-    enum DataType {
-      undefined = 0;
-      string = 1;
-      binary = 2;
-      stream = 3;
-    }
+  // Indicates the type of the data for the binding
+  enum DataType {
+    undefined = 0;
+    string = 1;
+    binary = 2;
+    stream = 3;
+  }
 
   // Type of binding (e.g. HttpTrigger)
   string type = 2;
@@ -518,6 +520,9 @@ message BindingInfo {
   Direction direction = 3;
 
   DataType data_type = 4;
+
+  // Properties for binding metadata
+  map<string, string> properties = 5;
 }
 
 // Used to send logs back to the Host
@@ -582,13 +587,13 @@ message RpcException {
   // Textual message describing the exception
   string message = 2;
 
-  // Worker specifies whether exception is a user exception, 
-  // for purpose of application insights logging. Defaults to false. 
+  // Worker specifies whether exception is a user exception,
+  // for purpose of application insights logging. Defaults to false.
   bool is_user_exception = 4;
 
   // Type of exception. If it's a user exception, the type is passed along to app insights.
   // Otherwise, it's ignored for now.
-  string type = 5; 
+  string type = 5;
 }
 
 // Http cookie type. Note that only name and value are used for Http requests
@@ -646,4 +651,21 @@ message RpcHttp {
   map<string,NullableString> nullable_headers = 20;
   map<string,NullableString> nullable_params = 21;
   map<string,NullableString> nullable_query = 22;
+}
+
+// Message representing Microsoft.Azure.WebJobs.ParameterBindingData
+// Used for hydrating SDK-type bindings in out-of-proc workers
+message ModelBindingData
+{
+    // The version of the binding data content
+    string version = 1;
+
+    // The extension source of the binding data
+    string source = 2;
+
+    // The content type of the binding data content
+    string content_type = 3;
+
+    // The binding data content
+    bytes content = 4;
 }


### PR DESCRIPTION
Updated subtree from https://github.com/azure/azure-functions-language-worker-protobuf. Tag: v1.5.9-protofile. Commit: 1492027

[Release v1.5.9](https://github.com/Azure/azure-functions-language-worker-protobuf/releases/tag/v1.5.9-protofile)