### PR TITLE
[LinuxDedicated] Emit Function Execution Logs faster

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/ILinuxAppServiceFileLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/ILinuxAppServiceFileLogger.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
+{
+    public interface ILinuxAppServiceFileLogger
+    {
+        public void Log(string message);
+    }
+}

--- a/src/WebJobs.Script.WebHost/Diagnostics/ILinuxAppServiceFileLoggerFactory.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/ILinuxAppServiceFileLoggerFactory.cs
@@ -7,6 +7,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 {
     public interface ILinuxAppServiceFileLoggerFactory
     {
-        public Lazy<ILinuxAppServiceFileLogger> Create(string category, bool backoffEnabled);
+        public ILinuxAppServiceFileLogger Create(string category, bool backoffEnabled);
     }
 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/ILinuxAppServiceFileLoggerFactory.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/ILinuxAppServiceFileLoggerFactory.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
+{
+    public interface ILinuxAppServiceFileLoggerFactory
+    {
+        public Lazy<ILinuxAppServiceFileLogger> Create(string category, bool backoffEnabled);
+    }
+}

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceEventGenerator.cs
@@ -2,23 +2,47 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.CompilerServices;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 {
     internal class LinuxAppServiceEventGenerator : LinuxEventGenerator
     {
         private readonly Action<string> _writeEvent;
-        private readonly LinuxAppServiceFileLoggerFactory _loggerFactory;
         private readonly HostNameProvider _hostNameProvider;
+        private readonly IOptions<FunctionsHostingConfigOptions> _functionsHostingConfigOptions;
+        private readonly Lazy<ILinuxAppServiceFileLogger> _functionsExecutionEventsCategoryLogger;
+        private readonly Lazy<ILinuxAppServiceFileLogger> _functionsLogsCategoryLogger;
+        private readonly Lazy<ILinuxAppServiceFileLogger> _functionsMetricsCategoryLogger;
+        private readonly Lazy<ILinuxAppServiceFileLogger> _functionsDetailsCategoryLogger;
 
-        public LinuxAppServiceEventGenerator(LinuxAppServiceFileLoggerFactory loggerFactory, HostNameProvider hostNameProvider, Action<string> writeEvent = null)
+        public LinuxAppServiceEventGenerator(
+            ILinuxAppServiceFileLoggerFactory loggerFactory,
+            HostNameProvider hostNameProvider,
+            IOptions<FunctionsHostingConfigOptions> functionsHostingConfigOptions,
+            Action<string> writeEvent = null)
         {
             _writeEvent = writeEvent ?? WriteEvent;
-            _loggerFactory = loggerFactory;
             _hostNameProvider = hostNameProvider ?? throw new ArgumentNullException(nameof(hostNameProvider));
+            _functionsHostingConfigOptions = functionsHostingConfigOptions;
+            bool executionLogBackoffEnabled = !functionsHostingConfigOptions.Value.DisableLinuxAppServiceLogBackoff;
+            _functionsExecutionEventsCategoryLogger = loggerFactory.Create(FunctionsExecutionEventsCategory, backoffEnabled: executionLogBackoffEnabled);
+            _functionsLogsCategoryLogger = loggerFactory.Create(FunctionsLogsCategory, backoffEnabled: false);
+            _functionsMetricsCategoryLogger = loggerFactory.Create(FunctionsMetricsCategory, backoffEnabled: false);
+            _functionsDetailsCategoryLogger = loggerFactory.Create(FunctionsDetailsCategory, backoffEnabled: false);
         }
+
+        //Exposing Loggers for Unit tests
+        internal Lazy<ILinuxAppServiceFileLogger> FunctionsExecutionEventsCategoryLogger => _functionsExecutionEventsCategoryLogger;
+
+        internal Lazy<ILinuxAppServiceFileLogger> FunctionsLogsCategoryLogger => _functionsLogsCategoryLogger;
+
+        internal Lazy<ILinuxAppServiceFileLogger> FunctionsMetricsCategoryLogger => _functionsMetricsCategoryLogger;
+
+        internal Lazy<ILinuxAppServiceFileLogger> FunctionsDetailsCategoryLogger => _functionsDetailsCategoryLogger;
 
         public static string TraceEventRegex { get; } = "(?<Level>[0-6]),(?<SubscriptionId>[^,]*),(?<HostName>[^,]*),(?<AppName>[^,]*),(?<FunctionName>[^,]*),(?<EventName>[^,]*),(?<Source>[^,]*),\"(?<Details>.*)\",\"(?<Summary>.*)\",(?<HostVersion>[^,]*),(?<EventTimestamp>[^,]+),(?<ExceptionType>[^,]*),\"(?<ExceptionMessage>.*)\",(?<FunctionInvocationId>[^,]*),(?<HostInstanceId>[^,]*),(?<ActivityId>[^,\"]*)";
 
@@ -39,8 +63,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             var hostName = _hostNameProvider.Value;
             using (FunctionsSystemLogsEventSource.SetActivityId(activityId))
             {
-                var logger = _loggerFactory.GetOrCreate(FunctionsLogsCategory);
-                WriteEvent(logger, $"{(int)ToEventLevel(level)},{subscriptionId},{hostName},{appName},{functionName},{eventName},{source},{NormalizeString(details)},{NormalizeString(summary)},{hostVersion},{formattedEventTimestamp},{exceptionType},{NormalizeString(exceptionMessage)},{functionInvocationId},{hostInstanceId},{activityId}");
+                WriteEvent(_functionsLogsCategoryLogger.Value, $"{(int)ToEventLevel(level)},{subscriptionId},{hostName},{appName},{functionName},{eventName},{source},{NormalizeString(details)},{NormalizeString(summary)},{hostVersion},{formattedEventTimestamp},{exceptionType},{NormalizeString(exceptionMessage)},{functionInvocationId},{hostInstanceId},{activityId}");
             }
         }
 
@@ -48,15 +71,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             long minimum, long maximum, long count, DateTime eventTimestamp, string data, string runtimeSiteName, string slotName)
         {
             var hostVersion = ScriptHost.Version;
-            var logger = _loggerFactory.GetOrCreate(FunctionsMetricsCategory);
-            WriteEvent(logger, $"{subscriptionId},{appName},{functionName},{eventName},{average},{minimum},{maximum},{count},{hostVersion},{eventTimestamp.ToString(EventTimestampFormat)},{data}");
+            WriteEvent(_functionsMetricsCategoryLogger.Value, $"{subscriptionId},{appName},{functionName},{eventName},{average},{minimum},{maximum},{count},{hostVersion},{eventTimestamp.ToString(EventTimestampFormat)},{data}");
         }
 
         public override void LogFunctionDetailsEvent(string siteName, string functionName, string inputBindings, string outputBindings,
             string scriptType, bool isDisabled)
         {
-            var logger = _loggerFactory.GetOrCreate(FunctionsDetailsCategory);
-            WriteEvent(logger, $"{siteName},{functionName},{NormalizeString(inputBindings)},{NormalizeString(outputBindings)},{scriptType},{(isDisabled ? 1 : 0)}");
+            WriteEvent(_functionsDetailsCategoryLogger.Value, $"{siteName},{functionName},{NormalizeString(inputBindings)},{NormalizeString(outputBindings)},{scriptType},{(isDisabled ? 1 : 0)}");
         }
 
         public override void LogFunctionExecutionAggregateEvent(string siteName, string functionName, long executionTimeInMs,
@@ -67,20 +88,20 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         public override void LogFunctionExecutionEvent(string executionId, string siteName, int concurrency, string functionName,
             string invocationId, string executionStage, long executionTimeSpan, bool success)
         {
-            var logger = _loggerFactory.GetOrCreate(FunctionsExecutionEventsCategory);
             string currentUtcTime = DateTime.UtcNow.ToString();
-            if (FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableLinuxEPExecutionCount))
+            bool detailedExecutionEventsDisabled = _functionsHostingConfigOptions.Value.DisableLinuxAppServiceExecutionDetails;
+            if (!detailedExecutionEventsDisabled)
             {
                 string log = string.Join(",", executionId, siteName, concurrency.ToString(), functionName, invocationId, executionStage, executionTimeSpan.ToString(), success.ToString(), currentUtcTime);
-                WriteEvent(logger, log);
+                WriteEvent(_functionsExecutionEventsCategoryLogger.Value, log);
             }
             else
             {
-                WriteEvent(logger, currentUtcTime);
+                WriteEvent(_functionsExecutionEventsCategoryLogger.Value, currentUtcTime);
             }
         }
 
-        private static void WriteEvent(LinuxAppServiceFileLogger logger, string evt)
+        private static void WriteEvent(ILinuxAppServiceFileLogger logger, string evt)
         {
             logger.Log(evt);
         }

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceFileLoggerFactory.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceFileLoggerFactory.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             _logRootPath = Environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsLogsMountPath);
         }
 
