### PR TITLE
capping the bundle version to 3.19.0 and 4.2.0

### DIFF
--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -32,6 +32,28 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         }
 
         /// <summary>
+        /// Gets the highest version of extension bundle v4 supported
+        /// </summary>
+        public string MaximumSupportedBundleV3Version
+        {
+            get
+            {
+                return GetFeature(ScriptConstants.MaximumSupportedBundleV3Version) ?? "3.19.0";
+            }
+        }
+
+        /// <summary>
+        /// Gets the highest version of extension bundle v3 supported
+        /// </summary>
+        public string MaximumSupportedBundleV4Version
+        {
+            get
+            {
+                return GetFeature(ScriptConstants.MaximumSupportedBundleV4Version) ?? "4.2.0";
+            }
+        }
+
+        /// <summary>
         /// Gets feature by name.
         /// </summary>
         /// <param name="name">Feature name.</param>

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         }
 
         /// <summary>
-        /// Gets the highest version of extension bundle v4 supported
+        /// Gets the highest version of extension bundle v3 supported
         /// </summary>
         public string MaximumSupportedBundleV3Version
         {
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         }
 
         /// <summary>
-        /// Gets the highest version of extension bundle v3 supported
+        /// Gets the highest version of extension bundle v4 supported
         /// </summary>
         public string MaximumSupportedBundleV4Version
         {

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -212,5 +212,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public static readonly ImmutableArray<string> SystemLogCategoryPrefixes = ImmutableArray.Create("Microsoft.Azure.WebJobs.", "Function.", "Worker.", "Host.");
 
         public static readonly string FunctionsHostingConfigSectionName = "FunctionsHostingConfig";
+        public static readonly string MaximumSupportedBundleV3Version = "FunctionRuntimeV3MaxBundleV3Version";
+        public static readonly string MaximumSupportedBundleV4Version = "FunctionRuntimeV3MaxBundleV4Version";
     }
 }

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -100,6 +100,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 {
                     configBuilder.Add(new HostJsonFileConfigurationSource(applicationOptions, SystemEnvironment.Instance, loggerFactory, metricsLogger));
                 }
+                configBuilder.Add(new FunctionsHostingConfigSource(SystemEnvironment.Instance));
             });
 
             // WebJobs configuration
@@ -111,7 +112,11 @@ namespace Microsoft.Azure.WebJobs.Script
                 // Pre-build configuration here to load bundles and to store for later validation.
                 var config = configBuilder.Build();
                 var extensionBundleOptions = GetExtensionBundleOptions(config);
-                var bundleManager = new ExtensionBundleManager(extensionBundleOptions, SystemEnvironment.Instance, loggerFactory);
+                FunctionsHostingConfigOptions configOption = new FunctionsHostingConfigOptions();
+                var optionsSetup = new FunctionsHostingConfigOptionsSetup(config);
+                optionsSetup.Configure(configOption);
+
+                var bundleManager = new ExtensionBundleManager(extensionBundleOptions, SystemEnvironment.Instance, loggerFactory, configOption);
                 var metadataServiceManager = applicationOptions.RootServiceProvider.GetService<IFunctionMetadataManager>();
                 var languageWorkerOptions = applicationOptions.RootServiceProvider.GetService<IOptions<LanguageWorkerOptions>>();
 

