### PR TITLE
fetching IsToolingConsoleJsonLogEntry earlier to break the debugging deadlock

### DIFF
--- a/src/WebJobs.Script/Workers/Http/HttpWorkerProcess.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpWorkerProcess.cs
@@ -31,8 +31,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
                                        IWorkerConsoleLogSource consoleLogSource,
                                        IEnvironment environment,
                                        IMetricsLogger metricsLogger,
-                                       IServiceProvider serviceProvider)
-            : base(eventManager, processRegistry, workerProcessLogger, consoleLogSource, metricsLogger, serviceProvider, httpWorkerOptions.Description.UseStdErrorStreamForErrorsOnly)
+                                       IServiceProvider serviceProvider,
+                                       ILoggerFactory loggerFactory)
+            : base(eventManager, processRegistry, workerProcessLogger, consoleLogSource, metricsLogger, serviceProvider, loggerFactory, httpWorkerOptions.Description.UseStdErrorStreamForErrorsOnly)
         {
             _processFactory = processFactory;
             _eventManager = eventManager;

--- a/src/WebJobs.Script/Workers/Http/HttpWorkerProcessFactory.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpWorkerProcessFactory.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
         public IWorkerProcess Create(string workerId, string scriptRootPath, HttpWorkerOptions httpWorkerOptions)
         {
             ILogger workerProcessLogger = _loggerFactory.CreateLogger($"Worker.HttpWorkerProcess.{workerId}");
-            return new HttpWorkerProcess(workerId, scriptRootPath, httpWorkerOptions, _eventManager, _workerProcessFactory, _processRegistry, workerProcessLogger, _consoleLogSource, _environment, _metricsLogger, _serviceProvider);
+            return new HttpWorkerProcess(workerId, scriptRootPath, httpWorkerOptions, _eventManager, _workerProcessFactory, _processRegistry, workerProcessLogger, _consoleLogSource, _environment, _metricsLogger, _serviceProvider, _loggerFactory);
         }
     }
 }

--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcess.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcess.cs
@@ -201,6 +201,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             {
                 _consoleLogSource?.Log(consoleLog);
             }
+
+            if (WorkerProcessUtilities.IsToolingConsoleJsonLogEntry(msg))
+            {
+                // log with the message prefix as coretools expects it.
+                _workerProcessLogger?.Log(level, msg);
+            }
         }
 
         internal abstract void HandleWorkerProcessExitError(WorkerProcessExitException langExc);

--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcessUtilities.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcessUtilities.cs
@@ -39,11 +39,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             return Regex.Replace(msg, WorkerConstants.LanguageWorkerConsoleLogPrefix, string.Empty, RegexOptions.IgnoreCase);
         }
 
-        public static bool IsToolingConsoleJsonLogEntry(ConsoleLog consoleLog)
-        {
-            return consoleLog.Message.StartsWith(WorkerConstants.ToolingConsoleLogPrefix, StringComparison.OrdinalIgnoreCase);
-        }
-
         public static bool IsToolingConsoleJsonLogEntry(string msg)
         {
             return msg.StartsWith(WorkerConstants.ToolingConsoleLogPrefix, StringComparison.OrdinalIgnoreCase);

--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcessUtilities.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcessUtilities.cs
@@ -43,5 +43,10 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         {
             return consoleLog.Message.StartsWith(WorkerConstants.ToolingConsoleLogPrefix, StringComparison.OrdinalIgnoreCase);
         }
+
+        public static bool IsToolingConsoleJsonLogEntry(string msg)
+        {
+            return msg.StartsWith(WorkerConstants.ToolingConsoleLogPrefix, StringComparison.OrdinalIgnoreCase);
+        }
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerProcess.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerProcess.cs
@@ -38,8 +38,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                                        IMetricsLogger metricsLogger,
                                        IServiceProvider serviceProvider,
                                        IOptions<FunctionsHostingConfigOptions> hostingConfigOptions,
-                                       IEnvironment environment)
-            : base(eventManager, processRegistry, workerProcessLogger, consoleLogSource, metricsLogger, serviceProvider, rpcWorkerConfig.Description.UseStdErrorStreamForErrorsOnly)
+                                       IEnvironment environment,
+                                       ILoggerFactory loggerFactory)
+            : base(eventManager, processRegistry, workerProcessLogger, consoleLogSource, metricsLogger, serviceProvider, loggerFactory, rpcWorkerConfig.Description.UseStdErrorStreamForErrorsOnly)
         {
             _runtime = runtime;
             _processFactory = processFactory;

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerProcessFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerProcessFactory.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public IWorkerProcess Create(string workerId, string runtime, string scriptRootPath, RpcWorkerConfig workerConfig)
         {
             ILogger workerProcessLogger = _loggerFactory.CreateLogger($"Worker.rpcWorkerProcess.{runtime}.{workerId}");
-            return new RpcWorkerProcess(runtime, workerId, scriptRootPath, _rpcServer.Uri, workerConfig, _eventManager, _workerProcessFactory, _processRegistry, workerProcessLogger, _consoleLogSource, _metricsLogger, _serviceProvider, _hostingConfigOptions, _environment);
+            return new RpcWorkerProcess(runtime, workerId, scriptRootPath, _rpcServer.Uri, workerConfig, _eventManager, _workerProcessFactory, _processRegistry, workerProcessLogger, _consoleLogSource, _metricsLogger, _serviceProvider, _hostingConfigOptions, _environment, _loggerFactory);
         }
     }
 }

