### PR TITLE
Check if URI is valid in token expiration service

### DIFF
--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -894,7 +894,7 @@ namespace Microsoft.Azure.WebJobs.Script
             else
             {
                 var isUri = Uri.IsWellFormedUriString(valueToParse, UriKind.Absolute);
-                if (!isUri)
+                if (!Uri.IsWellFormedUriString(valueToParse, UriKind.Absolute);)
                 {
                     return null;
                 }

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -893,8 +893,7 @@ namespace Microsoft.Azure.WebJobs.Script
             }
             else
             {
-                var isUri = Uri.IsWellFormedUriString(valueToParse, UriKind.Absolute);
-                if (!isUri)
+                if (!Uri.IsWellFormedUriString(valueToParse, UriKind.Absolute))
                 {
                     return null;
                 }

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -893,6 +893,11 @@ namespace Microsoft.Azure.WebJobs.Script
             }
             else
             {
+                var isUri = Uri.IsWellFormedUriString(valueToParse, UriKind.Absolute);
+                if (!isUri)
+                {
+                    return null;
+                }
                 var resourceUri = new Uri(valueToParse);
                 queryParams = HttpUtility.ParseQueryString(resourceUri.Query);
             }

--- a/test/WebJobs.Script.Tests/TokenExpirationServiceTests.cs
+++ b/test/WebJobs.Script.Tests/TokenExpirationServiceTests.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [InlineData("UseDevelopmentStorage=true", true, false)]
         [InlineData("BlobEndpoint=https://storage.blob.core.windows.net;TableEndpoint=https://table.core.windows.net;SharedAccessSignature=sv=2015-07-08&sig=f%2BGLvBih%2BoFuQvckBSHWKMXwqGJHlPkESmZh9pjnHuc%3D&spr=https&st=2016-04-12T03%3A24%3A31Z&srt=s&ss=bf&sp=rwl", true, false)]
         [InlineData("BlobEndpoint=https://storage.blob.core.windows.net;TableEndpoint=https://table.core.windows.net;SharedAccessSignature=sv=2015-07-08&sig=f%2BGLvBih%2BoFuQvckBSHWKMXwqGJHlPkESmZh9pjnHuc%3D&spr=https&st=2016-04-12T03%3A24%3A31Z&se=2023-07-20T05:27:05Z&srt=s&ss=bf&sp=rwl", true, true)]
+        [InlineData("1", false, false)]
         public async Task StartAsync_Tests(string input, bool isAzureWebJobsStorage, bool shouldEmitEvent)
         {
             var options = new StandbyOptions { InStandbyMode = true };


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-host/issues/9558

We were expecting `AzureWebsiteRunFromPackage` to be in a URI form, but sometimes it isn't so the token expiration service fails which causes an error in the host. This PR mitigates this by adding a check to ensure the string being parsed actually is a URI.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
