### PR TITLE
[V4] Allow site auth JWT tokens to be passed via x-ms-site-token header.

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -708,7 +708,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 var requestId = Guid.NewGuid().ToString();
                 request.Headers.Add(ScriptConstants.AntaresLogIdHeaderName, requestId);
                 request.Headers.Add("User-Agent", ScriptConstants.FunctionsUserAgent);
-                request.Headers.Add(ScriptConstants.SiteTokenHeaderName, token);
+                request.Headers.Add(ScriptConstants.SiteRestrictedTokenHeaderName, token);
                 request.Content = new StringContent(content, Encoding.UTF8, "application/json");
 
                 if (_environment.IsManagedAppEnvironment())

--- a/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
@@ -289,7 +289,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             // add the required authentication headers
             request.Headers.Add(ContainerNameHeader, _containerName);
             request.Headers.Add(HostNameHeader, _hostNameProvider.Value);
-            request.Headers.Add(ScriptConstants.SiteTokenHeaderName, token);
+            request.Headers.Add(ScriptConstants.SiteRestrictedTokenHeaderName, token);
             request.Headers.Add(StampNameHeader, _stampName);
 
             return request;

--- a/src/WebJobs.Script.WebHost/Security/Authentication/Arm/ArmAuthenticationHandler.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Arm/ArmAuthenticationHandler.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication
         private AuthenticateResult HandleAuthenticate()
         {
             string token = null;
-            if (!Context.Request.Headers.TryGetValue(ScriptConstants.SiteTokenHeaderName, out StringValues values))
+            if (!Context.Request.Headers.TryGetValue(ScriptConstants.SiteRestrictedTokenHeaderName, out StringValues values))
             {
                 return AuthenticateResult.NoResult();
             }

--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -1,19 +1,18 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
+using System.Linq;
 using System.Security.Claims;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.Azure.Web.DataProtection;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication;
+using Microsoft.Extensions.Primitives;
 using Microsoft.IdentityModel.Tokens;
 using static Microsoft.Azure.WebJobs.Script.EnvironmentSettingNames;
 using static Microsoft.Azure.WebJobs.Script.ScriptConstants;
@@ -31,8 +30,16 @@ namespace Microsoft.Extensions.DependencyInjection
                             {
                                 OnMessageReceived = c =>
                                 {
+                                    // By default, tokens are passed via the standard Authorization Bearer header. However we also support
+                                    // passing tokens via the x-ms-site-token header.
+                                    if (c.Request.Headers.TryGetValue(ScriptConstants.SiteTokenHeaderName, out StringValues values))
+                                    {
+                                        // the token we set here will be the one used - Authorization header won't be checked.
+                                        c.Token = values.FirstOrDefault();
+                                    }
+
                                     // Temporary: Tactical fix to address specialization issues. This should likely be moved to a token validator
-                                    // TODO: DI (FACAVAL) This will be fixed once the permanent fix is in plance
+                                    // TODO: DI (FACAVAL) This will be fixed once the permanent fix is in place
                                     if (_specialized == 0 && !SystemEnvironment.Instance.IsPlaceholderModeEnabled() && Interlocked.CompareExchange(ref _specialized, 1, 0) == 0)
                                     {
                                         o.TokenValidationParameters = CreateTokenValidationParameters();
@@ -55,7 +62,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
                             o.TokenValidationParameters = CreateTokenValidationParameters();
 
-                            // TODO: DI (FACAVAL) Remove this once th work above is completed.
+                            // TODO: DI (FACAVAL) Remove this once the work above is completed.
                             if (!SystemEnvironment.Instance.IsPlaceholderModeEnabled())
                             {
                                 // We're not in standby mode, so flag as specialized
@@ -65,17 +72,23 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static TokenValidationParameters CreateTokenValidationParameters()
         {
-            string defaultKey = Util.GetDefaultKeyValue();
-
             var result = new TokenValidationParameters();
-            if (defaultKey != null)
+            if (SecretsUtility.TryGetEncryptionKey(out byte[] key))
             {
                 // TODO: Once ScriptSettingsManager is gone, Audience and Issuer shouold be pulled from configuration.
-                result.IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(defaultKey));
+                result.IssuerSigningKey = new SymmetricSecurityKey(key);
                 result.ValidateAudience = true;
                 result.ValidateIssuer = true;
-                result.ValidAudience = string.Format(AdminJwtValidAudienceFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName));
-                result.ValidIssuer = string.Format(AdminJwtValidIssuerFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName));
+                result.ValidAudiences = new string[]
+                {
+                    string.Format(AdminJwtValidAudienceFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName)),
+                    AdminJwtAppServiceIssuer
+                };
+                result.ValidIssuers = new string[]
+                {
+                    string.Format(AdminJwtValidIssuerFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName)),
+                    AdminJwtAppServiceIssuer
+                };
             }
 
             return result;

--- a/src/WebJobs.Script.WebHost/Security/SecretsUtility.cs
+++ b/src/WebJobs.Script.WebHost/Security/SecretsUtility.cs
@@ -2,11 +2,12 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.IO;
+using System.Linq;
+using Microsoft.Azure.Web.DataProtection;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
 {
-    internal class SecretsUtility
+    internal static class SecretsUtility
     {
         public static string GetNonDecryptableName(string secretsPath)
         {
@@ -16,6 +17,79 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 secretsPath = secretsPath.Substring(0, secretsPath.Length - 5);
             }
             return secretsPath + $".{ScriptConstants.Snapshot}.{timeStamp}.json";
+        }
+
+        public static bool TryGetEncryptionKey(out byte[] key, IEnvironment environment = null)
+        {
+            environment = environment ?? SystemEnvironment.Instance;
+
+            if (environment.IsKubernetesManagedHosting())
+            {
+                var podEncryptionKey = environment.GetEnvironmentVariable(EnvironmentSettingNames.PodEncryptionKey);
+                if (!string.IsNullOrEmpty(podEncryptionKey))
+                {
+                    key = Convert.FromBase64String(podEncryptionKey);
+                    return true;
+                }
+            }
+
+            // Use WebSiteAuthEncryptionKey if available else fall back to ContainerEncryptionKey.
+            // Until the container is specialized to a specific site WebSiteAuthEncryptionKey will not be available.
+            if (TryGetEncryptionKey(environment, EnvironmentSettingNames.WebSiteAuthEncryptionKey, out key) ||
+                TryGetEncryptionKey(environment, EnvironmentSettingNames.ContainerEncryptionKey, out key))
+            {
+                return true;
+            }
+
+            // Fall back to using DataProtection APIs to get the key
+            string defaultKey = Util.GetDefaultKeyValue();
+            if (!string.IsNullOrEmpty(defaultKey))
+            {
+                key = defaultKey.ToKeyBytes();
+                return true;
+            }
+
+            return false;
+        }
+
+        public static byte[] GetEncryptionKey(IEnvironment environment = null)
+        {
+            if (TryGetEncryptionKey(out byte[] key, environment))
+            {
+                return key;
+            }
+            else
+            {
+                throw new InvalidOperationException($"No encryption key defined in the environment.");
+            }
+        }
+
+        public static byte[] ToKeyBytes(this string hexOrBase64)
+        {
+            // only support 32 bytes (256 bits) key length
+            if (hexOrBase64.Length == 64)
+            {
+                return Enumerable.Range(0, hexOrBase64.Length)
+                    .Where(x => x % 2 == 0)
+                    .Select(x => Convert.ToByte(hexOrBase64.Substring(x, 2), 16))
+                    .ToArray();
+            }
+
+            return Convert.FromBase64String(hexOrBase64);
+        }
+
+        private static bool TryGetEncryptionKey(IEnvironment environment, string keyName, out byte[] encryptionKey)
+        {
+            encryptionKey = null;
+            var hexOrBase64 = environment.GetEnvironmentVariable(keyName);
+            if (string.IsNullOrEmpty(hexOrBase64))
+            {
+                return false;
+            }
+
+            encryptionKey = hexOrBase64.ToKeyBytes();
+
+            return true;
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Security/SimpleWebTokenHelper.cs
+++ b/src/WebJobs.Script.WebHost/Security/SimpleWebTokenHelper.cs
@@ -24,10 +24,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security
 
         internal static string Encrypt(string value, byte[] key = null, IEnvironment environment = null)
         {
-            if (key == null)
-            {
-                TryGetEncryptionKey(environment, EnvironmentSettingNames.WebSiteAuthEncryptionKey, out key);
-            }
+            key = key ?? SecretsUtility.GetEncryptionKey(environment);
 
             using (var aes = Aes.Create())
             {
@@ -90,19 +87,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security
 
         public static string Decrypt(string value, IEnvironment environment = null)
         {
-            if ((environment != null) && environment.IsKubernetesManagedHosting())
-            {
-                var encryptionKey = GetPodEncryptionKey(environment);
-                return Decrypt(encryptionKey, value);
-            }
-            // Use WebSiteAuthEncryptionKey if available else fallback to ContainerEncryptionKey.
-            // Until the container is specialized to a specific site WebSiteAuthEncryptionKey will not be available.
-            byte[] key;
-            if (!TryGetEncryptionKey(environment, EnvironmentSettingNames.WebSiteAuthEncryptionKey, out key, false))
-            {
-                TryGetEncryptionKey(environment, EnvironmentSettingNames.ContainerEncryptionKey, out key);
-            }
-
+            byte[] key = SecretsUtility.GetEncryptionKey(environment);
             return Decrypt(key, value);
         }
 
@@ -139,51 +124,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security
             {
                 return Convert.ToBase64String(sha256.ComputeHash(key));
             }
-        }
-
-        private static bool TryGetEncryptionKey(IEnvironment environment, string keyName, out byte[] encryptionKey, bool throwIfFailed = true)
-        {
-            environment = environment ?? SystemEnvironment.Instance;
-
-            encryptionKey = null;
-            var hexOrBase64 = environment.GetEnvironmentVariable(keyName);
-            if (string.IsNullOrEmpty(hexOrBase64))
-            {
-                if (throwIfFailed)
-                {
-                    throw new InvalidOperationException($"No {keyName} defined in the environment");
-                }
-
-                return false;
-            }
-
-            encryptionKey = hexOrBase64.ToKeyBytes();
-
-            return true;
-        }
-
-        private static byte[] GetPodEncryptionKey(IEnvironment environment)
-        {
-            var podEncryptionKey = environment.GetEnvironmentVariable(EnvironmentSettingNames.PodEncryptionKey);
-            if (string.IsNullOrEmpty(podEncryptionKey))
-            {
-                throw new Exception("Pod encryption key is empty.");
-            }
-            return Convert.FromBase64String(podEncryptionKey);
-        }
-
-        public static byte[] ToKeyBytes(this string hexOrBase64)
-        {
-            // only support 32 bytes (256 bits) key length
-            if (hexOrBase64.Length == 64)
-            {
-                return Enumerable.Range(0, hexOrBase64.Length)
-                    .Where(x => x % 2 == 0)
-                    .Select(x => Convert.ToByte(hexOrBase64.Substring(x, 2), 16))
-                    .ToArray();
-            }
-
-            return Convert.FromBase64String(hexOrBase64);
         }
     }
 }

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -100,7 +100,8 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AntaresLogIdHeaderName = "X-ARR-LOG-ID";
         public const string AntaresScaleOutHeaderName = "X-FUNCTION-SCALEOUT";
         public const string AntaresColdStartHeaderName = "X-MS-COLDSTART";
-        public const string SiteTokenHeaderName = "x-ms-site-restricted-token";
+        public const string SiteRestrictedTokenHeaderName = "x-ms-site-restricted-token";
+        public const string SiteTokenHeaderName = "x-ms-site-token";
         public const string EasyAuthIdentityHeader = "x-ms-client-principal";
         public const string AntaresPlatformInternal = "x-ms-platform-internal";
         public const string AzureVersionHeader = "x-ms-version";
@@ -129,6 +130,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public const string AdminJwtValidAudienceFormat = "https://{0}.azurewebsites.net/azurefunctions";
         public const string AdminJwtValidIssuerFormat = "https://{0}.scm.azurewebsites.net";
+        public const string AdminJwtAppServiceIssuer = "https://appservice.core.azurewebsites.net";
 
         public const string AzureFunctionsSystemDirectoryName = ".azurefunctions";
         public const string HttpMethodConstraintName = "httpMethod";

--- a/test/WebJobs.Script.Tests.Integration/Management/KubernetesPodControllerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/KubernetesPodControllerTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
@@ -138,7 +139,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             environment.SetEnvironmentVariable(EnvironmentSettingNames.KubernetesServiceHost, "http://localhost:80");
             environment.SetEnvironmentVariable(EnvironmentSettingNames.PodNamespace, "k8se-apps");
 
-            var ex = await Assert.ThrowsAsync<System.Exception>(async () =>
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
                 await (podController.Assign(encryptedHostAssignmentContext));
             });

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -409,15 +409,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             return await response.Content.ReadAsAsync<HostStatus>();
         }
 
