### PR TITLE
Delaying execution of "LogWorkerMetadata" method until after coldstart is done.

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -29,6 +29,13 @@
     <Configurations>$(Configurations);DebugPlaceholder;ReleasePlaceholder</Configurations>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugPlaceholder|AnyCPU'">
+    <DefineConstants>$(DefineConstants);PLACEHOLDERSIMULATION</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlaceholder|AnyCPU'">
+    <DefineConstants>$(DefineConstants);PLACEHOLDERSIMULATION</DefineConstants>
+  </PropertyGroup>
+
   <Target Name="EchoVersion">
       <Message Importance="high" Text="$(Version)" />
   </Target>

--- a/release_notes.md
+++ b/release_notes.md
@@ -19,4 +19,5 @@
 - Limit dotnet-isolated specialization to 64 bit host process (#9548)
 - Sending command line arguments to language workers with `functions-` prefix to prevent conflicts (#9514)
 - Adding code to simulate placeholder and specilization locally (#9618)
+- Delaying execution of `LogWorkerMetadata` method until after coldstart is done. (#9627)
 

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -33,12 +33,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugPlaceholder|AnyCPU'">
-    <DefineConstants>$(DefineConstants);PLACEHOLDERSIMULATION</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleasePlaceholder|AnyCPU'">
-    <DefineConstants>$(DefineConstants);PLACEHOLDERSIMULATION</DefineConstants>
-  </PropertyGroup>
   <ItemGroup>
     <Content Remove="Resources\Functions\host.json" />
     <Content Remove="Resources\Functions\proxies.json" />

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -52,6 +52,12 @@ namespace Microsoft.Azure.WebJobs.Script
 
         private static List<string> dotNetLanguages = new List<string>() { DotNetScriptTypes.CSharp, DotNetScriptTypes.DotNetAssembly };
 
+#if PLACEHOLDERSIMULATION
+        private static bool isInPlaceholderSimulationMode = true;
+#else
+        private static bool isInPlaceholderSimulationMode = false;
+#endif
+
         public static int ColdStartDelayMS { get; set; } = 5000;
 
         internal static bool TryGetHostService<TService>(IScriptHostManager scriptHostManager, out TService service) where TService : class
@@ -774,7 +780,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public static void ExecuteAfterColdStartDelay(IEnvironment environment, Action targetAction, CancellationToken cancellationToken = default)
         {
             // for Dynamic SKUs where coldstart is important, we want to delay the action
-            if (environment.IsDynamicSku())
+            if (isInPlaceholderSimulationMode || environment.IsDynamicSku())
             {
                 ExecuteAfterDelay(targetAction, TimeSpan.FromMilliseconds(ColdStartDelayMS), cancellationToken);
             }


### PR DESCRIPTION
Delaying execution of "LogWorkerMetadata" method until after coldstart is done.

resolves #9627

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
