### PR TITLE
Include also null entries as empty when building InvocationRequest payload for OOP workers

### DIFF
--- a/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
+++ b/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     continue;
                 }
 
-                // Convert null entries to emptyEntry
+                // Convert null entries to emptyEntry because "Add" method doesn't support null (will throw)
                 collectionString.String.Add(element ?? string.Empty);
             }
             typedData.CollectionString = collectionString;

--- a/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
+++ b/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
@@ -301,19 +301,14 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             CollectionString collectionString = new CollectionString();
             foreach (string element in arrString)
             {
-                // Don't add null entries.("Add" method below will throw)
-                if (element is null)
+                // Empty string/null entries are okay to add based on includeEmptyEntries param value.
+                if (string.IsNullOrEmpty(element) && !includeEmptyEntries)
                 {
                     continue;
                 }
 
-                // Empty string entries are okay to add based on includeEmptyEntries param value.
-                if (element == string.Empty && !includeEmptyEntries)
-                {
-                    continue;
-                }
-
-                collectionString.String.Add(element);
+                // Convert null entries to emptyEntry
+                collectionString.String.Add(element ?? string.Empty);
             }
             typedData.CollectionString = collectionString;
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcMessageConversionExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcMessageConversionExtensionsTests.cs
@@ -503,7 +503,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
-        public async Task ToRpc_Collection_String_IncludeEmptyEntries_When_Capability_Is_Present()
+        public async Task ToRpc_Collection_String_IncludeEmptyAndNullEntries_When_Capability_Is_Present()
         {
             var logger = MockNullLoggerFactory.CreateLogger();
             var capabilities = new GrpcCapabilities(logger);
@@ -516,7 +516,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             string[] arrString = { "element1", string.Empty, "element_2", null };
             TypedData actual = await arrString.ToRpc(logger, capabilities);
 
-            var expected = new RepeatedField<string> { "element1", string.Empty, "element_2" }; // null entry should be still skipped
+            var expected = new RepeatedField<string> { "element1", string.Empty, "element_2", string.Empty }; // null entry should be converted to string.Empty because collection doesn't support null's
             Assert.Equal(expected, actual.CollectionString.String);
         }
 


### PR DESCRIPTION
Fixes #8924 

The current behavior is to skip entries which are null or empty. This causes issues like https://github.com/Azure/azure-functions-dotnet-worker/issues/876. So, we decided to introduce a new capability called IncludeEmptyEntriesInMessagePayload which language workers can advertise and if it is present, we will now also convert null entries to empty empty entries and include them in the array we create for the message payload.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
Please refer https://github.com/Azure/azure-functions-host/issues/8499 which has details about the current behavior and problems caused by that.