### PR TITLE
Changes for sync trigger, keys, lease management.

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -659,15 +659,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         internal HttpRequestMessage BuildSetTriggersRequest()
         {
             var url = default(string);
-            if (_environment.IsKubernetesManagedHosting() || _environment.IsManagedAppEnvironment())
+            if (_environment.IsAnyKubernetesEnvironment())
             {
-                var buildServiceHostname = _environment.GetEnvironmentVariable("FUNCTIONS_API_SERVER") ??
+                var hostName = _environment.GetEnvironmentVariable("FUNCTIONS_API_SERVER") ??
                     _environment.GetEnvironmentVariable("BUILD_SERVICE_HOSTNAME");
-                if (string.IsNullOrEmpty(buildServiceHostname))
+                if (string.IsNullOrEmpty(hostName))
                 {
-                    buildServiceHostname = $"http://{ManagedKubernetesBuildServiceName}.{ManagedKubernetesBuildServiceNamespace}.svc.cluster.local:{ManagedKubernetesBuildServicePort}";
+                    hostName = $"http://{ManagedKubernetesBuildServiceName}.{ManagedKubernetesBuildServiceNamespace}.svc.cluster.local:{ManagedKubernetesBuildServicePort}";
                 }
-                url = $"{buildServiceHostname}/api/operations/settriggers";
+                url = $"{hostName}/api/operations/settriggers";
             }
             else
             {
@@ -717,8 +717,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                     request.Headers.Add("K8SE-APP-NAMESPACE", _environment.GetEnvironmentVariable("CONTAINER_APP_NAMESPACE"));
                     request.Headers.Add("K8SE-APP-REVISION", _environment.GetEnvironmentVariable("CONTAINER_APP_REVISION"));
                 }
-
-                if (_environment.IsKubernetesManagedHosting())
+                else if (_environment.IsKubernetesManagedHosting())
                 {
                     request.Headers.Add(ScriptConstants.KubernetesManagedAppName, _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName));
                     request.Headers.Add(ScriptConstants.KubernetesManagedAppNamespace, _environment.GetEnvironmentVariable(EnvironmentSettingNames.PodNamespace));

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 PrepareSyncTriggers();
 
                 var hashBlobClient = await GetHashBlobAsync();
-                if (isBackgroundSync && hashBlobClient == null && !_environment.IsKubernetesManagedHosting() && !_environment.IsManagedAppEnvironment())
+                if (isBackgroundSync && hashBlobClient == null && !_environment.IsKubernetesManagedHosting())
                 {
                     // short circuit before doing any work in background sync
                     // cases where we need to check/update hash but don't have
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
                 bool shouldSyncTriggers = true;
                 string newHash = null;
-                if (isBackgroundSync && !_environment.IsKubernetesManagedHosting() && !_environment.IsManagedAppEnvironment())
+                if (isBackgroundSync && !_environment.IsKubernetesManagedHosting())
                 {
                     newHash = await CheckHashAsync(hashBlobClient, payload.Content);
                     shouldSyncTriggers = newHash != null;

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     var hostNameProvider = p.GetService<HostNameProvider>();
                     return new LinuxAppServiceEventGenerator(new LinuxAppServiceFileLoggerFactory(), hostNameProvider);
                 }
-                else if (environment.IsKubernetesManagedHosting())
+                else if (environment.IsKubernetesManagedHosting() || environment.IsManagedAppEnvironment())
                 {
                     return new KubernetesEventGenerator();
                 }

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     var hostNameProvider = p.GetService<HostNameProvider>();
                     return new LinuxAppServiceEventGenerator(new LinuxAppServiceFileLoggerFactory(), hostNameProvider);
                 }
-                else if (environment.IsKubernetesManagedHosting() || environment.IsManagedAppEnvironment())
+                else if (environment.IsAnyKubernetesEnvironment())
                 {
                     return new KubernetesEventGenerator();
                 }

--- a/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             builder.UseMiddleware<HttpRequestBodySizeMiddleware>();
             builder.UseMiddleware<SystemTraceMiddleware>();
             builder.UseMiddleware<HostnameFixupMiddleware>();
-            if (environment.IsAnyLinuxConsumption() || environment.IsKubernetesManagedHosting() || environment.IsManagedAppEnvironment())
+            if (environment.IsAnyLinuxConsumption() || environment.IsAnyKubernetesEnvironment())
             {
                 builder.UseMiddleware<EnvironmentReadyCheckMiddleware>();
             }

--- a/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             builder.UseMiddleware<HttpRequestBodySizeMiddleware>();
             builder.UseMiddleware<SystemTraceMiddleware>();
             builder.UseMiddleware<HostnameFixupMiddleware>();
-            if (environment.IsAnyLinuxConsumption() || environment.IsKubernetesManagedHosting())
+            if (environment.IsAnyLinuxConsumption() || environment.IsKubernetesManagedHosting() || environment.IsManagedAppEnvironment())
             {
                 builder.UseMiddleware<EnvironmentReadyCheckMiddleware>();
             }

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -255,6 +255,16 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
+        /// Gets a value indicating whether the application is running in Centauri environment.
+        /// </summary>
+        /// <param name="environment">The environment to verify.</param>
+        /// <returns><see cref="true"/> if running in Managed App environment; otherwise, false.</returns>
+        public static bool IsManagedAppEnvironment(this IEnvironment environment)
+        {
+            return !string.IsNullOrEmpty(environment.GetEnvironmentVariable(ManagedEnvironment));
+        }
+
+        /// <summary>
         /// Gets a value indicating whether the application is running in a Linux Consumption (dynamic)
         /// App Service environment.
         /// </summary>
@@ -262,7 +272,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <returns><see cref="true"/> if running in a Linux Consumption App Service app; otherwise, false.</returns>
         public static bool IsAnyLinuxConsumption(this IEnvironment environment)
         {
-            return environment.IsLinuxConsumptionOnAtlas() || environment.IsLinuxConsumptionOnLegion();
+            return environment.IsLinuxConsumptionOnAtlas() || environment.IsLinuxConsumptionOnLegion() && !environment.IsManagedAppEnvironment();
         }
 
         public static bool IsLinuxConsumptionOnAtlas(this IEnvironment environment)
@@ -320,7 +330,8 @@ namespace Microsoft.Azure.WebJobs.Script
         public static bool IsKubernetesManagedHosting(this IEnvironment environment)
         {
             return !string.IsNullOrEmpty(environment.GetEnvironmentVariable(KubernetesServiceHost))
-            && !string.IsNullOrEmpty(environment.GetEnvironmentVariable(PodNamespace));
+            && !string.IsNullOrEmpty(environment.GetEnvironmentVariable(PodNamespace))
+            && !environment.IsManagedAppEnvironment();
         }
 
         /// <summary>

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -272,7 +272,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <returns><see cref="true"/> if running in a Linux Consumption App Service app; otherwise, false.</returns>
         public static bool IsAnyLinuxConsumption(this IEnvironment environment)
         {
-            return environment.IsLinuxConsumptionOnAtlas() || environment.IsLinuxConsumptionOnLegion() && !environment.IsManagedAppEnvironment();
+            return (environment.IsLinuxConsumptionOnAtlas() || environment.IsLinuxConsumptionOnLegion()) && !environment.IsManagedAppEnvironment();
         }
 
         public static bool IsLinuxConsumptionOnAtlas(this IEnvironment environment)

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -255,7 +255,17 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
-        /// Gets a value indicating whether the application is running in Centauri environment.
+        /// Gets a value indicating whether the application is running in Kubernetes Environment.
+        /// </summary>
+        /// <param name="environment">The environment to verify.</param>
+        /// <returns><see cref="true"/> if running in Kubernetes environment; otherwise, false.</returns>
+        public static bool IsAnyKubernetesEnvironment(this IEnvironment environment)
+        {
+            return environment.IsKubernetesManagedHosting() || environment.IsManagedAppEnvironment();
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the application is running in Managed App environment.
         /// </summary>
         /// <param name="environment">The environment to verify.</param>
         /// <returns><see cref="true"/> if running in Managed App environment; otherwise, false.</returns>

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -77,6 +77,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string PodName = "POD_NAME";
         public const string PodEncryptionKey = "POD_ENCRYPTION_KEY";
         public const string HttpLeaderEndpoint = "HTTP_LEADER_ENDPOINT";
+        public const string ManagedEnvironment = "MANAGED_ENVIRONMENT";
 
         /// <summary>
         /// Environment variable dynamically set by the platform when it is safe to

--- a/src/WebJobs.Script/Host/ScriptHostIdProvider.cs
+++ b/src/WebJobs.Script/Host/ScriptHostIdProvider.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script
             // If the user has explicitly set the HostID via host.json, it will overwrite
             // what we set here
             string hostId = null;
-            if (environment.IsAppService() || environment.IsKubernetesManagedHosting())
+            if (environment.IsAppService() || environment.IsAnyKubernetesEnvironment())
             {
                 string uniqueSlotName = environment?.GetAzureWebsiteUniqueSlotName();
                 if (!string.IsNullOrEmpty(uniqueSlotName))

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -431,7 +431,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 _mockHttpHandler.MockStatusCode = HttpStatusCode.InternalServerError;
                 var syncResult = await _functionsSyncManager.TrySyncTriggersAsync(isBackgroundSync: true);
                 Assert.False(syncResult.Success);
-                string expectedErrorMessage = "SyncTriggers operation failed (StatusCode=InternalServerError).";
+                string expectedErrorMessage = "SyncTriggers call failed (StatusCode=InternalServerError).";
                 Assert.Equal(expectedErrorMessage, syncResult.Error);
                 Assert.Equal(1, _mockHttpHandler.RequestCount);
                 var result = JObject.Parse(_contentBuilder.ToString());
@@ -831,8 +831,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         {
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.KubernetesServiceHost)).Returns(kubernetesServiceHost);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.PodNamespace)).Returns("POD_NAMESPACE");
-            _mockEnvironment.Setup(p => p.GetEnvironmentVariable("BUILD_SERVICE_HOSTNAME"))
-                .Returns("");
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable("BUILD_SERVICE_HOSTNAME")).Returns("");
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable("FUNCTIONS_API_SERVER")).Returns("");
+
             var httpRequest = _functionsSyncManager.BuildSetTriggersRequest();
             Assert.Equal(expectedSyncTriggersUri, httpRequest.RequestUri.AbsoluteUri);
             Assert.Equal(HttpMethod.Post, httpRequest.Method);

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -135,6 +135,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsSecretStorageType)).Returns("blob");
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.KubernetesServiceHost)).Returns("");
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.PodNamespace)).Returns("");
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ManagedEnvironment)).Returns((string)null);
 
             _hostNameProvider = new HostNameProvider(_mockEnvironment.Object);
 
