### PR TITLE
Fixing v3.x build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -346,14 +346,15 @@ jobs:
   - task: UseDotNet@2
     inputs:
       packageType: 'sdk'
-      version: '3.1.x'
-      installationPath: 'C:\Program Files\dotnet'
+      version: '3.1.x'      
       performMultiLevelLookup: true
   - task: PowerShell@2
     displayName: 'dotnet --info'
     inputs:
       targetType: 'inline'
-      script: '& dotnet --info'
+      script: |
+        Write-Host $Env:PATH
+        & dotnet --info
   - task: DotNetCoreCLI@2
     displayName: 'Unit Tests'
     inputs:
@@ -375,7 +376,15 @@ jobs:
     inputs:
       packageType: 'sdk'
       version: '3.1.x'
+      installationPath: 'C:\Program Files\dotnet'
       performMultiLevelLookup: true
+  - task: PowerShell@2
+    displayName: 'dotnet --info'
+    inputs:
+      targetType: 'inline'
+      script: |
+        Write-Host $Env:PATH
+        & dotnet --info
   - task: UseNode@1
     inputs:
       version: '10.x'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -347,6 +347,7 @@ jobs:
     inputs:
       packageType: 'sdk'
       version: '3.1.x'
+      installationPath: 'C:\Program Files\dotnet'
       performMultiLevelLookup: true
   - task: PowerShell@2
     displayName: 'dotnet --info'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -348,6 +348,11 @@ jobs:
       packageType: 'sdk'
       version: '3.1.x'
       performMultiLevelLookup: true
+  - task: PowerShell@2
+    displayName: 'dotnet --info'
+    inputs:
+      targetType: 'inline'
+      script: '& dotnet --info'
   - task: DotNetCoreCLI@2
     displayName: 'Unit Tests'
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,11 +57,7 @@ jobs:
     demands:
       - ImageOverride -equals MMS2019TLS
   steps:
-  - task: UseDotNet@2
-    inputs:
-      packageType: 'sdk'
-      version: '3.1.x'
-      performMultiLevelLookup: true
+  - template: build/install-dotnet.yml
   - task: UseDotNet@2
     displayName: 'Install .NET Core 2.1 runtime'
     inputs:
@@ -343,18 +339,7 @@ jobs:
     demands:
       - ImageOverride -equals MMS2019TLS
   steps:
-  - task: UseDotNet@2
-    inputs:
-      packageType: 'sdk'
-      version: '3.1.x'      
-      performMultiLevelLookup: true
-  - task: PowerShell@2
-    displayName: 'dotnet --info'
-    inputs:
-      targetType: 'inline'
-      script: |
-        Write-Host $Env:PATH
-        & dotnet --info
+  - template: build/install-dotnet.yml
   - task: DotNetCoreCLI@2
     displayName: 'Unit Tests'
     inputs:
@@ -372,19 +357,7 @@ jobs:
     demands:
       - ImageOverride -equals MMS2019TLS
   steps:
-  - task: UseDotNet@2
-    inputs:
-      packageType: 'sdk'
-      version: '3.1.x'
-      installationPath: 'C:\Program Files\dotnet'
-      performMultiLevelLookup: true
-  - task: PowerShell@2
-    displayName: 'dotnet --info'
-    inputs:
-      targetType: 'inline'
-      script: |
-        Write-Host $Env:PATH
-        & dotnet --info
+  - template: build/install-dotnet.yml
   - task: UseNode@1
     inputs:
       version: '10.x'
@@ -440,17 +413,13 @@ jobs:
     demands:
       - ImageOverride -equals MMS2019TLS
   steps:
-  - task: UseDotNet@2
-    inputs:
-      packageType: 'sdk'
-      version: '3.1.x'
-      performMultiLevelLookup: true
+  - template: build/install-dotnet.yml
   - task: UseDotNet@2
     displayName: 'Install .NET Core 2.1 runtime (tests)'
     inputs:
       packageType: runtime
       version: 2.1.x
-      performMultiLevelLookup: true      
+      performMultiLevelLookup: true   
   - task: UseNode@1
     inputs:
       version: '10.x'

--- a/build/install-dotnet.yml
+++ b/build/install-dotnet.yml
@@ -1,0 +1,14 @@
+steps:
+- task: UseDotNet@2
+  inputs:
+    packageType: 'sdk'
+    version: '3.1.x'
+    installationPath: 'C:\Program Files\dotnet'
+    performMultiLevelLookup: true
+- task: PowerShell@2
+  displayName: 'dotnet --info'
+  inputs:
+    targetType: 'inline'
+    script: |
+      Write-Host "PATH: $Env:PATH"
+      & dotnet --info


### PR DESCRIPTION
Something seems to have changed in the v3.x branch and caused our dotnet installations to not work. This change did a little re-arranging to make it easier to fix in the future, but the real fix is adding this to the UseDotNet task:

```
    installationPath: 'C:\Program Files\dotnet'
```

It's unclear why this broke suddenly; I'm looking into an RCA.