-        public string GenerateAdminJwtToken()
+        public string GenerateAdminJwtToken(string audience = null, string issuer = null)
         {
             var tokenHandler = new JwtSecurityTokenHandler();
-            string defaultKey = Util.GetDefaultKeyValue();
-            var key = Encoding.ASCII.GetBytes(defaultKey);
+            byte[] key = SecretsUtility.GetEncryptionKey();
             var tokenDescriptor = new SecurityTokenDescriptor
             {
-                Audience = string.Format(ScriptConstants.AdminJwtValidAudienceFormat, Environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)),
-                Issuer = string.Format(ScriptConstants.AdminJwtValidIssuerFormat, Environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)),
+                Audience = audience ?? string.Format(ScriptConstants.AdminJwtValidAudienceFormat, Environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)),
+                Issuer = issuer ?? string.Format(ScriptConstants.AdminJwtValidIssuerFormat, Environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)),
                 Expires = DateTime.UtcNow.AddHours(1),
                 SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
             };

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
@@ -27,6 +27,7 @@ using Microsoft.WebJobs.Script.Tests;
 using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using NuGet.Common;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
@@ -42,6 +43,25 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         {
             _fixture = fixture;
             _settingsManager = ScriptSettingsManager.Instance;
+        }
+
+        [Fact]
+        public async Task HostAdminApis_ValidAdminToken_Succeeds()
+        {
+            // verify with SWT
+            string uri = "admin/host/status";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
+            string token = SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddMinutes(1));
+            request.Headers.Add(ScriptConstants.SiteRestrictedTokenHeaderName, token);
+            HttpResponseMessage response = await _fixture.Host.HttpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            // verify with JWT
+            request = new HttpRequestMessage(HttpMethod.Get, uri);
+            token = _fixture.Host.GenerateAdminJwtToken();
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            response = await _fixture.Host.HttpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
         [Fact]
