### PR TITLE
Worker code path warmup

### DIFF
--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -14,6 +14,7 @@ using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
+using Azure.Core;
 using Google.Protobuf.Collections;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Azure.WebJobs.Logging;
@@ -526,6 +527,23 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             SendStreamingMessage(new StreamingMessage
             {
                 FunctionEnvironmentReloadRequest = request
+            });
+
+            return _reloadTask.Task;
+        }
+
+        public Task SendWorkerWarmupRequest()
+        {
+            _workerChannelLogger.LogDebug("Sending WorkerWarmupRequest to WorkerProcess with Pid: '{0}'", _rpcWorkerProcess.Id);
+
+            WorkerWarmupRequest request = new WorkerWarmupRequest()
+            {
+                WorkerDirectory = _workerConfig.Description.WorkerDirectory,
+            };
+
+            SendStreamingMessage(new StreamingMessage
+            {
+                WorkerWarmupRequest = request
             });
 
             return _reloadTask.Task;

--- a/src/WebJobs.Script.WebHost/Middleware/HostWarmupMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/HostWarmupMiddleware.cs
@@ -2,16 +2,17 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Extensions;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Diagnostics.JitTrace;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
@@ -19,6 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
     public class HostWarmupMiddleware
     {
         private readonly IWebHostRpcWorkerChannelManager _webHostRpcWorkerChannelManager;
+        private readonly IOptions<FunctionsHostingConfigOptions> _hostingConfigOptions;
         private readonly RequestDelegate _next;
         private readonly IScriptWebHostEnvironment _webHostEnvironment;
         private readonly IEnvironment _environment;
@@ -30,7 +32,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
         private static readonly PathString _warmupRoutePath = new PathString($"/api/{WarmUpConstants.FunctionName}");
         private static readonly PathString _warmupRouteAlternatePath = new PathString($"/api/{WarmUpConstants.AlternateRoute}");
 
-        public HostWarmupMiddleware(RequestDelegate next, IScriptWebHostEnvironment webHostEnvironment, IEnvironment environment, IScriptHostManager hostManager, ILogger<HostWarmupMiddleware> logger, IWebHostRpcWorkerChannelManager rpcWorkerChannelManager)
+        public HostWarmupMiddleware(
+            RequestDelegate next,
+            IScriptWebHostEnvironment webHostEnvironment,
+            IEnvironment environment,
+            IScriptHostManager hostManager,
+            ILogger<HostWarmupMiddleware> logger,
+            IWebHostRpcWorkerChannelManager rpcWorkerChannelManager,
+            IOptions<FunctionsHostingConfigOptions> hostingConfigOptions)
         {
             _next = next;
             _webHostEnvironment = webHostEnvironment;
@@ -39,6 +48,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
             _logger = logger;
             _assemblyLocalPath = Path.GetDirectoryName(new Uri(typeof(HostWarmupMiddleware).Assembly.Location).LocalPath);
             _webHostRpcWorkerChannelManager = rpcWorkerChannelManager ?? throw new ArgumentNullException(nameof(rpcWorkerChannelManager));
+            _hostingConfigOptions = hostingConfigOptions;
         }
 
         public Task Invoke(HttpContext httpContext)
@@ -69,16 +79,19 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
 
             ReadRuntimeAssemblyFiles();
 
-            SendWorkerWarmupRequest();
+            WorkerWarmup();
 
             await WarmUp(httpContext.Request);
 
             await _next.Invoke(httpContext);
         }
 
-        private async void SendWorkerWarmupRequest()
+        private async void WorkerWarmup()
         {
-            await _webHostRpcWorkerChannelManager.SendWorkerWarmupRequest();
+            if (_hostingConfigOptions.Value.WorkerWarmupEnabled)
+            {
+                await _webHostRpcWorkerChannelManager.WorkerWarmup();
+            }
         }
 
         internal void ReadRuntimeAssemblyFiles()

--- a/src/WebJobs.Script.WebHost/Middleware/HostWarmupMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/HostWarmupMiddleware.cs
@@ -90,7 +90,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
         {
             if (_hostingConfigOptions.Value.WorkerWarmupEnabled)
             {
-                _logger.LogDebug("Worker warmup hosting configuration is enabled");
                 await _webHostRpcWorkerChannelManager.WorkerWarmup();
             }
         }

--- a/src/WebJobs.Script.WebHost/Middleware/HostWarmupMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/HostWarmupMiddleware.cs
@@ -79,17 +79,18 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
 
             ReadRuntimeAssemblyFiles();
 
-            WorkerWarmup();
+            await WorkerWarmup();
 
-            await WarmUp(httpContext.Request);
+            await HostWarmUp(httpContext.Request);
 
             await _next.Invoke(httpContext);
         }
 
