### PR TITLE
Upgrade PowerShell language worker 7.0 to 4.0.2823

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -11,3 +11,4 @@
 - Update PowerShell Worker 7.2 to 4.0.2803 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2803)
 - Update PowerShell Worker 7.4 to 4.0.2802 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2802)
 - Fixing bug with placeholder misses in dotnet-isolated #9253
+- Update PowerShell Worker 7.0 to 4.0.2823 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2823)

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -59,7 +59,7 @@
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.2.20220831.41" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.11.0" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.6.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" Version="4.0.2733" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" Version="4.0.2823" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" Version="4.0.2803" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" Version="4.0.2802" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="5.0.0-beta.2-10879" />


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This PR contains the following change:
* Upgrade PowerShell Language Worker 7.0 to 4.0.2823 (Release Notes: https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2823)

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
