### PR TITLE
modifying approach to ignoring app insights coming from workers

### DIFF
--- a/src/WebJobs.Script.Grpc/Channel/GrpcCapabilities.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcCapabilities.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Google.Protobuf.Collections;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.Grpc
@@ -27,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             return null;
         }
 
-        public void UpdateCapabilities(MapField<string, string> capabilities)
+        public void UpdateCapabilities(IDictionary<string, string> capabilities)
         {
             if (capabilities == null)
             {

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannelFactory.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannelFactory.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         private readonly IOptions<WorkerConcurrencyOptions> _workerConcurrencyOptions;
         private readonly IOptions<FunctionsHostingConfigOptions> _hostingConfigOptions;
 
-        public GrpcWorkerChannelFactory(IScriptEventManager eventManager, IEnvironment environment, IRpcServer rpcServer, ILoggerFactory loggerFactory, IOptionsMonitor<LanguageWorkerOptions> languageWorkerOptions,
+        public GrpcWorkerChannelFactory(IScriptEventManager eventManager, IEnvironment environment, ILoggerFactory loggerFactory,
             IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, IRpcWorkerProcessFactory rpcWorkerProcessManager, ISharedMemoryManager sharedMemoryManager,
             IOptions<WorkerConcurrencyOptions> workerConcurrencyOptions, IOptions<FunctionsHostingConfigOptions> hostingConfigOptions)
         {

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannelFactory.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannelFactory.cs
@@ -25,12 +25,11 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         private readonly IEnvironment _environment = null;
         private readonly IOptionsMonitor<ScriptApplicationHostOptions> _applicationHostOptions = null;
         private readonly ISharedMemoryManager _sharedMemoryManager = null;
-        private readonly IFunctionDataCache _functionDataCache = null;
         private readonly IOptions<WorkerConcurrencyOptions> _workerConcurrencyOptions;
         private readonly IOptions<FunctionsHostingConfigOptions> _hostingConfigOptions;
 
         public GrpcWorkerChannelFactory(IScriptEventManager eventManager, IEnvironment environment, IRpcServer rpcServer, ILoggerFactory loggerFactory, IOptionsMonitor<LanguageWorkerOptions> languageWorkerOptions,
-            IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, IRpcWorkerProcessFactory rpcWorkerProcessManager, ISharedMemoryManager sharedMemoryManager, IFunctionDataCache functionDataCache,
+            IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, IRpcWorkerProcessFactory rpcWorkerProcessManager, ISharedMemoryManager sharedMemoryManager,
             IOptions<WorkerConcurrencyOptions> workerConcurrencyOptions, IOptions<FunctionsHostingConfigOptions> hostingConfigOptions)
         {
             _eventManager = eventManager;
@@ -39,7 +38,6 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             _environment = environment;
             _applicationHostOptions = applicationHostOptions;
             _sharedMemoryManager = sharedMemoryManager;
-            _functionDataCache = functionDataCache;
             _workerConcurrencyOptions = workerConcurrencyOptions;
             _hostingConfigOptions = hostingConfigOptions;
         }
@@ -55,20 +53,28 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             _eventManager.AddGrpcChannels(workerId); // prepare the inbound/outbound dedicated channels
             ILogger workerLogger = _loggerFactory.CreateLogger($"Worker.LanguageWorkerChannel.{runtime}.{workerId}");
             IWorkerProcess rpcWorkerProcess = _rpcWorkerProcessFactory.Create(workerId, runtime, scriptRootPath, languageWorkerConfig);
+
+            return CreateInternal(workerId, _eventManager, languageWorkerConfig, rpcWorkerProcess, workerLogger, metricsLogger, attemptCount,
+                _environment, _applicationHostOptions, _sharedMemoryManager, _workerConcurrencyOptions, _hostingConfigOptions);
+        }
+
+        internal virtual IRpcWorkerChannel CreateInternal(string workerId, IScriptEventManager eventManager, RpcWorkerConfig languageWorkerConfig, IWorkerProcess rpcWorkerProcess,
+            ILogger workerLogger, IMetricsLogger metricsLogger, int attemptCount, IEnvironment environment, IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions,
+            ISharedMemoryManager sharedMemoryManager, IOptions<WorkerConcurrencyOptions> workerConcurrencyOptions, IOptions<FunctionsHostingConfigOptions> hostingConfigOptions)
+        {
             return new GrpcWorkerChannel(
                          workerId,
-                         _eventManager,
+                         eventManager,
                          languageWorkerConfig,
                          rpcWorkerProcess,
                          workerLogger,
                          metricsLogger,
                          attemptCount,
-                         _environment,
-                         _applicationHostOptions,
-                         _sharedMemoryManager,
-                         _functionDataCache,
-                         _workerConcurrencyOptions,
-                         _hostingConfigOptions);
+                         environment,
+                         applicationHostOptions,
+                         sharedMemoryManager,
+                         workerConcurrencyOptions,
+                         hostingConfigOptions);
         }
     }
 }

