### PR TITLE
Add support for additional key encodings

### DIFF
--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -128,8 +128,10 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string HostingConfigDisableLinuxAppServiceDetailedExecutionEvents = "DisableLinuxExecutionDetails";
         public const string HostingConfigDisableLinuxAppServiceExecutionEventLogBackoff = "DisableLinuxLogBackoff";
 
-        public const string AdminJwtValidAudienceFormat = "https://{0}.azurewebsites.net/azurefunctions";
-        public const string AdminJwtValidIssuerFormat = "https://{0}.scm.azurewebsites.net";
+        public const string AdminJwtSiteFunctionsValidAudienceFormat = "https://{0}.azurewebsites.net/azurefunctions";
+        public const string AdminJwtSiteValidAudienceFormat = "https://{0}.azurewebsites.net";
+        public const string AdminJwtScmValidIssuerFormat = "https://{0}.scm.azurewebsites.net";
+        public const string AdminJwtSiteValidIssuerFormat = "https://{0}.azurewebsites.net";
         public const string AdminJwtAppServiceIssuer = "https://appservice.core.azurewebsites.net";
 
         public const string AzureFunctionsSystemDirectoryName = ".azurefunctions";

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -409,14 +409,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             return await response.Content.ReadAsAsync<HostStatus>();
         }
 
-        public string GenerateAdminJwtToken(string audience = null, string issuer = null)
+        public string GenerateAdminJwtToken(string audience = null, string issuer = null, byte[] key = null)
         {
             var tokenHandler = new JwtSecurityTokenHandler();
-            byte[] key = SecretsUtility.GetEncryptionKey();
+            key = key ?? SecretsUtility.GetEncryptionKey();
             var tokenDescriptor = new SecurityTokenDescriptor
             {
-                Audience = audience ?? string.Format(ScriptConstants.AdminJwtValidAudienceFormat, Environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)),
-                Issuer = issuer ?? string.Format(ScriptConstants.AdminJwtValidIssuerFormat, Environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)),
+                Audience = audience ?? string.Format(ScriptConstants.AdminJwtSiteFunctionsValidAudienceFormat, Environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)),
+                Issuer = issuer ?? string.Format(ScriptConstants.AdminJwtScmValidIssuerFormat, Environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)),
                 Expires = DateTime.UtcNow.AddHours(1),
                 SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
             };

--- a/test/WebJobs.Script.Tests/Helpers/SecretsUtilityTest.cs
+++ b/test/WebJobs.Script.Tests/Helpers/SecretsUtilityTest.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Helpers
+{
+    public class SecretsUtilityTest
+    {
+        [Fact]
+        public void ToKeyBytes_ReturnsExpectedValue()
+        {
+            byte[] keyBytes = TestHelpers.GenerateKeyBytes();
+
+            string hexKey = TestHelpers.GenerateKeyHexString(keyBytes);
+            string base64Key = Convert.ToBase64String(keyBytes);
+
+            Assert.Equal(keyBytes, SecretsUtility.ToKeyBytes(hexKey));
+            Assert.Equal(keyBytes, SecretsUtility.ToKeyBytes(base64Key));
+            Assert.Equal(keyBytes, Convert.FromBase64String(base64Key));
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Helpers/SimpleWebTokenTests.cs
+++ b/test/WebJobs.Script.Tests/Helpers/SimpleWebTokenTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Security.Cryptography;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security;
 using Xunit;


### PR DESCRIPTION
In my PR https://github.com/Azure/azure-functions-host/pull/9168 I inadvertently changed the encoding being used for the key signing key when creating TokenValidationParameters. The previous logic before my change is [here](https://github.com/Azure/azure-functions-host/blob/e7e3df5805f1417c0b2b06f1e795edfff820f039/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs#L74) and used UTF8. This PR retains support for the previous UTF8 encoding while also supporting hex/base64 encodings.

I'm also adjusting the list of valid audience/issuers, while retaining back compat.