### PR TITLE
Update valid audience for legion applications during specialization

### DIFF
--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Extensions.DependencyInjection
                         // TODO: DI (FACAVAL) This will be fixed once the permanent fix is in place
                         if (_specialized == 0 && !SystemEnvironment.Instance.IsPlaceholderModeEnabled() && Interlocked.CompareExchange(ref _specialized, 1, 0) == 0)
                         {
-                            o.TokenValidationParameters = CreateTokenValidationParameters(GetValidAudiences());
+                            o.TokenValidationParameters = CreateTokenValidationParameters();
                         }
 
                         return Task.CompletedTask;
@@ -61,7 +61,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     }
                 };
 
-                o.TokenValidationParameters = CreateTokenValidationParameters(GetValidAudiences());
+                o.TokenValidationParameters = CreateTokenValidationParameters();
 
                 // TODO: DI (FACAVAL) Remove this once the work above is completed.
                 if (!SystemEnvironment.Instance.IsPlaceholderModeEnabled())
@@ -89,7 +89,7 @@ namespace Microsoft.Extensions.DependencyInjection
             };
         }
 
-        private static TokenValidationParameters CreateTokenValidationParameters(string[] validAudiences)
+        public static TokenValidationParameters CreateTokenValidationParameters()
         {
             var signingKeys = SecretsUtility.GetTokenIssuerSigningKeys();
             var result = new TokenValidationParameters();
@@ -98,7 +98,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 result.IssuerSigningKeys = signingKeys;
                 result.ValidateAudience = true;
                 result.ValidateIssuer = true;
-                result.ValidAudiences = validAudiences;
+                result.ValidAudiences = GetValidAudiences();
                 result.ValidIssuers = new string[]
                 {
                     AppServiceCoreUri,

--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -26,52 +26,70 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static AuthenticationBuilder AddScriptJwtBearer(this AuthenticationBuilder builder)
             => builder.AddJwtBearer(o =>
+            {
+                o.Events = new JwtBearerEvents()
+                {
+                    OnMessageReceived = c =>
+                    {
+                        // By default, tokens are passed via the standard Authorization Bearer header. However we also support
+                        // passing tokens via the x-ms-site-token header.
+                        if (c.Request.Headers.TryGetValue(ScriptConstants.SiteTokenHeaderName, out StringValues values))
                         {
-                            o.Events = new JwtBearerEvents()
-                            {
-                                OnMessageReceived = c =>
-                                {
-                                    // By default, tokens are passed via the standard Authorization Bearer header. However we also support
-                                    // passing tokens via the x-ms-site-token header.
-                                    if (c.Request.Headers.TryGetValue(ScriptConstants.SiteTokenHeaderName, out StringValues values))
-                                    {
-                                        // the token we set here will be the one used - Authorization header won't be checked.
-                                        c.Token = values.FirstOrDefault();
-                                    }
+                            // the token we set here will be the one used - Authorization header won't be checked.
+                            c.Token = values.FirstOrDefault();
+                        }
 
-                                    // Temporary: Tactical fix to address specialization issues. This should likely be moved to a token validator
-                                    // TODO: DI (FACAVAL) This will be fixed once the permanent fix is in place
-                                    if (_specialized == 0 && !SystemEnvironment.Instance.IsPlaceholderModeEnabled() && Interlocked.CompareExchange(ref _specialized, 1, 0) == 0)
-                                    {
-                                        o.TokenValidationParameters = CreateTokenValidationParameters();
-                                    }
+                        // Temporary: Tactical fix to address specialization issues. This should likely be moved to a token validator
+                        // TODO: DI (FACAVAL) This will be fixed once the permanent fix is in place
+                        if (_specialized == 0 && !SystemEnvironment.Instance.IsPlaceholderModeEnabled() && Interlocked.CompareExchange(ref _specialized, 1, 0) == 0)
+                        {
+                            o.TokenValidationParameters = CreateTokenValidationParameters(GetValidAudiences());
+                        }
 
-                                    return Task.CompletedTask;
-                                },
-                                OnTokenValidated = c =>
-                                {
-                                    c.Principal.AddIdentity(new ClaimsIdentity(new Claim[]
-                                    {
-                                        new Claim(SecurityConstants.AuthLevelClaimType, AuthorizationLevel.Admin.ToString())
-                                    }));
+                        return Task.CompletedTask;
+                    },
+                    OnTokenValidated = c =>
+                    {
+                        c.Principal.AddIdentity(new ClaimsIdentity(new Claim[]
+                        {
+                            new Claim(SecurityConstants.AuthLevelClaimType, AuthorizationLevel.Admin.ToString())
+                        }));
 
-                                    c.Success();
+                        c.Success();
 
-                                    return Task.CompletedTask;
-                                }
-                            };
+                        return Task.CompletedTask;
+                    }
+                };
 
-                            o.TokenValidationParameters = CreateTokenValidationParameters();
+                o.TokenValidationParameters = CreateTokenValidationParameters(GetValidAudiences());
 
-                            // TODO: DI (FACAVAL) Remove this once the work above is completed.
-                            if (!SystemEnvironment.Instance.IsPlaceholderModeEnabled())
-                            {
-                                // We're not in standby mode, so flag as specialized
-                                _specialized = 1;
-                            }
-                        });
+                // TODO: DI (FACAVAL) Remove this once the work above is completed.
+                if (!SystemEnvironment.Instance.IsPlaceholderModeEnabled())
+                {
+                    // We're not in standby mode, so flag as specialized
+                    _specialized = 1;
+                }
+            });
 
