### PR TITLE
Console logging optimizations

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/BufferedConsoleWriter.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/BufferedConsoleWriter.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             }
         }
 
+        // internal only for testing - should only be used from the constructor, not intended for concurrent callers.
         internal void StartProcessingBuffer()
         {
             // intentional no-op if the task is already running

--- a/src/WebJobs.Script.WebHost/Diagnostics/ConsoleWriter.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/ConsoleWriter.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
     internal class ConsoleWriter
     {
         // A typical out-of-proc function execution will generate 8 log lines.
-        // A single core container can potentially get around 1K RPS at the higher end, so this is about 1 second of buffer in the extreme case.
-        // A typical log line is around 300 bytes, so this is about 2.4MB of buffer in the extreme case.
+        // A single core container can potentially get around 1K RPS at the higher end, and a typical log line is around 300 bytes
+        // So in the extreme case, this is about 1 second of buffer and should be less than 3MB
         private const int DefaultBufferSize = 8000;
 
         private static readonly TimeSpan DefaultConsoleBufferTimeout = TimeSpan.FromSeconds(1);

--- a/src/WebJobs.Script.WebHost/Diagnostics/ConsoleWriter.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/ConsoleWriter.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         // we can influence the latency distribution by controlling how much of the buffer we will process in one pass.
         // If we set this to 1, the P50 latency will be low, but the P99 latency will be high.
         // If we set this to a large value, it keeps the P99 latency under control but the P50 degrades.
-        // In local testing with a console attached, processing 1/10th of the buffer size per iteration yields single digit P50 while keeping P99 under 100ms.
+        // In local testing with a console attached, processing 1/10th of the buffer size per iteration yields P50 under 10ms with P99 under 100ms.
         private const int SingleWriteBufferDenominator = 10;
 
         private static readonly TimeSpan DisposeTimeout = TimeSpan.FromSeconds(5);

--- a/src/WebJobs.Script.WebHost/Diagnostics/ConsoleWriter.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/ConsoleWriter.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
+{
+    public class ConsoleWriter
+    {
+        private readonly bool _consoleEnabled = true;
+        private readonly Channel<string> _consoleBuffer;
+        private readonly TimeSpan _consoleBufferTimeout = TimeSpan.FromSeconds(1);
+        private readonly Task _consoleBufferReadLoop;
+        private readonly bool _consoleBufferBatched = false;
+        private readonly Action<string> _writeEvent;
+        private readonly Action<Exception> _unhandledExceptionHandler;
+
+        public ConsoleWriter(IEnvironment environment, Action<Exception> unhandledExceptionHandler)
+        {
+            if (environment.GetEnvironmentVariable(EnvironmentSettingNames.ConsoleLoggingDisabled) == "1")
+            {
+                _consoleEnabled = false;
+            }
+
+            // We are going to used stdout, but do we write directly or use a buffer?
+            _consoleBuffer = environment.GetEnvironmentVariable(EnvironmentSettingNames.ConsoleLoggingBufferSize) switch
+            {
+                "-1" => Channel.CreateUnbounded<string>(), // buffer size of -1 indicates that buffer should be enabled but unbounded
+                var s when int.TryParse(s, out int i) && i > 0 => Channel.CreateBounded<string>(i),
+                _ => null // do not buffer in all other cases
+            };
+
+            if (_consoleEnabled == false)
+            {
+                _writeEvent = (string s) => { };
+            }
+            else if (_consoleBuffer == null)
+            {
+                _writeEvent = Console.WriteLine;
+            }
+            else
+            {
+                _consoleBufferBatched = environment.GetEnvironmentVariable(EnvironmentSettingNames.ConsoleLoggingBufferBatched) switch
+                {
+                    "1" => true,
+                    _ => false
+                };
+
+                _writeEvent = WriteToConsoleBuffer;
+                _consoleBufferReadLoop = ProcessConsoleBuffer();
+            }
+
+            _unhandledExceptionHandler = unhandledExceptionHandler;
+        }
+
+        public Action<string> WriteHandler => _writeEvent;
+
+        private void WriteToConsoleBuffer(string evt)
+        {
+            try
+            {
+                while (_consoleBuffer.Writer.TryWrite(evt) == false)
+                {
+                    // Buffer is currently full, wait until writing is permitted.
+                    // This is the downside of using channels, we are on a sync code path and so we have to block on this task
+                    var writeTask = _consoleBuffer.Writer.WaitToWriteAsync().AsTask();
+                    if (writeTask.WaitAsync(_consoleBufferTimeout).Result == false)
+                    {
+                        // The buffer has been completed and does not allow further writes.
+                        // Currently this should not be possible, but the safest thing to do is just write directly to the console.
+                        Console.WriteLine(evt);
+                        break;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // Most likely a task cancellation exception from the timeout expiring, but regardless we handle it the same way:
+                // dump the raw exception and write the event to the console directly
+                _unhandledExceptionHandler(ex);
+                Console.WriteLine(evt);
+            }
+        }
+
+        private async Task ProcessConsoleBuffer()
+        {
+            if (_consoleBufferBatched)
+            {
+                var builder = new StringBuilder();
+
+                while (true)
+                {
+                    if (await _consoleBuffer.Reader.WaitToReadAsync() == false)
+                    {
+                        // The buffer has been completed and does not allow further reads.
+                        // Currently this should not be possible, but safest thing to do is break out of the loop.
+                        break;
+                    }
+
+                    while (_consoleBuffer.Reader.TryRead(out var line))
+                    {
+                        builder.AppendLine(line);
+                    }
+                    Console.WriteLine(builder.ToString());
+                    builder.Clear();
+                }
+            }
+            else
+            {
+                await foreach (var line in _consoleBuffer.Reader.ReadAllAsync())
+                {
+                    Console.WriteLine(line);
+                }
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Diagnostics/ConsoleWriter.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/ConsoleWriter.cs
@@ -33,8 +33,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 _consoleBuffer = environment.GetEnvironmentVariable(EnvironmentSettingNames.ConsoleLoggingBufferSize) switch
                 {
                     "-1" => Channel.CreateUnbounded<string>(),              // buffer size of -1 indicates that buffer should be enabled but unbounded
+                    "0" => null,                                            // buffer size of 0 indicates that buffer should be disabled
                     var s when int.TryParse(s, out int i) && i > 0 => Channel.CreateBounded<string>(i),
-                    _ => null,                                              // default behavior is do not use the buffer
+                    _ => Channel.CreateBounded<string>(DefaultBufferSize),  // default behavior is to use buffer with default size
                 };
 
                 if (_consoleBuffer == null)

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxContainerEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxContainerEventGenerator.cs
@@ -2,15 +2,11 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Text;
-using System.Threading;
-using System.Threading.Channels;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 {
-    internal class LinuxContainerEventGenerator : LinuxEventGenerator
+    internal class LinuxContainerEventGenerator : LinuxEventGenerator, IDisposable
     {
         private const int MaxDetailsLength = 10000;
         private static readonly Lazy<LinuxContainerEventGenerator> _Lazy = new Lazy<LinuxContainerEventGenerator>(() => new LinuxContainerEventGenerator(SystemEnvironment.Instance, Console.WriteLine));
@@ -20,6 +16,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         private string _containerName;
         private string _stampName;
         private string _tenantId;
+        private bool _disposed;
 
         public LinuxContainerEventGenerator(IEnvironment environment, Action<string> writeEvent = null)
         {
@@ -151,6 +148,24 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 runtimeSiteName: SystemEnvironment.Instance.GetRuntimeSiteName() ?? string.Empty,
                 slotName: SystemEnvironment.Instance.GetSlotName() ?? string.Empty,
                 eventTimestamp: DateTime.UtcNow);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _consoleWriter?.Dispose();
+                }
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxContainerEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxContainerEventGenerator.cs
@@ -35,6 +35,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             _containerName = _environment.GetEnvironmentVariable(EnvironmentSettingNames.ContainerName)?.ToUpperInvariant();
         }
 
+        // For testing
+        internal LinuxContainerEventGenerator(IEnvironment environment, ConsoleWriter consoleWriter)
+        {
+            _environment = environment;
+            _consoleWriter = consoleWriter;
+            _writeEvent = consoleWriter.WriteHandler;
+
+            _containerName = _environment.GetEnvironmentVariable(EnvironmentSettingNames.ContainerName)?.ToUpperInvariant();
+        }
+
         // Note: the strange escaping of backslashes in these expressions for string literals (e.g. '\\\\\"') is because
         // of the current JSON serialization our log messages undergoe.
         public static string TraceEventRegex { get; } = $"{ScriptConstants.LinuxLogEventStreamName} (?<Level>[0-6]),(?<SubscriptionId>[^,]*),(?<AppName>[^,]*),(?<FunctionName>[^,]*),(?<EventName>[^,]*),(?<Source>[^,]*),\"(?<Details>.*)\",\"(?<Summary>.*)\",(?<HostVersion>[^,]*),(?<EventTimestamp>[^,]+),(?<ExceptionType>[^,]*),\"(?<ExceptionMessage>.*)\",(?<FunctionInvocationId>[^,]*),(?<HostInstanceId>[^,]*),(?<ActivityId>[^,\"]*),(?<ContainerName>[^,\"]*),(?<StampName>[^,\"]*),(?<TenantId>[^,\"]*),(?<RuntimeSiteName>[^,]*),(?<SlotName>[^,]*)";

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -99,14 +99,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddSingleton<IEventGenerator>(p =>
             {
                 var environment = p.GetService<IEnvironment>();
-                if (environment.IsLinuxConsumptionOnAtlas())
+                if (environment.IsAnyLinuxConsumption())
                 {
-                    return new LinuxContainerEventGenerator(environment);
-                }
-                else if (environment.IsLinuxConsumptionOnLegion())
-                {
-                    //todo: Replace with legion specific logger
-                    return new LinuxContainerEventGenerator(environment);
+                    var consoleLoggingOptions = p.GetService<IOptions<ConsoleLoggingOptions>>();
+                    return new LinuxContainerEventGenerator(environment, consoleLoggingOptions);
                 }
                 else if (SystemEnvironment.Instance.IsLinuxAppService())
                 {
@@ -207,6 +203,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.ConfigureOptionsWithChangeTokenSource<LanguageWorkerOptions, LanguageWorkerOptionsSetup, SpecializationChangeTokenSource<LanguageWorkerOptions>>();
             services.ConfigureOptionsWithChangeTokenSource<AppServiceOptions, AppServiceOptionsSetup, SpecializationChangeTokenSource<AppServiceOptions>>();
             services.ConfigureOptionsWithChangeTokenSource<HttpBodyControlOptions, HttpBodyControlOptionsSetup, SpecializationChangeTokenSource<HttpBodyControlOptions>>();
+            services.ConfigureOptions<ConsoleLoggingOptionsSetup>();
             services.ConfigureOptions<FunctionsHostingConfigOptionsSetup>();
             if (configuration != null)
             {

--- a/src/WebJobs.Script/Config/ConsoleLoggingOptions.cs
+++ b/src/WebJobs.Script/Config/ConsoleLoggingOptions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script.Config
+{
+    public class ConsoleLoggingOptions
+    {
+        // A typical out-of-proc function execution will generate 8 log lines.
+        // A single core container can potentially get around 1K RPS at the higher end, and a typical log line is around 300 bytes
+        // So in the extreme case, this is about 1 second of buffer and should be less than 3MB
+        public const int DefaultBufferSize = 8000;
+
+        public ConsoleLoggingOptions()
+        {
+            LoggingDisabled = false;
+            BufferEnabled = true;
+            BufferSize = DefaultBufferSize;
+        }
+
+        public bool LoggingDisabled { get; set; }
+
+        public bool BufferEnabled { get; set; }
+
+        public int BufferSize { get; set; }
+    }
+}

--- a/src/WebJobs.Script/Config/ConsoleLoggingOptions.cs
+++ b/src/WebJobs.Script/Config/ConsoleLoggingOptions.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Azure.WebJobs.Script.Config
 
         public bool LoggingDisabled { get; set; }
 
-        public bool BufferEnabled { get; set; }
+        // Use BufferSize = 0 to disable the buffer
+        public bool BufferEnabled { get; internal set; }
 
         public int BufferSize { get; set; }
     }

--- a/src/WebJobs.Script/Config/ConsoleLoggingOptionsSetup.cs
+++ b/src/WebJobs.Script/Config/ConsoleLoggingOptionsSetup.cs
@@ -20,14 +20,17 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         {
             options.LoggingDisabled = _configuration.GetValue<int>(EnvironmentSettingNames.ConsoleLoggingDisabled) == 1;
 
-            int bufferSize = _configuration.GetValue<int>(EnvironmentSettingNames.ConsoleLoggingBufferSize, ConsoleLoggingOptions.DefaultBufferSize);
-            if (bufferSize < 0)
+            int? bufferSize = _configuration.GetValue<int?>(EnvironmentSettingNames.ConsoleLoggingBufferSize);
+            if (bufferSize != null)
             {
-                throw new ArgumentOutOfRangeException(nameof(EnvironmentSettingNames.ConsoleLoggingBufferSize), "Console buffer size cannot be negative");
-            }
+                if (bufferSize < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(EnvironmentSettingNames.ConsoleLoggingBufferSize), "Console buffer size cannot be negative");
+                }
 
-            options.BufferEnabled = bufferSize > 0;
-            options.BufferSize = bufferSize;
+                options.BufferEnabled = bufferSize > 0;
+                options.BufferSize = bufferSize.Value;
+            }
         }
     }
 }

--- a/src/WebJobs.Script/Config/ConsoleLoggingOptionsSetup.cs
+++ b/src/WebJobs.Script/Config/ConsoleLoggingOptionsSetup.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebJobs.Script.Config
+{
+    public class ConsoleLoggingOptionsSetup : IConfigureOptions<ConsoleLoggingOptions>
+    {
+        private readonly IConfiguration _configuration;
+
+        public ConsoleLoggingOptionsSetup(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public void Configure(ConsoleLoggingOptions options)
+        {
+            options.LoggingDisabled = _configuration.GetValue<int>(EnvironmentSettingNames.ConsoleLoggingDisabled) == 1;
+
+            int bufferSize = _configuration.GetValue<int>(EnvironmentSettingNames.ConsoleLoggingBufferSize, ConsoleLoggingOptions.DefaultBufferSize);
+            if (bufferSize < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(EnvironmentSettingNames.ConsoleLoggingBufferSize), "Console buffer size cannot be negative");
+            }
+
+            options.BufferEnabled = bufferSize > 0;
+            options.BufferSize = bufferSize;
+        }
+    }
+}

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -37,7 +37,6 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string WebSiteAuthEncryptionKey = "WEBSITE_AUTH_ENCRYPTION_KEY";
         public const string ContainerEncryptionKey = "CONTAINER_ENCRYPTION_KEY";
         public const string ConsoleLoggingDisabled = "CONSOLE_LOGGING_DISABLED";
-        public const string ConsoleLoggingBufferBatched = "CONSOLE_LOGGING_BUFFER_BATCHED";
         public const string ConsoleLoggingBufferSize = "CONSOLE_LOGGING_BUFFER_SIZE";
         public const string SkipSslValidation = "SCM_SKIP_SSL_VALIDATION";
         public const string EnvironmentNameKey = "AZURE_FUNCTIONS_ENVIRONMENT";

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string WebSiteAuthEncryptionKey = "WEBSITE_AUTH_ENCRYPTION_KEY";
         public const string ContainerEncryptionKey = "CONTAINER_ENCRYPTION_KEY";
         public const string ConsoleLoggingDisabled = "CONSOLE_LOGGING_DISABLED";
+        public const string ConsoleLoggingBufferSize = "CONSOLE_LOGGING_BUFFER_SIZE";
         public const string SkipSslValidation = "SCM_SKIP_SSL_VALIDATION";
         public const string EnvironmentNameKey = "AZURE_FUNCTIONS_ENVIRONMENT";
         public const string FunctionsV2CompatibilityModeKey = "FUNCTIONS_V2_COMPATIBILITY_MODE";

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string WebSiteAuthEncryptionKey = "WEBSITE_AUTH_ENCRYPTION_KEY";
         public const string ContainerEncryptionKey = "CONTAINER_ENCRYPTION_KEY";
         public const string ConsoleLoggingDisabled = "CONSOLE_LOGGING_DISABLED";
+        public const string ConsoleLoggingBufferBatched = "CONSOLE_LOGGING_BUFFER_BATCHED";
         public const string ConsoleLoggingBufferSize = "CONSOLE_LOGGING_BUFFER_SIZE";
         public const string SkipSslValidation = "SCM_SKIP_SSL_VALIDATION";
         public const string EnvironmentNameKey = "AZURE_FUNCTIONS_ENVIRONMENT";

--- a/test/WebJobs.Script.Tests/Configuration/ConsoleLoggingOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ConsoleLoggingOptionsSetupTests.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
+{
+    public class ConsoleLoggingOptionsSetupTests
+    {
+        [Fact]
+        public void ConsoleLoggingOptionsSetup_ConfiguresExpectedDefaults()
+        {
+            IConfiguration config = new ConfigurationBuilder()
+               .AddInMemoryCollection(new Dictionary<string, string>
+               {
+                   //{ $"{SamplingSettings}:MaxTelemetryItemsPerSecond", "25" },
+                   //{ $"{SamplingSettings}:IsEnabled", "false" }
+               })
+               .Build();
+
+            ConsoleLoggingOptionsSetup setup = new ConsoleLoggingOptionsSetup(config);
+            ConsoleLoggingOptions options = new ConsoleLoggingOptions();
+
+            setup.Configure(options);
+
+            Assert.Equal(true, options.BufferEnabled);
+            Assert.Equal(false, options.LoggingDisabled);
+            Assert.Equal(8000, options.BufferSize);
+        }
+
+        [Theory]
+        [InlineData("1", true)]
+        [InlineData("0", false)]
+        [InlineData(null, false)]
+        public void ConsoleLoggingOptionsSetup_CanDisableLogging(string value, bool expectLoggingDisabled)
+        {
+            var settings = new Dictionary<string, string>();
+
+            if (value != null)
+            {
+                settings[EnvironmentSettingNames.ConsoleLoggingDisabled] = value;
+            }
+
+            IConfiguration config = new ConfigurationBuilder()
+               .AddInMemoryCollection(settings)
+               .Build();
+
+            ConsoleLoggingOptionsSetup setup = new ConsoleLoggingOptionsSetup(config);
+            ConsoleLoggingOptions options = new ConsoleLoggingOptions();
+            setup.Configure(options);
+
+            Assert.Equal(expectLoggingDisabled, options.LoggingDisabled);
+        }
+
+        [Fact]
+        public void ConsoleLoggingOptionsSetup_CanDisableBuffer()
+        {
+            var settings = new Dictionary<string, string>();
+            settings[EnvironmentSettingNames.ConsoleLoggingBufferSize] = "0";
+
+            IConfiguration config = new ConfigurationBuilder()
+               .AddInMemoryCollection(settings)
+               .Build();
+
+            ConsoleLoggingOptionsSetup setup = new ConsoleLoggingOptionsSetup(config);
+            ConsoleLoggingOptions options = new ConsoleLoggingOptions();
+            setup.Configure(options);
+
+            Assert.Equal(false, options.BufferEnabled);
+        }
+
+        [Fact]
+        public void ConsoleLoggingOptionsSetup_CanSetBufferSize()
+        {
+            var settings = new Dictionary<string, string>();
+            settings[EnvironmentSettingNames.ConsoleLoggingBufferSize] = "100";
+
+            IConfiguration config = new ConfigurationBuilder()
+               .AddInMemoryCollection(settings)
+               .Build();
+
+            ConsoleLoggingOptionsSetup setup = new ConsoleLoggingOptionsSetup(config);
+            ConsoleLoggingOptions options = new ConsoleLoggingOptions();
+            setup.Configure(options);
+
+            Assert.Equal(100, options.BufferSize);
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Configuration/ConsoleLoggingOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ConsoleLoggingOptionsSetupTests.cs
@@ -88,5 +88,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 
             Assert.Equal(100, options.BufferSize);
         }
+
+        [Fact]
+        public void ConsoleLoggingOptionsSetup_DoesNotOverwriteCustomBufferSizeIfNotSet()
+        {
+            var settings = new Dictionary<string, string>();
+
+            IConfiguration config = new ConfigurationBuilder()
+               .AddInMemoryCollection(settings)
+               .Build();
+
+            ConsoleLoggingOptionsSetup setup = new ConsoleLoggingOptionsSetup(config);
+            ConsoleLoggingOptions options = new ConsoleLoggingOptions { BufferSize = 100 };
+            setup.Configure(options);
+
+            Assert.Equal(100, options.BufferSize);
+        }
     }
 }

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxContainerEventGeneratorWithConsoleOutputTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxContainerEventGeneratorWithConsoleOutputTests.cs
@@ -152,14 +152,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             var output = sr.ReadToEnd().Trim().SplitLines();
 
             // The first two messages are still stuck in the buffer. The third message will have been written to the console.
-            // We should also have a log for the timeout exception that occurred while waiting for the buffer to become available.
-            Assert.Equal(2, output.Length);
-            Assert.StartsWith("MS_FUNCTION_LOGS 2,,,,,LogUnhandledException,\"System.OperationCanceledException: The operation was canceled.", output[0]);
-            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction3,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[1]);
+            Assert.Equal(1, output.Length);
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction3,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[0]);
         }
 
         [Fact]
-        public async Task MultipleEventsBatchedWithTinyBuffer_BlocksOnWriteOnBufferFull_IfTimeoutNotReached()
+        public async Task WritesLogsDirectlyWhenBufferIsFull()
         {
             // setup in a state where the buffer isn't being processed and can only hold two messages
             var env = CreateEnvironment(bufferSize: 2, batched: true);
@@ -170,14 +168,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction1", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
             generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction2", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
 
-            // The third write will block until the first two are flushed.
-            var logTask = Task.Run(() => generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction3", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp));
+            // The third write will go direct to console
+            generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction3", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
             await Task.Delay(TimeSpan.FromMilliseconds(10));
-            Assert.False(logTask.IsCompleted);
 
             consoleWriter.StartProcessingBuffer(batched: true);
             await Task.Delay(TimeSpan.FromMilliseconds(50));
-            Assert.True(logTask.IsCompleted);
 
             using var sr = new StreamReader(_consoleOut);
             _consoleOut.Position = 0;
@@ -185,9 +181,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 
             Assert.Equal(3, output.Length);
 
-            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction1,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[0]);
-            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction2,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[1]);
-            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction3,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[2]);
+            // the log from TestFunction3 will be first because it was written directly to the console
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction3,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[0]);
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction1,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[1]);
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction2,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[2]);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxContainerEventGeneratorWithConsoleOutputTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxContainerEventGeneratorWithConsoleOutputTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             _consoleOut.Position = 0;
             var output = sr.ReadToEnd().Trim();
 
