### PR TITLE
Improving error handling in SecretManager

### DIFF
--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
@@ -189,12 +189,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                         }
                         catch (Exception ex)
                         {
-                            _logger.LogDebug("Potential conflict, attempting to load function secrets for the second time.");
+                            _logger.LogDebug(ex, "Exception while generating function secrets. This can happen if another instance is also generating secrets. Attempting to read secrets again.");
                             secrets = await LoadFunctionSecretsAsync(functionName);
 
                             if (secrets == null)
                             {
-                                _logger.LogError(ex, "Failed to load function secrets on second attempt");
+                                _logger.LogError("Function secrets are still null on second attempt.");
                                 throw;
                             }
                         }

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
@@ -11,10 +11,13 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using DryIoc;
+using Microsoft.Azure.Web.DataProtection;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Properties;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using DataProtectionConstants = Microsoft.Azure.Web.DataProtection.Constants;
 
@@ -101,12 +104,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                         }
                         catch (Exception ex)
                         {
-                            _logger.LogDebug("Potential conflict, attempting to load host secrets for the second time.");
+                            _logger.LogDebug(ex, "Exception while generating host secrets. This can happen if another instance is also generating secrets. Attempting to read secrets again.");
                             hostSecrets = await LoadSecretsAsync<HostSecrets>();
 
                             if (hostSecrets == null)
                             {
-                                _logger.LogError(ex, "Failed to load host secrets on second attempt");
+                                _logger.LogError("Host secrets are still null on second attempt.");
                                 throw;
                             }
                         }

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                         }
                         catch (Exception ex)
                         {
-                            _logger.LogDebug("Trying again to ensure potential race condition is handled correctly");
+                            _logger.LogDebug("Potential conflict, attempting to load host secrets for the second time.");
                             hostSecrets = await LoadSecretsAsync<HostSecrets>();
 
                             if (hostSecrets == null)

--- a/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
@@ -448,6 +448,41 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
         }
 
         [Fact]
+        public async Task SecretsRepository_SimultaneousCreates_Throws_Conflict()
+        {
+            var mockValueConverterFactory = GetConverterFactoryMock(false, false);
+            var metricsLogger = new TestMetricsLogger();
+
+            // Test repository that will fail on WriteAsync() due to a conflict, but will replicate a success when LoadSecretsAsync() is called
+            // indicating that there was race condition
+            var testRepository = new TestSecretsRepository(true, true, true);
+            string testFunctionName = "host";
+
+            using (var secretManager = new SecretManager(testRepository, mockValueConverterFactory.Object, _logger, metricsLogger, _hostNameProvider, _startupContextProvider))
+            {
+                var tasks = new List<Task<HostSecretsInfo>>();
+                for (int i = 0; i < 2; i++)
+                {
+                    tasks.Add(secretManager.GetHostSecretsAsync());
+                }
+
+                // Ensure nothing is there.
+                HostSecrets secretsContent = await testRepository.ReadAsync(ScriptSecretsType.Host, testFunctionName) as HostSecrets;
+                Assert.Null(secretsContent);
+                await Task.WhenAll(tasks);
+
+                // verify all calls return the same result
+                var masterKey = tasks.First().Result.MasterKey;
+                var functionKey = tasks.First().Result.FunctionKeys.First();
+                Assert.True(tasks.Select(p => p.Result).All(q => q.MasterKey == masterKey));
+                Assert.True(tasks.Select(p => p.Result).All(q => q.FunctionKeys.First().Value == functionKey.Value));
+
+                // verify generated master and function keys are valid
+                tasks.Select(p => p.Result).All(q => ValidateHostSecrets(q));
+            }
+        }
+
+        [Fact]
         public async Task GetHostSecrets_WhenNoHostSecretFileExists_GeneratesSecretsAndPersistsFiles()
         {
             using (var directory = new TempDirectory())
@@ -532,7 +567,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
 
                 KeyOperationResult result;
 
-                ISecretsRepository repository = new TestSecretsRepository(false, true, HttpStatusCode.InternalServerError);
+                ISecretsRepository repository = new TestSecretsRepository(false, true, false, HttpStatusCode.InternalServerError);
                 using (var secretManager = CreateSecretManager(directory.Path, simulateWriteConversion: false, secretsRepository: repository))
                 {
                     try
@@ -1265,6 +1300,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             private Random _rand = new Random();
             private bool _enforceSerialWrites = false;
             private bool _forceWriteErrors = false;
+            private bool _shouldSuceedAfterFailing = false;
             private HttpStatusCode _httpstaus;
 
             public TestSecretsRepository(bool enforceSerialWrites)
@@ -1272,10 +1308,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                 _enforceSerialWrites = enforceSerialWrites;
             }
 
-            public TestSecretsRepository(bool enforceSerialWrites, bool forceWriteErrors, HttpStatusCode httpstaus = HttpStatusCode.InternalServerError)
+            public TestSecretsRepository(bool enforceSerialWrites, bool forceWriteErrors, bool shouldSucceedAfterFailing = false, HttpStatusCode httpstaus = HttpStatusCode.InternalServerError)
                 : this(enforceSerialWrites)
             {
                 _forceWriteErrors = forceWriteErrors;
+                _shouldSuceedAfterFailing = shouldSucceedAfterFailing;
                 _httpstaus = httpstaus;
             }
 
@@ -1319,6 +1356,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             {
                 if (_forceWriteErrors)
                 {
+                    // Replicate making the first write fail, but succeed on the second attempt
+                    if (_shouldSuceedAfterFailing)
+                    {
+                        await WriteAsyncHelper(type, functionName, secrets);
+                    }
                     throw new RequestFailedException((int)_httpstaus, "Error");
                 }
 
@@ -1327,6 +1369,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                     throw new Exception("Concurrent writes detected!");
                 }
 
+                await WriteAsyncHelper(type, functionName, secrets);
+            }
+
+            private async Task WriteAsyncHelper(ScriptSecretsType type, string functionName, ScriptSecrets secrets)
+            {
                 Interlocked.Increment(ref _writeCount);
 
                 await Task.Delay(_rand.Next(100, 300));


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
This PR improves error handling in the Secret manager so that if there's a race condition (ie multiple secret repositories are created, each try to create their own version of a secret, and whichever one actually creates it first succeeds and the rest error out). If an error happens with `WriteAsync`, we simply call `LoadSecretsAsync` first before failing and throwing an exception to make sure the issue is not a race condition

resolves #8731

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
