### PR TITLE
Fix Blob Trigger Error

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,8 +2,6 @@
 <configuration>
   <packageSources>
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
-    <add key="azure_app_service" value="https://www.myget.org/F/azure-appservice/api/v3/index.json" />
-    <add key="azure_app_service_staging" value="https://www.myget.org/F/azure-appservice-staging/api/v2" />
     <add key="azure-appservice-test" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/azure-appservice-test%40Local/nuget/v3/index.json" />
     <add key="Microsoft.Azure.Functions.PowerShellWorker" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/Microsoft.Azure.Functions.PowerShellWorker/nuget/v3/index.json" />
     <add key="AzureFunctions@staging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctions%40staging/nuget/v3/index.json" />

--- a/src/WebJobs.Script/Extensions/FunctionMetadataExtensions.cs
+++ b/src/WebJobs.Script/Extensions/FunctionMetadataExtensions.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Azure.WebJobs.Script
                         return !string.Equals(token.ToString(), BlobEventGridSourceValue, StringComparison.OrdinalIgnoreCase);
                     }
                 }
+                return true;
             }
             return false;
         }

--- a/src/WebJobs.Script/Extensions/FunctionMetadataExtensions.cs
+++ b/src/WebJobs.Script/Extensions/FunctionMetadataExtensions.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Script
                     }
                 }
             }
-            return true;
+            return false;
         }
 
         public static string GetFunctionId(this FunctionMetadata metadata)

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var extensionsToInstall = GetExtensionsToInstall();
             if (extensionsToInstall != null && extensionsToInstall.Length > 0)
             {
-                TestFunctionHost.WriteNugetPackageSources(_copiedRootPath, "http://www.myget.org/F/azure-appservice/api/v2", "https://www.myget.org/F/azure-appservice-staging/api/v2", "https://api.nuget.org/v3/index.json");
+                TestFunctionHost.WriteNugetPackageSources(_copiedRootPath, "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json", "https://api.nuget.org/v3/index.json");
                 var options = new OptionsWrapper<ScriptJobHostOptions>(new ScriptJobHostOptions
                 {
                     RootScriptPath = _copiedRootPath

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -1453,6 +1453,39 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public void ValidateFunction_DoesntThrowForHttpTrigger_OnFlexConsumption()
+        {
+            var httpFunctions = new Dictionary<string, HttpTriggerAttribute>();
+            var name = "test";
+
+            BindingMetadata httpTriggerMetadata = BindingMetadata.Create(JObject.Parse("{\"type\": \"httpTrigger\",\"name\": \"req\",\"direction\": \"in\"}"));
+
+            var metadata = new FunctionMetadata();
+            metadata.Bindings.Add(httpTriggerMetadata);
+            var function = new Mock<FunctionDescriptor>(MockBehavior.Strict, name, null, metadata, null, null, null, null);
+            function.SetupGet(p => p.HttpTriggerAttribute).Returns(() => null);
+
+            TestEnvironment testEnvironment = new TestEnvironment();
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, ScriptConstants.FlexConsumptionSku);
+
+            var exception = Record.Exception(() =>
+            {
+                ScriptHost.ValidateFunction(function.Object, httpFunctions, testEnvironment);
+            });
+            Assert.Null(exception);
+
+            metadata.Bindings.Clear();
+
+            exception = Record.Exception(() =>
+            {
+                ScriptHost.ValidateFunction(function.Object, httpFunctions, testEnvironment);
+            });
+            Assert.Null(exception);
+
+            ScriptHost.ValidateFunction(function.Object, httpFunctions, testEnvironment);
+        }
+
+        [Fact]
         public async Task IsFunction_ReturnsExpectedResult()
         {
             var host = TestHelpers.GetDefaultHost(o =>


### PR DESCRIPTION
Fixing the issue in https://github.com/Azure/azure-functions-host/pull/9385
Http trigger apps are running into the error:
_The Flex Consumption SKU only supports EventGrid as the source for BlobTrigger functions. Please update function 'SimpleHttpRequest' to use EventGrid. For more information see https://aka.ms/blob-trigger-eg._

Issue seems like the check is defaulting to true which runs for all triggers

### Issue describing the changes in this PR

resolves #9386

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

