### PR TITLE
Improve host.json sanitization

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -21,3 +21,4 @@
 - Add new Host to Worker RPC extensibility feature for out-of-proc workers. (https://github.com/Azure/azure-functions-host/pull/9292)
 - Apply capabilities on environment reload (placeholder mode scenarios) (https://github.com/Azure/azure-functions-host/pull/9367)
 - Update PowerShell Worker 7.2 to 4.0.2890 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2890)
+- Improve host.json sanitization

--- a/src/WebJobs.Script/Sanitizer.cs
+++ b/src/WebJobs.Script/Sanitizer.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.WebJobs.Logging
     // Note: This file is shared between the WebJobs SDK and Script repos. Update both if changes are needed.
     internal static class Sanitizer
     {
-        private const string SecretReplacement = "[Hidden Credential]";
+        public const string SecretReplacement = "[Hidden Credential]";
         private static readonly char[] ValueTerminators = new char[] { '<', '"', '\'' };
 
         // List of keywords that should not be replaced with [Hidden Credential]

--- a/test/WebJobs.Script.Tests/Configuration/HostJsonFileConfigurationSourceTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/HostJsonFileConfigurationSourceTests.cs
@@ -161,11 +161,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                     'categoryFilter': {
                         'defaultLevel': 'Information'
                     },
+                    'applicationInsights': {
+                        'prop': 'Hey=AS1$@%#$%W-k2j"";SharedAccessKey=foo,Data Source=barzons,Server=bathouse""testing',
+                        'values': [ 'plain', 10, 'Password=hunter2' ],
+                        'sampleSettings': {
+                            'my-password': 'hunter2',
+                            'service_token': 'token',
+                            'StorageSas': 'access'
+                        }
+                    },
                     'prop': 'Hey=AS1$@%#$%W-k2j"";SharedAccessKey=foo,Data Source=barzons,Server=bathouse""testing',
                     'values': [ 'plain', 10, 'Password=hunter2' ],
                     'my-password': 'hunter2',
                     'service_token': 'token',
-                    'StorageSas': 'access'
+                    'StorageSas': 'access',
+                    'aSecret': { 'value1': 'value' }
                 },
                 'Values': {
                     'MyCustomValue': 'abc'
@@ -188,11 +198,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                     'categoryFilter': {
                         'defaultLevel': 'Information'
                     },
+                    'applicationInsights': {
+                        'prop': 'Hey=AS1$@%#$%W-k2j"";[Hidden Credential]""testing',
+                        'values': [ 'plain', 10, '[Hidden Credential]' ],
+                        'sampleSettings': {
+                            'my-password': '[Hidden Credential]',
+                            'service_token': '[Hidden Credential]',
+                            'StorageSas': '[Hidden Credential]'
+                        }
+                    },
                     'prop': 'Hey=AS1$@%#$%W-k2j"";[Hidden Credential]""testing',
                     'values': [ 'plain', 10, '[Hidden Credential]' ],
                     'my-password': '[Hidden Credential]',
                     'service_token': '[Hidden Credential]',
-                    'StorageSas': '[Hidden Credential]'
+                    'StorageSas': '[Hidden Credential]',
+                    'aSecret': '[Hidden Credential]'
                 }
             }";
 

--- a/test/WebJobs.Script.Tests/Configuration/HostJsonFileConfigurationSourceTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/HostJsonFileConfigurationSourceTests.cs
@@ -161,8 +161,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                     'categoryFilter': {
                         'defaultLevel': 'Information'
                     },
-                    'secret': 'Hey=AS1$@%#$%W-k2j"";SharedAccessKey=foo,Data Source=barzons,Server=bathouse""testing',
-                    'values': [ 'plain', 10, 'Password=hunter2' ]
+                    'prop': 'Hey=AS1$@%#$%W-k2j"";SharedAccessKey=foo,Data Source=barzons,Server=bathouse""testing',
+                    'values': [ 'plain', 10, 'Password=hunter2' ],
+                    'my-password': 'hunter2',
+                    'service_token': 'token',
+                    'StorageSas': 'access'
                 },
                 'Values': {
                     'MyCustomValue': 'abc'
@@ -185,8 +188,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                     'categoryFilter': {
                         'defaultLevel': 'Information'
                     },
-                    'secret': 'Hey=AS1$@%#$%W-k2j"";[Hidden Credential]""testing',
-                    'values': [ 'plain', 10, '[Hidden Credential]' ]
+                    'prop': 'Hey=AS1$@%#$%W-k2j"";[Hidden Credential]""testing',
+                    'values': [ 'plain', 10, '[Hidden Credential]' ],
+                    'my-password': '[Hidden Credential]',
+                    'service_token': '[Hidden Credential]',
+                    'StorageSas': '[Hidden Credential]'
                 }
             }";
 

--- a/test/WebJobs.Script.Tests/Configuration/HostJsonFileConfigurationSourceTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/HostJsonFileConfigurationSourceTests.cs
@@ -160,7 +160,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 'logging': {
                     'categoryFilter': {
                         'defaultLevel': 'Information'
-                    }
+                    },
+                    'secret': 'Hey=AS1$@%#$%W-k2j"";SharedAccessKey=foo,Data Source=barzons,Server=bathouse""testing',
+                    'values': [ 'plain', 10, 'Password=hunter2' ]
                 },
                 'Values': {
                     'MyCustomValue': 'abc'
@@ -182,7 +184,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 'logging': {
                     'categoryFilter': {
                         'defaultLevel': 'Information'
-                    }
+                    },
+                    'secret': 'Hey=AS1$@%#$%W-k2j"";[Hidden Credential]""testing',
+                    'values': [ 'plain', 10, '[Hidden Credential]' ]
                 }
             }";
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves internal issue

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This PR improves redaction of host.json contents. Typically, the sections we allow-list in the log should not contain creds (no json file should have them really), but some could be mistakenly checked in there.
