### PR TITLE
4.22.0 Release Prep

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <MajorVersion>4</MajorVersion>
-    <MinorVersion>21</MinorVersion>
+    <MinorVersion>22</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <BuildNumber Condition="'$(BuildNumber)' == '' ">0</BuildNumber>
     <PreviewVersion></PreviewVersion>        

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,9 +4,8 @@
 - My change description (#PR)
 -->
 - Update Python Worker Version to [4.12.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.12.0)
-- Update Java Worker Version to [2.11.0](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.11.0)
 
-**Release sprint:** Sprint 142
+**Release sprint:** Sprint 143
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+143%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+143%22+label%3Afeature+is%3Aclosed) ]
 - Update PowerShell Worker 7.2 to 4.0.2803 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2803)
 - Update PowerShell Worker 7.4 to 4.0.2802 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2802)


### PR DESCRIPTION
Resetting release notes to everything pushed since [4.21.0](https://github.com/Azure/azure-functions-host/releases/tag/v4.21.0)

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)