### PR TITLE
Restart workers when we need to refresh the worker metadata

### DIFF
--- a/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script
     internal class WorkerFunctionMetadataProvider : IWorkerFunctionMetadataProvider
     {
         private readonly Dictionary<string, ICollection<string>> _functionErrors = new Dictionary<string, ICollection<string>>();
-        private readonly IOptions<ScriptJobHostOptions> _scriptOptions;
+        private readonly IOptionsMonitor<ScriptApplicationHostOptions> _scriptOptions;
         private readonly ILogger _logger;
         private readonly IEnvironment _environment;
         private readonly IWebHostRpcWorkerChannelManager _channelManager;
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Script
         private ImmutableArray<FunctionMetadata> _functions;
 
         public WorkerFunctionMetadataProvider(
-            IOptions<ScriptJobHostOptions> scriptOptions,
+            IOptionsMonitor<ScriptApplicationHostOptions> scriptOptions,
             ILogger<WorkerFunctionMetadataProvider> logger,
             IEnvironment environment,
             IWebHostRpcWorkerChannelManager webHostRpcWorkerChannelManager)
@@ -59,6 +59,15 @@ namespace Microsoft.Azure.WebJobs.Script
                 if (_channelManager == null)
                 {
                     throw new InvalidOperationException(nameof(_channelManager));
+                }
+
+                // We reuse the worker started in placeholderMode only when the fileSystem is readonly
+                // otherwise we shutdown the channel in which case the channel should not have any channels anyway
+                // forceRefresh in only true once in the script host intialization flow.
+                // forceRefresh will be false when bundle is not used (dotnet and dotnet-isolated).
+                if (!_environment.IsPlaceholderModeEnabled() && forceRefresh && !_scriptOptions.CurrentValue.IsFileSystemReadOnly)
+                {
+                    _channelManager.ShutdownChannelsAsync().GetAwaiter().GetResult();
                 }
 
                 var channels = _channelManager.GetChannels(_workerRuntime);
@@ -95,7 +104,7 @@ namespace Microsoft.Azure.WebJobs.Script
                             _logger.FunctionMetadataProviderFunctionFound(_functions.IsDefault ? 0 : _functions.Count());
 
                             // Validate if the app has functions in legacy format and add in logs to inform about the mixed app
-                            _ = Task.Delay(TimeSpan.FromMinutes(1)).ContinueWith(t => ValidateFunctionAppFormat(_scriptOptions.Value.RootScriptPath, _logger, _environment));
+                            _ = Task.Delay(TimeSpan.FromMinutes(1)).ContinueWith(t => ValidateFunctionAppFormat(_scriptOptions.CurrentValue.ScriptPath, _logger, _environment));
 
                             break;
                         }

--- a/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Azure.WebJobs.Script
                     throw new InvalidOperationException(nameof(_channelManager));
                 }
 
+                // Scenario: Restart worker for hot reload on a readwrite file system
                 // We reuse the worker started in placeholderMode only when the fileSystem is readonly
                 // otherwise we shutdown the channel in which case the channel should not have any channels anyway
                 // forceRefresh in only true once in the script host intialization flow.

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/NodeWithBundles/HttpTriggerNoAuth/function.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/NodeWithBundles/HttpTriggerNoAuth/function.json
@@ -1,0 +1,16 @@
+﻿{
+    "bindings": [
+        {
+            "type": "httpTrigger",
+            "name": "request",
+            "direction": "in",
+            "methods": [ "get", "post" ],
+            "authLevel": "anonymous"
+        },
+        {
+            "type": "http",
+            "name": "response",
+            "direction": "out"
+        }
+    ]
+}

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/NodeWithBundles/HttpTriggerNoAuth/index.js
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/NodeWithBundles/HttpTriggerNoAuth/index.js
@@ -1,0 +1,25 @@
+﻿var util = require('util');
+
+module.exports = function (context, req) {
+    context.log('Node.js HttpTrigger function invoked.');
+
+    context.res = {
+        status: 200,
+        body: {
+            reqBodyType: 'Node.js HttpTrigger function invoked.',
+            reqBodyIsArray: util.isArray(req.body),
+            reqBody: req.body,
+            reqRawBodyType: typeof req.rawBody,
+            reqRawBody: req.rawBody,
+            reqHeaders: req.headers,
+            bindingData: context.bindingData,
+            reqOriginalUrl: req.originalUrl
+        },
+        headers: {
+            'test-header': 'Test Response Header',
+            "Content-Type": "application/json; charset=utf-8"
+        }
+    };
+
+    context.done();
+};

