### PR TITLE
installing .net core 3.1 in CI

### DIFF
--- a/build/install-dotnet.yml
+++ b/build/install-dotnet.yml
@@ -1,5 +1,12 @@
 steps:
 - task: PowerShell@2
+  displayName: 'Install .NET 3.1'
+  inputs:
+    targetType: 'inline'
+    script: |
+      Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -OutFile 'dotnet-install.ps1'
+      ./dotnet-install.ps1 -InstallDir 'C:\Program Files\dotnet' -Verbose -Channel 3.1
+- task: PowerShell@2
   displayName: 'Install .NET 6'
   inputs:
     targetType: 'inline'
@@ -8,3 +15,4 @@ steps:
       # Official release versions can be found at: https://dotnet.microsoft.com/download/dotnet/6.0
       # Newer versions can be found at: https://github.com/dotnet/installer#installers-and-binaries
       ./dotnet-install.ps1 -InstallDir 'C:\Program Files\dotnet' -Verbose -Channel 6.0
+      & dotnet --info


### PR DESCRIPTION
Some of our tests rely on .NET Core 3.1, which was recently removed from the CI images. Re-adding it here.