--- a/test/CSharpPrecompiledTestProjects/WebJobsStartupTests/Function1.cs
+++ b/test/CSharpPrecompiledTestProjects/WebJobsStartupTests/Function1.cs
@@ -93,7 +93,7 @@ namespace WebJobsStartupTests
         {
             if (_config is ConfigurationRoot root)
             {
-                if (root.Providers.Count() != 7)
+                if (root.Providers.Count() != 8)
                 {
                     return false;
                 }

--- a/test/CSharpPrecompiledTestProjects/WebJobsStartupTests/Function1.cs
+++ b/test/CSharpPrecompiledTestProjects/WebJobsStartupTests/Function1.cs
@@ -99,18 +99,17 @@ namespace WebJobsStartupTests
                 }
 
                 int i = 0;
-
+                
                 return
-                    root.Providers.ElementAt(i++) is ChainedConfigurationProvider &&
-                    root.Providers.ElementAt(i++) is MemoryConfigurationProvider &&
-                    root.Providers.ElementAt(i++).GetType().Name.StartsWith("HostJsonFile") &&
-                    root.Providers.ElementAt(i++) is JsonConfigurationProvider &&
-                    root.Providers.ElementAt(i++) is EnvironmentVariablesConfigurationProvider &&
-                    root.Providers.ElementAt(i++) is MemoryConfigurationProvider && // From Startup.cs
-                    root.Providers.ElementAt(i++) is JsonConfigurationProvider; // From test settings; Always runs last in tests.
+                root.Providers.ElementAt(i++) is ChainedConfigurationProvider &&
+                root.Providers.ElementAt(i++) is MemoryConfigurationProvider &&
+                root.Providers.ElementAt(i++).GetType().Name.StartsWith("HostJsonFile") &&
+                root.Providers.ElementAt(i++).GetType().Name.StartsWith("FunctionsHostingConfigProvider") &&
+                root.Providers.ElementAt(i++) is JsonConfigurationProvider &&
+                root.Providers.ElementAt(i++) is EnvironmentVariablesConfigurationProvider &&
+                root.Providers.ElementAt(i++) is MemoryConfigurationProvider && // From Startup.cs
+                           root.Providers.ElementAt(i++) is JsonConfigurationProvider; // From test settings; Always runs last in tests.
             }
-
             return false;
         }
     }
-}

--- a/test/CSharpPrecompiledTestProjects/WebJobsStartupTests/Function1.cs
+++ b/test/CSharpPrecompiledTestProjects/WebJobsStartupTests/Function1.cs
@@ -99,7 +99,7 @@ namespace WebJobsStartupTests
                 }
 
                 int i = 0;
-                
+
                 return
                 root.Providers.ElementAt(i++) is ChainedConfigurationProvider &&
                 root.Providers.ElementAt(i++) is MemoryConfigurationProvider &&
@@ -113,3 +113,4 @@ namespace WebJobsStartupTests
             return false;
         }
     }
+}

--- a/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
@@ -14,6 +14,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.ExtensionBundle;
 using Microsoft.Extensions.Configuration;
@@ -384,10 +385,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
             Assert.Null(await manager.GetExtensionBundlePath(httpClient));
         }
 
+        [Theory]
+        [InlineData("[3.*, 4.0.0)", "3.19.0")]
+        [InlineData("[4.*, 5.0.0)", "4.2.0")]
+        public void LimitMaxVersion(string versionRange, string version)
+        {
+            var range = VersionRange.Parse(versionRange);
+            var resolvedVersion = ExtensionBundleManager.FindBestVersionMatch(range, new List<string>()
+            { "3.7.0", "3.10.0", "3.11.0", "3.15.0", "3.14.0", "2.16.0", "3.13.0", "3.12.0", "3.9.1", "2.12.1", "2.18.0", "3.16.0", "2.19.0", "3.17.0", "4.0.2", "2.20.0", "3.18.0", "4.1.0", "4.2.0", "2.21.0", "3.19.0", "3.19.2", "4.3.0", "3.20.0" },
+            ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+            Assert.Equal(version, resolvedVersion);
+        }
+
         private ExtensionBundleManager GetExtensionBundleManager(ExtensionBundleOptions bundleOptions, TestEnvironment environment = null)
         {
             environment = environment ?? new TestEnvironment();
-            return new ExtensionBundleManager(bundleOptions, environment, MockNullLoggerFactory.CreateLoggerFactory());
+            return new ExtensionBundleManager(bundleOptions, environment, MockNullLoggerFactory.CreateLoggerFactory(), new FunctionsHostingConfigOptions());
         }
 
         private TestEnvironment GetTestAppServiceEnvironment()


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Setting the max version of extension bundle v3 runtime can use to 3.19.0 and 4.2.0

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