-        private async void WorkerWarmup()
+        private async Task WorkerWarmup()
         {
             if (_hostingConfigOptions.Value.WorkerWarmupEnabled)
             {
+                _logger.LogDebug("Worker warmup hosting configuration is enabled");
                 await _webHostRpcWorkerChannelManager.WorkerWarmup();
             }
         }
@@ -157,7 +158,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
             }
         }
 
-        public async Task WarmUp(HttpRequest request)
+        public async Task HostWarmUp(HttpRequest request)
         {
             if (request.Query.TryGetValue("restart", out StringValues value) && string.Compare("1", value) == 0)
             {

--- a/src/WebJobs.Script.WebHost/Middleware/HostWarmupMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/HostWarmupMiddleware.cs
@@ -79,9 +79,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
 
             ReadRuntimeAssemblyFiles();
 
-            await WorkerWarmup();
+            await HostWarmup(httpContext.Request);
 
-            await HostWarmUp(httpContext.Request);
+            await WorkerWarmup();
 
             await _next.Invoke(httpContext);
         }
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
             }
         }
 
-        public async Task HostWarmUp(HttpRequest request)
+        public async Task HostWarmup(HttpRequest request)
         {
             if (request.Query.TryGetValue("restart", out StringValues value) && string.Compare("1", value) == 0)
             {

--- a/src/WebJobs.Script.WebHost/Middleware/HostWarmupMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/HostWarmupMiddleware.cs
@@ -79,18 +79,18 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
 
             ReadRuntimeAssemblyFiles();
 
-            await HostWarmup(httpContext.Request);
+            await HostWarmupAsync(httpContext.Request);
 
-            await WorkerWarmup();
+            await WorkerWarmupAsync();
 
             await _next.Invoke(httpContext);
         }
 
-        private async Task WorkerWarmup()
+        private async Task WorkerWarmupAsync()
         {
             if (_hostingConfigOptions.Value.WorkerWarmupEnabled)
             {
-                await _webHostRpcWorkerChannelManager.WorkerWarmup();
+                await _webHostRpcWorkerChannelManager.WorkerWarmupAsync();
             }
         }
 
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
             }
         }
 
-        public async Task HostWarmup(HttpRequest request)
+        public async Task HostWarmupAsync(HttpRequest request)
         {
             if (request.Query.TryGetValue("restart", out StringValues value) && string.Compare("1", value) == 0)
             {

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -32,6 +32,17 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         }
 
         /// <summary>
+        /// Gets a value indicating whether language workers warmup feature is enabled in the hosting config.
+        /// </summary>
+        public bool WorkerWarmupEnabled
+        {
+            get
+            {
+                return GetFeature(RpcWorkerConstants.WorkerWarmupEnabled) == "1";
+            }
+        }
+
+        /// <summary>
         /// Gets feature by name.
         /// </summary>
         /// <param name="name">Feature name.</param>

--- a/src/WebJobs.Script/Workers/Rpc/IRpcWorkerChannel.cs
+++ b/src/WebJobs.Script/Workers/Rpc/IRpcWorkerChannel.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         Task SendFunctionEnvironmentReloadRequest();
 
-        Task SendWorkerWarmupRequest();
+        void SendWorkerWarmupRequest();
 
         Task<List<RawFunctionMetadata>> GetFunctionMetadata();
 

--- a/src/WebJobs.Script/Workers/Rpc/IRpcWorkerChannel.cs
+++ b/src/WebJobs.Script/Workers/Rpc/IRpcWorkerChannel.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         Task SendFunctionEnvironmentReloadRequest();
 
+        Task SendWorkerWarmupRequest();
+
         Task<List<RawFunctionMetadata>> GetFunctionMetadata();
 
         Task DrainInvocationsAsync();

--- a/src/WebJobs.Script/Workers/Rpc/IWebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/IWebHostRpcWorkerChannelManager.cs
@@ -19,6 +19,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         Task ShutdownChannelsAsync();
 
-        Task SendWorkerWarmupRequest();
+        Task WorkerWarmup();
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/IWebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/IWebHostRpcWorkerChannelManager.cs
@@ -19,6 +19,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         Task ShutdownChannelsAsync();
 
-        Task WorkerWarmup();
+        Task WorkerWarmupAsync();
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/IWebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/IWebHostRpcWorkerChannelManager.cs
@@ -18,5 +18,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         Task<bool> ShutdownChannelIfExistsAsync(string language, string workerId, Exception workerException);
 
         Task ShutdownChannelsAsync();
+
+        Task SendWorkerWarmupRequest();
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
@@ -73,5 +73,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public const string PythonThreadpoolThreadCount = "PYTHON_THREADPOOL_THREAD_COUNT";
         public const string PSWorkerInProcConcurrencyUpperBound = "PSWorkerInProcConcurrencyUpperBound";
         public const string DefaultConcurrencyLimit = "1000";
+
+        // Language worker warmup
+        public const string WorkerWarmupEnabled = "WORKER_WARMUP_ENABLED";
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public const string SupportsLoadResponseCollection = "SupportsLoadResponseCollection";
         public const string HandlesWorkerTerminateMessage = "HandlesWorkerTerminateMessage";
         public const string HandlesInvocationCancelMessage = "HandlesInvocationCancelMessage";
+        public const string HandlesWorkerWarmupMessage = "HandlesWorkerWarmupMessage";
         public const string WorkerApplicationInsightsLoggingEnabled = nameof(WorkerApplicationInsightsLoggingEnabled);
 
         /// <summary>

--- a/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -152,7 +152,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             IRpcWorkerChannel rpcWorkerChannel = await GetChannelAsync(_workerRuntime);
             if (rpcWorkerChannel != null)
             {
-                _logger.LogDebug("Starting worker warmup");
                 rpcWorkerChannel.SendWorkerWarmupRequest();
             }
         }

