### PR TITLE
Sending metadata request once per scriptHost instance

### DIFF
--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -804,21 +804,24 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             {
                 lock (_metadataLock)
                 {
-                    RegisterCallbackForNextGrpcMessage(MsgType.FunctionMetadataResponse, _functionLoadTimeout, 1,
+                    if (!_functionMetadataRequestSent)
+                    {
+                        RegisterCallbackForNextGrpcMessage(MsgType.FunctionMetadataResponse, _functionLoadTimeout, 1,
                     msg => ProcessFunctionMetadataResponses(msg.Message.FunctionMetadataResponse), HandleWorkerMetadataRequestError);
 
-                    _workerChannelLogger.LogDebug("Sending WorkerMetadataRequest to {language} worker with worker ID {workerID}", _runtime, _workerId);
+                        _workerChannelLogger.LogDebug("Sending WorkerMetadataRequest to {language} worker with worker ID {workerID}", _runtime, _workerId);
 
-                    // sends the function app directory path to worker for indexing
-                    SendStreamingMessage(new StreamingMessage
-                    {
-                        FunctionsMetadataRequest = new FunctionsMetadataRequest()
+                        // sends the function app directory path to worker for indexing
+                        SendStreamingMessage(new StreamingMessage
                         {
-                            FunctionAppDirectory = _applicationHostOptions.CurrentValue.ScriptPath
-                        }
-                    });
+                            FunctionsMetadataRequest = new FunctionsMetadataRequest()
+                            {
+                                FunctionAppDirectory = _applicationHostOptions.CurrentValue.ScriptPath
+                            }
+                        });
 
-                    _functionMetadataRequestSent = true;
+                        _functionMetadataRequestSent = true;
+                    }
                 }
             }
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Currently we have a race condition inside of `SendFunctionMetadataRequest` where if more than one thread enters the code block before the execution is complete. Then second thread would run into an exception as it would try to complete an already completed task. This PR adds a lock around that code block so we have only one thread enter the code block at a time.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