@@ -430,7 +431,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 _mockHttpHandler.MockStatusCode = HttpStatusCode.InternalServerError;
                 var syncResult = await _functionsSyncManager.TrySyncTriggersAsync(isBackgroundSync: true);
                 Assert.False(syncResult.Success);
-                string expectedErrorMessage = "SyncTriggers call failed (StatusCode=InternalServerError).";
+                string expectedErrorMessage = "SyncTriggers operation failed (StatusCode=InternalServerError).";
                 Assert.Equal(expectedErrorMessage, syncResult.Error);
                 Assert.Equal(1, _mockHttpHandler.RequestCount);
                 var result = JObject.Parse(_contentBuilder.ToString());

--- a/test/WebJobs.Script.Tests/FunctionsSyncServiceTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionsSyncServiceTests.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         // Setting AzureWebsiteInstanceId to null will make it fail the IsAppServiceWindows, and it shouldn't affect the check for dedicated linux
         [InlineData(false, true, false, true, false, false, false, false)] // dedicated linux
         [InlineData(false, true, false, false, false, false, false, true)] // dedicated linux
-        [InlineData(false, true, false, false, false, false, true, true)] // Centauri
+        [InlineData(false, true, false, false, false, false, true, true)] // managed app environment
         public void IsSyncTriggersEnvironment_StandbyMode_ReturnsExpectedResult(bool isAppService, bool hasEncryptionKey, bool isConsumptionLinuxOnAtlas, bool isConsumptionLinuxOnLegion, bool standbyMode, bool containerReady, bool isManagedAppEnvironment, bool expected)
         {
             _mockWebHostEnvironment.SetupGet(p => p.InStandbyMode).Returns(standbyMode);

--- a/test/WebJobs.Script.Tests/FunctionsSyncServiceTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionsSyncServiceTests.cs
@@ -109,24 +109,25 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
-        [InlineData(true, true, false, true, true, true, false)] // in standby
-        [InlineData(true, true, false, false, true, true, false)] // in standby
-        [InlineData(true, true, false, true, true, false, false)] // in standby
-        [InlineData(true, true, false, false, true, false, false)] // in standby
-        [InlineData(true, true, false, true, false, true, true)]
-        [InlineData(true, true, false, false, false, true, true)]
-        [InlineData(false, true, true, true, false, false, false)] // container not ready
-        [InlineData(false, true, true, false, false, false, false)] // container not ready
-        [InlineData(false, true, true, true, false, true, true)]
-        [InlineData(false, true, true, false, false, true, true)]
-        [InlineData(false, false, true, true, false, true, false)] // no encryption key
-        [InlineData(false, false, true, false, false, true, false)] // no encryption key
+        [InlineData(true, true, false, true, true, true, false, false)] // in standby
+        [InlineData(true, true, false, false, true, true, false, false)] // in standby
+        [InlineData(true, true, false, true, true, false, false, false)] // in standby
+        [InlineData(true, true, false, false, true, false, true, false)] // in standby
+        [InlineData(true, true, false, true, false, true, false, true)]
+        [InlineData(true, true, false, false, false, true, false, true)]
+        [InlineData(false, true, true, true, false, false, false, false)] // container not ready
+        [InlineData(false, true, true, false, false, false, false, false)] // container not ready
+        [InlineData(false, true, true, true, false, true, false, true)]
+        [InlineData(false, true, true, false, false, true, false, true)]
+        [InlineData(false, false, true, true, false, true, false, false)] // no encryption key
+        [InlineData(false, false, true, false, false, true, false, false)] // no encryption key
         // note: normally linux dedicated would have AzureWebsiteInstanceId set.
         // However the test will always catch it as Windows because it checks the OS of the running process.
         // Setting AzureWebsiteInstanceId to null will make it fail the IsAppServiceWindows, and it shouldn't affect the check for dedicated linux
-        [InlineData(false, true, false, true, false, false, false)] // dedicated linux
-        [InlineData(false, true, false, false, false, false, true)] // dedicated linux
-        public void IsSyncTriggersEnvironment_StandbyMode_ReturnsExpectedResult(bool isAppService, bool hasEncryptionKey, bool isConsumptionLinuxOnAtlas, bool isConsumptionLinuxOnLegion, bool standbyMode, bool containerReady, bool expected)
+        [InlineData(false, true, false, true, false, false, false, false)] // dedicated linux
+        [InlineData(false, true, false, false, false, false, false, true)] // dedicated linux
+        [InlineData(false, true, false, false, false, false, true, true)] // Centauri
+        public void IsSyncTriggersEnvironment_StandbyMode_ReturnsExpectedResult(bool isAppService, bool hasEncryptionKey, bool isConsumptionLinuxOnAtlas, bool isConsumptionLinuxOnLegion, bool standbyMode, bool containerReady, bool isManagedAppEnvironment, bool expected)
         {
             _mockWebHostEnvironment.SetupGet(p => p.InStandbyMode).Returns(standbyMode);
 
@@ -135,6 +136,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ContainerName)).Returns(isConsumptionLinuxOnAtlas || isConsumptionLinuxOnLegion ? "1" : null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.LegionServiceHost)).Returns(isConsumptionLinuxOnLegion ? "1" : null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady)).Returns(containerReady ? "1" : null);
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ManagedEnvironment)).Returns(isManagedAppEnvironment ? "1" : null);
 
             var result = FunctionsSyncManager.IsSyncTriggersEnvironment(_mockWebHostEnvironment.Object, _mockEnvironment.Object);
             Assert.Equal(expected, result);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Changes for functions host to be able to support sync trigger in Managed App Environment.

