### PR TITLE
KeyVaultSecretsRepository comparisons are now case insensitive 

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -19,4 +19,6 @@
 - Limit dotnet-isolated specialization to 64 bit host process (#9548)
 - Sending command line arguments to language workers with `functions-` prefix to prevent conflicts (#9514)
 - Adding code to simulate placeholder and specilization locally (#9618)
+- Bug fix: Comparisons in the Azure Key Vault Secrets Repository are now case insensitive (#9644)
+  - This fixes a bug where Host and System keys could be automatically recreated if they had been manually added to Key Vault with all lowercase secret names
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -20,5 +20,5 @@
 - Sending command line arguments to language workers with `functions-` prefix to prevent conflicts (#9514)
 - Adding code to simulate placeholder and specilization locally (#9618)
 - Bug fix: Comparisons in the Azure Key Vault Secrets Repository are now case insensitive (#9644)
-  - This fixes a bug where Host and System keys could be automatically recreated if they had been manually added to Key Vault with all lowercase secret names
+  - This fixes a bug where keys could be automatically recreated if they had been manually added to Key Vault with all lowercase secret names
 

--- a/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceSecurityExtension.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceSecurityExtension.cs
@@ -15,9 +15,31 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
                 new EventId(600, nameof(BlobStorageSecretRepoError)),
                 "There was an error performing a {operation} operation on the Blob Storage Secret Repository.");
 
+        private static readonly Action<ILogger, string, Exception> _keyVaultSecretRepoSetKey =
+            LoggerMessage.Define<string>(
+                LogLevel.Debug,
+                new EventId(601, nameof(KeyVaultSecretRepoSetKey)),
+                "Setting key '{key}' on the KeyVault Secret Repository.");
+
+        private static readonly Action<ILogger, string, Exception> _keyVaultSecretRepoDeleteKey =
+            LoggerMessage.Define<string>(
+                LogLevel.Debug,
+                new EventId(602, nameof(KeyVaultSecretRepoDeleteKey)),
+                "Deleting key '{key}' on the KeyVault Secret Repository.");
+
         public static void BlobStorageSecretRepoError(this ILogger logger, string operation, Exception exception)
         {
             _blobStorageSecretRepoError(logger, operation, exception);
+        }
+
+        public static void KeyVaultSecretRepoSetKey(this ILogger logger, string key)
+        {
+            _keyVaultSecretRepoSetKey(logger, key, null);
+        }
+
+        public static void KeyVaultSecretRepoDeleteKey(this ILogger logger, string key)
+        {
+            _keyVaultSecretRepoDeleteKey(logger, key, null);
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/KeyVaultSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/KeyVaultSecretsRepository.cs
@@ -50,6 +50,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
         }
 
+        // For testing
+        internal KeyVaultSecretsRepository(SecretClient secretClient, string secretsSentinelFilePath, ILogger logger, IEnvironment environment) : base(secretsSentinelFilePath, logger, environment)
+        {
+            _secretClient = new Lazy<SecretClient>(() => secretClient);
+        }
+
         public override bool IsEncryptionSupported
         {
             get

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/KeyVaultSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/KeyVaultSecretsRepository.cs
@@ -9,6 +9,7 @@ using Azure;
 using Azure.Core;
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
@@ -86,6 +87,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 // Delete only keys which no longer exist in passed-in secrets
                 if (!dictionary.Keys.Contains(item.Name))
                 {
+                    Logger?.KeyVaultSecretRepoDeleteKey(item.Name);
                     deleteTasks.Add(_secretClient.Value.StartDeleteSecretAsync(item.Name));
                 }
             }
@@ -99,6 +101,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             List<Task> setTasks = new List<Task>();
             foreach (string key in dictionary.Keys)
             {
+                Logger?.KeyVaultSecretRepoSetKey(key);
                 setTasks.Add(_secretClient.Value.SetSecretAsync(key, dictionary[key]));
             }
             await Task.WhenAll(setTasks);

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/KeyVaultSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/KeyVaultSecretsRepository.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             List<Task> deleteTasks = new List<Task>();
             string prefix = (type == ScriptSecretsType.Host) ? HostPrefix : FunctionPrefix + Normalize(functionName);
 
-            foreach (SecretProperties item in await FindSecrets(secretsPages, x => x.Name.StartsWith(prefix)))
+            foreach (SecretProperties item in await FindSecrets(secretsPages, x => x.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
             {
                 // Delete only keys which no longer exist in passed-in secrets
                 if (!dictionary.Keys.Contains(item.Name))
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             List<Task<Response<KeyVaultSecret>>> tasks = new List<Task<Response<KeyVaultSecret>>>();
 
             // Add master key task
-            List<SecretProperties> masterItems = await FindSecrets(secretsPages, x => x.Name.StartsWith(MasterKey));
+            List<SecretProperties> masterItems = await FindSecrets(secretsPages, x => x.Name.StartsWith(MasterKey, StringComparison.OrdinalIgnoreCase));
             if (masterItems.Count > 0)
             {
                 tasks.Add(_secretClient.Value.GetSecretAsync(masterItems[0].Name));
@@ -136,13 +136,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
 
             // Add functionKey tasks
-            foreach (SecretProperties item in await FindSecrets(secretsPages, x => x.Name.StartsWith(FunctionKeyPrefix)))
+            foreach (SecretProperties item in await FindSecrets(secretsPages, x => x.Name.StartsWith(FunctionKeyPrefix, StringComparison.OrdinalIgnoreCase)))
             {
                 tasks.Add(_secretClient.Value.GetSecretAsync(item.Name));
             }
 
             // Add systemKey tasks
-            foreach (SecretProperties item in await FindSecrets(secretsPages, x => x.Name.StartsWith(SystemKeyPrefix)))
+            foreach (SecretProperties item in await FindSecrets(secretsPages, x => x.Name.StartsWith(SystemKeyPrefix, StringComparison.OrdinalIgnoreCase)))
             {
                 tasks.Add(_secretClient.Value.GetSecretAsync(item.Name));
             }
@@ -158,15 +158,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             foreach (Task<Response<KeyVaultSecret>> task in tasks)
             {
                 KeyVaultSecret item = task.Result;
-                if (item.Name.StartsWith(MasterKey))
+                if (item.Name.StartsWith(MasterKey, StringComparison.OrdinalIgnoreCase))
                 {
                     hostSecrets.MasterKey = KeyVaultSecretToKey(item, MasterKey);
                 }
-                else if (item.Name.StartsWith(FunctionKeyPrefix))
+                else if (item.Name.StartsWith(FunctionKeyPrefix, StringComparison.OrdinalIgnoreCase))
                 {
                     hostSecrets.FunctionKeys.Add(KeyVaultSecretToKey(item, FunctionKeyPrefix));
                 }
-                else if (item.Name.StartsWith(SystemKeyPrefix))
+                else if (item.Name.StartsWith(SystemKeyPrefix, StringComparison.OrdinalIgnoreCase))
                 {
                     hostSecrets.SystemKeys.Add(KeyVaultSecretToKey(item, SystemKeyPrefix));
                 }
@@ -234,7 +234,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         public static Dictionary<string, string> GetDictionaryFromScriptSecrets(ScriptSecrets secrets, string functionName)
         {
-            Dictionary<string, string> dic = new Dictionary<string, string>();
+            Dictionary<string, string> dic = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             HostSecrets hostSecrets = secrets as HostSecrets;
             FunctionSecrets functionSecrets = secrets as FunctionSecrets;
             if (hostSecrets != null)

--- a/test/WebJobs.Script.Tests/Security/KeyVaultSecretsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests/Security/KeyVaultSecretsRepositoryTests.cs
@@ -4,10 +4,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Security.KeyVault.Secrets;
 using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Extensions.Logging;
+using Moq;
+using WebJobs.Script.Tests;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
@@ -45,6 +49,50 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
+        [MemberData(nameof(HostSecretsDataProvider.TestCases), MemberType = typeof(HostSecretsDataProvider))]
+        public async Task ReadHostKeys(List<KeyVaultSecret> keyVaultSecrets, HostSecrets expectedHostSecrets)
+        {
+            var mockClient = new Mock<SecretClient>(MockBehavior.Strict);
+            List<SecretProperties> properties = keyVaultSecrets.Select(kvSecret => kvSecret.Properties).ToList();
+            mockClient.Setup(client => client.GetPropertiesOfSecretsAsync(It.IsAny<CancellationToken>())).Returns(GetPageableSecretProperties(properties));
+
+            foreach (var keyVaultSecret in keyVaultSecrets)
+            {
+                mockClient.Setup(client => client.GetSecretAsync(keyVaultSecret.Name, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                          .ReturnsAsync(Response.FromValue(keyVaultSecret, Mock.Of<Response>()));
+            }
+
+            var loggerFactory = MockNullLoggerFactory.CreateLoggerFactory();
+            using var secretSentinelDirectory = new TempDirectory();
+            var repository = new KeyVaultSecretsRepository(mockClient.Object, secretSentinelDirectory.Path, loggerFactory.CreateLogger<KeyVaultSecretsRepository>(), new TestEnvironment());
+            var secrets = await repository.ReadAsync(ScriptSecretsType.Host, string.Empty);
+            var hostSecrets = secrets as HostSecrets;
+
+            Assert.True(expectedHostSecrets.MasterKey.Name == hostSecrets?.MasterKey.Name);
+            Assert.True(expectedHostSecrets.MasterKey.Value == hostSecrets?.MasterKey.Value);
+
+            Assert.Equal(expectedHostSecrets.SystemKeys.Count, hostSecrets?.SystemKeys.Count);
+            foreach (var expectedKey in expectedHostSecrets.SystemKeys)
+            {
+                var keys = hostSecrets?.SystemKeys.Where(k => k.Name == expectedKey.Name);
+                Assert.Single(keys);
+                var key = keys.First();
+                Assert.True(expectedKey.Name == key.Name);
+                Assert.True(expectedKey.Value == key.Value);
+            }
+
+            Assert.Equal(expectedHostSecrets.FunctionKeys.Count, hostSecrets?.FunctionKeys.Count);
+            foreach (var expectedKey in expectedHostSecrets.SystemKeys)
+            {
+                var keys = hostSecrets?.FunctionKeys.Where(k => k.Name == expectedKey.Name);
+                Assert.Single(keys);
+                var key = keys.First();
+                Assert.True(expectedKey.Name == key.Name);
+                Assert.True(expectedKey.Value == key.Value);
+            }
+        }
+
+        [Theory]
         [InlineData("Func-test", "te%st-te^st-")]
         [InlineData("Func--test-", "te--%st-te^s-t")]
         public void FunctionKeys(string functionName, string secretName)
@@ -73,6 +121,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Assert.Equal(matchingNames.Count(), 1);
                 Assert.Equal(matchingNames.First().Name, name);
             }
+        }
+
+        private AsyncPageable<SecretProperties> GetPageableSecretProperties(IReadOnlyList<SecretProperties> secretProperties)
+        {
+            return AsyncPageable<SecretProperties>.FromPages(new[] { Page<SecretProperties>.FromValues(secretProperties, default, null) });
         }
 
         private AsyncPageable<SecretProperties> GetSecretProperties()
@@ -108,6 +161,47 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 {
                     yield return new object[] { (Func<SecretProperties, bool>)(x => x.Name.StartsWith("S")), new List<string>() { "Seattle", "SanDiego" } };
                     yield return new object[] { (Func<SecretProperties, bool>)(x => x.Name.EndsWith("o")), new List<string>() { "Chicago", "SanDiego" } };
+                }
+            }
+        }
+
+        public class HostSecretsDataProvider
+        {
+            public static IEnumerable<object[]> TestCases
+            {
+                get
+                {
+                    var secrets = new List<KeyVaultSecret>()
+                    {
+                        SecretModelFactory.KeyVaultSecret(new SecretProperties("host--masterKey--master"), "test"),
+                        SecretModelFactory.KeyVaultSecret(new SecretProperties("host--systemKey--test"), "test"),
+                        SecretModelFactory.KeyVaultSecret(new SecretProperties("host--functionKey--test"), "test")
+                    };
+
+                    HostSecrets hostSecrets = new HostSecrets()
+                    {
+                        MasterKey = new Key("master", "test"),
+                        FunctionKeys = new List<Key>() { new Key("test", "test") },
+                        SystemKeys = new List<Key>() { new Key("test", "test") }
+                    };
+
+                    yield return new object[] { secrets, hostSecrets };
+
+                    secrets = new List<KeyVaultSecret>()
+                    {
+                        SecretModelFactory.KeyVaultSecret(new SecretProperties("host--masterkey--master"), "test"),
+                        SecretModelFactory.KeyVaultSecret(new SecretProperties("host--systemkey--test"), "test"),
+                        SecretModelFactory.KeyVaultSecret(new SecretProperties("host--functionkey--test"), "test"),
+                    };
+
+                    hostSecrets = new HostSecrets()
+                    {
+                        MasterKey = new Key("master", "test"),
+                        FunctionKeys = new List<Key>() { new Key("test", "test") },
+                        SystemKeys = new List<Key>() { new Key("test", "test") }
+                    };
+
+                    yield return new object[] { secrets, hostSecrets };
                 }
             }
         }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
Updating comparisons on `KeyVaultSecretsRepository` to ignore casing as KeyVault secrets are case insensitive. 
resolves #9620

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)