### PR TITLE
[v3.x] Update WebJobsScriptHostService to remove hardcoded sleep during shut down

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,3 +6,5 @@
 
 **Release sprint:** Sprint 146
 [ [bugs](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+146%22+label%3Abug+is%3Aclosed) | [features](https://github.com/Azure/azure-functions-host/issues?q=is%3Aissue+milestone%3A%22Functions+Sprint+146%22+label%3Afeature+is%3Aclosed) ]
+
+- Update WebJobsScriptHostService to remove hardcoded sleep during application shut down (#9521)

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -793,8 +793,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     {
                         _logger.LogDebug("Application Stopping: initiate drain mode");
                         drainModeManager.EnableDrainModeAsync(CancellationToken.None);
-                        // Workaround until https://github.com/Azure/azure-functions-host/issues/7188 is addressed.
-                        Thread.Sleep(TimeSpan.FromMinutes(10));
                     }
                 }
             });


### PR DESCRIPTION
Backport of #9520 
