### PR TITLE
Changing the logic to identify dotnet isolated apps

### DIFF
--- a/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs
+++ b/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs
@@ -340,7 +340,7 @@ namespace Microsoft.Azure.WebJobs.Script.DependencyInjection
         private bool IsDotnetIsolatedApp(IEnumerable<FunctionMetadata> functions, IEnvironment environment)
         {
             string workerRuntime = Utility.GetWorkerRuntime(functions, environment);
-            return workerRuntime.Equals(RpcWorkerConstants.DotNetIsolatedLanguageWorkerName, StringComparison.OrdinalIgnoreCase);
+            return workerRuntime?.Equals(RpcWorkerConstants.DotNetIsolatedLanguageWorkerName, StringComparison.OrdinalIgnoreCase) ?? false;
         }
 
         private class TypeNameEqualityComparer : IEqualityComparer<Type>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

The original logic for identifying the dotnet isolated apps was using worker config. However, we were getting a false positive on the check if the customer did not have `FUNCTIONS_WORKER_RUNTIME` set. The new check would take into account function metadata and worker runtime instead of worker config. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
