### PR TITLE
Update active profile when multiple runtimes use worker description profiles 

### DIFF
--- a/src/WebJobs.Script/Workers/Profiles/WorkerProfileManager.cs
+++ b/src/WebJobs.Script/Workers/Profiles/WorkerProfileManager.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         private readonly IEnvironment _environment;
         private readonly IEnumerable<IWorkerProfileConditionProvider> _conditionProviders;
 
-        private string _activeProfile = string.Empty;
+        private Dictionary<string, string> _activeProfiles;
         private Dictionary<string, List<WorkerDescriptionProfile>> _profiles;
 
         public WorkerProfileManager(ILogger<WorkerProfileManager> logger, IEnvironment environment)
@@ -26,6 +26,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
+            _activeProfiles = new Dictionary<string, string>();
             _profiles = new Dictionary<string, List<WorkerDescriptionProfile>>();
             _conditionProviders = new List<IWorkerProfileConditionProvider>
             {
@@ -63,7 +64,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             if (GetEvaluatedProfile(defaultWorkerDescription.Language, out WorkerDescriptionProfile profile))
             {
                 _logger?.LogInformation($"Worker initialized with profile - {profile.Name}, Profile ID {profile.ProfileId} from worker config.");
-                _activeProfile = profile.ProfileId;
+                _activeProfiles[defaultWorkerDescription.Language] = profile.ProfileId;
                 workerDescription = profile.ApplyProfile(defaultWorkerDescription);
             }
             else
@@ -97,7 +98,13 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             {
                 profileId = profile.ProfileId;
             }
-            return _activeProfile.Equals(profileId);
+
+            var activeProfile = string.Empty;
+            if (!_activeProfiles.TryGetValue(workerRuntime, out activeProfile))
+            {
+                activeProfile = string.Empty;
+            }
+            return activeProfile.Equals(profileId);
         }
     }
 }

--- a/src/WebJobs.Script/Workers/Profiles/WorkerProfileManager.cs
+++ b/src/WebJobs.Script/Workers/Profiles/WorkerProfileManager.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
                 profileId = profile.ProfileId;
             }
 
-            var activeProfile = string.Empty;
+            string activeProfile;
             if (!_activeProfiles.TryGetValue(workerRuntime, out activeProfile))
             {
                 activeProfile = string.Empty;


### PR DESCRIPTION
### Update active profile when multiple runtimes use worker description profiles 

resolves #9052

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

