### PR TITLE
Reducing noise for metadata logging

### DIFF
--- a/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
+++ b/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
 
         private static readonly Action<ILogger, string, Exception> _readingFunctionMetadataFromProvider =
             LoggerMessage.Define<string>(LogLevel.Information,
-                new EventId(326, nameof(FunctionMetadataManagerLoadingFunctionsMetadata)),
+                new EventId(326, nameof(ReadingFunctionMetadataFromProvider)),
                 "Reading functions metadata ({provider})");
 
         private static readonly Action<ILogger, int, string, Exception> _functionsReturnedByProvider =
@@ -280,14 +280,14 @@ Lock file hash: {currentLockFileHash}";
             _functionMetadataManagerLoadingFunctionsMetadata(logger, null);
         }
 
-        public static void FunctionMetadataManagerFunctionsLoaded(this ILogger logger, int count)
-        {
-            _functionMetadataManagerFunctionsLoaded(logger, count, null);
-        }
-
         public static void ReadingFunctionMetadataFromProvider(this ILogger logger, string provider)
         {
             _readingFunctionMetadataFromProvider(logger, provider, null);
+        }
+
+        public static void FunctionMetadataManagerFunctionsLoaded(this ILogger logger, int count)
+        {
+            _functionMetadataManagerFunctionsLoaded(logger, count, null);
         }
 
         public static void FunctionsReturnedByProvider(this ILogger logger, int count, string provider)

--- a/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
+++ b/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
@@ -84,12 +84,12 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
         private static readonly Action<ILogger, Exception> _functionMetadataManagerLoadingFunctionsMetadata =
             LoggerMessage.Define(LogLevel.Information,
                 new EventId(314, nameof(FunctionMetadataManagerLoadingFunctionsMetadata)),
-                "Loading functions metadata");
+                "Loading functions metadata From FunctionMetadataManager");
 
         private static readonly Action<ILogger, int, Exception> _functionMetadataManagerFunctionsLoaded =
             LoggerMessage.Define<int>(LogLevel.Information,
                 new EventId(315, nameof(FunctionMetadataManagerFunctionsLoaded)),
-                "{count} functions loaded");
+                "{count} functions loaded from FunctionMetadataManager");
 
         private static readonly Action<ILogger, string, string, Exception> _autoRecoveringFileSystemWatcherFailureDetected =
             LoggerMessage.Define<string, string>(LogLevel.Warning,
@@ -121,15 +121,15 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
                 new EventId(325, nameof(ScriptStartUpLoadedExtension)),
                 "Loaded extension '{startupExtensionName}' ({startupExtensionVersion})");
 
-        private static readonly Action<ILogger, Exception> _functionMetadataProviderReadingMetadata =
-            LoggerMessage.Define(LogLevel.Information,
+        private static readonly Action<ILogger, string, Exception> _functionMetadataProviderReadingMetadata =
+            LoggerMessage.Define<string>(LogLevel.Information,
                 new EventId(326, nameof(FunctionMetadataManagerLoadingFunctionsMetadata)),
-                "Reading functions metadata");
+                "Reading functions metadata from {source}");
 
-        private static readonly Action<ILogger, int, Exception> _functionMetadataProviderFunctionsFound =
-            LoggerMessage.Define<int>(LogLevel.Information,
+        private static readonly Action<ILogger, int, string, Exception> _functionMetadataProviderFunctionsFound =
+            LoggerMessage.Define<int, string>(LogLevel.Information,
                 new EventId(327, nameof(FunctionMetadataManagerFunctionsLoaded)),
-                "{count} functions found");
+                "{count} functions found in {source}");
 
         private static readonly Action<ILogger, string, Guid, Exception> _customHandlerForwardingHttpTriggerInvocation =
             LoggerMessage.Define<string, Guid>(LogLevel.Debug,
@@ -182,6 +182,11 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
             LogLevel.Error,
             new EventId(335, nameof(MinimumBundleVersionNotSatisfied)),
             "Referenced bundle {bundleId} of version {bundleVersion} does not meet the required minimum version of {minimumVersion}. Update your extension bundle reference in host.json to reference {minimumVersion2} or later.");
+
+        private static readonly Action<ILogger, int, Exception> _functionMetadataProviderFunctionsFoundCustomProvider =
+            LoggerMessage.Define<int>(LogLevel.Information,
+            new EventId(336, nameof(FunctionMetadataManagerFunctionsLoaded)),
+            "{count} functions found in FunctionMetadataManager from custom provider");
 
         public static void ExtensionsManagerRestoring(this ILogger logger)
         {
@@ -285,14 +290,19 @@ Lock file hash: {currentLockFileHash}";
             _functionMetadataManagerFunctionsLoaded(logger, count, null);
         }
 
