### PR TITLE
Use auth to decrypt signature and use container name for audience for…

### DIFF
--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -73,13 +73,22 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static string[] GetValidAudiences()
         {
-            if (SystemEnvironment.Instance.IsPlaceholderModeEnabled() &&
-                SystemEnvironment.Instance.IsFlexConsumptionSku())
+            if (SystemEnvironment.Instance.IsPlaceholderModeEnabled())
             {
-                return new string[]
+                if (SystemEnvironment.Instance.IsFlexConsumptionSku())
                 {
-                    ScriptSettingsManager.Instance.GetSetting(WebsitePodName)
-                };
+                    return new string[]
+                    {
+                        ScriptSettingsManager.Instance.GetSetting(WebsitePodName)
+                    };
+                }
+                else if (SystemEnvironment.Instance.IsLinuxConsumptionOnAtlas())
+                {
+                    return new string[]
+                    {
+                        ScriptSettingsManager.Instance.GetSetting(ContainerName)
+                    };
+                }
             }
 
             return new string[]

--- a/src/WebJobs.Script.WebHost/Security/SimpleWebTokenHelper.cs
+++ b/src/WebJobs.Script.WebHost/Security/SimpleWebTokenHelper.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security
             var iv = Convert.FromBase64String(parts[0]);
             var data = Convert.FromBase64String(parts[1]);
             var base64KeyHash = parts.Length == 3 ? parts[2] : null;
-            var signature = parts.Length >= 4 ? Convert.FromBase64String(parts[3]) : null;
+            var signature = parts.Length == 4 ? Convert.FromBase64String(parts[3]) : null;
 
             if (!string.IsNullOrEmpty(base64KeyHash) && !string.Equals(GetSHA256Base64String(encryptionKey), base64KeyHash))
             {
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security
                         throw new InvalidOperationException("Signature mismatches!");
                     }
 
-                    return Encoding.UTF8.GetString(ms.ToArray());
+                    return Encoding.UTF8.GetString(input);
                 }
             }
         }

--- a/src/WebJobs.Script/Config/ScriptSettingsManager.cs
+++ b/src/WebJobs.Script/Config/ScriptSettingsManager.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         }
 
         /// <summary>
-        /// Gets a value indicating whether we are running in App Service
+        /// Gets a value indicating whether we are running in App Service.
         /// </summary>
         public virtual bool IsAppServiceEnvironment => !string.IsNullOrEmpty(GetSetting(EnvironmentSettingNames.AzureWebsiteInstanceId));
 

--- a/test/WebJobs.Script.Tests/Extensions/ScriptJwtBearerExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/ScriptJwtBearerExtensionsTests.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
             var siteName = "RandomSiteName";
             ScriptSettingsManager.Instance.SetSetting(AzureWebsiteName, siteName);
             ScriptSettingsManager.Instance.SetSetting(WebsitePodName, podName);
+            ScriptSettingsManager.Instance.SetSetting(ContainerName, string.Empty);
 
             var expectedWithSiteName = new string[]
             {
@@ -89,7 +90,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
                     Assert.True(audiences.Contains(expectedWithSiteName[0]));
                     Assert.True(audiences.Contains(expectedWithSiteName[1]));
                 }
-                ScriptSettingsManager.Instance.SetSetting(ContainerName, string.Empty);
             }
         }
     }

