### PR TITLE
Update maximum request content size limits

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,3 +5,4 @@
 -->
 - Increase timeout for http proxying requests [#9433](https://github.com/Azure/azure-functions-host/pull/9433)
 - Improve host.json sanitization
+- Increased maximum HTTP request content size to 210000000 Bytes (~200MB)

--- a/src/WebJobs.Script.WebHost/web.config
+++ b/src/WebJobs.Script.WebHost/web.config
@@ -16,7 +16,7 @@
     </httpProtocol>
     <security>
       <requestFiltering allowDoubleEscaping="true" removeServerHeader="true">
-        <requestLimits maxQueryString="4096" maxUrl="8192" maxAllowedContentLength="104857600"/>
+        <requestLimits maxQueryString="4096" maxUrl="8192" maxAllowedContentLength="210000000"/>
       </requestFiltering>
     </security>
   </system.webServer>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Updating request size limit to 210000000 bytes (~=200MB) to accommodate recent application requirements

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [x] Otherwise: Documentation change is required for https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger?tabs=python-v2%2Cin-process%2Cfunctionsv2&pivots=programming-language-csharp#limits
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

