### PR TITLE
improving handling and logging of exceptions thrown during external startup

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventLoggerProvider.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventLoggerProvider.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 {
@@ -11,16 +11,19 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
     {
         private readonly IDiagnosticEventRepositoryFactory _diagnosticEventRepositoryFactory;
         private readonly IEnvironment _environment;
+        private readonly IOptionsMonitor<StandbyOptions> _standbyOptions;
 
-        public DiagnosticEventLoggerProvider(IDiagnosticEventRepositoryFactory diagnosticEventRepositoryFactory, IEnvironment environment)
+        public DiagnosticEventLoggerProvider(IDiagnosticEventRepositoryFactory diagnosticEventRepositoryFactory, IEnvironment environment,
+            IOptionsMonitor<StandbyOptions> standbyOptions)
         {
             _diagnosticEventRepositoryFactory = diagnosticEventRepositoryFactory ?? throw new ArgumentNullException(nameof(diagnosticEventRepositoryFactory));
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
+            _standbyOptions = standbyOptions ?? throw new ArgumentNullException(nameof(standbyOptions));
         }
 
         public ILogger CreateLogger(string categoryName)
         {
-            return new DiagnosticEventLogger(_diagnosticEventRepositoryFactory, _environment);
+            return new DiagnosticEventLogger(_diagnosticEventRepositoryFactory, _environment, _standbyOptions);
         }
 
         public void Dispose()

--- a/src/WebJobs.Script.WebHost/Program.cs
+++ b/src/WebJobs.Script.WebHost/Program.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -79,6 +77,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                     loggingBuilder.AddDefaultWebJobsFilters();
                     loggingBuilder.AddWebJobsSystem<WebHostSystemLoggerProvider>();
+
+                    if (!FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableDiagnosticEventLogging))
+                    {
+                        loggingBuilder.Services.AddSingleton<ILoggerProvider, DiagnosticEventLoggerProvider>();
+                        loggingBuilder.Services.TryAddSingleton<IDiagnosticEventRepository, DiagnosticEventTableStorageRepository>();
+                        loggingBuilder.Services.TryAddSingleton<IDiagnosticEventRepositoryFactory, DiagnosticEventRepositoryFactory>();
+                    }
                 })
                 .UseStartup<Startup>();
         }

--- a/src/WebJobs.Script.WebHost/Program.cs
+++ b/src/WebJobs.Script.WebHost/Program.cs
@@ -77,13 +77,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                     loggingBuilder.AddDefaultWebJobsFilters();
                     loggingBuilder.AddWebJobsSystem<WebHostSystemLoggerProvider>();
-
-                    if (!FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableDiagnosticEventLogging))
-                    {
-                        loggingBuilder.Services.AddSingleton<ILoggerProvider, DiagnosticEventLoggerProvider>();
-                        loggingBuilder.Services.TryAddSingleton<IDiagnosticEventRepository, DiagnosticEventTableStorageRepository>();
-                        loggingBuilder.Services.TryAddSingleton<IDiagnosticEventRepositoryFactory, DiagnosticEventRepositoryFactory>();
-                    }
                 })
                 .UseStartup<Startup>();
         }

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.IO.Abstractions;
 using System.Net.Http;
 using System.Runtime.InteropServices;
@@ -146,6 +145,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
             // Logging and diagnostics
             services.AddSingleton<IMetricsLogger, WebHostMetricsLogger>();
+            if (!FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableDiagnosticEventLogging))
+            {
+                services.AddSingleton<ILoggerProvider, DiagnosticEventLoggerProvider>();
+                services.TryAddSingleton<IDiagnosticEventRepository, DiagnosticEventTableStorageRepository>();
+                services.TryAddSingleton<IDiagnosticEventRepositoryFactory, DiagnosticEventRepositoryFactory>();
+            }
 
             // Secret management
             services.TryAddSingleton<ISecretManagerProvider, DefaultSecretManagerProvider>();

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -157,6 +157,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     services.AddSingleton(hostingConfigOptions);
                     services.AddSingleton(hostingConfigOptionsMonitor);
 
