### PR TITLE
Adding RestoreRawRequestPath middlware to restore the raw request path value to current request

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -16,3 +16,4 @@
     - Microsoft.IdentityModel.JsonWebTokens
     - Microsoft.IdentityModel.Logging
 - Updated Grpc.AspNetCore package to 2.55.0 (https://github.com/Azure/azure-functions-host/pull/9373)
+- Added RestoreRawRequestPath middleware to restore the raw un-decoded request path value to the current request (https://github.com/Azure/azure-functions-host/pull/9402)

--- a/src/WebJobs.Script.WebHost/Middleware/RestoreRawRequestPathMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/RestoreRawRequestPathMiddleware.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
+{
+    /// <summary>
+    /// Middleware to restore the raw request URL path received, in the current request URL.
+    /// App service front end decodes encoded strings in the request URL path.
+    /// This causes routing to fail if the route param value has %2F in it.
+    /// Refer below issues for more context:
+    /// https://github.com/dotnet/aspnetcore/issues/40532#issuecomment-1083562919
+    /// https://github.com/Azure/azure-functions-host/issues/9290.
+    /// </summary>
+    internal class RestoreRawRequestPathMiddleware
+    {
+        private readonly RequestDelegate _next;
+        internal const string UnEncodedUrlPathHeaderName = "X-Waws-Unencoded-Url";
+
+        public RestoreRawRequestPathMiddleware(RequestDelegate next)
+        {
+            _next = next ?? throw new ArgumentNullException(nameof(next));
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            if (context.Request.Headers.TryGetValue(UnEncodedUrlPathHeaderName, out var unencodedUrlValue) &&
+                unencodedUrlValue.Count > 0)
+            {
+                context.Request.Path = new PathString(unencodedUrlValue.First());
+            }
+
+            await _next(context);
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             // Ensure the ClrOptimizationMiddleware is registered before all middleware
             builder.UseMiddleware<ClrOptimizationMiddleware>();
 
-            // Update the request URL path(which was altered by App service FE) to raw request path
+            // Update the request URL path (which was altered by App service FE) to raw request path
             // only if customer has opted in using the app setting.
             builder.UseWhen(
                 _ => string.Equals(

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -138,5 +138,8 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AppKind = "APP_KIND";
 
         public const string DrainOnApplicationStopping = "FUNCTIONS_ENABLE_DRAIN_ON_APP_STOPPING";
+
+        // Restore the raw request path from wire to the current request.
+        public const string RestoreRawRequestPathEnabled = "WEBSITE_RESTORE_RAW_REQUEST_PATH";
     }
 }

--- a/test/WebJobs.Script.Tests/Middleware/RestoreRawRequestPathMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Middleware/RestoreRawRequestPathMiddlewareTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Script.WebHost.Middleware;
+using Moq;
+using Xunit;
+
+public class RestoreRawRequestPathMiddlewareTests
+{
+    [Fact]
+    public async Task Invoke_WithUnencodedHeaderValue_SetsRequestPath()
+    {
+        // Arrange
+        const string unEncodedHeaderValue = "/cloud%2Fdevdiv";
+        const string requestPathValue = "/cloud/devdiv";
+        var context = CreateHttpContextWithHeader(requestPathValue, unEncodedHeaderValue);
+        var mockNext = new Mock<RequestDelegate>();
+        var middleware = new RestoreRawRequestPathMiddleware(mockNext.Object);
+        var originalPath = context.Request.Path;
+
+        // Act
+        await middleware.Invoke(context);
+
+        // Assert
+        Assert.NotEqual(new PathString(originalPath), context.Request.Path);
+        Assert.Equal(new PathString(unEncodedHeaderValue), context.Request.Path);
+        mockNext.Verify(next => next(context), Times.Once());
+    }
+
+    [Fact]
+    public async Task Invoke_WithoutUnencodedUrlHeader_DoesNotChangeRequestPath()
+    {
+        // Arrange
+        const string requestPathValue = "/cloud/devdiv";
+        var context = CreateHttpContextWithHeader(requestPathValue);
+        var mockNext = new Mock<RequestDelegate>();
+        var middleware = new RestoreRawRequestPathMiddleware(mockNext.Object);
+        var originalPath = context.Request.Path;
+
+        // Act
+        await middleware.Invoke(context);
+
+        // Assert
+        Assert.Equal(originalPath, context.Request.Path);
+        mockNext.Verify(next => next(context), Times.Once());
+    }
+
+    private static HttpContext CreateHttpContextWithHeader(string requestPathValue, string unEncodedHeaderValue = null)
+    {
+        var context = new DefaultHttpContext
+        {
+            Request =
+            {
+                Path = requestPathValue
+            }
+        };
+
+        if (unEncodedHeaderValue is not null)
+        {
+            context.Request.Headers[RestoreRawRequestPathMiddleware.UnEncodedUrlPathHeaderName] = unEncodedHeaderValue;
+        }
+
+        return context;
+    }
+}


### PR DESCRIPTION
Fixes #9290

The current behavior is caused by the App service front end decoding the encoded request path value before forwarding the request to the application (in this case functions host instance). When doing this, the front end stores the raw request path value it received and add it as a special request header.

Below are some relevant comments from other thread where this issue was discussed before.


> [crosenblatt](https://github.com/crosenblatt) commented [on Oct 14, 2022](https://github.com/dotnet/aspnetcore/issues/44461#issuecomment-1279296476)
Hi @ccromer - This behavior is present in App Service for backwards compatibility reasons. In order to get the raw bytes of the url exactly as they are received on the wire, you can use the header "X-Waws-Unencoded-Url".


and 

> [bradygaster](https://github.com/bradygaster) commented [on Mar 30, 2022](https://github.com/dotnet/aspnetcore/issues/40532#issuecomment-1083562919)
After corresponding with the service team, I learned that this is By Design: IIS FE's URL parse the request URL during proxying, so the URI will be modified (canonicalized and normalized).
>
>The work around is for the app to use the HTTP_X_WAWS_UNENCODED_URL server variable (a.k.a. X-WAWS-Unencoded-URL: header). This header contains the exact bytes as they were received from the wire.

The fix here is to use the `X-Waws-Unencoded-Url` header value which has the raw request path (un decoded) and update the request path with that so that the routing middleware can use that and route to the correct endpoint. I added a new middleware to do this. This is an opt-in feature customers needs to explicitly opt-in by setting the `WEBSITE_RESTORE_RAW_REQUEST_PATH` app setting.

[This ](https://github.com/dotnet/aspnetcore/issues/49454)issue is a minimal repro of the original issue.

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [x] #9403
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

