### PR TITLE
Update WebJobsScriptHostService to remove hardcoded sleep during shut down

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -8,3 +8,4 @@
 - Increased maximum HTTP request content size to 210000000 Bytes (~200MB)
 - Update Node.js Worker Version to [3.8.1](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.8.1)
 - Update PowerShell 7.4 Worker Version to [4.0.2930](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2930)
+- Update WebJobsScriptHostService to remove hardcoded sleep during restart (#9520)

--- a/release_notes.md
+++ b/release_notes.md
@@ -8,4 +8,4 @@
 - Increased maximum HTTP request content size to 210000000 Bytes (~200MB)
 - Update Node.js Worker Version to [3.8.1](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.8.1)
 - Update PowerShell 7.4 Worker Version to [4.0.2930](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2930)
-- Update WebJobsScriptHostService to remove hardcoded sleep during restart (#9520)
+- Update WebJobsScriptHostService to remove hardcoded sleep during application shut down (#9520)

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -814,8 +814,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     {
                         _logger.LogDebug("Application Stopping: initiate drain mode");
                         drainModeManager.EnableDrainModeAsync(CancellationToken.None);
-                        // Workaround until https://github.com/Azure/azure-functions-host/issues/7188 is addressed.
-                        Thread.Sleep(TimeSpan.FromMinutes(10));
                     }
                 }
             });


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #8681

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

Antares does not rely on the flag `FUNCTIONS_ENABLE_DRAIN_ON_APP_STOPPING` – so we can safely assume that this code path is only used in LIMA. Speaking to the LIMA team we learnt that the time for sleep is inconsequential for the LIMA scenario and therefore should be safe to remove.