### PR TITLE
Updating DotNetIsolatedNativeHost package to 1.0.0-preview805 (Managed code + Linux support)

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.21.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.0-preview6" />
+    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.0-preview805" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.37" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.0-beta.2-11957" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.1.1" />


### PR DESCRIPTION
Updating DotNetIsolatedNativeHost package to 1.0.0-preview805.

The major difference between preview6 and preview805 are:

1. FunctionsNetHost native component was built from managed code (Preivous version was created from C++) and built using AOT publishing to create the native component.
2. Added support for linux placeholders for dotnet isolated.

The dotnet isolated placeholder feature is still an explicit opt-in experience (need to set env variable `WEBSITE_USE_PLACEHOLDER_DOTNETISOLATED` for this to be enabled)