### PR TITLE
Bump Microsoft.Azure.WebJobs.Logging.ApplicationInsights to 3.0.38

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -66,7 +66,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Timers.Storage" Version="1.0.0-beta.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.Abstractions" Version="1.0.4-preview" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.37" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.38" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.3.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />


### PR DESCRIPTION
This is just like #9313, but a newer version. It was released two weeks ago in https://github.com/Azure/azure-webjobs-sdk/pull/3025 to fix https://github.com/Azure/azure-sdk-for-net/issues/37832 . It carries this fix that was merged two months ago. https://github.com/Azure/azure-webjobs-sdk/pull/3005 .