### PR TITLE
Revert "Comment out package reference for Azure.Functions.DotNetIsolatedNativeHost  (#9282)"

### DIFF
--- a/src/WebJobs.Script/Diagnostics/Extensions/ScriptHostLoggerExtension.cs
+++ b/src/WebJobs.Script/Diagnostics/Extensions/ScriptHostLoggerExtension.cs
@@ -12,111 +12,123 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
 
         private static readonly Action<ILogger, Exception> _hostIdIsSet =
             LoggerMessage.Define(
-            LogLevel.Warning,
-            new EventId(400, nameof(HostIdIsSet)),
-            "Host id explicitly set in configuration. This is not a recommended configuration and may lead to unexpected behavior.");
+                LogLevel.Warning,
+                new EventId(400, nameof(HostIdIsSet)),
+                "Host id explicitly set in configuration. This is not a recommended configuration and may lead to unexpected behavior.");
 
         private static readonly Action<ILogger, string, string, Exception> _functionError =
             LoggerMessage.Define<string, string>(
-            LogLevel.Error,
-            new EventId(402, nameof(FunctionError)),
-            "The '{functionName}' function is in error: {errorMessage}");
+                LogLevel.Error,
+                new EventId(402, nameof(FunctionError)),
+                "The '{functionName}' function is in error: {errorMessage}");
 
         private static readonly Action<ILogger, Exception> _hostIsInPlaceholderMode =
             LoggerMessage.Define(
-            LogLevel.Debug,
-            new EventId(403, nameof(HostIsInPlaceholderMode)),
-            "Host is in placeholdermode");
+                LogLevel.Debug,
+                new EventId(403, nameof(HostIsInPlaceholderMode)),
+                "Host is in placeholdermode");
 
         private static readonly Action<ILogger, string, Exception> _addingDescriptorProviderForLanguage =
             LoggerMessage.Define<string>(
-            LogLevel.Debug,
-            new EventId(404, nameof(AddingDescriptorProviderForLanguage)),
-            "Adding Function descriptor provider for language {workerRuntime}.");
+                LogLevel.Debug,
+                new EventId(404, nameof(AddingDescriptorProviderForLanguage)),
+                "Adding Function descriptor provider for language {workerRuntime}.");
 
         private static readonly Action<ILogger, Exception> _creatingDescriptors =
             LoggerMessage.Define(
-            LogLevel.Debug,
-            new EventId(405, nameof(CreatingDescriptors)),
-            "Creating function descriptors.");
+                LogLevel.Debug,
+                new EventId(405, nameof(CreatingDescriptors)),
+                "Creating function descriptors.");
 
         private static readonly Action<ILogger, Exception> _descriptorsCreated =
             LoggerMessage.Define(
-            LogLevel.Debug,
-            new EventId(406, nameof(DescriptorsCreated)),
-            "Function descriptors created.");
+                LogLevel.Debug,
+                new EventId(406, nameof(DescriptorsCreated)),
+                "Function descriptors created.");
 
         private static readonly Action<ILogger, Exception> _errorPurgingLogFiles =
             LoggerMessage.Define(
-            LogLevel.Error,
-            new EventId(407, nameof(ErrorPurgingLogFiles)),
-            "An error occurred while purging log files");
+                LogLevel.Error,
+                new EventId(407, nameof(ErrorPurgingLogFiles)),
+                "An error occurred while purging log files");
 
         private static readonly Action<ILogger, string, Exception> _deletingLogDirectory =
             LoggerMessage.Define<string>(
-            LogLevel.Debug,
-            new EventId(408, nameof(DeletingLogDirectory)),
-            "Deleting log directory '{logDir}'");
+                LogLevel.Debug,
+                new EventId(408, nameof(DeletingLogDirectory)),
+                "Deleting log directory '{logDir}'");
 
         private static readonly Action<ILogger, string, string, Exception> _failedToLoadType =
             LoggerMessage.Define<string, string>(
-            LogLevel.Warning,
-            new EventId(409, nameof(FailedToLoadType)),
-            "Failed to load type '{typeName}' from '{path}'");
+                LogLevel.Warning,
+                new EventId(409, nameof(FailedToLoadType)),
+                "Failed to load type '{typeName}' from '{path}'");
 
         private static readonly Action<ILogger, string, Exception> _configurationError =
             LoggerMessage.Define<string>(
-            LogLevel.Information,
-            new EventId(410, nameof(ConfigurationError)),
-            "{message}");
+                LogLevel.Information,
+                new EventId(410, nameof(ConfigurationError)),
+                "{message}");
 
         private static readonly Action<ILogger, string, string, Exception> _versionRecommendation =
             LoggerMessage.Define<string, string>(
-            LogLevel.Warning,
-            new EventId(411, nameof(VersionRecommendation)),
-            "Site extension version currently set to '{extensionVersion}'. It is recommended that you target a major version (e.g. ~2) to avoid unintended upgrades. You can change that value by updating the '{settingName}' App Setting.");
+                LogLevel.Warning,
+                new EventId(411, nameof(VersionRecommendation)),
+                "Site extension version currently set to '{extensionVersion}'. It is recommended that you target a major version (e.g. ~2) to avoid unintended upgrades. You can change that value by updating the '{settingName}' App Setting.");
 
         private static readonly Action<ILogger, long, Exception> _scriptHostInitialized =
             LoggerMessage.Define<long>(
-            LogLevel.Information,
-            new EventId(412, nameof(ScriptHostInitialized)),
-            "Host initialized ({ms}ms)");
+                LogLevel.Information,
+                new EventId(412, nameof(ScriptHostInitialized)),
+                "Host initialized ({ms}ms)");
 
         private static readonly Action<ILogger, long, Exception> _scriptHostStarted =
             LoggerMessage.Define<long>(
-            LogLevel.Information,
-            new EventId(413, nameof(ScriptHostStarted)),
-            "Host started ({ms}ms)");
+                LogLevel.Information,
+                new EventId(413, nameof(ScriptHostStarted)),
+                "Host started ({ms}ms)");
 
         private static readonly Action<ILogger, Exception> _addingDescriptorProviderForHttpWorker =
            LoggerMessage.Define(
-           LogLevel.Debug,
-           new EventId(414, nameof(AddingDescriptorProviderForHttpWorker)),
-           "Adding Function descriptor provider for HttpWorker.");
+               LogLevel.Debug,
+               new EventId(414, nameof(AddingDescriptorProviderForHttpWorker)),
+               "Adding Function descriptor provider for HttpWorker.");
 
         private static readonly Action<ILogger, string, Exception> _stoppingScriptHost =
             LoggerMessage.Define<string>(
-            LogLevel.Debug,
-            new EventId(415, nameof(StoppingScriptHost)),
-            "Stopping ScriptHost instance '{hostInstanceId}'.");
+                LogLevel.Debug,
+                new EventId(415, nameof(StoppingScriptHost)),
+                "Stopping ScriptHost instance '{hostInstanceId}'.");
 
         private static readonly Action<ILogger, string, Exception> _stoppedScriptHost =
