### PR TITLE
Create new test project for Abstractions

### DIFF
--- a/test/WebJobs.Script.Abstractions/BindingMetadataTests.cs
+++ b/test/WebJobs.Script.Abstractions/BindingMetadataTests.cs
@@ -21,8 +21,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal("AzureWebJobsStorage", result.Connection);
             Assert.Equal(triggerBinding, result.Raw);
             Assert.Equal(BindingDirection.In, result.Direction);
-            Assert.True(result.Properties.TryGetValue("SupportsDeferredBinding", out bool supportsDeferredBinding));
-            Assert.False(supportsDeferredBinding);
+            Assert.True(result.Properties.TryGetValue("SupportsDeferredBinding", out var supportsDeferredBinding));
+            Assert.False((bool)supportsDeferredBinding);
             Assert.True(result.IsTrigger);
             Assert.False(result.IsReturn);
         }
@@ -38,8 +38,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal("AzureWebJobsStorage", result.Connection);
             Assert.Equal(inputBinding, result.Raw);
             Assert.Equal(BindingDirection.In, result.Direction);
-            Assert.True(result.Properties.TryGetValue("SupportsDeferredBinding", out bool supportsDeferredBinding));
-            Assert.True(supportsDeferredBinding);
+            Assert.True(result.Properties.TryGetValue("SupportsDeferredBinding", out var supportsDeferredBinding));
+            Assert.True((bool)supportsDeferredBinding);
             Assert.False(result.IsTrigger);
             Assert.False(result.IsReturn);
         }

--- a/test/WebJobs.Script.Abstractions/WebJobs.Script.Tests.Abstractions.csproj
+++ b/test/WebJobs.Script.Abstractions/WebJobs.Script.Tests.Abstractions.csproj
@@ -1,16 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
+    <AssemblyName>Microsoft.Azure.WebJobs.Script.Tests.Abstractions</AssemblyName>
+    <RootNamespace>Microsoft.Azure.WebJobs.Script.Tests.Abstractions</RootNamespace>
   </PropertyGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.0.1-beta1.21177.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/WebJobs.Script.Abstractions/WebJobs.Script.Tests.Abstractions.csproj
+++ b/test/WebJobs.Script.Abstractions/WebJobs.Script.Tests.Abstractions.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.0.1-beta1.21177.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="coverlet.collector" Version="1.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\WebJobs.Script.Abstractions\WebJobs.Script.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/WebJobs.Script.Abstractions/xunit.runner.json
+++ b/test/WebJobs.Script.Abstractions/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+    "parallelizeTestCollections": false
+}

--- a/test/WebJobs.Script.Abstractions/xunit.runner.json
+++ b/test/WebJobs.Script.Abstractions/xunit.runner.json
@@ -1,3 +1,0 @@
-﻿{
-    "parallelizeTestCollections": false
-}

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -74,7 +74,6 @@
     <ProjectReference Include="..\..\src\WebJobs.Script.WebHost\WebJobs.Script.WebHost.csproj" />
     <ProjectReference Include="..\..\src\WebJobs.Script\WebJobs.Script.csproj" />
     <ProjectReference Include="..\..\src\WebJobs.Script.Grpc\WebJobs.Script.Grpc.csproj" />
-    <ProjectReference Include="..\..\src\WebJobs.Script.Abstractions\WebJobs.Script.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The reference to the Abstractions project in the Script tests is causing issues as the WebHost project references the Abstractions nuget package - this is causing some sort of conflict. This PR separates the Abstractions unit tests into their own project to avoid any conflict