### PR TITLE
Distributed Tracing for Java Azure Functions - Duplicate logs in AI issue

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,6 +6,7 @@
 
 - Update ApplicationInsights packages to 2.21.0 (#8838)
 - Support model-type bindings for out-of-proc workers (#8815)
+- Fix the duplicate log issue with Java ApplicationInsights agent
 
 **Release sprint:** Sprint 132
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+132%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+132%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -419,7 +419,7 @@ namespace Microsoft.Azure.WebJobs.Script
                     {
                         options.AddFilter<ApplicationInsightsLoggerProvider>((category, logLevel) =>
                         {
-                            // match Function.<FunctionName>.User
+                            // match Function.<FunctionName>.User category
                             if (!string.IsNullOrEmpty(category) && category.Length > 14 && category.EndsWith(".User", StringComparison.Ordinal))
                             {
                                 return false;

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -420,7 +420,7 @@ namespace Microsoft.Azure.WebJobs.Script
                         options.AddFilter<ApplicationInsightsLoggerProvider>((category, logLevel) =>
                         {
                             // match Function.<FunctionName>.User
-                            if (category.Length > 14 && category.EndsWith(".User", StringComparison.Ordinal))
+                            if (!string.IsNullOrEmpty(category) && category.Length > 14 && category.EndsWith(".User", StringComparison.Ordinal))
                             {
                                 return false;
                             }

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -405,22 +405,24 @@ namespace Microsoft.Azure.WebJobs.Script
                     });
                 }
 
-                if (SystemEnvironment.Instance.IsApplicationInsightsAgentEnabled())
+                builder.Services.AddOptions<LoggerFilterOptions>().Configure<IEnvironment>((options, environment) =>
                 {
-                    // Skip sending user generated logs to AI and QuickPulse if worker AI agent is configured, worker will send these logs to AI and Quickpulse service.
-                    builder.Services.Configure<LoggerFilterOptions>(options => options.AddFilter<ApplicationInsightsLoggerProvider>((category, logLevel) =>
+                    if (environment.IsApplicationInsightsAgentEnabled())
                     {
-                        // match Function.<FunctionName>.User
-                        if (category.Length > 14 && category.EndsWith(".User", StringComparison.Ordinal))
+                        options.AddFilter<ApplicationInsightsLoggerProvider>((category, logLevel) =>
                         {
-                            return false;
-                        }
-                        else
-                        {
-                            return true;
-                        }
-                    }));
-                }
+                            // match Function.<FunctionName>.User
+                            if (category.Length > 14 && category.EndsWith(".User", StringComparison.Ordinal))
+                            {
+                                return false;
+                            }
+                            else
+                            {
+                                return true;
+                            }
+                        });
+                    }
+                });
             }
         }
 

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -404,6 +404,23 @@ namespace Microsoft.Azure.WebJobs.Script
                         o.EnableDependencyTracking = false;
                     });
                 }
+
+                if (SystemEnvironment.Instance.IsApplicationInsightsAgentEnabled())
+                {
+                    // Skip sending user generated logs to AI and QuickPulse if worker AI agent is configured, worker will send these logs to AI and Quickpulse service.
+                    builder.Services.Configure<LoggerFilterOptions>(options => options.AddFilter<ApplicationInsightsLoggerProvider>((category, logLevel) =>
+                    {
+                        // match Function.<FunctionName>.User
+                        if (category.Length > 14 && category.EndsWith(".User", StringComparison.Ordinal))
+                        {
+                            return false;
+                        }
+                        else
+                        {
+                            return true;
+                        }
+                    }));
+                }
             }
         }
 

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -414,6 +414,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
                 builder.Services.AddOptions<LoggerFilterOptions>().Configure<IEnvironment>((options, environment) =>
                 {
+                    // Skip sending user generated logs to AI and QuickPulse if worker AI agent is configured, worker will send these logs to AI and Quickpulse service.
                     if (environment.IsApplicationInsightsAgentEnabled())
                     {
                         options.AddFilter<ApplicationInsightsLoggerProvider>((category, logLevel) =>

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -419,7 +419,7 @@ namespace Microsoft.Azure.WebJobs.Script
                     {
                         options.AddFilter<ApplicationInsightsLoggerProvider>((category, logLevel) =>
                         {
-                            // match Function.<FunctionName>.User category
+                            // skip Function.<FunctionName>.User category
                             if (!string.IsNullOrEmpty(category) && category.Length > 14 && category.EndsWith(".User", StringComparison.Ordinal))
                             {
                                 return false;


### PR DESCRIPTION
Java worker has an option to use an ApplicationInsights agent to send logs and traces to AI. If the worker agent is enabled (APPLICATIONINSIGHTS_ENABLE_AGENT) then the host won't send logs to AI and Quick pulse service. 
[Distributed Tracing for Java Azure Functions](https://github.com/Azure/azure-functions-java-worker/wiki/Distributed-Tracing-for-Java-Azure-Functions)

<!-- Please provide all the information below.  -->

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [] I have added all required tests (Unit tests, E2E tests)
