### PR TITLE
[V3] Allow site auth JWT tokens to be passed via x-ms-site-token header

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -707,7 +707,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 var requestId = Guid.NewGuid().ToString();
                 request.Headers.Add(ScriptConstants.AntaresLogIdHeaderName, requestId);
                 request.Headers.Add("User-Agent", ScriptConstants.FunctionsUserAgent);
-                request.Headers.Add(ScriptConstants.SiteTokenHeaderName, token);
+                request.Headers.Add(ScriptConstants.SiteRestrictedTokenHeaderName, token);
                 request.Content = new StringContent(content, Encoding.UTF8, "application/json");
 
                 if (_environment.IsKubernetesManagedHosting())

--- a/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
@@ -289,7 +289,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             // add the required authentication headers
             request.Headers.Add(ContainerNameHeader, _containerName);
             request.Headers.Add(HostNameHeader, _hostNameProvider.Value);
-            request.Headers.Add(ScriptConstants.SiteTokenHeaderName, token);
+            request.Headers.Add(ScriptConstants.SiteRestrictedTokenHeaderName, token);
             request.Headers.Add(StampNameHeader, _stampName);
 
             return request;

--- a/src/WebJobs.Script.WebHost/Security/Authentication/Arm/ArmAuthenticationHandler.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Arm/ArmAuthenticationHandler.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication
         private AuthenticateResult HandleAuthenticate()
         {
             string token = null;
-            if (!Context.Request.Headers.TryGetValue(ScriptConstants.SiteTokenHeaderName, out StringValues values))
+            if (!Context.Request.Headers.TryGetValue(ScriptConstants.SiteRestrictedTokenHeaderName, out StringValues values))
             {
                 return AuthenticateResult.NoResult();
             }

--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -1,19 +1,19 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
+using System.Linq;
 using System.Security.Claims;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.Azure.Web.DataProtection;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication;
+using Microsoft.Extensions.Primitives;
 using Microsoft.IdentityModel.Tokens;
 using static Microsoft.Azure.WebJobs.Script.EnvironmentSettingNames;
 using static Microsoft.Azure.WebJobs.Script.ScriptConstants;
@@ -31,8 +31,16 @@ namespace Microsoft.Extensions.DependencyInjection
                             {
                                 OnMessageReceived = c =>
                                 {
+                                    // By default, tokens are passed via the standard Authorization Bearer header. However we also support
+                                    // passing tokens via the x-ms-site-token header.
+                                    if (c.Request.Headers.TryGetValue(ScriptConstants.SiteTokenHeaderName, out StringValues values))
+                                    {
+                                        // the token we set here will be the one used - Authorization header won't be checked.
+                                        c.Token = values.FirstOrDefault();
+                                    }
+
                                     // Temporary: Tactical fix to address specialization issues. This should likely be moved to a token validator
-                                    // TODO: DI (FACAVAL) This will be fixed once the permanent fix is in plance
+                                    // TODO: DI (FACAVAL) This will be fixed once the permanent fix is in place
                                     if (_specialized == 0 && !SystemEnvironment.Instance.IsPlaceholderModeEnabled() && Interlocked.CompareExchange(ref _specialized, 1, 0) == 0)
                                     {
                                         o.TokenValidationParameters = CreateTokenValidationParameters();
@@ -55,7 +63,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
                             o.TokenValidationParameters = CreateTokenValidationParameters();
 
-                            // TODO: DI (FACAVAL) Remove this once th work above is completed.
+                            // TODO: DI (FACAVAL) Remove this once the work above is completed.
                             if (!SystemEnvironment.Instance.IsPlaceholderModeEnabled())
                             {
                                 // We're not in standby mode, so flag as specialized
@@ -65,17 +73,28 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static TokenValidationParameters CreateTokenValidationParameters()
         {
-            string defaultKey = Util.GetDefaultKeyValue();
-
             var result = new TokenValidationParameters();
-            if (defaultKey != null)
+            if (SecretsUtility.TryGetEncryptionKey(out string key))
             {
-                // TODO: Once ScriptSettingsManager is gone, Audience and Issuer shouold be pulled from configuration.
-                result.IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(defaultKey));
+                // TODO: Once ScriptSettingsManager is gone, Audience and Issuer should be pulled from configuration.
+                result.IssuerSigningKeys = new SecurityKey[]
+                {
+                    new SymmetricSecurityKey(key.ToKeyBytes()),
+                    new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key))
+                };
                 result.ValidateAudience = true;
                 result.ValidateIssuer = true;
-                result.ValidAudience = string.Format(AdminJwtValidAudienceFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName));
-                result.ValidIssuer = string.Format(AdminJwtValidIssuerFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName));
+                result.ValidAudiences = new string[]
+                {
+                    string.Format(AdminJwtSiteFunctionsValidAudienceFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName)),
+                    string.Format(AdminJwtSiteValidAudienceFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName))
+                };
+                result.ValidIssuers = new string[]
+                {
+                    AdminJwtAppServiceIssuer,
+                    string.Format(AdminJwtScmValidIssuerFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName)),
+                    string.Format(AdminJwtSiteValidIssuerFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName))
+                };
             }
 
             return result;

