### PR TITLE
Use the V3 NuGet.org package source index of V2

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="azure-appservice-test" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/azure-appservice-test%40Local/nuget/v3/index.json" />
     <add key="Microsoft.Azure.Functions.PowerShellWorker" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/Microsoft.Azure.Functions.PowerShellWorker/nuget/v3/index.json" />
     <add key="AzureFunctions@internalrelease" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctions%40internalrelease/nuget/v3/index.json" />


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR


I'm on the NuGet.org team and I was playing around with the Azure Functions Host (running it on spot VMs). I noticed that the NuGet.org V2 package source was used in the root NuGet.config.

https://github.com/Azure/azure-functions-host/blob/02c9f9447f4ed04f032d65039824e6d7ef16d1a9/NuGet.config#L4

The V3 package source (https://api.nuget.org/v3/index.json) is the recommended approach over the V2 API. Although the package content is the same, the performance, availability SLOs, and extended features are superior on V3. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] My changes **should not** be added to the release notes for the next release
* [x] My changes **do not** need to be backported to a previous version
* [x] My changes **do not** require diagnostic events changes
* [ ] ~I have added all required tests (Unit tests, E2E tests)~

<!-- Optional: delete if not applicable  -->
### Additional information

(feel free to close this if there is a good reason to use V2 -- but I have not heard of one in several years myself 😊).
