### PR TITLE
Ignore SA1518 to allow build from ZIP source download

### DIFF
--- a/src.ruleset
+++ b/src.ruleset
@@ -45,6 +45,7 @@
     <Rule Id="SA1502" Action="None" />
     <Rule Id="SA1512" Action="None" />
     <Rule Id="SA1513" Action="None" />
+    <Rule Id="SA1518" Action="None" />
     <Rule Id="SA1611" Action="None" />
     <Rule Id="SA1615" Action="None" />
     <Rule Id="SA1618" Action="None" />


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

If you download a release-tagged ZIP file of source from GitHub, the line endings at the end of the file are not what StyleCop is looking for. GitHub has a link to the source code here:

![image](https://github.com/Azure/azure-functions-host/assets/94054/1215ed64-e952-480f-8d95-45f8d84eb37c)


This edge case causes a `dotnet build` to fail with many errors like this:

`
C:\z\GH\NuGet\Insights\artifacts\azure-functions\azure-functions-host-4.27.1\src\WebJobs.Script\WorkerUtilities.cs(21,2): error SA1518: File is required to end with a single newline character [C:\z\GH\NuGet\Insights\artifacts\azure-functions\azure-functions-host-4.27.1\src\WebJobs.Script\WebJobs.Script.csproj]
`

This problem is new since the 4.3.0 release. 

The relevant StyleCop docs are here: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1518.md

IMO this analyzer is a little too aggressive for a project on GitHub since line endings may be varied if the source code is acquired without a `crlf` Git line ending setting or some other source code acquisition method aside from `git clone` (such as the source ZIP as mentioned above).

BTW I think the analyzer is actually buggy because both `git clone` on Windows and the ZIP download show no EOL sequence on the reported files. This leads me to believe there's an off-by-one error and StyleCop is actually policing the 2nd to last character (which is indeed `crlf` on Windows and `lf` from the ZIP and a Linux `git clone`)

Windows:
![image](https://github.com/Azure/azure-functions-host/assets/94054/32fc825c-e760-4320-98a2-52c09bc8ae36)
(no EOL at the end of the file, but uses `crlf` in the file)

ZIP:
![image](https://github.com/Azure/azure-functions-host/assets/94054/5dfaea50-9035-4ea5-9131-dba08efd0771)
(no EOL at the end of the file, but uses `lf` in the file)

### Pull request checklist

* [x] My changes **do not** require documentation changes
* [x] My changes **should not** be added to the release notes for the next release
* [x] My changes **do not** need to be backported to a previous version
* [x] My changes **do not** require diagnostic events changes
* [ ] ~I have added all required tests (Unit tests, E2E tests)~

<!-- Optional: delete if not applicable  -->
### Additional information

No worries at all if you want to reject this PR! If you need to enforce the EOL marker and the end of the file, I can work around it in other ways. 