-        public static void FunctionMetadataProviderParsingFunctions(this ILogger logger)
+        public static void FunctionMetadataProviderParsingFunctions(this ILogger logger, string source)
         {
-            _functionMetadataProviderReadingMetadata(logger, null);
+            _functionMetadataProviderReadingMetadata(logger, source, null);
         }
 
-        public static void FunctionMetadataProviderFunctionFound(this ILogger logger, int count)
+        public static void FunctionMetadataProviderFunctionFound(this ILogger logger, int count, string source)
         {
-            _functionMetadataProviderFunctionsFound(logger, count, null);
+            _functionMetadataProviderFunctionsFound(logger, count, source, null);
+        }
+
+        public static void FunctionMetadataProviderFunctionFoundCustomProvider(this ILogger logger, int count)
+        {
+            _functionMetadataProviderFunctionsFoundCustomProvider(logger, count, null);
         }
 
         public static void AutoRecoveringFileSystemWatcherFailureDetected(this ILogger logger, string errorMessage, string path)

--- a/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
+++ b/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
@@ -86,9 +86,9 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
                 new EventId(314, nameof(FunctionMetadataManagerLoadingFunctionsMetadata)),
                 "Loading functions metadata");
 
-        private static readonly Action<ILogger, int, Exception> _functionMetadataProviderFunctionsLoaded =
+        private static readonly Action<ILogger, int, Exception> _functionMetadataManagerFunctionsLoaded =
             LoggerMessage.Define<int>(LogLevel.Information,
-                new EventId(315, nameof(FunctionsLoadedByProvider)),
+                new EventId(315, nameof(FunctionMetadataManagerFunctionsLoaded)),
                 "{count} functions loaded");
 
         private static readonly Action<ILogger, string, string, Exception> _autoRecoveringFileSystemWatcherFailureDetected =
@@ -280,12 +280,12 @@ Lock file hash: {currentLockFileHash}";
             _functionMetadataManagerLoadingFunctionsMetadata(logger, null);
         }
 
-        public static void FunctionsLoadedByProvider(this ILogger logger, int count)
+        public static void FunctionMetadataManagerFunctionsLoaded(this ILogger logger, int count)
         {
-            _functionMetadataProviderFunctionsLoaded(logger, count, null);
+            _functionMetadataManagerFunctionsLoaded(logger, count, null);
         }
 
-        public static void FunctionMetadataProviderParsingFunctions(this ILogger logger, string provider)
+        public static void ReadingFunctionMetadataFromProvider(this ILogger logger, string provider)
         {
             _readingFunctionMetadataFromProvider(logger, provider, null);
         }

--- a/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
+++ b/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
@@ -84,12 +84,12 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
         private static readonly Action<ILogger, Exception> _functionMetadataManagerLoadingFunctionsMetadata =
             LoggerMessage.Define(LogLevel.Information,
                 new EventId(314, nameof(FunctionMetadataManagerLoadingFunctionsMetadata)),
-                "Loading functions metadata From FunctionMetadataManager");
+                "Loading functions metadata");
 
         private static readonly Action<ILogger, int, Exception> _functionMetadataManagerFunctionsLoaded =
             LoggerMessage.Define<int>(LogLevel.Information,
                 new EventId(315, nameof(FunctionMetadataManagerFunctionsLoaded)),
-                "{count} functions loaded from FunctionMetadataManager");
+                "{count} functions loaded");
 
         private static readonly Action<ILogger, string, string, Exception> _autoRecoveringFileSystemWatcherFailureDetected =
             LoggerMessage.Define<string, string>(LogLevel.Warning,

--- a/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
+++ b/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
@@ -86,9 +86,9 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
                 new EventId(314, nameof(FunctionMetadataManagerLoadingFunctionsMetadata)),
                 "Loading functions metadata");
 
-        private static readonly Action<ILogger, int, Exception> _functionMetadataManagerFunctionsLoaded =
+        private static readonly Action<ILogger, int, Exception> _functionMetadataProviderFunctionsLoaded =
             LoggerMessage.Define<int>(LogLevel.Information,
-                new EventId(315, nameof(FunctionMetadataManagerFunctionsLoaded)),
+                new EventId(315, nameof(FunctionsLoadedByProvider)),
                 "{count} functions loaded");
 
         private static readonly Action<ILogger, string, string, Exception> _autoRecoveringFileSystemWatcherFailureDetected =
