### PR TITLE
Include also null entries as empty when building InvocationRequest payload for OOP workers

### DIFF
--- a/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
+++ b/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     continue;
                 }
 
-                // Convert null entries to emptyEntry
+                // Convert null entries to emptyEntry because "Add" method doesn't support null (will throw)
                 collectionString.String.Add(element ?? string.Empty);
             }
             typedData.CollectionString = collectionString;

--- a/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
+++ b/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs
@@ -301,19 +301,14 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             CollectionString collectionString = new CollectionString();
             foreach (string element in arrString)
             {
-                // Don't add null entries.("Add" method below will throw)
-                if (element is null)
+                // Empty string/null entries are okay to add based on includeEmptyEntries param value.
+                if (string.IsNullOrEmpty(element) && !includeEmptyEntries)
                 {
                     continue;
                 }
 
-                // Empty string entries are okay to add based on includeEmptyEntries param value.
-                if (element == string.Empty && !includeEmptyEntries)
-                {
-                    continue;
-                }
-
-                collectionString.String.Add(element);
+                // Convert null entries to emptyEntry
+                collectionString.String.Add(element ?? string.Empty);
             }
             typedData.CollectionString = collectionString;
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcMessageConversionExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcMessageConversionExtensionsTests.cs
@@ -503,7 +503,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
-        public async Task ToRpc_Collection_String_IncludeEmptyEntries_When_Capability_Is_Present()
+        public async Task ToRpc_Collection_String_IncludeEmptyAndNullEntries_When_Capability_Is_Present()
         {
             var logger = MockNullLoggerFactory.CreateLogger();
             var capabilities = new GrpcCapabilities(logger);
@@ -516,7 +516,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             string[] arrString = { "element1", string.Empty, "element_2", null };
             TypedData actual = await arrString.ToRpc(logger, capabilities);
 
-            var expected = new RepeatedField<string> { "element1", string.Empty, "element_2" }; // null entry should be still skipped
+            var expected = new RepeatedField<string> { "element1", string.Empty, "element_2", string.Empty }; // null entry should be converted to string.Empty because collection doesn't support null's
             Assert.Equal(expected, actual.CollectionString.String);
         }
 


### PR DESCRIPTION
This PR brings in the commits made by external contributor in #8926.  Currently our CI won't build from external forks. So I created this PR, cherry picking his commits.

This is a safe change because customers/worker needs to explicitly opt-in to this behavior by providing this capability (which we recently introduced to fix the issue @wesselkranenborg  [reported originally](https://github.com/Azure/azure-functions-dotnet-worker/issues/876)). Currently only dotnet worker is sending this capability (only when customer specify this behavior via worker options in [bootstrapping time](https://github.com/Azure/azure-functions-dotnet-worker/issues/876#issuecomment-1276646202))