-            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output);
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output);
         }
 
         [Theory]
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             _consoleOut.Position = 0;
             var output = sr.ReadToEnd().Trim();
 
-            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output);
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output);
         }
 
         [Theory]
@@ -124,9 +124,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 
             Assert.Equal(3, output.Length);
 
-            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction1,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[0]);
-            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction2,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[1]);
-            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction3,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[2]);
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction1,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[0]);
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction2,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[1]);
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction3,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[2]);
         }
 
         [Theory]
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             // We should also have a log for the timeout exception that occurred while waiting for the buffer to become available.
             Assert.Equal(2, output.Length);
             Assert.StartsWith("MS_FUNCTION_LOGS 2,,,,,LogUnhandledException,\"System.AggregateException: One or more errors occurred. (The operation has timed out.)", output[0]);
-            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction3,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[1]);
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction3,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[1]);
         }
 
         [Fact]
@@ -184,9 +184,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 
             Assert.Equal(3, output.Length);
 
-            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction1,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[0]);
-            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction2,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[1]);
-            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction3,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[2]);
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction1,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[0]);
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction2,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[1]);
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction3,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[2]);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxContainerEventGeneratorWithConsoleOutputTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxContainerEventGeneratorWithConsoleOutputTests.cs
@@ -1,0 +1,208 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
+{
+    public class LinuxContainerEventGeneratorWithConsoleOutputTests : IDisposable
+    {
+        private readonly MemoryStream _consoleOut = new MemoryStream();
+        private readonly string _containerName = "test-container";
+        private readonly string _stampName = "test-stamp";
+        private readonly string _tenantId = "test-tenant";
+        private readonly string _testNodeAddress = "test-address";
+
+        public LinuxContainerEventGeneratorWithConsoleOutputTests()
+        {
+            var streamWriter = new StreamWriter(_consoleOut);
+            streamWriter.AutoFlush = true;
+            Console.SetOut(streamWriter);
+        }
+
+        public void Dispose()
+        {
+            var standardOutput = new StreamWriter(Console.OpenStandardOutput());
+            standardOutput.AutoFlush = true;
+            Console.SetOut(standardOutput);
+        }
+
+        private IEnvironment CreateEnvironment(bool consoleDisabled = false, int bufferSize = 0, bool batched = false)
+        {
+            var mockEnvironment = new Mock<IEnvironment>(MockBehavior.Strict);
+            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ContainerName)).Returns(_containerName);
+            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.WebSiteHomeStampName)).Returns(_stampName);
+            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.WebSiteStampDeploymentId)).Returns(_tenantId);
+            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.LinuxNodeIpAddress)).Returns(_testNodeAddress);
+
+            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ConsoleLoggingDisabled)).Returns(consoleDisabled ? "1" : "0");
+            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ConsoleLoggingBufferSize)).Returns(bufferSize.ToString());
+            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ConsoleLoggingBufferBatched)).Returns(batched ? "1" : "0");
+            return mockEnvironment.Object;
+        }
+
+        [Fact]
+        public void GenerateNothingWhenDisabled()
+        {
+            var env = CreateEnvironment(consoleDisabled: true);
+            var generator = new LinuxContainerEventGenerator(env);
+
+            generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", DateTime.Now);
+
+            using var sr = new StreamReader(_consoleOut);
+            _consoleOut.Position = 0;
+            var output = sr.ReadToEnd().Trim();
+
+            Assert.Equal(string.Empty, output);
+        }
+
+        [Fact]
+        public void SingleEventNoBuffer()
+        {
+            var env = CreateEnvironment(bufferSize: 0);
+            var generator = new LinuxContainerEventGenerator(env);
+
+            var timestamp = DateTime.Parse("2023-04-19T14:12:00.0000000Z");
+            generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
+
+            using var sr = new StreamReader(_consoleOut);
+            _consoleOut.Position = 0;
+            var output = sr.ReadToEnd().Trim();
+
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output);
+        }
+
+        [Fact]
+        public async Task SingleEventBuffer()
+        {
+            var env = CreateEnvironment(bufferSize: 10);
+            var generator = new LinuxContainerEventGenerator(env);
+
+            var timestamp = DateTime.Parse("2023-04-19T14:12:00.0000000Z");
+            generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+
+            using var sr = new StreamReader(_consoleOut);
+            _consoleOut.Position = 0;
+            var output = sr.ReadToEnd().Trim();
+
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output);
+        }
+
+        [Fact]
+        public async Task MultipleEventsBuffered()
+        {
+            var env = CreateEnvironment(bufferSize: 10);
+            var generator = new LinuxContainerEventGenerator(env);
+
+            var timestamp = DateTime.Parse("2023-04-19T14:12:00.0000000Z");
+            generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction1", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
+            generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction2", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
+            generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction3", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+
+            using var sr = new StreamReader(_consoleOut);
+            _consoleOut.Position = 0;
+            var output = sr.ReadToEnd().Trim().SplitLines();
+
+            Assert.Equal(3, output.Length);
+
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction1,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[0]);
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction2,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[1]);
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction3,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[2]);
+        }
+
+        [Fact]
+        public async Task MultipleEventsBatched()
+        {
+            var env = CreateEnvironment(bufferSize: 10, batched: true);
+            var generator = new LinuxContainerEventGenerator(env);
+
+            var timestamp = DateTime.Parse("2023-04-19T14:12:00.0000000Z");
+            generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction1", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
+            generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction2", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
+            generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction3", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+
+            using var sr = new StreamReader(_consoleOut);
+            _consoleOut.Position = 0;
+            var output = sr.ReadToEnd().Trim().SplitLines();
+
+            Assert.Equal(3, output.Length);
+
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction1,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[0]);
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction2,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[1]);
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction3,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[2]);
+        }
+
+        [Fact]
+        public async Task MultipleEventsBatchedWithTinyBuffer()
+        {
+            // setup in a state where the buffer isn't being processed and can only hold two messages
+            var env = CreateEnvironment(bufferSize: 2, batched: true);
+            var consoleWriter = new ConsoleWriter(env, LinuxContainerEventGenerator.LogUnhandledException, consoleBufferTimeout: TimeSpan.FromMilliseconds(500), autoStart: false);
+            var generator = new LinuxContainerEventGenerator(env, consoleWriter);
+
+            var timestamp = DateTime.Parse("2023-04-19T14:12:00.0000000Z");
+            generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction1", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
+            generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction2", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
+
+            // The third write will block until the first two are flushed.
+            var logTask = Task.Run(() => generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction3", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp));
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+            Assert.False(logTask.IsCompleted);
+
+            var logProcessingTask = consoleWriter.ProcessConsoleBufferAsync();
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+            Assert.True(logTask.IsCompleted);
+
+            using var sr = new StreamReader(_consoleOut);
+            _consoleOut.Position = 0;
+            var output = sr.ReadToEnd().Trim().SplitLines();
+
+            Assert.Equal(3, output.Length);
+
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction1,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[0]);
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction2,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[1]);
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction3,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[2]);
+        }
+
+        [Fact]
+        public void MultipleEventsBatchedWithTinyBuffer_WritesDirectlyToConsoleOnTimeout()
+        {
+            // setup in a state where the buffer isn't being processed and can only hold two messages
+            var env = CreateEnvironment(bufferSize: 2, batched: true);
+            var consoleWriter = new ConsoleWriter(env, LinuxContainerEventGenerator.LogUnhandledException, consoleBufferTimeout: TimeSpan.FromMilliseconds(10), autoStart: false);
+            var generator = new LinuxContainerEventGenerator(env, consoleWriter);
+
+            var timestamp = DateTime.Parse("2023-04-19T14:12:00.0000000Z");
+            generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction1", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
+            generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction2", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
+
+            // This write will block until the above timeout expires, and then it should write directly to the console
+            generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction3", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
+
+            using var sr = new StreamReader(_consoleOut);
+            _consoleOut.Position = 0;
+            var output = sr.ReadToEnd().Trim().SplitLines();
+
+            // The first two messages are still stuck in the buffer. The third message will have been written to the console.
+            // We should also have a log for the timeout exception that occurred while waiting for the buffer to become available.
+            Assert.Equal(2, output.Length);
+            Assert.StartsWith("MS_FUNCTION_LOGS 2,,,,,LogUnhandledException,\"System.AggregateException: One or more errors occurred. (The operation has timed out.)", output[0]);
+            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction3,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[1]);
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxContainerEventGeneratorWithConsoleOutputTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxContainerEventGeneratorWithConsoleOutputTests.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             await Task.Delay(TimeSpan.FromMilliseconds(10));
             Assert.False(logTask.IsCompleted);
 