@@ -121,15 +121,15 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
                 new EventId(325, nameof(ScriptStartUpLoadedExtension)),
                 "Loaded extension '{startupExtensionName}' ({startupExtensionVersion})");
 
-        private static readonly Action<ILogger, string, Exception> _functionMetadataProviderReadingMetadata =
+        private static readonly Action<ILogger, string, Exception> _readingFunctionMetadataFromProvider =
             LoggerMessage.Define<string>(LogLevel.Information,
                 new EventId(326, nameof(FunctionMetadataManagerLoadingFunctionsMetadata)),
-                "Reading functions metadata from {source}");
+                "Reading functions metadata ({provider})");
 
-        private static readonly Action<ILogger, int, string, Exception> _functionMetadataProviderFunctionsFound =
+        private static readonly Action<ILogger, int, string, Exception> _functionsReturnedByProvider =
             LoggerMessage.Define<int, string>(LogLevel.Information,
-                new EventId(327, nameof(FunctionMetadataManagerFunctionsLoaded)),
-                "{count} functions found in {source}");
+                new EventId(327, nameof(FunctionsReturnedByProvider)),
+                "{count} functions found ({provider})");
 
         private static readonly Action<ILogger, string, Guid, Exception> _customHandlerForwardingHttpTriggerInvocation =
             LoggerMessage.Define<string, Guid>(LogLevel.Debug,
@@ -182,11 +182,6 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
             LogLevel.Error,
             new EventId(335, nameof(MinimumBundleVersionNotSatisfied)),
             "Referenced bundle {bundleId} of version {bundleVersion} does not meet the required minimum version of {minimumVersion}. Update your extension bundle reference in host.json to reference {minimumVersion2} or later.");
-
-        private static readonly Action<ILogger, int, Exception> _functionMetadataProviderFunctionsFoundCustomProvider =
-            LoggerMessage.Define<int>(LogLevel.Information,
-            new EventId(336, nameof(FunctionMetadataManagerFunctionsLoaded)),
-            "{count} functions found in FunctionMetadataManager from custom provider");
 
         public static void ExtensionsManagerRestoring(this ILogger logger)
         {
@@ -285,24 +280,19 @@ Lock file hash: {currentLockFileHash}";
             _functionMetadataManagerLoadingFunctionsMetadata(logger, null);
         }
 
-        public static void FunctionMetadataManagerFunctionsLoaded(this ILogger logger, int count)
+        public static void FunctionsLoadedByProvider(this ILogger logger, int count)
         {
-            _functionMetadataManagerFunctionsLoaded(logger, count, null);
+            _functionMetadataProviderFunctionsLoaded(logger, count, null);
         }
 
-        public static void FunctionMetadataProviderParsingFunctions(this ILogger logger, string source)
+        public static void FunctionMetadataProviderParsingFunctions(this ILogger logger, string provider)
         {
-            _functionMetadataProviderReadingMetadata(logger, source, null);
+            _readingFunctionMetadataFromProvider(logger, provider, null);
         }
 
-        public static void FunctionMetadataProviderFunctionFound(this ILogger logger, int count, string source)
+        public static void FunctionsReturnedByProvider(this ILogger logger, int count, string provider)
         {
-            _functionMetadataProviderFunctionsFound(logger, count, source, null);
-        }
-
-        public static void FunctionMetadataProviderFunctionFoundCustomProvider(this ILogger logger, int count)
-        {
-            _functionMetadataProviderFunctionsFoundCustomProvider(logger, count, null);
+            _functionsReturnedByProvider(logger, count, provider, null);
         }
 
         public static void AutoRecoveringFileSystemWatcherFailureDetected(this ILogger logger, string errorMessage, string path)