@@ -75,13 +95,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 
                 // verify the token is valid by invoking an admin API
                 request = new HttpRequestMessage(HttpMethod.Get, "admin/host/status");
-                request.Headers.Add(ScriptConstants.SiteTokenHeaderName, token);
+                request.Headers.Add(ScriptConstants.SiteRestrictedTokenHeaderName, token);
                 response = await _fixture.Host.HttpClient.SendAsync(request);
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
                 // verify it can't be used to invoke user functions
                 request = new HttpRequestMessage(HttpMethod.Get, uri);
-                request.Headers.Add(ScriptConstants.SiteTokenHeaderName, token);
+                request.Headers.Add(ScriptConstants.SiteRestrictedTokenHeaderName, token);
                 response = await _fixture.Host.HttpClient.SendAsync(request);
                 Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
             }
@@ -1125,11 +1145,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 
                 // The legacy http tests use sync IO so explicitly allow this
                 var environment = new TestEnvironment();
+                string testSiteName = "somewebsite";
                 environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagAllowSynchronousIO);
-                environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName, "somewebsite");
+                environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName, testSiteName);
                 environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, "e777fde04dea4eb931d5e5f06e65b4fdf5b375aed60af41dd7b491cf5792e01b");
                 environment.SetEnvironmentVariable(EnvironmentSettingNames.AntaresPlatformVersionWindows, "89.0.7.73");
                 environment.SetEnvironmentVariable(EnvironmentSettingNames.AntaresComputerName, "RD281878FCB8E7");