--- a/src/WebJobs.Script/Workers/WorkerConsoleLogService.cs
+++ b/src/WebJobs.Script/Workers/WorkerConsoleLogService.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
     internal class WorkerConsoleLogService : IHostedService, IDisposable
     {
         private readonly ILogger _logger;
-        private readonly Lazy<ILogger> _toolingConsoleJsonLoggerLazy;
         private readonly IWorkerConsoleLogSource _source;
         private readonly CancellationTokenSource _cts = new CancellationTokenSource();
         private Task _processingTask;
@@ -28,14 +27,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
 
             _source = consoleLogSource ?? throw new ArgumentNullException(nameof(consoleLogSource));
             _logger = loggerFactory.CreateLogger(WorkerConstants.ConsoleLogCategoryName);
-            _toolingConsoleJsonLoggerLazy = new Lazy<ILogger>(() => loggerFactory.CreateLogger(WorkerConstants.ToolingConsoleLogCategoryName), isThreadSafe: true);
         }
 
         internal WorkerConsoleLogService(ILogger logger, Lazy<ILogger> toolingConsoleJsonLoggerLazy, IWorkerConsoleLogSource consoleLogSource)
         {
             _source = consoleLogSource ?? throw new ArgumentNullException(nameof(consoleLogSource));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            _toolingConsoleJsonLoggerLazy = toolingConsoleJsonLoggerLazy ?? throw new ArgumentNullException(nameof(toolingConsoleJsonLoggerLazy));
         }
 
         public Task StartAsync(CancellationToken cancellationToken)
@@ -62,16 +59,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
                 while (await source.OutputAvailableAsync(_cts.Token))
                 {
                     var consoleLog = await source.ReceiveAsync();
-
-                    if (WorkerProcessUtilities.IsToolingConsoleJsonLogEntry(consoleLog))
-                    {
-                        // log with the message prefix as coretools expects it.
-                        _toolingConsoleJsonLoggerLazy.Value.Log(consoleLog.Level, consoleLog.Message);
-                    }
-                    else
-                    {
-                        _logger.Log(consoleLog.Level, consoleLog.Message);
-                    }
+                    _logger.Log(consoleLog.Level, consoleLog.Message);
                 }
             }
             catch (OperationCanceledException)

--- a/src/WebJobs.Script/Workers/WorkerConsoleLogService.cs
+++ b/src/WebJobs.Script/Workers/WorkerConsoleLogService.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             _logger = loggerFactory.CreateLogger(WorkerConstants.ConsoleLogCategoryName);
         }
 
-        internal WorkerConsoleLogService(ILogger logger, Lazy<ILogger> toolingConsoleJsonLoggerLazy, IWorkerConsoleLogSource consoleLogSource)
+        internal WorkerConsoleLogService(ILogger logger, IWorkerConsoleLogSource consoleLogSource)
         {
             _source = consoleLogSource ?? throw new ArgumentNullException(nameof(consoleLogSource));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));

--- a/test/WebJobs.Script.Tests/Workers/Http/HttpWorkerProcessTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Http/HttpWorkerProcessTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
                 Arguments = new WorkerProcessArguments() { ExecutablePath = "test" },
                 Description = new HttpWorkerDescription()
                 {
-                   WorkingDirectory = @"c:\testDir"
+                    WorkingDirectory = @"c:\testDir"
                 }
             };
             _settingsManager = ScriptSettingsManager.Instance;
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
                 {
                     Assert.Equal(Environment.GetEnvironmentVariable(HttpWorkerConstants.PortEnvVarName), processEnvValue);
                 }