--- a/src/WebJobs.Script.WebHost/Security/SecretsUtility.cs
+++ b/src/WebJobs.Script.WebHost/Security/SecretsUtility.cs
@@ -2,11 +2,12 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.IO;
+using System.Linq;
+using Microsoft.Azure.Web.DataProtection;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
 {
-    internal class SecretsUtility
+    internal static class SecretsUtility
     {
         public static string GetNonDecryptableName(string secretsPath)
         {
@@ -16,6 +17,75 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 secretsPath = secretsPath.Substring(0, secretsPath.Length - 5);
             }
             return secretsPath + $".{ScriptConstants.Snapshot}.{timeStamp}.json";
+        }
+
+        public static bool TryGetEncryptionKey(out string key, IEnvironment environment = null)
+        {
+            environment = environment ?? SystemEnvironment.Instance;
+
+            if (environment.IsKubernetesManagedHosting())
+            {
+                key = environment.GetEnvironmentVariable(EnvironmentSettingNames.PodEncryptionKey);
+                if (!string.IsNullOrEmpty(key))
+                {
+                    return true;
+                }
+            }
+
+            // Use WebSiteAuthEncryptionKey if available else fall back to ContainerEncryptionKey.
+            // Until the container is specialized to a specific site WebSiteAuthEncryptionKey will not be available.
+            if (TryGetEncryptionKey(environment, EnvironmentSettingNames.WebSiteAuthEncryptionKey, out key) ||
+                TryGetEncryptionKey(environment, EnvironmentSettingNames.ContainerEncryptionKey, out key))
+            {
+                return true;
+            }
+
+            // Fall back to using DataProtection APIs to get the key
+            key = Util.GetDefaultKeyValue();
+            if (!string.IsNullOrEmpty(key))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public static string GetEncryptionKeyValue(IEnvironment environment = null)
+        {
+            if (TryGetEncryptionKey(out string key, environment))
+            {
+                return key;
+            }
+            else
+            {
+                throw new InvalidOperationException($"No encryption key defined in the environment.");
+            }
+        }
+
+        public static byte[] GetEncryptionKey(IEnvironment environment = null)
+        {
+            string key = GetEncryptionKeyValue(environment);
+            return key.ToKeyBytes();
+        }
+
+        public static byte[] ToKeyBytes(this string hexOrBase64)
+        {
+            // only support 32 bytes (256 bits) key length
+            if (hexOrBase64.Length == 64)
+            {
+                return Enumerable.Range(0, hexOrBase64.Length)
+                    .Where(x => x % 2 == 0)
+                    .Select(x => Convert.ToByte(hexOrBase64.Substring(x, 2), 16))
+                    .ToArray();
+            }
+
+            return Convert.FromBase64String(hexOrBase64);
+        }
+
+        private static bool TryGetEncryptionKey(IEnvironment environment, string keyName, out string encryptionKey)
+        {
+            encryptionKey = environment.GetEnvironmentVariable(keyName);
+            return !string.IsNullOrEmpty(encryptionKey);
         }
     }
 }

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -95,7 +95,8 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AntaresLogIdHeaderName = "X-ARR-LOG-ID";
         public const string AntaresScaleOutHeaderName = "X-FUNCTION-SCALEOUT";
         public const string AntaresColdStartHeaderName = "X-MS-COLDSTART";