-        private static TokenValidationParameters CreateTokenValidationParameters()
+        private static string[] GetValidAudiences()
+        {
+            if (SystemEnvironment.Instance.IsPlaceholderModeEnabled() &&
+                SystemEnvironment.Instance.IsLinuxConsumptionOnLegion())
+            {
+                return new string[]
+                {
+                    ScriptSettingsManager.Instance.GetSetting(WebsitePodName)
+                };
+            }
+
+            return new string[]
+            {
+                string.Format(SiteAzureFunctionsUriFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName)),
+                string.Format(SiteUriFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName))
+            };
+        }
+
+        private static TokenValidationParameters CreateTokenValidationParameters(string[] validAudiences)
         {
             var signingKeys = SecretsUtility.GetTokenIssuerSigningKeys();
             var result = new TokenValidationParameters();
@@ -80,11 +98,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 result.IssuerSigningKeys = signingKeys;
                 result.ValidateAudience = true;
                 result.ValidateIssuer = true;
-                result.ValidAudiences = new string[]
-                {
-                    string.Format(SiteAzureFunctionsUriFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName)),
-                    string.Format(SiteUriFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName))
-                };
+                result.ValidAudiences = validAudiences;
                 result.ValidIssuers = new string[]
                 {
                     AppServiceCoreUri,

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -312,7 +312,8 @@ namespace Microsoft.Azure.WebJobs.Script
         public static bool IsLinuxConsumptionOnLegion(this IEnvironment environment)
         {
             return !environment.IsAppService() &&
-                   !string.IsNullOrEmpty(environment.GetEnvironmentVariable(ContainerName)) &&
+                   (!string.IsNullOrEmpty(environment.GetEnvironmentVariable(ContainerName)) ||
+                   !string.IsNullOrEmpty(environment.GetEnvironmentVariable(WebsitePodName))) &&
                    !string.IsNullOrEmpty(environment.GetEnvironmentVariable(LegionServiceHost));
         }
 

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FunctionsExtensionVersion = "FUNCTIONS_EXTENSION_VERSION";
         public const string FunctionWorkerRuntime = "FUNCTIONS_WORKER_RUNTIME";
         public const string ContainerName = "CONTAINER_NAME";
+        public const string WebsitePodName = "WEBSITE_POD_NAME";
         public const string LegionServiceHost = "LEGION_SERVICE_HOST";
         public const string WebSiteHomeStampName = "WEBSITE_HOME_STAMPNAME";
         public const string WebSiteStampDeploymentId = "WEBSITE_STAMP_DEPLOYMENT_ID";

--- a/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
@@ -195,28 +195,37 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
         }
 
         [Theory]
