### PR TITLE
Add SignalR heartbeat as an approved service

### DIFF
--- a/src/WebJobs.Script.WebHost/DependencyInjection/DependencyValidator/DependencyValidator.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/DependencyValidator/DependencyValidator.cs
@@ -56,7 +56,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
                 .OptionalExternal("Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherHostedService", "Microsoft.Extensions.Diagnostics.HealthChecks", "adb9793829ddae60") // Popularly-registered by Health Check Monitor.
                 .OptionalExternal("OpenTelemetry.Extensions.Hosting.Implementation.TelemetryHostedService", "OpenTelemetry.Extensions.Hosting", "7bd6737fe5b67e3c") // Enable OpenTelemetry.Net instrumentation library
                 .OptionalExternal("Microsoft.Azure.WebJobs.Hosting.PrimaryHostCoordinator", "Microsoft.Azure.WebJobs.Host", "31bf3856ad364e35")
-                .OptionalExternal("Microsoft.Azure.WebJobs.Host.Scale.ConcurrencyManagerService", "Microsoft.Azure.WebJobs.Host", "31bf3856ad364e35");
+                .OptionalExternal("Microsoft.Azure.WebJobs.Host.Scale.ConcurrencyManagerService", "Microsoft.Azure.WebJobs.Host", "31bf3856ad364e35")
+                .OptionalExternal("Microsoft.Azure.SignalR.HeartBeat", "Microsoft.Azure.SignalR", "adb9793829ddae60");
 
             expected.ExpectSubcollection<ILoggerProvider>()
                 .Expect<FunctionFileLoggerProvider>()


### PR DESCRIPTION
### Issue describing the changes in this PR

I haven't created an issue for this Pull Request, but the problem it is solving is that when you register Azure SignalR service to use in your own code (rather than what is passed in as a function) you receive an error both in the local emulator and the Functions runtime indicating that the Heartbeat service is not permitted.

```
Invalid host services. Microsoft.Azure.WebJobs.Script.WebHost: The following service registrations did not match the expected services:
[Invalid] ServiceType: Microsoft.Extensions.Hosting.IHostedService, Lifetime: Singleton, ImplementationType: Microsoft.Azure.SignalR.HeartBeat, Microsoft.Azure.SignalR, Version = 1.19.2.0, Culture = neutral, PublicKeyToken = adb9793829ddae60.
```

This change adds that class to the approved list.

### Pull request checklist

I don't know if this is a big enough change to be included in the release notes, or if it needs a specific test (it's akin to a configuration change as far as I can see).

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [?] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [?] I have added all required tests (Unit tests, E2E tests)