--- a/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -144,16 +144,16 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         {
             _workerRuntime = _environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName);
 
-            if (_workerRuntime != null)
+            if (_workerRuntime == null)
             {
-                IRpcWorkerChannel rpcWorkerChannel = await GetChannelAsync(_workerRuntime);
+                return;
+            }
 
-                if (rpcWorkerChannel != null)
-                {
-                    _logger.LogDebug("Starting worker warmup");
-                    await rpcWorkerChannel.SendWorkerWarmupRequest();
-                    _logger.LogDebug("Completed worker warmup");
-                }
+            IRpcWorkerChannel rpcWorkerChannel = await GetChannelAsync(_workerRuntime);
+            if (rpcWorkerChannel != null)
+            {
+                _logger.LogDebug("Starting worker warmup");
+                rpcWorkerChannel.SendWorkerWarmupRequest();
             }
         }
 

--- a/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             _logger.LogDebug("Completed language worker channel specialization");
         }
 
-        public async Task SendWorkerWarmupRequest()
+        public async Task WorkerWarmup()
         {
             _logger.LogInformation("Starting Worker warmup");
             _workerRuntime = _environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName);

--- a/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -140,6 +140,20 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             _logger.LogDebug("Completed language worker channel specialization");
         }
 
+        public async Task SendWorkerWarmupRequest()
+        {
+            _logger.LogInformation("Starting Worker warmup");
+            _workerRuntime = _environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName);
+
+            IRpcWorkerChannel rpcWorkerChannel = await GetChannelAsync(_workerRuntime);
+
+            if (_workerRuntime != null && rpcWorkerChannel != null)
+            {
+                await rpcWorkerChannel.SendWorkerWarmupRequest();
+            }
+            _logger.LogDebug("Completed Worker warmup");
+        }
+
         private bool UsePlaceholderChannel(string workerRuntime)
         {
             if (string.IsNullOrEmpty(workerRuntime))

--- a/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -142,16 +142,19 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         public async Task WorkerWarmup()
         {
-            _logger.LogInformation("Starting Worker warmup");
             _workerRuntime = _environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName);
 
-            IRpcWorkerChannel rpcWorkerChannel = await GetChannelAsync(_workerRuntime);
-
-            if (_workerRuntime != null && rpcWorkerChannel != null)
+            if (_workerRuntime != null)
             {
-                await rpcWorkerChannel.SendWorkerWarmupRequest();
+                IRpcWorkerChannel rpcWorkerChannel = await GetChannelAsync(_workerRuntime);
+
+                if (rpcWorkerChannel != null)
+                {
+                    _logger.LogDebug("Starting worker warmup");
+                    await rpcWorkerChannel.SendWorkerWarmupRequest();
+                    _logger.LogDebug("Completed worker warmup");
+                }
             }
-            _logger.LogDebug("Completed Worker warmup");
         }
 
         private bool UsePlaceholderChannel(string workerRuntime)

