### PR TITLE
bumping stylecop and addressing all errors

### DIFF
--- a/src/WebJobs.Script.Abstractions/WebJobs.Script.Abstractions.csproj
+++ b/src/WebJobs.Script.Abstractions/WebJobs.Script.Abstractions.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.21.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         private readonly IOptions<WorkerConcurrencyOptions> _workerConcurrencyOptions;
         private readonly WaitCallback _processInbound;
         private readonly object _syncLock = new object();
-        private readonly Dictionary<MsgType, Queue<PendingItem>> _pendingActions = new ();
+        private readonly Dictionary<MsgType, Queue<PendingItem>> _pendingActions = new();
         private readonly ChannelWriter<OutboundGrpcEvent> _outbound;
         private readonly ChannelReader<InboundGrpcEvent> _inbound;
         private readonly IOptions<FunctionsHostingConfigOptions> _hostingConfigOptions;

--- a/src/WebJobs.Script.Grpc/Extensions/ScriptInvocationContextExtensions.cs
+++ b/src/WebJobs.Script.Grpc/Extensions/ScriptInvocationContextExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -53,12 +52,12 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                 if (isSharedMemoryDataTransferEnabled)
                 {
                     // Try to transfer this data over shared memory instead of RPC
-                    if (input.val == null || !sharedMemValueCache.TryGetValue(input.val, out sharedMemValue))
+                    if (input.Val == null || !sharedMemValueCache.TryGetValue(input.Val, out sharedMemValue))
                     {
-                        sharedMemValue = await input.val.ToRpcSharedMemoryAsync(input.type, logger, invocationRequest.InvocationId, sharedMemoryManager);
-                        if (input.val != null)
+                        sharedMemValue = await input.Val.ToRpcSharedMemoryAsync(input.Type, logger, invocationRequest.InvocationId, sharedMemoryManager);
+                        if (input.Val != null)
                         {
-                            sharedMemValueCache.Add(input.val, sharedMemValue);
+                            sharedMemValueCache.Add(input.Val, sharedMemValue);
                         }
                     }
                 }
@@ -68,19 +67,19 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     // Data was successfully transferred over shared memory; create a ParameterBinding accordingly
                     parameterBinding = new ParameterBinding
                     {
-                        Name = input.name,
+                        Name = input.Name,
                         RpcSharedMemory = sharedMemValue
                     };
 
                     usedSharedMemory = true;