-        [InlineData(true, false, false, true)]
-        [InlineData(false, true, false, true)]
-        [InlineData(true, true, false, true)]
-        [InlineData(false, false, false, false)]
-        [InlineData(false, false, true, false)]
-        public void IsAnyLinuxConsumption_ReturnsExpectedResult(bool isLinuxConsumptionOnAtlas, bool isLinuxConsumptionOnLegion, bool isManagedAppEnvironment, bool expectedValue)
+        [InlineData(true, false, false, true, false)]
+        [InlineData(false, true, false, true, false)]
+        [InlineData(false, true, false, true, true)]
+        [InlineData(true, true, false, true, false)]
+        [InlineData(true, true, false, true, true)]
+        [InlineData(false, false, false, false, false)]
+        [InlineData(false, false, true, false, false)]
+        public void IsAnyLinuxConsumption_ReturnsExpectedResult(bool isLinuxConsumptionOnAtlas, bool isLinuxConsumptionOnLegion, bool isManagedAppEnvironment, bool expectedValue, bool setPodName)
         {
             IEnvironment env = new TestEnvironment();
             if (isLinuxConsumptionOnAtlas)
             {
-                env.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "RandomContainerName");
+                env.SetEnvironmentVariable(ContainerName, "RandomContainerName");
             }
 
             if (isLinuxConsumptionOnLegion)
             {
-                env.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "RandomContainerName");
-                env.SetEnvironmentVariable(EnvironmentSettingNames.LegionServiceHost, "RandomLegionServiceHostName");
+                if (setPodName)
+                {
+                    env.SetEnvironmentVariable(WebsitePodName, "RandomPodName");
+                }
+                else
+                {
+                    env.SetEnvironmentVariable(ContainerName, "RandomContainerName");
+                }
+                env.SetEnvironmentVariable(LegionServiceHost, "RandomLegionServiceHostName");
             }
 
             if (isManagedAppEnvironment)
             {
-                env.SetEnvironmentVariable(EnvironmentSettingNames.ManagedEnvironment, "true");
+                env.SetEnvironmentVariable(ManagedEnvironment, "true");
             }
 
             Assert.Equal(expectedValue, env.IsAnyLinuxConsumption());

--- a/test/WebJobs.Script.Tests/Extensions/ScriptJwtBearerExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/ScriptJwtBearerExtensionsTests.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using static Microsoft.Azure.WebJobs.Script.EnvironmentSettingNames;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
+{
+    public class ScriptJwtBearerExtensionsTests
+    {
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void CreateTokenValidationParameters_HasExpectedAudience(bool isPlaceholderModeEnabled, bool isLinuxConsumptionOnLegion)
+        {
+            var podName = "RandomPodName";
+            var siteName = "RandomSiteName";
+            ScriptSettingsManager.Instance.SetSetting(AzureWebsiteName, siteName);
+            ScriptSettingsManager.Instance.SetSetting(WebsitePodName, podName);
+
+            var expectedWithSiteName = new string[]
+            {
+                string.Format(ScriptConstants.SiteAzureFunctionsUriFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName)),
+                string.Format(ScriptConstants.SiteUriFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName))
+            };
+            var expectedWithPodName = new string[]
+            {
+                ScriptSettingsManager.Instance.GetSetting(WebsitePodName)
+            };
+
+            var testData = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            if (isPlaceholderModeEnabled)
+            {
+                testData[AzureWebsitePlaceholderMode] = "1";
+            }
+
+            if (isLinuxConsumptionOnLegion)
+            {
+                testData[AzureWebsiteInstanceId] = string.Empty;
+                testData[WebsitePodName] = podName;
+                testData[LegionServiceHost] = "1";
+            }
+
+            testData[ContainerEncryptionKey] = Convert.ToBase64String(TestHelpers.GenerateKeyBytes());
+            using (new TestScopedEnvironmentVariable(testData))
+            {
+                var tokenValidationParameters = ScriptJwtBearerExtensions.CreateTokenValidationParameters();
+                var audiences = tokenValidationParameters.ValidAudiences.ToList();
+
+                if (isPlaceholderModeEnabled &&
+                    isLinuxConsumptionOnLegion)
+                {
+                    Assert.Equal(audiences.Count, expectedWithPodName.Length);
+                    Assert.Equal(audiences[0], expectedWithPodName[0]);
+                }
+                else
+                {
+                    Assert.Equal(audiences.Count, expectedWithSiteName.Length);
+                    Assert.True(audiences.Contains(expectedWithSiteName[0]));
+                    Assert.True(audiences.Contains(expectedWithSiteName[1]));
+                }
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/FunctionsSyncServiceTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionsSyncServiceTests.cs
@@ -137,6 +137,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.LegionServiceHost)).Returns(isConsumptionLinuxOnLegion ? "1" : null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady)).Returns(containerReady ? "1" : null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ManagedEnvironment)).Returns(isManagedAppEnvironment ? "1" : null);
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.WebsitePodName)).Returns(isConsumptionLinuxOnLegion ? "RandomPodName" : null);
 
             var result = FunctionsSyncManager.IsSyncTriggersEnvironment(_mockWebHostEnvironment.Object, _mockEnvironment.Object);
             Assert.Equal(expected, result);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Expected valid audience modified based on SKU and based on whether it's during specialization. For legion, there will not be a `WEBSITE_SITE_NAME` populated while in placeholder mode, and therefore no sense in taking dependency on it.

Instead, it will look at `WEBSITE_POD_NAME`.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
