### PR TITLE
Upgrading Microsoft.Azure.WebJobs.Logging.ApplicationInsights package.

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -66,7 +66,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Timers.Storage" Version="1.0.0-beta.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.Abstractions" Version="1.0.4-preview" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.37" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.38" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.3.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />


### PR DESCRIPTION
<!-- Please provide all the information below.  -->
Fixes the issue with custom metrics. Removed prop_{OrigionalFormat} as this is not required for a metrics.
https://github.com/Azure/azure-webjobs-sdk/pull/3005

The GenevaSink was erroring out with the following message due to the additional attribute. 

`Failed to send metric for state of type: Microsoft.Azure.WebJobs.Logging.MetricState. Exception message=Name for dimension number 2 (
"{OriginalFormat}"
) contains a disallowed character at position 0.,`

<img width="749" alt="image" src="https://github.com/Azure/azure-functions-host/assets/90008725/e04fcdfb-317b-4d7c-b914-2d452b65504e">

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
