### PR TITLE
Add a log for the StartAsync cancellation exception 

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -178,8 +178,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             {
                 await StartHostAsync(tokenSource.Token);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException ex)
             {
+                _logger.LogWarning("Host startup operation has been cancelled", ex);
+
                 if (cancellationToken.IsCancellationRequested)
                 {
                     _logger.ScriptHostServiceInitCanceledByRuntime();


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Part 1 of #9037

In a recent CRI (355435073), we saw a host startup cancellation log but there was no exception or other details/information about what might have caused this cancellation. In this specific case, it was most likely due to to customer code startup issues which resulted in the host taking too long to start and therefore being cancelled.

![Screenshot 2023-01-17 at 2 13 58 PM](https://user-images.githubusercontent.com/2198905/213024181-b14ec3dc-0f9c-48f6-90c4-8689f867ff28.png)

Looking at the host codebase, we see that this is most likely not a host cancellation as we did not see this log `Initialization cancellation requested by runtime` at all in the Function Logs. Therefore, it looks like the exception is being swallowed as we're not logging or throwing at this point, which could potentially lead to a scenario where the host is running but not working (in a state that cannot be recovered from without a FunctionApp restart).

In this PR we are adding logs to the above code so we can see what exception might be happening

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
