### PR TITLE
Limit dotnet-isolated specialization to 64 bit host process

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -16,3 +16,4 @@
   - This fixes a bug with worker indexing where we are shutting down worker channels and creating a new channel that never
     gets properly initialized as the invocation buffers are not created - this leads to a "Did not find initialized workers" error.
 - Check if a blob container or table exists before trying to create it (#9555)
+- Limit dotnet-isolated specialization to 64 bit host process (#9548)

--- a/src/WebJobs.Script/Environment/IEnvironment.cs
+++ b/src/WebJobs.Script/Environment/IEnvironment.cs
@@ -13,6 +13,11 @@ namespace Microsoft.Azure.WebJobs.Script
     public interface IEnvironment
     {
         /// <summary>
+        /// Gets a value indicating whether the current process is a 64-bit process.
+        /// </summary>
+        public bool Is64BitProcess { get; }
+
+        /// <summary>
         /// Returns the value of an environment variable for the current <see cref="IEnvironment"/>.
         /// </summary>
         /// <param name="name">The environment variable name.</param>
@@ -20,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Script
         string GetEnvironmentVariable(string name);
 
         /// <summary>
-        /// Creates, modifies, or deletes an environment variable stored in the current <see cref="IEnvironment"/>
+        /// Creates, modifies, or deletes an environment variable stored in the current <see cref="IEnvironment"/>.
         /// </summary>
         /// <param name="name">The environment variable name.</param>
         /// <param name="value">The value to assign to the variable.</param>

--- a/src/WebJobs.Script/Environment/SystemEnvironment.cs
+++ b/src/WebJobs.Script/Environment/SystemEnvironment.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public static SystemEnvironment Instance => _instance.Value;
 
+        public bool Is64BitProcess => Environment.Is64BitProcess;
+
         private static SystemEnvironment CreateInstance()
         {
             return new SystemEnvironment();

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
         /// <summary>
         /// Attempts to locate the extension bundle inside the probing paths and download paths. If the extension bundle is not found then it will download the extension bundle.
         /// </summary>
-        /// <returns>Path of the extension bundle</returns>
+        /// <returns>Path of the extension bundle.</returns>
         public async Task<string> GetExtensionBundlePath()
         {
             using (var httpClient = new HttpClient())
@@ -83,8 +83,8 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
         /// <summary>
         /// Attempts to locate the extension bundle inside the probing paths and download paths. If the extension bundle is not found then it will download the extension bundle.
         /// </summary>
-        /// <param name="httpClient">HttpClient used to download the extension bundle</param>
-        /// <returns>Path of the extension bundle</returns>
+        /// <param name="httpClient">HttpClient used to download the extension bundle.</param>
+        /// <returns>Path of the extension bundle.</returns>
         public async Task<string> GetExtensionBundlePath(HttpClient httpClient)
         {
             return await GetBundle(httpClient);

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -88,6 +88,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string DefaultMasterKeyName = "master";
         public const string DefaultFunctionKeyName = "default";
         public const string ColdStartEventName = "ColdStart";
+        public const string PlaceholderMissDueToBitnessEventName = "PlaceholderMissDueToBitness";
 
         public const string FunctionsUserAgent = "AzureFunctionsRuntime";
         public const string HttpScaleUserAgent = "HttpScaleManager";

--- a/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 // We support specialization of dotnet-isolated only on 64bit host process.
                 if (!_environment.Is64BitProcess)
                 {
-                    _logger.LogDebug("This app is configured as 32-bit and therefore does not leverage all performance optimizations. See https://aka.ms/azure-functions/dotnet/placeholders for more information.");
+                    _logger.LogInformation("This app is configured as 32-bit and therefore does not leverage all performance optimizations. See https://aka.ms/azure-functions/dotnet/placeholders for more information.");
                     return false;
                 }
 

--- a/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -184,7 +184,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 // We support specialization of dotnet-isolated only on 64bit host process.
                 if (!_environment.Is64BitProcess)
                 {
-                    _logger.LogInformation("This app is configured as 32-bit and therefore does not leverage all performance optimizations. See https://aka.ms/azure-functions/dotnet/placeholders for more information.");
+                    _logger.LogInformation(new EventId(421, "PlaceholderMissDueToBitness"), 
+                        "This app is configured as 32-bit and therefore does not leverage all performance optimizations. See https://aka.ms/azure-functions/dotnet/placeholders for more information.");
                     return false;
                 }
 

--- a/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -181,6 +181,15 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     return false;
                 }
 
+                // We support specialization of dotnet-isolated only on 64bit host process.
+                var is64Bit = _environment.Is64BitProcess;
+                _logger.LogDebug("Is64BitProcess: {is64Bit}", is64Bit.ToString());
+
+                if (!is64Bit)
+                {
+                    return false;
+                }
+
                 // Do not specialize if the placeholder is 6.0 but the site is 7.0 (for example).
                 var currentWorkerRuntimeVersion = _environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName);
                 channel.WorkerProcess.Process.StartInfo.Environment.TryGetValue(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName, out string placeholderWorkerRuntimeVersion);

--- a/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -184,8 +184,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 // We support specialization of dotnet-isolated only on 64bit host process.
                 if (!_environment.Is64BitProcess)
                 {
-                    _logger.LogInformation(new EventId(421, "PlaceholderMissDueToBitness"), 
+                    _logger.LogInformation(new EventId(421, ScriptConstants.PlaceholderMissDueToBitnessEventName),
                         "This app is configured as 32-bit and therefore does not leverage all performance optimizations. See https://aka.ms/azure-functions/dotnet/placeholders for more information.");
+
                     return false;
                 }
 

--- a/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -182,11 +182,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 }
 
                 // We support specialization of dotnet-isolated only on 64bit host process.
-                var is64Bit = _environment.Is64BitProcess;
-                _logger.LogDebug("Is64BitProcess: {is64Bit}", is64Bit.ToString());
-
-                if (!is64Bit)
+                if (!_environment.Is64BitProcess)
                 {
+                    _logger.LogDebug("This app is configured as 32-bit and therefore does not leverage all performance optimizations. See https://aka.ms/azure-functions/dotnet/placeholders for more information.");
                     return false;
                 }
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -830,6 +830,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var log = _loggerProvider.GetLog();
             Assert.Contains("UsePlaceholderDotNetIsolated: True", log);
+            Assert.Contains("Is64BitProcess: True", log);
             Assert.Contains("Placeholder runtime version: '6.0'. Site runtime version: '6.0'. Match: True", log);
             Assert.DoesNotContain("Shutting down placeholder worker.", log);
         }
@@ -880,6 +881,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var log = _loggerProvider.GetLog();
             Assert.Contains("UsePlaceholderDotNetIsolated: True", log);
+            Assert.Contains("Is64BitProcess: True", log);
             Assert.Contains("Placeholder runtime version: '6.0'. Site runtime version: '6.0'. Match: True", log);
             Assert.DoesNotContain("Shutting down placeholder worker.", log);
         }
@@ -896,6 +898,24 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public async Task DotNetIsolated_PlaceholderMiss_Not64Bit()
+        {
+            _environment.SetProcessBitness(is64Bitness: false);
+
+            // We only specialize when host process is 64 bit process.
+            await DotNetIsolatedPlaceholderMiss(() =>
+            {
+                _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteUsePlaceholderDotNetIsolated, "1");
+                _environment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName, "6.0");
+            });
+
+            var log = _loggerProvider.GetLog();
+            Assert.Contains("UsePlaceholderDotNetIsolated: True", log);
+            Assert.Contains("Is64BitProcess: False", log);
+            Assert.Contains("Shutting down placeholder worker. Worker is not compatible for runtime: dotnet-isolated", log);
+        }
+
+        [Fact]
         public async Task DotNetIsolated_PlaceholderMiss_DotNetVer()
         {
             // Even with placeholders enabled via the WEBSITE_USE_PLACEHOLDER_DOTNETISOLATED env var,
@@ -908,6 +928,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var log = _loggerProvider.GetLog();
             Assert.Contains("UsePlaceholderDotNetIsolated: True", log);
+            Assert.Contains("Is64BitProcess: True", log);
             Assert.Contains("Placeholder runtime version: '6.0'. Site runtime version: '7.0'. Match: False", log);
             Assert.Contains("Shutting down placeholder worker. Worker is not compatible for runtime: dotnet-isolated", log);
         }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -830,7 +830,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var log = _loggerProvider.GetLog();
             Assert.Contains("UsePlaceholderDotNetIsolated: True", log);
