### PR TITLE
Ensure worker process is executable in linux consumption

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -11,3 +11,4 @@
 - Update PowerShell 7.4 Worker Version to [4.0.2975](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2975)
 - Update PowerShell 7.2 Worker Version to [4.0.2974](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2974)
 - Update PowerShell 7.0 Worker Version to [4.0.2973](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.2973)
+- Add support for standalone executable (ie: `dotnet build --standalone`) for out-of-proc workers in Linux Consumption.

--- a/src/WebJobs.Script/Workers/Http/HttpWorkerProcess.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpWorkerProcess.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Extensions.Logging;
-using Mono.Unix;
 
 namespace Microsoft.Azure.WebJobs.Script.Workers.Http
 {
@@ -19,7 +18,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
         private readonly string _scriptRootPath;
         private readonly string _workerId;
         private readonly WorkerProcessArguments _workerProcessArguments;
-        private readonly IEnvironment _environment;
 
         internal HttpWorkerProcess(string workerId,
                                        string rootScriptPath,
@@ -33,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
                                        IMetricsLogger metricsLogger,
                                        IServiceProvider serviceProvider,
                                        ILoggerFactory loggerFactory)
-            : base(eventManager, processRegistry, workerProcessLogger, consoleLogSource, metricsLogger, serviceProvider, loggerFactory, httpWorkerOptions.Description.UseStdErrorStreamForErrorsOnly)
+            : base(eventManager, processRegistry, workerProcessLogger, consoleLogSource, metricsLogger, serviceProvider, loggerFactory, environment, httpWorkerOptions.Description.UseStdErrorStreamForErrorsOnly)
         {
             _processFactory = processFactory;
             _eventManager = eventManager;
@@ -42,7 +40,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
             _scriptRootPath = rootScriptPath;
             _httpWorkerOptions = httpWorkerOptions;
             _workerProcessArguments = _httpWorkerOptions.Arguments;
-            _environment = environment;
         }
 
         internal override Process CreateWorkerProcess()
@@ -60,31 +57,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
             workerContext.EnvironmentVariables.Add(HttpWorkerConstants.CustomHandlerPortEnvVarName, _httpWorkerOptions.Port.ToString());
             workerContext.EnvironmentVariables.Add(HttpWorkerConstants.CustomHandlerWorkerIdEnvVarName, _workerId);
             workerContext.EnvironmentVariables.Add(HttpWorkerConstants.FunctionAppRootVarName, _scriptRootPath);
-            Process workerProcess = _processFactory.CreateWorkerProcess(workerContext);
-            if (_environment.IsAnyLinuxConsumption())
-            {
-                AssignUserExecutePermissionsIfNotExists(workerProcess.StartInfo.FileName);
-            }
-            return workerProcess;
-        }
 
-        private void AssignUserExecutePermissionsIfNotExists(string filePath)
-        {
-            try
-            {
-                UnixFileInfo fileInfo = new UnixFileInfo(filePath);
-                if (!fileInfo.FileAccessPermissions.HasFlag(FileAccessPermissions.UserExecute))
-                {
-                    _workerProcessLogger.LogDebug("Assigning execute permissions to file: {filePath}", filePath);
-                    fileInfo.FileAccessPermissions |= FileAccessPermissions.UserExecute |
-                                                      FileAccessPermissions.GroupExecute |
-                                                      FileAccessPermissions.OtherExecute;
-                }
-            }
-            catch (Exception ex)
-            {
-                _workerProcessLogger.LogWarning(ex, "Error while assigning execute permission.");
-            }
+            return _processFactory.CreateWorkerProcess(workerContext);
         }
 
         internal override void HandleWorkerProcessExitError(WorkerProcessExitException httpWorkerProcessExitException)

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerProcess.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerProcess.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                                        IOptions<FunctionsHostingConfigOptions> hostingConfigOptions,
                                        IEnvironment environment,
                                        ILoggerFactory loggerFactory)