-                HttpWorkerProcess httpWorkerProcess = new HttpWorkerProcess(_testWorkerId, _rootScriptPath, _httpWorkerOptions, _mockEventManager.Object, _defaultWorkerProcessFactory, _processRegistry, _testLogger, _languageWorkerConsoleLogSource.Object, new TestEnvironment(), new TestMetricsLogger(), _serviceProviderMock.Object);
+                HttpWorkerProcess httpWorkerProcess = new HttpWorkerProcess(_testWorkerId, _rootScriptPath, _httpWorkerOptions, _mockEventManager.Object, _defaultWorkerProcessFactory, _processRegistry, _testLogger, _languageWorkerConsoleLogSource.Object, new TestEnvironment(), new TestMetricsLogger(), _serviceProviderMock.Object, new LoggerFactory());
                 Process childProcess = httpWorkerProcess.CreateWorkerProcess();
                 Assert.NotNull(childProcess.StartInfo.EnvironmentVariables);
                 Assert.Equal(childProcess.StartInfo.EnvironmentVariables[HttpWorkerConstants.PortEnvVarName], _workerPort.ToString());
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
         {
             TestEnvironment testEnvironment = new TestEnvironment();
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "TestContainer");
-            var mockHttpWorkerProcess = new HttpWorkerProcess(_testWorkerId, _rootScriptPath, _httpWorkerOptions, _mockEventManager.Object, _defaultWorkerProcessFactory, _processRegistry, _testLogger, _languageWorkerConsoleLogSource.Object, testEnvironment, new TestMetricsLogger(), _serviceProviderMock.Object);
+            var mockHttpWorkerProcess = new HttpWorkerProcess(_testWorkerId, _rootScriptPath, _httpWorkerOptions, _mockEventManager.Object, _defaultWorkerProcessFactory, _processRegistry, _testLogger, _languageWorkerConsoleLogSource.Object, testEnvironment, new TestMetricsLogger(), _serviceProviderMock.Object, new LoggerFactory());
             mockHttpWorkerProcess.CreateWorkerProcess();
             // Verify method invocation
             var testLogs = _testLogger.GetLogMessages();

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerProcessTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerProcessTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -57,7 +58,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 new TestMetricsLogger(),
                 serviceProviderMock.Object,
                 _functionsHostingConfigOptions,
