### PR TITLE
Adding new HostId generation logic for CV2

### DIFF
--- a/test/WebJobs.Script.Tests/ScriptHostIdProviderTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostIdProviderTests.cs
@@ -94,6 +94,29 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.False(result.IsLocal);
         }
 
+        [Theory]
+        [InlineData("myfunctionstestapp", "6606e225f163a70190e4f4357d3dad78")]
+        [InlineData("TEST-FUNCTIONS-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "9dd2d6d54f1135ee6db6116f084b29bd")]
+        [InlineData("TEST-FUNCTIONS-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXA", "c842e18afa2a84eac2818a956687a72e")]
+        [InlineData("TEST-FUNCTIONS-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXB", "b595edd5b794d34e79c81361c823487c")]
+        public void GetDefaultHostId_FlexConsumption_ReturnsExpectedResult(string siteName, string expected)
+        {
+            var options = new ScriptApplicationHostOptions
+            {
+                ScriptPath = @"c:\testscripts"
+            };
+
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, ScriptConstants.FlexConsumptionSku);
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName, siteName);
+
+            var result = ScriptHostIdProvider.GetDefaultHostId(environment, options);
+
+            Assert.Equal(expected, result.HostId);
+            Assert.Equal(32, result.HostId.Length);
+            Assert.False(result.IsTruncated);
+        }
+
         [Fact]
         public void GetDefaultHostId_SelfHost_ReturnsExpectedResult()
         {


### PR DESCRIPTION
Introducing a new algorithm for host ID generation that doesn't truncate. Also updating sync triggers to include the HostId along with the sync triggers payload (initially for CV2 only). ScaleController has already been updated to use the payload HostId when specified by the host.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
