### PR TITLE
Changing CV2 Context Filename for Crash Recovery

### DIFF
--- a/src/WebJobs.Script.WebHost/ContainerManagement/LegionContainerInitializationHostedService.cs
+++ b/src/WebJobs.Script.WebHost/ContainerManagement/LegionContainerInitializationHostedService.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
 {
     public class LegionContainerInitializationHostedService : LinuxContainerInitializationHostedService
     {
-        private const string ContextFile = "Context.txt";
+        private const string ContextFile = "context.txt";
 
         private readonly IEnvironment _environment;
         private readonly ILogger _logger;

--- a/test/WebJobs.Script.Tests.Integration/ContainerManagement/LegionContainerInitializationHostedServiceTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ContainerManagement/LegionContainerInitializationHostedServiceTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ContainerManagement
     public class LegionContainerInitializationHostedServiceTests : IDisposable
     {
         private const string ContainerStartContextUri = "https://containerstartcontexturi";
-        private const string ContextFile = "Context.txt";
+        private const string ContextFile = "context.txt";
         private const string ContainerSpecializationContextPath = "/container-specialization-context";
         private readonly Mock<IInstanceManager> _instanceManagerMock;
         private readonly StartupContextProvider _startupContextProvider;


### PR DESCRIPTION
Renaming Context file name to match with Mesh
https://msazure.visualstudio.com/One/_git/AAPT-Antares-Functions-Docker/pullrequest/8330070?

### Issue describing the changes in this PR

resolves #9236

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