--- a/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             _logger.LogDebug("Completed language worker channel specialization");
         }
 
-        public async Task WorkerWarmup()
+        public async Task WorkerWarmupAsync()
         {
             _workerRuntime = _environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName);
 

--- a/test/WebJobs.Script.Tests/Middleware/HostWarmupMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Middleware/HostWarmupMiddlewareTests.cs
@@ -1,18 +1,90 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Linq;
+using Castle.Core.Logging;
+using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.Grpc;
+using Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Middleware;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Azure.WebJobs.Script.Workers.Profiles;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client;
 using Microsoft.WebJobs.Script.Tests;
 using Moq;
 using Xunit;
+using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
 {
     public class HostWarmupMiddlewareTests
     {
+        private readonly IScriptEventManager _eventManager;
+        private readonly IEnvironment _testEnvironment;
+        private readonly IRpcServer _rpcServer;
+        private readonly TestLoggerProvider _loggerProvider;
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly LanguageWorkerOptions _languageWorkerOptions;
+        private readonly Mock<IRpcWorkerProcessFactory> _rpcWorkerProcessFactory;
+        private readonly IRpcWorkerChannelFactory _rpcWorkerChannelFactory;
+        private readonly IOptionsMonitor<ScriptApplicationHostOptions> _optionsMonitor;
+        private readonly IOptionsMonitor<LanguageWorkerOptions> _workerOptionsMonitor;
+        private readonly Mock<IWorkerProcess> _rpcWorkerProcess;
+        private readonly TestLogger _testLogger;
+        private readonly IConfiguration _emptyConfig;
+        private readonly TestSystemRuntimeInformation _testSysRuntimeInfo = new TestSystemRuntimeInformation();
+
+        private WebHostRpcWorkerChannelManager _rpcWorkerChannelManager;
+        private IWorkerProfileManager _workerProfileManager;
+
+        private string _scriptRootPath = @"c:\testing\FUNCTIONS-TEST";
+        private IDictionary<string, string> _capabilities = new Dictionary<string, string>()
+            {
+                { "StandbyModeEnabled", "true" }
+            };
+
+        public HostWarmupMiddlewareTests()
+        {
+            _eventManager = new ScriptEventManager();
+            _rpcServer = new TestRpcServer();
+            _loggerProvider = new TestLoggerProvider();
+            _loggerFactory = new LoggerFactory();
+            _testEnvironment = new TestEnvironment();
+            _loggerFactory.AddProvider(_loggerProvider);
+            _rpcWorkerProcess = new Mock<IWorkerProcess>();
+            _languageWorkerOptions = new LanguageWorkerOptions
+            {
+                WorkerConfigs = TestHelpers.GetTestWorkerConfigs()
+            };
+
+            var workerProfileLogger = new TestLogger<WorkerProfileManager>();
+            _workerProfileManager = new WorkerProfileManager(workerProfileLogger, _testEnvironment);
+
+            var applicationHostOptions = new ScriptApplicationHostOptions
+            {
+                IsSelfHost = true,
+                ScriptPath = @"c:\testing\FUNCTIONS-TEST\test$#"
+            };
+
+            _optionsMonitor = TestHelpers.CreateOptionsMonitor(applicationHostOptions);
+
+            _workerOptionsMonitor = TestHelpers.CreateOptionsMonitor(_languageWorkerOptions);
+
+            _rpcWorkerProcessFactory = new Mock<IRpcWorkerProcessFactory>();
+            _rpcWorkerProcessFactory.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RpcWorkerConfig>())).Returns(_rpcWorkerProcess.Object);
+
+            _testLogger = new TestLogger("WebHostLanguageWorkerChannelManagerTests");
+            _rpcWorkerChannelFactory = new TestRpcWorkerChannelFactory(_eventManager, _testLogger, _scriptRootPath);
+            _emptyConfig = new ConfigurationBuilder().Build();
+            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, new TestMetricsLogger(), _workerOptionsMonitor, _emptyConfig, _workerProfileManager);
+        }
+
         [Fact]
         public void IsWarmUpRequest_ReturnsExpectedValue()
         {
@@ -81,7 +153,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
             TestLoggerProvider testLoggerProvider = new TestLoggerProvider();
             testLoggerFactory.AddProvider(testLoggerProvider);
             ILogger<HostWarmupMiddleware> testLogger = testLoggerFactory.CreateLogger<HostWarmupMiddleware>();
-            HostWarmupMiddleware hostWarmupMiddleware = new HostWarmupMiddleware(null, new Mock<IScriptWebHostEnvironment>().Object, environment, new Mock<IScriptHostManager>().Object, testLogger);
+
+            WebHostRpcWorkerChannelManager rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, environment, testLoggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, new TestMetricsLogger(), _workerOptionsMonitor, _emptyConfig, _workerProfileManager);
+            HostWarmupMiddleware hostWarmupMiddleware = new HostWarmupMiddleware(null, new Mock<IScriptWebHostEnvironment>().Object, environment, new Mock<IScriptHostManager>().Object, testLogger, rpcWorkerChannelManager);
+
             hostWarmupMiddleware.ReadRuntimeAssemblyFiles();
             // Assert
             var traces = testLoggerProvider.GetAllLogMessages();

