### PR TITLE
Add unit test for the SDK binding feature

### DIFF
--- a/src/WebJobs.Script.Analyzers/WebJobs.Script.Analyzers.csproj
+++ b/src/WebJobs.Script.Analyzers/WebJobs.Script.Analyzers.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.3.1" />
 
     <!-- Packed in Microsoft.Azure.Functions.Analyzers NuGet -->
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.35" PrivateAssets="All" IncludeInPackage="true" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.36" PrivateAssets="All" IncludeInPackage="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/WebJobs.Script.Tests.Analyzers/WebJobs.Script.Tests.Analyzers.csproj
+++ b/test/WebJobs.Script.Tests.Analyzers/WebJobs.Script.Tests.Analyzers.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.36" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.11" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="4.0.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.0.1-beta1.21177.1" />

--- a/test/WebJobs.Script.Tests/Binding/FunctionBindingTests.cs
+++ b/test/WebJobs.Script.Tests/Binding/FunctionBindingTests.cs
@@ -173,5 +173,26 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal("Value2", (string)collection[1]);
             Assert.Equal("Value3", (string)collection[2]);
         }
+
+        [Fact]
+        public async Task BindParameterBindingDataAsync()
+        {
+            string contentString = "hello world";
+            ParameterBindingData bindingData = new ("1.0.0", "AzureStorageBlob", BinaryData.FromString(contentString), "application/json");
+
+            var binderMock = new Mock<Binder>(MockBehavior.Strict);
+            var attributes = new Attribute[] { new BlobAttribute("test") };
+            binderMock.Setup(p => p.BindAsync<ParameterBindingData>(attributes, CancellationToken.None)).ReturnsAsync(bindingData);
+
+            BindingContext bindingContext = new BindingContext
+            {
+                Attributes = attributes,
+                Binder = binderMock.Object
+            };
+
+            await FunctionBinding.BindParameterBindingDataAsync(bindingContext);
+
+            Assert.Equal(bindingData, bindingContext.Value);
+        }
     }
 }

