### PR TITLE
Fix event type for FunctionMetrics Logs

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/KubernetesEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/KubernetesEventGenerator.cs
@@ -51,9 +51,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public override void LogFunctionMetricEvent(string subscriptionId, string appName, string functionName, string eventName, long average, long minimum, long maximum, long count, DateTime eventTimestamp, string data, string runtimeSiteName, string slotName)
         {
-            // Set event type to MS_FUNCTION_LOGS to send these events as part of infra logs.
+            // Set event type to MS_FUNCTION_METRICS to send these events as part of infra logs.
             JObject metricEvent = new JObject();
-            metricEvent.Add("EventType", ScriptConstants.LinuxLogEventStreamName);
+            metricEvent.Add("EventType", ScriptConstants.LinuxMetricEventStreamName);
             metricEvent.Add("SubscriptionId", subscriptionId);
             metricEvent.Add("AppName", appName);
             metricEvent.Add("FunctionName", functionName);

--- a/test/WebJobs.Script.Tests/Diagnostics/KubernetesEventGeneratorTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/KubernetesEventGeneratorTests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 
             DateTime dt;
             Assert.Collection(jObject.Properties(),
-                p => Assert.Equal(ScriptConstants.LinuxLogEventStreamName, p.Value),
+                p => Assert.Equal(ScriptConstants.LinuxMetricEventStreamName, p.Value),
                 p => Assert.Equal(subscriptionId, p.Value),
                 p => Assert.Equal(appName, p.Value),
                 p => Assert.Equal(functionName, p.Value),


### PR DESCRIPTION
Changes event type to MS_FUNCTION_METRICS for logging metrics events in KubernetesEventGenerator.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)
