### PR TITLE
making yarp a private assembly

### DIFF
--- a/src/WebJobs.Script/runtimeassemblies.json
+++ b/src/WebJobs.Script/runtimeassemblies.json
@@ -1598,6 +1598,10 @@
     {
       "name": "WindowsBase",
       "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
+      "name": "Yarp.ReverseProxy",
+      "resolutionPolicy": "private"
     }
   ]
 }


### PR DESCRIPTION
This makes it less problematic for functions and bindings to reference Yarp themselves.