### PR TITLE
Delete log message that prints argument list

### DIFF
--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 }
             }
 
-            logger.LogDebug($"Worker description arguments after formatting: {Arguments}");
+            logger.LogDebug($"Worker description arguments after formatting: {string.Join(" ", Arguments)} ");
         }
 
         internal bool ShouldFormatWorkerPath(string workerPath)

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
@@ -217,8 +217,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     Arguments[i] = Arguments[i].Replace(RpcWorkerConstants.WorkerDirectoryPath, WorkerDirectory);
                 }
             }
-
-            logger.LogDebug($"Worker description arguments after formatting: {string.Join(" ", Arguments)} ");
         }
 
         internal bool ShouldFormatWorkerPath(string workerPath)


### PR DESCRIPTION
### Delete log message that prints argument list

Argument list can be found when worker process is started.
![image](https://user-images.githubusercontent.com/11889130/213310553-c1e58563-fee3-4297-ac8f-988c3c944b72.png)

resolves #8929

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

