### PR TITLE
Fixing null reference exception when AzureWebJobsStorage is not set.

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventNullRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventNullRepository.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos.Table;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Script.WebHost.Helpers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
+{
+    public class DiagnosticEventNullRepository : IDiagnosticEventRepository
+    {
+        public void WriteDiagnosticEvent(DateTime timestamp, string errorCode, LogLevel level, string message, string helpLink, Exception exception)
+        {
+            return;
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventNullRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventNullRepository.cs
@@ -15,9 +15,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 {
     public class DiagnosticEventNullRepository : IDiagnosticEventRepository
     {
-        public void WriteDiagnosticEvent(DateTime timestamp, string errorCode, LogLevel level, string message, string helpLink, Exception exception)
-        {
-            return;
-        }
+        public void WriteDiagnosticEvent(DateTime timestamp, string errorCode, LogLevel level, string message, string helpLink, Exception exception) { }
     }
 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventRepositoryFactory.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventRepositoryFactory.cs
@@ -2,24 +2,40 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 {
     public class DiagnosticEventRepositoryFactory : IDiagnosticEventRepositoryFactory
     {
         private readonly IServiceProvider _serviceProvider;
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<DiagnosticEventRepositoryFactory> _logger;
 
-        public DiagnosticEventRepositoryFactory(IServiceProvider serviceProvider)
+        public DiagnosticEventRepositoryFactory(IServiceProvider serviceProvider, IConfiguration configuration, ILogger<DiagnosticEventRepositoryFactory> logger)
         {
             _serviceProvider = serviceProvider;
+            _configuration = configuration;
+            _logger = logger;
         }
 
         public IDiagnosticEventRepository Create()
         {
             // Using this to break ciruclar dependency for ILoggers. Typically you cannot log errors within the logging pipeline because it creates infinte loop.
             // However in this case that loop is broken because of the filtering in the DiagnosticEventLogger
-            return _serviceProvider.GetRequiredService<IDiagnosticEventRepository>();
+
+            string storageConnectionString = _configuration.GetWebJobsConnectionString(ConnectionStringNames.Storage);
+            if (string.IsNullOrEmpty(storageConnectionString))
+            {
+                _logger.LogError("Azure Storage connection string is empty or invalid. Unable to write diagnostic events to table storage.");
+                return new DiagnosticEventNullRepository();
+            }
+            else
+            {
+                return _serviceProvider.GetRequiredService<IDiagnosticEventRepository>();
+            }
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventRepositoryFactory.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventRepositoryFactory.cs
@@ -12,13 +12,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
     {
         private readonly IServiceProvider _serviceProvider;
         private readonly IConfiguration _configuration;
-        private readonly ILogger<DiagnosticEventRepositoryFactory> _logger;
 
-        public DiagnosticEventRepositoryFactory(IServiceProvider serviceProvider, IConfiguration configuration, ILogger<DiagnosticEventRepositoryFactory> logger)
+        public DiagnosticEventRepositoryFactory(IServiceProvider serviceProvider, IConfiguration configuration)
         {
             _serviceProvider = serviceProvider;
             _configuration = configuration;
-            _logger = logger;
         }
 
         public IDiagnosticEventRepository Create()
@@ -29,7 +27,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             string storageConnectionString = _configuration.GetWebJobsConnectionString(ConnectionStringNames.Storage);
             if (string.IsNullOrEmpty(storageConnectionString))
             {
-                _logger.LogError("Azure Storage connection string is empty or invalid. Unable to write diagnostic events to table storage.");
                 return new DiagnosticEventNullRepository();
             }
             else

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
@@ -53,15 +53,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 if (!_environment.IsPlaceholderModeEnabled() && _tableClient == null)
                 {
                     string storageConnectionString = _configuration.GetWebJobsConnectionString(ConnectionStringNames.Storage);
-                    if (string.IsNullOrEmpty(storageConnectionString))
-                    {
-                        _logger.LogError("Azure Storage connection string is empty or invalid. Unable to write diagnostic events.");
-                    }
-
-                    if (CloudStorageAccount.TryParse(storageConnectionString, out CloudStorageAccount account))
+                    if (!string.IsNullOrEmpty(storageConnectionString)
+                        && CloudStorageAccount.TryParse(storageConnectionString, out CloudStorageAccount account))
                     {
                         var tableClientConfig = new TableClientConfiguration();
                         _tableClient = new CloudTableClient(account.TableStorageUri, account.Credentials, tableClientConfig);
+                    }
+                    else
+                    {
+                        _logger.LogError("Azure Storage connection string is empty or invalid. Unable to write diagnostic events.");
                     }
                 }
 

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
@@ -183,14 +183,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public void WriteDiagnosticEvent(DateTime timestamp, string errorCode, LogLevel level, string message, string helpLink, Exception exception)
         {
-            if (TableClient == null)
+            if (TableClient == null || string.IsNullOrEmpty(HostId))
             {
-                return;
-            }
-
-            if (string.IsNullOrEmpty(HostId))
-            {
-                _logger.LogError("Unable to write diagnostic events. Host id is set to null.");
                 return;
             }
 

--- a/test/WebJobs.Script.Tests.Integration/Diagnostics/DiagnosticEventTableStorageRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Diagnostics/DiagnosticEventTableStorageRepositoryTests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             repository.WriteDiagnosticEvent(DateTime.UtcNow, "eh1", LogLevel.Information, "This is the message", "https://fwlink/", new Exception("exception message"));
 
             var messages = _loggerProvider.GetAllLogMessages();
-            Assert.Equal(messages[0].FormattedMessage, "Unable to write diagnostic events. Host id is set to null.");
+            Assert.Equal(0, repository.Events.Values.Count());
         }
 
         [Fact]
@@ -214,15 +214,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
 
             // Act
             repository.WriteDiagnosticEvent(DateTime.UtcNow, "eh1", LogLevel.Information, "This is the message", "https://fwlink/", new Exception("exception message"));
-            Assert.Equal(1, repository.Events.Values.Count());
             await repository.FlushLogs();
 
             // Assert 
             var logMessage = _loggerProvider.GetAllLogMessages().SingleOrDefault(m => m.FormattedMessage.Contains("Unable to get table reference"));
             Assert.NotNull(logMessage);
 
-            logMessage = _loggerProvider.GetAllLogMessages().SingleOrDefault(m => m.FormattedMessage.Contains("Azure Storage connection string is empty or invalid. Unable to write diagnostic events."));
-            Assert.NotNull(logMessage);
+            var messagePresent = _loggerProvider.GetAllLogMessages().Any(m => m.FormattedMessage.Contains("Azure Storage connection string is empty or invalid. Unable to write diagnostic events."));
+            Assert.True(messagePresent);
             
             Assert.Equal(0, repository.Events.Values.Count());
         }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

closes #9640

Static web apps do not have AzureWebJobStorage connection string set for functions. This causes a null reference exception when trying to log diagnostic events. This PR is addressing the null reference exception and fixing the relevant test.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