-            : base(eventManager, processRegistry, workerProcessLogger, consoleLogSource, metricsLogger, serviceProvider, loggerFactory, rpcWorkerConfig.Description.UseStdErrorStreamForErrorsOnly)
+            : base(eventManager, processRegistry, workerProcessLogger, consoleLogSource, metricsLogger, serviceProvider, loggerFactory, environment, rpcWorkerConfig.Description.UseStdErrorStreamForErrorsOnly)
         {
             _runtime = runtime;
             _processFactory = processFactory;

--- a/test/WebJobs.Script.Tests/Workers/Http/HttpWorkerProcessTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Http/HttpWorkerProcessTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.Workers;
@@ -66,12 +67,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
         }
 
         [Fact]
-        public void CreateWorkerProcess_LinuxConsumption_AssingnsExecutePermissions_invoked()
+        public async Task StartProcess_LinuxConsumption_TriesToAssignExecutePermissions()
         {
             TestEnvironment testEnvironment = new TestEnvironment();
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "TestContainer");
             var mockHttpWorkerProcess = new HttpWorkerProcess(_testWorkerId, _rootScriptPath, _httpWorkerOptions, _mockEventManager.Object, _defaultWorkerProcessFactory, _processRegistry, _testLogger, _languageWorkerConsoleLogSource.Object, testEnvironment, new TestMetricsLogger(), _serviceProviderMock.Object, new LoggerFactory());
-            mockHttpWorkerProcess.CreateWorkerProcess();
+
+            try
+            {
+                await mockHttpWorkerProcess.StartProcessAsync();
+            }
+            catch
+            {
+                // expected to throw. Just verifying a log statement occured before then.
+            }
+
             // Verify method invocation
             var testLogs = _testLogger.GetLogMessages();
             Assert.Contains("Error while assigning execute permission", testLogs[0].FormattedMessage);

--- a/test/WebJobs.Script.Tests/Workers/TestWorkerProcess.cs
+++ b/test/WebJobs.Script.Tests/Workers/TestWorkerProcess.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
 {
     internal class TestWorkerProcess : WorkerProcess
     {
-        internal TestWorkerProcess(IScriptEventManager eventManager, IProcessRegistry processRegistry, ILogger workerProcessLogger, IWorkerConsoleLogSource consoleLogSource, IMetricsLogger metricsLogger, IServiceProvider serviceProvider, ILoggerFactory loggerFactory, bool useStdErrStreamForErrorsOnly = false)
-        : base(eventManager, processRegistry, workerProcessLogger, consoleLogSource, metricsLogger, serviceProvider, loggerFactory, useStdErrStreamForErrorsOnly)
+        internal TestWorkerProcess(IScriptEventManager eventManager, IProcessRegistry processRegistry, ILogger workerProcessLogger, IWorkerConsoleLogSource consoleLogSource, IMetricsLogger metricsLogger, IServiceProvider serviceProvider, ILoggerFactory loggerFactory, IEnvironment environment, bool useStdErrStreamForErrorsOnly = false)
+        : base(eventManager, processRegistry, workerProcessLogger, consoleLogSource, metricsLogger, serviceProvider, loggerFactory, environment, useStdErrStreamForErrorsOnly)
         {
         }
 

--- a/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/WorkerConsoleLogServiceTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             _workerConsoleLogService = new WorkerConsoleLogService(_testUserLogger, _workerConsoleLogSource);
             _serviceProviderMock = new Mock<IServiceProvider>(MockBehavior.Strict);
 
-            WorkerProcess workerProcess = new TestWorkerProcess(_eventManager, _processRegistry, _testSystemLogger, _workerConsoleLogSource, null, _serviceProviderMock.Object, _testLoggerFactory, useStdErrForErrorLogsOnly);
+            WorkerProcess workerProcess = new TestWorkerProcess(_eventManager, _processRegistry, _testSystemLogger, _workerConsoleLogSource, null, _serviceProviderMock.Object, _testLoggerFactory, Mock.Of<IEnvironment>(), useStdErrForErrorLogsOnly);
             workerProcess.ParseErrorMessageAndLog("Test Message No keyword");
             workerProcess.ParseErrorMessageAndLog("Test Error Message");
             workerProcess.ParseErrorMessageAndLog("Test Warning Message");


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #9522

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This PR moves the logic to ensure the worker process is executable from `HttpWorkerProcess` to the base-class `WorkerProcess`. This ensures both HTTP and RPC worker process implementations will work for linux consumption.
