### PR TITLE
Update capabilities and log worker metadata after specialization

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -17,4 +17,5 @@
 **Release sprint:** Sprint 132
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+132%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+132%22+label%3Afeature+is%3Aclosed) ]
 - Update App Service Authentication/Authorization on Linux Consumption from 1.4.17 to 1.5.1 [Release Note](https://github.com/Azure/app-service-announcements/issues/406)
+- Upgraded proto files to v1.7.1-protofile release (#9023)
 - Refresh capabilities & log worker metadata after specialization (#9020)

--- a/release_notes.md
+++ b/release_notes.md
@@ -17,3 +17,4 @@
 **Release sprint:** Sprint 132
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+132%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+132%22+label%3Afeature+is%3Aclosed) ]
 - Update App Service Authentication/Authorization on Linux Consumption from 1.4.17 to 1.5.1 [Release Note](https://github.com/Azure/app-service-announcements/issues/406)
+- Refresh capabilities & log worker metadata after specialization (#9020)

--- a/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageExtensionUtilities.cs
+++ b/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageExtensionUtilities.cs
@@ -78,12 +78,12 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             return new Tuple<string, string, CookieOptions>(cookie.Name, cookie.Value, cookieOptions);
         }
 
-        internal static void UpdateWorkerMetadata(this WorkerInitResponse initResponse, RpcWorkerConfig workerConfig)
+        internal static void UpdateWorkerMetadata(this WorkerMetadata workerMetadata, RpcWorkerConfig workerConfig)
         {
-            initResponse.WorkerMetadata.RuntimeName = string.IsNullOrEmpty(initResponse.WorkerMetadata.RuntimeName)
-                                            ? workerConfig.Description.Language : initResponse.WorkerMetadata.RuntimeName;
-            initResponse.WorkerMetadata.RuntimeVersion = string.IsNullOrEmpty(initResponse.WorkerMetadata.RuntimeVersion)
-                                            ? workerConfig.Description.DefaultRuntimeVersion : initResponse.WorkerMetadata.RuntimeVersion;
+            workerMetadata.RuntimeName = string.IsNullOrEmpty(workerMetadata.RuntimeName)
+                                            ? workerConfig.Description.Language : workerMetadata.RuntimeName;
+            workerMetadata.RuntimeVersion = string.IsNullOrEmpty(workerMetadata.RuntimeVersion)
+                                            ? workerConfig.Description.DefaultRuntimeVersion : workerMetadata.RuntimeVersion;
         }
 
         private static SameSiteMode RpcSameSiteEnumConverter(RpcHttpCookie.Types.SameSite sameSite)


### PR DESCRIPTION
This is a second set of changes on host side to address https://github.com/Azure/azure-functions-host/issues/8983. This changes follows the proto file changes made in https://github.com/Azure/azure-functions-language-worker-protobuf/pull/90

In placeholder & specialization use case, the worker metadata and capabilities are available only after specialization (env reload response). In this PR, Updating the code path which handles env reload request to refresh the capabilities and log the worker metadata. 



### Pull request checklist

* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [X] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information


