### PR TITLE
[LinuxConsumption]Fix BYOS

### DIFF
--- a/src/WebJobs.Script.WebHost/Models/AzureStorageInfoValue.cs
+++ b/src/WebJobs.Script.WebHost/Models/AzureStorageInfoValue.cs
@@ -83,7 +83,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
             }
 
             var parts = environmentVariable.Value?.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries);
-            if (parts == null || parts.Length != 4)
+            if (parts == null)
+            {
+                return null;
+            }
+
+            if (parts.Length != 4 && parts.Length != 5)
             {
                 return null;
             }

--- a/test/WebJobs.Script.Tests.Integration/Management/AzureStorageInfoValueTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/AzureStorageInfoValueTests.cs
@@ -10,18 +10,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
     public class AzureStorageInfoValueTests
     {
         [Theory]
-        [InlineData(null, null, null, null, null, null, false)]
-        [InlineData("", null, "", "", "", "", false)]
-        [InlineData("AZUREFILESSTORAGE_storageid", AzureStorageType.AzureFiles, "", "", "", "", false)]
-        [InlineData("AZUREBLOBSTORAGE_storageid", AzureStorageType.AzureBlob, "", "", "", "", false)]
-        [InlineData("AZUREFILESSTORAGE_storageid", AzureStorageType.AzureFiles, "", "sharename", "accesskey", "mountpath", false)]
-        [InlineData("AZUREFILESSTORAGE_storageid", AzureStorageType.AzureFiles, "accountname", "sharename", "accesskey", "mountpath", true)]
-        [InlineData("AZUREBLOBSTORAGE_storageid", AzureStorageType.AzureBlob, "accountname", "", "accesskey", "mountpath", false)]
-        [InlineData("AZUREBLOBSTORAGE_storageid", AzureStorageType.AzureBlob, "accountname", "sharename", "accesskey", "mountpath", true)]
-        public void Builds_AzureStorageInfoValue(string id, AzureStorageType? type, string accountName, string shareName, string accessKey, string mountPath, bool isValid)
+        [InlineData(null, null, null, null, null, null, null, false)]
+        [InlineData("", null, "", "", "", "", "", false)]
+        [InlineData("AZUREFILESSTORAGE_storageid", AzureStorageType.AzureFiles, "", "", "", "", "", false)]
+        [InlineData("AZUREBLOBSTORAGE_storageid", AzureStorageType.AzureBlob, "", "", "", "", "", false)]
+        [InlineData("AZUREFILESSTORAGE_storageid", AzureStorageType.AzureFiles, "", "sharename", "accesskey", "mountpath", "", false)]
+        [InlineData("AZUREFILESSTORAGE_storageid", AzureStorageType.AzureFiles, "accountname", "sharename", "accesskey", "mountpath", "", true)]
+        [InlineData("AZUREFILESSTORAGE_storageid", AzureStorageType.AzureFiles, "accountname", "sharename", "accesskey", "mountpath", "smb", true)]
+        [InlineData("AZUREBLOBSTORAGE_storageid", AzureStorageType.AzureBlob, "accountname", "", "accesskey", "mountpath", "", false)]
+        [InlineData("AZUREBLOBSTORAGE_storageid", AzureStorageType.AzureBlob, "accountname", "sharename", "accesskey", "mountpath", "", true)]
+        [InlineData("AZUREFILESSTORAGE_storageid", AzureStorageType.AzureFiles, "accountname", "sharename", "accesskey", "mountpath", "http", true)]
+        public void Builds_AzureStorageInfoValue(string id, AzureStorageType? type, string accountName, string shareName, string accessKey, string mountPath, string protocol, bool isValid)
         {
             var key = id;
-            var value = $"{accountName}|{shareName}|{accessKey}|{mountPath}";
+            var value = $"{accountName}|{shareName}|{accessKey}|{mountPath}|{protocol}";
             var environmentVariable = new KeyValuePair<string, string>(key, value);
             var azureStorageInfoValue = AzureStorageInfoValue.FromEnvironmentVariable(environmentVariable);
             if (isValid)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

What happened?

There was a change in platform  which now includes protocol information as part of environment variables. Since we explicitly look for the length of 4, BYOS volumes are therefore not mounted.

Fix:
The fix includes both length 4 and 5 to accommodate on regions that weren't upgraded and regions that were upgraded.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