-            Assert.Contains("Is64BitProcess: True", log);
             Assert.Contains("Placeholder runtime version: '6.0'. Site runtime version: '6.0'. Match: True", log);
             Assert.DoesNotContain("Shutting down placeholder worker.", log);
         }
@@ -881,7 +880,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var log = _loggerProvider.GetLog();
             Assert.Contains("UsePlaceholderDotNetIsolated: True", log);
-            Assert.Contains("Is64BitProcess: True", log);
             Assert.Contains("Placeholder runtime version: '6.0'. Site runtime version: '6.0'. Match: True", log);
             Assert.DoesNotContain("Shutting down placeholder worker.", log);
         }
@@ -911,7 +909,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var log = _loggerProvider.GetLog();
             Assert.Contains("UsePlaceholderDotNetIsolated: True", log);
-            Assert.Contains("Is64BitProcess: False", log);
+            Assert.Contains("This app is configured as 32-bit and therefore does not leverage all performance optimizations. See https://aka.ms/azure-functions/dotnet/placeholders for more information.", log);
             Assert.Contains("Shutting down placeholder worker. Worker is not compatible for runtime: dotnet-isolated", log);
         }
 
@@ -928,7 +926,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var log = _loggerProvider.GetLog();
             Assert.Contains("UsePlaceholderDotNetIsolated: True", log);