-                testEnv);
+                testEnv,
+                new LoggerFactory());
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Workers/TestWorkerProcess.cs
+++ b/test/WebJobs.Script.Tests/Workers/TestWorkerProcess.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
 {
     internal class TestWorkerProcess : WorkerProcess
     {
-        internal TestWorkerProcess(IScriptEventManager eventManager, IProcessRegistry processRegistry, ILogger workerProcessLogger, IWorkerConsoleLogSource consoleLogSource, IMetricsLogger metricsLogger, IServiceProvider serviceProvider, bool useStdErrStreamForErrorsOnly = false)
-        : base(eventManager, processRegistry, workerProcessLogger, consoleLogSource, metricsLogger, serviceProvider, useStdErrStreamForErrorsOnly)
+        internal TestWorkerProcess(IScriptEventManager eventManager, IProcessRegistry processRegistry, ILogger workerProcessLogger, IWorkerConsoleLogSource consoleLogSource, IMetricsLogger metricsLogger, IServiceProvider serviceProvider, ILoggerFactory loggerFactory, bool useStdErrStreamForErrorsOnly = false)
+        : base(eventManager, processRegistry, workerProcessLogger, consoleLogSource, metricsLogger, serviceProvider, loggerFactory, useStdErrStreamForErrorsOnly)
         {
         }
 

--- a/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
@@ -5,9 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Castle.Core.Logging;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Extensions.Logging;
+using Microsoft.WebJobs.Script.Tests;
 using Moq;
 using Xunit;
 
@@ -15,20 +17,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
 {
     public class WorkerConsoleLogServiceTests
     {
-        private TestLogger _toolingConsoleTestLogger;
         private IScriptEventManager _eventManager;
         private IProcessRegistry _processRegistry;
         private TestLogger _testUserLogger = new TestLogger("Host.Function.Console");
         private TestLogger _testSystemLogger = new TestLogger("Worker.rpcWorkerProcess");
-        private Lazy<ILogger> _toolingConsoleJsonLoggerLazy;
         private WorkerConsoleLogService _workerConsoleLogService;
         private WorkerConsoleLogSource _workerConsoleLogSource;
         private Mock<IServiceProvider> _serviceProviderMock;
+        private static Microsoft.Extensions.Logging.ILogger _testLogger;
+        private static TestLoggerProvider _testLoggerProvider;
+        private static LoggerFactory _testLoggerFactory;
 
         public WorkerConsoleLogServiceTests()
         {
-            _toolingConsoleTestLogger = new TestLogger("Host.Function.ToolingConsoleLog");
-            _toolingConsoleJsonLoggerLazy = new Lazy<ILogger>(() => _toolingConsoleTestLogger, true);
+            _testLoggerProvider = new TestLoggerProvider();
+            _testLoggerFactory = new LoggerFactory();
+            _testLoggerFactory.AddProvider(_testLoggerProvider);
+            _testLogger = _testLoggerProvider.CreateLogger(WorkerConstants.ToolingConsoleLogCategoryName);
         }
 
         [Theory]
@@ -40,10 +45,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             _workerConsoleLogSource = new WorkerConsoleLogSource();
             _eventManager = new ScriptEventManager();
             _processRegistry = new EmptyProcessRegistry();
-            _workerConsoleLogService = new WorkerConsoleLogService(_testUserLogger, _toolingConsoleJsonLoggerLazy, _workerConsoleLogSource);
+            _workerConsoleLogService = new WorkerConsoleLogService(_testUserLogger, _workerConsoleLogSource);
             _serviceProviderMock = new Mock<IServiceProvider>(MockBehavior.Strict);
 
-            WorkerProcess workerProcess = new TestWorkerProcess(_eventManager, _processRegistry, _testSystemLogger, _workerConsoleLogSource, null, _serviceProviderMock.Object, new LoggerFactory(), useStdErrForErrorLogsOnly);
+            WorkerProcess workerProcess = new TestWorkerProcess(_eventManager, _processRegistry, _testSystemLogger, _workerConsoleLogSource, null, _serviceProviderMock.Object, _testLoggerFactory, useStdErrForErrorLogsOnly);
             workerProcess.ParseErrorMessageAndLog("Test Message No keyword");
             workerProcess.ParseErrorMessageAndLog("Test Error Message");
             workerProcess.ParseErrorMessageAndLog("Test Warning Message");
@@ -57,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             await _workerConsoleLogService.StopAsync(System.Threading.CancellationToken.None);
             var userLogs = _testUserLogger.GetLogMessages();
             var systemLogs = _testSystemLogger.GetLogMessages();
-            var toolingConsoleLogs = _toolingConsoleTestLogger.GetLogMessages();
+            var toolingConsoleLogs = _testLoggerProvider.GetAllLogMessages();
 
             // Assert
             Assert.Equal(3, userLogs.Count);

--- a/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             _workerConsoleLogService = new WorkerConsoleLogService(_testUserLogger, _toolingConsoleJsonLoggerLazy, _workerConsoleLogSource);
             _serviceProviderMock = new Mock<IServiceProvider>(MockBehavior.Strict);
 
-            WorkerProcess workerProcess = new TestWorkerProcess(_eventManager, _processRegistry, _testSystemLogger, _workerConsoleLogSource, null, _serviceProviderMock.Object, useStdErrForErrorLogsOnly);
+            WorkerProcess workerProcess = new TestWorkerProcess(_eventManager, _processRegistry, _testSystemLogger, _workerConsoleLogSource, null, _serviceProviderMock.Object, new LoggerFactory(), useStdErrForErrorLogsOnly);
             workerProcess.ParseErrorMessageAndLog("Test Message No keyword");
             workerProcess.ParseErrorMessageAndLog("Test Error Message");
             workerProcess.ParseErrorMessageAndLog("Test Warning Message");


### PR DESCRIPTION
Debugging isolated dotnet worker does not work with worker indexing enabled. This is because we have a deadlock.

- VS waits for json file to be written by core tools to attach a debugger
- core tools is waiting for worker console service to write logs
- Worker is waiting for debugger to attach in order to move on
- Webhost waits for response from the init / metadata response from the worker
- Worker service never starts as the metadata response has not been received yet.

This PR breaks the deadlock by logging message outside the context of worker service.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-dotnet-worker/issues/1818

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