+                    if (!FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableDiagnosticEventLogging))
+                    {
+                        services.AddSingleton<ILoggerProvider, DiagnosticEventLoggerProvider>();
+                        services.TryAddSingleton<IDiagnosticEventRepository, DiagnosticEventTableStorageRepository>();
+                        services.TryAddSingleton<IDiagnosticEventRepositoryFactory, DiagnosticEventRepositoryFactory>();
+                    }
+
                     ConfigureRegisteredBuilders(services, rootServiceProvider);
                 });
 

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -93,9 +93,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                     if (!FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableDiagnosticEventLogging))
                     {
+                        // Services that this logger depends on are registered at the WebHost level.
                         loggingBuilder.Services.AddSingleton<ILoggerProvider, DiagnosticEventLoggerProvider>();
-                        loggingBuilder.Services.TryAddSingleton<IDiagnosticEventRepository, DiagnosticEventTableStorageRepository>();
-                        loggingBuilder.Services.TryAddSingleton<IDiagnosticEventRepositoryFactory, DiagnosticEventRepositoryFactory>();
                     }
 
                     ConfigureRegisteredBuilders(loggingBuilder, rootServiceProvider);

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                     if (!FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableDiagnosticEventLogging))
                     {
-                        // Services that this logger depends on are registered at the WebHost level.
+                        // services that this depends on are registered at the webhost level
                         loggingBuilder.Services.AddSingleton<ILoggerProvider, DiagnosticEventLoggerProvider>();
                     }
 
@@ -156,13 +156,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     IOptionsMonitor<FunctionsHostingConfigOptions> hostingConfigOptionsMonitor = rootServiceProvider.GetService<IOptionsMonitor<FunctionsHostingConfigOptions>>();
                     services.AddSingleton(hostingConfigOptions);
                     services.AddSingleton(hostingConfigOptionsMonitor);
-
-                    if (!FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableDiagnosticEventLogging))
-                    {
-                        services.AddSingleton<ILoggerProvider, DiagnosticEventLoggerProvider>();
-                        services.TryAddSingleton<IDiagnosticEventRepository, DiagnosticEventTableStorageRepository>();
-                        services.TryAddSingleton<IDiagnosticEventRepositoryFactory, DiagnosticEventRepositoryFactory>();
-                    }
 
                     ConfigureRegisteredBuilders(services, rootServiceProvider);
                 });

--- a/src/WebJobs.Script/Diagnostics/DiagnosticEventConstants.cs
+++ b/src/WebJobs.Script/Diagnostics/DiagnosticEventConstants.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script
+{
+    internal static class DiagnosticEventConstants
+    {
+        public const string HostIdCollisionErrorCode = "AZFD004";
+        public const string HostIdCollisionHelpLink = "https://go.microsoft.com/fwlink/?linkid=2224100";
+
+        public const string ExternalStartupErrorCode = "AZFD0005";
+        public const string ExternalStartupErrorHelpLink = "https://go.microsoft.com/fwlink/?linkid=2224847";
+    }
+}