--- a/test/WebJobs.Script.Tests/Middleware/HostWarmupMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Middleware/HostWarmupMiddlewareTests.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc;
@@ -27,9 +24,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
     {
         private readonly IScriptEventManager _eventManager;
         private readonly IEnvironment _testEnvironment;
-        private readonly IRpcServer _rpcServer;
         private readonly TestLoggerProvider _loggerProvider;
-        private readonly Microsoft.Extensions.Logging.ILoggerFactory _loggerFactory;
+        private readonly ILoggerFactory _loggerFactory;
         private readonly LanguageWorkerOptions _languageWorkerOptions;
         private readonly Mock<IRpcWorkerProcessFactory> _rpcWorkerProcessFactory;
         private readonly IRpcWorkerChannelFactory _rpcWorkerChannelFactory;
@@ -38,7 +34,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
         private readonly Mock<IWorkerProcess> _rpcWorkerProcess;
         private readonly TestLogger _testLogger;
         private readonly IConfiguration _emptyConfig;
-        private readonly TestSystemRuntimeInformation _testSysRuntimeInfo = new TestSystemRuntimeInformation();
 
         private WebHostRpcWorkerChannelManager _rpcWorkerChannelManager;
         private IWorkerProfileManager _workerProfileManager;
@@ -55,7 +50,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
         {
             _functionsHostingConfigOptions = Options.Create(new FunctionsHostingConfigOptions());
             _eventManager = new ScriptEventManager();
-            _rpcServer = new TestRpcServer();
             _loggerProvider = new TestLoggerProvider();
             _loggerFactory = new LoggerFactory();
             _testEnvironment = new TestEnvironment();
@@ -164,47 +158,5 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
             var traces = testLoggerProvider.GetAllLogMessages();
             Assert.True(traces.Any(m => m.FormattedMessage.Contains("Number of files read:")));
         }
-
-        //[Fact]
-        //public async void WorkerWarmup_VerifyLogs()
-        //{
-        //    var environment = new TestEnvironment();
-        //    environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
-        //    environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, "12345");
-        //    environment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, "java");
-
-        //    var hostEnvironment = new ScriptWebHostEnvironment(environment);
-        //    var testLoggerFactory = new LoggerFactory();
-        //    TestLoggerProvider testLoggerProvider = new TestLoggerProvider();
-        //    testLoggerFactory.AddProvider(testLoggerProvider);
-        //    ILogger<HostWarmupMiddleware> testLogger = testLoggerFactory.CreateLogger<HostWarmupMiddleware>();
-
-        //    _functionsHostingConfigOptions.Value.Features[RpcWorkerConstants.WorkerWarmupEnabled] = "1";
-        //    HostWarmupMiddleware hostWarmupMiddleware = new HostWarmupMiddleware(null, hostEnvironment, environment, new Mock<IScriptHostManager>().Object, testLogger, _rpcWorkerChannelManager, _functionsHostingConfigOptions);
-
-        //    string requestId = Guid.NewGuid().ToString();
-        //    var context = new DefaultHttpContext();
-        //    Uri uri = new Uri("http://azure.com/api/warmup");
-        //    var requestFeature = context.Request.HttpContext.Features.Get<IHttpRequestFeature>();
-        //    requestFeature.Method = "POST";
-        //    requestFeature.Scheme = uri.Scheme;
-        //    requestFeature.Path = uri.GetComponents(UriComponents.KeepDelimiter | UriComponents.Path, UriFormat.Unescaped);
-        //    requestFeature.PathBase = string.Empty;
-        //    requestFeature.QueryString = uri.GetComponents(UriComponents.KeepDelimiter | UriComponents.Query, UriFormat.Unescaped);
-
-        //    var headers = new HeaderDictionary();
-
-        //    if (!string.IsNullOrEmpty(uri.Host))
-        //    {
-        //        headers.Add("Host", uri.Host);
-        //    }
-
-        //    requestFeature.Headers = headers;
-
-        //    await hostWarmupMiddleware.Invoke(context);
-
-        //    var traces = testLoggerProvider.GetAllLogMessages();
-        //    Assert.True(traces.Any(m => m.FormattedMessage.Contains("Completed Worker warmup")));
-        //}
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannel.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannel.cs
@@ -162,5 +162,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         {
             return null;
         }
+
+        public Task SendWorkerWarmupRequest()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannel.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannel.cs
@@ -163,10 +163,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             return null;
         }
 