-            var logProcessingTask = consoleWriter.ProcessConsoleBufferAsync();
+            var logProcessingTask = consoleWriter.ProcessConsoleBufferAsync(batched: true);
             await Task.Delay(TimeSpan.FromMilliseconds(10));
             Assert.True(logTask.IsCompleted);
 

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxContainerEventGeneratorWithConsoleOutputTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxContainerEventGeneratorWithConsoleOutputTests.cs
@@ -2,14 +2,9 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
-using System.Linq;
-using System.Net.Http;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -39,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             Console.SetOut(standardOutput);
         }
 
-        private IEnvironment CreateEnvironment(bool consoleDisabled = false, int bufferSize = 0, bool batched = false)
+        private IEnvironment CreateEnvironment(bool consoleDisabled = false, int? bufferSize = null, bool? batched = null)
         {
             var mockEnvironment = new Mock<IEnvironment>(MockBehavior.Strict);
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ContainerName)).Returns(_containerName);
@@ -48,8 +43,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.LinuxNodeIpAddress)).Returns(_testNodeAddress);
 
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ConsoleLoggingDisabled)).Returns(consoleDisabled ? "1" : "0");
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ConsoleLoggingBufferSize)).Returns(bufferSize.ToString());
-            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ConsoleLoggingBufferBatched)).Returns(batched ? "1" : "0");
+            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ConsoleLoggingBufferSize)).Returns(bufferSize?.ToString());
+            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ConsoleLoggingBufferBatched)).Returns(
+                batched switch
+                {
+                    null => null,
+                    true => "1",
+                    false => "0",
+                });
             return mockEnvironment.Object;
         }
 