-          LoggerMessage.Define<string>(
-          LogLevel.Debug,
-          new EventId(416, nameof(StoppedScriptHost)),
-          "Stopped ScriptHost instance '{hostInstanceId}'.");
+            LoggerMessage.Define<string>(
+                LogLevel.Debug,
+                new EventId(416, nameof(StoppedScriptHost)),
+                "Stopped ScriptHost instance '{hostInstanceId}'.");
 
         private static readonly Action<ILogger, string, Exception> _disposingScriptHost =
-          LoggerMessage.Define<string>(
-          LogLevel.Debug,
-          new EventId(417, nameof(DisposingScriptHost)),
-          "Disposing ScriptHost instance '{hostInstanceId}'.");
+            LoggerMessage.Define<string>(
+                LogLevel.Debug,
+                new EventId(417, nameof(DisposingScriptHost)),
+                "Disposing ScriptHost instance '{hostInstanceId}'.");
 
         private static readonly Action<ILogger, string, Exception> _disposedScriptHost =
-          LoggerMessage.Define<string>(
-          LogLevel.Debug,
-          new EventId(418, nameof(DisposedScriptHost)),
-          "Disposed ScriptHost instance '{hostInstanceId}'.");
+            LoggerMessage.Define<string>(
+              LogLevel.Debug,
+              new EventId(418, nameof(DisposedScriptHost)),
+              "Disposed ScriptHost instance '{hostInstanceId}'.");
+
+        private static readonly Action<ILogger, string, Exception> _functionsWorkerRuntimeValue =
+            LoggerMessage.Define<string>(
+                LogLevel.Debug,
+                new EventId(419, nameof(FunctionsWorkerRuntimeValue)),
+                $"{EnvironmentSettingNames.FunctionWorkerRuntime} value: '{{workerRuntime}}'");
+
+        private static readonly Action<ILogger, string, Exception> _resolvedWorkerRuntimeFromMetadata =
+            LoggerMessage.Define<string>(
+                LogLevel.Debug,
+                new EventId(420, nameof(ResolvedWorkerRuntimeFromMetadata)),
+                $"{EnvironmentSettingNames.FunctionWorkerRuntime} is null. Resolved worker runtime from function metadata: '{{workerRuntime}}'");
 
         public static void HostIdIsSet(this ILogger logger)
         {
@@ -214,6 +226,16 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
         public static void DisposedScriptHost(this ILogger logger, string hostInstanceId)
         {
             _disposedScriptHost(logger, hostInstanceId, null);
+        }
+
+        public static void FunctionsWorkerRuntimeValue(this ILogger logger, string workerRuntime)
+        {
+            _functionsWorkerRuntimeValue(logger, workerRuntime, null);
+        }
+
+        public static void ResolvedWorkerRuntimeFromMetadata(this ILogger logger, string workerRuntime)
+        {
+            _resolvedWorkerRuntimeFromMetadata(logger, workerRuntime, null);
         }
     }
 }

