### PR TITLE
Improve logging when a InvocationRequest is cancelled

### DIFF
--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -298,7 +298,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     await tcs.Task;
                     var elapsed = sw.GetElapsedTime();
                     workerStatus.Latency = elapsed;
-                    _workerChannelLogger.LogDebug($"[HostMonitor] Worker status request took {elapsed.TotalMilliseconds}ms");
+                    _workerChannelLogger.LogDebug("[HostMonitor] Worker status request took {totalMs}ms", elapsed.TotalMilliseconds);
                 }
             }
 
@@ -374,14 +374,14 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
             _workerChannelLogger.LogDebug("Received WorkerInitResponse. Worker process initialized");
             _initMessage = initEvent.Message.WorkerInitResponse;
-            _workerChannelLogger.LogDebug($"Worker capabilities: {_initMessage.Capabilities}");
+            _workerChannelLogger.LogDebug("Worker capabilities: {capabilities}", _initMessage.Capabilities);
 
             if (_initMessage.WorkerMetadata != null)
             {
                 _initMessage.UpdateWorkerMetadata(_workerConfig);
                 var workerMetadata = _initMessage.WorkerMetadata.ToString();
                 _metricsLogger.LogEvent(MetricEventNames.WorkerMetadata, functionName: null, workerMetadata);
-                _workerChannelLogger.LogDebug($"Worker metadata: {workerMetadata}");
+                _workerChannelLogger.LogDebug("Worker metadata: {workerMetadata}", workerMetadata);
             }
 
             if (_initMessage.Result.IsFailure(out Exception exc))
@@ -458,7 +458,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
             FunctionLoadRequestCollection functionLoadRequestCollection = GetFunctionLoadRequestCollection(functions, managedDependencyOptions);
 
