### PR TITLE
Capture the property bag from metadata request and pass it to Function load request

### DIFF
--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -528,10 +528,9 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
         internal FunctionLoadRequest GetFunctionLoadRequest(FunctionMetadata metadata, ManagedDependencyOptions managedDependencyOptions)
         {
-            var functionId = metadata.GetFunctionId();
             FunctionLoadRequest request = new FunctionLoadRequest()
             {
-                FunctionId = functionId,
+                FunctionId = metadata.GetFunctionId(),
                 Metadata = new RpcFunctionMetadata()
                 {
                     Name = metadata.Name,
@@ -558,7 +557,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             foreach (var property in metadata.Properties)
             {
                 // worker properties are expected to be string values
-                request.Metadata.Properties.Add(property.Key, property.Value.ToString());
+                request.Metadata.Properties.Add(property.Key, property.Value?.ToString());
             }
 
             return request;
@@ -733,7 +732,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     {
                         if (!functionMetadata.Properties.TryAdd(property.Key, property.Value.ToString()))
                         {
-                            _workerChannelLogger?.LogDebug("{metadataPropertyKey} is already a part of metadata properties", property.Key);
+                            _workerChannelLogger?.LogDebug("{metadataPropertyKey} is already a part of metadata properties for {functionId}", property.Key, metadata.FunctionId);
                         }
                     }
 

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -730,7 +730,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
                     foreach (var property in metadata.Properties)
                     {
-                        if (!functionMetadata.Properties.TryAdd(property.Key, property.Value.ToString()))
+                        if (!functionMetadata.Properties.TryAdd(property.Key, property.Value?.ToString()))
                         {
                             _workerChannelLogger?.LogDebug("{metadataPropertyKey} is already a part of metadata properties for {functionId}", property.Key, metadata.FunctionId);
                         }

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -561,8 +561,6 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                 request.Metadata.Properties.Add(property.Key, property.Value.ToString());
             }
 
-            _workerChannelLogger?.LogDebug($"Adding {request.Metadata.Properties.Count} worker properties for {functionId}");
-
             return request;
         }
 
@@ -733,7 +731,10 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
                     foreach (var property in metadata.Properties)
                     {
-                        functionMetadata.Properties.TryAdd(property.Key, property.Value.ToString());
+                        if (!functionMetadata.Properties.TryAdd(property.Key, property.Value.ToString()))
+                        {
+                            _workerChannelLogger?.LogDebug("{metadataPropertyKey} is already a part of metadata properties", property.Key);
+                        }
                     }
 
                     var bindings = new List<string>();

--- a/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
+++ b/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
@@ -326,7 +326,7 @@ message RpcFunctionMetadata {
   // Properties for function metadata
   // They're usually specific to a worker and largely passed along to the controller API for use
   // outside the host
-   map<string,string> Properties = 16;
+   map<string,string> properties = 16;
 }
 
 // Host tells worker it is ready to receive metadata

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -641,7 +641,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var traces = _logger.GetLogMessages();
             ShowOutput(traces);
 
-            string expectedLogMessage = "Adding 1 worker properties";
+            string expectedLogMessage = "Adding 4 worker properties";
             var functionLoadLogs = traces.Where(m => m.FormattedMessage?.Contains(expectedLogMessage) ?? false);
 
             Assert.Equal(2, functionLoadLogs.Count());

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -637,14 +637,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _workerChannel.SetupFunctionInvocationBuffers(functionMetadata);
             _workerChannel.SendFunctionLoadRequests(null, null);
 
+            _testFunctionRpcService.OnMessage(StreamingMessage.ContentOneofCase.FunctionLoadRequest,
+               (m) =>
+               {
+                   Assert.Contains("\"worker.functionId\": \"fn1\"", m.Message.ToString());
+               });
+
             await Task.Delay(500);
-            var traces = _logger.GetLogMessages();
-            ShowOutput(traces);
-
-            string expectedLogMessage = "Adding 4 worker properties";
-            var functionLoadLogs = traces.Where(m => m.FormattedMessage?.Contains(expectedLogMessage) ?? false);
-
-            Assert.Equal(2, functionLoadLogs.Count());
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Workers/Rpc/TestFunctionRpcService.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/TestFunctionRpcService.cs
@@ -11,7 +11,9 @@ using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.Grpc.Eventing;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 {
@@ -323,6 +325,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                         Status = statusResult,
                         FunctionId = functionId
                     };
+
+                    foreach (var property in response.Properties)
+                    {
+                        indexingResponse.Properties.Add(property.Key, property.Value.ToString());
+                    }
 
                     overallResponse.FunctionMetadataResults.Add(indexingResponse);
                 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

resolves #8302
resolves #8898

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
As part of work for project stein. The function host send a metadata request to the worker process to get the function metadata. That worker would index functions and send the function metadata response. This request is only sent to one worker, however there is indexing related data that needs to be shared between workers. 

Proposed solution.
1. Worker sends the data that it needs to share between workers as part of the function metadata response with a prefix "worker."
2. The host reads the properties from the RpcFunctionMetadata and includes the properties in the function load request.