-            Assert.Contains("Is64BitProcess: True", log);
             Assert.Contains("Placeholder runtime version: '6.0'. Site runtime version: '7.0'. Match: False", log);
             Assert.Contains("Shutting down placeholder worker. Worker is not compatible for runtime: dotnet-isolated", log);
         }

--- a/test/WebJobs.Script.Tests.Shared/TestEnvironment.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestEnvironment.cs
@@ -63,5 +63,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             return new TestEnvironment(variables);
         }
+
+        public void SetProcessBitness(bool is64Bitness)
+        {
+            _is64BitProcess = is64Bitness;
+        }
     }
 }

--- a/test/WebJobs.Script.Tests.Shared/TestEnvironment.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestEnvironment.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
         }
 
-        public TestEnvironment(IDictionary<string, string> variables) 
+        public TestEnvironment(IDictionary<string, string> variables)
             : this(variables, is64BitProcess: true)
         {
         }

--- a/test/WebJobs.Script.Tests.Shared/TestEnvironment.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestEnvironment.cs
@@ -12,15 +12,24 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
     public class TestEnvironment : IEnvironment
     {
         private readonly IDictionary<string, string> _variables;
+        private bool _is64BitProcess;
+
+        public bool Is64BitProcess => _is64BitProcess;
 
         public TestEnvironment()
-            : this(new Dictionary<string, string>())
+    : this(new Dictionary<string, string>())
         {
         }
 
-        public TestEnvironment(IDictionary<string, string> variables)
+        public TestEnvironment(IDictionary<string, string> variables) 
+            : this(variables, is64BitProcess: true)
+        {
+        }
+
+        public TestEnvironment(IDictionary<string, string> variables, bool is64BitProcess)
         {
             _variables = variables ?? throw new ArgumentNullException(nameof(variables));
+            _is64BitProcess = is64BitProcess;
         }
 
         public void Clear()

--- a/test/WebJobs.Script.Tests.Shared/TestEnvironment.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestEnvironment.cs
@@ -14,8 +14,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         private readonly IDictionary<string, string> _variables;
         private bool _is64BitProcess;
 
-        public bool Is64BitProcess => _is64BitProcess;
-
         public TestEnvironment()
     : this(new Dictionary<string, string>())
         {
@@ -31,6 +29,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _variables = variables ?? throw new ArgumentNullException(nameof(variables));
             _is64BitProcess = is64BitProcess;
         }
+
+        public bool Is64BitProcess => _is64BitProcess;
 
         public void Clear()
         {


### PR DESCRIPTION
Fixes #9548 

With this change, specialization for dotnet isolated using native placeholder will happen only if the host process is 64 bit.
Our Linux distros are 64 bit and customers cannot change that via portal.

https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide#placeholders-preview

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [x] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

