### PR TITLE
fixing exception when accessing a disposed Process

### DIFF
--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcess.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcess.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             }
             catch (Exception ex)
             {
-                _workerProcessLogger.LogDebug(ex, "An exception was thrown while waiting for process {processId} to exit. It is possible that the process had already exited and this can be ignored.", Process?.Id);
+                _workerProcessLogger.LogDebug(ex, "An exception was thrown while waiting for a worker process to exit. It is possible that the process had already exited and this can be ignored.");
             }
         }
 


### PR DESCRIPTION
The exception handling introduced by #8917 can inadvertently re-throw the exception by accessing the disposed `Process?.Id` in the exception message.

I've also added a test that failed before fixing the message.