--- a/test/WebJobs.Script.Tests.Integration/TestScripts/NodeWithBundles/host.json
+++ b/test/WebJobs.Script.Tests.Integration/TestScripts/NodeWithBundles/host.json
@@ -1,0 +1,7 @@
+﻿{
+    "version": "2.0",
+    "extensionBundle": {
+        "id": "Microsoft.Azure.Functions.ExtensionBundle",
+        "version": "[3.*, 4.0.0)"
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -32,6 +32,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
+using TestFunctions;
 using Xunit;
 using Xunit.Abstractions;
 using IApplicationLifetime = Microsoft.AspNetCore.Hosting.IApplicationLifetime;
@@ -247,6 +248,158 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
                 Assert.NotSame(placeholderContext, specializedContext);
             }
+        }
+
+        [Fact]
+        public async Task ForNonReadOnlyFileSystem_RestartWorkerForSpecializationAndHotReload()
+        {
+            _environment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, "node");
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagEnableWorkerIndexing);
+
+            var builder = CreateStandbyHostBuilder("HttpTriggerNoAuth");
+
+            builder.ConfigureAppConfiguration(config =>
+            {
+                string scriptRootConfigPath = ConfigurationPath.Combine(ConfigurationSectionNames.WebHost, nameof(ScriptApplicationHostOptions.ScriptPath));
+                config.AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { _scriptRootConfigPath, Path.GetFullPath(@"TestScripts\NodeWithBundles") }
+                });
+            });
+
+            using var testServer = new TestServer(builder);
+
+            var client = testServer.CreateClient();
+
+            var response = await client.GetAsync("api/warmup");
+            response.EnsureSuccessStatusCode();
+
+            var placeholderContext = FunctionAssemblyLoadContext.Shared;
+
+            // Validate that the channel is set up with native worker
+            var webChannelManager = testServer.Services.GetService<IWebHostRpcWorkerChannelManager>();
+            var channel = await webChannelManager.GetChannels("node").Single().Value.Task;
+            var dotnetProcessId = channel.WorkerProcess.Process.Id;
+
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+
+            //await _pauseBeforeHostBuild.WaitAsync(10000);
+            response = await client.GetAsync("api/HttpTriggerNoAuth");
+            response.EnsureSuccessStatusCode();
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            string content = "Node.js HttpTrigger function invoked.";
+            responseContent.Contains(content);
+
+            channel = await webChannelManager.GetChannels("node").Single().Value.Task;
+            var newDotnetProcessId = channel.WorkerProcess.Process.Id;
+            Assert.NotEqual(dotnetProcessId, newDotnetProcessId);
+            Assert.Contains(content, responseContent);
+
+            var indexJS = Path.GetFullPath(@"TestScripts\NodeWithBundles\HttpTriggerNoAuth\index.js");
+
+            string fileContent = File.ReadAllText(indexJS);
+            string newContent = "Updated Node.js HttpTrigger function invoked.";
+            string updatedContent = fileContent.Replace(content, newContent);
+            File.WriteAllText(indexJS, updatedContent);
+
+            await Task.Delay(1000);
+
+            response = await client.GetAsync("api/HttpTriggerNoAuth");
+            response.EnsureSuccessStatusCode();
+            responseContent = await response.Content.ReadAsStringAsync();
+            responseContent.Contains(newContent);
+
+            channel = await webChannelManager.GetChannels("node").Single().Value.Task;
+            var hotReloadProcessId = channel.WorkerProcess.Process.Id;
+            Assert.NotEqual(hotReloadProcessId, newDotnetProcessId);
+            Assert.Contains(newContent, responseContent);
+        }
+
+        [Fact]
+        public async Task Specialization_RestartsWorkerForNonReadOnlyFileSystem()
+        {
+            _environment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, "node");
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagEnableWorkerIndexing);
+
+            var builder = CreateStandbyHostBuilder("HttpTriggerNoAuth");
+
+            builder.ConfigureAppConfiguration(config =>
+            {
+                string scriptRootConfigPath = ConfigurationPath.Combine(ConfigurationSectionNames.WebHost, nameof(ScriptApplicationHostOptions.ScriptPath));
+                config.AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { _scriptRootConfigPath, Path.GetFullPath(@"TestScripts\NodeWithBundles") }
+                });
+            });
+
+            using var testServer = new TestServer(builder);
+
+            var client = testServer.CreateClient();
+
+            var response = await client.GetAsync("api/warmup");
+            response.EnsureSuccessStatusCode();
+
+            var placeholderContext = FunctionAssemblyLoadContext.Shared;
+
+            // Validate that the channel is set up with native worker
+            var webChannelManager = testServer.Services.GetService<IWebHostRpcWorkerChannelManager>();
+            var channel = await webChannelManager.GetChannels("node").Single().Value.Task;
+            var dotnetProcessId = channel.WorkerProcess.Process.Id;
+
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+
+            //await _pauseBeforeHostBuild.WaitAsync(10000);
+            response = await client.GetAsync("api/HttpTriggerNoAuth");
+            response.EnsureSuccessStatusCode();
+
+            channel = await webChannelManager.GetChannels("node").Single().Value.Task;
+            var newDotnetProcessId = channel.WorkerProcess.Process.Id;
+            Assert.NotEqual(dotnetProcessId, newDotnetProcessId);
+        }
+
+        [Fact]
+        public async Task Specialization_UsePlaceholderWorkerforReadOnlyFileSystem()
+        {
+            _environment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, "node");
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagEnableWorkerIndexing);
+
+            var builder = CreateStandbyHostBuilder("HttpTriggerNoAuth");
+            string isFileSystemReadOnly = ConfigurationPath.Combine(ConfigurationSectionNames.WebHost, nameof(ScriptApplicationHostOptions.IsFileSystemReadOnly));
+
+            builder.ConfigureAppConfiguration(config =>
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string>
+                    {
+                        { _scriptRootConfigPath, Path.GetFullPath(@"TestScripts\NodeWithBundles") }
+                    });
+                });
+
+
+            using var testServer = new TestServer(builder);
+
+            var client = testServer.CreateClient();
+
+            var response = await client.GetAsync("api/warmup");
+            response.EnsureSuccessStatusCode();
+
+            // Validate that the channel is set up with native worker
+            var webChannelManager = testServer.Services.GetService<IWebHostRpcWorkerChannelManager>();
+            var channel = await webChannelManager.GetChannels("node").Single().Value.Task;
+            var dotnetProcessId = channel.WorkerProcess.Process.Id;
+
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteRunFromPackage, "1");
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+
+            response = await client.GetAsync("api/HttpTriggerNoAuth");
+            response.EnsureSuccessStatusCode();
+
+            channel = await webChannelManager.GetChannels("node").Single().Value.Task;
+            var newDotnetProcessId = channel.WorkerProcess.Process.Id;
+            Assert.Equal(dotnetProcessId, newDotnetProcessId);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -274,15 +274,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var response = await client.GetAsync("api/warmup");
             response.EnsureSuccessStatusCode();
 
