### PR TITLE
Extend http proxying timeout

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,20 +3,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-- Update Java Worker Version to [2.12.1](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.12.1)
-- Update Python Worker Version to [4.15.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.15.0)
-
-- Remove feature flag for http proxying (https://github.com/Azure/azure-functions-host/pull/9341)
-- Add error handling for http proxying failure scenarios (https://github.com/Azure/azure-functions-host/pull/9342)
-- Update PowerShell Worker 7.0 to 4.0.2850 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2850)
-- Update Node.js Worker Version to [3.8.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.8.0)
-- Identity dependencies updated to 6.31.0:
-    - Microsoft.IdentityModel.Tokens
-    - System.IdentityModel.Tokens.Jwt
-    - Microsoft.IdentityModel.Abstractions
-    - Microsoft.IdentityModel.JsonWebTokens
-    - Microsoft.IdentityModel.Logging
-- Updated Grpc.AspNetCore package to 2.55.0 (https://github.com/Azure/azure-functions-host/pull/9373)
-- Update protobuf file to v1.10.0 (https://github.com/Azure/azure-functions-host/pull/9405)
-- Send an empty RpcHttp payload if proxying the http request to the worker (https://github.com/Azure/azure-functions-host/pull/9415)
-- Add new Host to Worker RPC extensibility feature for out-of-proc workers. (https://github.com/Azure/azure-functions-host/pull/9292)
+- Increase timeout for http proxying requests [#9433](https://github.com/Azure/azure-functions-host/pull/9433)

--- a/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
+++ b/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
@@ -31,7 +31,10 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             };
 
             _messageInvoker = new HttpMessageInvoker(_handler);
-            _forwarderRequestConfig = new ForwarderRequestConfig();
+            _forwarderRequestConfig = new ForwarderRequestConfig
+            {
+                ActivityTimeout = TimeSpan.FromSeconds(230)
+            };
         }
 
         public void Dispose()

--- a/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
+++ b/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             _messageInvoker = new HttpMessageInvoker(_handler);
             _forwarderRequestConfig = new ForwarderRequestConfig
             {
-                ActivityTimeout = TimeSpan.FromSeconds(230)
+                ActivityTimeout = TimeSpan.FromSeconds(240)
             };
         }
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves [#1745 in dotnet worker](https://github.com/Azure/azure-functions-dotnet-worker/issues/1745).

Default yarp timeout is 100 seconds ([docs](https://microsoft.github.io/reverse-proxy/articles/http-client-config.html#httprequest)) which is shorter than the Antares default for HTTP requests (230s) so we need to set our own default value.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Filed an issue for http timeout test suite [here](https://github.com/Azure/azure-functions-host/issues/9438). 