@@ -103,10 +104,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output);
         }
 
-        [Fact]
-        public async Task MultipleEventsBuffered()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task MultipleEventsBuffered(bool batched)
         {
-            var env = CreateEnvironment(bufferSize: 10);
+            var env = CreateEnvironment(bufferSize: 10, batched: batched);
             var generator = new LinuxContainerEventGenerator(env);
 
             var timestamp = DateTime.Parse("2023-04-19T14:12:00.0000000Z");
@@ -126,11 +129,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction3,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[2]);
         }
 
-        [Fact]
-        public void MultipleEventsWithTinyBuffer_WritesDirectlyToConsoleOnTimeout()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void MultipleEventsWithTinyBuffer_WritesDirectlyToConsoleOnTimeout(bool batched)
         {
             // setup in a state where the buffer isn't being processed and can only hold two messages
-            var env = CreateEnvironment(bufferSize: 2);
+            var env = CreateEnvironment(bufferSize: 2, batched: batched);
             var consoleWriter = new ConsoleWriter(env, LinuxContainerEventGenerator.LogUnhandledException, consoleBufferTimeout: TimeSpan.FromMilliseconds(10), autoStart: false);
             var generator = new LinuxContainerEventGenerator(env, consoleWriter);
 
@@ -153,30 +158,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         }
 
         [Fact]
