### PR TITLE
Added telemetry to indicate when ParameterBindingData is being used

### DIFF
--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -674,7 +674,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
                 foreach ((string, DataType, object) element in context.Inputs)
                 {
-                    if (element.Item3.GetType() == typeof(ParameterBindingData))
+                    if (element.Item3.GetType() == typeof(ParameterBindingData) || element.Item3.GetType() == typeof(ParameterBindingData[]))
                     {
                         _workerChannelLogger.LogInformation($"Binding to ParameterBindingData:{element}");
                         _metricsLogger.LogEvent(string.Format(MetricEventNames.BindToParameterBindingData, context.FunctionMetadata.Name, element.Item1));

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -672,6 +672,15 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     return;
                 }
 
+                foreach ((string, DataType, object) element in context.Inputs)
+                {
+                    if (element.Item3.GetType() == typeof(ParameterBindingData))
+                    {
+                        _workerChannelLogger.LogInformation($"Binding to ParameterBindingData:{element}");
+                        _metricsLogger.LogEvent(string.Format(MetricEventNames.BindToParameterBindingData, context.FunctionMetadata.Name, element.Item1));
+                    }
+                }
+
                 var invocationRequest = await context.ToRpcInvocationRequest(_workerChannelLogger, _workerCapabilities, _isSharedMemoryDataTransferEnabled, _sharedMemoryManager);
                 AddAdditionalTraceContext(invocationRequest.TraceContext.Attributes, context);
                 _executingInvocations.TryAdd(invocationRequest.InvocationId, context);

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -594,7 +594,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
                 if (binding.SupportsDeferredBinding() && !binding.SkipDeferredBinding())
                 {
-                    _metricsLogger.LogEvent(string.Format(MetricEventNames.BindToParameterBindingData, metadata.Name));
+                    _metricsLogger.LogEvent(MetricEventNames.FunctionBindingDeferred);
                 }
             }
 

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -676,8 +676,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                 {
                     if (element.Item3.GetType() == typeof(ParameterBindingData) || element.Item3.GetType() == typeof(ParameterBindingData[]))
                     {
-                        _workerChannelLogger.LogInformation($"Binding to ParameterBindingData:{element}");
-                        _metricsLogger.LogEvent(string.Format(MetricEventNames.BindToParameterBindingData, context.FunctionMetadata.Name, element.Item1));
+                        _workerChannelLogger.LogInformation("Function '{functionName}' binding to ParameterBindingData for parameter '{name}', datatype '{datatype}' and binding '{binding}'", context.FunctionMetadata.Name, element.Item1, element.Item2, element.Item3);
+                        _metricsLogger.LogEvent(string.Format(MetricEventNames.BindToParameterBindingData, context.FunctionMetadata.Name));
                     }
                 }
 

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -594,7 +594,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
                 if (binding.SupportsDeferredBinding() && !binding.SkipDeferredBinding())
                 {
-                    _metricsLogger.LogEvent(MetricEventNames.FunctionBindingDeferred);
+                    _metricsLogger.LogEvent(MetricEventNames.FunctionBindingDeferred, functionName: metadata.Name);
                 }
             }
 

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -14,7 +14,6 @@ using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
-using System.Xml.Linq;
 using Google.Protobuf.Collections;
 using Google.Protobuf.WellKnownTypes;
 using Microsoft.Azure.WebJobs.Logging;

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -22,6 +22,7 @@ using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.Extensions;
 using Microsoft.Azure.WebJobs.Script.Grpc.Eventing;
 using Microsoft.Azure.WebJobs.Script.Grpc.Extensions;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
@@ -592,21 +593,9 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
                 request.Metadata.Bindings.Add(binding.Name, bindingInfo);
 
-                binding.Properties.TryGetValue(ScriptConstants.SupportsDeferredBindingKey, out bool supportsDeferredBindingFlag);
-
-                if (supportsDeferredBindingFlag)
+                if (binding.SupportsDeferredBinding() && !binding.SkipDeferredBinding())
                 {
-                    binding.Properties.TryGetValue(ScriptConstants.SkipDeferredBindingKey, out bool skipDeferredBindingFlag);
-
-                    if (skipDeferredBindingFlag)
-                    {
-                        _workerChannelLogger.LogInformation("Function '{functionName}' skipping binding to ParameterBindingData for binding name '{name}' and type '{type}' as '{SkipDeferredBinding}' set to '{value}'", metadata.Name, binding.Name, binding.Type, ScriptConstants.SkipDeferredBindingKey, skipDeferredBindingFlag);
-                    }
-                    else
-                    {
-                        _workerChannelLogger.LogInformation("Function '{functionName}' binding to ParameterBindingData for binding name '{name}' and type '{type}' as '{supportsDeferredBinding}' set to '{value}'", metadata.Name, binding.Name, binding.Type, ScriptConstants.SupportsDeferredBindingKey, supportsDeferredBindingFlag);
-                        _metricsLogger.LogEvent(string.Format(MetricEventNames.BindToParameterBindingData, metadata.Name));
-                    }
+                    _metricsLogger.LogEvent(string.Format(MetricEventNames.BindToParameterBindingData, metadata.Name));
                 }
             }
 

