### PR TITLE
Improve host.json sanitization on v1.x

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -503,7 +503,6 @@
     <Compile Include="Diagnostics\ExtendedEventSource.cs" />
     <Compile Include="Diagnostics\FunctionsEventSource.cs" />
     <Compile Include="Diagnostics\FunctionsSystemLogsEventSource.cs" />
-    <Compile Include="Diagnostics\Sanitizer.cs" />
     <Compile Include="Extensions\FunctionMetadataExtensions.cs" />
     <Compile Include="Extensions\HttpRouteCollectionExtensions.cs" />
     <Compile Include="Extensions\HttpRouteFactoryExtensions.cs" />

--- a/src/WebJobs.Script/Diagnostics/Sanitizer.cs
+++ b/src/WebJobs.Script/Diagnostics/Sanitizer.cs
@@ -11,12 +11,12 @@ namespace Microsoft.Azure.WebJobs.Logging
     // Note: This file is shared between the WebJobs SDK and Script repos. Update both if changes are needed.
     internal static class Sanitizer
     {
-        private const string SecretReplacement = "[Hidden Credential]";
+        public const string SecretReplacement = "[Hidden Credential]";
         private static readonly char[] ValueTerminators = new char[] { '<', '"', '\'' };
 
         // List of keywords that should not be replaced with [Hidden Credential]
         private static readonly string[] AllowedTokens = new string[] { "PublicKeyToken=" };
-        private static readonly string[] CredentialTokens = new string[] { "Token=", "DefaultEndpointsProtocol=http", "AccountKey=", "Data Source=", "Server=", "Password=", "pwd=", "&amp;sig=", "SharedAccessKey=" };
+        private static readonly string[] CredentialTokens = new string[] { "Token=", "DefaultEndpointsProtocol=http", "AccountKey=", "Data Source=", "Server=", "Password=", "pwd=", "&amp;sig=", "&sig=", "?sig=", "SharedAccessKey=" };
 
         /// <summary>
         /// Removes well-known credential strings from strings.

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -516,6 +516,7 @@
     <Compile Include="HostInitializationException.cs" />
     <Compile Include="Scale\ApplicationPerformanceCounters.cs" />
     <Compile Include="Diagnostics\CompositeTraceWriter.cs" />
+    <Compile Include="Diagnostics\Sanitizer.cs" />
     <Compile Include="Description\Binding\BindingDirection.cs" />
     <Compile Include="Description\Binding\BindingMetadata.cs" />
     <Compile Include="Description\DotNet\DotNetConstants.cs" />

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -1244,7 +1244,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Directory.CreateDirectory(rootPath);
             }
 
-            // Turn off all logging. We shouldn't see any output.
             string hostJsonContent = @"
             {
                 'functionTimeout': '00:05:00',
@@ -1252,10 +1251,25 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 'logger': {
                     'categoryFilter': {
                         'defaultLevel': 'Information'
-                    }
+                    },
+                    'prop': 'Hey=AS1$@%#$%W-k2j"";SharedAccessKey=foo,Data Source=barzons,Server=bathouse""testing',
+                    'values': [ 'plain', 10, 'Password=hunter2' ],
+                    'my-password': 'hunter2',
+                    'service_token': 'token',
+                    'StorageSas': 'access',
+                    'aSecret': { 'value1': 'value' }
                 },
                 'Values': {
                     'MyCustomValue': 'abc'
+                },
+                'applicationInsights': {
+                    'prop': 'Hey=AS1$@%#$%W-k2j"";SharedAccessKey=foo,Data Source=barzons,Server=bathouse""testing',
+                    'values': [ 'plain', 10, 'Password=hunter2' ],
+                    'sampleSettings': {
+                        'my-password': 'hunter2',
+                        'service_token': 'token',
+                        'StorageSas': 'access'
+                    }
                 }
             }";
 
@@ -1283,6 +1297,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 'logger': {
                     'categoryFilter': {
                         'defaultLevel': 'Information'
+                    },
+                    'prop': 'Hey=AS1$@%#$%W-k2j"";[Hidden Credential]""testing',
+                    'values': [ 'plain', 10, '[Hidden Credential]' ],
+                    'my-password': '[Hidden Credential]',
+                    'service_token': '[Hidden Credential]',
+                    'StorageSas': '[Hidden Credential]',
+                    'aSecret': '[Hidden Credential]'
+                },
+                'applicationInsights': {
+                    'prop': 'Hey=AS1$@%#$%W-k2j"";[Hidden Credential]""testing',
+                    'values': [ 'plain', 10, '[Hidden Credential]' ],
+                    'sampleSettings': {
+                        'my-password': '[Hidden Credential]',
+                        'service_token': '[Hidden Credential]',
+                        'StorageSas': '[Hidden Credential]'
                     }
                 }
             }";


### PR DESCRIPTION
Port of #9459

The sanitization logic is the same, but had to make the following adjustments for v1.x:

1. Move `Sanitizer` from `WebJobs.Script.WebHost` to `WebJobs.Script`
2. Pull local functions out into static functions
3. Replace `.Contains(string, cultureInfo)` with `.IndexOf(...) != -1`