-            // Validate that the channel is set up with native worker
             var webChannelManager = testServer.Services.GetService<IWebHostRpcWorkerChannelManager>();
             var channel = await webChannelManager.GetChannels("node").Single().Value.Task;
-            var dotnetProcessId = channel.WorkerProcess.Process.Id;
+            var processId = channel.WorkerProcess.Process.Id;
 
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
 
-            //await _pauseBeforeHostBuild.WaitAsync(10000);
             response = await client.GetAsync("api/HttpTriggerNoAuth");
             response.EnsureSuccessStatusCode();
             var responseContent = await response.Content.ReadAsStringAsync();
@@ -291,8 +289,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             responseContent.Contains(content);
 
             channel = await webChannelManager.GetChannels("node").Single().Value.Task;
-            var newDotnetProcessId = channel.WorkerProcess.Process.Id;
-            Assert.NotEqual(dotnetProcessId, newDotnetProcessId);
+            var newProcessId = channel.WorkerProcess.Process.Id;
+            Assert.NotEqual(processId, newProcessId);
             Assert.Contains(content, responseContent);
 
             var indexJS = Path.GetFullPath(@"TestScripts\NodeWithBundles\HttpTriggerNoAuth\index.js");
@@ -322,7 +320,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             channel = await webChannelManager.GetChannels("node").Single().Value.Task;
             var hotReloadProcessId = channel.WorkerProcess.Process.Id;