--- a/src/WebJobs.Script/ExternalStartupException.cs
+++ b/src/WebJobs.Script/ExternalStartupException.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Script
+{
+    /// <summary>
+    /// An exception that indicates an issue calling into an external Startup class. This will
+    /// prevent the host from starting.
+    /// </summary>
+    [Serializable]
+    public class ExternalStartupException : Exception
+    {
+        public ExternalStartupException() { }
+
+        public ExternalStartupException(string message) : base(message) { }
+
+        public ExternalStartupException(string message, Exception inner) : base(message, inner) { }
+
+        protected ExternalStartupException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+}

--- a/src/WebJobs.Script/Host/HostIdValidator.cs
+++ b/src/WebJobs.Script/Host/HostIdValidator.cs
@@ -28,8 +28,6 @@ namespace Microsoft.Azure.WebJobs.Script
     public class HostIdValidator
     {
         public const string BlobPathFormat = "ids/usage/{0}";
-        private const string HostIdCollisionErrorCode = "AZFD004";
-        private const string HostIdCollisionHelpLink = "https://go.microsoft.com/fwlink/?linkid=2224100";
         private const LogLevel DefaultLevel = LogLevel.Error;
 
         private readonly IEnvironment _environment;
@@ -125,7 +123,7 @@ namespace Microsoft.Azure.WebJobs.Script
             {
                 _logger.LogWarning(message);
 
-                DiagnosticEventLoggerExtensions.LogDiagnosticEventInformation(_logger, HostIdCollisionErrorCode, message, HostIdCollisionHelpLink);
+                DiagnosticEventLoggerExtensions.LogDiagnosticEventInformation(_logger, DiagnosticEventConstants.HostIdCollisionErrorCode, message, DiagnosticEventConstants.HostIdCollisionHelpLink);
             }
             else
             {
@@ -133,7 +131,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 // so anything other than Warning is treated as Error.
                 _logger.LogError(message);
 
-                DiagnosticEventLoggerExtensions.LogDiagnosticEventError(_logger, HostIdCollisionErrorCode, message, HostIdCollisionHelpLink, new InvalidOperationException(message));
+                DiagnosticEventLoggerExtensions.LogDiagnosticEventError(_logger, DiagnosticEventConstants.HostIdCollisionErrorCode, message, DiagnosticEventConstants.HostIdCollisionHelpLink, new InvalidOperationException(message));
 
                 _applicationLifetime.StopApplication();
             }

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -51,9 +51,6 @@ namespace Microsoft.Azure.WebJobs.Script
         private const string DelayedConfigurationActionKey = "MS_DelayedConfigurationAction";
         private const string ConfigurationSnapshotKey = "MS_ConfigurationSnapshot";
 
-        private const string ExternalStartupErrorDiagnosticId = "AZFD0005";
-        private const string ExternalStartupErrorHelpLink = "https://go.microsoft.com/fwlink/?linkid=2224847";
-
         public static IHostBuilder AddScriptHost(this IHostBuilder builder, Action<ScriptApplicationHostOptions> configureOptions, ILoggerFactory loggerFactory = null)
         {
             if (configureOptions == null)
@@ -507,7 +504,7 @@ namespace Microsoft.Azure.WebJobs.Script
             var startupEx = new ExternalStartupException(message, ex);
 
             var logger = loggerFactory.CreateLogger(LogCategories.Startup);
-            logger.LogDiagnosticEventError(ExternalStartupErrorDiagnosticId, message, ExternalStartupErrorHelpLink, startupEx);
+            logger.LogDiagnosticEventError(DiagnosticEventConstants.ExternalStartupErrorCode, message, DiagnosticEventConstants.ExternalStartupErrorHelpLink, startupEx);
 
             // Send the error to App Insights if possible. This is happening during ScriptHost construction so we
             // have no existing TelemetryClient to use. Create a one-off client and flush it ASAP.

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -4,7 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
 using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Executors;
@@ -46,6 +50,9 @@ namespace Microsoft.Azure.WebJobs.Script
         private const string StartupTypeLocatorKey = "MS_StartupTypeLocator";
         private const string DelayedConfigurationActionKey = "MS_DelayedConfigurationAction";
         private const string ConfigurationSnapshotKey = "MS_ConfigurationSnapshot";
+
+        private const string ExternalStartupErrorDiagnosticId = "AZFD0005";
+        private const string ExternalStartupErrorHelpLink = "https://go.microsoft.com/fwlink/?linkid=2224847";
 
         public static IHostBuilder AddScriptHost(this IHostBuilder builder, Action<ScriptApplicationHostOptions> configureOptions, ILoggerFactory loggerFactory = null)
         {
@@ -209,7 +216,15 @@ namespace Microsoft.Azure.WebJobs.Script
                     // Only set our external startup if we're not suppressing host initialization
                     // as we don't want to load user assemblies otherwise.
                     var locator = context.Properties.GetAndRemove<ScriptStartupTypeLocator>(StartupTypeLocatorKey);
-                    webJobsBuilder.UseExternalStartup(locator, webJobsBuilderContext, loggerFactory);
+
+                    try
+                    {
+                        webJobsBuilder.UseExternalStartup(locator, webJobsBuilderContext, loggerFactory);
+                    }
+                    catch (Exception ex)
+                    {
+                        RecordAndThrowExternalStartupException("Error configuring services in an external startup class.", ex, loggerFactory);
+                    }
                 }
 
                 configureWebJobs?.Invoke(webJobsBuilder);
@@ -226,7 +241,17 @@ namespace Microsoft.Azure.WebJobs.Script
                     };
 
                     // Delay this call so we can call the customer's setup last.
-                    context.Properties[DelayedConfigurationActionKey] = new Action<IWebJobsStartupTypeLocator>(locator => webJobsConfigBuilder.UseExternalConfigurationStartup(locator, webJobsBuilderContext, loggerFactory));
+                    context.Properties[DelayedConfigurationActionKey] = new Action<IWebJobsStartupTypeLocator>(locator =>
+                    {
+                        try
+                        {
+                            webJobsConfigBuilder.UseExternalConfigurationStartup(locator, webJobsBuilderContext, loggerFactory);
+                        }
+                        catch (Exception ex)
+                        {
+                            RecordAndThrowExternalStartupException("Error building configuration in an external startup class.", ex, loggerFactory);
+                        }
+                    });
                 }
             });
 
