### PR TITLE
Filter the secret for preventing logging

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/BashCommandHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/BashCommandHandler.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
                             CreateNoWindow = true
                         }
                     };
-                    _logger.LogInformation($"Running: {process.StartInfo.FileName} {process.StartInfo.Arguments}");
+                    _logger.LogInformation(ReplaceStorageSASTokenSecret($"Running: {process.StartInfo.FileName} {process.StartInfo.Arguments}"));
                     process.Start();
                     var output = process.StandardOutput.ReadToEnd().Trim();
                     var error = process.StandardError.ReadToEnd().Trim();

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/BashCommandHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/BashCommandHandler.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
                             CreateNoWindow = true
                         }
                     };
-                    _logger.LogInformation(Sanitizer.Sanitize($"Running: {process.StartInfo.FileName} {process.StartInfo.Arguments}"));
+
                     process.Start();
                     var output = process.StandardOutput.ReadToEnd().Trim();
                     var error = process.StandardError.ReadToEnd().Trim();

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/BashCommandHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/BashCommandHandler.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
+using System.Text.RegularExpressions;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Extensions.Logging;
 
@@ -13,6 +14,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
     public class BashCommandHandler : IBashCommandHandler
     {
         public const string FileCommand = "file";
+        private static readonly Regex _storageSASTokenPatterns = new Regex("(sig|st|se)=.+?&");
 
         private readonly IMetricsLogger _metricsLogger;
         private readonly ILogger<BashCommandHandler> _logger;
@@ -65,6 +67,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
             }
 
             return (string.Empty, string.Empty, -1);
+        }
+
+        private static string ReplaceStorageSASTokenSecret(string target)
+        {
+            return _storageSASTokenPatterns.Replace(target, m => $"{m.Groups[1]?.Value}=<Secret>&");
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/BashCommandHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/BashCommandHandler.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
                             CreateNoWindow = true
                         }
                     };
-                    _logger.LogInformation($"Running: {process.StartInfo.FileName}");
+                    _logger.LogInformation($"Running: bash.exe (arguments omitted)");
                     process.Start();
                     var output = process.StandardOutput.ReadToEnd().Trim();
                     var error = process.StandardError.ReadToEnd().Trim();

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/BashCommandHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/BashCommandHandler.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
                             CreateNoWindow = true
                         }
                     };
-
+                    _logger.LogInformation($"Running: {process.StartInfo.FileName}");
                     process.Start();
                     var output = process.StandardOutput.ReadToEnd().Trim();
                     var error = process.StandardError.ReadToEnd().Trim();

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/BashCommandHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/BashCommandHandler.cs
@@ -3,9 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.IO;
-using System.IO.Compression;
-using System.Text.RegularExpressions;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Extensions.Logging;

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/PackageDownloadHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/PackageDownloadHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Abstractions;
 using System.Net;
@@ -10,6 +11,7 @@ using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using DryIoc;
+using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 using Microsoft.Extensions.Logging;
@@ -127,6 +129,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
             (string stdout, string stderr, int exitCode) = _bashCommandHandler.RunBashCommand(
                 $"{Aria2CExecutable} --allow-overwrite -x12 -d {directory} -o {fileName} '{zipUri}'",
                 downloadMetricName);
+            _logger.LogInformation(Sanitizer.Sanitize($"Running: {Aria2CExecutable} --allow-overwrite -x12 -d {directory} -o {fileName} '{Sanitizer.Sanitize(zipUri?.AbsoluteUri)}"));
             if (exitCode != 0)
             {
                 var msg = $"Error downloading package. stdout: {stdout}, stderr: {stderr}, exitCode: {exitCode}";

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/PackageDownloadHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/PackageDownloadHandler.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
                 _logger.LogError(msg);
                 throw new InvalidOperationException(msg);
             }