--- a/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
         // function level events
         public const string FunctionInvokeLatency = "function.invoke.latency";
         public const string FunctionBindingTypeFormat = "function.binding.{0}";
-        public const string BindToParameterBindingData = "function{0}.binding.parameterbindingdata.{0}";
+        public const string BindToParameterBindingData = "function{0}.binding.parameterbindingdata.{1}";
         public const string FunctionCompileLatencyByLanguageFormat = "function.compile.{0}.latency";
         public const string FunctionInvokeThrottled = "function.invoke.throttled";
         public const string FunctionUserLog = "function.userlog";

--- a/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
         // function level events
         public const string FunctionInvokeLatency = "function.invoke.latency";
         public const string FunctionBindingTypeFormat = "function.binding.{0}";
-        public const string BindToParameterBindingData = "function{0}.binding.parameterbindingdata.{1}";
+        public const string BindToParameterBindingData = "function{0}.binding.parameterbindingdata";
         public const string FunctionCompileLatencyByLanguageFormat = "function.compile.{0}.latency";
         public const string FunctionInvokeThrottled = "function.invoke.throttled";
         public const string FunctionUserLog = "function.userlog";

--- a/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
         // function level events
         public const string FunctionInvokeLatency = "function.invoke.latency";
         public const string FunctionBindingTypeFormat = "function.binding.{0}";
-        public const string BindToParameterBindingData = "function{0}.binding.parameterbindingdata";
+        public const string FunctionBindingDeferred = "function.binding.deferred";
         public const string FunctionCompileLatencyByLanguageFormat = "function.compile.{0}.latency";
         public const string FunctionInvokeThrottled = "function.invoke.throttled";
         public const string FunctionUserLog = "function.userlog";

--- a/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
         // function level events
         public const string FunctionInvokeLatency = "function.invoke.latency";
         public const string FunctionBindingTypeFormat = "function.binding.{0}";
+        public const string BindToParameterBindingData = "function{0}.binding.parameterbindingdata.{0}";
         public const string FunctionCompileLatencyByLanguageFormat = "function.compile.{0}.latency";
         public const string FunctionInvokeThrottled = "function.invoke.throttled";
         public const string FunctionUserLog = "function.userlog";

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -570,19 +570,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             binding.Properties.Add(ScriptConstants.SkipDeferredBindingKey, true);
             binding.Properties.Add(ScriptConstants.SupportsDeferredBindingKey, true);
 
-            var function = new FunctionMetadata()
+            IEnumerable<FunctionMetadata> functionMetadata = GetTestFunctionsList("node");
+            foreach (var function in functionMetadata)
             {
-                Language = "node",
-                Name = "js1"
-            };
+                function.Bindings.Add(binding);
+            }
 
-            function.Bindings.Add(binding);
-
-            _workerChannel.SetupFunctionInvocationBuffers(new List<FunctionMetadata>() { function });
+            _workerChannel.SetupFunctionInvocationBuffers(functionMetadata);
             _workerChannel.SendFunctionLoadRequests(null, TimeSpan.FromMinutes(5));
             await Task.Delay(500);
             AreExpectedMetricsGenerated();
-            Assert.Equal(0, _metricsLogger.LoggedEvents.Count(e => e.Contains(string.Format(MetricEventNames.BindToParameterBindingData, function.Name))));
+            Assert.Equal(0, _metricsLogger.LoggedEvents.Count(e => e.Contains(string.Format(MetricEventNames.BindToParameterBindingData, "js1"))));
         }
 
         [Fact]
@@ -599,19 +597,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             binding.Properties.Add(ScriptConstants.SupportsDeferredBindingKey, true);
 
-            var function = new FunctionMetadata()
+            IEnumerable<FunctionMetadata> functionMetadata = GetTestFunctionsList("node");
+            foreach (var function in functionMetadata)
             {
-                Language = "node",
-                Name = "js1"
-            };
+                function.Bindings.Add(binding);
+            }
 
