### PR TITLE
Replace Where+FirstOrDefault call with FirstOrDefault and other minor cleanups

### DIFF
--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannelFactory.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannelFactory.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reactive.Linq;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
@@ -44,10 +43,10 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
         public IRpcWorkerChannel Create(string scriptRootPath, string runtime, IMetricsLogger metricsLogger, int attemptCount, IEnumerable<RpcWorkerConfig> workerConfigs)
         {
-            var languageWorkerConfig = workerConfigs.Where(c => c.Description.Language.Equals(runtime, StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+            var languageWorkerConfig = workerConfigs.FirstOrDefault(c => c.Description.Language.Equals(runtime, StringComparison.OrdinalIgnoreCase));
             if (languageWorkerConfig == null)
             {
-                throw new InvalidOperationException($"WorkerCofig for runtime: {runtime} not found");
+                throw new InvalidOperationException($"WorkerConfig for runtime: {runtime} not found");
             }
             string workerId = Guid.NewGuid().ToString();
             _eventManager.AddGrpcChannels(workerId); // prepare the inbound/outbound dedicated channels

--- a/src/WebJobs.Script/Description/FunctionGenerator.cs
+++ b/src/WebJobs.Script/Description/FunctionGenerator.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                     continue;
                 }
 
-                var retValue = function.Parameters.Where(x => x.Name == ScriptConstants.SystemReturnParameterName).FirstOrDefault();
+                var retValue = function.Parameters.FirstOrDefault(x => x.Name == ScriptConstants.SystemReturnParameterName);
                 var parameters = function.Parameters.Where(x => x != retValue).ToArray();
 
                 MethodBuilder methodBuilder = tb.DefineMethod(function.Name, MethodAttributes.Public | MethodAttributes.Static);

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -37,8 +37,8 @@ namespace Microsoft.Azure.WebJobs.Script
     {
         // Prefix that uniquely identifies our assemblies
         // i.e.: "f-<functionname>"
-        public const string AssemblyPrefix = "f-";
-        public const string AssemblySeparator = "__";
+        private const string AssemblyPrefix = "f-";
+        private const string AssemblySeparator = "__";
         private const string BlobServiceDomain = "blob";
         private const string SasVersionQueryParam = "sv";
 
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// </summary>
         /// <param name="timeoutSeconds">The maximum number of seconds to delay.</param>
         /// <param name="pollingIntervalMilliseconds">The polling interval.</param>
-        /// <param name="condition">The condition to check</param>
+        /// <param name="condition">The condition to check.</param>
         /// <returns>A Task representing the delay.</returns>
         internal static Task<bool> DelayAsync(int timeoutSeconds, int pollingIntervalMilliseconds, Func<bool> condition)
         {
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// </summary>
         /// <param name="timeoutSeconds">The maximum number of seconds to delay.</param>
         /// <param name="pollingIntervalMilliseconds">The polling interval.</param>
-        /// <param name="condition">The async condition to check</param>
+        /// <param name="condition">The async condition to check.</param>
         /// <returns>A Task representing the delay.</returns>
         internal static Task<bool> DelayAsync(int timeoutSeconds, int pollingIntervalMilliseconds, Func<Task<bool>> condition, CancellationToken cancellationToken)
         {
@@ -262,7 +262,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public static IReadOnlyDictionary<string, string> ToStringValues(this IReadOnlyDictionary<string, object> data)
         {
-            return data.ToDictionary(p => p.Key, p => p.Value != null ? p.Value.ToString() : null, StringComparer.OrdinalIgnoreCase);
+            return data.ToDictionary(p => p.Key, p => p.Value?.ToString(), StringComparer.OrdinalIgnoreCase);
         }
 
         public static string GetValueOrNull(this StringDictionary dictionary, string key)
@@ -348,7 +348,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
         /// <summary>
         /// Applies any additional binding data from the input value to the specified binding data.
-        /// This binding data then becomes available to the binding process (in the case of late bound bindings)
+        /// This binding data then becomes available to the binding process (in the case of late bound bindings).
         /// </summary>
         internal static void ApplyBindingData(object value, Dictionary<string, object> bindingData)
         {
@@ -424,9 +424,9 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
-        /// Checks if a given string has a UTF8 BOM
+        /// Checks if a given string has a UTF8 BOM.
         /// </summary>
-        /// <param name="input">The string to be evalutated</param>
+        /// <param name="input">The string to be evaluated.</param>
         /// <returns>True if the string begins with a UTF8 BOM; Otherwise, false.</returns>
         public static bool HasUtf8ByteOrderMark(string input)
             => input != null && CultureInfo.InvariantCulture.CompareInfo.IsPrefix(input, UTF8ByteOrderMark, CompareOptions.Ordinal);
@@ -632,11 +632,9 @@ namespace Microsoft.Azure.WebJobs.Script
 
         internal static string GetWorkerRuntime(IEnumerable<FunctionMetadata> functions, IEnvironment environment = null)
         {
-            string workerRuntime = null;
-
             if (environment != null)
             {
-                workerRuntime = environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime);
+                var workerRuntime = environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime);
 
                 if (!string.IsNullOrEmpty(workerRuntime))
                 {
@@ -729,7 +727,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 // No valid functions
                 return null;
             }
-            return indexedFunctions.Where(m => functionDescriptors.Select(fd => fd.Metadata.Name).Contains(m.Name) == true);
+            return indexedFunctions.Where(m => functionDescriptors.Select(fd => fd.Metadata.Name).Contains(m.Name));
         }
 
         public static bool CheckAppOffline(string scriptPath)
@@ -840,10 +838,10 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
-        /// Computes a stable non-cryptographic hash
+        /// Computes a stable non-cryptographic hash.
         /// </summary>
-        /// <param name="value">The string to use for computation</param>
-        /// <returns>A stable, non-cryptographic, hash</returns>
+        /// <param name="value">The string to use for computation.</param>
+        /// <returns>A stable, non-cryptographic, hash.</returns>
         internal static int GetStableHash(string value)
         {
             if (value == null)
@@ -916,7 +914,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 && !environment.IsMultiLanguageRuntimeEnvironment())
             {
                 var workerRuntime = environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime);
-                var workerConfig = workerConfigs.Where(c => c.Description != null && c.Description.Language != null && c.Description.Language.Equals(workerRuntime, StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault();
+                var workerConfig = workerConfigs.FirstOrDefault(c => c.Description?.Language != null && c.Description.Language.Equals(workerRuntime, StringComparison.InvariantCultureIgnoreCase));
 
                 // if feature flag is enabled and workerConfig.WorkerIndexing == true, then return true
                 if (workerConfig != null

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -117,8 +117,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
             if (!string.IsNullOrEmpty(_workerRuntime))
             {
-                var workerConfig = _workerConfigs.Where(c => c.Description.Language.Equals(_workerRuntime, StringComparison.InvariantCultureIgnoreCase))
-                                                .FirstOrDefault();
+                var workerConfig = _workerConfigs
+                    .FirstOrDefault(c => c.Description.Language.Equals(_workerRuntime, StringComparison.InvariantCultureIgnoreCase));
                 if (workerConfig != null)
                 {
                     return workerConfig.CountOptions.ProcessCount;
@@ -261,7 +261,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 return;
             }
 
-            var workerConfig = _workerConfigs.Where(c => c.Description.Language.Equals(_workerRuntime, StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault();
+            var workerConfig = _workerConfigs.FirstOrDefault(c => c.Description.Language.Equals(_workerRuntime, StringComparison.InvariantCultureIgnoreCase));
 
             // For other OOP workers, workerconfigs are present inside "workers" folder of host bin directory and is used to populate "_workerConfigs".
             // For dotnet-isolated _workerConfigs is populated by reading workerconfig.json from the deployed payload(customer function app code).
@@ -271,7 +271,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
             // We are skipping this check for multi-language environments because they use multiple workers and thus doesn't honor 'FUNCTIONS_WORKER_RUNTIME'
             // Also, skip if dotnet-isolated app without payload as it is a valid case to exist.
-            if ((workerConfig == null && (functions == null || functions.Count() == 0))
+            if (workerConfig == null && (functions == null || !functions.Any())
                 && !_environment.IsMultiLanguageRuntimeEnvironment()
                 && !isDotNetIsolatedAppWithoutPayload)
             {
@@ -283,7 +283,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 throw new InvalidOperationException($"WorkerConfig for runtime: {_workerRuntime} not found");
             }
 
-            if (functions == null || functions.Count() == 0)
+            if (functions == null || !functions.Any())
             {
                 // do not initialize function dispatcher if there are no functions, unless the worker is indexing
                 _logger.LogDebug($"{nameof(RpcFunctionInvocationDispatcher)} received no functions");
@@ -443,7 +443,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             return initializedWorkers;
         }
 
-        public async void WorkerError(WorkerErrorEvent workerError)
+        private async void WorkerError(WorkerErrorEvent workerError)
         {
             if (_disposing || _disposed)
             {
@@ -473,7 +473,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             }
         }
 
-        public async void WorkerRestart(WorkerRestartEvent workerRestart)
+        private async void WorkerRestart(WorkerRestartEvent workerRestart)
         {
             if (_disposing || _disposed)
             {
@@ -582,7 +582,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     }
                 }
             }
-            else if (_jobHostLanguageWorkerChannelManager.GetChannels().Count() == 0)
+            else if (!_jobHostLanguageWorkerChannelManager.GetChannels().Any())
             {
                 _logger.LogError("Exceeded language worker restart retry count for runtime:{runtime}. Shutting down and proactively recycling the Functions Host to recover", runtime);
                 _applicationLifetime.StopApplication();

--- a/test/WebJobs.Script.Tests/UtilityTests.cs
+++ b/test/WebJobs.Script.Tests/UtilityTests.cs
@@ -3,23 +3,18 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Dynamic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Azure.WebJobs.Logging;
-using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Models;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
@@ -950,7 +945,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         private static void VerifyLogLevel(IList<LogMessage> allLogs, string msg, LogLevel expectedLevel)
         {
-            var message = allLogs.Where(l => l.FormattedMessage.Contains(msg)).FirstOrDefault();
+            var message = allLogs.FirstOrDefault(l => l.FormattedMessage.Contains(msg));
             Assert.NotNull(message);
             Assert.Equal(expectedLevel, message.Level);
         }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var testLogger = new TestLogger("test");
             var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger(), _testWorkerProfileManager);
             var workerConfigs = configFactory.GetConfigs();
-            var javaPath = workerConfigs.Where(c => c.Description.Language.Equals("java", StringComparison.OrdinalIgnoreCase)).FirstOrDefault().Description.DefaultExecutablePath;
+            var javaPath = workerConfigs.FirstOrDefault(c => c.Description.Language.Equals("java", StringComparison.OrdinalIgnoreCase)).Description.DefaultExecutablePath;
             Assert.DoesNotContain(@"%JAVA_HOME%", javaPath);
             Assert.Contains(@"/bin/java", javaPath);
         }
@@ -128,8 +128,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             {
                 var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger(), _testWorkerProfileManager);
                 var workerConfigs = configFactory.GetConfigs();
-                var pythonWorkerConfig = workerConfigs.Where(w => w.Description.Language.Equals("python", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
-                var powershellWorkerConfig = workerConfigs.Where(w => w.Description.Language.Equals("powershell", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                var pythonWorkerConfig = workerConfigs.FirstOrDefault(w => w.Description.Language.Equals("python", StringComparison.OrdinalIgnoreCase));
+                var powershellWorkerConfig = workerConfigs.FirstOrDefault(w => w.Description.Language.Equals("powershell", StringComparison.OrdinalIgnoreCase));
                 Assert.Equal(4, workerConfigs.Count);
                 Assert.NotNull(pythonWorkerConfig);
                 Assert.NotNull(powershellWorkerConfig);
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var testLogger = new TestLogger("test");
             var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, testEnvironment, new TestMetricsLogger(), _testWorkerProfileManager);
             var workerConfigs = configFactory.GetConfigs();
-            var powershellWorkerConfig = workerConfigs.Where(w => w.Description.Language.Equals("powershell", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+            var powershellWorkerConfig = workerConfigs.FirstOrDefault(w => w.Description.Language.Equals("powershell", StringComparison.OrdinalIgnoreCase));
             Assert.Equal(1, workerConfigs.Count);
             Assert.NotNull(powershellWorkerConfig);
             Assert.Equal("7.2", powershellWorkerConfig.Description.DefaultRuntimeVersion);

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigTests.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var workerConfigs = TestReadWorkerProviderFromConfig(configs, testLogger, testMetricsLogger);
             AreRequiredMetricsEmitted(testMetricsLogger);
             var logs = testLogger.GetLogMessages();
-            var errorLog = logs.Where(log => log.Level == LogLevel.Error).FirstOrDefault();
+            var errorLog = logs.FirstOrDefault(log => log.Level == LogLevel.Error);
             Assert.NotNull(errorLog);
             Assert.NotNull(errorLog.Exception);
             Assert.True(errorLog.FormattedMessage.Contains("Failed to initialize"));


### PR DESCRIPTION
- Replaced LINQ `Where`+`FirstOrDefault` call with single call to `FirstOrDefault`. This is [slightly more performant](https://gist.github.com/kshyju/d5c528bb590a18c49c6c1fe6beb17243) because [WhereEnumerableIterator](https://github.com/dotnet/runtime/blob/1af80ba017f6f7644305e1781d8cc9845a92b5f8/src/libraries/System.Linq/src/System/Linq/Where.cs#L80) will not be [allocated ](https://github.com/dotnet/runtime/blob/1af80ba017f6f7644305e1781d8cc9845a92b5f8/src/libraries/System.Linq/src/System/Linq/Where.cs#L41)in this case.

- Fixed few typos
- Removed unused using statements.
- Changed some public methods to private.