-        public Task SendWorkerWarmupRequest()
+        public void SendWorkerWarmupRequest()
         {
             _testLogger.LogInformation("SendWorkerWarmupRequest called");
-            return Task.CompletedTask;
+            return;
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannel.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannel.cs
@@ -165,7 +165,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
         public Task SendWorkerWarmupRequest()
         {
-            throw new NotImplementedException();
+            _testLogger.LogInformation("SendWorkerWarmupRequest called");
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannelManager.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannelManager.cs
@@ -143,5 +143,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 }
             }
         }
+
+        public Task SendWorkerWarmupRequest()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannelManager.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannelManager.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             }
         }
 
-        public Task SendWorkerWarmupRequest()
+        public Task WorkerWarmup()
         {
             throw new NotImplementedException();
         }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannelManager.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannelManager.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             }
         }
 
-        public Task WorkerWarmup()
+        public Task WorkerWarmupAsync()
         {
             throw new NotImplementedException();
         }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
@@ -419,6 +419,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.Contains("Process startup failed", ex.InnerException.Message);
         }
 
+        [Fact]
+        public async void WorkerWarmup_VerifyLogs()
+        {
+            var testMetricsLogger = new TestMetricsLogger();
+            _testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, RpcWorkerConstants.JavaLanguageWorkerName);
+            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, testMetricsLogger, _workerOptionsMonitor, _emptyConfig, _workerProfileManager);
+
+            IRpcWorkerChannel javaWorkerChannel = CreateTestChannel(RpcWorkerConstants.JavaLanguageWorkerName);
+
+            await _rpcWorkerChannelManager.WorkerWarmup();
+
+            // Verify logs
+            var traces = _testLogger.GetLogMessages();
+            var functionLoadLogs = traces.Where(m => string.Equals(m.FormattedMessage, "SendWorkerWarmupRequest called"));
+            Assert.True(functionLoadLogs.Count() == 1);
+        }
+
         private bool AreRequiredMetricsEmitted(TestMetricsLogger metricsLogger)
         {
             bool hasBegun = false;

--- a/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
@@ -428,7 +428,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             IRpcWorkerChannel javaWorkerChannel = CreateTestChannel(RpcWorkerConstants.JavaLanguageWorkerName);
 
-            await _rpcWorkerChannelManager.WorkerWarmup();
+            await _rpcWorkerChannelManager.WorkerWarmupAsync();
 
             // Verify logs
             var traces = _testLogger.GetLogMessages();


### PR DESCRIPTION
### Worker code path warmup

Use the HostWarmupMiddleware to send the WorkerWarmupRequest to warm up the worker code path before specialization. 

PR for protobuf changes: https://github.com/Azure/azure-functions-language-worker-protobuf/pull/84

- [Design doc](https://dev.azure.com/msazure/One/_git/AAPT-Antares-Docs/pullrequest/7030389?_a=files)
- [Draft host changes](https://github.com/Azure/azure-functions-host/pull/9018/files)
- [Draft Java worker changes](https://github.com/Azure/azure-functions-java-worker/pull/672/files)


### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [x] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)