-        public async Task MultipleEventsBatched()
-        {
-            var env = CreateEnvironment(bufferSize: 10, batched: true);
-            var generator = new LinuxContainerEventGenerator(env);
-
-            var timestamp = DateTime.Parse("2023-04-19T14:12:00.0000000Z");
-            generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction1", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
-            generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction2", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
-            generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction3", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
-            await Task.Delay(TimeSpan.FromMilliseconds(10));
-
-            using var sr = new StreamReader(_consoleOut);
-            _consoleOut.Position = 0;
-            var output = sr.ReadToEnd().Trim().SplitLines();
-
-            Assert.Equal(3, output.Length);
-
-            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction1,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[0]);
-            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction2,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[1]);
-            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction3,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[2]);
-        }
-
-        [Fact]
-        public async Task MultipleEventsBatchedWithTinyBuffer()
+        public async Task MultipleEventsBatchedWithTinyBuffer_BlocksOnWriteOnBufferFull_IfTimeoutNotReached()
         {
             // setup in a state where the buffer isn't being processed and can only hold two messages
             var env = CreateEnvironment(bufferSize: 2, batched: true);
@@ -205,32 +187,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction1,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[0]);
             Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction2,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[1]);
             Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction3,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[2]);
-        }
-
-        [Fact]
-        public void MultipleEventsBatchedWithTinyBuffer_WritesDirectlyToConsoleOnTimeout()
-        {
-            // setup in a state where the buffer isn't being processed and can only hold two messages
-            var env = CreateEnvironment(bufferSize: 2, batched: true);
-            var consoleWriter = new ConsoleWriter(env, LinuxContainerEventGenerator.LogUnhandledException, consoleBufferTimeout: TimeSpan.FromMilliseconds(10), autoStart: false);
-            var generator = new LinuxContainerEventGenerator(env, consoleWriter);
-
-            var timestamp = DateTime.Parse("2023-04-19T14:12:00.0000000Z");
-            generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction1", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
-            generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction2", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
-
-            // This write will block until the above timeout expires, and then it should write directly to the console
-            generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction3", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
-
-            using var sr = new StreamReader(_consoleOut);
-            _consoleOut.Position = 0;
-            var output = sr.ReadToEnd().Trim().SplitLines();
-
-            // The first two messages are still stuck in the buffer. The third message will have been written to the console.
-            // We should also have a log for the timeout exception that occurred while waiting for the buffer to become available.
-            Assert.Equal(2, output.Length);
-            Assert.StartsWith("MS_FUNCTION_LOGS 2,,,,,LogUnhandledException,\"System.AggregateException: One or more errors occurred. (The operation has timed out.)", output[0]);
-            Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction3,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",4.21.0.0,{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName", output[1]);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxContainerEventGeneratorWithConsoleOutputTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxContainerEventGeneratorWithConsoleOutputTests.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             await Task.Delay(TimeSpan.FromMilliseconds(10));
             Assert.False(logTask.IsCompleted);
 
