### PR TITLE
Update FilePathToVfsUri so it works when filePath is not in "home" path

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/VirtualFileSystem.cs
+++ b/src/WebJobs.Script.WebHost/Management/VirtualFileSystem.cs
@@ -204,14 +204,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
         public static Uri FilePathToVfsUri(string filePath, string baseUrl, ScriptJobHostOptions config, bool isDirectory = false)
         {
-            var home = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                ? ScriptSettingsManager.Instance.GetSetting(EnvironmentSettingNames.AzureWebsiteHomePath) ?? config.RootScriptPath
-                : Path.DirectorySeparatorChar.ToString();
+            int lastSeparatorIndex = filePath.LastIndexOfAny(new char[] { '\\', '/' });
 
-            filePath = filePath
-                .Substring(home.Length)
-                .Trim('\\', '/')
-                .Replace("\\", "/");
+            if (lastSeparatorIndex != -1)
+            {
+                // Gets the last component of 'filePath' which should be the file or directory name.
+                filePath = filePath.Substring(lastSeparatorIndex + 1);
+            }
 
             return new Uri($"{baseUrl}/admin/vfs/{filePath}{(isDirectory ? "/" : string.Empty)}");
         }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

`filePath .Substring(home.Length).Trim('\\', '/').Replace("\\", "/");` throws an exception if `filePath` doesn't start with the as `home` path. This can sometimes happen with the TestData is not in the same place as the app e.g.:

a) home (script root) is: `"C:\\Users\\likasem\\apps\\dni-app\\bin\\Debug\\net7.0";`
b) test data path is: `"C:\\Users\\likasem\\AppData\\Local\\Temp\\FunctionsData\\HttpTrigger.dat"`

This fix makes it so that in all scenarios we are able to get the last part of the filePath so that we can extract the file or directory name.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests) (should be covered by existing tests)