--- a/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
@@ -184,20 +184,22 @@ namespace Microsoft.Azure.WebJobs.Script
             // determine the script type based on the primary script file extension
             string extension = Path.GetExtension(scriptFilePath).ToLowerInvariant().TrimStart('.');
 
-            // In the special case of a null FUNCTIONS_WORKER_RUNTIME and an extension of "dll",
-            // we want to skip the worker config check (to prevent the dotnet-isolated worker from
+            // In the special case of a null `functionsWorkerRuntime` and an extension of "dll",
+            // we want to short-circuit the worker config check (to prevent the dotnet-isolated worker from
             // being chosen) and allow in-proc handling to be used.
             // Other notes:
-            // - when dotnet-isolated, the FUNCTIONS_WORKER_RUNTIME is required to be set to "dotnet-isolated"
-            // - when FUNCTIONS_WORKER_RUNTIME is set to "dotnet", workerConfigs is empty so this correctly falls
+            // - when dotnet-isolated, the `functionsWorkerRuntime` is required to be set to "dotnet-isolated"
+            // - when `functionsWorkerRuntime` is set to "dotnet", workerConfigs is empty so this correctly falls
             //   through to choose DotNetAssembly with a "dll" extension
-            if (!(functionsWorkerRuntime is null && extension == "dll"))
+            if (functionsWorkerRuntime is null && string.Equals(extension, "dll", StringComparison.OrdinalIgnoreCase))
             {
-                var workerConfig = workerConfigs.FirstOrDefault(config => config.Description.Extensions.Contains("." + extension));
-                if (workerConfig != null)
-                {
-                    return workerConfig.Description.Language;
-                }
+                return DotNetScriptTypes.DotNetAssembly;
+            }
+
+            var workerConfig = workerConfigs.FirstOrDefault(config => config.Description.Extensions.Contains($".{extension}", StringComparer.OrdinalIgnoreCase));
+            if (workerConfig != null)
+            {
+                return workerConfig.Description.Language;
             }
 
             // If no worker claimed these extensions, use in-proc.

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -275,9 +275,6 @@ namespace Microsoft.Azure.WebJobs.Script
                 PreInitialize();
                 HostInitializing?.Invoke(this, EventArgs.Empty);
 
-                // get worker config information and check to see if worker should index or not
-                var workerConfigs = _languageWorkerOptions.CurrentValue.WorkerConfigs;
-
                 // Generate Functions
                 IEnumerable<FunctionMetadata> functionMetadataList = GetFunctionsMetadata();
 

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -67,16 +67,15 @@ namespace Microsoft.Azure.WebJobs.Script
         private readonly IEnvironment _environment;
         private readonly IFunctionDataCache _functionDataCache;
         private readonly IOptionsMonitor<LanguageWorkerOptions> _languageWorkerOptions;
+        private readonly ILogger _logger;
+        private readonly IPrimaryHostStateProvider _primaryHostStateProvider;
+        private readonly IList<IDisposable> _eventSubscriptions = new List<IDisposable>();
+        private readonly IFunctionInvocationDispatcher _functionDispatcher;
         private static readonly int _processId = Process.GetCurrentProcess().Id;
+        public static readonly string Version = GetAssemblyFileVersion(typeof(ScriptHost).Assembly);
 
         private ValueStopwatch _stopwatch;
-        private IPrimaryHostStateProvider _primaryHostStateProvider;
-        public static readonly string Version = GetAssemblyFileVersion(typeof(ScriptHost).Assembly);
         private ScriptSettingsManager _settingsManager;
-        private ILogger _logger = null;
-        private string _workerRuntime;
-        private IList<IDisposable> _eventSubscriptions = new List<IDisposable>();
-        private IFunctionInvocationDispatcher _functionDispatcher;
 
         // Specify the "builtin binding types". These are types that are directly accesible without needing an explicit load gesture.
         // This is the set of bindings we shipped prior to binding extensibility.
@@ -137,7 +136,6 @@ namespace Microsoft.Azure.WebJobs.Script
 
             _hostLogPath = Path.Combine(ScriptOptions.RootLogPath, "Host");
 
-            _workerRuntime = _environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName);
             _languageWorkerOptions = languageWorkerOptions;
 
             _loggerFactory = loggerFactory;
@@ -234,10 +232,10 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
-        /// Lookup a function by name
+        /// Lookup a function by name.
         /// </summary>
-        /// <param name="name">name of function</param>
-        /// <returns>function or null if not found</returns>
+        /// <param name="name">name of function.</param>
+        /// <returns>function or null if not found.</returns>
         public FunctionDescriptor GetFunctionOrNull(string name)
         {
             return Functions.FirstOrDefault(p => string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase));
@@ -277,17 +275,24 @@ namespace Microsoft.Azure.WebJobs.Script
                 PreInitialize();
                 HostInitializing?.Invoke(this, EventArgs.Empty);
 