-            var logProcessingTask = consoleWriter.ProcessConsoleBufferAsync(batched: true);
+            consoleWriter.StartProcessingBuffer(batched: true);
             await Task.Delay(TimeSpan.FromMilliseconds(10));
             Assert.True(logTask.IsCompleted);
 


### PR DESCRIPTION
Resolves #9228

For Linux Consumption, system logs go through standard out. Analysis shows that there is a significant cost associated with this code path, and the cost can be reduced by:
1. Moving the Console.WriteLine call to a background thread
2. Reducing the total number of Console.WriteLine calls by appending log lines together first.

This PR implements both of these improvements, but they can be controlled with the following environment variables:
- CONSOLE_LOGGING_BUFFER_SIZE - this controls the size of the log buffer (how many log lines), defaults to 8000, set to 0 to disable, ~set to -1 for unbounded buffer size.~
~- CONSOLE_LOGGING_BUFFER_BATCHED - when enabled, uses a string builder to write many log lines to stdout with a single Console.WriteLine call, defaults to enabled, set to zero to disable the batching.~

Naming for these variables was based on the existing CONSOLE_LOGGING_DISABLED setting for consistency.

## Performance Test Results

All tests run with Python 3.9 function app running hello world,  median result from 3 runs.

### ACI (single instance, private network)

