### PR TITLE
Add more information to extension validation error messages

### DIFF
--- a/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs
+++ b/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs
@@ -268,10 +268,11 @@ namespace Microsoft.Azure.WebJobs.Script.DependencyInjection
         {
             var errors = new List<string>();
 
-            void CollectError(Type extensionType, Version minimumVersion, ExtensionStartupTypeRequirement requirement)
+            void CollectError(Type extensionType, Version minimumVersion, Version actualVersion, ExtensionStartupTypeRequirement requirement, bool isAssemblyVersion)
             {
-                _logger.MinimumExtensionVersionNotSatisfied(extensionType.Name, extensionType.Assembly.FullName, minimumVersion, requirement.PackageName, requirement.MinimumPackageVersion);
-                string requirementNotMetError = $"ExtensionStartupType {extensionType.Name} from assembly '{extensionType.Assembly.FullName}' does not meet the required minimum version of {minimumVersion}. Update your NuGet package reference for {requirement.PackageName} to {requirement.MinimumPackageVersion} or later.";
+                _logger.MinimumExtensionVersionNotSatisfied(extensionType.Name, extensionType.Assembly.FullName, minimumVersion, actualVersion, requirement.PackageName, requirement.MinimumPackageVersion);
+                string versionType = isAssemblyVersion ? "assembly" : "file";
+                string requirementNotMetError = $"ExtensionStartupType {extensionType.Name} from assembly '{extensionType.Assembly.FullName}' has {versionType} version {actualVersion} which does not meet the required minimum version of {minimumVersion}. Update your NuGet package reference for {requirement.PackageName} to {requirement.MinimumPackageVersion} or later.";
                 errors.Add(requirementNotMetError);
             }
 
@@ -300,7 +301,7 @@ namespace Microsoft.Azure.WebJobs.Script.DependencyInjection
                             Version extensionAssemblyFileVersion = new Version(System.Diagnostics.FileVersionInfo.GetVersionInfo(extensionType.Assembly.Location).FileVersion);
                             if (extensionAssemblyFileVersion < minimumAssemblyFileVersion)
                             {
-                                CollectError(extensionType, minimumAssemblyFileVersion, requirement);
+                                CollectError(extensionType, minimumAssemblyFileVersion, extensionAssemblyFileVersion, requirement, isAssemblyVersion: true);
                                 continue;
                             }
                         }
@@ -313,7 +314,7 @@ namespace Microsoft.Azure.WebJobs.Script.DependencyInjection
 
                     if (extensionAssemblyVersion < minimumAssemblyVersion)
                     {
-                        CollectError(extensionType, minimumAssemblyVersion, requirement);
+                        CollectError(extensionType, minimumAssemblyVersion, extensionAssemblyVersion, requirement, isAssemblyVersion: false);
                     }
                 }
             }

--- a/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
+++ b/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
@@ -171,11 +171,11 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
                 new EventId(335, nameof(ScriptStartupResettingLoadContextWithBasePath)),
                 "Script Startup resetting load context with base path: '{path}'.");
 
-        private static readonly Action<ILogger, string, string, Version, string, string, Exception> _minimumExtensionVersionNotSatisfied =
-            LoggerMessage.Define<string, string, Version, string, string>(
+        private static readonly Action<ILogger, string, string, Version, Version, string, string, Exception> _minimumExtensionVersionNotSatisfied =
+            LoggerMessage.Define<string, string, Version, Version, string, string>(
             LogLevel.Error,
             new EventId(334, nameof(MinimumExtensionVersionNotSatisfied)),
-            "ExtensionStartupType {extensionTypeName} from assembly '{extensionTypeAssemblyFullName}' does not meet the required minimum version of {minimumAssemblyVersion}. Update your NuGet package reference for {requirementPackageName} to {requirementMinimumPackageVersion} or later.");
+            "ExtensionStartupType {extensionTypeName} from assembly '{extensionTypeAssemblyFullName}' has version {actualVersion} which does not meet the required minimum version of {minimumAssemblyVersion}. Update your NuGet package reference for {requirementPackageName} to {requirementMinimumPackageVersion} or later.");
 
         private static readonly Action<ILogger, string, string, string, string, Exception> _minimumBundleVersionNotSatisfied =
             LoggerMessage.Define<string, string, string, string>(
@@ -350,9 +350,9 @@ Lock file hash: {currentLockFileHash}";
             _incorrectAutorestGeneratedJSONFile(logger, contents, null);
         }
 
-        public static void MinimumExtensionVersionNotSatisfied(this ILogger logger, string extensionTypeName, string extensionTypeAssemblyFullName, Version minimumAssemblyVersion, string requirementPackageName, string requirementMinimumPackageVersion)
+        public static void MinimumExtensionVersionNotSatisfied(this ILogger logger, string extensionTypeName, string extensionTypeAssemblyFullName, Version minimumAssemblyVersion, Version actualVersion, string requirementPackageName, string requirementMinimumPackageVersion)
         {
-            _minimumExtensionVersionNotSatisfied(logger, extensionTypeName, extensionTypeAssemblyFullName, minimumAssemblyVersion, requirementPackageName, requirementMinimumPackageVersion, null);
+            _minimumExtensionVersionNotSatisfied(logger, extensionTypeName, extensionTypeAssemblyFullName, actualVersion, minimumAssemblyVersion, requirementPackageName, requirementMinimumPackageVersion, null);
         }
 
         public static void MinimumBundleVersionNotSatisfied(this ILogger logger, string bundleId, string bundleVersion, string minimumVersion)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

I'm currently investigating an IcM where a customer is receiving the following non-blocking exception in Application Insights:

"""
Error building configuration in an external startup class. One or more loaded extensions do not meet the minimum requirements. For more information see https://aka.ms/func-min-extension-versions.
ExtensionStartupType DurableTaskWebJobsStartup from assembly 'Microsoft.Azure.WebJobs.Extensions.DurableTask, Version=2.0.0.0, Culture=neutral, PublicKeyToken=014045d636e89289' does not meet the required minimum version of 2.4.1. Update your NuGet package reference for Microsoft.Azure.WebJobs.Extensions.DurableTask to 2.4.1 or later.
"""

As far as I can tell, the customer is using the latest DF Extension, so they should be passing this check. In order to help with future debugging, I want to augment this error message to include the version of the extension that's triggering this error. This PR does just that.

### Issue describing the changes in this PR

No such issue

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)