- [IsSyncTriggersEnvironment()](https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs#L192-L225) check modified to pass.
- Method [BuildSetTriggersRequest](https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs#L662-L671) modified to read endpoint from FUNCTIONS_API_SERVER.
- Add [request headers](https://github.com/Azure/azure-functions-host/blob/268674893728a3b7d5a197edc5b961cd5e095849/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs#L714-L719) for Managed App Environment.
- Update host id for hash blob to use WEBSITE_SITE_NAME, modify this [check](https://github.com/Azure/azure-functions-host/blob/7b828af7614660bc4b902f5e931517a5352f0968/src/WebJobs.Script/Host/ScriptHostIdProvider.cs#L55) to pass.
- [WebsiteAuthEncryptionKey](https://github.com/Azure/azure-functions-host/blob/54941dba8cece0c93744c9bc6a23ea469d0873b7/src/WebJobs.Script.WebHost/Security/SimpleWebTokenHelper.cs#L93) - Managed App environment wants to leverage WEBSITE_AUTH_ENCRYPTION_KEY.
- [KubernetesDistributedLockManager](https://github.com/Azure/azure-functions-host/blob/54941dba8cece0c93744c9bc6a23ea469d0873b7/src/WebJobs.Script/ScriptHostBuilderExtensions.cs#L301) - Requires this to fail since managed app environment is using storage account for secrets.
- [KubernetesEventGenerator](https://github.com/Azure/azure-functions-host/blob/268674893728a3b7d5a197edc5b961cd5e095849/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs#L117-L119) - Want this to be successful for trace logs to be published in functions logs.
- [EnvironmentReadyCheckMiddleware](https://github.com/Azure/azure-functions-host/blob/268674893728a3b7d5a197edc5b961cd5e095849/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs#L41-L43) - Want this to be successful in managed app environment.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

