### PR TITLE
Using source generated version of Regex in cold start code path

### DIFF
--- a/src/WebJobs.Script/Description/Workers/WorkerFunctionDescriptorProvider.cs
+++ b/src/WebJobs.Script/Description/Workers/WorkerFunctionDescriptorProvider.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             _loggerFactory = loggerFactory;
             _applicationLifetime = applicationLifetime;
             _workerInitializationTimeout = workerInitializationTimeout;
-            _expressionRegex = new Regex(@"{(.*?)\}", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            _expressionRegex = RegularExpressions.GetFunctionBindingAttributeExpressionRegex();
         }
 
         public override async Task<(bool Success, FunctionDescriptor Descriptor)> TryCreate(FunctionMetadata functionMetadata)

--- a/src/WebJobs.Script/Host/ProxyFunctionProvider.cs
+++ b/src/WebJobs.Script/Host/ProxyFunctionProvider.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.WebJobs.Script
             var functionErrors = new Dictionary<string, ICollection<string>>();
             Collection<ProxyFunctionMetadata> proxies = ReadProxyMetadata(_scriptOptions.Value.RootScriptPath, _logger, functionErrors);
 
-            ImmutableArray<FunctionMetadata> metadata;
+            ImmutableArray<FunctionMetadata> metadata = ImmutableArray<FunctionMetadata>.Empty;
             if (proxies != null && proxies.Any())
             {
                 metadata = proxies.ToImmutableArray<FunctionMetadata>();

--- a/src/WebJobs.Script/RegularExpressions.cs
+++ b/src/WebJobs.Script/RegularExpressions.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Azure.WebJobs.Script
+{
+    internal partial class RegularExpressions
+    {
+        [GeneratedRegex(@"{(.*?)\}", RegexOptions.IgnoreCase)]
+        internal static partial Regex GetFunctionBindingAttributeExpressionRegex();
+    }
+}

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageId>Microsoft.Azure.WebJobs.Script</PackageId>
     <AssemblyName>Microsoft.Azure.WebJobs.Script</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Script</RootNamespace>


### PR DESCRIPTION
Using source generated version of Regex (instead of Regex constructor) in `WorkerFunctionDescriptorProvider` constructor which gets executed during specialization.

https://github.com/Azure/azure-functions-host/blob/6760b11e582c7dc2fb3e33ab9b77611238d4f837/src/WebJobs.Script/Description/Workers/WorkerFunctionDescriptorProvider.cs#L39

[Benchmark ](https://github.com/kshyju/Benchmarks/blob/6e5bd90b541274073de58e2effc89b77b0e26e62/src/Benchmarks.ConsoleApp/RegexBenchmarks.cs)results

```

BenchmarkDotNet v0.13.9+228a464e8be6c580ad9408e98f18813f6407fb5a, Windows 11 (10.0.22621.2428/22H2/2022Update/SunValley2)
11th Gen Intel Core i7-1185G7 3.00GHz, 1 CPU, 8 logical and 4 physical cores
.NET SDK 8.0.100-rc.2.23502.2
  [Host]     : .NET 8.0.0 (8.0.23.47906), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.0 (8.0.23.47906), X64 RyuJIT AVX2


```
| Method           | Mean         | Ratio |
|----------------- |-------------:|------:|
| RegexConstructor | 9,442.424 ns | 1.000 |
| SourceGenRegex   |     5.675 ns | 0.001 |


### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