Baseline:
```
Bombarding http://py39-aci-noai-consolebuffer-baseline.app:80/api/helloworld for 1m0s using 30 connection(s)
Statistics        Avg      Stdev        Max
  Reqs/sec        94.88      63.33     949.95
  Latency      315.32ms    46.99ms   611.99ms
  Latency Distribution
     50%   315.00ms
     75%   343.34ms
     90%   371.79ms
     95%   389.36ms
     99%   450.89ms
  HTTP codes:
    1xx - 0, 2xx - 5715, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    27.19KB/s
```

Buffer 1000, batched:
```
Bombarding http://py39-aci-noai-consolebuffer-buffer1000-batched.app:80/api/helloworld for 1m0s using 30 connection(s)
Statistics        Avg      Stdev        Max
  Reqs/sec       233.86     180.42    1526.60
  Latency      128.20ms    19.10ms   269.31ms
  Latency Distribution
     50%   129.00ms
     75%   143.78ms
     90%   157.98ms
     95%   167.23ms
     99%   188.00ms
  HTTP codes:
    1xx - 0, 2xx - 14050, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    69.20KB/s
```

### Legion (single instance, private network)

Baseline:
```
Bombarding http://py39-noai-mesh-perfcollect-consolebuffer-baseline.app:80/api/helloworld for 1m0s using 30 connection(s)
Statistics        Avg      Stdev        Max
  Reqs/sec       342.15     233.37    1578.96
  Latency       88.11ms    64.55ms      0.98s
  Latency Distribution
     50%    73.80ms
     75%    83.00ms
     90%    93.00ms
     95%   102.52ms
     99%   693.74ms
  HTTP codes:
    1xx - 0, 2xx - 20538, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:   101.72KB/s
```
Buffer 1000, batched:
```
Bombarding http://py39-noai-mesh-perfcollect-consolebuffer-buffer1000-batched.app:80/api/helloworld for 1m0s using 30 connection(s)
Statistics        Avg      Stdev        Max
  Reqs/sec       393.31     248.12    1650.02
  Latency       76.23ms    33.30ms      0.86s
  Latency Distribution
     50%    71.22ms
     75%    81.00ms
     90%    90.00ms
     95%    97.29ms
     99%   233.16ms
  HTTP codes:
    1xx - 0, 2xx - 23628, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:   121.39KB/s
```

### Linux Consumption, EUAP (burst scale to 30 instances, tested over public internet)

1000 concurrent clients, burst scale test
```
Baseline: 1,183 RPS (average over 5 minutes)
Buffer 1000, batched: 1,603 RPS (average over 5 minutes)
```

### Test results summary
All runs with this PR had better results, though there is significant variability. I am not 100% sure about why my EUAP tests did not see the same gains as the single instance tests I ran on ACI, but I suspect that network travel time is a factor here, because the EUAP tests were conducted over the public internet. We'll wait to see whether we get similar numbers as part of the official release. Console.WriteLine performance on Legion is not a major issue, so the gains are smaller there, but still worthwhile.

## Functional testing checklist
* [x] Test in Linux Consumption EUAP and confirm that system logs appear in kusto as expected, with expected volume (i.e. requests completed during the test matches number of function completion events
* [x] Test in Legion and confirm system logs appear in kusto as expected

## Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

