### PR TITLE
Prevent language worker specialization code path from executing when script root path is empty (no deployed payload)

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -18,3 +18,4 @@
 - Check if a blob container or table exists before trying to create it (#9555)
 - Limit dotnet-isolated specialization to 64 bit host process (#9548)
 - Sending command line arguments to language workers with `functions-` prefix to prevent conflicts (#9514)
+- Prevent language worker specialization if no valid deployed payload is present at script root. (#9589)

--- a/test/EmptyScriptRoot/host.json
+++ b/test/EmptyScriptRoot/host.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -902,7 +902,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public async Task DotNetIsolated_PlaceholderMiss_EmptyScriptRoot()
         {
-            // We do not execute language worker specialization if the script root does not have valid app payload.
+            // Placeholder miss if the script root does not have valid app payload.
             await DotNetIsolatedPlaceholderMiss(() =>
             {
                 _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteUsePlaceholderDotNetIsolated, "1");


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Adding an additional check to ensure the script root path contains valid function payload (deployment payload) present before we trigger language worker specialization code path.

During instance assignment, we executes the host specialization code path. Language worker specialization is a child activity of this and if user has not deployed a payload yet, this will cause host to send language worker specialization call which is of no use.


### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [x] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
