### PR TITLE
adding regression tests for missing FUNCTION_WORKER_RUNTIME

### DIFF
--- a/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
                     JObject hostConfigObject;
                     try
                     {
-                        string json = File.ReadAllText(configFilePath);
+                        string json = FileUtility.Instance.File.ReadAllText(configFilePath);
                         hostConfigObject = JObject.Parse(json);
                     }
                     catch (JsonException ex)

--- a/test/CSharpPrecompiledTestProjects/WebJobsStartupTests/Function1.cs
+++ b/test/CSharpPrecompiledTestProjects/WebJobsStartupTests/Function1.cs
@@ -89,6 +89,17 @@ namespace WebJobsStartupTests
         {
         }
 
+        [FunctionName("Echo")]
+        public IActionResult Echo([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)] HttpRequest req)
+        {
+            if (req.Query.TryGetValue("echo", out var value))
+            {
+                return new OkObjectResult(value.Single());
+            }
+
+            return new BadRequestResult();
+        }
+
         private static bool ValidateConfig(IConfiguration _config)
         {
             if (_config is ConfigurationRoot root)

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpPrecompiledEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpPrecompiledEndToEndTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
+{
+    public class CSharpPrecompiledEndToEndTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("dotnet")]
+        public async Task InProc_ChoosesCorrectLanguage(string functionWorkerRuntime)
+        {
+            var fixture = new CSharpPrecompiledEndToEndTestFixture("WebJobsStartupTests", functionWorkerRuntime: functionWorkerRuntime);
+            try
+            {
+                await fixture.InitializeAsync();
+                var client = fixture.Host.HttpClient;
+
+                var echo = Guid.NewGuid().ToString();
+                var response = await client.GetAsync($"api/echo?echo={echo}");
+
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.Equal(echo, await response.Content.ReadAsStringAsync());
+
+                // Previous bug incorrectly chose dotnet-isolated as the Language for C# precompiled functions
+                // if FUNCTIONS_WORKER_RUNTIME was missing
+                var metadataManager = fixture.Host.WebHostServices.GetService<IFunctionMetadataManager>();
+                var metadata = metadataManager.GetFunctionMetadata();
+                foreach (var functionMetadata in metadata)
+                {
+                    Assert.Equal(DotNetScriptTypes.DotNetAssembly, functionMetadata.Language);
+                }
+            }
+            finally
+            {
+                await fixture.DisposeAsync();
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpPrecompiledTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpPrecompiledTestFixture.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
         private const string TestPathTemplate = "..\\..\\..\\..\\CSharpPrecompiledTestProjects\\{0}\\bin\\Debug\\netcoreapp3.1";
         private readonly IDisposable _dispose;
 
-        public CSharpPrecompiledEndToEndTestFixture(string testProjectName, IDictionary<string, string> envVars = null)
-            : base(string.Format(TestPathTemplate, testProjectName), testProjectName, "dotnet")
+        public CSharpPrecompiledEndToEndTestFixture(string testProjectName, IDictionary<string, string> envVars = null, string functionWorkerRuntime = "dotnet")
+            : base(string.Format(TestPathTemplate, testProjectName), testProjectName, functionWorkerRuntime)
         {
             if (envVars != null)
             {

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -6,6 +6,7 @@
     <IsPackable>false</IsPackable>
     <AssemblyName>Microsoft.Azure.WebJobs.Script.Tests</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Script.Tests</RootNamespace>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG;NETCOREAPP2_0;SCRIPT_TEST</DefineConstants>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

We found issues where we were incorrectly choosing the function language when the dotnet-isolated placeholder was deployed with the Functions site extension. These tests add protection against that happening again.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