-            function.Bindings.Add(binding);
-
-            _workerChannel.SetupFunctionInvocationBuffers(new List<FunctionMetadata>() { function });
+            _workerChannel.SetupFunctionInvocationBuffers(functionMetadata);
             _workerChannel.SendFunctionLoadRequests(null, TimeSpan.FromMinutes(5));
             await Task.Delay(500);
             AreExpectedMetricsGenerated();
-            Assert.Equal(1, _metricsLogger.LoggedEvents.Count(e => e.Contains(string.Format(MetricEventNames.BindToParameterBindingData, function.Name))));
+            Assert.Equal(1, _metricsLogger.LoggedEvents.Count(e => e.Contains(string.Format(MetricEventNames.BindToParameterBindingData, "js1"))));
+            Assert.Equal(1, _metricsLogger.LoggedEvents.Count(e => e.Contains(string.Format(MetricEventNames.BindToParameterBindingData, "js2"))));
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -580,7 +580,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _workerChannel.SendFunctionLoadRequests(null, TimeSpan.FromMinutes(5));
             await Task.Delay(500);
             AreExpectedMetricsGenerated();
-            Assert.Equal(0, _metricsLogger.LoggedEvents.Count(e => e.Contains(string.Format(MetricEventNames.BindToParameterBindingData, "js1"))));
+            Assert.Equal(0, _metricsLogger.LoggedEvents.Count(e => e.Contains(MetricEventNames.FunctionBindingDeferred)));
         }
 
         [Fact]
@@ -607,8 +607,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _workerChannel.SendFunctionLoadRequests(null, TimeSpan.FromMinutes(5));
             await Task.Delay(500);
             AreExpectedMetricsGenerated();
-            Assert.Equal(1, _metricsLogger.LoggedEvents.Count(e => e.Contains(string.Format(MetricEventNames.BindToParameterBindingData, "js1"))));
-            Assert.Equal(1, _metricsLogger.LoggedEvents.Count(e => e.Contains(string.Format(MetricEventNames.BindToParameterBindingData, "js2"))));
+            Assert.Equal(2, _metricsLogger.LoggedEvents.Count(e => e.Contains(MetricEventNames.FunctionBindingDeferred)));
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -608,6 +608,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             await Task.Delay(500);
             AreExpectedMetricsGenerated();
             Assert.Equal(2, _metricsLogger.LoggedEvents.Count(e => e.Contains(MetricEventNames.FunctionBindingDeferred)));
+            Assert.Equal(1, _metricsLogger.LoggedEvents.Count(e => e.Contains($"{MetricEventNames.FunctionBindingDeferred}_js1")));
+            Assert.Equal(1, _metricsLogger.LoggedEvents.Count(e => e.Contains($"{MetricEventNames.FunctionBindingDeferred}_js2")));
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -581,9 +581,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _workerChannel.SetupFunctionInvocationBuffers(new List<FunctionMetadata>() { function });
             _workerChannel.SendFunctionLoadRequests(null, TimeSpan.FromMinutes(5));
             await Task.Delay(500);
-            var traces = _logger.GetLogMessages();
-            string expectedLog = $"Function '{function.Name}' skipping binding to ParameterBindingData for binding name '{binding.Name}' and type '{binding.Type}' as '{ScriptConstants.SkipDeferredBindingKey}' set to 'True'";
-            var functionLoadLogs = traces.Where(m => string.Equals(m.FormattedMessage, expectedLog));
             AreExpectedMetricsGenerated();
             Assert.Equal(0, _metricsLogger.LoggedEvents.Count(e => e.Contains(string.Format(MetricEventNames.BindToParameterBindingData, function.Name))));
         }
@@ -613,9 +610,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _workerChannel.SetupFunctionInvocationBuffers(new List<FunctionMetadata>() { function });
             _workerChannel.SendFunctionLoadRequests(null, TimeSpan.FromMinutes(5));
             await Task.Delay(500);
-            var traces = _logger.GetLogMessages();
-            string expectedLog = $"Function '{function.Name}' binding to ParameterBindingData for binding name '{binding.Name}' and type '{binding.Type}' as '{ScriptConstants.SupportsDeferredBindingKey}' set to 'True'";
-            var functionLoadLogs = traces.Where(m => string.Equals(m.FormattedMessage, expectedLog));
             AreExpectedMetricsGenerated();
             Assert.Equal(1, _metricsLogger.LoggedEvents.Count(e => e.Contains(string.Format(MetricEventNames.BindToParameterBindingData, function.Name))));
         }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #9021 

This PR adds telemetry in host to indicate when ParameterBindingData is being used to help track adoption of this new feature

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
