### PR TITLE
Improving Http log tracing (#1357)

### DIFF
--- a/src/WebJobs.Script.WebHost/Properties/Resources.Designer.cs
+++ b/src/WebJobs.Script.WebHost/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -80,10 +80,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Properties {
         
         /// <summary>
         ///   Looks up a localized string similar to Executed HTTP request: {{
-        ///  requestId: &quot;{mS_ActivityId}&quot;,
-        ///  identities: &quot;{identities}&quot;,
-        ///  status: &quot;{statusCode}&quot;,
-        ///  duration: &quot;{duration}&quot;
+        ///  &quot;requestId&quot;: &quot;{mS_ActivityId}&quot;,
+        ///  &quot;identities&quot;: &quot;{identities}&quot;,
+        ///  &quot;status&quot;: &quot;{statusCode}&quot;,
+        ///  &quot;duration&quot;: &quot;{duration}&quot;
         ///}}.
         /// </summary>
         internal static string ExecutedHttpRequest {
@@ -94,10 +94,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Properties {
         
         /// <summary>
         ///   Looks up a localized string similar to Executing HTTP request: {{
-        ///  requestId: &quot;{mS_ActivityId}&quot;,
-        ///  method: &quot;{httpMethod}&quot;,
-        ///  userAgent: &quot;{userAgent}&quot;,
-        ///  uri: &quot;{uri}&quot;
+        ///  &quot;requestId&quot;: &quot;{mS_ActivityId}&quot;,
+        ///  &quot;method&quot;: &quot;{httpMethod}&quot;,
+        ///  &quot;userAgent&quot;: &quot;{userAgent}&quot;,
+        ///  &quot;uri&quot;: &quot;{uri}&quot;
         ///}}.
         /// </summary>
         internal static string ExecutingHttpRequest {

--- a/src/WebJobs.Script.WebHost/Properties/Resources.resx
+++ b/src/WebJobs.Script.WebHost/Properties/Resources.resx
@@ -125,18 +125,18 @@
   </data>
   <data name="ExecutedHttpRequest" xml:space="preserve">
     <value>Executed HTTP request: {{
-  requestId: "{mS_ActivityId}",
-  identities: "{identities}",
-  status: "{statusCode}",
-  duration: "{duration}"
+  "requestId": "{mS_ActivityId}",
+  "identities": "{identities}",
+  "status": "{statusCode}",
+  "duration": "{duration}"
 }}</value>
   </data>
   <data name="ExecutingHttpRequest" xml:space="preserve">
     <value>Executing HTTP request: {{
-  requestId: "{mS_ActivityId}",
-  method: "{httpMethod}",
-  userAgent: "{userAgent}",
-  uri: "{uri}"
+  "requestId": "{mS_ActivityId}",
+  "method": "{httpMethod}",
+  "userAgent": "{userAgent}",
+  "uri": "{uri}"
 }}</value>
   </data>
   <data name="FunctionSecretsSchemaV0" xml:space="preserve">

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -354,7 +354,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public string GetLog() => string.Join(Environment.NewLine, GetScriptHostLogMessages().Concat(GetWebHostLogMessages()).OrderBy(m => m.Timestamp));
 
-        public void ClearLogMessages() => _scriptHostLoggerProvider.ClearAllLogMessages();
+        public void ClearLogMessages()
+        {
+            _webHostLoggerProvider.ClearAllLogMessages();
+            _scriptHostLoggerProvider.ClearAllLogMessages();
+        }
 
         public async Task BeginFunctionAsync(string functionName, JToken payload)
         {


### PR DESCRIPTION
These changes enable Http request correlation to function invocations via ActivityID/RequestID. This is done by ensuring that function invocation logs are also stamped with the ActivityID. Addresses https://github.com/Azure/azure-functions-host/issues/1357. Currently there's no foolproof way to do this correlation. 

As part of these changes, I'm also fixing a JSON formatting issue with our http logs. Currently they're not valid JSON meaning Kusto parse_json can't be used.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
* [ ] 