### PR TITLE
Unifying CV2 SKU/Environment checks

### DIFF
--- a/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerInitializationHostService.cs
+++ b/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerInitializationHostService.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
             {
                 await ApplyStartContextIfPresent();
             }
-            else if (_environment.IsLinuxConsumptionOnLegion())
+            else if (_environment.IsFlexConsumptionSku())
             {
                 _logger.LogInformation("Container has (re)started. Waiting for specialization");
             }

--- a/src/WebJobs.Script.WebHost/Program.cs
+++ b/src/WebJobs.Script.WebHost/Program.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             {
                 AppDomain.CurrentDomain.UnhandledException += CurrentDomainOnUnhandledExceptionInLinuxConsumption;
             }
-            else if (SystemEnvironment.Instance.IsLinuxConsumptionOnLegion())
+            else if (SystemEnvironment.Instance.IsFlexConsumptionSku())
             {
                 //todo: Replace with legion specific logger.
                 AppDomain.CurrentDomain.UnhandledException += CurrentDomainOnUnhandledExceptionInLinuxConsumption;

--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Extensions.DependencyInjection
         private static string[] GetValidAudiences()
         {
             if (SystemEnvironment.Instance.IsPlaceholderModeEnabled() &&
-                SystemEnvironment.Instance.IsLinuxConsumptionOnLegion())
+                SystemEnvironment.Instance.IsFlexConsumptionSku())
             {
                 return new string[]
                 {

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddTransient<VirtualFileSystem>();
             services.AddTransient<VirtualFileSystemMiddleware>();
 
-            if (SystemEnvironment.Instance.IsLinuxConsumptionOnLegion())
+            if (SystemEnvironment.Instance.IsFlexConsumptionSku())
             {
                 services.AddSingleton<IInstanceManager, LegionInstanceManager>();
             }

--- a/test/WebJobs.Script.Tests.Integration/ContainerManagement/LinuxContainerInitializationHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ContainerManagement/LinuxContainerInitializationHostServiceTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ContainerManagement
             _environment.SetEnvironmentVariable(LegionServiceHost, "1");
             Assert.True(_environment.IsAnyLinuxConsumption());
             Assert.False(_environment.IsLinuxConsumptionOnAtlas());
-            Assert.True(_environment.IsLinuxConsumptionOnLegion());
+            Assert.True(_environment.IsFlexConsumptionSku());
 
             var initializationHostService = new LinuxContainerInitializationHostService(_environment, _instanceManagerMock.Object, NullLogger<LinuxContainerInitializationHostService>.Instance, _startupContextProvider);
             await initializationHostService.StartAsync(CancellationToken.None);

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Linux.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Linux.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var environment = new TestEnvironment(vars);
 
             Assert.True(environment.IsLinuxConsumptionOnAtlas());
-            Assert.False(environment.IsLinuxConsumptionOnLegion());
+            Assert.False(environment.IsFlexConsumptionSku());
             Assert.True(environment.IsAnyLinuxConsumption());
 
             await InitializeTestHostAsync("Linux", environment);

--- a/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
+++ b/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
@@ -232,7 +232,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.LegionServiceHost, legionServiceHost);
             Assert.Equal(isLinuxConsumptionOnAtlas || isLinuxConsumptionOnLegion, testEnvironment.IsAnyLinuxConsumption());
             Assert.Equal(isLinuxConsumptionOnAtlas, testEnvironment.IsLinuxConsumptionOnAtlas());
-            Assert.Equal(isLinuxConsumptionOnLegion, testEnvironment.IsLinuxConsumptionOnLegion());
+            Assert.Equal(isLinuxConsumptionOnLegion, testEnvironment.IsFlexConsumptionSku());
             Assert.Equal(isLinuxConsumptionOnAtlas || isLinuxConsumptionOnLegion, testEnvironment.IsConsumptionSku());
             Assert.Equal(isLinuxConsumptionOnAtlas || isLinuxConsumptionOnLegion, testEnvironment.IsDynamicSku());
             Assert.False(isLinuxConsumptionOnAtlas ? isLinuxConsumptionOnLegion : isLinuxConsumptionOnAtlas);

--- a/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
@@ -183,14 +183,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
         }
 
         [Theory]
-        [InlineData("FlexConsumption", true)]
-        [InlineData("Dynamic", false)]
-        [InlineData("ElasticPremium", false)]
-        [InlineData("", false)]
-        public void IsFlexConsumptionSku_ReturnsExpectedResult(string sku, bool expected)
+        [InlineData("FlexConsumption", "", "", "", true)] // not a valid configuration, but testing for thoroughness
+        [InlineData(null, "", "container-name", "1", true)] // simulate placeholder mode where SKU not available yet
+        [InlineData("FlexConsumption", "", "container-name", "1", true)] // expected state when specialized
+        [InlineData(null, "website-instance-id", "container-name", "1", false)] // not a valid configuration, but testing for thoroughness
+        [InlineData("Dynamic", "", "", "", false)]
+        [InlineData("ElasticPremium", "", "", "", false)]
+        [InlineData("", "", "", "", false)]
+        public void IsFlexConsumptionSku_ReturnsExpectedResult(string sku, string websiteInstanceId, string containerName, string legionServiceHost, bool expected)
         {
             IEnvironment env = new TestEnvironment();
             env.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, sku);
+            env.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, websiteInstanceId);
+            env.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, containerName);
+            env.SetEnvironmentVariable(EnvironmentSettingNames.LegionServiceHost, legionServiceHost);
+
             Assert.Equal(expected, env.IsFlexConsumptionSku());
         }
 

--- a/test/WebJobs.Script.Tests/FunctionsSyncServiceTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionsSyncServiceTests.cs
@@ -131,6 +131,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             _mockWebHostEnvironment.SetupGet(p => p.InStandbyMode).Returns(standbyMode);
 
+            if (isConsumptionLinuxOnLegion)
+            {
+                _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku)).Returns(ScriptConstants.FlexConsumptionSku);
+            }
+            else
+            {
+                _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku)).Returns(ScriptConstants.DynamicSku);
+            }
+
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId)).Returns(isAppService ? "1" : null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey)).Returns(hasEncryptionKey ? "1" : null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ContainerName)).Returns(isConsumptionLinuxOnAtlas || isConsumptionLinuxOnLegion ? "1" : null);

--- a/test/WebJobs.Script.Tests/Middleware/HostWarmupMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Middleware/HostWarmupMiddlewareTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
             environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "TestContainer");
             Assert.True(environment.IsAnyLinuxConsumption());
             Assert.True(environment.IsLinuxConsumptionOnAtlas());
-            Assert.False(environment.IsLinuxConsumptionOnLegion());
+            Assert.False(environment.IsFlexConsumptionSku());
             Assert.True(HostWarmupMiddleware.IsWarmUpRequest(request, hostEnvironment.InStandbyMode, environment));
 
             // Reset environment
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
             environment.SetEnvironmentVariable(EnvironmentSettingNames.LegionServiceHost, "1");
             Assert.True(environment.IsAnyLinuxConsumption());
             Assert.False(environment.IsLinuxConsumptionOnAtlas());
-            Assert.True(environment.IsLinuxConsumptionOnLegion());
+            Assert.True(environment.IsFlexConsumptionSku());
             Assert.True(HostWarmupMiddleware.IsWarmUpRequest(request, hostEnvironment.InStandbyMode, environment));
         }
 


### PR DESCRIPTION
Unifying the SKU/Environment check used for CV2 so that a single check can be used regardless of whether we're in placeholder mode or fully specialized. Currently we have two different helpers because in placeholder mode SKU is not available yet.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
