### PR TITLE
sending an empty rpchttp to worker when proxying

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -17,3 +17,4 @@
     - Microsoft.IdentityModel.Logging
 - Updated Grpc.AspNetCore package to 2.55.0 (https://github.com/Azure/azure-functions-host/pull/9373)
 - Update protobuf file to v1.10.0 (https://github.com/Azure/azure-functions-host/pull/9405)
+- Send an empty RpcHttp payload if proxying the http request to the worker (https://github.com/Azure/azure-functions-host/pull/9415)


### PR DESCRIPTION
When http proxying is enabled, there's no need to send the http payload over grpc as well. This PR short-circuits the generation of the grpc payload and returns a static, empty RpcHttp object if we know we're proxying the request.

Note that we still send the entry in the dictionary that maps to the trigger -- but it's effectively a placeholder. This is just in case any worker depends on this entry being present.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