+
+                // have to set these statically here because some APIs in the host aren't going through IEnvironment
+                string key = TestHelpers.GenerateKeyHexString();
+                Environment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, key);
+                Environment.SetEnvironmentVariable("AzureWebEncryptionKey", key);
+                Environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName, testSiteName);
 
                 services.AddSingleton<IEnvironment>(_ => environment);
             }

--- a/test/WebJobs.Script.Tests/Helpers/SimpleWebTokenTests.cs
+++ b/test/WebJobs.Script.Tests/Helpers/SimpleWebTokenTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Helpers
             catch (Exception ex)
             {
                 Assert.IsType<InvalidOperationException>(ex);
-                Assert.Contains("WEBSITE_AUTH_ENCRYPTION_KEY", ex.Message);
+                Assert.Equal("No encryption key defined in the environment.", ex.Message);
             }
         }
 

--- a/test/WebJobs.Script.Tests/Metrics/LinuxContainerMetricsPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/LinuxContainerMetricsPublisherTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             Assert.Equal(request.Headers.GetValues(LinuxContainerMetricsPublisher.ContainerNameHeader).Single(), _containerName);
             Assert.Equal(request.Headers.GetValues(LinuxContainerMetricsPublisher.HostNameHeader).Single(), _testHostName);
             Assert.Equal(request.Headers.GetValues(LinuxContainerMetricsPublisher.StampNameHeader).Single(), _testStampName);