--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.WebJobs.Script
     public class FunctionMetadataManager : IFunctionMetadataManager
     {
         private const string _functionConfigurationErrorMessage = "Unable to determine the primary function script.Make sure atleast one script file is present.Try renaming your entry point script to 'run' or alternatively you can specify the name of the entry point script explicitly by adding a 'scriptFile' property to your function metadata.";
+        private const string _customProviderLog = "Custom";
         private readonly IServiceProvider _serviceProvider;
         private readonly ILoggerFactory _loggerFactory;
         private IFunctionMetadataProvider _functionMetadataProvider;
@@ -87,7 +88,7 @@ namespace Microsoft.Azure.WebJobs.Script
             if (forceRefresh || _servicesReset || _functionMetadataArray.IsDefaultOrEmpty)
             {
                 _functionMetadataArray = LoadFunctionMetadata(forceRefresh, includeCustomProviders, workerConfigs: workerConfigs);
-                _logger.FunctionMetadataManagerFunctionsLoaded(ApplyAllowList(_functionMetadataArray).Count());
+                _logger.FunctionsLoadedByProvider(ApplyAllowList(_functionMetadataArray).Count());
                 _servicesReset = false;
             }
 
@@ -228,7 +229,7 @@ namespace Microsoft.Azure.WebJobs.Script
             // This is used to make sure no duplicates are registered
             var distinctFunctionNames = new HashSet<string>(functionMetadataList.Select(m => m.Name));
 
-            _logger.FunctionMetadataProviderFunctionFoundCustomProvider(functionMetadataListArray.Length);
+            _logger.FunctionsReturnedByProvider(functionMetadataListArray.Length, _customProviderLog);
 
             foreach (var metadataArray in functionMetadataListArray)
             {

--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Script
     public class FunctionMetadataManager : IFunctionMetadataManager
     {
         private const string _functionConfigurationErrorMessage = "Unable to determine the primary function script.Make sure atleast one script file is present.Try renaming your entry point script to 'run' or alternatively you can specify the name of the entry point script explicitly by adding a 'scriptFile' property to your function metadata.";
-        private const string _customProviderLog = "Custom";
+        private const string _metadataProviderName = "Custom";
         private readonly IServiceProvider _serviceProvider;
         private readonly ILoggerFactory _loggerFactory;
         private IFunctionMetadataProvider _functionMetadataProvider;
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
         private void AddMetadataFromCustomProviders(IEnumerable<IFunctionProvider> functionProviders, List<FunctionMetadata> functionMetadataList)
         {
-            _logger.FunctionMetadataProviderParsingFunctions(nameof(FunctionMetadataManager));
+            _logger.FunctionMetadataProviderParsingFunctions(_metadataProviderName);
 
             var functionProviderTasks = new List<Task<ImmutableArray<FunctionMetadata>>>();
             foreach (var functionProvider in functionProviders)
@@ -229,7 +229,7 @@ namespace Microsoft.Azure.WebJobs.Script
             // This is used to make sure no duplicates are registered
             var distinctFunctionNames = new HashSet<string>(functionMetadataList.Select(m => m.Name));
 
-            _logger.FunctionsReturnedByProvider(functionMetadataListArray.Length, _customProviderLog);
+            _logger.FunctionsReturnedByProvider(functionMetadataListArray.Length, _metadataProviderName);
 
             foreach (var metadataArray in functionMetadataListArray)
             {

--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -87,7 +87,11 @@ namespace Microsoft.Azure.WebJobs.Script
             if (forceRefresh || _servicesReset || _functionMetadataArray.IsDefaultOrEmpty)
             {
                 _functionMetadataArray = LoadFunctionMetadata(forceRefresh, includeCustomProviders, workerConfigs: workerConfigs);
-                _logger.FunctionMetadataManagerFunctionsLoaded(ApplyAllowList(_functionMetadataArray).Count());
+                // The host and worker metadata are checked in parallel, so we don't want to emit this extra logging reading the metadata
+                if (!includeCustomProviders)
+                {
+                    _logger.FunctionMetadataManagerFunctionsLoaded(ApplyAllowList(_functionMetadataArray).Count());
+                }
                 _servicesReset = false;
             }
 

--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.WebJobs.Script
             if (forceRefresh || _servicesReset || _functionMetadataArray.IsDefaultOrEmpty)
             {
                 _functionMetadataArray = LoadFunctionMetadata(forceRefresh, includeCustomProviders, workerConfigs: workerConfigs);
-                _logger.FunctionsLoadedByProvider(ApplyAllowList(_functionMetadataArray).Count());
+                _logger.FunctionMetadataManagerFunctionsLoaded(ApplyAllowList(_functionMetadataArray).Count());
                 _servicesReset = false;
             }
 
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
         private void AddMetadataFromCustomProviders(IEnumerable<IFunctionProvider> functionProviders, List<FunctionMetadata> functionMetadataList)
         {
-            _logger.FunctionMetadataProviderParsingFunctions(_metadataProviderName);
+            _logger.ReadingFunctionMetadataFromProvider(_metadataProviderName);
 
             var functionProviderTasks = new List<Task<ImmutableArray<FunctionMetadata>>>();
             foreach (var functionProvider in functionProviders)

--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -87,11 +87,7 @@ namespace Microsoft.Azure.WebJobs.Script
             if (forceRefresh || _servicesReset || _functionMetadataArray.IsDefaultOrEmpty)
             {
                 _functionMetadataArray = LoadFunctionMetadata(forceRefresh, includeCustomProviders, workerConfigs: workerConfigs);
-                // The host and worker metadata are checked in parallel, so we don't want to emit this extra logging reading the metadata
-                if (!includeCustomProviders)
-                {
-                    _logger.FunctionMetadataManagerFunctionsLoaded(ApplyAllowList(_functionMetadataArray).Count());
-                }
+                _logger.FunctionMetadataManagerFunctionsLoaded(ApplyAllowList(_functionMetadataArray).Count());
                 _servicesReset = false;
             }
 
@@ -219,7 +215,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
         private void AddMetadataFromCustomProviders(IEnumerable<IFunctionProvider> functionProviders, List<FunctionMetadata> functionMetadataList)
         {
-            _logger.FunctionMetadataProviderParsingFunctions();
+            _logger.FunctionMetadataProviderParsingFunctions(nameof(FunctionMetadataManager));
 
             var functionProviderTasks = new List<Task<ImmutableArray<FunctionMetadata>>>();
             foreach (var functionProvider in functionProviders)
@@ -232,7 +228,7 @@ namespace Microsoft.Azure.WebJobs.Script
             // This is used to make sure no duplicates are registered
             var distinctFunctionNames = new HashSet<string>(functionMetadataList.Select(m => m.Name));
 
-            _logger.FunctionMetadataProviderFunctionFound(functionMetadataListArray.Length);
+            _logger.FunctionMetadataProviderFunctionFoundCustomProvider(functionMetadataListArray.Length);
 
             foreach (var metadataArray in functionMetadataListArray)
             {

--- a/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Script
 {
     internal class HostFunctionMetadataProvider : IHostFunctionMetadataProvider
     {
-        private const string _hostProviderLog = "Host";
+        private const string _metadataProviderName = "Host";
         private readonly IOptionsMonitor<ScriptApplicationHostOptions> _applicationHostOptions;
         private readonly IMetricsLogger _metricsLogger;
         private readonly Dictionary<string, ICollection<string>> _functionErrors = new Dictionary<string, ICollection<string>>();
@@ -48,9 +48,9 @@ namespace Microsoft.Azure.WebJobs.Script
 
             if (_functions.IsDefaultOrEmpty || forceRefresh)
             {
-                _logger.FunctionMetadataProviderParsingFunctions(_hostProviderLog);
+                _logger.FunctionMetadataProviderParsingFunctions(_metadataProviderName);
                 Collection<FunctionMetadata> functionMetadata = ReadFunctionsMetadata(workerConfigs);
-                _logger.FunctionsReturnedByProvider(functionMetadata.Count, _hostProviderLog);
+                _logger.FunctionsReturnedByProvider(functionMetadata.Count, _metadataProviderName);
                 _functions = functionMetadata.ToImmutableArray();
             }
 

--- a/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.WebJobs.Script
 {
     internal class HostFunctionMetadataProvider : IHostFunctionMetadataProvider
     {
+        private const string _hostProviderLog = "Host";
         private readonly IOptionsMonitor<ScriptApplicationHostOptions> _applicationHostOptions;
         private readonly IMetricsLogger _metricsLogger;
         private readonly Dictionary<string, ICollection<string>> _functionErrors = new Dictionary<string, ICollection<string>>();
@@ -47,9 +48,9 @@ namespace Microsoft.Azure.WebJobs.Script
 
             if (_functions.IsDefaultOrEmpty || forceRefresh)
             {
-                _logger.FunctionMetadataProviderParsingFunctions(nameof(HostFunctionMetadataProvider));
+                _logger.FunctionMetadataProviderParsingFunctions(_hostProviderLog);
                 Collection<FunctionMetadata> functionMetadata = ReadFunctionsMetadata(workerConfigs);
-                _logger.FunctionMetadataProviderFunctionFound(functionMetadata.Count, nameof(HostFunctionMetadataProvider));
+                _logger.FunctionsReturnedByProvider(functionMetadata.Count, _hostProviderLog);
                 _functions = functionMetadata.ToImmutableArray();
             }
 

--- a/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
             if (_functions.IsDefaultOrEmpty || forceRefresh)
             {
-                _logger.FunctionMetadataProviderParsingFunctions(_metadataProviderName);
+                _logger.ReadingFunctionMetadataFromProvider(_metadataProviderName);
                 Collection<FunctionMetadata> functionMetadata = ReadFunctionsMetadata(workerConfigs);
                 _logger.FunctionsReturnedByProvider(functionMetadata.Count, _metadataProviderName);
                 _functions = functionMetadata.ToImmutableArray();

--- a/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
@@ -47,9 +47,9 @@ namespace Microsoft.Azure.WebJobs.Script
 
             if (_functions.IsDefaultOrEmpty || forceRefresh)
             {
-                _logger.FunctionMetadataProviderParsingFunctions();
+                _logger.FunctionMetadataProviderParsingFunctions(nameof(HostFunctionMetadataProvider));
                 Collection<FunctionMetadata> functionMetadata = ReadFunctionsMetadata(workerConfigs);
-                _logger.FunctionMetadataProviderFunctionFound(functionMetadata.Count);
+                _logger.FunctionMetadataProviderFunctionFound(functionMetadata.Count, nameof(HostFunctionMetadataProvider));
                 _functions = functionMetadata.ToImmutableArray();
             }
 

--- a/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Script
 {
     internal class WorkerFunctionMetadataProvider : IWorkerFunctionMetadataProvider
     {
-        private const string _customProviderLog = "Worker";
+        private const string _metadataProviderName = "Worker";
         private readonly Dictionary<string, ICollection<string>> _functionErrors = new Dictionary<string, ICollection<string>>();
         private readonly IOptionsMonitor<ScriptApplicationHostOptions> _scriptOptions;
         private readonly ILogger _logger;
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script
             _logger.LogInformation("Fetching metadata for workerRuntime: {workerRuntime}", _workerRuntime);
 
             IEnumerable<FunctionMetadata> functions = new List<FunctionMetadata>();
-            _logger.ReadingFunctionMetadataFromProvider(_customProviderLog);
+            _logger.ReadingFunctionMetadataFromProvider(_metadataProviderName);
 
             if (_functions.IsDefaultOrEmpty || forceRefresh)
             {
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.WebJobs.Script
                             }
 
                             _functions = functions.ToImmutableArray();
-                            _logger.FunctionsReturnedByProvider(_functions.IsDefault ? 0 : _functions.Count(), _customProviderLog);
+                            _logger.FunctionsReturnedByProvider(_functions.IsDefault ? 0 : _functions.Count(), _metadataProviderName);
 
                             // Validate if the app has functions in legacy format and add in logs to inform about the mixed app
                             _ = Task.Delay(TimeSpan.FromMinutes(1)).ContinueWith(t => ValidateFunctionAppFormat(_scriptOptions.CurrentValue.ScriptPath, _logger, _environment));

--- a/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script
             _logger.LogInformation("Fetching metadata for workerRuntime: {workerRuntime}", _workerRuntime);
 
             IEnumerable<FunctionMetadata> functions = new List<FunctionMetadata>();
-            _logger.FunctionMetadataProviderParsingFunctions(_customProviderLog);
+            _logger.ReadingFunctionMetadataFromProvider(_customProviderLog);
 
             if (_functions.IsDefaultOrEmpty || forceRefresh)
             {

--- a/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Script
 {
     internal class WorkerFunctionMetadataProvider : IWorkerFunctionMetadataProvider
     {
-        private const string _workerFunctionMetadataProviderLog = "Worker";
+        private const string _customProviderLog = "Worker";
         private readonly Dictionary<string, ICollection<string>> _functionErrors = new Dictionary<string, ICollection<string>>();
         private readonly IOptionsMonitor<ScriptApplicationHostOptions> _scriptOptions;
         private readonly ILogger _logger;
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script
             _logger.LogInformation("Fetching metadata for workerRuntime: {workerRuntime}", _workerRuntime);
 
             IEnumerable<FunctionMetadata> functions = new List<FunctionMetadata>();
-            _logger.FunctionMetadataProviderParsingFunctions(_workerFunctionMetadataProviderLog);
+            _logger.FunctionMetadataProviderParsingFunctions(_customProviderLog);
 
             if (_functions.IsDefaultOrEmpty || forceRefresh)
             {
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.WebJobs.Script
                             }
 
                             _functions = functions.ToImmutableArray();
-                            _logger.FunctionsReturnedByProvider(_functions.IsDefault ? 0 : _functions.Count(), _workerFunctionMetadataProviderLog);
+                            _logger.FunctionsReturnedByProvider(_functions.IsDefault ? 0 : _functions.Count(), _customProviderLog);
 
                             // Validate if the app has functions in legacy format and add in logs to inform about the mixed app
                             _ = Task.Delay(TimeSpan.FromMinutes(1)).ContinueWith(t => ValidateFunctionAppFormat(_scriptOptions.CurrentValue.ScriptPath, _logger, _environment));

--- a/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.WebJobs.Script
 {
     internal class WorkerFunctionMetadataProvider : IWorkerFunctionMetadataProvider
     {
+        private const string _workerFunctionMetadataProviderLog = "Worker";
         private readonly Dictionary<string, ICollection<string>> _functionErrors = new Dictionary<string, ICollection<string>>();
         private readonly IOptionsMonitor<ScriptApplicationHostOptions> _scriptOptions;
         private readonly ILogger _logger;
@@ -50,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script
             _logger.LogInformation("Fetching metadata for workerRuntime: {workerRuntime}", _workerRuntime);
 
             IEnumerable<FunctionMetadata> functions = new List<FunctionMetadata>();
-            _logger.FunctionMetadataProviderParsingFunctions(nameof(WorkerFunctionMetadataProvider));
+            _logger.FunctionMetadataProviderParsingFunctions(_workerFunctionMetadataProviderLog);
 
             if (_functions.IsDefaultOrEmpty || forceRefresh)
             {
@@ -102,7 +103,7 @@ namespace Microsoft.Azure.WebJobs.Script
                             }
 
                             _functions = functions.ToImmutableArray();
-                            _logger.FunctionMetadataProviderFunctionFound(_functions.IsDefault ? 0 : _functions.Count(), nameof(WorkerFunctionMetadataProvider));
+                            _logger.FunctionsReturnedByProvider(_functions.IsDefault ? 0 : _functions.Count(), _workerFunctionMetadataProviderLog);
 
                             // Validate if the app has functions in legacy format and add in logs to inform about the mixed app
                             _ = Task.Delay(TimeSpan.FromMinutes(1)).ContinueWith(t => ValidateFunctionAppFormat(_scriptOptions.CurrentValue.ScriptPath, _logger, _environment));

--- a/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script
             _logger.LogInformation("Fetching metadata for workerRuntime: {workerRuntime}", _workerRuntime);
 
             IEnumerable<FunctionMetadata> functions = new List<FunctionMetadata>();
-            _logger.FunctionMetadataProviderParsingFunctions();
+            _logger.FunctionMetadataProviderParsingFunctions(nameof(WorkerFunctionMetadataProvider));
 
             if (_functions.IsDefaultOrEmpty || forceRefresh)
             {
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.WebJobs.Script
                             }
 
                             _functions = functions.ToImmutableArray();
-                            _logger.FunctionMetadataProviderFunctionFound(_functions.IsDefault ? 0 : _functions.Count());
+                            _logger.FunctionMetadataProviderFunctionFound(_functions.IsDefault ? 0 : _functions.Count(), nameof(WorkerFunctionMetadataProvider));
 
                             // Validate if the app has functions in legacy format and add in logs to inform about the mixed app
                             _ = Task.Delay(TimeSpan.FromMinutes(1)).ContinueWith(t => ValidateFunctionAppFormat(_scriptOptions.CurrentValue.ScriptPath, _logger, _environment));

--- a/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             // Assert logging traces print out as expected
             Assert.Equal(7, traces.Count);
-            Assert.Equal(2, traces.Count(t => t.FormattedMessage.Contains("Reading functions metadata (FunctionMetadataManager)")));
+            Assert.Equal(2, traces.Count(t => t.FormattedMessage.Contains("Reading functions metadata (Custom)")));
             Assert.Equal(2, traces.Count(t => t.FormattedMessage.Contains("1 functions found (Custom)")));
             Assert.Equal(1, traces.Count(t => t.FormattedMessage.Contains("1 functions loaded")));
             Assert.Equal(2, traces.Count(t => t.FormattedMessage.Contains("Loading functions metadata")));

--- a/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
@@ -169,8 +169,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             // Assert logging traces print out as expected
             Assert.Equal(7, traces.Count);
-            Assert.Equal(2, traces.Count(t => t.FormattedMessage.Contains("Reading functions metadata from FunctionMetadataManager")));
-            Assert.Equal(2, traces.Count(t => t.FormattedMessage.Contains("1 functions found in FunctionMetadataManager from custom provider")));
+            Assert.Equal(2, traces.Count(t => t.FormattedMessage.Contains("Reading functions metadata (FunctionMetadataManager)")));
+            Assert.Equal(2, traces.Count(t => t.FormattedMessage.Contains("1 functions found (Custom)")));
+            Assert.Equal(1, traces.Count(t => t.FormattedMessage.Contains("1 functions loaded")));
+            Assert.Equal(2, traces.Count(t => t.FormattedMessage.Contains("Loading functions metadata")));
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/HostFunctionMetadataProviderTests.cs
+++ b/test/WebJobs.Script.Tests/HostFunctionMetadataProviderTests.cs
@@ -10,7 +10,9 @@ using System.Linq;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.WebJobs.Script.Tests;
 using Moq;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -31,14 +33,24 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public void ReadFunctionMetadata_Succeeds()
         {
+            var testLoggerProvider = new TestLoggerProvider();
+            var loggerFactory = new LoggerFactory();
+            loggerFactory.AddProvider(testLoggerProvider);
+            var logger = loggerFactory.CreateLogger<HostFunctionMetadataProvider>();
             string functionsPath = Path.Combine(Environment.CurrentDirectory, @"..", "..", "..", "..", "..", "sample", "node");
             _scriptApplicationHostOptions.ScriptPath = functionsPath;
             var optionsMonitor = TestHelpers.CreateOptionsMonitor(_scriptApplicationHostOptions);
-            var metadataProvider = new HostFunctionMetadataProvider(optionsMonitor, NullLogger<HostFunctionMetadataProvider>.Instance, _testMetricsLogger, SystemEnvironment.Instance);
+            var metadataProvider = new HostFunctionMetadataProvider(optionsMonitor, logger, _testMetricsLogger, SystemEnvironment.Instance);
             var workerConfigs = TestHelpers.GetTestWorkerConfigs();
 
             Assert.Equal(18, metadataProvider.GetFunctionMetadataAsync(workerConfigs, SystemEnvironment.Instance, false).Result.Length);
+            var traces = testLoggerProvider.GetAllLogMessages();
             Assert.True(AreRequiredMetricsEmitted(_testMetricsLogger));
+
+            // Assert that the logs contain the expected messages
+            Assert.Equal(2, traces.Count);
+            Assert.Equal("Reading functions metadata from HostFunctionMetadataProvider", traces[0].FormattedMessage);
+            Assert.Equal("18 functions found in HostFunctionMetadataProvider", traces[1].FormattedMessage);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/HostFunctionMetadataProviderTests.cs
+++ b/test/WebJobs.Script.Tests/HostFunctionMetadataProviderTests.cs
@@ -49,8 +49,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             // Assert that the logs contain the expected messages
             Assert.Equal(2, traces.Count);
-            Assert.Equal("Reading functions metadata from HostFunctionMetadataProvider", traces[0].FormattedMessage);
-            Assert.Equal("18 functions found in HostFunctionMetadataProvider", traces[1].FormattedMessage);
+            Assert.Equal("Reading functions metadata (Host)", traces[0].FormattedMessage);
+            Assert.Equal("18 functions found (Host)", traces[1].FormattedMessage);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/WorkerFunctionMetadataProviderTests.cs
+++ b/test/WebJobs.Script.Tests/WorkerFunctionMetadataProviderTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.Logging;
 using Moq;
+using NuGet.ContentModel;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
@@ -161,6 +162,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
             });
 
+            var environment = SystemEnvironment.Instance;
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, "node");
+
             var workerFunctionMetadataProvider = new WorkerFunctionMetadataProvider(optionsMonitor, logger, SystemEnvironment.Instance, mockWebHostRpcWorkerChannelManager.Object);
             await workerFunctionMetadataProvider.GetFunctionMetadataAsync(workerConfigs, false);
 
@@ -169,6 +173,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             // Assert that the logs contain the expected messages
             Assert.Equal(2, traces.Count);
             Assert.Equal("Reading functions metadata (Worker)", traces[1].FormattedMessage);
+            Assert.Equal("Fetching metadata for workerRuntime: node", traces[0].FormattedMessage);
         }
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
The host and worker metadata providers can be checked in parallel due to `GetFunctionMetadata` being called in the `FunctionMetadataManager`. After stepping through the code, I saw that the function gets called twice, once when we set `includeCustomProviders` to false and the second time when `includeCustomProviders` is set to true. We don't want to log how many functions have been loaded after we log how many have been found.

Here's how the logging looked like before:

> [2023-07-25T23:22:43.607Z]  Loading functions metadata
> [2023-07-25T23:22:43.607Z] Reading functions metadata
> [2023-07-25T23:22:43.626Z] 1 functions found
> [2023-07-25T23:22:43.628Z] 0 functions loaded

And here is what the logging looks like now:

> [2023-07-25T23:22:43.607Z]  Loading functions metadata
> [2023-07-25T23:22:43.607Z] Reading functions metadata (Custom)
> [2023-07-25T23:22:43.626Z] Reading functions metadata (Custom)
> [2023-07-25T23:22:43.628Z] 0 functions loaded



resolves #9420 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
