### PR TITLE
Fixing key defaulting regression

### DIFF
--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
@@ -73,15 +73,11 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static TokenValidationParameters CreateTokenValidationParameters()
         {
+            var signingKeys = SecretsUtility.GetTokenIssuerSigningKeys();
             var result = new TokenValidationParameters();
-            if (SecretsUtility.TryGetEncryptionKey(out string key))
+            if (signingKeys.Length > 0)
             {
-                // TODO: Once ScriptSettingsManager is gone, Audience and Issuer should be pulled from configuration.
-                result.IssuerSigningKeys = new SecurityKey[]
-                {
-                    new SymmetricSecurityKey(key.ToKeyBytes()),
-                    new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key))
-                };
+                result.IssuerSigningKeys = signingKeys;
                 result.ValidateAudience = true;
                 result.ValidateIssuer = true;
                 result.ValidAudiences = new string[]

--- a/src/WebJobs.Script.WebHost/Security/SecretsUtility.cs
+++ b/src/WebJobs.Script.WebHost/Security/SecretsUtility.cs
@@ -2,8 +2,11 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Microsoft.Azure.Web.DataProtection;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
 {
@@ -80,6 +83,30 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
 
             return Convert.FromBase64String(hexOrBase64);
+        }
+
+        public static SymmetricSecurityKey[] GetTokenIssuerSigningKeys()
+        {
+            List<SymmetricSecurityKey> signingKeys = new List<SymmetricSecurityKey>();
+
+            // first we want to use the DataProtection APIs to get the default key,
+            // which will return any user specified AzureWebEncryptionKey with precedence
+            // over the platform default key
+            string defaultKey = Util.GetDefaultKeyValue();
+            if (defaultKey != null)
+            {
+                signingKeys.Add(new SymmetricSecurityKey(defaultKey.ToKeyBytes()));
+                signingKeys.Add(new SymmetricSecurityKey(Encoding.UTF8.GetBytes(defaultKey)));
+            }
+
+            // next we want to ensure a key is also added for the platform default key
+            // if it wasn't already added above
+            if (SecretsUtility.TryGetEncryptionKey(out string key) && !string.Equals(key, defaultKey))
+            {
+                signingKeys.Add(new SymmetricSecurityKey(key.ToKeyBytes()));
+            }
+
+            return signingKeys.ToArray();
         }
 
         private static bool TryGetEncryptionKey(IEnvironment environment, string keyName, out string encryptionKey)

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SWAEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SWAEndToEndTests.cs
@@ -1,9 +1,6 @@
-﻿using Microsoft.Azure.WebJobs.Script.WebHost;
-using Microsoft.Azure.WebJobs.Script.WebHost.Management;
-using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Newtonsoft.Json;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,6 +8,12 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Management;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
@@ -67,7 +70,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
         {
             // if an admin token is passed, the function invocation succeeds
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "api/HttpTrigger-FunctionAuth?code=test");
-            string token = _fixture.Host.GenerateAdminJwtToken();
+            string token = GetSWAAdminJwtToken();
 
             if (string.Compare(nameof(HttpRequestHeader.Authorization), headerName) == 0)
             {
@@ -80,6 +83,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
 
             var response = await _fixture.Host.HttpClient.SendAsync(request);
             response.EnsureSuccessStatusCode();
+        }
+
+        private string GetSWAAdminJwtToken()
+        {
+            // Ensure we use AzureWebEncryptionKey to generate tokens, as that's what SWA does
+            string keyValue = _fixture.SWAEncryptionKey;
+            byte[] keyBytes = keyValue.ToKeyBytes();
+            string token = _fixture.Host.GenerateAdminJwtToken(key: keyBytes);
+
+            return token;
         }
 
         [Fact]
@@ -108,18 +121,27 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
 
             public TestFixture() : base(@"TestScripts\CSharp", "csharp", RpcWorkerConstants.DotNetLanguageWorkerName, addTestSettings: false)
             {
+                // SWA generates their own key and sets via AzureWebEncryptionKey
+                // This should take precedence over the default key
                 var testKeyBytes = TestHelpers.GenerateKeyBytes();
                 var testKey = TestHelpers.GenerateKeyHexString(testKeyBytes);
+                SWAEncryptionKey = testKey;
+
+                // Default key provisioned by Antares and available via WEBSITE_AUTH_ENCRYPTION_KEY
+                var defaultTestKeyBytes = TestHelpers.GenerateKeyBytes();
+                var defaultTestKey = TestHelpers.GenerateKeyHexString(defaultTestKeyBytes);
 
                 var settings = new Dictionary<string, string>()
                 {
                     { "AzureWebEncryptionKey", testKey },
-                    { EnvironmentSettingNames.WebSiteAuthEncryptionKey, testKey },
+                    { EnvironmentSettingNames.WebSiteAuthEncryptionKey, defaultTestKey },
                     { "AzureWebJobsStorage", null },
                     { EnvironmentSettingNames.AzureWebsiteName, "testsite" }
                 };
                 _scopedEnvironment = new TestScopedEnvironmentVariable(settings);
             }
+
+            public string SWAEncryptionKey { get; }
 
             public override void ConfigureScriptHost(IWebJobsBuilder webJobsBuilder)
             {


### PR DESCRIPTION
Fixing a key ordering issue introduced by [this commit](https://github.com/Azure/azure-functions-host/commit/80f5ebcaba334a79ab049e2fe276dc15f257e554#diff-b407624f13720c64f179ca0ee3f592dc5317bd6e880e69431fdf88c397ee535a). The issue is that before that change, our JWT token handler used the DataProtection APIs to get the signing key. Those APIs would first use any user specified AzureWebEncryptionKey value, then fall back to the Antares platform provided key (machine key). The referenced commit changed that ordering so the platform key was used BEFORE the AzureWebEncryptionKey override.

The changes in this PR ensure that we allow both signing keys.

Backport:
- V3 https://github.com/Azure/azure-functions-host/pull/9307
- V1 https://github.com/Azure/azure-functions-host/pull/9309
