### PR TITLE
caching featureflags

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
@@ -27,14 +27,13 @@ using Microsoft.WebJobs.Script.Tests;
 using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using NuGet.Common;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 {
     [Trait(TestTraits.Category, TestTraits.EndToEnd)]
     [Trait(TestTraits.Group, TestTraits.SamplesEndToEnd)]
-    public class SamplesEndToEndTests_CSharp : IClassFixture<SamplesEndToEndTests_CSharp.TestFixture>
+    public class SamplesEndToEndTests_CSharp : IClassFixture<SamplesEndToEndTests_CSharp.TestFixture>, IDisposable
     {
         private readonly ScriptSettingsManager _settingsManager;
         private TestFixture _fixture;
@@ -189,7 +188,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                 }
 
                 HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
-                
+
                 if (addAuthKey)
                 {
                     await this._fixture.AddMasterKey(request);
@@ -1127,6 +1126,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 }";
             string easyAuthHeaderValue = Convert.ToBase64String(Encoding.UTF8.GetBytes(userIdentityJson));
             request.Headers.Add("x-ms-client-principal", easyAuthHeaderValue);
+        }
+
+        public void Dispose()
+        {
+            FeatureFlags.InternalCache = null;
         }
 
         public class TestFixture : EndToEndTestFixture

--- a/test/WebJobs.Script.Tests/Description/DotNet/FunctionAssemblyLoadContextTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/FunctionAssemblyLoadContextTests.cs
@@ -8,13 +8,14 @@ using System.IO.Abstractions;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Moq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
-    public class FunctionAssemblyLoadContextTests
+    public class FunctionAssemblyLoadContextTests : IDisposable
     {
         [Theory]
         [InlineData("Microsoft.Azure.WebJobs, Version=3.0.0.0")]
@@ -188,6 +189,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     OSPlatform.Linux
                 },
             };
+        }
+
+        public void Dispose()
+        {
+            FeatureFlags.InternalCache = null;
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Description/Proxy/ProxyFunctionDescriptorProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/Proxy/ProxyFunctionDescriptorProviderTests.cs
@@ -7,7 +7,6 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -173,6 +172,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             if (disposing)
             {
                 _scriptHost?.Dispose();
+                FeatureFlags.InternalCache = null;
             }
         }
 

--- a/test/WebJobs.Script.Tests/Diagnostics/DiagnosticEventLoggerTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/DiagnosticEventLoggerTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
@@ -12,7 +13,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 {
-    public class DiagnosticEventLoggerTests
+    public class DiagnosticEventLoggerTests : IDisposable
     {
         [Fact]
         public void DiagnosticEventLogger_OnlyLogsMessages_WithRequiredProperties()
@@ -86,6 +87,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             }
 
             Assert.Empty(repository.Events);
+        }
+
+        public void Dispose()
+        {
+            FeatureFlags.InternalCache = null;
         }
 
         public class TestDiagnosticEventRepositoryFactory : IDiagnosticEventRepositoryFactory

--- a/test/WebJobs.Script.Tests/RuntimeAssembliesInfoTests.cs
+++ b/test/WebJobs.Script.Tests/RuntimeAssembliesInfoTests.cs
@@ -2,15 +2,13 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
-    public class RuntimeAssembliesInfoTests
+    public class RuntimeAssembliesInfoTests : IDisposable
     {
         [Fact]
         public void Reset_WithUnloadedAssemblies_ReturnsFalse()
@@ -41,13 +39,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public void Reset_WithLoadedAssemblies_ChangedRules_ReturnsTrue()
         {
             var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
+
             var runtimeAssembliesInfo = new RuntimeAssembliesInfo(environment);
 
             // Cause a load
             var originalAssemblies = runtimeAssembliesInfo.Assemblies;
 
-            // Change environment
+            // Change environment; simulate specialization
             environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagRelaxedAssemblyUnification);
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, null);
 
             bool result = runtimeAssembliesInfo.ResetIfStale();
 
@@ -75,6 +76,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             Assert.NotNull(assemblies);
             Assert.Null(assembly);
+        }
+
+        public void Dispose()
+        {
+            FeatureFlags.InternalCache = null;
         }
     }
 }

--- a/test/WebJobs.Script.Tests/UtilityTests.cs
+++ b/test/WebJobs.Script.Tests/UtilityTests.cs
@@ -14,7 +14,6 @@ using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
-using Microsoft.Azure.WebJobs.Script.ExtensionBundle;
 using Microsoft.Azure.WebJobs.Script.Models;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.Logging;
@@ -22,7 +21,6 @@ using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
 using Moq;
 using Newtonsoft.Json.Linq;
-using NuGet.Versioning;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
@@ -60,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public IDictionary<string, string> Properties { get; set; }
     }
 
-    public class UtilityTests
+    public class UtilityTests : IDisposable
     {
         private TestLogger _testLogger = new TestLogger("test");
 
@@ -1034,6 +1032,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             FileUtility.EnsureDirectoryExists(tempDirectory);
             return tempDirectory;
+        }
+
+        public void Dispose()
+        {
+            FeatureFlags.InternalCache = null;
         }
     }
 }


### PR DESCRIPTION
### Issue describing the changes in this PR

Caching `FeatureFlags` values so we do not read and parse environment variables every time we access. This is a "papercut" perf improvement.

Benchmark details here -- the "Placeholder - True" runs are what we do today, with no caching. 

```
|                Method | Placeholder | FeatureFlagsValue |       Mean |     Error |    StdDev |     Median |        Min |        Max |  Gen 0 | Allocated |
|---------------------- |------------ |------------------ |-----------:|----------:|----------:|-----------:|-----------:|-----------:|-------:|----------:|
| FeatureFlag_IsEnabled |       False |                 ? |   9.009 ns | 0.3395 ns | 0.3486 ns |   9.002 ns |   8.454 ns |   9.874 ns |      - |         - |
| FeatureFlag_IsEnabled |       False |              Test |  14.097 ns | 0.0434 ns | 0.0385 ns |  14.104 ns |  14.029 ns |  14.159 ns |      - |         - |
| FeatureFlag_IsEnabled |       False |  Test,Test2,Test3 |  15.082 ns | 0.1724 ns | 0.1528 ns |  15.005 ns |  14.930 ns |  15.365 ns |      - |         - |
| FeatureFlag_IsEnabled |        True |                 ? | 248.394 ns | 4.2557 ns | 3.7726 ns | 246.317 ns | 244.996 ns | 255.852 ns | 0.0081 |      88 B |
| FeatureFlag_IsEnabled |        True |              Test | 266.581 ns | 0.7634 ns | 0.5960 ns | 266.457 ns | 265.624 ns | 267.514 ns | 0.0118 |     120 B |
| FeatureFlag_IsEnabled |        True |  Test,Test2,Test3 | 313.294 ns | 1.6296 ns | 1.4446 ns | 312.875 ns | 311.538 ns | 316.273 ns | 0.0251 |     256 B |
```

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)