@@ -475,6 +500,34 @@ namespace Microsoft.Azure.WebJobs.Script
             {
                 throw new InvalidOperationException($"The key '{key}' does not exist in the dictionary.");
             }
+        }
+
+        private static void RecordAndThrowExternalStartupException(string message, Exception ex, ILoggerFactory loggerFactory)
+        {
+            var startupEx = new ExternalStartupException(message, ex);
+
+            var logger = loggerFactory.CreateLogger(LogCategories.Startup);
+            logger.LogDiagnosticEventError(ExternalStartupErrorDiagnosticId, message, ExternalStartupErrorHelpLink, startupEx);
+
+            // Send the error to App Insights if possible. This is happening during ScriptHost construction so we
+            // have no existing TelemetryClient to use. Create a one-off client and flush it ASAP.
+            string appInsightsConnStr = Environment.GetEnvironmentVariable(EnvironmentSettingNames.AppInsightsConnectionString);
+            if (appInsightsConnStr is not null)
+            {
+                using TelemetryConfiguration telemetryConfiguration = new()
+                {
+                    ConnectionString = appInsightsConnStr,
+                    TelemetryChannel = new InMemoryChannel()
+                };
+
+                TelemetryClient telemetryClient = new(telemetryConfiguration);
+                telemetryClient.Context.GetInternalContext().SdkVersion = new ApplicationInsightsSdkVersionProvider().GetSdkVersion();
+                telemetryClient.TrackTrace(startupEx.ToString(), SeverityLevel.Error);
+                telemetryClient.TrackException(startupEx);
+                telemetryClient.Flush();
+            }
+
+            throw startupEx;
         }
     }
 }

--- a/test/CSharpPrecompiledTestProjects/WebJobsStartupTests/Startup.cs
+++ b/test/CSharpPrecompiledTestProjects/WebJobsStartupTests/Startup.cs
@@ -27,6 +27,12 @@ namespace WebJobsStartupTests
                 {
                     config.GetSection("MyOptions").Bind(options);
                 });
+
+            string message = Environment.GetEnvironmentVariable("SERVICE_THROW");
+            if (message != null)
+            {
+                throw new InvalidOperationException(message);
+            }
         }
 
         public void Configure(WebJobsBuilderContext context, IWebJobsConfigurationBuilder builder)
@@ -39,6 +45,12 @@ namespace WebJobsStartupTests
                 { "SomeOtherKey", "SomeOtherValue" },
                 { "Cron", "0 0 0 1 1 0" }
             });
