### PR TITLE
Upgrade PowerShell Language Worker 7.2 to 4.0.2673

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -8,6 +8,7 @@
 - Upgraded proto files to v1.7.1-protofile release (#9023)
 - Refresh capabilities & log worker metadata after specialization (#9020)
 - Update DiagnosticEventLoggerExtensions method names (#9056)
+- Update PowerShell Worker 7.2 to 4.0.2673 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2673)
 
 **Release sprint:** Sprint 138
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+138%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+138%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -59,7 +59,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.8.1" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.5.2" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" Version="4.0.2302" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" Version="4.0.2623" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" Version="4.0.2673" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" Version="4.0.2669" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="5.0.0-beta.2-10879" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This PR contains the following change:

* Upgrade PowerShell Worker 7.2 to 4.0.2673 (Release Notes: https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2673).

Please note that I have removed the the `worker.config.json` from the `PowerShell 7.2` language worker. Going forward, the Functions Host will use the `worker.config.json` included in the `PowerShell 7.4` language worker nuget package

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
