### PR TITLE
handling null refs in channel disposal

### DIFF
--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -1304,8 +1304,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     // shut down the channels
                     _eventManager.RemoveGrpcChannels(_workerId);
                 }
+                _disposed = true;
             }
-            _disposed = true;
         }
 
         public void Dispose()

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -1261,23 +1261,51 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     _timer?.Dispose();
 
                     // unlink function inputs
-                    foreach (var link in _inputLinks)
+                    if (_inputLinks is not null)
                     {
-                        link.Dispose();
+                        foreach (var link in _inputLinks)
+                        {
+                            if (link is null)
+                            {
+                                // This log is temporarily added for diagnostic purposes.
+                                _workerChannelLogger.LogDebug("An input link is null. Skipping disposal.");
+                            }
+
+                            link?.Dispose();
+                        }
+                    }
+                    else
+                    {
+                        // This log is temporarily added for diagnostic purposes.
+                        _workerChannelLogger.LogDebug("The input links collection is null. Skipping disposal of any individual input links.");
                     }
 
                     (_rpcWorkerProcess as IDisposable)?.Dispose();
 
-                    foreach (var sub in _eventSubscriptions)
+                    if (_eventSubscriptions is not null)
                     {
-                        sub.Dispose();
+                        foreach (var sub in _eventSubscriptions)
+                        {
+                            if (sub is null)
+                            {
+                                // This log is temporarily added for diagnostic purposes.
+                                _workerChannelLogger.LogDebug("An event subscription is null. Skipping disposal.");
+                            }
+
+                            sub?.Dispose();
+                        }
+                    }
+                    else
+                    {
+                        // This log is temporarily added for diagnostic purposes.
+                        _workerChannelLogger.LogDebug("The event subscriptions collection is null. Skipping disposal of any individual subscriptions.");
                     }
 
                     // shut down the channels
                     _eventManager.RemoveGrpcChannels(_workerId);
                 }
-                _disposed = true;
             }
+            _disposed = true;
         }
 
         public void Dispose()

--- a/src/WebJobs.Script/Workers/Rpc/JobHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/JobHostRpcWorkerChannelManager.cs
@@ -47,11 +47,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 {
                     if (channels.TryRemove(channelId, out IRpcWorkerChannel rpcChannel))
                     {
-                        _logger.LogDebug("Disposing language worker channel with id:{workerId}", rpcChannel.Id);
+                        string id = rpcChannel.Id;
+                        _logger.LogDebug("Disposing language worker channel with id:{workerId}", id);
                         rpcChannel.TryFailExecutions(workerException);
 
                         (rpcChannel as IDisposable)?.Dispose();
-                        _logger.LogDebug("Disposed language worker channel with id:{workerId}", rpcChannel.Id);
+                        _logger.LogDebug("Disposed language worker channel with id:{workerId}", id);
 
                         return Task.FromResult(true);
                     }

--- a/src/WebJobs.Script/Workers/Rpc/JobHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/JobHostRpcWorkerChannelManager.cs
@@ -49,7 +49,10 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     {
                         _logger.LogDebug("Disposing language worker channel with id:{workerId}", rpcChannel.Id);
                         rpcChannel.TryFailExecutions(workerException);
+
                         (rpcChannel as IDisposable)?.Dispose();
+                        _logger.LogDebug("Disposed language worker channel with id:{workerId}", rpcChannel.Id);
+
                         return Task.FromResult(true);
                     }
                 }


### PR DESCRIPTION
We have evidence that during a function timeout we can get ourselves into a state where:
- language worker disposal/shutdown silently fails
- we then never restart a new worker
- host is stuck in "Did not find any initialized language worker" state forever

Some diagnostic logging that I added to a private site extension and running on a constantly-timing-out function caught a curious null ref during GrpcWorkerChannel disposal:

```
System.NullReferenceException : Object reference not set to an instance of an object.
   at Microsoft.Azure.WebJobs.Script.Grpc.GrpcWorkerChannel.Dispose(Boolean disposing) at C:\git\azure-functions-host\src\WebJobs.Script.Grpc\Channel\GrpcWorkerChannel.cs : 1267
```

https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs#L1264-L1267

From looking at the code, it seems that either the `_inputLinks` collection or one of the entries inside of it is null while we are disposing, resulting in an exception being thrown.

And because this is all initiated via a function timeout (which is a Timer callback), the exception is ignored and things kinda just stop.

This PR is:
- Adding null handling for several things in this dispose path as well as logging if they are null. This can hopefully help us track down exactly what is happening because as far as we can see, there's no way for these values to ever be null.
- If we do ever catch an exception during channel shutdown, just abandon the host process completely and restart. We're in an unknown state at this point and the only real way to get back to a better one is to restart the host. This is a much better scenario than having us sit without a worker forever.