-            _logger.LogInformation(Sanitizer.Sanitize($"Executed: {Aria2CExecutable} --allow-overwrite -x12 -d {directory} -o {fileName} '{Sanitizer.Sanitize(zipUri?.AbsoluteUri)}"));
+            _logger.LogInformation($"Executed: {Aria2CExecutable} --allow-overwrite -x12 -d {directory} -o {fileName} '{Sanitizer.Sanitize(zipUri?.AbsoluteUri)}");
 
             var fileInfo = FileUtility.FileInfoFromFileName(Path.Combine(directory, fileName));
             _logger.LogInformation("'{fileInfo.Length}' bytes downloaded. IsWarmupRequest = '{isWarmupRequest}'",

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/PackageDownloadHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/PackageDownloadHandler.cs
@@ -126,8 +126,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
 
         private void AriaDownload(string directory, string fileName, Uri zipUri, bool isWarmupRequest, string downloadMetricName)
         {
+            var command = $"{Aria2CExecutable} --allow-overwrite -x12 -d {directory} -o {fileName} '{zipUri}'";
             (string stdout, string stderr, int exitCode) = _bashCommandHandler.RunBashCommand(
-                $"{Aria2CExecutable} --allow-overwrite -x12 -d {directory} -o {fileName} '{zipUri}'",
+                command,
                 downloadMetricName);
             if (exitCode != 0)
             {
@@ -135,7 +136,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
                 _logger.LogError(msg);
                 throw new InvalidOperationException(msg);
             }
-            _logger.LogInformation($"Executed: {Aria2CExecutable} --allow-overwrite -x12 -d {directory} -o {fileName} '{Sanitizer.Sanitize(zipUri?.AbsoluteUri)}");
+            _logger.LogInformation($"Executed: {Sanitizer.Sanitize(command)}");
 
             var fileInfo = FileUtility.FileInfoFromFileName(Path.Combine(directory, fileName));
             _logger.LogInformation("'{fileInfo.Length}' bytes downloaded. IsWarmupRequest = '{isWarmupRequest}'",

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/PackageDownloadHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/PackageDownloadHandler.cs
@@ -129,13 +129,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
             (string stdout, string stderr, int exitCode) = _bashCommandHandler.RunBashCommand(
                 $"{Aria2CExecutable} --allow-overwrite -x12 -d {directory} -o {fileName} '{zipUri}'",
                 downloadMetricName);
-            _logger.LogInformation(Sanitizer.Sanitize($"Running: {Aria2CExecutable} --allow-overwrite -x12 -d {directory} -o {fileName} '{Sanitizer.Sanitize(zipUri?.AbsoluteUri)}"));
             if (exitCode != 0)
             {
                 var msg = $"Error downloading package. stdout: {stdout}, stderr: {stderr}, exitCode: {exitCode}";
                 _logger.LogError(msg);
                 throw new InvalidOperationException(msg);
             }
+            _logger.LogInformation(Sanitizer.Sanitize($"Executed: {Aria2CExecutable} --allow-overwrite -x12 -d {directory} -o {fileName} '{Sanitizer.Sanitize(zipUri?.AbsoluteUri)}"));
+
             var fileInfo = FileUtility.FileInfoFromFileName(Path.Combine(directory, fileName));
             _logger.LogInformation("'{fileInfo.Length}' bytes downloaded. IsWarmupRequest = '{isWarmupRequest}'",
                 fileInfo.Length, isWarmupRequest);

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
@@ -2,12 +2,15 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 using Microsoft.Extensions.Logging;
+using NuGet.Protocol.Plugins;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
 {
@@ -149,6 +152,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
 
             // Check file magic-number using `file` command.
             (var output, _, _) = _bashCommandHandler.RunBashCommand($"{BashCommandHandler.FileCommand} -b {filePath}", MetricEventNames.LinuxContainerSpecializationFileCommand);
+            _logger.LogInformation(Sanitizer.Sanitize($"Running: {BashCommandHandler.FileCommand} -b {filePath} {MetricEventNames.LinuxContainerSpecializationFileCommand}"));
             if (output.StartsWith(SquashfsPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 return CodePackageType.Squashfs;
@@ -180,6 +184,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
 
             _bashCommandHandler.RunBashCommand($"{UnsquashFSExecutable} -f -d '{scriptPath}' '{filePath}'",
                 MetricEventNames.LinuxContainerSpecializationUnsquash);
+            _logger.LogInformation(Sanitizer.Sanitize($"Running: {UnsquashFSExecutable} -f -d '{scriptPath}' '{filePath}' {MetricEventNames.LinuxContainerSpecializationUnsquash}"));
         }
 
         public async Task<bool> MountAzureFileShare(HostAssignmentContext assignmentContext)

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
             _logger.LogDebug($"Unsquashing remote zip to {scriptPath}");
             var command = $"{UnsquashFSExecutable} -f -d '{scriptPath}' '{filePath}'";
             _bashCommandHandler.RunBashCommand(command, MetricEventNames.LinuxContainerSpecializationUnsquash);
-            _logger.LogInformation(Sanitizer.Sanitize(command));
+            _logger.LogInformation(Sanitizer.Sanitize($"Executed: {command}"));
         }
 
         public async Task<bool> MountAzureFileShare(HostAssignmentContext assignmentContext)

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
@@ -181,10 +181,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
         private void UnsquashImage(string filePath, string scriptPath)
         {
             _logger.LogDebug($"Unsquashing remote zip to {scriptPath}");
-
-            _bashCommandHandler.RunBashCommand($"{UnsquashFSExecutable} -f -d '{scriptPath}' '{filePath}'",
-                MetricEventNames.LinuxContainerSpecializationUnsquash);
-            _logger.LogInformation(Sanitizer.Sanitize($"Executed: {UnsquashFSExecutable} -f -d '{scriptPath}' '{filePath}' {MetricEventNames.LinuxContainerSpecializationUnsquash}"));
+            var command = $"{UnsquashFSExecutable} -f -d '{scriptPath}' '{filePath}'";
+            _bashCommandHandler.RunBashCommand(command, MetricEventNames.LinuxContainerSpecializationUnsquash);
+            _logger.LogInformation(Sanitizer.Sanitize(command));
         }
 
         public async Task<bool> MountAzureFileShare(HostAssignmentContext assignmentContext)

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
 
             // Check file magic-number using `file` command.
             (var output, _, _) = _bashCommandHandler.RunBashCommand($"{BashCommandHandler.FileCommand} -b {filePath}", MetricEventNames.LinuxContainerSpecializationFileCommand);
-            _logger.LogInformation(Sanitizer.Sanitize($"Running: {BashCommandHandler.FileCommand} -b {filePath} {MetricEventNames.LinuxContainerSpecializationFileCommand}"));
+            _logger.LogInformation(Sanitizer.Sanitize($"Executed: {BashCommandHandler.FileCommand} -b {filePath} {MetricEventNames.LinuxContainerSpecializationFileCommand}"));
             if (output.StartsWith(SquashfsPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 return CodePackageType.Squashfs;
@@ -184,7 +184,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
 
             _bashCommandHandler.RunBashCommand($"{UnsquashFSExecutable} -f -d '{scriptPath}' '{filePath}'",
                 MetricEventNames.LinuxContainerSpecializationUnsquash);
-            _logger.LogInformation(Sanitizer.Sanitize($"Running: {UnsquashFSExecutable} -f -d '{scriptPath}' '{filePath}' {MetricEventNames.LinuxContainerSpecializationUnsquash}"));
+            _logger.LogInformation(Sanitizer.Sanitize($"Executed: {UnsquashFSExecutable} -f -d '{scriptPath}' '{filePath}' {MetricEventNames.LinuxContainerSpecializationUnsquash}"));
         }
 
         public async Task<bool> MountAzureFileShare(HostAssignmentContext assignmentContext)

--- a/src/WebJobs.Script/Sanitizer.cs
+++ b/src/WebJobs.Script/Sanitizer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Logging
 
         // List of keywords that should not be replaced with [Hidden Credential]
         private static readonly string[] AllowedTokens = new string[] { "PublicKeyToken=" };
-        internal static readonly string[] CredentialTokens = new string[] { "Token=", "DefaultEndpointsProtocol=http", "AccountKey=", "Data Source=", "Server=", "Password=", "pwd=", "&amp;sig=", "SharedAccessKey=" };
+        internal static readonly string[] CredentialTokens = new string[] { "Token=", "DefaultEndpointsProtocol=http", "AccountKey=", "Data Source=", "Server=", "Password=", "pwd=", "&amp;sig=", "&sig=", "SharedAccessKey=" };
 
         /// <summary>
         /// Removes well-known credential strings from strings.

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
@@ -193,7 +193,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             await TestHelpers.CreateContentZip(contentRoot, zipFilePath, Path.Combine(@"TestScripts", "DotNet"));
 
             IConfiguration configuration = TestHelpers.GetTestConfiguration();
-            string connectionString = configuration.GetWebJobsConnectionString(ConnectionStringNames.Storage);
+            //string connectionString = configuration.GetWebJobsConnectionString(ConnectionStringNames.Storage);
+            string connectionString = "UseDevelopmentStorage=true";
             Uri sasUri = await TestHelpers.CreateBlobSas(connectionString, zipFilePath, "scm-run-from-pkg-test", "NonEmpty.zip");
 
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
@@ -226,7 +227,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             var logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
 
-            if (logs.Length == 9)
+            if (logs.Length == 10)
             {
                 Assert.Collection(logs,
                     p => Assert.StartsWith("Starting Assignment", p),
@@ -237,6 +238,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                     p => Assert.StartsWith("Output:", p),
                     p => Assert.True(true), // this line varies depending on whether WSL is on the machine; just ignore it
                     p => Assert.StartsWith("exitCode:", p),
+                    p => Assert.StartsWith("Executed: ", p),
                     p => Assert.StartsWith("Triggering specialization", p));
             }
             else
@@ -248,6 +250,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                     p => Assert.StartsWith("Unsquashing remote zip", p),
                     p => Assert.StartsWith("Running: ", p),
                     p => Assert.StartsWith("Error running bash", p),
+                    p => Assert.StartsWith("Executed: ", p),
                     p => Assert.StartsWith("Triggering specialization", p));
             }
         }

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
@@ -193,8 +193,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             await TestHelpers.CreateContentZip(contentRoot, zipFilePath, Path.Combine(@"TestScripts", "DotNet"));
 
             IConfiguration configuration = TestHelpers.GetTestConfiguration();
-            //string connectionString = configuration.GetWebJobsConnectionString(ConnectionStringNames.Storage);
-            string connectionString = "UseDevelopmentStorage=true";
+            string connectionString = configuration.GetWebJobsConnectionString(ConnectionStringNames.Storage);
+
             Uri sasUri = await TestHelpers.CreateBlobSas(connectionString, zipFilePath, "scm-run-from-pkg-test", "NonEmpty.zip");
 
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");

--- a/test/WebJobs.Script.Tests/SanitizerTests.cs
+++ b/test/WebJobs.Script.Tests/SanitizerTests.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [InlineData("Password=hunter2", "[Hidden Credential]")]
         [InlineData("pwd=hunter2", "[Hidden Credential]")]
         [InlineData("test&amp;sig=", "test[Hidden Credential]")]
+        [InlineData("test&sig=", "test[Hidden Credential]")]
         [InlineData("SharedAccessKey=foo", "[Hidden Credential]")]
         [InlineData(@"Hey=AS1$@%#$%W-k2j"";SharedAccessKey=foo,Data Source=barzons,Server=bathouse'testing", @"Hey=AS1$@%#$%W-k2j"";[Hidden Credential]'testing")]
         public void SanitizeString(string input, string expectedOutput)


### PR DESCRIPTION
# Description

The place I changed could potentially share the SAS token secret on logging system. 
This is the idea of filtering out the logging.  

I don't fully understand the pattern which parameter has comes, so that review required. 
@pragnagopa @balag0 

I'd like to discuss if this approach works first. 

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