-            _workerChannelLogger.LogDebug("Sending FunctionLoadRequestCollection with number of functions:'{count}'", functionLoadRequestCollection.FunctionLoadRequests.Count);
+            _workerChannelLogger.LogDebug("Sending FunctionLoadRequestCollection with number of functions: '{count}'", functionLoadRequestCollection.FunctionLoadRequests.Count);
 
             // send load requests for the registered functions
             SendStreamingMessage(new StreamingMessage
@@ -526,7 +526,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         internal void SendFunctionLoadRequest(FunctionMetadata metadata, ManagedDependencyOptions managedDependencyOptions)
         {
             _functionLoadRequestResponseEvent = _metricsLogger.LatencyEvent(MetricEventNames.FunctionLoadRequestResponse);
-            _workerChannelLogger.LogDebug("Sending FunctionLoadRequest for function:'{functionName}' with functionId:'{functionId}'", metadata.Name, metadata.GetFunctionId());
+            _workerChannelLogger.LogDebug("Sending FunctionLoadRequest for function: '{functionName}' with functionId: '{functionId}'", metadata.Name, metadata.GetFunctionId());
 
             // send a load request for the registered function
             SendStreamingMessage(new StreamingMessage
@@ -552,7 +552,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
             if (managedDependencyOptions != null && managedDependencyOptions.Enabled)
             {
-                _workerChannelLogger?.LogDebug($"Adding dependency download request to {_workerConfig.Description.Language} language worker");
+                _workerChannelLogger?.LogDebug("Adding dependency download request to {language} language worker", _workerConfig.Description.Language);
                 request.ManagedDependencyEnabled = managedDependencyOptions.Enabled;
             }
 
@@ -581,11 +581,11 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             {
                 if (functionLoadEx == null)
                 {
-                    _workerChannelLogger?.LogError("Worker failed to to load function: '{functionName}' with function id: '{functionId}'. Function load exception is not set by the worker.", functionName, loadResponse.FunctionId);
+                    _workerChannelLogger?.LogError("Worker failed to to load function: '{functionName}' with functionId: '{functionId}'. Function load exception is not set by the worker.", functionName, loadResponse.FunctionId);
                 }
                 else
                 {
-                    _workerChannelLogger?.LogError(functionLoadEx, "Worker failed to load function: '{functionName}' with function id: '{functionId}'.", functionName, loadResponse.FunctionId);
+                    _workerChannelLogger?.LogError(functionLoadEx, "Worker failed to load function: '{functionName}' with functionId: '{functionId}'.", functionName, loadResponse.FunctionId);
                 }
                 //Cache function load errors to replay error messages on invoking failed functions
                 _functionLoadErrors[loadResponse.FunctionId] = functionLoadEx;
@@ -593,7 +593,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
             if (loadResponse.IsDependencyDownloaded)
             {
-                _workerChannelLogger?.LogDebug($"Managed dependency successfully downloaded by the {_workerConfig.Description.Language} language worker");
+                _workerChannelLogger?.LogDebug("Managed dependency successfully downloaded by the {workerLanguage} language worker", _workerConfig.Description.Language);
             }
 
             // link the invocation inputs to the invoke call
@@ -617,26 +617,29 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         {
             try
             {
-                // do not send invocation requests for functions that failed to load or could not be indexed by the worker
+                var invocationId = context.ExecutionContext.InvocationId.ToString();
+
+                // do not send an invocation request for functions that failed to load or could not be indexed by the worker
                 if (_functionLoadErrors.ContainsKey(context.FunctionMetadata.GetFunctionId()))
                 {
-                    _workerChannelLogger.LogDebug($"Function {context.FunctionMetadata.Name} failed to load");
+                    _workerChannelLogger.LogDebug("Function {functionName} failed to load", context.FunctionMetadata.Name);
                     context.ResultSource.TrySetException(_functionLoadErrors[context.FunctionMetadata.GetFunctionId()]);
-                    _executingInvocations.TryRemove(context.ExecutionContext.InvocationId.ToString(), out ScriptInvocationContext _);
+                    _executingInvocations.TryRemove(invocationId, out ScriptInvocationContext _);
                     return;
                 }
                 else if (_metadataRequestErrors.ContainsKey(context.FunctionMetadata.GetFunctionId()))
                 {
-                    _workerChannelLogger.LogDebug($"Worker failed to load metadata for {context.FunctionMetadata.Name}");
+                    _workerChannelLogger.LogDebug("Worker failed to load metadata for {functionName}", context.FunctionMetadata.Name);
                     context.ResultSource.TrySetException(_metadataRequestErrors[context.FunctionMetadata.GetFunctionId()]);
-                    _executingInvocations.TryRemove(context.ExecutionContext.InvocationId.ToString(), out ScriptInvocationContext _);
+                    _executingInvocations.TryRemove(invocationId, out ScriptInvocationContext _);
                     return;
                 }
 
+                // do not send an invocation request if cancellation has been requested
                 if (context.CancellationToken.IsCancellationRequested)
                 {
-                    _workerChannelLogger.LogDebug("Cancellation has been requested, cancelling invocation request");
-                    context.ResultSource.SetCanceled();
+                    _workerChannelLogger.LogWarning("Cancellation has been requested. The invocation request with id '{invocationId}' is cancelled and will not be sent to the worker.", invocationId);
+                    context.ResultSource.TrySetCanceled();
                     return;
                 }
 
@@ -644,17 +647,17 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                 AddAdditionalTraceContext(invocationRequest.TraceContext.Attributes, context);
                 _executingInvocations.TryAdd(invocationRequest.InvocationId, context);
 
-                if (_cancelCapabilityEnabled)
-                {
-                    context.CancellationToken.Register(() => SendInvocationCancel(invocationRequest.InvocationId));
-                }
-
                 _metricsLogger.LogEvent(string.Format(MetricEventNames.WorkerInvoked, Id), functionName: context.FunctionMetadata.Name);
 
                 await SendStreamingMessageAsync(new StreamingMessage
                 {
                     InvocationRequest = invocationRequest
                 });
+
+                if (_cancelCapabilityEnabled)
+                {
+                    context.CancellationToken.Register(() => SendInvocationCancel(invocationRequest.InvocationId));
+                }
             }
             catch (Exception invokeEx)
             {
@@ -664,7 +667,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
         internal void SendInvocationCancel(string invocationId)
         {
-            _workerChannelLogger.LogDebug($"Sending invocation cancel request for InvocationId {invocationId}");
+            _workerChannelLogger.LogDebug("Sending InvocationCancel request for invocation: '{invocationId}'", invocationId);
 
             var invocationCancel = new InvocationCancel
             {
@@ -726,7 +729,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     }
                     if (metadata.Status != null && metadata.Status.IsFailure(out Exception metadataRequestEx))
                     {
-                        _workerChannelLogger.LogError($"Worker failed to index function {metadata.FunctionId}");
+                        _workerChannelLogger.LogError("Worker failed to index function {functionId}", metadata.FunctionId);
                         _metadataRequestErrors[metadata.FunctionId] = metadataRequestEx;
                     }
 
@@ -810,7 +813,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
         internal async Task InvokeResponse(InvocationResponse invokeResponse)
         {
-            _workerChannelLogger.LogDebug("InvocationResponse received for invocation id: '{invocationId}'", invokeResponse.InvocationId);
+            _workerChannelLogger.LogDebug("InvocationResponse received for invocation: '{invocationId}'", invokeResponse.InvocationId);
+
             // Check if the worker supports logging user-code-thrown exceptions to app insights
             bool capabilityEnabled = !string.IsNullOrEmpty(_workerCapabilities.GetCapabilityState(RpcWorkerConstants.EnableUserCodeException));
 
@@ -840,7 +844,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
                         if (usedSharedMemory)
                         {
-                            _workerChannelLogger.LogDebug("Shared memory usage for response of invocation Id: {Id} is {SharedMemoryUsage}", invokeResponse.InvocationId, logBuilder.ToString());
+                            _workerChannelLogger.LogDebug("Shared memory usage for response of invocation '{invocationId}' is {SharedMemoryUsage}", invokeResponse.InvocationId, logBuilder.ToString());
                         }
 
                         IDictionary<string, object> bindingsDictionary = await invokeResponse.OutputData
@@ -862,7 +866,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                         // Free memory allocated by the host (for input bindings) which was needed only for the duration of this invocation
                         if (!_sharedMemoryManager.TryFreeSharedMemoryMapsForInvocation(invokeResponse.InvocationId))
                         {
-                            _workerChannelLogger.LogWarning($"Cannot free all shared memory resources for invocation: {invokeResponse.InvocationId}");
+                            _workerChannelLogger.LogWarning("Cannot free all shared memory resources for invocation: {invocationId}", invokeResponse.InvocationId);
                         }
 
                         // List of shared memory maps that were produced by the worker (for output bindings)
@@ -1123,7 +1127,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                 GracePeriod = Duration.FromTimeSpan(TimeSpan.FromSeconds(gracePeriod))
             };
 
-            _workerChannelLogger.LogDebug($"Sending WorkerTerminate message with grace period {gracePeriod} seconds.");
+            _workerChannelLogger.LogDebug("Sending WorkerTerminate message with grace period of {gracePeriod} seconds.", gracePeriod);
 
             SendStreamingMessage(new StreamingMessage
             {
@@ -1135,7 +1139,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
         public async Task DrainInvocationsAsync()
         {
-            _workerChannelLogger.LogDebug($"Count of in-buffer invocations waiting to be drained out: {_executingInvocations.Count}");
+            _workerChannelLogger.LogDebug("Count of in-buffer invocations waiting to be drained out: {invocationCount}", _executingInvocations.Count);
             foreach (ScriptInvocationContext currContext in _executingInvocations.Values)
             {
                 await currContext.ResultSource.Task;
@@ -1157,7 +1161,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             foreach (ScriptInvocationContext currContext in _executingInvocations?.Values)
             {
                 string invocationId = currContext?.ExecutionContext?.InvocationId.ToString();
-                _workerChannelLogger.LogDebug("Worker '{workerId}' encountered a fatal error. Failing invocation id: '{invocationId}'", _workerId, invocationId);
+                _workerChannelLogger.LogDebug("Worker '{workerId}' encountered a fatal error. Failing invocation: '{invocationId}'", _workerId, invocationId);
                 currContext?.ResultSource?.TrySetException(workerException);
                 _executingInvocations.TryRemove(invocationId, out ScriptInvocationContext _);
             }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             _workerChannel.Dispose();
             var traces = _logger.GetLogMessages();
-            var expectedLogMsg = $"Sending WorkerTerminate message with grace period {WorkerConstants.WorkerTerminateGracePeriodInSeconds} seconds.";
+            var expectedLogMsg = $"Sending WorkerTerminate message with grace period of {WorkerConstants.WorkerTerminateGracePeriodInSeconds} seconds.";
             Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, expectedLogMsg)));
         }
 
@@ -200,7 +200,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             _workerChannel.Dispose();
             var traces = _logger.GetLogMessages();
-            var expectedLogMsg = $"Sending WorkerTerminate message with grace period {WorkerConstants.WorkerTerminateGracePeriodInSeconds} seconds.";
+            var expectedLogMsg = $"Sending WorkerTerminate message with grace period of {WorkerConstants.WorkerTerminateGracePeriodInSeconds} seconds.";
             Assert.False(traces.Any(m => string.Equals(m.FormattedMessage, expectedLogMsg)));
         }
 
@@ -393,7 +393,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         {
             var cancellationWaitTimeMs = 3000;
             var invocationId = Guid.NewGuid();
-            var expectedCancellationLog = $"Sending invocation cancel request for InvocationId {invocationId.ToString()}";
+            var expectedCancellationLog = $"Sending InvocationCancel request for invocation: '{invocationId.ToString()}'";
 
             var cts = new CancellationTokenSource();
             cts.CancelAfter(cancellationWaitTimeMs);
@@ -450,7 +450,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         {
             var cancellationWaitTimeMs = 3000;
             var invocationId = Guid.NewGuid();
-            var expectedCancellationLog = "Cancellation has been requested, cancelling invocation request";
+            var expectedCancellationLog = $"Cancellation has been requested. The invocation request with id '{invocationId}' is cancelled and will not be sent to the worker.";
 
             var cts = new CancellationTokenSource();
             cts.CancelAfter(cancellationWaitTimeMs);
@@ -479,7 +479,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         public async Task SendInvocationCancelRequest_PublishesOutboundEvent()
         {
             var invocationId = Guid.NewGuid();
-            var expectedCancellationLog = $"Sending invocation cancel request for InvocationId {invocationId.ToString()}";
+            var expectedCancellationLog = $"Sending InvocationCancel request for invocation: '{invocationId.ToString()}'";
 
             await CreateDefaultWorkerChannel(capabilities: new Dictionary<string, string>() { { RpcWorkerConstants.HandlesInvocationCancelMessage, "true" } });
             var scriptInvocationContext = GetTestScriptInvocationContext(invocationId, null);
@@ -499,19 +499,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var resultSource = new TaskCompletionSource<ScriptInvocationResult>();
             Guid invocationId = Guid.NewGuid();
             GrpcWorkerChannel channel = new GrpcWorkerChannel(
-               _workerId,
-               _eventManager,
-               _testWorkerConfig,
-               _mockrpcWorkerProcess.Object,
-               _logger,
-               _metricsLogger,
-               0,
-               _testEnvironment,
-               _hostOptionsMonitor,
-               _sharedMemoryManager,
-               _functionDataCache,
-               _workerConcurrencyOptions,
-               _hostingConfigOptions);
+                                            _workerId,
+                                            _eventManager,
+                                            _testWorkerConfig,
+                                            _mockrpcWorkerProcess.Object,
+                                            _logger,
+                                            _metricsLogger,
+                                            0,
+                                            _testEnvironment,
+                                            _hostOptionsMonitor,
+                                            _sharedMemoryManager,
+                                            _functionDataCache,
+                                            _workerConcurrencyOptions,
+                                            _hostingConfigOptions);
+
             channel.SetupFunctionInvocationBuffers(GetTestFunctionsList("node"));
             ScriptInvocationContext scriptInvocationContext = GetTestScriptInvocationContext(invocationId, resultSource);
             await channel.SendInvocationRequest(scriptInvocationContext);
@@ -585,7 +586,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var functionLoadLogs = traces.Where(m => string.Equals(m.FormattedMessage, _expectedLogMsg));
             AreExpectedMetricsGenerated();
             Assert.Equal(3, functionLoadLogs.Count());
-            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, string.Format("Sending FunctionLoadRequestCollection with number of functions:'{0}'", functionMetadata.ToList().Count))));
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, string.Format("Sending FunctionLoadRequestCollection with number of functions: '{0}'", functionMetadata.ToList().Count))));
         }
 
         [Fact]
@@ -770,14 +771,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         {
             await CreateDefaultWorkerChannel();
             _metricsLogger.ClearCollections();
-            var invocationid = Guid.NewGuid();
-            ScriptInvocationContext scriptInvocationContext = GetTestScriptInvocationContext(invocationid, new TaskCompletionSource<ScriptInvocationResult>());
+            var invocationId = Guid.NewGuid();
+            ScriptInvocationContext scriptInvocationContext = GetTestScriptInvocationContext(invocationId, new TaskCompletionSource<ScriptInvocationResult>());
             await _workerChannel.SendInvocationRequest(scriptInvocationContext);
-            _testFunctionRpcService.PublishInvocationResponseEvent(invocationid.ToString());
+            _testFunctionRpcService.PublishInvocationResponseEvent(invocationId.ToString());
             await Task.Delay(500);
             var testWorkerId = _workerId.ToLowerInvariant();
             var traces = _logger.GetLogMessages();
-            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, $"InvocationResponse received for invocation id: '{invocationid}'")));
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, $"InvocationResponse received for invocation: '{invocationId}'")));
             Assert.Equal(1, _metricsLogger.LoggedEvents.Count(e => e.Contains($"{string.Format(MetricEventNames.WorkerInvoked, testWorkerId)}_{scriptInvocationContext.FunctionMetadata.Name}")));
             Assert.Equal(1, _metricsLogger.LoggedEvents.Count(e => e.Contains(string.Format(MetricEventNames.WorkerInvokeSucceeded, testWorkerId))));
             Assert.Equal(0, _metricsLogger.LoggedEvents.Count(e => e.Contains(string.Format(MetricEventNames.WorkerInvokeFailed, testWorkerId))));