-        public virtual Lazy<ILinuxAppServiceFileLogger> Create(string category, bool logBackoffEnabled)
+        public virtual ILinuxAppServiceFileLogger Create(string category, bool logBackoffEnabled)
         {
-            return new Lazy<ILinuxAppServiceFileLogger>(() => new LinuxAppServiceFileLogger(category, _logRootPath, new FileSystem(), logBackoffEnabled: logBackoffEnabled));
+            return new LinuxAppServiceFileLogger(category, _logRootPath, new FileSystem(), logBackoffEnabled: logBackoffEnabled);
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceFileLoggerFactory.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxAppServiceFileLoggerFactory.cs
@@ -7,9 +7,8 @@ using System.IO.Abstractions;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 {
-    public class LinuxAppServiceFileLoggerFactory
+    public class LinuxAppServiceFileLoggerFactory : ILinuxAppServiceFileLoggerFactory
     {
-        private static readonly ConcurrentDictionary<string, Lazy<LinuxAppServiceFileLogger>> Loggers = new ConcurrentDictionary<string, Lazy<LinuxAppServiceFileLogger>>();
         private readonly string _logRootPath;
 
         public LinuxAppServiceFileLoggerFactory()
@@ -17,10 +16,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             _logRootPath = Environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsLogsMountPath);
         }
 
-        public virtual LinuxAppServiceFileLogger GetOrCreate(string category)
+        public virtual Lazy<ILinuxAppServiceFileLogger> Create(string category, bool logBackoffEnabled)
         {
-            return Loggers.GetOrAdd(category,
-                static (c, path) => new Lazy<LinuxAppServiceFileLogger>(() => new LinuxAppServiceFileLogger(c, path, new FileSystem())), _logRootPath).Value;
+            return new Lazy<ILinuxAppServiceFileLogger>(() => new LinuxAppServiceFileLogger(category, _logRootPath, new FileSystem(), logBackoffEnabled: logBackoffEnabled));
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -112,7 +112,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 else if (SystemEnvironment.Instance.IsLinuxAppService())
                 {
                     var hostNameProvider = p.GetService<HostNameProvider>();
-                    return new LinuxAppServiceEventGenerator(new LinuxAppServiceFileLoggerFactory(), hostNameProvider);
+                    IOptions<FunctionsHostingConfigOptions> functionsHostingConfigOptions = p.GetService<IOptions<FunctionsHostingConfigOptions>>();
+                    return new LinuxAppServiceEventGenerator(new LinuxAppServiceFileLoggerFactory(), hostNameProvider, functionsHostingConfigOptions);
                 }
                 else if (environment.IsKubernetesManagedHosting())
                 {

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -43,6 +43,33 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         }
 
         /// <summary>
+        /// Gets a value indicating whether Linux Log Backoff is disabled in the hosting config.
+        /// </summary>
+        public bool DisableLinuxAppServiceLogBackoff
+        {
+            get
+            {
+                return GetFeature(ScriptConstants.HostingConfigDisableLinuxAppServiceExecutionEventLogBackoff) == "1";
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether Linux Appservice/EP Detailed Execution Event is disabled in the hosting config.
+        /// </summary>
+        public bool DisableLinuxAppServiceExecutionDetails
+        {
+            get
+            {
+                return GetFeature(ScriptConstants.HostingConfigDisableLinuxAppServiceDetailedExecutionEvents) == "1";
+            }
+
+            set
+            {
+               _features[ScriptConstants.HostingConfigDisableLinuxAppServiceDetailedExecutionEvents] = value ? "1" : "0";
+            }
+        }
+
+        /// <summary>
         /// Gets feature by name.
         /// </summary>
         /// <param name="name">Feature name.</param>

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -124,7 +124,8 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FeatureFlagDisableWorkerIndexing = "DisableWorkerIndexing";
         public const string FeatureFlagEnableDebugTracing = "EnableDebugTracing";
         public const string FeatureFlagEnableProxies = "EnableProxies";
-        public const string FeatureFlagEnableLinuxEPExecutionCount = "EnableLinuxFEC";
+        public const string HostingConfigDisableLinuxAppServiceDetailedExecutionEvents = "DisableLinuxExecutionDetails";
+        public const string HostingConfigDisableLinuxAppServiceExecutionEventLogBackoff = "DisableLinuxLogBackoff";
 
         public const string AdminJwtValidAudienceFormat = "https://{0}.azurewebsites.net/azurefunctions";
         public const string AdminJwtValidIssuerFormat = "https://{0}.scm.azurewebsites.net";

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxAppServiceEventGeneratorTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxAppServiceEventGeneratorTests.cs
@@ -5,10 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Tests.Workers;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 using static Microsoft.Azure.WebJobs.Script.ScriptConstants;
@@ -21,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 
         private readonly LinuxAppServiceEventGenerator _generator;
         private readonly List<string> _events;
-        private readonly Dictionary<string, MockLinuxAppServiceFileLogger> _loggers;
+        private IOptions<FunctionsHostingConfigOptions> _functionsHostingConfigOptions;
 
         public LinuxAppServiceEventGeneratorTests()
         {
@@ -31,27 +33,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
                 _events.Add(s);
             };
 
-            _loggers = new Dictionary<string, MockLinuxAppServiceFileLogger>
-            {
-                [LinuxEventGenerator.FunctionsLogsCategory] =
-                    new MockLinuxAppServiceFileLogger(LinuxEventGenerator.FunctionsLogsCategory, string.Empty, null),
-                [LinuxEventGenerator.FunctionsMetricsCategory] =
-                    new MockLinuxAppServiceFileLogger(LinuxEventGenerator.FunctionsMetricsCategory, string.Empty, null),
-                [LinuxEventGenerator.FunctionsDetailsCategory] =
-                    new MockLinuxAppServiceFileLogger(LinuxEventGenerator.FunctionsDetailsCategory, string.Empty, null),
-                [LinuxEventGenerator.FunctionsExecutionEventsCategory] =
-                    new MockLinuxAppServiceFileLogger(LinuxEventGenerator.FunctionsExecutionEventsCategory, string.Empty, null)
-            };
+            var loggerFactoryMock = new MockLinuxAppServiceFileLoggerFactory();
 
-            var loggerFactoryMock = new Mock<LinuxAppServiceFileLoggerFactory>(MockBehavior.Strict);
-            loggerFactoryMock.Setup(f => f.GetOrCreate(It.IsAny<string>())).Returns<string>(s => _loggers[s]);
+            _functionsHostingConfigOptions = Options.Create(new FunctionsHostingConfigOptions());
 
             var environmentMock = new Mock<IEnvironment>();
             environmentMock.Setup(f => f.GetEnvironmentVariable(It.Is<string>(v => v == "WEBSITE_HOSTNAME")))
                 .Returns<string>(s => _hostNameDefault);
 
             var hostNameProvider = new HostNameProvider(environmentMock.Object);
-            _generator = new LinuxAppServiceEventGenerator(loggerFactoryMock.Object, hostNameProvider, writer);
+            _generator = new LinuxAppServiceEventGenerator(loggerFactoryMock, hostNameProvider, _functionsHostingConfigOptions, writer);
         }
 
         public static string UnNormalize(string normalized)
@@ -68,7 +59,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         {
             _generator.LogFunctionTraceEvent(level, subscriptionId, appName, functionName, eventName, source, details, summary, exceptionType, exceptionMessage, functionInvocationId, hostInstanceId, activityId, runtimeSiteName, slotName, DateTime.UtcNow);
 
-            var evt = _loggers[LinuxEventGenerator.FunctionsLogsCategory].Events.Single();
+            var logger = _generator.FunctionsLogsCategoryLogger.Value as MockLinuxAppServiceFileLogger;
+            var evt = logger.Events.Single();
 
             var regex = new Regex(LinuxAppServiceEventGenerator.TraceEventRegex);
             var match = regex.Match(evt);
@@ -103,7 +95,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         {
             _generator.LogFunctionMetricEvent(subscriptionId, appName, functionName, eventName, average, minimum, maximum, count, DateTime.Now, data, runtimeSiteName, slotName);
 
-            string evt = _loggers[LinuxEventGenerator.FunctionsMetricsCategory].Events.Single();
+            var logger = _generator.FunctionsMetricsCategoryLogger.Value as MockLinuxAppServiceFileLogger;
+            var evt = logger.Events.Single();
 
             Regex regex = new Regex(LinuxAppServiceEventGenerator.MetricEventRegex);
             var match = regex.Match(evt);
@@ -133,7 +126,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         {
             _generator.LogFunctionDetailsEvent(siteName, functionName, inputBindings, outputBindings, scriptType, isDisabled);
 
-            string evt = _loggers[LinuxEventGenerator.FunctionsDetailsCategory].Events.Single();
+            var logger = _generator.FunctionsDetailsCategoryLogger.Value as MockLinuxAppServiceFileLogger;
+            var evt = logger.Events.Single();
 
             Regex regex = new Regex(LinuxAppServiceEventGenerator.DetailsEventRegex);
             var match = regex.Match(evt);
@@ -179,46 +173,43 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         [Theory]
         [MemberData(nameof(LinuxEventGeneratorTestData.GetFunctionExecutionEvents), MemberType = typeof(LinuxEventGeneratorTestData))]
         public void ParseFunctionExecutionEvents(string executionId, string siteName, int concurrency, string functionName, string invocationId,
-            string executionStage, long executionTimeSpan, bool success, bool featureFlagEnabled)
+            string executionStage, long executionTimeSpan, bool success, bool detailedExecutionEventsDisabled)
         {
-            TestScopedEnvironmentVariable featureFlags = null;
-            try
+            if (detailedExecutionEventsDisabled)
             {
-                if (featureFlagEnabled)
-                {
-                    featureFlags = new TestScopedEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, FeatureFlagEnableLinuxEPExecutionCount);
-                }
-                _generator.LogFunctionExecutionEvent(executionId, siteName, concurrency, functionName, invocationId, executionStage, executionTimeSpan, success);
-                string evt = _loggers[LinuxEventGenerator.FunctionsExecutionEventsCategory].Events.Single();
-
-                if (featureFlagEnabled)
-                {
-                    Regex regex = new Regex(LinuxAppServiceEventGenerator.ExecutionEventRegex);
-                    var match = regex.Match(evt);
-
-                    Assert.True(match.Success);
-                    Assert.Equal(10, match.Groups.Count);
-
-                    var groupMatches = match.Groups.Cast<Group>().Select(p => p.Value).Skip(1).ToArray();
-                    Assert.Collection(groupMatches,
-                        p => Assert.Equal(executionId, p),
-                        p => Assert.Equal(siteName, p),
-                        p => Assert.Equal(concurrency.ToString(), p),
-                        p => Assert.Equal(functionName, p),
-                        p => Assert.Equal(invocationId, p),
-                        p => Assert.Equal(executionStage, p),
-                        p => Assert.Equal(executionTimeSpan.ToString(), p),
-                        p => Assert.True(Convert.ToBoolean(p)),
-                        p => Assert.True(DateTime.TryParse(p, out DateTime dt)));
-                }
-                else
-                {
-                    Assert.True(DateTime.TryParse(evt, out DateTime dt));
-                }
+                _functionsHostingConfigOptions.Value.DisableLinuxAppServiceExecutionDetails = true;
             }
-            finally
+            else
             {
-                featureFlags?.Dispose();
+                _functionsHostingConfigOptions.Value.DisableLinuxAppServiceExecutionDetails = false;
+            }
+            _generator.LogFunctionExecutionEvent(executionId, siteName, concurrency, functionName, invocationId, executionStage, executionTimeSpan, success);
+            var logger = _generator.FunctionsExecutionEventsCategoryLogger.Value as MockLinuxAppServiceFileLogger;
+            var evt = logger.Events.Single();
+
+            if (!detailedExecutionEventsDisabled)
+            {
+                Regex regex = new Regex(LinuxAppServiceEventGenerator.ExecutionEventRegex);
+                var match = regex.Match(evt);
+
+                Assert.True(match.Success);
+                Assert.Equal(10, match.Groups.Count);
+
+                var groupMatches = match.Groups.Cast<Group>().Select(p => p.Value).Skip(1).ToArray();
+                Assert.Collection(groupMatches,
+                    p => Assert.Equal(executionId, p),
+                    p => Assert.Equal(siteName, p),
+                    p => Assert.Equal(concurrency.ToString(), p),
+                    p => Assert.Equal(functionName, p),
+                    p => Assert.Equal(invocationId, p),
+                    p => Assert.Equal(executionStage, p),
+                    p => Assert.Equal(executionTimeSpan.ToString(), p),
+                    p => Assert.True(Convert.ToBoolean(p)),
+                    p => Assert.True(DateTime.TryParse(p, out DateTime dt)));
+            }
+            else
+            {
+                Assert.True(DateTime.TryParse(evt, out DateTime dt));
             }
         }
     }

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxAppServiceEventGeneratorTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxAppServiceEventGeneratorTests.cs
@@ -6,14 +6,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Azure.WebJobs.Script.Config;
-using Microsoft.Azure.WebJobs.Script.Tests.Workers;
-using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
-using static Microsoft.Azure.WebJobs.Script.ScriptConstants;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 {
@@ -59,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         {
             _generator.LogFunctionTraceEvent(level, subscriptionId, appName, functionName, eventName, source, details, summary, exceptionType, exceptionMessage, functionInvocationId, hostInstanceId, activityId, runtimeSiteName, slotName, DateTime.UtcNow);
 
-            var logger = _generator.FunctionsLogsCategoryLogger.Value as MockLinuxAppServiceFileLogger;
+            var logger = _generator.FunctionsLogsCategoryLogger as MockLinuxAppServiceFileLogger;
             var evt = logger.Events.Single();
 
             var regex = new Regex(LinuxAppServiceEventGenerator.TraceEventRegex);
@@ -95,7 +92,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         {
             _generator.LogFunctionMetricEvent(subscriptionId, appName, functionName, eventName, average, minimum, maximum, count, DateTime.Now, data, runtimeSiteName, slotName);
 
-            var logger = _generator.FunctionsMetricsCategoryLogger.Value as MockLinuxAppServiceFileLogger;
+            var logger = _generator.FunctionsMetricsCategoryLogger as MockLinuxAppServiceFileLogger;
             var evt = logger.Events.Single();
 
             Regex regex = new Regex(LinuxAppServiceEventGenerator.MetricEventRegex);
@@ -126,7 +123,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         {
             _generator.LogFunctionDetailsEvent(siteName, functionName, inputBindings, outputBindings, scriptType, isDisabled);
 
-            var logger = _generator.FunctionsDetailsCategoryLogger.Value as MockLinuxAppServiceFileLogger;
+            var logger = _generator.FunctionsDetailsCategoryLogger as MockLinuxAppServiceFileLogger;
             var evt = logger.Events.Single();
 
             Regex regex = new Regex(LinuxAppServiceEventGenerator.DetailsEventRegex);
@@ -184,7 +181,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
                 _functionsHostingConfigOptions.Value.DisableLinuxAppServiceExecutionDetails = false;
             }
             _generator.LogFunctionExecutionEvent(executionId, siteName, concurrency, functionName, invocationId, executionStage, executionTimeSpan, success);
-            var logger = _generator.FunctionsExecutionEventsCategoryLogger.Value as MockLinuxAppServiceFileLogger;
+            var logger = _generator.FunctionsExecutionEventsCategoryLogger as MockLinuxAppServiceFileLogger;
             var evt = logger.Events.Single();
 
             if (!detailedExecutionEventsDisabled)

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxAppServiceFileLoggerTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxAppServiceFileLoggerTests.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
+using System.Reactive.Concurrency;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Moq;
@@ -47,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
                 streamWriter.Setup(s => s.WriteLineAsync(It.Is<string>(log => log.Equals(expectedLogs[i1])))).Returns(Task.FromResult(true));
             }
 
-            var fileLogger = new LinuxAppServiceFileLogger(LogFileName, LogDirectoryPath, fileSystem.Object, false);
+            var fileLogger = new LinuxAppServiceFileLogger(LogFileName, LogDirectoryPath, fileSystem.Object, false, false);
 
             foreach (var log in GetLogs())
             {
@@ -76,7 +78,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         {
             // Expect no methods to be called on ILinuxAppServiceFileSystem
             var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
-            var fileLogger = new LinuxAppServiceFileLogger(LogFileName, LogDirectoryPath, fileSystem.Object, false);
+            var fileLogger = new LinuxAppServiceFileLogger(LogFileName, LogDirectoryPath, fileSystem.Object, false, false);
             await fileLogger.InternalProcessLogQueue();
         }
 
@@ -84,7 +86,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         public async void Rolls_Files_If_File_Size_Exceeds_Limit()
         {
             var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
-            var fileLogger = new LinuxAppServiceFileLogger(LogFileName, LogDirectoryPath, fileSystem.Object, false);
+            var fileLogger = new LinuxAppServiceFileLogger(LogFileName, LogDirectoryPath, fileSystem.Object, false, false);
             var dirBase = new Mock<DirectoryBase>(MockBehavior.Strict);
             var fileInfoFactory = new Mock<IFileInfoFactory>(MockBehavior.Strict);
             var fileInfoBase = new Mock<FileInfoBase>(MockBehavior.Strict);
@@ -135,7 +137,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         public async void Deletes_Oldest_File_If_Exceeds_Limit()
         {
             var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
-            var fileLogger = new LinuxAppServiceFileLogger(LogFileName, LogDirectoryPath, fileSystem.Object, false);
+            var fileLogger = new LinuxAppServiceFileLogger(LogFileName, LogDirectoryPath, fileSystem.Object, false, false);
             var dirBase = new Mock<DirectoryBase>(MockBehavior.Strict);
             var fileInfoFactory = new Mock<IFileInfoFactory>(MockBehavior.Strict);
             var fileInfoBase = new Mock<FileInfoBase>(MockBehavior.Strict);
@@ -196,6 +198,134 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
                 .Returns(fileInfosMock.Select(f => f.Object).ToArray);
 
             fileInfosMock[0].Setup(f => f.Delete());
+        }
+
+        [Fact]
+        public async void Logs_1_time_in_5_seconds_by_default()
+        {
+            var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
+            var dirBase = new Mock<DirectoryBase>(MockBehavior.Strict);
+            var fileInfoFactory = new Mock<IFileInfoFactory>(MockBehavior.Strict);
+            var fileInfoBase = new Mock<FileInfoBase>(MockBehavior.Strict);
+            var fileBase = new Mock<FileBase>(MockBehavior.Strict);
+            var stream = new Mock<Stream>();
+            stream.Setup(s => s.CanWrite).Returns(true);
+            var streamWriter = new Mock<StreamWriter>(MockBehavior.Default, stream.Object);
+
+            fileSystem.SetupGet(fs => fs.Directory).Returns(dirBase.Object);
+            dirBase.Setup(d => d.CreateDirectory(It.Is<string>(s => string.Equals(s, LogDirectoryPath)))).Returns(new DirectoryInfo(LogDirectoryPath));
+
+            fileSystem.SetupGet(fs => fs.FileInfo).Returns(fileInfoFactory.Object);
+            fileInfoFactory.Setup(f => f.FromFileName(It.Is<string>(s => MatchesLogFilePath(s))))
+                .Returns(fileInfoBase.Object);
+            fileInfoBase.Setup(f => f.Exists).Returns(false);
+
+            fileSystem.SetupGet(fs => fs.File).Returns(fileBase.Object);
+            fileBase.Setup(f => f.AppendText(It.Is<string>(s => MatchesLogFilePath(s)))).Returns(streamWriter.Object);
+
+            var expectedLogs = GetLogs();
+            for (var i = 0; i < expectedLogs.Count; i++)
+            {
+                var i1 = i;
+                streamWriter.Setup(s => s.WriteLineAsync(It.Is<string>(log => log.Equals(expectedLogs[i1])))).Returns(Task.FromResult(true));
+            }
+
+            var fileLogger = new LinuxAppServiceFileLogger(LogFileName, LogDirectoryPath, fileSystem.Object, false, false);
+
+            foreach (var log in GetLogs())
+            {
+                fileLogger.Log(log);
+            }
+            object testState = null;
+            _ = fileLogger.ProcessLogQueue(testState);
+            // Log not emitted due to 30 second delay
+            fileLogger.Log("4th Log, second batch");
+            await Task.Delay(5000);
+            fileLogger.Stop(new System.TimeSpan(0));
+
+            fileSystem.VerifyGet(fs => fs.Directory, Times.Once);
+            dirBase.Verify(d => d.CreateDirectory(It.Is<string>(s => string.Equals(s, LogDirectoryPath))), Times.Once);
+
+            fileInfoFactory.Verify(f => f.FromFileName(It.Is<string>(s => MatchesLogFilePath(s))), Times.Once);
+            fileInfoBase.Verify(f => f.Exists, Times.Once);
+
+            fileSystem.VerifyGet(fs => fs.File, Times.Once);
+            fileBase.Verify(f => f.AppendText(It.Is<string>(s => MatchesLogFilePath(s))), Times.Once);
+            for (var i = 0; i < expectedLogs.Count; i++)
+            {
+                var i1 = i;
+                streamWriter.Verify(s => s.WriteLineAsync(It.Is<string>(log => log.Equals(expectedLogs[i1]))), Times.Once);
+            }
+        }
+
+        [Fact]
+        public async void Logs_3_times_in_5_seconds_with_Backoff()
+        {
+            var fileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
+            var dirBase = new Mock<DirectoryBase>(MockBehavior.Strict);
+            var fileInfoFactory = new Mock<IFileInfoFactory>(MockBehavior.Strict);
+            var fileInfoBase = new Mock<FileInfoBase>(MockBehavior.Strict);
+            var fileBase = new Mock<FileBase>(MockBehavior.Strict);
+            var stream = new Mock<Stream>();
+            stream.Setup(s => s.CanWrite).Returns(true);
+            var streamWriter = new Mock<StreamWriter>(MockBehavior.Default, stream.Object);
+
+            fileSystem.SetupGet(fs => fs.Directory).Returns(dirBase.Object);
+            dirBase.Setup(d => d.CreateDirectory(It.Is<string>(s => string.Equals(s, LogDirectoryPath)))).Returns(new DirectoryInfo(LogDirectoryPath));
+
+            fileSystem.SetupGet(fs => fs.FileInfo).Returns(fileInfoFactory.Object);
+            fileInfoFactory.Setup(f => f.FromFileName(It.Is<string>(s => MatchesLogFilePath(s))))
+                .Returns(fileInfoBase.Object);
+            fileInfoBase.Setup(f => f.Exists).Returns(false);
+
+            fileSystem.SetupGet(fs => fs.File).Returns(fileBase.Object);
+            fileBase.Setup(f => f.AppendText(It.Is<string>(s => MatchesLogFilePath(s)))).Returns(streamWriter.Object);
+
+            var expectedLogs = GetLogs();
+            string expectedLog4 = "4th Log, second batch";
+            expectedLogs.Append(expectedLog4);
+            string expectedLog5 = "5th log, third batch";
+            expectedLogs.Append(expectedLog5);
+            for (var i = 0; i < expectedLogs.Count; i++)
+            {
+                var i1 = i;
+                streamWriter.Setup(s => s.WriteLineAsync(It.Is<string>(log => log.Equals(expectedLogs[i1])))).Returns(Task.FromResult(true));
+            }
+
+            var fileLogger = new LinuxAppServiceFileLogger(LogFileName, LogDirectoryPath, fileSystem.Object, true, false);
+
+            foreach (var log in GetLogs())
+            {
+                fileLogger.Log(log);
+            }
+            object testState = null;
+
+            // Kick off the fileLogger Process and ignore result, call stop. If no delay only one file write
+            _ = fileLogger.ProcessLogQueue(testState);
+            fileLogger.Log(expectedLog4);
+            await Task.Delay(2000);
+            fileLogger.Log(expectedLog5);
+            await Task.Delay(3000);
+            fileLogger.Stop(new System.TimeSpan(0));
+
+            fileSystem.VerifyGet(fs => fs.Directory, Times.Exactly(3));
+            dirBase.Verify(d => d.CreateDirectory(It.Is<string>(s => string.Equals(s, LogDirectoryPath))), Times.Exactly(3));
+
+            fileInfoFactory.Verify(f => f.FromFileName(It.Is<string>(s => MatchesLogFilePath(s))), Times.Exactly(3));
+            fileInfoBase.Verify(f => f.Exists, Times.Exactly(3));
+
+            fileSystem.VerifyGet(fs => fs.File, Times.Exactly(3));
+            fileBase.Verify(f => f.AppendText(It.Is<string>(s => MatchesLogFilePath(s))), Times.Exactly(3));
+            for (var i = 0; i < expectedLogs.Count; i++)
+            {
+                var i1 = i;
+                streamWriter.Verify(s => s.WriteLineAsync(It.Is<string>(log => log.Equals(expectedLogs[i1]))), Times.Once);
+                if (i >= 3)
+                {
+                    // Dispose StreamWriter from Using between batches
+                    streamWriter.Verify(s => s.Dispose(), Times.Once);
+                }
+            }
         }
 
         private static bool MatchesLogFilePath(string filePath)

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxEventGeneratorTestData.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxEventGeneratorTestData.cs
@@ -35,8 +35,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 
         public static IEnumerable<object[]> GetFunctionExecutionEvents()
         {
-            yield return new object[] { "testexecution", "testSite", 1, "testFunction", "testInvocation", "testStage", 1, true, true };
             yield return new object[] { "testexecution", "testSite", 1, "testFunction", "testInvocation", "testStage", 1, true, false };
+            yield return new object[] { "testexecution", "testSite", 1, "testFunction", "testInvocation", "testStage", 1, true, true };
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Diagnostics/MockLinuxAppServiceFileLogger.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/MockLinuxAppServiceFileLogger.cs
@@ -8,21 +8,21 @@ using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 {
-    public class MockLinuxAppServiceFileLogger : LinuxAppServiceFileLogger
+    public class MockLinuxAppServiceFileLogger : ILinuxAppServiceFileLogger
     {
-        public MockLinuxAppServiceFileLogger(string category, string logFileDirectory, IFileSystem fileSystem) : base(category, logFileDirectory, fileSystem)
+        public MockLinuxAppServiceFileLogger()
         {
             Events = new List<string>();
         }
 
         public List<string> Events { get; }
 
-        public override void Log(string evt)
+        public void Log(string evt)
         {
             Events.Add(evt);
         }
 
-        public override Task ProcessLogQueue(object state)
+        public Task ProcessLogQueue(object state)
         {
             return Task.CompletedTask;
         }

--- a/test/WebJobs.Script.Tests/Diagnostics/MockLinuxAppServiceFileLoggerFactory.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/MockLinuxAppServiceFileLoggerFactory.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
+{
+    public class MockLinuxAppServiceFileLoggerFactory : ILinuxAppServiceFileLoggerFactory
+    {
+        public Lazy<ILinuxAppServiceFileLogger> Create(string category, bool logBackoffEnabled)
+        {
+            return new Lazy<ILinuxAppServiceFileLogger>(() => new MockLinuxAppServiceFileLogger());
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Diagnostics/MockLinuxAppServiceFileLoggerFactory.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/MockLinuxAppServiceFileLoggerFactory.cs
@@ -1,16 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 {
     public class MockLinuxAppServiceFileLoggerFactory : ILinuxAppServiceFileLoggerFactory
     {
-        public Lazy<ILinuxAppServiceFileLogger> Create(string category, bool logBackoffEnabled)
+        public ILinuxAppServiceFileLogger Create(string category, bool logBackoffEnabled)
         {
-            return new Lazy<ILinuxAppServiceFileLogger>(() => new MockLinuxAppServiceFileLogger());
+            return new MockLinuxAppServiceFileLogger();
         }
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

This PR extends abandoned prior PR https://github.com/Azure/azure-functions-host/pull/8443.  It encompasses two logging changes that will only affect Linux App Service applications (Dedicated/EP). The change introduces an exponential backoff delay starting at 1 second and finishing at 32 seconds for Linux App Service FunctionExecutionCount events.  The logger uses the backoff delay to determine time between logging attempts. Platform takes dependency on the FunctionExecutionCount logger to determine if a Function is executing. If the host missed logging its initial execution for whatever reason, it would wait 30 seconds before attempting again. Therefore, the 30 second delay was causing platform to take a long time to determine when a function app started processing.

The other change present in this PR updates the Function Execution Event logs for Linux Dedicated and Elastic Premium to provide a more verbose explanation of the execution. 

This PR also puts the above feature behind a SCM Hosting Configuration flag to allow batched testing in production environments for both the LinuxFastLog feature above and Linux App Service FunctionExecutionCount metric logging. 


### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