--- a/test/WebJobs.Script.Tests/Binding/FunctionBindingTests.cs
+++ b/test/WebJobs.Script.Tests/Binding/FunctionBindingTests.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public async Task BindParameterBindingDataAsync()
         {
             string contentString = "hello world";
-            ParameterBindingData bindingData = new ("1.0.0", "AzureStorageBlob", BinaryData.FromString(contentString), "application/json");
+            ParameterBindingData bindingData = new("1.0.0", "AzureStorageBlob", BinaryData.FromString(contentString), "application/json");
 
             var binderMock = new Mock<Binder>(MockBehavior.Strict);
             var attributes = new Attribute[] { new BlobAttribute("test") };

--- a/test/WebJobs.Script.Tests/Binding/GeneralScriptBindingProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Binding/GeneralScriptBindingProviderTests.cs
@@ -21,27 +21,33 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [InlineData(null, null, typeof(object))]
         [InlineData(null, "many", typeof(object[]))]
         [InlineData("string", null, typeof(string))]
-        [InlineData("StRing", null, typeof(string))] // case insenstive
-        [InlineData("string", "mANy", typeof(string[]))] // case insensitve
+        [InlineData("StRing", null, typeof(string))] // case insensitive
+        [InlineData("string", "mANy", typeof(string[]))] // case insensitive
         [InlineData("binary", null, typeof(byte[]))]
         [InlineData("binary", "many", typeof(byte[][]))]
         [InlineData("stream", null, typeof(Stream))]
         [InlineData("stream", "many", typeof(Stream[]))] // nonsense?
-        public void Validate(string dataType, string cardinality, Type expectedType)
+        [InlineData("string", null, typeof(ParameterBindingData), true)]
+        [InlineData("string", "many", typeof(ParameterBindingData[]), true)]
+        [InlineData(null, null, typeof(ParameterBindingData), true)]
+        [InlineData(null, "many", typeof(ParameterBindingData[]), true)]
+        public void Validate(string dataType, string cardinality, Type expectedType, bool supportsDeferredBinding = false)
         {
-            var ctx = New(dataType, cardinality);
+            var ctx = New(dataType, cardinality, supportsDeferredBinding);
             var type = GeneralScriptBindingProvider.GetRequestedType(ctx);
             Assert.Equal(expectedType, type);
         }
 
-        private static ScriptBindingContext New(string dataType, string cardinality)
+        private static ScriptBindingContext New(string dataType, string cardinality, bool supportsDeferredBinding)
         {
-            var jobj = new JObject();
-            jobj["type"] = "test";
-            jobj["direction"] = "in";
-            jobj["datatype"] = dataType;
-            jobj["cardinality"] = cardinality;
-            return new ScriptBindingContext(jobj);
+            var bindingMetadataJObject = new JObject();
+            bindingMetadataJObject["type"] = "test";
+            bindingMetadataJObject["direction"] = "in";
+            bindingMetadataJObject["datatype"] = dataType;
+            bindingMetadataJObject["cardinality"] = cardinality;
+            bindingMetadataJObject["properties"] = new JObject { { "supportsDeferredBinding", supportsDeferredBinding } };
+
+            return new ScriptBindingContext(bindingMetadataJObject);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Description/Worker/WorkerFunctionDescriptorProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/Worker/WorkerFunctionDescriptorProviderTests.cs
@@ -114,7 +114,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Theory]
         [InlineData(true, true, typeof(byte[]))]
         [InlineData(false, true, typeof(byte[]))]
-        [InlineData(true, false, typeof(ParameterBindingData))]
         [InlineData(false, false, typeof(byte[]))]
         public async Task CreateTriggerParameter_DeferredBindingFlags_SetsTriggerType(bool supportsDeferredBinding, bool skipDeferredBinding, Type expectedType)
         {

--- a/test/WebJobs.Script.Tests/Description/Worker/WorkerFunctionDescriptorProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/Worker/WorkerFunctionDescriptorProviderTests.cs
@@ -3,13 +3,17 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Binding;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Extensibility;
 using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
 using Moq;
 using Newtonsoft.Json.Linq;
@@ -17,26 +21,36 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
-    public class WorkerFunctionDescriptorProviderTests
+    public class WorkerFunctionDescriptorProviderTests : IDisposable
     {
         private IHost _host;
         private TestWorkerDescriptorProvider _provider;
 
         public WorkerFunctionDescriptorProviderTests()
         {
-            var scriptHostOptions = new ScriptJobHostOptions();
-            var bindingProviders = new Mock<ICollection<IScriptBindingProvider>>();
             var mockApplicationLifetime = new Mock<Microsoft.AspNetCore.Hosting.IApplicationLifetime>();
             var mockFunctionInvocationDispatcher = new Mock<IFunctionInvocationDispatcher>();
+
+            string rootPath = Path.Combine(Environment.CurrentDirectory, @"TestScripts\Node");
 
             _host = new HostBuilder().ConfigureDefaultTestWebScriptHost(b =>
             {
                 b.AddAzureStorage();
-            }).Build();
+            },
+            o =>
+            {
+                o.ScriptPath = rootPath;
+                o.LogPath = TestHelpers.GetHostLogFileDirectory().Parent.FullName;
+            })
+            .Build();
 
             var scriptHost = _host.GetScriptHost();
+            scriptHost.InitializeAsync().GetAwaiter().GetResult();
 
-            _provider = new TestWorkerDescriptorProvider(scriptHost, null, bindingProviders.Object, mockFunctionInvocationDispatcher.Object,
+            var config = _host.Services.GetService<IOptions<ScriptJobHostOptions>>().Value;
+            var providers = _host.Services.GetService<ICollection<IScriptBindingProvider>>();
+
+            _provider = new TestWorkerDescriptorProvider(scriptHost, config, providers, mockFunctionInvocationDispatcher.Object,
                                 NullLoggerFactory.Instance, mockApplicationLifetime.Object, TimeSpan.FromSeconds(5));
         }
 
@@ -95,6 +109,46 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             bool result = _provider.BindingAttributeContainsExpression(bindings);
             Assert.False(result);
+        }
+
+        [Theory]
+        [InlineData(true, true, typeof(byte[]))]
+        [InlineData(false, true, typeof(byte[]))]
+        [InlineData(true, false, typeof(ParameterBindingData))]
+        [InlineData(false, false, typeof(byte[]))]
+        public async Task CreateTriggerParameter_DeferredBindingFlags_SetsTriggerType(bool supportsDeferredBinding, bool skipDeferredBinding, Type expectedType)
+        {
+            string bindingJson = $@"{{""name"":""book"",""direction"":""In"",""type"":""blobTrigger"",""blobPath"":""expression-trigger"",""connection"":""AzureWebJobsStorage"",""properties"":{{""SupportsDeferredBinding"":""{supportsDeferredBinding}""}}}}";
+
+            BindingMetadata metadata = BindingMetadata.Create(JObject.Parse(bindingJson));
+            metadata.Properties.Add("SkipDeferredBinding", skipDeferredBinding);
+
+            FunctionMetadata functionMetadata = new FunctionMetadata();
+            functionMetadata.Bindings.Add(metadata);
+
+            try
+            {
+                var (created, descriptor) = await _provider.TryCreate(functionMetadata);
+                Assert.Equal(expectedType, descriptor.TriggerParameter.Type);
+            }
+            catch (Exception ex)
+            {
+                Assert.True(false, "Exception not expected:" + ex.Message);
+                throw;
+            }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _host?.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
         }
 
         private class TestWorkerDescriptorProvider : WorkerFunctionDescriptorProvider

--- a/tools/ExtensionsMetadataGenerator/test/ExtensionsMetadataGeneratorTests/ExtensionsMetadataGeneratorTests.csproj
+++ b/tools/ExtensionsMetadataGenerator/test/ExtensionsMetadataGeneratorTests/ExtensionsMetadataGeneratorTests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.5" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.36" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit" Version="2.4.0" />


### PR DESCRIPTION
Adding unit for the SDK-binding feature. Related PRs can be found in the [epic](https://github.com/Azure/azure-functions-dotnet-worker/issues/1081#issuecomment-1276566098).
