### PR TITLE
Upgrade PowerShell Worker 7.2 to 4.0.2623

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -11,7 +11,7 @@
 - Fix the duplicate log issue with Java ApplicationInsights agent
 - Update Node.js Worker Version to [3.5.2](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.5.2)
 - Making feature flag for worker indexing opt-out instead of opt-in (#8864)
-- Update PowerShell Worker 7.2 to 4.0.2496 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2496)
+- Update PowerShell Worker 7.2 to 4.0.2623 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2623)
 
 
 **Release sprint:** Sprint 132

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -59,7 +59,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.8.1" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.5.2" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" Version="4.0.2302" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" Version="4.0.2496" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" Version="4.0.2623" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="5.0.0-beta.2-10879" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Timers.Storage" Version="1.0.0-beta.1" />

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -324,13 +324,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             // We want it to start first, but finish last, so unstick it in a couple seconds.
             Task ignore = Task.Delay(3000).ContinueWith(_ => _pauseAfterStandbyHostBuild.Release());
 
+            var expectedPowerShellVersion = "7.2";
             IWebHost host = builder.Build();
             var scriptHostService = host.Services.GetService<WebJobsScriptHostService>();
             var channelFactory = host.Services.GetService<IRpcWorkerChannelFactory>();
             var workerOptionsPlaceholderMode = host.Services.GetService<IOptions<LanguageWorkerOptions>>();
             Assert.Equal(4, workerOptionsPlaceholderMode.Value.WorkerConfigs.Count);
             var rpcChannelInPlaceholderMode = (GrpcWorkerChannel)channelFactory.Create("/", "powershell", null, 0, workerOptionsPlaceholderMode.Value.WorkerConfigs);
-            Assert.Equal("7", rpcChannelInPlaceholderMode.Config.Description.DefaultRuntimeVersion);
+            Assert.Equal(expectedPowerShellVersion, rpcChannelInPlaceholderMode.Config.Description.DefaultRuntimeVersion);
 
 
             // TestServer will block in the constructor so pull out the StandbyManager and use it
@@ -346,7 +347,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
             _environment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, "powershell");
-            _environment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName, "7");
+            _environment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName, expectedPowerShellVersion);
 
             var specializeTask = Task.Run(async () => await standbyManager.SpecializeHostAsync());
 
@@ -358,7 +359,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var workerOptionsAtJobhostLevel = scriptHostService.Services.GetService<IOptions<LanguageWorkerOptions>>();
             Assert.Equal(1, workerOptionsAtJobhostLevel.Value.WorkerConfigs.Count);
             var rpcChannelAfterSpecialization = (GrpcWorkerChannel)channelFactory.Create("/", "powershell", null, 0, workerOptionsAtJobhostLevel.Value.WorkerConfigs);
-            Assert.Equal("7", rpcChannelAfterSpecialization.Config.Description.DefaultRuntimeVersion);
+            Assert.Equal(expectedPowerShellVersion, rpcChannelAfterSpecialization.Config.Description.DefaultRuntimeVersion);
         }
 
         /// <summary>

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 Assert.NotNull(pythonWorkerConfig);
                 Assert.NotNull(powershellWorkerConfig);
                 Assert.Equal("3.8", pythonWorkerConfig.Description.DefaultRuntimeVersion);
-                Assert.Equal("7", powershellWorkerConfig.Description.DefaultRuntimeVersion);
+                Assert.Equal("7.2", powershellWorkerConfig.Description.DefaultRuntimeVersion);
             }
         }
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This PR contains the following change:

- Upgrade PowerShell Worker 7.2 to 4.0.2623 (Release Notes: https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2623)
- Update tests: `PowerShell 7.2` is the default in the `worker.config.json`

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
