### PR TITLE
Skip deferred binding for CosmosDB trigger

### DIFF
--- a/src/WebJobs.Script/Description/Workers/WorkerFunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/Workers/WorkerFunctionDescriptorProvider.cs
@@ -65,11 +65,15 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         {
             var bindings = inputBindings.Union(outputBindings);
 
-            // If an input or output binding uses expressions, we do not want to use ParameterBindingData for the trigger bindings
             if (triggerMetadata.SupportsDeferredBinding())
             {
-                bool skipDeferredBinding = BindingAttributeContainsExpression(bindings);
-                if (skipDeferredBinding)
+                // If an input or output binding uses expressions, we do not want to use ParameterBindingData for the trigger bindings
+                bool containsExpression = BindingAttributeContainsExpression(bindings);
+
+                // If the trigger is a CosmosDBTrigger, we do not want to use ParameterBindingData as it is not supported
+                bool isCosmosTrigger = IsCosmosDBTrigger(triggerMetadata);
+
+                if (containsExpression || isCosmosTrigger)
                 {
                     triggerMetadata.Properties.Add(ScriptConstants.SkipDeferredBindingKey, true);
                 }
@@ -134,6 +138,11 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
 
             return false;
+        }
+
+        internal bool IsCosmosDBTrigger(BindingMetadata triggerMetadata)
+        {
+            return triggerMetadata.Type == "cosmosDBTrigger" ? true : false;
         }
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #9026

With the way the cosmos db sdk is implemented it is not possible to use ParameterBindingData/DeferredBinding for cosmos DB triggers with out-of-proc workers. We need to make sure we continue to handle triggers the same way we do today, hence the skipDeferredBinding flag.

See this [issue](https://github.com/Azure/azure-webjobs-sdk-extensions/issues/800) discussion for reference.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

