### PR TITLE
Support for HttpContext.RequestAborted cancellation token for Http requests

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -16,6 +16,7 @@
 - Update PowerShell Worker 7.2 to 4.0.2719 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2719)
 - Update Node.js Worker Version to [3.6.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.6.0)
 - Upgrade PowerShell language worker 7.0 to 4.0.2733 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2733)
+- Support for HttpContext.RequestAborted in the HttpTrigger cancellation token (#9159)
 
 **Release sprint:** Sprint 139
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+139%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+139%22+label%3Afeature+is%3Aclosed) ]

--- a/release_notes.md
+++ b/release_notes.md
@@ -16,7 +16,7 @@
 - Update PowerShell Worker 7.2 to 4.0.2719 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2719)
 - Update Node.js Worker Version to [3.6.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.6.0)
 - Upgrade PowerShell language worker 7.0 to 4.0.2733 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2733)
-- Support for HttpContext.RequestAborted in the HttpTrigger cancellation token (#9159)
+- Support for HttpContext.RequestAborted cancellation token for Http requests (#9159)
 
 **Release sprint:** Sprint 139
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+139%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+139%22+label%3Afeature+is%3Aclosed) ]

--- a/src/WebJobs.Script.WebHost/Middleware/FunctionInvocationMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/FunctionInvocationMiddleware.cs
@@ -128,7 +128,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
                 using (logger.BeginScope(scopeState))
                 {
                     var applicationLifetime = context.RequestServices.GetService<IApplicationLifetime>();
-                    CancellationToken cancellationToken = applicationLifetime != null ? applicationLifetime.ApplicationStopping : CancellationToken.None;
+                    CancellationToken cancellationToken = context.RequestAborted;
+
                     await functionExecution.ExecuteAsync(context.Request, cancellationToken);
 
                     if (context.Items.TryGetValue(ScriptConstants.AzureFunctionsDuplicateHttpHeadersKey, out object value))


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #8903

**Use case**: InvocationCancel should be sent to the worker whether the host cancellation token is cancelled or if if the `RequestAborted` cancellation token is cancelled (in the case where we have a http trigger).

**Solution**: Update the cancellation token being used to be the RequestAborted on. This cancellation token is linked to the lifetime source so the cancellation token should trigger for both request aborted events, and lifetime events.

Verified that the `RequestAborted` CT works with application lifetime cancellations.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests) // TODO

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