-                    logBuilder.AppendFormat("{0}:{1},", input.name, sharedMemValue.Count);
+                    logBuilder.AppendFormat("{0}:{1},", input.Name, sharedMemValue.Count);
                 }
                 else
                 {
-                    if (!TryConvertObjectIfNeeded(input.val, logger, out object val))
+                    if (!TryConvertObjectIfNeeded(input.Val, logger, out object val))
                     {
                         // Conversion did not take place, keep the existing value as it is
-                        val = input.val;
+                        val = input.Val;
                     }
 
                     // Data was not transferred over shared memory (either disabled, type not supported or some error); resort to RPC
@@ -88,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     if (val == null || !rpcValueCache.TryGetValue(val, out rpcValue))
                     {
                         rpcValue = await val.ToRpc(logger, capabilities);
-                        if (input.val != null)
+                        if (input.Val != null)
                         {
                             rpcValueCache.Add(val, rpcValue);
                         }
@@ -96,7 +95,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
                     parameterBinding = new ParameterBinding
                     {
-                        Name = input.name,
+                        Name = input.Name,
                         Data = rpcValue
                     };
                 }

--- a/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
+++ b/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.21.0" />
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Threading.Channels" Version="6.0.0" />

--- a/src/WebJobs.Script.WebHost/Extensions/ExceptionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Extensions/ExceptionExtensions.cs
@@ -7,7 +7,7 @@ namespace System
 {
     internal static class ExceptionExtensions
     {
-        public static (string exceptionType, string exceptionMessage, string exceptionDetails) GetExceptionDetails(this Exception exception)
+        public static (string ExceptionType, string ExceptionMessage, string ExceptionDetails) GetExceptionDetails(this Exception exception)
         {
             if (exception == null)
             {

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -687,7 +687,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
         // This function will call POST https://{app}.azurewebsites.net/operation/settriggers with the content
         // of triggers. It'll verify app ownership using a SWT token valid for 5 minutes. It should be plenty.
-        private async Task<(bool, string)> SetTriggersAsync(string content)
+        private async Task<(bool Success, string ErrorMessage)> SetTriggersAsync(string content)
         {
             var token = SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddMinutes(5));
 

--- a/src/WebJobs.Script.WebHost/Management/IWebFunctionsManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/IWebFunctionsManager.cs
@@ -12,10 +12,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
     {
         Task<IEnumerable<FunctionMetadataResponse>> GetFunctionsMetadata(bool includeProxies);
 
-        Task<(bool, FunctionMetadataResponse)> TryGetFunction(string name, HttpRequest request);
+        Task<(bool Success, FunctionMetadataResponse Response)> TryGetFunction(string name, HttpRequest request);
 
-        Task<(bool, bool, FunctionMetadataResponse)> CreateOrUpdate(string name, FunctionMetadataResponse functionMetadata, HttpRequest request);
+        Task<(bool Success, bool ConfigChanged, FunctionMetadataResponse Response)> CreateOrUpdate(string name, FunctionMetadataResponse functionMetadata, HttpRequest request);
 
-        Task<(bool, string)> TryDeleteFunction(FunctionMetadataResponse function);
+        Task<(bool Success, string ErrorMessage)> TryDeleteFunction(FunctionMetadataResponse function);
     }
 }

--- a/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/InstanceManager.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             }
         }
 
-        private async Task<(string, long?)> ValidateBlobPackageContext(RunFromPackageContext context)
+        private async Task<(string Error, long? ContentLength)> ValidateBlobPackageContext(RunFromPackageContext context)
         {
             string blobUri = context.Url;
             string eventName = context.IsWarmUpRequest

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/BashCommandHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/BashCommandHandler.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Extensions.Logging;
 
@@ -22,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public (string, string, int) RunBashCommand(string command, string metricName)
+        public (string Output, string Error, int ExitCode) RunBashCommand(string command, string metricName)
         {
             try
             {

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/IBashCommandHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/IBashCommandHandler.cs
@@ -5,6 +5,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
 {
     public interface IBashCommandHandler
     {
-        (string, string, int) RunBashCommand(string command, string metricName);
+        (string Output, string Error, int ExitCode) RunBashCommand(string command, string metricName);
     }
 }

--- a/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
@@ -9,7 +9,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Script.Description;
-using Microsoft.Azure.WebJobs.Script.Extensions;
 using Microsoft.Azure.WebJobs.Script.Management.Models;
 using Microsoft.Azure.WebJobs.Script.WebHost.Extensions;
 using Microsoft.Extensions.Logging;
@@ -80,11 +79,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         /// It attempts to clean left over artifacts from a possible previous function with the same name
         /// if config is changed, then `configChanged` is set to true so the caller can call SyncTriggers if needed.
         /// </summary>
-        /// <param name="name">name of the function to be created</param>
-        /// <param name="functionMetadata">in case of update for function.json</param>
+        /// <param name="name">name of the function to be created.</param>
+        /// <param name="functionMetadata">in case of update for function.json.</param>
         /// <param name="request">Current HttpRequest.</param>
-        /// <returns>(success, configChanged, functionMetadataResult)</returns>
-        public async Task<(bool, bool, FunctionMetadataResponse)> CreateOrUpdate(string name, FunctionMetadataResponse functionMetadata, HttpRequest request)
+        /// <returns>(success, configChanged, functionMetadataResult).</returns>
+        public async Task<(bool Success, bool ConfigChanged, FunctionMetadataResponse Response)> CreateOrUpdate(string name, FunctionMetadataResponse functionMetadata, HttpRequest request)
         {
             var hostOptions = _applicationHostOptions.CurrentValue.ToHostOptions();
             var configChanged = false;
@@ -154,12 +153,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         }
 
         /// <summary>
-        /// maps a functionName to its FunctionMetadataResponse
+        /// maps a functionName to its FunctionMetadataResponse.
         /// </summary>
-        /// <param name="name">Function name to retrieve</param>
-        /// <param name="request">Current HttpRequest</param>
-        /// <returns>(success, FunctionMetadataResponse)</returns>
-        public async Task<(bool, FunctionMetadataResponse)> TryGetFunction(string name, HttpRequest request)
+        /// <param name="name">Function name to retrieve.</param>
+        /// <param name="request">Current HttpRequest.</param>
+        /// <returns>(success, FunctionMetadataResponse).</returns>
+        public async Task<(bool Success, FunctionMetadataResponse Response)> TryGetFunction(string name, HttpRequest request)
         {
             var hostOptions = _applicationHostOptions.CurrentValue.ToHostOptions();
             var functionMetadata = GetFunctionsMetadata(includeProxies: false, forceRefresh: true)
@@ -180,9 +179,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         /// <summary>
         /// Delete a function and all it's artifacts.
         /// </summary>
-        /// <param name="function">Function to be deleted</param>
-        /// <returns>(success, errorMessage)</returns>
-        public async Task<(bool, string)> TryDeleteFunction(FunctionMetadataResponse function)
+        /// <param name="function">Function to be deleted.</param>
+        /// <returns>(success, errorMessage).</returns>
+        public async Task<(bool Success, string ErrorMessage)> TryDeleteFunction(FunctionMetadataResponse function)
         {
             try
             {

--- a/src/WebJobs.Script.WebHost/Properties/AssemblyInfo.cs
+++ b/src/WebJobs.Script.WebHost/Properties/AssemblyInfo.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Runtime.CompilerServices;
+
 [assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.Script.Benchmarks")]
 [assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.Script.Tests")]
 [assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.Script.Tests.Integration")]

--- a/src/WebJobs.Script.WebHost/Security/Authentication/Keys/AuthenticationLevelHandler.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Keys/AuthenticationLevelHandler.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Authentication
             }
         }
 
-        internal static Task<(string, AuthorizationLevel)> GetAuthorizationKeyInfoAsync(HttpRequest request, ISecretManagerProvider secretManagerProvider)
+        internal static Task<(string KeyName, AuthorizationLevel Level)> GetAuthorizationKeyInfoAsync(HttpRequest request, ISecretManagerProvider secretManagerProvider)
         {
             if (secretManagerProvider.SecretsEnabled)
             {

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/ISecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/ISecretManager.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         /// <param name="key">The key to check.</param>
         /// <param name="functionName">Optional function name, if we're authorizing a specific function.</param>
         /// <returns>A key name, auth level pair.</returns>
-        Task<(string, AuthorizationLevel)> GetAuthorizationLevelOrNullAsync(string key, string functionName = null);
+        Task<(string KeyName, AuthorizationLevel Level)> GetAuthorizationLevelOrNullAsync(string key, string functionName = null);
 
         /// <summary>
         /// Deletes a function secret.

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
@@ -7,12 +7,10 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Properties;
@@ -388,7 +386,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             return await _repository.ReadAsync(type, keyScope);
         }
 
-        public async Task<(string, AuthorizationLevel)> GetAuthorizationLevelOrNullAsync(string keyValue, string functionName = null)
+        public async Task<(string KeyName, AuthorizationLevel Level)> GetAuthorizationLevelOrNullAsync(string keyValue, string functionName = null)
         {
             if (keyValue != null)
             {
@@ -404,7 +402,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 bool secretsCached = _hostSecrets != null || _functionSecrets.Any();
 
                 var result = await GetAuthorizationLevelAsync(this, keyValue, functionName);
-                if (result.Item2 != AuthorizationLevel.Anonymous)
+                if (result.Level != AuthorizationLevel.Anonymous)
                 {
                     // key match
                     _authorizationCache[cacheKey] = result;
@@ -430,7 +428,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             return (null, AuthorizationLevel.Anonymous);
         }
 
-        internal static async Task<(string, AuthorizationLevel)> GetAuthorizationLevelAsync(ISecretManager secretManager, string keyValue, string functionName = null)
+        internal static async Task<(string KeyName, AuthorizationLevel Level)> GetAuthorizationLevelAsync(ISecretManager secretManager, string keyValue, string functionName = null)
         {
             // see if the key specified is the master key
             HostSecretsInfo hostSecrets = await secretManager.GetHostSecretsAsync();

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SimpleKubernetesClient.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SimpleKubernetesClient.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
         }
 
-        private async Task<(string, bool)> GetObjectUrl(string objectName, bool watchUrl = false)
+        private async Task<(string Url, bool IsSecret)> GetObjectUrl(string objectName, bool watchUrl = false)
         {
             var isSecret = true;
             if (!objectName.StartsWith("secrets/") && !objectName.StartsWith("configmaps/"))

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -83,7 +83,7 @@
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="$(IdentityDependencyVersion)" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(IdentityDependencyVersion)" />
     <PackageReference Include="Microsoft.Security.Utilities" Version="1.3.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />

--- a/src/WebJobs.Script/Config/TransmissionStatusHandler.cs
+++ b/src/WebJobs.Script/Config/TransmissionStatusHandler.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
     /// </summary>
     internal class TransmissionStatusHandler : IDisposable
     {
-        private static readonly DiagnosticListener _source = new (ScriptConstants.HostDiagnosticSourcePrefix + "ApplicationInsights");
+        private static readonly DiagnosticListener _source = new(ScriptConstants.HostDiagnosticSourcePrefix + "ApplicationInsights");
 
         internal static void Handler(object sender, TransmissionStatusEventArgs args)
         {

--- a/src/WebJobs.Script/Description/DotNet/DotNetFunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/DotNet/DotNetFunctionDescriptorProvider.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
         }
 
-        public override async Task<(bool, FunctionDescriptor)> TryCreate(FunctionMetadata functionMetadata)
+        public override async Task<(bool Success, FunctionDescriptor Descriptor)> TryCreate(FunctionMetadata functionMetadata)
         {
             if (functionMetadata == null)
             {

--- a/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
+++ b/src/WebJobs.Script/Description/DotNet/FunctionAssemblyLoadContext.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         private static readonly ConcurrentDictionary<string, int> _sharedContextAssembliesInFallbackLoad = new ConcurrentDictionary<string, int>();
         private static readonly RuntimeAssembliesInfo _runtimeAssembliesInfo = new RuntimeAssembliesInfo();
 
-        private static Lazy<FunctionAssemblyLoadContext> _defaultContext = new (() => CreateSharedContext(ResolveFunctionBaseProbingPath()), true);
+        private static Lazy<FunctionAssemblyLoadContext> _defaultContext = new(() => CreateSharedContext(ResolveFunctionBaseProbingPath()), true);
 
         private readonly List<string> _probingPaths = new List<string>();
         private readonly IDictionary<string, RuntimeAsset[]> _depsAssemblies;
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             _runtimeAssembliesInfo.ResetIfStale();
         }
 
-        internal static (IDictionary<string, RuntimeAsset[]> depsAssemblies, IDictionary<string, RuntimeAsset[]> nativeLibraries) InitializeDeps(string basePath, List<string> ridFallbacks)
+        internal static (IDictionary<string, RuntimeAsset[]> DepsAssemblies, IDictionary<string, RuntimeAsset[]> NativeLibraries) InitializeDeps(string basePath, List<string> ridFallbacks)
         {
             string depsFilePath = Path.Combine(basePath, DotNetConstants.FunctionsDepsFileName);
 
@@ -421,7 +421,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             return LoadFromAssemblyPath(assemblyPath);
         }
 
-        internal (bool succeeded, Assembly assembly, bool isRuntimeAssembly) TryLoadAssembly(AssemblyName assemblyName)
+        internal (bool Succeeded, Assembly Assembly, bool IsRuntimeAssembly) TryLoadAssembly(AssemblyName assemblyName)
         {
             bool isRuntimeAssembly = IsRuntimeAssembly(assemblyName);
 

--- a/src/WebJobs.Script/Description/DotNet/ScriptFunctionMetadataResolver.cs
+++ b/src/WebJobs.Script/Description/DotNet/ScriptFunctionMetadataResolver.cs
@@ -10,7 +10,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Extensibility;
 using Microsoft.CodeAnalysis;
@@ -84,7 +83,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             "Microsoft.Identity.Client.Extensions.Msal"
         };
 
-        private static Lazy<IEnumerable<string>> _privateHostAssemblies = new (GetPrivateHostAssemblies);
+        private static Lazy<IEnumerable<string>> _privateHostAssemblies = new(GetPrivateHostAssemblies);
 
         public ScriptFunctionMetadataResolver(string scriptFilePath, ICollection<IScriptBindingProvider> bindingProviders, ILogger logger)
         {
@@ -119,7 +118,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 assembliesInfo.Reset -= RuntimeAssembliesResetHandler;
             }
 
-            _privateHostAssemblies = new (GetPrivateHostAssemblies);
+            _privateHostAssemblies = new(GetPrivateHostAssemblies);
         }
 
         public ScriptOptions CreateScriptOptions()

--- a/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/FunctionDescriptorProvider.cs
@@ -8,13 +8,11 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Binding;
 using Microsoft.Azure.WebJobs.Script.Extensibility;
 using Microsoft.Azure.WebJobs.Script.Extensions;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Script.Description
 {
@@ -33,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         protected ICollection<IScriptBindingProvider> BindingProviders { get; private set; }
 
-        public virtual async Task<(bool, FunctionDescriptor)> TryCreate(FunctionMetadata functionMetadata)
+        public virtual async Task<(bool Success, FunctionDescriptor Descriptor)> TryCreate(FunctionMetadata functionMetadata)
         {
             if (functionMetadata == null)
             {

--- a/src/WebJobs.Script/Description/Proxies/ProxyFunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/Proxies/ProxyFunctionDescriptorProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             _loggerFactory = loggerFactory;
         }
 
-        public override Task<(bool, FunctionDescriptor)> TryCreate(FunctionMetadata functionMetadata)
+        public override Task<(bool Success, FunctionDescriptor Descriptor)> TryCreate(FunctionMetadata functionMetadata)
         {
             if (functionMetadata == null)
             {

--- a/src/WebJobs.Script/Description/Workers/Rpc/MultiLanguageFunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/Workers/Rpc/MultiLanguageFunctionDescriptorProvider.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         }
 
         /// <inheritdoc/>
-        public override async Task<(bool, FunctionDescriptor)> TryCreate(FunctionMetadata functionMetadata)
+        public override async Task<(bool Success, FunctionDescriptor Descriptor)> TryCreate(FunctionMetadata functionMetadata)
         {
             if (functionMetadata == null)
             {

--- a/src/WebJobs.Script/Description/Workers/Rpc/RpcFunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/Workers/Rpc/RpcFunctionDescriptorProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             _workerRuntime = workerRuntime;
         }
 
-        public override async Task<(bool, FunctionDescriptor)> TryCreate(FunctionMetadata functionMetadata)
+        public override async Task<(bool Success, FunctionDescriptor Descriptor)> TryCreate(FunctionMetadata functionMetadata)
         {
             if (functionMetadata == null)
             {

--- a/src/WebJobs.Script/Description/Workers/ScriptInvocationContext.cs
+++ b/src/WebJobs.Script/Description/Workers/ScriptInvocationContext.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         public IEnumerable<KeyValuePair<string, string>> Attributes { get; set; }
 
-        public IEnumerable<(string name, DataType type, object val)> Inputs { get; set; }
+        public IEnumerable<(string Name, DataType Type, object Val)> Inputs { get; set; }
 
         public Dictionary<string, object> BindingData { get; set; }
 

--- a/src/WebJobs.Script/Description/Workers/WorkerFunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/Workers/WorkerFunctionDescriptorProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             _expressionRegex = new Regex(@"{(.*?)\}", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         }
 
-        public override async Task<(bool, FunctionDescriptor)> TryCreate(FunctionMetadata functionMetadata)
+        public override async Task<(bool Success, FunctionDescriptor Descriptor)> TryCreate(FunctionMetadata functionMetadata)
         {
             if (functionMetadata == null)
             {

--- a/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
         }
 
-        private async Task<(string name, DataType type, object value)[]> BindInputsAsync(Binder binder)
+        private async Task<(string Name, DataType Type, object Value)[]> BindInputsAsync(Binder binder)
         {
             var bindingTasks = _inputBindings
                 .Where(binding => !binding.Metadata.IsTrigger)

--- a/src/WebJobs.Script/Eventing/ScriptEventManager.cs
+++ b/src/WebJobs.Script/Eventing/ScriptEventManager.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.WebJobs.Script.Eventing
     public class ScriptEventManager : IScriptEventManager, IDisposable
     {
         private readonly Subject<ScriptEvent> _subject = new Subject<ScriptEvent>();
-        private readonly ConcurrentDictionary<(string, Type), object> _workerState = new ();
+        private readonly ConcurrentDictionary<(string, Type), object> _workerState = new();
 
         private bool _disposed = false;
 

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -71,7 +71,7 @@
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuGet.ProjectModel" Version="5.11.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.IO.Abstractions" Version="2.1.0.227">

--- a/src/WebJobs.Script/Workers/Http/DefaultHttpWorkerService.cs
+++ b/src/WebJobs.Script/Workers/Http/DefaultHttpWorkerService.cs
@@ -51,9 +51,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
 
         private static HttpClient CreateHttpClient(IOptions<HttpWorkerOptions> httpWorkerOptions)
         {
-            HttpClientHandler handler = new ();
+            HttpClientHandler handler = new();
             handler.AllowAutoRedirect = !httpWorkerOptions.Value.EnableForwardingHttpRequest;
-            return new (handler);
+            return new(handler);
         }
 
         public Task InvokeAsync(ScriptInvocationContext scriptInvocationContext)
@@ -79,12 +79,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
                 Outputs = new Dictionary<string, object>()
             };
 
-            (string name, DataType type, object request) input = scriptInvocationContext.Inputs.First();
+            (string Name, DataType Type, object Request) input = scriptInvocationContext.Inputs.First();
 
-            HttpRequest httpRequest = input.request as HttpRequest;
+            HttpRequest httpRequest = input.Request as HttpRequest;
             if (httpRequest == null)
             {
-                throw new InvalidOperationException($"HttpTrigger value for: `{input.name}` is null");
+                throw new InvalidOperationException($"HttpTrigger value for: `{input.Name}` is null");
             }
 
             try

--- a/src/WebJobs.Script/Workers/Http/DefaultHttpWorkerService.cs
+++ b/src/WebJobs.Script/Workers/Http/DefaultHttpWorkerService.cs
@@ -79,9 +79,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
                 Outputs = new Dictionary<string, object>()
             };
 
-            (string Name, DataType Type, object Request) input = scriptInvocationContext.Inputs.First();
+            var input = scriptInvocationContext.Inputs.First();
 
-            HttpRequest httpRequest = input.Request as HttpRequest;
+            HttpRequest httpRequest = input.Val as HttpRequest;
             if (httpRequest == null)
             {
                 throw new InvalidOperationException($"HttpTrigger value for: `{input.Name}` is null");

--- a/src/WebJobs.Script/Workers/MessageExtensions/ScriptInvocationContextExtensions.cs
+++ b/src/WebJobs.Script/Workers/MessageExtensions/ScriptInvocationContextExtensions.cs
@@ -41,12 +41,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             // populate input bindings
             foreach (var input in scriptInvocationContext.Inputs)
             {
-                if (input.val is HttpRequest httpRequest)
+                if (input.Val is HttpRequest httpRequest)
                 {
-                    httpScriptInvocationContext.Data[input.name] = await httpRequest.GetRequestAsJObject();
+                    httpScriptInvocationContext.Data[input.Name] = await httpRequest.GetRequestAsJObject();
                     continue;
                 }
-                httpScriptInvocationContext.Data[input.name] = GetHttpScriptInvocationContextValue(input.val, input.type);
+                httpScriptInvocationContext.Data[input.Name] = GetHttpScriptInvocationContextValue(input.Val, input.Type);
             }
 
             SetRetryContext(scriptInvocationContext, httpScriptInvocationContext);

--- a/src/WebJobs.Script/Workers/Profiles/WorkerDescriptionProfile.cs
+++ b/src/WebJobs.Script/Workers/Profiles/WorkerDescriptionProfile.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Profiles
         /// </summary>
         public RpcWorkerDescription ApplyProfile(RpcWorkerDescription defaultWorkerDescription)
         {
-            RpcWorkerDescription updatedDescription = new ();
+            RpcWorkerDescription updatedDescription = new();
             updatedDescription.Arguments = UseProfileOrDefault(ProfileDescription.Arguments, defaultWorkerDescription.Arguments);
             updatedDescription.DefaultExecutablePath = UseProfileOrDefault(ProfileDescription.DefaultExecutablePath, defaultWorkerDescription.DefaultExecutablePath);
             updatedDescription.DefaultWorkerPath = UseProfileOrDefault(ProfileDescription.DefaultWorkerPath, defaultWorkerDescription.DefaultWorkerPath);

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             // Validate
             if (workerProcessCount.ProcessCount <= 0)
             {
-                throw new ArgumentOutOfRangeException($"{nameof(workerProcessCount.ProcessCount)}", "ProcessCount must be greater than 0.");
+                throw new ArgumentOutOfRangeException(nameof(workerProcessCount.ProcessCount), "ProcessCount must be greater than 0.");
             }
             if (workerProcessCount.ProcessCount > workerProcessCount.MaxProcessCount)
             {

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -217,7 +217,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                         profileConditions.Add(condition);
                     }
 
-                    descriptionProfiles.Add(new (profile.ProfileName, profileConditions, profile.Description));
+                    descriptionProfiles.Add(new(profile.ProfileName, profileConditions, profile.Description));
                 }
             }
             catch (Exception)
@@ -251,7 +251,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             // Validate
             if (workerProcessCount.ProcessCount <= 0)
             {
-                throw new ArgumentOutOfRangeException($"{nameof(workerProcessCount.ProcessCount)}",  "ProcessCount must be greater than 0.");
+                throw new ArgumentOutOfRangeException($"{nameof(workerProcessCount.ProcessCount)}", "ProcessCount must be greater than 0.");
             }
             if (workerProcessCount.ProcessCount > workerProcessCount.MaxProcessCount)
             {

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var tcs = new TaskCompletionSource<bool>();
             var rwh = ThreadPool.RegisterWaitForSingleObject(waitHandle,
-                delegate { tcs.TrySetResult(true); }, null, -1, true);
+                (state, timedOut) => { tcs.TrySetResult(true); }, null, -1, true);
             var t = tcs.Task.ContinueWith((antecedent) => rwh.Unregister(null));
 
             return t;
@@ -519,7 +519,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         /// Mock an HttpClientFactory and its CreateClient functionality.
         /// </summary>
         /// <param name="handler">Some tests pass a mock HttpHandler into their HttpClient.</param>
-        /// <returns>IHttpClientFactory</returns>
+        /// <returns>IHttpClientFactory.</returns>
         public static IHttpClientFactory CreateHttpClientFactory(HttpMessageHandler handler = null)
         {
             var httpClient = handler == null ? new HttpClient() : new HttpClient(handler);

--- a/test/WebJobs.Script.Tests.Shared/TestSecretManager.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestSecretManager.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
         }
 
-        public async Task<(string, AuthorizationLevel)> GetAuthorizationLevelOrNullAsync(string key, string functionName = null)
+        public async Task<(string KeyName, AuthorizationLevel Level)> GetAuthorizationLevelOrNullAsync(string key, string functionName = null)
         {
             return await SecretManager.GetAuthorizationLevelAsync(this, key, functionName);
         }

--- a/test/WebJobs.Script.Tests/Configuration/TransmissionStatusHandlerTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/TransmissionStatusHandlerTest.cs
@@ -4,12 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Google.Protobuf.WellKnownTypes;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Extensibility.Implementation;
-using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -23,15 +20,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         [Fact]
         public void FormattedLog_Failure()
         {
-            Transmission transmission = new (new Uri("https://test"), new List<ITelemetry>() { new RequestTelemetry(), new EventTelemetry() }, new TimeSpan(500));
-            HttpWebResponseWrapper response = new ()
+            Transmission transmission = new(new Uri("https://test"), new List<ITelemetry>() { new RequestTelemetry(), new EventTelemetry() }, new TimeSpan(500));
+            HttpWebResponseWrapper response = new()
             {
                 StatusCode = 400,
                 StatusDescription = "Invalid IKey",
                 Content = null
             };
 
-            TransmissionStatusEventArgs args = new (response, 100);
+            TransmissionStatusEventArgs args = new(response, 100);
             JObject log = JsonConvert.DeserializeObject<JObject>(TransmissionStatusHandler.FormattedLog(transmission, args));
 
             Assert.Equal(400, log.Value<int>("statusCode"));
@@ -43,9 +40,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         [Fact]
         public void FormattedLog_PartialResponse()
         {
-            TransmissionStatusHandler handler = new ();
-            Transmission transmission = new (new Uri("https://test"), new List<ITelemetry>() { new RequestTelemetry(), new EventTelemetry() }, new TimeSpan(500));
-            IngestionServiceResponse backendResponse = new ()
+            TransmissionStatusHandler handler = new();
+            Transmission transmission = new(new Uri("https://test"), new List<ITelemetry>() { new RequestTelemetry(), new EventTelemetry() }, new TimeSpan(500));
+            IngestionServiceResponse backendResponse = new()
             {
                 Errors = new IngestionServiceResponse.Error[2]
                 {
@@ -55,14 +52,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 ItemsAccepted = 100,
                 ItemsReceived = 102
             };
-            HttpWebResponseWrapper response = new ()
+            HttpWebResponseWrapper response = new()
             {
                 StatusCode = 206,
                 StatusDescription = "Invalid IKey",
                 Content = JsonConvert.SerializeObject(backendResponse, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() })
             };
 
-            TransmissionStatusEventArgs args = new (response, 100);
+            TransmissionStatusEventArgs args = new(response, 100);
             JObject log = JsonConvert.DeserializeObject<JObject>(TransmissionStatusHandler.FormattedLog(transmission, args));
 
             Assert.Equal(206, log.Value<int>("statusCode"));
@@ -79,21 +76,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         [Fact]
         public void FormattedLog_Success()
         {
-            TransmissionStatusHandler handler = new ();
-            Transmission transmission = new (new ("https://test"), new List<ITelemetry>() { new RequestTelemetry(), new RequestTelemetry(), new EventTelemetry(), new DependencyTelemetry() }, new TimeSpan(500));
-            IngestionServiceResponse backendResponse = new ()
+            TransmissionStatusHandler handler = new();
+            Transmission transmission = new(new("https://test"), new List<ITelemetry>() { new RequestTelemetry(), new RequestTelemetry(), new EventTelemetry(), new DependencyTelemetry() }, new TimeSpan(500));
+            IngestionServiceResponse backendResponse = new()
             {
                 ItemsAccepted = 100,
                 ItemsReceived = 100
             };
-            HttpWebResponseWrapper response = new ()
+            HttpWebResponseWrapper response = new()
             {
                 StatusCode = 200,
                 StatusDescription = "ok",
                 Content = JsonConvert.SerializeObject(backendResponse, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() })
             };
 
-            TransmissionStatusEventArgs args = new (response, 100);
+            TransmissionStatusEventArgs args = new(response, 100);
             JObject log = JsonConvert.DeserializeObject<JObject>(TransmissionStatusHandler.FormattedLog(transmission, args));
 
             Assert.Equal(200, log.Value<int>("statusCode"));

--- a/test/WebJobs.Script.Tests/Description/FunctionEntryPointResolverTests.cs
+++ b/test/WebJobs.Script.Tests/Description/FunctionEntryPointResolverTests.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.CodeAnalysis.Scripting;
 using Xunit;
@@ -65,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var resolver = new FunctionEntryPointResolver();
 
             CompilationErrorException exc = Assert.Throws(typeof(CompilationErrorException), () => resolver.GetFunctionEntryPoint(new[]
-             {
+            {
                 new TestMethodReference("Run", false),
                 new TestMethodReference("PrivateMethodName", false)
             })) as CompilationErrorException;
@@ -80,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var resolver = new FunctionEntryPointResolver();
 
             CompilationErrorException exc = Assert.Throws(typeof(CompilationErrorException), () => resolver.GetFunctionEntryPoint(new[]
-             {
+            {
                 new TestMethodReference("Run", true),
                 new TestMethodReference("Run", true),
                 new TestMethodReference("Run", true)
@@ -96,7 +92,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var resolver = new FunctionEntryPointResolver("NamedMethod");
 
             var method = resolver.GetFunctionEntryPoint(new[]
-           {
+            {
                 new TestMethodReference("NamedMethod", true),
                 new TestMethodReference("Run", true),
                 new TestMethodReference("Run", true),
@@ -113,7 +109,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var resolver = new FunctionEntryPointResolver("NamedMethod");
 
             CompilationErrorException exc = Assert.Throws(typeof(CompilationErrorException), () => resolver.GetFunctionEntryPoint(new[]
-             {
+            {
                 new TestMethodReference("Method1", true),
                 new TestMethodReference("Method2", true),
                 new TestMethodReference("NamedMethod", false)

--- a/test/WebJobs.Script.Tests/HttpWorker/DefaultHttpWorkerServiceTests.cs
+++ b/test/WebJobs.Script.Tests/HttpWorker/DefaultHttpWorkerServiceTests.cs
@@ -549,8 +549,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
             Assert.Equal(expectedData.Count(), httpScriptInvocationContext.Data.Count());
             foreach (var item in expectedData)
             {
-                Assert.True(httpScriptInvocationContext.Data.Keys.Contains(item.name));
-                Assert.Equal(JsonConvert.SerializeObject(item.val), httpScriptInvocationContext.Data[item.name]);
+                Assert.True(httpScriptInvocationContext.Data.Keys.Contains(item.Name));
+                Assert.Equal(JsonConvert.SerializeObject(item.Val), httpScriptInvocationContext.Data[item.Name]);
             }
         }
 

--- a/test/WebJobs.Script.Tests/HttpWorker/HttpWorkerTestUtilities.cs
+++ b/test/WebJobs.Script.Tests/HttpWorker/HttpWorkerTestUtilities.cs
@@ -50,9 +50,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
             return new QueryCollection(QueryHelpers.ParseQuery(QueryParamString));
         }
 
-        public static List<(string name, DataType type, object val)> GetSimpleHttpTriggerScriptInvocationInputs()
+        public static List<(string Name, DataType Type, object Val)> GetSimpleHttpTriggerScriptInvocationInputs()
         {
-            List<(string name, DataType type, object val)> inputs = new List<(string name, DataType type, object val)>();
+            List<(string Name, DataType Type, object Val)> inputs = new();
             inputs.Add(("testInputReq", DataType.String, GetTestHttpRequest()));
             return inputs;
         }
@@ -186,9 +186,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.HttpWorker
             };
         }
 
-        public static List<(string name, DataType type, object val)> GetScriptInvocationInputs()
+        public static List<(string Name, DataType Type, object Val)> GetScriptInvocationInputs()
         {
-            List<(string name, DataType type, object val)> inputs = new List<(string name, DataType type, object val)>();
+            List<(string Name, DataType Type, object Val)> inputs = new();
             inputs.Add(("myqueueItem", DataType.String, "HelloWorld"));
             return inputs;
         }

--- a/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
@@ -11,7 +11,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Executors;
-using Microsoft.Azure.WebJobs.Script.Management.Models;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
 using Microsoft.Azure.WebJobs.Script.Workers.Http;
@@ -136,7 +135,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         public async Task TryGetFunction_NoMatchingFunction_ReturnsEmpty()
         {
             var result = await _webFunctionsManager.TryGetFunction("non-function", null);
-            Assert.False(result.Item1);
+            Assert.False(result.Success);
         }
 
         [Fact]
@@ -146,7 +145,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             {
                 FileUtility.Instance = CreateEmptyFileSystem(_hostOptions);
                 var action = await _webFunctionsManager.TryGetFunction("function1", null);
-                Assert.False(action.Item1);
+                Assert.False(action.Success);
             }
             finally
             {

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -59,7 +59,10 @@
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Moq" Version="4.9.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.5-11874" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="2.1.0.227">
     </PackageReference>

--- a/test/WebJobs.Script.Tests/Workers/Profiles/WorkerProfileManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Profiles/WorkerProfileManagerTests.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles
 {
     public class WorkerProfileManagerTests
     {
-        private static TestLogger<WorkerProfileManager> _testLogger = new ();
-        private static TestEnvironment _testEnvironment = new ();
+        private static TestLogger<WorkerProfileManager> _testLogger = new();
+        private static TestEnvironment _testEnvironment = new();
 
         [Fact]
         public void LoadWorkerDescriptionFromProfiles_ConditionsMet_ReturnsDescriptionWithChanges()
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles
 
             _testEnvironment.SetEnvironmentVariable("APPLICATIONINSIGHTS_ENABLE_AGENT", "true");
 
-            WorkerProfileManager profileManager = new (_testLogger, _testEnvironment);
+            WorkerProfileManager profileManager = new(_testLogger, _testEnvironment);
             profileManager.SetWorkerDescriptionProfiles(profiles, "java");
             profileManager.LoadWorkerDescriptionFromProfiles(defaultDescription, out var evaluatedDescription);
 
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles
             var profileDescription = RpcWorkerConfigTestUtilities.GetTestDefaultWorkerDescription("java", argumentListB);
             var profiles = WorkerDescriptionProfileData("java", profileDescription);
 
-            WorkerProfileManager profileManager = new (_testLogger, _testEnvironment);
+            WorkerProfileManager profileManager = new(_testLogger, _testEnvironment);
             profileManager.SetWorkerDescriptionProfiles(profiles, "java");
             profileManager.LoadWorkerDescriptionFromProfiles(defaultDescription, out var evaluatedDescription);
 
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles
             conditionJObject[WorkerConstants.WorkerDescriptionProfileConditionExpression] = "true";
             var conditionDescriptor = conditionJObject.ToObject<WorkerProfileConditionDescriptor>();
 
-            WorkerProfileManager profileManager = new (_testLogger, _testEnvironment);
+            WorkerProfileManager profileManager = new(_testLogger, _testEnvironment);
             var result = profileManager.TryCreateWorkerProfileCondition(conditionDescriptor, out var condition);
 
             Assert.True(result);
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles
             conditionJObject[WorkerConstants.WorkerDescriptionProfileConditionExpression] = "true";
             var conditionDescriptor = conditionJObject.ToObject<WorkerProfileConditionDescriptor>();
 
-            WorkerProfileManager profileManager = new (_testLogger, _testEnvironment);
+            WorkerProfileManager profileManager = new(_testLogger, _testEnvironment);
             var result = profileManager.TryCreateWorkerProfileCondition(conditionDescriptor, out var condition);
 
             Assert.False(result);
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles
 
             _testEnvironment.SetEnvironmentVariable("APPLICATIONINSIGHTS_ENABLE_AGENT", "true");
 
-            WorkerProfileManager profileManager = new (_testLogger, _testEnvironment);
+            WorkerProfileManager profileManager = new(_testLogger, _testEnvironment);
             profileManager.SetWorkerDescriptionProfiles(profiles, "java");
             profileManager.LoadWorkerDescriptionFromProfiles(description, out var workerDescription);
 
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles
 
             _testEnvironment.SetEnvironmentVariable("APPLICATIONINSIGHTS_ENABLE_AGENT", "true");
 
-            WorkerProfileManager profileManager = new (_testLogger, _testEnvironment);
+            WorkerProfileManager profileManager = new(_testLogger, _testEnvironment);
             profileManager.SetWorkerDescriptionProfiles(profiles, "java");
             profileManager.LoadWorkerDescriptionFromProfiles(description, out var workerDescription);
 
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles
             Assert.False(profileManager.IsCorrectProfileLoaded("java"));
         }
 
-        public static List<WorkerDescriptionProfile> WorkerDescriptionProfileData(string language,  RpcWorkerDescription description)
+        public static List<WorkerDescriptionProfile> WorkerDescriptionProfileData(string language, RpcWorkerDescription description)
         {
             var conditionLogger = new TestLogger("ConditionLogger");
             var profilesList = new List<WorkerDescriptionProfile>();

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -17,7 +17,6 @@ using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.Grpc;
 using Microsoft.Azure.WebJobs.Script.Grpc.Eventing;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
-using Microsoft.Azure.WebJobs.Script.Tests.Description.DotNet;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.FunctionDataCache;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
@@ -1287,7 +1286,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                     FunctionDirectory = _scriptRootPath
                 },
                 BindingData = new Dictionary<string, object>(),
-                Inputs = new List<(string name, DataType type, object val)>(),
+                Inputs = new List<(string Name, DataType Type, object Val)>(),
                 ResultSource = resultSource,
                 CancellationToken = token == null ? CancellationToken.None : (CancellationToken)token
             };
@@ -1298,7 +1297,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         /// </summary>
         /// <param name="invocationId">ID of the invocation.</param>
         /// <param name="resultSource">Task result source.</param>
-        /// <returns>A test <see cref="ScriptInvocationContext"/></returns>
+        /// <returns>A test <see cref="ScriptInvocationContext"/>.</returns>
         private ScriptInvocationContext GetTestScriptInvocationContextWithSharedMemoryInputs(Guid invocationId, TaskCompletionSource<ScriptInvocationResult> resultSource)
         {
             const int inputStringLength = 2 * 1024 * 1024;
@@ -1307,7 +1306,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             const int inputBytesLength = 2 * 1024 * 1024;
             byte[] inputBytes = TestUtils.GetRandomBytesInArray(inputBytesLength);
 
-            var inputs = new List<(string name, DataType type, object val)>
+            var inputs = new List<(string Name, DataType Type, object Val)>
             {
                 ("fooStr", DataType.String, inputString),
                 ("fooBytes", DataType.Binary, inputBytes),

--- a/test/WebJobs.Script.Tests/Workers/ScriptInvocationContextExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ScriptInvocationContextExtensionsTests.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             httpContext.Request.Path = "/test";
             httpContext.Request.Method = "Post";
 
-            var inputs = new List<(string name, DataType type, object val)>
+            var inputs = new List<(string Name, DataType Type, object Val)>
             {
                 ("req", DataType.String, httpContext.Request)
             };
@@ -206,7 +206,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
                 { "sys", new SystemBindingData() }
             };
 
-            var inputs = new List<(string name, DataType type, object val)>
+            var inputs = new List<(string Name, DataType Type, object Val)>
             {
                 ("req", DataType.String, httpContext.Request),
                 ("blob", DataType.String, null),  // verify that null values are handled
@@ -384,7 +384,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             const int inputBytesLength = 2 * 1024 * 1024;
             byte[] inputBytes = TestUtils.GetRandomBytesInArray(inputBytesLength);
 
-            var inputs = new List<(string name, DataType type, object val)>
+            var inputs = new List<(string Name, DataType Type, object Val)>
             {
                 ("req", DataType.String, httpContext.Request),
                 ("fooStr", DataType.String, inputString),
@@ -522,7 +522,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             FunctionDataCacheKey key2 = new FunctionDataCacheKey("fooBytes", "0x1");
             MockCacheAwareReadObject cacheObj2 = new MockCacheAwareReadObject(key2, sharedMemObj2, _functionDataCache);
 
-            var inputs = new List<(string name, DataType type, object val)>
+            var inputs = new List<(string Name, DataType Type, object Val)>
             {
                 ("req", DataType.String, httpContext.Request),
                 ("fooStr", DataType.String, cacheObj1),
@@ -666,7 +666,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             FunctionDataCacheKey key2 = new FunctionDataCacheKey("fooBytes", "0x1");
             MockCacheAwareReadObject cacheObj2 = new MockCacheAwareReadObject(key2, inputStream2, _functionDataCache);
 
-            var inputs = new List<(string name, DataType type, object val)>
+            var inputs = new List<(string Name, DataType Type, object Val)>
             {
                 ("req", DataType.String, httpContext.Request),
                 ("fooStr", DataType.String, cacheObj1),
@@ -811,7 +811,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             const int inputBytesLength = 32;
             byte[] inputBytes = TestUtils.GetRandomBytesInArray(inputBytesLength);
 
-            var inputs = new List<(string name, DataType type, object val)>
+            var inputs = new List<(string Name, DataType Type, object Val)>
             {
                 ("req", DataType.String, httpContext.Request),
                 ("fooStr", DataType.String, inputString),


### PR DESCRIPTION
A small issue with StyleCop (not allowing `... = new();` caused me to investigate bumping it up for newer C# language support. This resulted in a bunch of very similar, boilerplate errors that I went through and addressed. They were:
- Tuples with no element names.
- Tuples with lowercase element names.
- No `.` at the end of doc comments.
- Changing `new ();` -> `new();`