### PR TITLE
Updating Microsoft.Azure.Functions.DotNetIsolatedNativeHost package to 1.0.0

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -17,3 +17,5 @@
     gets properly initialized as the invocation buffers are not created - this leads to a "Did not find initialized workers" error.
 - Check if a blob container or table exists before trying to create it (#9555)
 - Limit dotnet-isolated specialization to 64 bit host process (#9548)
+- Update DotNetIsolatedNativeHost worker version to 1.0.0
+  - [Updated FunctionsNetHost to handle the new "functions-" prefix command line arguments.](https://github.com/Azure/azure-functions-dotnet-worker/pull/1901) 

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.21.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.0-preview805" />
+    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.39" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.0-beta.2-11957" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.0" />


### PR DESCRIPTION
Updating Microsoft.Azure.Functions.DotNetIsolatedNativeHost package to 1.0.0

This new package version will introduce the below change: 

[Updating FunctionsNetHost to handle the new "functions-" prefix cmdline args](https://github.com/Azure/azure-functions-dotnet-worker/pull/1901)
### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)
  *  PR #9514 will have the host changes to validate e2e tests for this case.

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