-        public const string SiteTokenHeaderName = "x-ms-site-restricted-token";
+        public const string SiteTokenHeaderName = "x-ms-site-token";
+        public const string SiteRestrictedTokenHeaderName = "x-ms-site-restricted-token";
         public const string EasyAuthIdentityHeader = "x-ms-client-principal";
         public const string AntaresPlatformInternal = "x-ms-platform-internal";
         public const string AzureVersionHeader = "x-ms-version";
@@ -123,8 +124,11 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FeatureFlagEnableMultiLanguageWorker = "EnableMultiLanguageWorker";
         public const string FeatureFlagEnableLinuxEPExecutionCount = "EnableLinuxFEC";
 
-        public const string AdminJwtValidAudienceFormat = "https://{0}.azurewebsites.net/azurefunctions";
-        public const string AdminJwtValidIssuerFormat = "https://{0}.scm.azurewebsites.net";
+        public const string AdminJwtSiteFunctionsValidAudienceFormat = "https://{0}.azurewebsites.net/azurefunctions";
+        public const string AdminJwtSiteValidAudienceFormat = "https://{0}.azurewebsites.net";
+        public const string AdminJwtScmValidIssuerFormat = "https://{0}.scm.azurewebsites.net";
+        public const string AdminJwtSiteValidIssuerFormat = "https://{0}.azurewebsites.net";
+        public const string AdminJwtAppServiceIssuer = "https://appservice.core.azurewebsites.net";
 
         public const string AzureFunctionsSystemDirectoryName = ".azurefunctions";
         public const string HttpMethodConstraintName = "httpMethod";

--- a/test/WebJobs.Script.Tests.Integration/Management/KubernetesPodControllerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/KubernetesPodControllerTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
@@ -138,10 +139,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             environment.SetEnvironmentVariable(EnvironmentSettingNames.KubernetesServiceHost, "http://localhost:80");
             environment.SetEnvironmentVariable(EnvironmentSettingNames.PodNamespace, "k8se-apps");
 
-            var ex = await Assert.ThrowsAsync<System.Exception>(async () =>
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
                 await (podController.Assign(encryptedHostAssignmentContext));
             });
+            Assert.Equal("No encryption key defined in the environment.", ex.Message);
             Assert.Null(startupContextProvider.Context);
         }
 

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -15,7 +15,6 @@ using System.Xml;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.Azure.Web.DataProtection;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Script.ExtensionBundle;
 using Microsoft.Azure.WebJobs.Script.Models;
@@ -404,15 +403,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             return await response.Content.ReadAsAsync<HostStatus>();
         }
 
