### PR TITLE
Adding null check to fix the issue with input/output binding for the sdk type scenario

### DIFF
--- a/src/WebJobs.Script/Description/Workers/WorkerFunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/Workers/WorkerFunctionDescriptorProvider.cs
@@ -129,11 +129,16 @@ namespace Microsoft.Azure.WebJobs.Script.Description
                 {
                     return attribute.GetType()
                                     .GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                                    .Any(prop => prop.PropertyType == typeof(string) && _expressionRegex.IsMatch((string)prop.GetValue(attribute)));
+                                    .Any(prop => prop.PropertyType == typeof(string) && IsMatch((string)prop.GetValue(attribute)));
                 }
             }
 
             return false;
+        }
+
+        private bool IsMatch(string value)
+        {
+            return string.IsNullOrEmpty(value) ? false : _expressionRegex.IsMatch(value);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Description/Worker/WorkerFunctionDescriptorProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/Worker/WorkerFunctionDescriptorProviderTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-        public void BindingAttributeContainsExpression__InputBinding_EmptyConnection_NoRegex_FindsRegexMatch_ReturnsTrue()
+        public void BindingAttributeContainsExpression__InputBinding_EmptyConnection_NoRegex_FindsRegexMatch_ReturnsFalse()
         {
             var inputBindingJObject = JObject.Parse("{\"name\":\"myBlob\",\"direction\":\"In\",\"type\":\"blob\",\"blobPath\":\"input-container//file.txt\",\"connection\":\"\",\"properties\":{\"supportsDeferredBinding\":true}}");
             FunctionBinding inputBinding = TestHelpers.CreateBindingFromHost(_host, inputBindingJObject);

--- a/test/WebJobs.Script.Tests/Description/Worker/WorkerFunctionDescriptorProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/Worker/WorkerFunctionDescriptorProviderTests.cs
@@ -85,6 +85,39 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public void BindingAttributeContainsExpression__InputBinding_EmptyConnection_FindsRegexMatch_ReturnsTrue()
+        {
+            var inputBindingJObject = JObject.Parse("{\"name\":\"myBlob\",\"direction\":\"In\",\"type\":\"blob\",\"blobPath\":\"input-container//{id}.txt\",\"connection\":\"\",\"properties\":{\"supportsDeferredBinding\":true}}");
+            FunctionBinding inputBinding = TestHelpers.CreateBindingFromHost(_host, inputBindingJObject);
+            IEnumerable<FunctionBinding> bindings = new List<FunctionBinding>() { inputBinding };
+
+            bool result = _provider.BindingAttributeContainsExpression(bindings);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void BindingAttributeContainsExpression__InputBinding_EmptyConnection_NoRegex_FindsRegexMatch_ReturnsTrue()
+        {
+            var inputBindingJObject = JObject.Parse("{\"name\":\"myBlob\",\"direction\":\"In\",\"type\":\"blob\",\"blobPath\":\"input-container//file.txt\",\"connection\":\"\",\"properties\":{\"supportsDeferredBinding\":true}}");
+            FunctionBinding inputBinding = TestHelpers.CreateBindingFromHost(_host, inputBindingJObject);
+            IEnumerable<FunctionBinding> bindings = new List<FunctionBinding>() { inputBinding };
+
+            bool result = _provider.BindingAttributeContainsExpression(bindings);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void BindingAttributeContainsExpression__InputBinding_EmptyFields_FindsRegexMatch_ReturnsFalse()
+        {
+            var inputBindingJObject = JObject.Parse("{\"name\":\"myBlob\",\"direction\":\"In\",\"type\":\"blob\",\"blobPath\":\"\",\"connection\":\"\",\"properties\":{\"supportsDeferredBinding\":true}}");
+            FunctionBinding inputBinding = TestHelpers.CreateBindingFromHost(_host, inputBindingJObject);
+            IEnumerable<FunctionBinding> bindings = new List<FunctionBinding>() { inputBinding };
+
+            bool result = _provider.BindingAttributeContainsExpression(bindings);
+            Assert.False(result);
+        }
+
+        [Fact]
         public void BindingAttributeContainsExpression_OutputBinding_FindsRegexMatch_ReturnsTrue()
         {
             var outputBindingJObject = JObject.Parse("{\"name\":\"$return\",\"direction\":\"Out\",\"type\":\"blob\",\"blobPath\":\"output-container//{name}-output.txt\",\"connection\":\"AzureWebJobsStorage\",\"properties\":{}}");
@@ -93,6 +126,28 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             bool result = _provider.BindingAttributeContainsExpression(bindings);
             Assert.True(result);
+        }
+
+        [Fact]
+        public void BindingAttributeContainsExpression_OutputBinding_EmptyConnection_FindsRegexMatch_ReturnsTrue()
+        {
+            var outputBindingJObject = JObject.Parse("{\"name\":\"$return\",\"direction\":\"Out\",\"type\":\"blob\",\"blobPath\":\"output-container//{name}-output.txt\",\"connection\":\"\",\"properties\":{}}");
+            FunctionBinding outputBinding = TestHelpers.CreateBindingFromHost(_host, outputBindingJObject);
+            IEnumerable<FunctionBinding> bindings = new List<FunctionBinding>() { outputBinding };
+
+            bool result = _provider.BindingAttributeContainsExpression(bindings);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void BindingAttributeContainsExpression_OutputBinding_EmptyFields_FindsRegexMatch_ReturnsFalse()
+        {
+            var outputBindingJObject = JObject.Parse("{\"name\":\"$return\",\"direction\":\"Out\",\"type\":\"blob\",\"blobPath\":\"\",\"connection\":\"\",\"properties\":{}}");
+            FunctionBinding outputBinding = TestHelpers.CreateBindingFromHost(_host, outputBindingJObject);
+            IEnumerable<FunctionBinding> bindings = new List<FunctionBinding>() { outputBinding };
+
+            bool result = _provider.BindingAttributeContainsExpression(bindings);
+            Assert.False(result);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-dotnet-worker/issues/1362

Can repro the issue with InputBinding as well, hence added tests for both input and output binding

```csharp
        [Function(nameof(SampleFunction))]
        public void SampleFunction(
            [BlobTrigger("stream-trigger/sample1.txt")] string content,
            [BlobInput("input-container/file.txt")] string myBlob,
            FunctionContext context)
        {
            _logger.LogInformation("Trigger content: {content}", content);
            _logger.LogInformation("Blob content: {content}", myBlob);
        }
```


### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