@@ -810,7 +811,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _testFunctionRpcService.PublishInvocationResponseEvent();
             await Task.Delay(500);
             var traces = _logger.GetLogMessages();
-            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "InvocationResponse received for invocation id: 'TestInvocationId'")));
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "InvocationResponse received for invocation: 'TestInvocationId'")));
         }
 
         [Fact]
@@ -865,8 +866,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var traces = _logger.GetLogMessages();
             Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Setting up FunctionInvocationBuffer for function: 'js1' with functionId: 'TestFunctionId1'")), "setup TestFunctionId1");
             Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Setting up FunctionInvocationBuffer for function: 'js2' with functionId: 'TestFunctionId2'")), "setup TestFunctionId2");
-            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Worker failed to load function: 'js1' with function id: 'TestFunctionId1'.")), "fail TestFunctionId1");
-            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Worker failed to load function: 'js2' with function id: 'TestFunctionId2'.")), "fail TestFunctionId2");
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Worker failed to load function: 'js1' with functionId: 'TestFunctionId1'.")), "fail TestFunctionId1");
+            Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, "Worker failed to load function: 'js2' with functionId: 'TestFunctionId2'.")), "fail TestFunctionId2");
         }
 
         [Fact]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #8978

1. Improve log for when we cancel before we send an invocation request to the worker
2. Move the cancellation token callback registration to after we send an invocation message so we don't end up in a scenario where we cancel an invocation before we actually send the invocation to the worker
3. General logging clean up 

Tested with private site extension and works as expected (updated warning log text after test)

<img width="1044" alt="Screenshot 2022-12-19 at 2 21 11 PM" src="https://user-images.githubusercontent.com/2198905/208538715-add3d097-e869-482a-84c4-559d7387eb0d.png">

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
