### PR TITLE
ForwarderError handling and logging

### DIFF
--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -939,12 +939,9 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                             {
                                 ForwarderError httpProxyTaskResult = await httpProxyTask;
 
-                                //testing error with hard coded value
-                                httpProxyTaskResult = ForwarderError.ResponseBodyClient;
-
                                 if (httpProxyTaskResult is not ForwarderError.None)
                                 {
-                                    throw new InvalidOperationException($"Failed to proxy request with ForwarderError: {nameof(httpProxyTaskResult)}.");
+                                    throw new InvalidOperationException($"Failed to proxy request with ForwarderError: {httpProxyTaskResult}");
                                 }
                             }
                         }


### PR DESCRIPTION
### Issue describing the changes in this PR

resolves #9194 

When the function invocation pipeline succeeds but the http pipeline fails for any reason, an error will be thrown because the function cannot complete execution on the host side without information from the http pipeline. 

In the case where both function invocation and the http pipeline fail, we will just use the error path for function invocation failure.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

### Additional information

Deployed a private site extension and forced an error to see how this bubbled up in kusto - this is the details column of the error log:

Microsoft.Azure.WebJobs.Host.FunctionInvocationException : Exception while executing function: Functions.Function1 ---> System.InvalidOperationException : Failed to proxy request with ForwarderError: ResponseBodyClient
   at async Microsoft.Azure.WebJobs.Script.Grpc.GrpcWorkerChannel.InvokeResponse(InvocationResponse invokeResponse) at C:\Users\sarahvu\source\repos\azure-functions-host\src\WebJobs.Script.Grpc\Channel\GrpcWorkerChannel.cs : 947
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at async Microsoft.Azure.WebJobs.Script.Description.WorkerFunctionInvoker.InvokeCore(Object[] parameters,FunctionInvocationContext context) at C:\Users\sarahvu\source\repos\azure-functions-host\src\WebJobs.Script\Description\Workers\WorkerFunctionInvoker.cs : 96
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
.....

