### PR TITLE
Revert python worker to 4.14.0

### DIFF
--- a/build/python.props
+++ b/build/python.props
@@ -1,5 +1,5 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.16.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.14.0" />
   </ItemGroup>
 </Project>

--- a/release_notes.md
+++ b/release_notes.md
@@ -5,7 +5,7 @@
 -->
 - Increase timeout for http proxying requests [#9433](https://github.com/Azure/azure-functions-host/pull/9433)
 
-- Update Python Worker Version to [4.16.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.16.0)
+- Update Python Worker Version to [4.14.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.14.0)
 - Update Java Worker Version to [2.12.1](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.12.1)
 - Update PowerShell Worker 7.0 to 4.0.2850 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2850)
 - Update Node.js Worker Version to [3.8.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.8.0)

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="appinsights.testlogger" Version="1.0.0" />
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.16.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.14.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Moq" Version="4.9.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
Revert python worker to 4.14 due to a bug in retry policy

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
