### PR TITLE
Add check to see if worker channels are null

### DIFF
--- a/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
@@ -99,6 +99,13 @@ namespace Microsoft.Azure.WebJobs.Script
                     channels = _channelManager.GetChannels(_workerRuntime);
                 }
 
+                if (channels is null)
+                {
+                    _logger.LogWarning("No initialized language worker channel found for runtime: {workerRuntime}. "
+                        + "There is likely an issue with the worker not being able to start.", _workerRuntime);
+                    return; // should we throw our own exception here so that it's not a null ref exception?
+                }
+
                 foreach (string workerId in channels.Keys.ToList())
                 {
                     if (channels.TryGetValue(workerId, out TaskCompletionSource<IRpcWorkerChannel> languageWorkerChannelTask))

--- a/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
@@ -101,11 +101,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
                 if (channels is null)
                 {
-                    _logger.LogWarning("No initialized language worker channel found for runtime: {workerRuntime}. "
-                        + "There is likely an issue with the worker not being able to start.", _workerRuntime);
-                    // Q: Instead of the null reference exception, we now fallback to default (host) metadata indexing.
-                    // Is this the right thing to do? Should we throw an exception instead?
-                    return new FunctionMetadataResult(useDefaultMetadataIndexing: true, _functions);
+                    _logger.LogDebug("Worker channels are null, there is likely an issue with the worker not being able to start.");
+                    throw new InvalidOperationException($"No initialized language worker channel found for runtime: {_workerRuntime}.");
                 }
 
                 foreach (string workerId in channels.Keys.ToList())

--- a/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
@@ -103,7 +103,9 @@ namespace Microsoft.Azure.WebJobs.Script
                 {
                     _logger.LogWarning("No initialized language worker channel found for runtime: {workerRuntime}. "
                         + "There is likely an issue with the worker not being able to start.", _workerRuntime);
-                    return; // should we throw our own exception here so that it's not a null ref exception?
+                    // Q: Instead of the null reference exception, we now fallback to default (host) metadata indexing.
+                    // Is this the right thing to do? Should we throw an exception instead?
+                    return new FunctionMetadataResult(useDefaultMetadataIndexing: true, _functions);
                 }
 
                 foreach (string workerId in channels.Keys.ToList())


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #9484

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

I've investigated several applications that are reporting this issue and in every case, there is a valid worker error that is leading to this null reference. Examples of errors leading up to this:

- node: Incompatible Node.js version
- python: ERROR: unhandled error in functions worker: Descriptors cannot not be created directly.,
- dotnet-isolated: Win32Exception : Insufficient system resources exist to complete the requested service.
    - when specializing on a 32 bit system (specialization is only supported in 64) 

These are all valid reasons to dispose the worker channel, so I'm not sure a change in behaviour is required here assuming we are always logging the real issue prior to this exception. We can however add a null check and maybe log a better message to point folks in the right direction (but I'm not sure that we are able to log here what the issue with the worker was).

 