-        public string GenerateAdminJwtToken()
+        public string GenerateAdminJwtToken(string audience = null, string issuer = null, byte[] key = null)
         {
             var tokenHandler = new JwtSecurityTokenHandler();
-            string defaultKey = Util.GetDefaultKeyValue();
-            var key = Encoding.ASCII.GetBytes(defaultKey);
+            key = key ?? SecretsUtility.GetEncryptionKey();
             var tokenDescriptor = new SecurityTokenDescriptor
             {
-                Audience = string.Format(ScriptConstants.AdminJwtValidAudienceFormat, Environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)),
-                Issuer = string.Format(ScriptConstants.AdminJwtValidIssuerFormat, Environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)),
+                Audience = audience ?? string.Format(ScriptConstants.AdminJwtSiteFunctionsValidAudienceFormat, Environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)),
+                Issuer = issuer ?? string.Format(ScriptConstants.AdminJwtScmValidIssuerFormat, Environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)),
                 Expires = DateTime.UtcNow.AddHours(1),
                 SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
             };

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/JwtTokenAuthTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/JwtTokenAuthTests.cs
@@ -1,0 +1,157 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Management;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
+{
+    /// <summary>
+    /// Tests for our JWT token auth handler.
+    /// </summary>
+    public class JwtTokenAuthTests : IClassFixture<JwtTokenAuthTests.TestFixture>
+    {
+        private TestFixture _fixture;
+
+        public JwtTokenAuthTests(TestFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Theory]
+        [InlineData(nameof(HttpRequestHeader.Authorization))]
+        [InlineData(nameof(HttpRequestHeader.Authorization), "https://appservice.core.azurewebsites.net", "https://testsite.azurewebsites.net")]
+        [InlineData(nameof(HttpRequestHeader.Authorization), "https://appservice.core.azurewebsites.net", "https://testsite.azurewebsites.net/azurefunctions")]
+        [InlineData(nameof(HttpRequestHeader.Authorization), "https://testsite.scm.azurewebsites.net", "https://testsite.azurewebsites.net")]
+        [InlineData(nameof(HttpRequestHeader.Authorization), "https://testsite.scm.azurewebsites.net", "https://testsite.azurewebsites.net/azurefunctions")]
+        [InlineData(nameof(HttpRequestHeader.Authorization), "https://testsite.azurewebsites.net", "https://testsite.azurewebsites.net")]
+        [InlineData(ScriptConstants.SiteTokenHeaderName)]
+        [InlineData(ScriptConstants.SiteTokenHeaderName, "https://appservice.core.azurewebsites.net", "https://testsite.azurewebsites.net")]
+        [InlineData(ScriptConstants.SiteTokenHeaderName, "https://appservice.core.azurewebsites.net", "https://testsite.azurewebsites.net/azurefunctions")]
+        [InlineData(ScriptConstants.SiteTokenHeaderName, "https://testsite.scm.azurewebsites.net", "https://testsite.azurewebsites.net")]
+        [InlineData(ScriptConstants.SiteTokenHeaderName, "https://testsite.scm.azurewebsites.net", "https://testsite.azurewebsites.net/azurefunctions")]
+        [InlineData(ScriptConstants.SiteTokenHeaderName, "https://testsite.azurewebsites.net", "https://testsite.azurewebsites.net")]
+        public async Task InvokeAdminApi_ValidToken_Succeeds(string headerName, string issuer = null, string audience = null)
+        {
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "admin/host/status");
+            string token = _fixture.Host.GenerateAdminJwtToken(audience, issuer);
+
+            if (string.Compare(nameof(HttpRequestHeader.Authorization), headerName) == 0)
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
+            else
+            {
+                request.Headers.Add(headerName, token);
+            }
+
+            var response = await _fixture.Host.HttpClient.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+        }
+
+        [Theory]
+        [InlineData(nameof(HttpRequestHeader.Authorization))]
+        [InlineData(ScriptConstants.SiteTokenHeaderName)]
+        public async Task InvokeAdminApi_InvalidToken_Fails(string headerName)
+        {
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "admin/host/status");
+            string token = _fixture.Host.GenerateAdminJwtToken("invalid", "invalid");
+
+            if (string.Compare(nameof(HttpRequestHeader.Authorization), headerName) == 0)
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
+            else
+            {
+                request.Headers.Add(headerName, token);
+            }
+
+            var response = await _fixture.Host.HttpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task InvokeAdminApi_ValidToken_UTF8Encoding_Succeeds()
+        {
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "admin/host/status");
+            string key = SecretsUtility.GetEncryptionKeyValue();
+            string token = _fixture.Host.GenerateAdminJwtToken(key: Encoding.UTF8.GetBytes(key));
+            request.Headers.Add(ScriptConstants.SiteTokenHeaderName, token);
+
+            var response = await _fixture.Host.HttpClient.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+        }
+
+        public class TestFixture : EndToEndTestFixture
+        {
+            private TestScopedEnvironmentVariable _scopedEnvironment;
+
+            public TestFixture() : base(@"TestScripts\CSharp", "csharp", RpcWorkerConstants.DotNetLanguageWorkerName, addTestSettings: false)
+            {
+                var testKeyBytes = TestHelpers.GenerateKeyBytes();
+                var testKey = TestHelpers.GenerateKeyHexString(testKeyBytes);
+
+                var settings = new Dictionary<string, string>()
+                {
+                    { "AzureWebEncryptionKey", testKey },
+                    { EnvironmentSettingNames.WebSiteAuthEncryptionKey, testKey },
+                    { "AzureWebJobsStorage", null },
+                    { EnvironmentSettingNames.AzureWebsiteName, "testsite" }
+                };
+                _scopedEnvironment = new TestScopedEnvironmentVariable(settings);
+            }
+
+            public override void ConfigureScriptHost(IWebJobsBuilder webJobsBuilder)
+            {
+                base.ConfigureScriptHost(webJobsBuilder);
+
+                webJobsBuilder.Services.Configure<ScriptJobHostOptions>(o =>
+                {
+                    o.Functions = new[]
+                    {
+                        "HttpTrigger-Scenarios",
+                        "HttpTrigger-FunctionAuth"
+                    };
+                });
+            }
+
+            public override void ConfigureScriptHost(IServiceCollection services)
+            {
+                base.ConfigureScriptHost(services);
+
+                // replace the base mock FunctionsSyncManager
+                var service = services.FirstOrDefault(d => d.ServiceType == typeof(IFunctionsSyncManager));
+                services.Remove(service);
+                services.AddSingleton<IFunctionsSyncManager, FunctionsSyncManager>();
+            }
+
+            public override void ConfigureWebHost(IServiceCollection services)
+            {
+                base.ConfigureWebHost(services);
+
+                // replace the base mock ISecretManagerProvider
+                var service = services.FirstOrDefault(d => d.ServiceType == typeof(ISecretManagerProvider));
+                services.Remove(service);
+                services.TryAddSingleton<ISecretManagerProvider, DefaultSecretManagerProvider>();
+            }
+
+            public override async Task DisposeAsync()
+            {
+                await base.DisposeAsync();
+
+                _scopedEnvironment.Dispose();
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SWAEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SWAEndToEndTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -60,13 +61,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
 
-        [Fact]
-        public async Task InvokeFunction_FunctionLevel_ValidToken_Succeeds()
+        [Theory]
+        [InlineData(nameof(HttpRequestHeader.Authorization))]
+        [InlineData(ScriptConstants.SiteTokenHeaderName)]
+        public async Task InvokeFunction_FunctionLevel_ValidToken_Succeeds(string headerName)
         {
             // if an admin token is passed, the function invocation succeeds
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "api/HttpTrigger-FunctionAuth?code=test");
             string token = _fixture.Host.GenerateAdminJwtToken();
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            if (string.Compare(nameof(HttpRequestHeader.Authorization), headerName) == 0)
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
+            else
+            {
+                request.Headers.Add(headerName, token);
+            }
 
             var response = await _fixture.Host.HttpClient.SendAsync(request);
             response.EnsureSuccessStatusCode();

--- a/test/WebJobs.Script.Tests/Helpers/SecretsUtilityTest.cs
+++ b/test/WebJobs.Script.Tests/Helpers/SecretsUtilityTest.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Helpers
+{
+    public class SecretsUtilityTest
+    {
+        [Fact]
+        public void ToKeyBytes_ReturnsExpectedValue()
+        {
+            byte[] keyBytes = TestHelpers.GenerateKeyBytes();
+
+            string hexKey = TestHelpers.GenerateKeyHexString(keyBytes);
+            string base64Key = Convert.ToBase64String(keyBytes);
+
+            Assert.Equal(keyBytes, SecretsUtility.ToKeyBytes(hexKey));
+            Assert.Equal(keyBytes, SecretsUtility.ToKeyBytes(base64Key));
+            Assert.Equal(keyBytes, Convert.FromBase64String(base64Key));
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Helpers/SimpleWebTokenTests.cs
+++ b/test/WebJobs.Script.Tests/Helpers/SimpleWebTokenTests.cs
@@ -12,20 +12,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Helpers
     public class SimpleWebTokenTests : IDisposable
     {
         [Fact]
-        public void EncryptShouldThrowIdNoEncryptionKeyDefined()
+        public void EncryptShouldThrowIfNoEncryptionKeyDefined()
         {
             // Make sure WEBSITE_AUTH_ENCRYPTION_KEY is empty
             Environment.SetEnvironmentVariable("WEBSITE_AUTH_ENCRYPTION_KEY", string.Empty);
 
-            try
+            var ex = Assert.Throws<InvalidOperationException>(() =>
             {
                 SimpleWebTokenHelper.Encrypt("value");
-            }
-            catch (Exception ex)
-            {
-                Assert.IsType<InvalidOperationException>(ex);
-                Assert.Contains("WEBSITE_AUTH_ENCRYPTION_KEY", ex.Message);
-            }
+            });
+            Assert.Equal("No encryption key defined in the environment.", ex.Message);
         }
 
         [Theory]

--- a/test/WebJobs.Script.Tests/Metrics/LinuxContainerMetricsPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/LinuxContainerMetricsPublisherTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             Assert.Equal(request.Headers.GetValues(LinuxContainerMetricsPublisher.ContainerNameHeader).Single(), _containerName);
             Assert.Equal(request.Headers.GetValues(LinuxContainerMetricsPublisher.HostNameHeader).Single(), _testHostName);
             Assert.Equal(request.Headers.GetValues(LinuxContainerMetricsPublisher.StampNameHeader).Single(), _testStampName);
-            Assert.NotEmpty(request.Headers.GetValues(ScriptConstants.SiteTokenHeaderName));
+            Assert.NotEmpty(request.Headers.GetValues(ScriptConstants.SiteRestrictedTokenHeaderName));
 
             Assert.Equal(request.RequestUri.Host, _testIpAddress);
 

--- a/test/WebJobs.Script.Tests/Security/Authentication/ArmAuthenticationHandlerTests.cs
+++ b/test/WebJobs.Script.Tests/Security/Authentication/ArmAuthenticationHandlerTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security.Authentication
                 DefaultHttpContext context = GetContext();
 
                 string token = SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddMinutes(2), websiteAuthEncryptionKeyBytes);
-                context.Request.Headers.Add(ScriptConstants.SiteTokenHeaderName, token);
+                context.Request.Headers.Add(ScriptConstants.SiteRestrictedTokenHeaderName, token);
 
                 // Act
                 AuthenticateResult result = await context.AuthenticateAsync();
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security.Authentication
                 DefaultHttpContext context = GetContext();
 
                 string token = SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddMinutes(2), containerEncryptionKeyBytes);
-                context.Request.Headers.Add(ScriptConstants.SiteTokenHeaderName, token);
+                context.Request.Headers.Add(ScriptConstants.SiteRestrictedTokenHeaderName, token);
 
                 // Act
                 AuthenticateResult result = await context.AuthenticateAsync();
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security.Authentication
                 DefaultHttpContext context = GetContext();
 
                 string token = SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddMinutes(2));
-                context.Request.Headers.Add(ScriptConstants.SiteTokenHeaderName, token);
+                context.Request.Headers.Add(ScriptConstants.SiteRestrictedTokenHeaderName, token);
 
                 // Act
                 AuthenticateResult result = await context.AuthenticateAsync();
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security.Authentication
 
                 string token = SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddMinutes(2));
                 token = token.Substring(0, token.Length - 5);
-                context.Request.Headers.Add(ScriptConstants.SiteTokenHeaderName, token);
+                context.Request.Headers.Add(ScriptConstants.SiteRestrictedTokenHeaderName, token);
 
                 // Act
                 AuthenticateResult result = await context.AuthenticateAsync();
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security.Authentication
                 DefaultHttpContext context = GetContext();
 
                 string token = SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddMinutes(-20));
-                context.Request.Headers.Add(ScriptConstants.SiteTokenHeaderName, token);
+                context.Request.Headers.Add(ScriptConstants.SiteRestrictedTokenHeaderName, token);
 
                 // Act
                 AuthenticateResult result = await context.AuthenticateAsync();


### PR DESCRIPTION
In addition to accepting admin JWT tokens as we do now via the standard Authorization header, we want to allow them to be passed via our own custom x-ms-site-token header. This avoids conflicts in scenarios where an application may be using the Authorization header themselves. Addresses https://github.com/Azure/azure-functions-host/issues/6886.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] v1 https://github.com/Azure/azure-functions-host/pull/9176
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