+
+            string message = Environment.GetEnvironmentVariable("CONFIG_THROW");
+            if (message != null)
+            {
+                throw new InvalidOperationException(message);
+            }
         }
 
         private static void ValidateContext(WebJobsBuilderContext context)

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -93,6 +93,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 .ConfigureLogging(b =>
                 {
                     b.AddProvider(_webHostLoggerProvider);
+                    b.AddFilter<TestLoggerProvider>("Host", LogLevel.Trace);
+                    b.AddFilter<TestLoggerProvider>("Microsoft.Azure.WebJobs", LogLevel.Trace);
                 })
                 .ConfigureServices(services =>
                   {

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
@@ -38,9 +38,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         private string _functionsWorkerRuntimeVersion;
         private bool _addTestSettings;
 
-        protected EndToEndTestFixture(string rootPath, string testId, 
-            string functionsWorkerRuntime, 
-            int workerProcessesCount = 1, 
+        protected EndToEndTestFixture(string rootPath, string testId,
+            string functionsWorkerRuntime,
+            int workerProcessesCount = 1,
             string functionsWorkerRuntimeVersion = null,
             bool addTestSettings = true)
         {
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     ConfigureWebHost(configBuilder);
                 });
 
-            string connectionString = Host.JobHostServices.GetService<IConfiguration>().GetWebJobsConnectionString(ConnectionStringNames.Storage);
+            string connectionString = Host.JobHostServices?.GetService<IConfiguration>().GetWebJobsConnectionString(ConnectionStringNames.Storage);
             if (!string.IsNullOrEmpty(connectionString))
             {
                 CloudStorageAccount storageAccount = CloudStorageAccount.Parse(connectionString);

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebJobsStartupEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebJobsStartupEndToEndTests.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -76,6 +78,56 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
             }
         }
 
+        [Fact]
+        public Task ExternalConfigurationStartup_Exception_SetsErrorAndRetries()
+        {
+            var message = "Something happend during Configuration building.";
+            _envVars["CONFIG_THROW"] = message;
 
+            return RunStartupExceptionTest(message);
+        }
+
+        [Fact]
+        public Task ExternalStartup_Exception_SetsErrorAndRetries()
+        {
+            var message = "Something happend during Service registration.";
+            _envVars["SERVICE_THROW"] = message;
+
+            return RunStartupExceptionTest(message);
+        }
+
+        private async Task RunStartupExceptionTest(string expectedErrorMessage)
+        {
+            _envVars[EnvironmentSettingNames.FunctionsExtensionVersion] = "~4";
+
+            // We need different fixture setup for each test.
+            var fixture = new CSharpPrecompiledEndToEndTestFixture(_projectName, _envVars);
+            try
+            {
+                await fixture.InitializeAsync();
+                var client = fixture.Host.HttpClient;
+
+                var response = await client.GetAsync($"api/Function1");
+
+                Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+
+                var manager = fixture.Host.WebHostServices.GetService<IScriptHostManager>();
+                Assert.Equal(ScriptHostState.Error, manager.State);
+                Assert.IsType<ExternalStartupException>(manager.LastError);
+                Assert.Equal(expectedErrorMessage, manager.LastError.InnerException.Message);
+
+                // Check that we continuously retry this (it will backoff).
+                var logMessages = fixture.Host.GetWebHostLogMessages();
+                var buildingMessageCount = logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Building host: version spec: ~4, startup suppressed: 'False'"));
+                Assert.True(buildingMessageCount > 1, $"Expected more than one host restart. Actual: {buildingMessageCount}.");
+
+                var diagnosticEventCount = logMessages.Count(p => p.Category == LogCategories.Startup && p.State?.Any(k => k.Key == ScriptConstants.DiagnosticEventKey) == true);
+                Assert.True(diagnosticEventCount > 1, $"Expected more than one diagnostic event. Actual: {diagnosticEventCount}.");
+            }
+            finally
+            {
+                await fixture.DisposeAsync();
+            }
+        }
     }
 }

--- a/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
@@ -59,6 +59,7 @@ namespace Microsoft.WebJobs.Script.Tests
             AddMockedSingleton<IApplicationLifetime>(services);
             AddMockedSingleton<IDependencyValidator>(services);
             AddMockedSingleton<IAzureBlobStorageProvider>(services);
+            AddMockedSingleton<IDiagnosticEventRepositoryFactory>(services);
             services.AddSingleton<HostNameProvider>();
             services.AddSingleton<IMetricsLogger>(metricsLogger);
             services.AddWebJobsScriptHostRouting();