--- a/test/WebJobs.Script.Tests/Extensions/ScriptJwtBearerExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/ScriptJwtBearerExtensionsTests.cs
@@ -15,13 +15,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
     public class ScriptJwtBearerExtensionsTests
     {
         [Theory]
-        [InlineData(true, true, false)]
-        [InlineData(true, false, false)]
-        [InlineData(false, true, false)]
-        [InlineData(false, false, false)]
-        [InlineData(true, false, true)]
-        [InlineData(false, false, true)]
-        public void CreateTokenValidationParameters_HasExpectedAudience(bool isPlaceholderModeEnabled, bool isLinuxConsumptionOnLegion, bool isLinuxConsumptionOnAtlas)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void CreateTokenValidationParameters_HasExpectedAudience(bool isPlaceholderModeEnabled, bool isLinuxConsumptionOnLegion)
         {
             var podName = "RandomPodName";
             var containerName = "RandomContainerName";
@@ -54,8 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
                 testData[WebsitePodName] = podName;
                 testData[LegionServiceHost] = "1";
             }
-
-            if (isLinuxConsumptionOnAtlas)
+            else
             {
                 ScriptSettingsManager.Instance.SetSetting(ContainerName, containerName);
                 expectedWithContainerName = new string[]
@@ -78,8 +75,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
                     Assert.Equal(audiences.Count, expectedWithPodName.Length);
                     Assert.Equal(audiences[0], expectedWithPodName[0]);
                 }
-                else if (isPlaceholderModeEnabled &&
-                    isLinuxConsumptionOnAtlas)
+                else if (isPlaceholderModeEnabled)
                 {
                     Assert.Equal(audiences.Count, expectedWithContainerName.Length);
                     Assert.Equal(audiences[0], expectedWithContainerName[0]);

--- a/test/WebJobs.Script.Tests/Helpers/SimpleWebTokenTests.cs
+++ b/test/WebJobs.Script.Tests/Helpers/SimpleWebTokenTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security;
 using Xunit;
 
@@ -86,6 +87,24 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Helpers
             Environment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, websiteAuthEncryptionStringKey);
 
             var token = SimpleWebTokenHelper.CreateToken(timeStamp, websiteAuthEncryptionKey);
+            Assert.True(SimpleWebTokenHelper.TryValidateToken(token, new SystemClock()));
+        }
+
+        [Fact]
+        public void Validate_Token_Checks_Signature_If_Signature_Is_Available()
+        {
+            var websiteAuthEncryptionKey = TestHelpers.GenerateKeyBytes();
+            var websiteAuthEncryptionStringKey = TestHelpers.GenerateKeyHexString(websiteAuthEncryptionKey);
+
+            var timeStamp = DateTime.UtcNow.AddHours(1);
+
+            Environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, string.Empty);
+            Environment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, websiteAuthEncryptionStringKey);
+
+            //var token = SimpleWebTokenHelper.CreateToken(timeStamp, websiteAuthEncryptionKey);
+
+            var token = SimpleWebTokenHelper.Encrypt($"exp={timeStamp.Ticks}", websiteAuthEncryptionKey, includesSignature: true);
+
             Assert.True(SimpleWebTokenHelper.TryValidateToken(token, new SystemClock()));
         }
 

--- a/test/WebJobs.Script.Tests/Helpers/SimpleWebTokenTests.cs
+++ b/test/WebJobs.Script.Tests/Helpers/SimpleWebTokenTests.cs
@@ -2,9 +2,12 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Helpers
@@ -101,11 +104,27 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Helpers
             Environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, string.Empty);
             Environment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, websiteAuthEncryptionStringKey);
 
-            //var token = SimpleWebTokenHelper.CreateToken(timeStamp, websiteAuthEncryptionKey);
-
             var token = SimpleWebTokenHelper.Encrypt($"exp={timeStamp.Ticks}", websiteAuthEncryptionKey, includesSignature: true);
 
             Assert.True(SimpleWebTokenHelper.TryValidateToken(token, new SystemClock()));
+        }
+
+        [Fact]
+        public void Encrypt_And_Decrypt_Context_With_Signature()
+        {
+            var websiteAuthEncryptionKey = TestHelpers.GenerateKeyBytes();
+            var websiteAuthEncryptionStringKey = TestHelpers.GenerateKeyHexString(websiteAuthEncryptionKey);
+            var hostContext = GetHostAssignmentContext();
+            var hostContextJson = JsonConvert.SerializeObject(hostContext);
+
+            Environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, string.Empty);
+            Environment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, websiteAuthEncryptionStringKey);
+
+            var encryptedHostContextWithSignature = SimpleWebTokenHelper.Encrypt(hostContextJson, websiteAuthEncryptionKey, includesSignature: true);
+
+            var decryptedHostContextJson = SimpleWebTokenHelper.Decrypt(websiteAuthEncryptionKey, encryptedHostContextWithSignature);
+
+            Assert.Equal(hostContextJson, decryptedHostContextJson);
         }
 
         public void Dispose()
@@ -113,6 +132,24 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Helpers
             // Clean up
             Environment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, string.Empty);
             Environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, string.Empty);
+        }
+
+        private static HostAssignmentContext GetHostAssignmentContext()
+        {
+            var hostAssignmentContext = new HostAssignmentContext();
+            hostAssignmentContext.SiteId = 1;
+            hostAssignmentContext.SiteName = "sitename";
+            hostAssignmentContext.LastModifiedTime = DateTime.UtcNow.Add(TimeSpan.FromMinutes(new Random().Next()));
+            hostAssignmentContext.Environment = new Dictionary<string, string>();
+            hostAssignmentContext.MSIContext = new MSIContext();
+            hostAssignmentContext.EncryptedTokenServiceSpecializationPayload = "payload";
+            hostAssignmentContext.TokenServiceApiEndpoint = "endpoints";
+            hostAssignmentContext.CorsSettings = new CorsSettings();
+            hostAssignmentContext.EasyAuthSettings = new EasyAuthSettings();
+            hostAssignmentContext.Secrets = new FunctionAppSecrets();
+            hostAssignmentContext.IsWarmupRequest = false;
+
+            return hostAssignmentContext;
         }
     }
 }


### PR DESCRIPTION
… cv1

Using auth to decrypt signature for encrypted context and adding the container name as the valid audience for cv1 containers

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