-            Assert.NotEmpty(request.Headers.GetValues(ScriptConstants.SiteTokenHeaderName));
+            Assert.NotEmpty(request.Headers.GetValues(ScriptConstants.SiteRestrictedTokenHeaderName));
 
             Assert.Equal(request.RequestUri.Host, _testIpAddress);
 

--- a/test/WebJobs.Script.Tests/Security/Authentication/ArmAuthenticationHandlerTests.cs
+++ b/test/WebJobs.Script.Tests/Security/Authentication/ArmAuthenticationHandlerTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security.Authentication
                 DefaultHttpContext context = GetContext();
 
                 string token = SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddMinutes(2), websiteAuthEncryptionKeyBytes);
-                context.Request.Headers.Add(ScriptConstants.SiteTokenHeaderName, token);
+                context.Request.Headers.Add(ScriptConstants.SiteRestrictedTokenHeaderName, token);
 
                 // Act
                 AuthenticateResult result = await context.AuthenticateAsync();
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security.Authentication
                 DefaultHttpContext context = GetContext();
 
                 string token = SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddMinutes(2), containerEncryptionKeyBytes);
-                context.Request.Headers.Add(ScriptConstants.SiteTokenHeaderName, token);
+                context.Request.Headers.Add(ScriptConstants.SiteRestrictedTokenHeaderName, token);
 
                 // Act
                 AuthenticateResult result = await context.AuthenticateAsync();
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security.Authentication
                 DefaultHttpContext context = GetContext();
 
                 string token = SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddMinutes(2));
-                context.Request.Headers.Add(ScriptConstants.SiteTokenHeaderName, token);
+                context.Request.Headers.Add(ScriptConstants.SiteRestrictedTokenHeaderName, token);
 
                 // Act
                 AuthenticateResult result = await context.AuthenticateAsync();
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security.Authentication
 
                 string token = SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddMinutes(2));
                 token = token.Substring(0, token.Length - 5);
-                context.Request.Headers.Add(ScriptConstants.SiteTokenHeaderName, token);
+                context.Request.Headers.Add(ScriptConstants.SiteRestrictedTokenHeaderName, token);
 
                 // Act
                 AuthenticateResult result = await context.AuthenticateAsync();
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security.Authentication
                 DefaultHttpContext context = GetContext();
 
                 string token = SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddMinutes(-20));
-                context.Request.Headers.Add(ScriptConstants.SiteTokenHeaderName, token);
+                context.Request.Headers.Add(ScriptConstants.SiteRestrictedTokenHeaderName, token);
 
                 // Act
                 AuthenticateResult result = await context.AuthenticateAsync();


### PR DESCRIPTION
In addition to accepting admin JWT tokens as we do now via the standard Authorization header, we want to allow them to be passed via our own custom x-ms-site-token header. This avoids conflicts in scenarios where an application may be using the Authorization header themselves. Addresses https://github.com/Azure/azure-functions-host/issues/6886.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] v3 https://github.com/Azure/azure-functions-host/pull/9175
    * [x] v1 https://github.com/Azure/azure-functions-host/pull/9176
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