--- a/test/WebJobs.Script.Tests.Shared/TestOptionsMonitor.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestOptionsMonitor.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
     public class TestOptionsMonitor<T> : IOptionsMonitor<T> where T : class, new()
     {
         private readonly Func<T> _optionsFactory;
+        private Action<T, string> _listener;
 
         public TestOptionsMonitor(T options)
             : this(() => options ?? new T())
@@ -30,7 +31,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public IDisposable OnChange(Action<T, string> listener)
         {
+            _listener = listener;
             return Disposable.Empty;
+        }
+
+        internal void InvokeChanged()
+        {
+            _listener?.Invoke(CurrentValue, null);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Diagnostics/DiagnosticEventLoggerTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/DiagnosticEventLoggerTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -19,8 +20,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             var repository = new TestDiagnosticEventRepository();
             var repositoryFactory = new TestDiagnosticEventRepositoryFactory(repository);
             var environment = new TestEnvironment();
-            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
-            using (var provider = new DiagnosticEventLoggerProvider(repositoryFactory, environment))
+            var standbyOptions = new TestOptionsMonitor<StandbyOptions>(new StandbyOptions { InStandbyMode = false });
+            using (var provider = new DiagnosticEventLoggerProvider(repositoryFactory, environment, standbyOptions))
             {
                 var logger = provider.CreateLogger("MS_DiagnosticEvents");
 
@@ -39,19 +40,52 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             var repository = new TestDiagnosticEventRepository();
             var repositoryFactory = new TestDiagnosticEventRepositoryFactory(repository);
             var environment = new TestEnvironment();
-            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
-            using (var provider = new DiagnosticEventLoggerProvider(repositoryFactory, environment))
+            var options = new StandbyOptions { InStandbyMode = true };
+            var standbyOptions = new TestOptionsMonitor<StandbyOptions>(options);
+            using (var provider = new DiagnosticEventLoggerProvider(repositoryFactory, environment, standbyOptions))
             {
                 var logger = provider.CreateLogger("MS_DiagnosticEvents");
-                logger.LogInformation("Error code: {MS_errorCode}, Error Message: {message}, HelpLink: {MS_HelpLink}", "Error123", "Unknown Error", "http://helpLink");
 
-                environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+                // this one should not appear
+                logger.LogDiagnosticEvent(LogLevel.Error, 123, "FN999", "Actionable event occurred", "https://fwlink", null);
 
+                options.InStandbyMode = false;
+                standbyOptions.InvokeChanged();
+
+                // now that specialized, logger works
                 logger.LogDiagnosticEvent(LogLevel.Error, 123, "FN123", "Actionable event occurred", "https://fwlink", null);
             }
 
             Assert.Equal(1, repository.Events.Count);
             Assert.Equal("FN123", repository.Events.First().ErrorCode);
+        }
+
+        [Fact]
+        public void DiagnosticEventLogger_DoesNotLog_IfFeatureFlagDisabled()
+        {
+            var repository = new TestDiagnosticEventRepository();
+            var repositoryFactory = new TestDiagnosticEventRepositoryFactory(repository);
+            var environment = new TestEnvironment();
+            var options = new StandbyOptions { InStandbyMode = true };
+            var standbyOptions = new TestOptionsMonitor<StandbyOptions>(options);
+            using (var provider = new DiagnosticEventLoggerProvider(repositoryFactory, environment, standbyOptions))
+            {
+                var logger = provider.CreateLogger("MS_DiagnosticEvents");
+
+                // this one will not appear because of standby mode
+                logger.LogDiagnosticEvent(LogLevel.Error, 123, "FN123", "Actionable event occurred", "https://fwlink", null);
+
+                // we cache the _isEnabled, so need to force it to re-evaluate
+                // this will happen during specialization
+                options.InStandbyMode = false;
+                environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagDisableDiagnosticEventLogging);
+                standbyOptions.InvokeChanged();
+
+                // this one will still not appear due to the feature flag
+                logger.LogDiagnosticEvent(LogLevel.Error, 123, "FN999", "Actionable event occurred", "https://fwlink", null);
+            }
+
+            Assert.Empty(repository.Events);
         }
 
         public class TestDiagnosticEventRepositoryFactory : IDiagnosticEventRepositoryFactory


### PR DESCRIPTION
Fixes #9030, #9037

Today we let exceptions from startup classes flow through to the `WebJobsScriptHostService`. Because the customer's host has not been created, they have no logger and no direct way to surface errors other than via the portal's "LastError" check.

This now adds two more ways to send errors:
- via the DiagnosticEvent logging infrastructure
- via App Insights (if there's a connection string present)

By wrapping the exception in our own type, it also eliminates the special handling of the OperationCanceledExcpetion that was causing us to sit idle if a startup class threw this excpetion. Now we'll mark the host as in Error and retry (with backoff) as we would with any other startup exception.

The experience after this is in:
- Exceptions are logged as a `Microsoft.Azure.WebJobs.Script.ExternalStartupException`.
- These exceptions will be retried in case they are transient. It's hard for us to know, but something like pulling config from a db in your startup may be transient, so the host will retry with a backoff forever just in case.
- If Application Insights is enabled, we will attempt to create a `TelemetryClient` and send the exception there.
- A diagnostic exception will be logged, which means you will get a banner like this:

![image](https://user-images.githubusercontent.com/1089915/227231180-6cc77a80-cd0b-437c-9237-9b2cf19a609e.png)

which then leads to this

![image](https://user-images.githubusercontent.com/1089915/227231577-60105c4b-7c47-4d0f-a189-17a7eb9184e8.png)

which ultimately links to https://learn.microsoft.com/en-us/azure/azure-functions/errors-diagnostics/diagnostic-events/azfd0005

Hopefully this helps diagnose previously silent startup problems...