--- a/src/WebJobs.Script.Grpc/GrpcServiceCollectionsExtensions.cs
+++ b/src/WebJobs.Script.Grpc/GrpcServiceCollectionsExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/WebJobs.Script/Config/WorkerTraceFilterTelemetryProcessor.cs
+++ b/src/WebJobs.Script/Config/WorkerTraceFilterTelemetryProcessor.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+
+namespace Microsoft.Azure.WebJobs.Script.Config
+{
+    internal class WorkerTraceFilterTelemetryProcessor : ITelemetryProcessor
+    {
+        private readonly ITelemetryProcessor _next;
+
+        internal static readonly AsyncLocal<bool> FilterApplicationInsightsFromWorker = new();
+
+        public WorkerTraceFilterTelemetryProcessor(ITelemetryProcessor next)
+        {
+            _next = next;
+        }
+
+        public void Process(ITelemetry item)
+        {
+            if (FilterApplicationInsightsFromWorker.Value)
+            {
+                return;
+            }
+
+            _next.Process(item);
+        }
+    }
+}

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -8,9 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.Azure.WebJobs.Script.Config;
-using Microsoft.Azure.WebJobs.Script.Models;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
-using Microsoft.Extensions.Options;
 using static Microsoft.Azure.WebJobs.Script.EnvironmentSettingNames;
 
 namespace Microsoft.Azure.WebJobs.Script
@@ -189,7 +187,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// Gets a value indicating whether the application is running in a Windows Consumption (dynamic)
         /// App Service environment.
         /// </summary>