-                _workerRuntime = _workerRuntime ?? _environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime);
-
                 // get worker config information and check to see if worker should index or not
                 var workerConfigs = _languageWorkerOptions.CurrentValue.WorkerConfigs;
 
                 // Generate Functions
                 IEnumerable<FunctionMetadata> functionMetadataList = GetFunctionsMetadata();
 
+                string workerRuntime = _environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime);
+                _logger.FunctionsWorkerRuntimeValue(workerRuntime);
+
+                if (workerRuntime is null)
+                {
+                    workerRuntime = Utility.GetWorkerRuntime(functionMetadataList);
+                    _logger.ResolvedWorkerRuntimeFromMetadata(workerRuntime);
+                }
+
                 if (!_environment.IsPlaceholderModeEnabled())
                 {
-                    string runtimeStack = _workerRuntime;
+                    string runtimeStack = workerRuntime;
 
                     if (!string.IsNullOrEmpty(runtimeStack))
                     {
@@ -307,9 +312,9 @@ namespace Microsoft.Azure.WebJobs.Script
                     Utility.LogAutorestGeneratedJsonIfExists(ScriptOptions.RootScriptPath, _logger);
                 }
 
-                IsFunctionDataCacheEnabled = GetIsFunctionDataCacheEnabled();
+                IsFunctionDataCacheEnabled = GetIsFunctionDataCacheEnabled(workerRuntime);
 
-                await InitializeFunctionDescriptorsAsync(functionMetadataList, cancellationToken);
+                await InitializeFunctionDescriptorsAsync(functionMetadataList, workerRuntime, cancellationToken);
 
                 var filteredFunctionMetadata = functionMetadataList.Where(m => m.IsProxy() || !Utility.IsCodelessDotNetLanguageFunction(m));
                 await _functionDispatcher.InitializeAsync(Utility.GetValidFunctions(filteredFunctionMetadata, Functions), cancellationToken);
@@ -324,9 +329,9 @@ namespace Microsoft.Azure.WebJobs.Script
         /// if the setting was enabled, the app is using out-of-proc languages which communicate with the host over shared memory).
         /// </summary>
         /// <returns><see cref="true"/> if <see cref="IFunctionDataCache"/> can be used, <see cref="false"/> otherwise.</returns>
-        private bool GetIsFunctionDataCacheEnabled()
+        private bool GetIsFunctionDataCacheEnabled(string workerRuntime)
         {
-            if (Utility.IsDotNetLanguageFunction(_workerRuntime) ||
+            if (Utility.IsDotNetLanguageFunction(workerRuntime) ||
                 ContainsDotNetFunctionDescriptorProvider() ||
                 _functionDataCache == null)
             {
@@ -368,7 +373,7 @@ namespace Microsoft.Azure.WebJobs.Script
             IEnumerable<FunctionMetadata> functionMetadata;
 
             functionMetadata = _functionMetadataManager.GetFunctionMetadata(forceRefresh: false, workerConfigs: _languageWorkerOptions.CurrentValue.WorkerConfigs);
-            _workerRuntime ??= Utility.GetWorkerRuntime(functionMetadata);
+
             foreach (var error in _functionMetadataManager.Errors)
             {
                 FunctionErrors.Add(error.Key, error.Value.ToArray());
@@ -505,23 +510,23 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <summary>
         /// Initialize function descriptors from metadata.
         /// </summary>
-        internal async Task InitializeFunctionDescriptorsAsync(IEnumerable<FunctionMetadata> functionMetadata, CancellationToken cancellationToken)
+        internal async Task InitializeFunctionDescriptorsAsync(IEnumerable<FunctionMetadata> functionMetadata, string workerRuntime, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            AddFunctionDescriptors(functionMetadata);
+            AddFunctionDescriptors(functionMetadata, workerRuntime);
 
             Collection<FunctionDescriptor> functions;
             using (_metricsLogger.LatencyEvent(MetricEventNames.HostStartupGetFunctionDescriptorsLatency))
             {
                 _logger.CreatingDescriptors();
-                functions = await GetFunctionDescriptorsAsync(functionMetadata, _descriptorProviders, cancellationToken);
+                functions = await GetFunctionDescriptorsAsync(functionMetadata, _descriptorProviders, workerRuntime, cancellationToken);
                 _logger.DescriptorsCreated();
             }
             Functions = functions;
         }
 
-        private void AddFunctionDescriptors(IEnumerable<FunctionMetadata> functionMetadata)
+        private void AddFunctionDescriptors(IEnumerable<FunctionMetadata> functionMetadata, string workerRuntime)
         {
             if (_environment.IsPlaceholderModeEnabled())
             {
@@ -543,21 +548,21 @@ namespace Microsoft.Azure.WebJobs.Script
                 _logger.AddingDescriptorProviderForHttpWorker();
                 _descriptorProviders.Add(new HttpFunctionDescriptorProvider(this, ScriptOptions, _bindingProviders, _functionDispatcher, _loggerFactory, _applicationLifetime, _httpWorkerOptions.InitializationTimeout));
             }
-            else if (string.Equals(_workerRuntime, RpcWorkerConstants.DotNetLanguageWorkerName, StringComparison.OrdinalIgnoreCase))
+            else if (string.Equals(workerRuntime, RpcWorkerConstants.DotNetLanguageWorkerName, StringComparison.OrdinalIgnoreCase))
             {
                 _logger.AddingDescriptorProviderForLanguage(RpcWorkerConstants.DotNetLanguageWorkerName);
                 _descriptorProviders.Add(new DotNetFunctionDescriptorProvider(this, ScriptOptions, _bindingProviders, _metricsLogger, _loggerFactory));
             }
             else
             {
-                _logger.AddingDescriptorProviderForLanguage(_workerRuntime);
+                _logger.AddingDescriptorProviderForLanguage(workerRuntime);
 
-                var workerConfig = _languageWorkerOptions.CurrentValue.WorkerConfigs?.FirstOrDefault(c => c.Description.Language.Equals(_workerRuntime, StringComparison.OrdinalIgnoreCase));
+                var workerConfig = _languageWorkerOptions.CurrentValue.WorkerConfigs?.FirstOrDefault(c => c.Description.Language.Equals(workerRuntime, StringComparison.OrdinalIgnoreCase));
 
                 // If there's no worker config, use the default (for legacy behavior; mostly for tests).
                 TimeSpan initializationTimeout = workerConfig?.CountOptions?.InitializationTimeout ?? WorkerProcessCountOptions.DefaultInitializationTimeout;
 
-                _descriptorProviders.Add(new RpcFunctionDescriptorProvider(this, _workerRuntime, ScriptOptions, _bindingProviders,
+                _descriptorProviders.Add(new RpcFunctionDescriptorProvider(this, workerRuntime, ScriptOptions, _bindingProviders,
                     _functionDispatcher, _loggerFactory, _applicationLifetime, initializationTimeout));
             }
 
@@ -734,14 +739,14 @@ namespace Microsoft.Azure.WebJobs.Script
             }
         }
 
-        internal async Task<Collection<FunctionDescriptor>> GetFunctionDescriptorsAsync(IEnumerable<FunctionMetadata> functions, IEnumerable<FunctionDescriptorProvider> descriptorProviders, CancellationToken cancellationToken)
+        internal async Task<Collection<FunctionDescriptor>> GetFunctionDescriptorsAsync(IEnumerable<FunctionMetadata> functions, IEnumerable<FunctionDescriptorProvider> descriptorProviders, string workerRuntime, CancellationToken cancellationToken)
         {
             Collection<FunctionDescriptor> functionDescriptors = new Collection<FunctionDescriptor>();
             if (!cancellationToken.IsCancellationRequested)
             {
                 var httpFunctions = new Dictionary<string, HttpTriggerAttribute>();
 
-                Utility.VerifyFunctionsMatchSpecifiedLanguage(functions, _workerRuntime, _environment.IsPlaceholderModeEnabled(), _isHttpWorker, cancellationToken);
+                Utility.VerifyFunctionsMatchSpecifiedLanguage(functions, workerRuntime, _environment.IsPlaceholderModeEnabled(), _isHttpWorker, cancellationToken);
 
                 foreach (FunctionMetadata metadata in functions)
                 {

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.21.0" />
-    <!--<PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.0-preview6" />-->
+    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.0-preview6" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.37" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.0-beta.2-11957" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.1" />

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             _hostNameProvider = new HostNameProvider(_mockEnvironment.Object);
 
-            var functionMetadataProvider = new HostFunctionMetadataProvider(optionsMonitor, NullLogger<HostFunctionMetadataProvider>.Instance, new TestMetricsLogger());
+            var functionMetadataProvider = new HostFunctionMetadataProvider(optionsMonitor, NullLogger<HostFunctionMetadataProvider>.Instance, new TestMetricsLogger(), SystemEnvironment.Instance);
             var defaultProvider = new FunctionMetadataProvider(NullLogger<FunctionMetadataProvider>.Instance, null, functionMetadataProvider, new OptionsWrapper<FunctionsHostingConfigOptions>(new FunctionsHostingConfigOptions()), _mockEnvironment.Object);
             var functionMetadataManager = TestFunctionMetadataManager.GetFunctionMetadataManager(new OptionsWrapper<ScriptJobHostOptions>(jobHostOptions), defaultProvider, null, new OptionsWrapper<HttpWorkerOptions>(new HttpWorkerOptions()), loggerFactory, new TestOptionsMonitor<LanguageWorkerOptions>(CreateLanguageWorkerConfigSettings()));
 

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -477,7 +477,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var managerServiceProvider = manager as IServiceProvider;
 
-            var metadataProvider = new HostFunctionMetadataProvider(optionsMonitor, NullLogger<HostFunctionMetadataProvider>.Instance, new TestMetricsLogger());
+            var metadataProvider = new HostFunctionMetadataProvider(optionsMonitor, NullLogger<HostFunctionMetadataProvider>.Instance, new TestMetricsLogger(), SystemEnvironment.Instance);
             var defaultProvider = new FunctionMetadataProvider(NullLogger<FunctionMetadataProvider>.Instance, null, metadataProvider, new OptionsWrapper<FunctionsHostingConfigOptions>(new FunctionsHostingConfigOptions()), SystemEnvironment.Instance);
             var metadataManager = new FunctionMetadataManager(managerServiceProvider.GetService<IOptions<ScriptJobHostOptions>>(), defaultProvider,
                 managerServiceProvider.GetService<IOptions<HttpWorkerOptions>>(), manager, factory, environment);

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/ProxyEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/ProxyEndToEndTests.cs
@@ -411,7 +411,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     WorkerConfigs = TestHelpers.GetTestWorkerConfigs()
                 };
 
-                var hostProvider = new HostFunctionMetadataProvider(optionsMonitor, NullLogger<HostFunctionMetadataProvider>.Instance, new TestMetricsLogger());
+                var hostProvider = new HostFunctionMetadataProvider(optionsMonitor, NullLogger<HostFunctionMetadataProvider>.Instance, new TestMetricsLogger(), SystemEnvironment.Instance);
                 var provider = new FunctionMetadataProvider(NullLogger<FunctionMetadataProvider>.Instance, null, hostProvider, new OptionsWrapper<FunctionsHostingConfigOptions>(new FunctionsHostingConfigOptions()), SystemEnvironment.Instance);
 
                 TestHost = new TestFunctionHost(HostOptions.ScriptPath, HostOptions.LogPath,

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -523,7 +523,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
         }
 
-        [Fact(Skip ="Skipping this for hotfix build")]
+        [Fact]
         public async Task StartAsync_SetsCorrectActiveHost_RefreshesLanguageWorkerOptions()
         {
             var builder = CreateStandbyHostBuilder();
@@ -794,8 +794,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
         }
 
-        [Fact(Skip ="To unblock hotfix for dotnet-isolated placeholder issue")]
-        
+        [Fact]
         public async Task DotNetIsolated_PlaceholderHit()
         {
             var builder = InitializeDotNetIsolatedPlaceholderBuilder();
@@ -833,7 +832,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.DoesNotContain("Shutting down placeholder worker.", log);
         }
 
-        [Fact(Skip ="For hotfix build")]
+        [Fact]
         public async Task DotNetIsolated_PlaceholderMiss_EnvVar()
         {
             // Placeholder miss if the WEBSITE_USE_PLACEHOLDER_DOTNETISOLATED env var is not set
@@ -844,7 +843,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Contains("Shutting down placeholder worker. Worker is not compatible for runtime: dotnet-isolated", log);
         }
 
-        [Fact(Skip = "For hotfix build")]
+        [Fact]
         public async Task DotNetIsolated_PlaceholderMiss_DotNetVer()
         {
             // Even with placeholders enabled via the WEBSITE_USE_PLACEHOLDER_DOTNETISOLATED env var,

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WarmupFunctionEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WarmupFunctionEndToEndTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -12,10 +11,8 @@ using System.Web.Http;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Azure.WebJobs.Script.Config;
-using Microsoft.Azure.WebJobs.Script.Management.Models;
-using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Azure.WebJobs.Script.WebHost;
-using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -41,16 +38,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             HttpResponseMessage response = await _fixture.HttpClient.GetAsync($"/admin/warmup");
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            Assert.False(response.Headers.Contains("myversion"), "/admin/warmup cannot be overriden by proxies." );
+            Assert.False(response.Headers.Contains("myversion"), "/admin/warmup cannot be overriden by proxies.");
         }
-        
+
         [Fact]
         public async Task Normal_Api_Warmup_HttpTrigger_Succeeds()
         {
             HttpResponseMessage response = await _fixture.HttpClient.GetAsync("/warmup");
 
             string content = await response.Content.ReadAsStringAsync();
-            Assert.True(response.StatusCode.ToString("D") =="200", "Normal http trigger with 'warmup' route failed to run. ");
+            Assert.True(response.StatusCode.ToString("D") == "200", "Normal http trigger with 'warmup' route failed to run. ");
             Assert.Equal("Pong", content);
         }
 
@@ -107,7 +104,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     WorkerConfigs = TestHelpers.GetTestWorkerConfigs()
                 };
 
-                var provider = new HostFunctionMetadataProvider(optionsMonitor, NullLogger<HostFunctionMetadataProvider>.Instance, new TestMetricsLogger());
+                var provider = new HostFunctionMetadataProvider(optionsMonitor, NullLogger<HostFunctionMetadataProvider>.Instance, new TestMetricsLogger(), SystemEnvironment.Instance);
 
                 var builder = AspNetCore.WebHost.CreateDefaultBuilder()
                    .UseStartup<Startup>()

--- a/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
@@ -65,10 +65,7 @@ namespace Microsoft.WebJobs.Script.Tests
             services.AddSingleton<IMetricsLogger>(metricsLogger);
             services.AddWebJobsScriptHostRouting();
             services.AddLogging();
-            services.AddFunctionMetadataManager(webHostOptions, metricsLogger);
-
-            var sp = services.BuildServiceProvider();
-            var man = sp.GetService<IFunctionMetadataManager>();
+            services.AddFunctionMetadataManager();
 
             configureRootServices?.Invoke(services);
 
@@ -100,7 +97,7 @@ namespace Microsoft.WebJobs.Script.Tests
             return services.AddSingleton<T>(mock.Object);
         }
 
-        private static IServiceCollection AddFunctionMetadataManager(this IServiceCollection services, ScriptApplicationHostOptions options, IMetricsLogger metricsLogger)
+        private static IServiceCollection AddFunctionMetadataManager(this IServiceCollection services)
         {
             AddMockedSingleton<IWorkerFunctionMetadataProvider>(services);
             services.AddSingleton<IHostFunctionMetadataProvider, HostFunctionMetadataProvider>();

--- a/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
@@ -2,12 +2,9 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Host.Storage;
 using Microsoft.Azure.WebJobs.Script;
-using Microsoft.Azure.WebJobs.Script.Config;
-using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Grpc;
 using Microsoft.Azure.WebJobs.Script.Tests;
@@ -15,12 +12,10 @@ using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Workers;
-using Microsoft.Azure.WebJobs.Script.Workers.Http;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using IApplicationLifetime = Microsoft.AspNetCore.Hosting.IApplicationLifetime;
@@ -48,6 +43,13 @@ namespace Microsoft.WebJobs.Script.Tests
 
             // Register root services
             var services = new ServiceCollection();
+            services.AddOptions<ScriptApplicationHostOptions>()
+                .Configure(o =>
+                {
+                    o.IsSelfHost = webHostOptions.IsSelfHost;
+                    o.ScriptPath = webHostOptions.ScriptPath;
+                    o.LogPath = webHostOptions.LogPath;
+                });
             AddMockedSingleton<IDebugStateProvider>(services);
             AddMockedSingleton<IScriptHostManager>(services);
             AddMockedSingleton<IEnvironment>(services);
@@ -64,6 +66,10 @@ namespace Microsoft.WebJobs.Script.Tests
             services.AddWebJobsScriptHostRouting();
             services.AddLogging();
             services.AddFunctionMetadataManager(webHostOptions, metricsLogger);
+
+            var sp = services.BuildServiceProvider();
+            var man = sp.GetService<IFunctionMetadataManager>();
+
             configureRootServices?.Invoke(services);
 
             var rootProvider = new WebHostServiceProvider(services);
@@ -96,17 +102,21 @@ namespace Microsoft.WebJobs.Script.Tests
 
         private static IServiceCollection AddFunctionMetadataManager(this IServiceCollection services, ScriptApplicationHostOptions options, IMetricsLogger metricsLogger)
         {
-            var factory = new TestOptionsFactory<ScriptApplicationHostOptions>(options);
-            var source = new TestChangeTokenSource<ScriptApplicationHostOptions>();
-            var changeTokens = new[] { source };
-            var optionsMonitor = new OptionsMonitor<ScriptApplicationHostOptions>(factory, changeTokens, factory);
+            AddMockedSingleton<IWorkerFunctionMetadataProvider>(services);
+            services.AddSingleton<IHostFunctionMetadataProvider, HostFunctionMetadataProvider>();
+            services.AddSingleton<IFunctionMetadataProvider, FunctionMetadataProvider>();
 
-            var metadataProvider = new HostFunctionMetadataProvider(optionsMonitor, NullLogger<HostFunctionMetadataProvider>.Instance, metricsLogger);
-            var hostingOptionsMonitor = TestHelpers.CreateOptionsMonitor(new FunctionsHostingConfigOptions());
-            var defaultProvider = new FunctionMetadataProvider(NullLogger<FunctionMetadataProvider>.Instance, null, metadataProvider, new OptionsWrapper<FunctionsHostingConfigOptions>(new FunctionsHostingConfigOptions()), SystemEnvironment.Instance);
-            var metadataManager = TestFunctionMetadataManager.GetFunctionMetadataManager(new OptionsWrapper<ScriptJobHostOptions>(new ScriptJobHostOptions()), defaultProvider, new List<IFunctionProvider>(), new OptionsWrapper<HttpWorkerOptions>(new HttpWorkerOptions()), new NullLoggerFactory(), new TestOptionsMonitor<LanguageWorkerOptions>(TestHelpers.GetTestLanguageWorkerOptions()));
-            services.AddSingleton<IFunctionMetadataManager>(metadataManager);
-            services.AddSingleton<IFunctionMetadataProvider>(defaultProvider);
+            services.AddSingleton<IScriptHostManager>(s =>
+            {
+                var managerMock = new Mock<IScriptHostManager>();
+                managerMock
+                    .As<IServiceProvider>()
+                    .Setup(m => m.GetService(typeof(IOptionsMonitor<LanguageWorkerOptions>)))
+                    .Returns(s.GetService<IOptionsMonitor<LanguageWorkerOptions>>);
+                return managerMock.Object;
+            });
+
+            services.AddSingleton<IFunctionMetadataManager, FunctionMetadataManager>();
 
             return services;
         }

--- a/test/WebJobs.Script.Tests/Configuration/LanguageWorkerOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/LanguageWorkerOptionsSetupTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 
             if (string.IsNullOrEmpty(workerRuntime))
             {
-                Assert.Equal(4, options.WorkerConfigs.Count);
+                Assert.Equal(5, options.WorkerConfigs.Count);
             }
             else if (workerRuntime.Equals(RpcWorkerConstants.DotNetLanguageWorkerName, StringComparison.OrdinalIgnoreCase))
             {

--- a/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             var workerOptions = new LanguageWorkerOptions();
             FileUtility.Instance = fileSystem;
             _fileSystem = fileSystem;
-            var metadataProvider = new HostFunctionMetadataProvider(optionsMonitor, NullLogger<HostFunctionMetadataProvider>.Instance, new TestMetricsLogger());
+            var metadataProvider = new HostFunctionMetadataProvider(optionsMonitor, NullLogger<HostFunctionMetadataProvider>.Instance, new TestMetricsLogger(), SystemEnvironment.Instance);
             var defaultProvider = new FunctionMetadataProvider(NullLogger<FunctionMetadataProvider>.Instance, null, metadataProvider, new OptionsWrapper<FunctionsHostingConfigOptions>(new FunctionsHostingConfigOptions()), SystemEnvironment.Instance);
             var functionMetadataManager = TestFunctionMetadataManager.GetFunctionMetadataManager(new OptionsWrapper<ScriptJobHostOptions>(new ScriptJobHostOptions()), defaultProvider, null, new OptionsWrapper<HttpWorkerOptions>(new HttpWorkerOptions()), loggerFactory, new TestOptionsMonitor<LanguageWorkerOptions>(TestHelpers.GetTestLanguageWorkerOptions()));
 

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -1574,12 +1574,26 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
                 FileUtility.Instance = CreateFileSystem(rootPath);
 
+                TaskCompletionSource<bool> processCreated = new();
+                var processFactoryMock = new Mock<IRpcWorkerProcessFactory>(MockBehavior.Strict);
+                processFactoryMock.Setup(m => m.Create(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RpcWorkerConfig>()))
+                    .Callback(() =>
+                    {
+                        // this happens as a fire-and-forget, so we'll need to wait to avoid races
+                        processCreated.SetResult(true);
+                    });
+
                 IHost host = new HostBuilder()
                     .ConfigureDefaultTestWebScriptHost(null, o => o.ScriptPath = rootPath, false,
                     configureRootServices: s =>
                     {
                         s.AddSingleton<IMetricsLogger>(metricsLogger);
                         s.AddSingleton<IEnvironment>(environment);
+
+                        // Mock out the worker process factory so we don't actually start a worker.
+                        // Doing this via IConfigureBuilder to ensure it correctly overrides the default.
+                        s.AddSingleton<IConfigureBuilder<IServiceCollection>>(
+                            new DelegatedConfigureBuilder<IServiceCollection>(c => c.AddSingleton(processFactoryMock.Object)));
                     })
                     .ConfigureServices(s =>
                     {
@@ -1591,6 +1605,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 await scriptHost.InitializeAsync();
 
                 Assert.Contains($"host.startup.runtime.language.{expectedMetricLanguage}", metricsLogger.LoggedEvents);
+
+                // In-proc does not start the language worker process
+                if (expectedMetricLanguage != "dotnet")
+                {
+                    await processCreated.Task;
+                    processFactoryMock.Verify(m => m.Create(It.IsAny<string>(), expectedMetadataLanguage, rootPath, It.IsAny<RpcWorkerConfig>()), Times.Once);
+                }
 
                 // Previous bug incorrectly chose dotnet-isolated as the Language for C# precompiled functions
                 // if FUNCTIONS_WORKER_RUNTIME was missing

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 var workerConfigs = configFactory.GetConfigs();
                 var pythonWorkerConfig = workerConfigs.FirstOrDefault(w => w.Description.Language.Equals("python", StringComparison.OrdinalIgnoreCase));
                 var powershellWorkerConfig = workerConfigs.FirstOrDefault(w => w.Description.Language.Equals("powershell", StringComparison.OrdinalIgnoreCase));
-                Assert.Equal(4, workerConfigs.Count);
+                Assert.Equal(5, workerConfigs.Count);
                 Assert.NotNull(pythonWorkerConfig);
                 Assert.NotNull(powershellWorkerConfig);
                 Assert.Equal("3.8", pythonWorkerConfig.Description.DefaultRuntimeVersion);


### PR DESCRIPTION
This reverts commit 4ec73a34dea76db91b6861db59d57d1ff00265f8, which will re-add the dotnet-isolated placeholder.

Then also updates code to treat a null FUNCTIONS_WORKER_RUNTIME and "dll" scriptFile extension as "dotnet"... previously, this would choose "dotnet-isolated" and cause issues.