-            Assert.NotEqual(hotReloadProcessId, newDotnetProcessId);
+            Assert.NotEqual(hotReloadProcessId, newProcessId);
             Assert.Contains(newContent, responseContent);
         }
 
@@ -352,10 +350,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var placeholderContext = FunctionAssemblyLoadContext.Shared;
 
-            // Validate that the channel is set up with native worker
             var webChannelManager = testServer.Services.GetService<IWebHostRpcWorkerChannelManager>();
             var channel = await webChannelManager.GetChannels("node").Single().Value.Task;
-            var dotnetProcessId = channel.WorkerProcess.Process.Id;
+            var processId = channel.WorkerProcess.Process.Id;
 
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
@@ -365,9 +362,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             response.EnsureSuccessStatusCode();
 
             channel = await webChannelManager.GetChannels("node").Single().Value.Task;
-            var newDotnetProcessId = channel.WorkerProcess.Process.Id;
-            Assert.NotEqual(dotnetProcessId, newDotnetProcessId);
+            var newProcessId = channel.WorkerProcess.Process.Id;
+            Assert.NotEqual(processId, newProcessId);
         }
+
 
         [Fact]
         public async Task Specialization_UsePlaceholderWorkerforReadOnlyFileSystem()
@@ -394,10 +392,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var response = await client.GetAsync("api/warmup");
             response.EnsureSuccessStatusCode();
 
-            // Validate that the channel is set up with native worker
             var webChannelManager = testServer.Services.GetService<IWebHostRpcWorkerChannelManager>();
             var channel = await webChannelManager.GetChannels("node").Single().Value.Task;
-            var dotnetProcessId = channel.WorkerProcess.Process.Id;
+            var processId = channel.WorkerProcess.Process.Id;
 
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteRunFromPackage, "1");
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
@@ -407,8 +404,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             response.EnsureSuccessStatusCode();
 
             channel = await webChannelManager.GetChannels("node").Single().Value.Task;
-            var newDotnetProcessId = channel.WorkerProcess.Process.Id;
-            Assert.Equal(dotnetProcessId, newDotnetProcessId);
+            var newProcessId = channel.WorkerProcess.Process.Id;
+            Assert.Equal(processId, newProcessId);
         }
 
         [Fact]


### PR DESCRIPTION
Adding logic to do the following
We should not have any channels on script host start up when specializing with with non readonly file system for node, python and powershell
However, we would have channels and would need to shut them down in case of hot reload

resolves #9185 

#issue_for_this_pr

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