-        /// <param name="environment">The environment to verify</param>
+        /// <param name="environment">The environment to verify.</param>
         /// <returns><see cref="true"/> if running in a Windows Consumption App Service app; otherwise, false.</returns>
         public static bool IsWindowsConsumption(this IEnvironment environment)
         {
@@ -201,7 +199,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// Gets a value indicating whether the application is running in a Windows or Linux Consumption (dynamic)
         /// App Service environment.
         /// </summary>
-        /// <param name="environment">The environment to verify</param>
+        /// <param name="environment">The environment to verify.</param>
         /// <returns><see cref="true"/> if running in a Windows or Linux Consumption App Service app; otherwise, false.</returns>
         public static bool IsConsumptionSku(this IEnvironment environment)
         {
@@ -209,7 +207,7 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
-        /// Returns true if the app is running on Virtual Machine Scale Sets (VMSS)
+        /// Returns true if the app is running on Virtual Machine Scale Sets (VMSS).
         /// </summary>
         public static bool IsVMSS(this IEnvironment environment)
         {
@@ -232,7 +230,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// Gets a value indicating whether the application is running in a Windows Elastic Premium
         /// App Service environment.
         /// </summary>
-        /// <param name="environment">The environment to verify</param>
+        /// <param name="environment">The environment to verify.</param>
         /// <returns><see cref="true"/> if running in a Windows Elastic Premium app; otherwise, false.</returns>
         public static bool IsWindowsElasticPremium(this IEnvironment environment)
         {
@@ -247,9 +245,9 @@ namespace Microsoft.Azure.WebJobs.Script
 
         /// <summary>
         /// Gets a value indicating whether the application is running in an Azure Windows managed hosting environment
-        /// (i.e. Windows Consumption or Windows Dedicated)
+        /// (i.e. Windows Consumption or Windows Dedicated).
         /// </summary>
-        /// <param name="environment">The environment to verify</param>
+        /// <param name="environment">The environment to verify.</param>
         /// <returns><see cref="true"/> if running in a Windows Azure managed hosting environment; otherwise, false.</returns>
         public static bool IsWindowsAzureManagedHosting(this IEnvironment environment)
         {
@@ -260,7 +258,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// Gets a value indicating whether the application is running in a Linux Consumption (dynamic)
         /// App Service environment.
         /// </summary>
-        /// <param name="environment">The environment to verify</param>
+        /// <param name="environment">The environment to verify.</param>
         /// <returns><see cref="true"/> if running in a Linux Consumption App Service app; otherwise, false.</returns>
         public static bool IsAnyLinuxConsumption(this IEnvironment environment)
         {
@@ -285,7 +283,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// Gets a value indicating whether the application is running in a Linux App Service
         /// environment (Dedicated Linux).
         /// </summary>
-        /// <param name="environment">The environment to verify</param>
+        /// <param name="environment">The environment to verify.</param>
         /// <returns><see cref="true"/> if running in a Linux Azure App Service; otherwise, false.</returns>
         public static bool IsLinuxAppService(this IEnvironment environment)
         {
@@ -294,9 +292,9 @@ namespace Microsoft.Azure.WebJobs.Script
 
         /// <summary>
         /// Gets a value indicating whether the application is running in an Azure Linux managed hosting environment
-        /// (i.e. Linux Consumption or Linux Dedicated)
+        /// (i.e. Linux Consumption or Linux Dedicated).
         /// </summary>
-        /// <param name="environment">The environment to verify</param>
+        /// <param name="environment">The environment to verify.</param>
         /// <returns><see cref="true"/> if running in a Linux Azure managed hosting environment; otherwise, false.</returns>
         public static bool IsLinuxAzureManagedHosting(this IEnvironment environment)
         {
@@ -307,7 +305,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// Gets a value indicating whether the application is running in App Service
         /// (Windows Consumption, Windows Dedicated or Linux Dedicated).
         /// </summary>
-        /// <param name="environment">The environment to verify</param>
+        /// <param name="environment">The environment to verify.</param>
         /// <returns><see cref="true"/> if running in a Azure App Service; otherwise, false.</returns>
         public static bool IsAppService(this IEnvironment environment)
         {
@@ -315,9 +313,9 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
-        /// Gets a value indicating whether the application is running in Kubernetes App Service environment(K8SE)
+        /// Gets a value indicating whether the application is running in Kubernetes App Service environment(K8SE).
         /// </summary>
-        /// <param name="environment">The environment to verify</param>
+        /// <param name="environment">The environment to verify.</param>
         /// <returns><see cref="true"/> If running in a Kubernetes Azure App Service; otherwise, false.</returns>
         public static bool IsKubernetesManagedHosting(this IEnvironment environment)
         {
@@ -360,7 +358,7 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
-        /// Gets if runtime environment needs multi language
+        /// Gets if runtime environment needs multi language.
         /// </summary>
         public static bool IsMultiLanguageRuntimeEnvironment(this IEnvironment environment)
         {
@@ -594,9 +592,9 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
-        /// Gets a value indicated in the variable FUNCTIONS_EXTENSION_VERSION
+        /// Gets a value indicated in the variable FUNCTIONS_EXTENSION_VERSION.
         /// </summary>
-        /// <returns>Value of FUNCTIONS_EXTENSION_VERSION variable</returns>
+        /// <returns>Value of FUNCTIONS_EXTENSION_VERSION variable.</returns>
         public static string GetFunctionsExtensionVersion(this IEnvironment environment)
         {
             return environment.GetEnvironmentVariableOrDefault(FunctionsExtensionVersion, string.Empty);
@@ -605,6 +603,14 @@ namespace Microsoft.Azure.WebJobs.Script
         public static bool IsTargetBasedScalingEnabled(this IEnvironment environment)
         {
             return string.Equals(environment.GetEnvironmentVariable(TargetBaseScalingEnabled), "1");
+        }
+
+        public static bool IsDotNetInProc(this IEnvironment environment)
+        {
+            var workerRuntime = environment.GetFunctionsWorkerRuntime();
+
+            return string.IsNullOrEmpty(workerRuntime) ||
+                   string.Compare(workerRuntime, RpcWorkerConstants.DotNetLanguageWorkerName, StringComparison.OrdinalIgnoreCase) == 0;
         }
     }
 }

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -604,13 +604,5 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             return string.Equals(environment.GetEnvironmentVariable(TargetBaseScalingEnabled), "1");
         }
-
-        public static bool IsDotNetInProc(this IEnvironment environment)
-        {
-            var workerRuntime = environment.GetFunctionsWorkerRuntime();
-
-            return string.IsNullOrEmpty(workerRuntime) ||
-                   string.Compare(workerRuntime, RpcWorkerConstants.DotNetLanguageWorkerName, StringComparison.OrdinalIgnoreCase) == 0;
-        }
     }
 }

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -394,6 +394,7 @@ namespace Microsoft.Azure.WebJobs.Script
                         channel.TransmissionStatusEvent += TransmissionStatusHandler.Handler;
                     }
 
+                    t.TelemetryProcessorChainBuilder.Use(next => new WorkerTraceFilterTelemetryProcessor(next));
                     t.TelemetryProcessorChainBuilder.Use(next => new ScriptTelemetryProcessor(next));
                 });
 
@@ -410,26 +411,6 @@ namespace Microsoft.Azure.WebJobs.Script
                         o.EnableDependencyTracking = false;
                     });
                 }
-
-                builder.Services.AddOptions<LoggerFilterOptions>().Configure<IEnvironment>((options, environment) =>
-                {
-                    // Skip sending user generated logs to AI and QuickPulse if worker AI agent is configured, worker will send these logs to AI and Quickpulse service.
-                    if (environment.IsApplicationInsightsAgentEnabled())
-                    {
-                        options.AddFilter<ApplicationInsightsLoggerProvider>((category, logLevel) =>
-                        {
-                            // skip Function.<FunctionName>.User category
-                            if (!string.IsNullOrEmpty(category) && category.Length > 14 && category.EndsWith(".User", StringComparison.Ordinal))
-                            {
-                                return false;
-                            }
-                            else
-                            {
-                                return true;
-                            }
-                        });
-                    }
-                });
             }
         }
 

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 {
     public static class RpcWorkerConstants
@@ -54,6 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public const string SupportsLoadResponseCollection = "SupportsLoadResponseCollection";
         public const string HandlesWorkerTerminateMessage = "HandlesWorkerTerminateMessage";
         public const string HandlesInvocationCancelMessage = "HandlesInvocationCancelMessage";
+        public const string WorkerApplicationInsightsLoggingEnabled = nameof(WorkerApplicationInsightsLoggingEnabled);
 
         /// <summary>
         /// Indicates whether empty entries in the trigger message should be included when sending RpcInvocation data to OOP workers.

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsIgnoredNodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsIgnoredNodeEndToEndTests.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.ApplicationInsights.DataContracts;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
+{
+    public class ApplicationInsightsIgnoredNodeEndToEndTests : IClassFixture<ApplicationInsightsIgnoredNodeEndToEndTests.TestFixture>
+    {
+        private ApplicationInsightsTestFixture _fixture;
+
+        public ApplicationInsightsIgnoredNodeEndToEndTests(TestFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task Validate_Manual()
+        {
+            string functionName = "Scenarios";
+            int invocationCount = 5;
+
+            List<string> functionTraces = new List<string>();
+
+            // We want to invoke this multiple times specifically to make sure Node invocationIds
+            // are correctly being set. Invoke them all first, then come back and validate all.
+            for (int i = 0; i < invocationCount; i++)
+            {
+                string functionTrace = $"Function trace: {Guid.NewGuid().ToString()}";
+                functionTraces.Add(functionTrace);
+
+                JObject input = new JObject()
+                {
+                    { "scenario", "appInsights" },
+                    { "container", "not-used" },
+                    { "value",  functionTrace }
+                };
+
+                await _fixture.TestHost.BeginFunctionAsync(functionName, input);
+            }
+
+            await TestHelpers.Await(() =>
+            {
+                var loggerLogs = _fixture.TestHost.GetScriptHostLogMessages()
+                    .Count(p => p.EventId.Name == "FunctionCompleted");
+
+                var appInsightsLogs = _fixture.Channel.Telemetries
+                    .Count(p => p is TraceTelemetry t && t.Message.StartsWith("Executed"));
+
+                // We've now seen all 5 executions in host logs
+                return loggerLogs == invocationCount && appInsightsLogs == invocationCount;
+            });
+
+            var appInsightsFromWorker = _fixture.Channel.Telemetries
+                .Where(p => p is ISupportProperties t && t.Properties["Category"].EndsWith(".User"));
+
+            // if ignoreAppInsightsFromWorker is false, this is 5, as the test function writes out
+            // one log per invocation
+            Assert.Equal(0, appInsightsFromWorker.Count());
+
+            // However, logs should still have made it to the other loggers
+            var loggerFromWorker = _fixture.TestHost.GetScriptHostLogMessages()
+                    .Where(p => p.Category.EndsWith(".User"));
+
+            Assert.Equal(5, loggerFromWorker.Count());
+        }
+
+        public class TestFixture : ApplicationInsightsTestFixture
+        {
+            private const string ScriptRoot = @"TestScripts\Node";
+
+            public TestFixture() : base(ScriptRoot, "node", ignoreAppInsightsFromWorker: true)
+            {
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
@@ -97,8 +97,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
 
         private class TestGrpcWorkerChannelFactory : GrpcWorkerChannelFactory
         {
-            public TestGrpcWorkerChannelFactory(IScriptEventManager eventManager, IEnvironment environment, IRpcServer rpcServer, ILoggerFactory loggerFactory, IOptionsMonitor<LanguageWorkerOptions> languageWorkerOptions, IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, IRpcWorkerProcessFactory rpcWorkerProcessManager, ISharedMemoryManager sharedMemoryManager, IOptions<WorkerConcurrencyOptions> workerConcurrencyOptions, IOptions<FunctionsHostingConfigOptions> hostingConfigOptions)
-                : base(eventManager, environment, rpcServer, loggerFactory, languageWorkerOptions, applicationHostOptions, rpcWorkerProcessManager, sharedMemoryManager, workerConcurrencyOptions, hostingConfigOptions)
+            public TestGrpcWorkerChannelFactory(IScriptEventManager eventManager, IEnvironment environment, ILoggerFactory loggerFactory, IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, IRpcWorkerProcessFactory rpcWorkerProcessManager, ISharedMemoryManager sharedMemoryManager, IOptions<WorkerConcurrencyOptions> workerConcurrencyOptions, IOptions<FunctionsHostingConfigOptions> hostingConfigOptions)
+                : base(eventManager, environment, loggerFactory, applicationHostOptions, rpcWorkerProcessManager, sharedMemoryManager, workerConcurrencyOptions, hostingConfigOptions)
             {
             }
 

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
@@ -7,9 +7,17 @@ using System.IO;
 using System.Net.Http;
 using System.Threading;
 using Microsoft.ApplicationInsights.Channel;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.Grpc;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
@@ -18,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
     {
         public const string ApplicationInsightsKey = "some_key";
 
-        public ApplicationInsightsTestFixture(string scriptRoot, string testId)
+        public ApplicationInsightsTestFixture(string scriptRoot, string testId, bool ignoreAppInsightsFromWorker = false)
         {
             string scriptPath = Path.Combine(Environment.CurrentDirectory, scriptRoot);
             string logPath = Path.Combine(Path.GetTempPath(), @"Functions");
@@ -52,6 +60,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
                     {
                         [EnvironmentSettingNames.AppInsightsInstrumentationKey] = ApplicationInsightsKey
                     });
+                },
+                configureWebHostServices: s =>
+                {
+                    if (ignoreAppInsightsFromWorker)
+                    {
+                        s.AddSingleton<IRpcWorkerChannelFactory, TestGrpcWorkerChannelFactory>();
+                    }
                 });
 
             HttpClient = TestHost.HttpClient;
@@ -78,6 +93,37 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
             // is disposed on a background task, it doesn't block. So waiting here to ensure
             // everything is flushed and can't affect subsequent tests.
             Thread.Sleep(2000);
+        }
+
+        private class TestGrpcWorkerChannelFactory : GrpcWorkerChannelFactory
+        {
+            public TestGrpcWorkerChannelFactory(IScriptEventManager eventManager, IEnvironment environment, IRpcServer rpcServer, ILoggerFactory loggerFactory, IOptionsMonitor<LanguageWorkerOptions> languageWorkerOptions, IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, IRpcWorkerProcessFactory rpcWorkerProcessManager, ISharedMemoryManager sharedMemoryManager, IOptions<WorkerConcurrencyOptions> workerConcurrencyOptions, IOptions<FunctionsHostingConfigOptions> hostingConfigOptions)
+                : base(eventManager, environment, rpcServer, loggerFactory, languageWorkerOptions, applicationHostOptions, rpcWorkerProcessManager, sharedMemoryManager, workerConcurrencyOptions, hostingConfigOptions)
+            {
+            }
+
+            internal override IRpcWorkerChannel CreateInternal(string workerId, IScriptEventManager eventManager, RpcWorkerConfig languageWorkerConfig, IWorkerProcess rpcWorkerProcess,
+            ILogger workerLogger, IMetricsLogger metricsLogger, int attemptCount, IEnvironment environment, IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions,
+            ISharedMemoryManager sharedMemoryManager, IOptions<WorkerConcurrencyOptions> workerConcurrencyOptions, IOptions<FunctionsHostingConfigOptions> hostingConfigOptions)
+            {
+                return new TestGrpcWorkerChannel(workerId, eventManager, languageWorkerConfig, rpcWorkerProcess, workerLogger, metricsLogger,
+                    attemptCount, environment, applicationHostOptions, sharedMemoryManager, workerConcurrencyOptions, hostingConfigOptions);
+            }
+
+            private class TestGrpcWorkerChannel : GrpcWorkerChannel
+            {
+                internal TestGrpcWorkerChannel(string workerId, IScriptEventManager eventManager, RpcWorkerConfig workerConfig, IWorkerProcess rpcWorkerProcess, ILogger logger, IMetricsLogger metricsLogger, int attemptCount, IEnvironment environment, IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, ISharedMemoryManager sharedMemoryManager, IOptions<WorkerConcurrencyOptions> workerConcurrencyOptions, IOptions<FunctionsHostingConfigOptions> hostingConfigOptions)
+                    : base(workerId, eventManager, workerConfig, rpcWorkerProcess, logger, metricsLogger, attemptCount, environment, applicationHostOptions, sharedMemoryManager, workerConcurrencyOptions, hostingConfigOptions)
+                {
+                }
+
+                internal override void UpdateCapabilities(IDictionary<string, string> fields)
+                {
+                    // inject a capability
+                    fields[RpcWorkerConstants.WorkerApplicationInsightsLoggingEnabled] = bool.TrueString;
+                    base.UpdateCapabilities(fields);
+                }
+            }
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -117,7 +117,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                _testEnvironment,
                _hostOptionsMonitor,
                _sharedMemoryManager,
-               _functionDataCache,
                _workerConcurrencyOptions,
                _hostingConfigOptions);
 
@@ -284,7 +283,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                _testEnvironment,
                _hostOptionsMonitor,
                _sharedMemoryManager,
-               _functionDataCache,
                _workerConcurrencyOptions,
                _hostingConfigOptions);
             await Assert.ThrowsAsync<FileNotFoundException>(async () => await _workerChannel.StartWorkerProcessAsync(CancellationToken.None));
@@ -509,7 +507,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                _testEnvironment,
                _hostOptionsMonitor,
                _sharedMemoryManager,
-               _functionDataCache,
                _workerConcurrencyOptions,
                _hostingConfigOptions);
             channel.SetupFunctionInvocationBuffers(GetTestFunctionsList("node"));
@@ -1107,7 +1104,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                _testEnvironment,
                _hostOptionsMonitor,
                _sharedMemoryManager,
-               _functionDataCache,
                _workerConcurrencyOptions,
                _hostingConfigOptions);
 
@@ -1147,7 +1143,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                _testEnvironment,
                _hostOptionsMonitor,
                _sharedMemoryManager,
-               _functionDataCache,
                _workerConcurrencyOptions,
                _hostingConfigOptions);
 


### PR DESCRIPTION
#8915 introduced a way to ignore logs coming from App Insights based on an app setting. This takes that approach and modifies it so that it will also work for a worker that declares this behavior via a capability at startup.

Rather than relying strictly on the app setting, this now looks at a ~custom property on the current `Activity`~. This value is set in the grpc channel and is based on that channel's capabilities (or on the app setting as before).

Edit: Approach changed to using an `AsyncLocal`.