### PR TITLE
Enable worker indexing by default

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -19,6 +19,7 @@
 - Limit dotnet-isolated specialization to 64 bit host process (#9548)
 - Sending command line arguments to language workers with `functions-` prefix to prevent conflicts (#9514)
 - Adding code to simulate placeholder and specilization locally (#9618)
+- Enable worker indexing by default without the need for hosting config (#9574)
 - Delaying execution of `LogWorkerMetadata` method until after coldstart is done. (#9627)
 - Update PowerShell Worker 7.2 to 4.0.3070 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.3070)
 - Update PowerShell Worker 7.4 to 4.0.3030 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.3030)

--- a/sample/NodeWithoutBundle/HttpTrigger/function.json
+++ b/sample/NodeWithoutBundle/HttpTrigger/function.json
@@ -1,0 +1,15 @@
+﻿{
+    "bindings": [
+        {
+            "type": "httpTrigger",
+            "name": "req",
+            "direction": "in",
+            "methods": [ "get" ]
+        },
+        {
+            "type": "http",
+            "name": "$return",
+            "direction": "out"
+        }
+    ]
+}

--- a/sample/NodeWithoutBundle/HttpTrigger/index.js
+++ b/sample/NodeWithoutBundle/HttpTrigger/index.js
@@ -1,0 +1,33 @@
+﻿var test = require('../Shared/test');
+
+module.exports = function (context, req) {
+    context.log('Node.js HTTP trigger function processed a request. Name=%s', req.query.name);
+
+    var headerValue = req.headers['test-header'];
+    if (headerValue) {
+        context.log('test-header=' + headerValue);
+    }
+
+    var res;
+    if (typeof req.query.name === 'undefined') {
+        res = {
+            status: 400,
+            body: "Please pass a name on the query string",
+            headers: {
+                'Content-Type': 'text/plain'
+            }
+        };
+    }
+    else {
+        res = {
+            status: 200,
+            body: test.greeting(req.query.name),
+            headers: {
+                'Content-Type': 'text/plain',
+                'Shared-Module': test.timestamp
+            }
+        };
+    }
+
+    context.done(null, res);
+};

--- a/sample/NodeWithoutBundle/Shared/test.js
+++ b/sample/NodeWithoutBundle/Shared/test.js
@@ -1,0 +1,8 @@
+var timestamp = new Date().getTime();
+
+module.exports = {
+    timestamp: timestamp,
+    greeting: function (name) {
+        return 'Hello ' + name;
+    }
+};

--- a/sample/NodeWithoutBundle/host.json
+++ b/sample/NodeWithoutBundle/host.json
@@ -1,10 +1,5 @@
 {
     "version": "2.0",
-    "extensionBundle": {
-        "id": "Microsoft.Azure.Functions.ExtensionBundle",
-        "version": "[3.*, 4.0.0)"
-    },
-    "watchDirectories": [ "Shared", "Test" ],
     "healthMonitor": {
         "enabled": true,
         "healthCheckInterval": "00:00:10",

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -82,6 +82,17 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         }
 
         /// <summary>
+        /// Gets a value indicating whether the host should revert the worker shutdown behavior in the webhostworkerchannelmanager.
+        /// </summary>
+        public bool RevertWorkerShutdownBehaviour
+        {
+            get
+            {
+                return GetFeature(RpcWorkerConstants.RevertWorkerShutdownBehavior) == "1";
+            }
+        }
+
+        /// <summary>
         /// Gets feature by name.
         /// </summary>
         /// <param name="name">Feature name.</param>

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -1007,12 +1007,12 @@ namespace Microsoft.Azure.WebJobs.Script
         // WORKER_INDEXING_DISABLED contains the customers app name worker indexing is then disabled for that customer only
         public static bool CanWorkerIndex(IEnumerable<RpcWorkerConfig> workerConfigs, IEnvironment environment, FunctionsHostingConfigOptions functionsHostingConfigOptions)
         {
-            string appName = environment.GetAzureWebsiteUniqueSlotName();
-
             if (environment.IsLogicApp())
             {
                 return false;
             }
+
+            string appName = environment.GetAzureWebsiteUniqueSlotName();
 
             bool workerIndexingFeatureFlagSet = FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableWorkerIndexing, environment);
             bool workerIndexingDisabledViaHostingConfig = functionsHostingConfigOptions.WorkerIndexingDisabledApps.ToLowerInvariant().Split("|").Contains(appName);

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
@@ -84,5 +84,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         public const string WorkerIndexingEnabled = "WORKER_INDEXING_ENABLED";
         public const string WorkerIndexingDisabledApps = "WORKER_INDEXING_DISABLED_APPS";
+        public const string RevertWorkerShutdownBehavior = "REVERT_WORKER_SHUTDOWN_BEHAVIOR";
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -128,6 +128,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteArmCacheEnabled)).Returns("1");
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady)).Returns("1");
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.CoreToolsEnvironment)).Returns((string)null);
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AppKind)).Returns((string)null);
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime)).Returns("dotnet");
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey)).Returns("1");
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId)).Returns("1");
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName)).Returns(testHostName);

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcessesNoBundle.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcessesNoBundle.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.WebJobs.Script.Tests;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
+{
+    [Trait(TestTraits.Category, TestTraits.EndToEnd)]
+    [Trait(TestTraits.Group, TestTraits.SamplesEndToEnd)]
+    public class SamplesEndToEndTests_Node_MultipleProcessesNoBundle : IClassFixture<SamplesEndToEndTests_Node_MultipleProcessesNoBundle.MultiplepleProcessesTestFixtureNoBundles>
+    {
+        private readonly ScriptSettingsManager _settingsManager;
+        private MultiplepleProcessesTestFixtureNoBundles _fixture;
+        private IEnumerable<int> _nodeProcessesBeforeTestStarted;
+
+        public SamplesEndToEndTests_Node_MultipleProcessesNoBundle(MultiplepleProcessesTestFixtureNoBundles fixture)
+        {
+            _fixture = fixture;
+            _nodeProcessesBeforeTestStarted = fixture.NodeProcessesBeforeTestStarted;
+            _settingsManager = ScriptSettingsManager.Instance;
+        }
+
+        [Fact(Skip = "https://github.com/Azure/azure-functions-host/issues")]
+        public async Task NodeProcessNoBundleConfigured_Different_AfterHostRestart()
+        {
+            await SamplesTestHelpers.InvokeAndValidateHttpTrigger(_fixture, "HttpTrigger");
+            IEnumerable<int> nodeProcessesBeforeHostRestart = Process.GetProcessesByName("node").Select(p => p.Id);
+            // Trigger a restart
+            await _fixture.Host.RestartAsync(CancellationToken.None);
+
+            await SamplesTestHelpers.InvokeAndValidateHttpTrigger(_fixture, "HttpTrigger");
+
+            // Wait for all the 3 process to start
+            await Task.Delay(TimeSpan.FromMinutes(1));
+
+            IEnumerable<int> nodeProcessesAfter = Process.GetProcessesByName("node").Select(p => p.Id);
+
+            // Verify node process is different after host restart
+            var result = nodeProcessesAfter.Where(pId1 => !nodeProcessesBeforeHostRestart.Any(pId2 => pId2 == pId1) && !_fixture.NodeProcessesBeforeTestStarted.Any(pId3 => pId3 == pId1));
+            Assert.Equal(3, result.Count());
+        }
+
+        public class MultiplepleProcessesTestFixtureNoBundles : EndToEndTestFixture
+        {
+            private IEnumerable<int> _nodeProcessesBeforeTestStarted;
+
+            public IEnumerable<int> NodeProcessesBeforeTestStarted => _nodeProcessesBeforeTestStarted;
+
+            static MultiplepleProcessesTestFixtureNoBundles()
+            {
+            }
+
+            public MultiplepleProcessesTestFixtureNoBundles()
+                : base(Path.Combine(Environment.CurrentDirectory, @"..", "..", "..", "..", "..", "sample", "NodeWithoutBundle"), "samples", RpcWorkerConstants.NodeLanguageWorkerName, 3)
+            {
+                _nodeProcessesBeforeTestStarted = Process.GetProcessesByName("node").Select(p => p.Id);
+                _nodeProcessesBeforeTestStarted = _nodeProcessesBeforeTestStarted ?? new List<int>();
+            }
+
+            public override void ConfigureScriptHost(IWebJobsBuilder webJobsBuilder)
+            {
+                base.ConfigureScriptHost(webJobsBuilder);
+                webJobsBuilder.Services.Configure<ScriptJobHostOptions>(o =>
+                {
+                    o.Functions = new[]
+                    {
+                        "HttpTrigger"
+                    };
+                });
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
@@ -2,9 +2,13 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Host.Storage;
 using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Grpc;
 using Microsoft.Azure.WebJobs.Script.Tests;
@@ -99,9 +103,12 @@ namespace Microsoft.WebJobs.Script.Tests
 
         private static IServiceCollection AddFunctionMetadataManager(this IServiceCollection services)
         {
-            AddMockedSingleton<IWorkerFunctionMetadataProvider>(services);
+            var workerMetadataProvider = new Mock<IWorkerFunctionMetadataProvider>();
+            workerMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), false)).Returns(Task.FromResult(new FunctionMetadataResult(true, ImmutableArray<FunctionMetadata>.Empty)));
+
             services.AddSingleton<IHostFunctionMetadataProvider, HostFunctionMetadataProvider>();
             services.AddSingleton<IFunctionMetadataProvider, FunctionMetadataProvider>();
+            services.AddSingleton<IWorkerFunctionMetadataProvider>(workerMetadataProvider.Object);
 
             services.AddSingleton<IScriptHostManager>(s =>
             {

--- a/test/WebJobs.Script.Tests/Middleware/HostWarmupMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Middleware/HostWarmupMiddlewareTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
             _testLogger = new TestLogger("WebHostLanguageWorkerChannelManagerTests");
             _rpcWorkerChannelFactory = new TestRpcWorkerChannelFactory(_eventManager, _testLogger, _scriptRootPath);
             _emptyConfig = new ConfigurationBuilder().Build();
-            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, new TestMetricsLogger(), _emptyConfig, _workerProfileManager);
+            _rpcWorkerChannelManager = new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, _rpcWorkerChannelFactory, _optionsMonitor, new TestMetricsLogger(), _emptyConfig, _workerProfileManager, new OptionsWrapper<FunctionsHostingConfigOptions>(new FunctionsHostingConfigOptions()));
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/UtilityTests.cs
+++ b/test/WebJobs.Script.Tests/UtilityTests.cs
@@ -868,7 +868,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
-        [InlineData(false, true, false)]
+        [InlineData(false, true, true)]
         [InlineData(false, false, false)]
         [InlineData(true, false, false)]
         [InlineData(true, true, true)]
@@ -886,57 +886,51 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
-        [InlineData(true, true, false, "", true)]
-        [InlineData(true, true, true, "NonApp", true)]
-        [InlineData(true, true, true, "AppName", true)]
-        [InlineData(true, true, false, "NonApp", true)]
-        [InlineData(true, true, false, "AppName", true)]
-        public void VerifyWorkerIndexingFeatureFlagTakesPrecedence(bool workerIndexingFeatureFlag, bool workerIndexingConfigProperty, bool enabledHostingConfig, string disabledHostingConfig, bool expected)
+        [InlineData(true, true, "", true)]
+        [InlineData(true, true, "NonApp", true)]
+        [InlineData(true, true, "AppName", true)]
+        public void VerifyWorkerIndexingFeatureFlagTakesPrecedence(bool workerIndexingFeatureFlag, bool workerIndexingConfigProperty, string disabledHostingConfig, bool expected)
         {
-            VerifyCanWorkerIndexUtility(workerIndexingFeatureFlag, workerIndexingConfigProperty, enabledHostingConfig, disabledHostingConfig, expected);
+            VerifyCanWorkerIndexUtility(workerIndexingFeatureFlag, workerIndexingConfigProperty, disabledHostingConfig, expected);
         }
 
         [Theory]
-        [InlineData(true, false, false, "", false)]
-        [InlineData(true, false, true, "NonApp", false)]
-        [InlineData(true, false, true, "AppName", false)]
-        [InlineData(true, false, false, "NonApp", false)]
-        [InlineData(true, false, false, "AppName", false)]
-        [InlineData(true, true, false, "AppName", true)]
-        public void VerifyWorkerConfigTakesPrecedence(bool workerIndexingFeatureFlag, bool workerIndexingConfigProperty, bool enabledHostingConfig, string disabledHostingConfig, bool expected)
+        [InlineData(true, false, "", false)]
+        [InlineData(true, false, "NonApp", false)]
+        [InlineData(true, false, "AppName", false)]
+        [InlineData(true, true, "AppName", true)]
+        public void VerifyWorkerConfigTakesPrecedence(bool workerIndexingFeatureFlag, bool workerIndexingConfigProperty, string disabledHostingConfig, bool expected)
         {
-            VerifyCanWorkerIndexUtility(workerIndexingFeatureFlag, workerIndexingConfigProperty, enabledHostingConfig, disabledHostingConfig, expected);
+            VerifyCanWorkerIndexUtility(workerIndexingFeatureFlag, workerIndexingConfigProperty, disabledHostingConfig, expected);
         }
 
         [Theory]
-        [InlineData(false, true, true, "", true)]
-        [InlineData(false, true, true, "NonApp", true)]
-        [InlineData(false, true, false, "NonApp", false)]
-        [InlineData(false, false, false, "NonApp", false)]
-        public void VerifyStampLevelHostingConfigHonored(bool workerIndexingFeatureFlag, bool workerIndexingConfigProperty, bool enabledHostingConfig, string disabledHostingConfig, bool expected)
+        [InlineData(false, true, "", true)]
+        [InlineData(false, true, "NonApp", true)]
+        [InlineData(false, false, "NonApp", false)]
+        public void VerifyStampLevelHostingConfigHonored(bool workerIndexingFeatureFlag, bool workerIndexingConfigProperty, string disabledHostingConfig, bool expected)
         {
-            VerifyCanWorkerIndexUtility(workerIndexingFeatureFlag, workerIndexingConfigProperty, enabledHostingConfig, disabledHostingConfig, expected);
+            VerifyCanWorkerIndexUtility(workerIndexingFeatureFlag, workerIndexingConfigProperty, disabledHostingConfig, expected);
         }
 
         [Theory]
-        [InlineData(false, true, true, "", true)]
-        [InlineData(false, true, true, "NonApp|AppName", false)]
-        [InlineData(false, true, true, "NonApp|AnotherAppName", true)]
-        [InlineData(false, true, true, "nonapp|AppName", false)]
-        [InlineData(false, true, true, "appname", false)]
-        [InlineData(false, true, true, "nonapp|appname", false)]
-        [InlineData(false, true, true, "NonApp|anotherAppname", true)]
-        [InlineData(false, false, true, "NonApp", false)]
-        [InlineData(false, false, true, "AppName", false)]
-        [InlineData(false, false, false, "Appname", false)]
-        [InlineData(false, true, false, "AppName", false)]
-        [InlineData(false, true, true, "AppName", false)]
-        public void VerifyDisabledAppConfigHonored(bool workerIndexingFeatureFlag, bool workerIndexingConfigProperty, bool enabledHostingConfig, string disabledHostingConfig, bool expected)
+        [InlineData(false, true, "", true)]
+        [InlineData(false, true, "NonApp|AppName", false)]
+        [InlineData(false, true, "NonApp|AnotherAppName", true)]
+        [InlineData(false, true, "nonapp|AppName", false)]
+        [InlineData(false, true, "appname", false)]
+        [InlineData(false, true, "nonapp|appname", false)]
+        [InlineData(false, true, "NonApp|anotherAppname", true)]
+        [InlineData(false, false, "NonApp", false)]
+        [InlineData(false, false, "AppName", false)]
+        [InlineData(false, false, "Appname", false)]
+        [InlineData(false, true, "AppName", false)]
+        public void VerifyDisabledAppConfigHonored(bool workerIndexingFeatureFlag, bool workerIndexingConfigProperty, string disabledHostingConfig, bool expected)
         {
-            VerifyCanWorkerIndexUtility(workerIndexingFeatureFlag, workerIndexingConfigProperty, enabledHostingConfig, disabledHostingConfig, expected);
+            VerifyCanWorkerIndexUtility(workerIndexingFeatureFlag, workerIndexingConfigProperty, disabledHostingConfig, expected);
         }
 
-        private void VerifyCanWorkerIndexUtility(bool workerIndexingFeatureFlag, bool workerIndexingConfigProperty, bool enabledHostingConfig, string disabledHostingConfig, bool expected)
+        private void VerifyCanWorkerIndexUtility(bool workerIndexingFeatureFlag, bool workerIndexingConfigProperty, string disabledHostingConfig, bool expected)
         {
             var testEnv = new TestEnvironment();
             testEnv.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, RpcWorkerConstants.PythonLanguageWorkerName);
@@ -950,10 +944,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             RpcWorkerConfig workerConfig = new RpcWorkerConfig() { Description = TestHelpers.GetTestWorkerDescription("python", "none", workerIndexingConfigProperty) };
             var hostingOptions = new FunctionsHostingConfigOptions();
-            if (enabledHostingConfig)
-            {
-                hostingOptions.Features.Add(RpcWorkerConstants.WorkerIndexingEnabled, "1");
-            }
 
             hostingOptions.Features.Add(RpcWorkerConstants.WorkerIndexingDisabledApps, disabledHostingConfig);
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
@@ -471,7 +472,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             channelFactory ??= _rpcWorkerChannelFactory;
             config ??= _emptyConfig;
             return new WebHostRpcWorkerChannelManager(_eventManager, _testEnvironment, _loggerFactory, channelFactory,
-                _optionsMonitor, metrics, config, _workerProfileManager);
+                _optionsMonitor, metrics, config, _workerProfileManager, new OptionsWrapper<FunctionsHostingConfigOptions>(new FunctionsHostingConfigOptions()));
         }
 
         private bool AreRequiredMetricsEmitted(TestMetricsLogger metricsLogger)

