### PR TITLE
Sending command line args with functions- prefix to prevent conflicts

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -17,3 +17,4 @@
     gets properly initialized as the invocation buffers are not created - this leads to a "Did not find initialized workers" error.
 - Check if a blob container or table exists before trying to create it (#9555)
 - Limit dotnet-isolated specialization to 64 bit host process (#9548)
+- Sending command line arguments to language workers with `functions-` prefix to prevent conflicts (#9514)

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <PackageId>Microsoft.Azure.WebJobs.Script</PackageId>
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.21.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.0-preview805" />
+    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.39" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.0-beta.2-11957" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.0" />

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerContext.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerContext.cs
@@ -44,7 +44,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         public override string GetFormattedArguments()
         {
-            return $" --host {ServerUri.Host} --port {ServerUri.Port} --workerId {WorkerId} --requestId {RequestId} --grpcMaxMessageLength {MaxMessageLength}";
+            // We are adding a second copy of the commandline arguments with the FUNCTIONS_ prefix.
+            // Once all workers starts using the new parameters, we can retire the old ones.
+            // Tracking item: https://github.com/Azure/azure-functions-host/issues/9504
+
+            return $" --host {ServerUri.Host} --port {ServerUri.Port} --workerId {WorkerId} --requestId {RequestId} --grpcMaxMessageLength {MaxMessageLength} --FUNCTIONS_HOST {ServerUri.Host} --FUNCTIONS_PORT {ServerUri.Port} --FUNCTIONS_WORKERID {WorkerId} --requestId {RequestId} --FUNCTIONS_GRPCMAXMESSAGELENGTH {MaxMessageLength}";
         }
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerContext.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerContext.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             // Adding a second copy of the commandline arguments with the "functions-" prefix to prevent any conflicts caused by the existing generic names.
             // Language workers are advised to use the "functions-" prefix ones and if not present fallback to existing ones.
 
-            return $" --host {ServerUri.Host} --port {ServerUri.Port} --workerId {WorkerId} --requestId {RequestId} --grpcMaxMessageLength {MaxMessageLength} --functions-uri {ServerUri.AbsoluteUri} --functions-workerid {WorkerId} --functions-requestid {RequestId} --functions-grpcmaxmessagelength {MaxMessageLength}";
+            return $" --host {ServerUri.Host} --port {ServerUri.Port} --workerId {WorkerId} --requestId {RequestId} --grpcMaxMessageLength {MaxMessageLength} --functions-uri {ServerUri.AbsoluteUri} --functions-worker-id {WorkerId} --functions-request-id {RequestId} --functions-grpc-max-message-length {MaxMessageLength}";
         }
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerContext.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerContext.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             // Adding a second copy of the commandline arguments with the FUNCTIONS_ prefix to prevent any conflicts caused by the existing generic names(ex:HOST).
             // Language workers are advised to use the FUNCTIONS_ prefix ones and if not present fallback to existing ones.
 
-            return $" --host {ServerUri.Host} --port {ServerUri.Port} --workerId {WorkerId} --requestId {RequestId} --grpcMaxMessageLength {MaxMessageLength} --FUNCTIONS_HOST {ServerUri.Host} --FUNCTIONS_PORT {ServerUri.Port} --FUNCTIONS_WORKERID {WorkerId} --requestId {RequestId} --FUNCTIONS_GRPCMAXMESSAGELENGTH {MaxMessageLength}";
+            return $" --host {ServerUri.Host} --port {ServerUri.Port} --workerId {WorkerId} --requestId {RequestId} --grpcMaxMessageLength {MaxMessageLength} --FUNCTIONS_HOST {ServerUri.Host} --FUNCTIONS_PORT {ServerUri.Port} --FUNCTIONS_WORKERID {WorkerId} --FUNCTIONS_REQUESTID {RequestId} --FUNCTIONS_GRPCMAXMESSAGELENGTH {MaxMessageLength}";
         }
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerContext.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerContext.cs
@@ -44,9 +44,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         public override string GetFormattedArguments()
         {
-            // We are adding a second copy of the commandline arguments with the FUNCTIONS_ prefix.
-            // Once all workers starts using the new parameters, we can retire the old ones.
-            // Tracking item: https://github.com/Azure/azure-functions-host/issues/9504
+            // Adding a second copy of the commandline arguments with the FUNCTIONS_ prefix to prevent any conflicts caused by the existing generic names(ex:HOST).
+            // Language workers are advised to use the FUNCTIONS_ prefix ones and if not present fallback to existing ones.
 
             return $" --host {ServerUri.Host} --port {ServerUri.Port} --workerId {WorkerId} --requestId {RequestId} --grpcMaxMessageLength {MaxMessageLength} --FUNCTIONS_HOST {ServerUri.Host} --FUNCTIONS_PORT {ServerUri.Port} --FUNCTIONS_WORKERID {WorkerId} --requestId {RequestId} --FUNCTIONS_GRPCMAXMESSAGELENGTH {MaxMessageLength}";
         }

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerContext.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerContext.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             // Adding a second copy of the commandline arguments with the "functions-" prefix to prevent any conflicts caused by the existing generic names.
             // Language workers are advised to use the "functions-" prefix ones and if not present fallback to existing ones.
 
-            return $" --host {ServerUri.Host} --port {ServerUri.Port} --workerId {WorkerId} --requestId {RequestId} --grpcMaxMessageLength {MaxMessageLength} --functions-uri {ServerUri.AbsoluteUri.TrimEnd('/')}:{ServerUri.Port} --functions-workerid {WorkerId} --functions-requestid {RequestId} --functions-grpcmaxmessagelength {MaxMessageLength}";
+            return $" --host {ServerUri.Host} --port {ServerUri.Port} --workerId {WorkerId} --requestId {RequestId} --grpcMaxMessageLength {MaxMessageLength} --functions-uri {ServerUri.AbsoluteUri} --functions-workerid {WorkerId} --functions-requestid {RequestId} --functions-grpcmaxmessagelength {MaxMessageLength}";
         }
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerContext.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerContext.cs
@@ -44,10 +44,10 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         public override string GetFormattedArguments()
         {
-            // Adding a second copy of the commandline arguments with the FUNCTIONS_ prefix to prevent any conflicts caused by the existing generic names(ex:HOST).
-            // Language workers are advised to use the FUNCTIONS_ prefix ones and if not present fallback to existing ones.
+            // Adding a second copy of the commandline arguments with the "functions-" prefix to prevent any conflicts caused by the existing generic names.
+            // Language workers are advised to use the "functions-" prefix ones and if not present fallback to existing ones.
 
-            return $" --host {ServerUri.Host} --port {ServerUri.Port} --workerId {WorkerId} --requestId {RequestId} --grpcMaxMessageLength {MaxMessageLength} --FUNCTIONS_HOST {ServerUri.Host} --FUNCTIONS_PORT {ServerUri.Port} --FUNCTIONS_WORKERID {WorkerId} --FUNCTIONS_REQUESTID {RequestId} --FUNCTIONS_GRPCMAXMESSAGELENGTH {MaxMessageLength}";
+            return $" --host {ServerUri.Host} --port {ServerUri.Port} --workerId {WorkerId} --requestId {RequestId} --grpcMaxMessageLength {MaxMessageLength} --functions-uri {ServerUri.AbsoluteUri.TrimEnd('/')}:{ServerUri.Port} --functions-workerid {WorkerId} --functions-requestid {RequestId} --functions-grpcmaxmessagelength {MaxMessageLength}";
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/DefaultWorkerProcessFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/DefaultWorkerProcessFactoryTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             }
             if (workerContext is RpcWorkerContext)
             {
-                Assert.Equal(" httpvalue1 TestVal httpvalue2 --host localhost --port 80 --workerId testWorkerId --requestId testId --grpcMaxMessageLength 2147483647", childProcess.StartInfo.Arguments);
+                Assert.Equal(" httpvalue1 TestVal httpvalue2 --host localhost --port 80 --workerId testWorkerId --requestId testId --grpcMaxMessageLength 2147483647 --FUNCTIONS_HOST localhost --FUNCTIONS_PORT 80 --FUNCTIONS_WORKERID testWorkerId --FUNCTIONS_REQUESTID testId --FUNCTIONS_GRPCMAXMESSAGELENGTH 2147483647", childProcess.StartInfo.Arguments);
             }
             else
             {

--- a/test/WebJobs.Script.Tests/Workers/DefaultWorkerProcessFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/DefaultWorkerProcessFactoryTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             }
             if (workerContext is RpcWorkerContext)
             {
-                Assert.Equal(" httpvalue1 TestVal httpvalue2 --host localhost --port 80 --workerId testWorkerId --requestId testId --grpcMaxMessageLength 2147483647 --FUNCTIONS_HOST localhost --FUNCTIONS_PORT 80 --FUNCTIONS_WORKERID testWorkerId --FUNCTIONS_REQUESTID testId --FUNCTIONS_GRPCMAXMESSAGELENGTH 2147483647", childProcess.StartInfo.Arguments);
+                Assert.Equal(" httpvalue1 TestVal httpvalue2 --host localhost --port 80 --workerId testWorkerId --requestId testId --grpcMaxMessageLength 2147483647 --functions-uri http://localhost:80 --functions-workerid testWorkerId --functions-requestid testId --functions-grpcmaxmessagelength 2147483647", childProcess.StartInfo.Arguments);
             }
             else
             {

--- a/test/WebJobs.Script.Tests/Workers/DefaultWorkerProcessFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/DefaultWorkerProcessFactoryTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             }
             if (workerContext is RpcWorkerContext)
             {
-                Assert.Equal(" httpvalue1 TestVal httpvalue2 --host localhost --port 80 --workerId testWorkerId --requestId testId --grpcMaxMessageLength 2147483647 --functions-uri http://localhost:80 --functions-workerid testWorkerId --functions-requestid testId --functions-grpcmaxmessagelength 2147483647", childProcess.StartInfo.Arguments);
+                Assert.Equal(" httpvalue1 TestVal httpvalue2 --host localhost --port 80 --workerId testWorkerId --requestId testId --grpcMaxMessageLength 2147483647 --functions-uri http://localhost/ --functions-worker-id testWorkerId --functions-request-id testId --functions-grpc-max-message-length 2147483647", childProcess.StartInfo.Arguments);
             }
             else
             {


### PR DESCRIPTION
Fixes #9504

During initial testing, we identified 3 language workers were not able to handle the extra/new command line arguments sent to them. Fixed those on the language worker sides and host was updated to consume the new version of language worker nuget package with the fix.

1. PowerShell  - https://github.com/Azure/azure-functions-host/pull/9528
2. Java  - https://github.com/Azure/azure-functions-host/pull/9544
3. Python - https://github.com/Azure/azure-functions-host/pull/9556


### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
