### PR TITLE
Fixing bug in Flex Consumption HostId generation in placeholder mode

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHostIdProvider.cs
+++ b/src/WebJobs.Script/Host/ScriptHostIdProvider.cs
@@ -54,13 +54,16 @@ namespace Microsoft.Azure.WebJobs.Script
             {
                 // in Flex Consumption, we use a Guid based host ID without truncation.
                 string uniqueSlotName = environment?.GetAzureWebsiteUniqueSlotName();
-                byte[] hash;
-                using (MD5 md5 = MD5.Create())
+                if (!string.IsNullOrEmpty(uniqueSlotName))
                 {
-                    hash = md5.ComputeHash(Encoding.UTF8.GetBytes(uniqueSlotName));
-                }
+                    byte[] hash;
+                    using (MD5 md5 = MD5.Create())
+                    {
+                        hash = md5.ComputeHash(Encoding.UTF8.GetBytes(uniqueSlotName));
+                    }
 
-                result.HostId = new Guid(hash).ToString().Replace("-", string.Empty).ToLowerInvariant();
+                    result.HostId = new Guid(hash).ToString().Replace("-", string.Empty).ToLowerInvariant();
+                }
 
                 return result;
             }

--- a/test/WebJobs.Script.Tests/ScriptHostIdProviderTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostIdProviderTests.cs
@@ -118,6 +118,47 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public void GetDefaultHostId_PlaceholderMode_ReturnsExpectedResult()
+        {
+            var options = new ScriptApplicationHostOptions
+            {
+                ScriptPath = @"c:\testscripts"
+            };
+
+            // In placeholder mode, site name and other settings aren't available to compute the
+            // default HostId, so we expect null.
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, "123123");
+
+            Assert.False(environment.IsFlexConsumptionSku());
+
+            var result = ScriptHostIdProvider.GetDefaultHostId(environment, options);
+
+            Assert.Equal(null, result.HostId);
+        }
+
+        [Fact]
+        public void GetDefaultHostId_PlaceholderMode_FlexConsumption_ReturnsExpectedResult()
+        {
+            var options = new ScriptApplicationHostOptions
+            {
+                ScriptPath = @"c:\testscripts"
+            };
+
+            // In placeholder mode, site name and other settings aren't available to compute the
+            // default HostId, so we expect null.
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "testContainer");
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.LegionServiceHost, "legionhost");
+
+            Assert.True(environment.IsFlexConsumptionSku());
+
+            var result = ScriptHostIdProvider.GetDefaultHostId(environment, options);
+
+            Assert.Equal(null, result.HostId);
+        }
+
+        [Fact]
         public void GetDefaultHostId_SelfHost_ReturnsExpectedResult()
         {
             var options = new ScriptApplicationHostOptions


### PR DESCRIPTION
I recently added a new HostId generation algorithm for Flex Consumption in https://github.com/Azure/azure-functions-host/pull/9157. However, there was a bug discovered in that logic. When in placeholder mode, site name used to calculate the ID won't be available.

For the fix, I'm following the behavior we have for other SKUs and return null if the values required for the ID aren't available.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