--- a/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
@@ -399,7 +399,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             await _rpcWorkerChannelManager.ShutdownChannelIfExistsAsync(RpcWorkerConstants.JavaLanguageWorkerName, javaWorkerChannel1.Id);
             await _rpcWorkerChannelManager.ShutdownChannelIfExistsAsync(RpcWorkerConstants.JavaLanguageWorkerName, javaWorkerChannel2.Id);
 
-            Assert.Null(_rpcWorkerChannelManager.GetChannels(RpcWorkerConstants.JavaLanguageWorkerName));
+            var channels = _rpcWorkerChannelManager.GetChannels(RpcWorkerConstants.JavaLanguageWorkerName);
+            Assert.Equal(0, channels.Values.Count);
 
             var initializedChannel = await _rpcWorkerChannelManager.GetChannelAsync(RpcWorkerConstants.JavaLanguageWorkerName);
             Assert.Null(initializedChannel);
@@ -423,7 +424,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             // Channel is removed immediately but is not failed immediately
             await _rpcWorkerChannelManager.ShutdownChannelIfExistsAsync(RpcWorkerConstants.JavaLanguageWorkerName, javaWorkerChannel.Id, workerException);
 
-            Assert.Null(_rpcWorkerChannelManager.GetChannels(RpcWorkerConstants.JavaLanguageWorkerName));
+            var channels = _rpcWorkerChannelManager.GetChannels(RpcWorkerConstants.JavaLanguageWorkerName);
+            Assert.Equal(0, channels.Values.Count);
 
             var initializedChannel = await _rpcWorkerChannelManager.GetChannelAsync(RpcWorkerConstants.JavaLanguageWorkerName);
             Assert.Null(initializedChannel);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Update the worker indexing enablement logic to the following:
1. Worker indexing is disabled for Logic apps]
2. EnableWorkerIndexing set through AzureWebjobsFeatuerFlag always take precdence
3. If AzureWebjobsFeatuerFlag is not set and WORKER_INDEXING_DISABLED contains the customers app name worker indexing is then disabled for that customer only

resolves #9536

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
