### PR TITLE
[pack] Enable ordering of RpcLog and InvocationResponse messages

### DIFF
--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -159,8 +159,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             if (_hostingConfigOptions.Value.EnableOrderedInvocationMessages ||
                 FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableOrderedInvocationmessages, _environment))
             {
-                _workerChannelLogger.LogDebug($"Using {nameof(OrderedInvocationProcessorFactory)}.");
-                return new OrderedInvocationProcessorFactory(ProcessItem, _workerChannelLogger);
+                _workerChannelLogger.LogDebug($"Using {nameof(OrderedInvocationMessageDispatcherFactory)}.");
+                return new OrderedInvocationMessageDispatcherFactory(ProcessItem, _workerChannelLogger);
             }
             else
             {

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -1,39 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Reactive.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Channels;
-using System.Threading.Tasks;
-using System.Threading.Tasks.Dataflow;
-using Google.Protobuf.Collections;
-using Google.Protobuf.WellKnownTypes;
-using Microsoft.Azure.WebJobs.Logging;
-using Microsoft.Azure.WebJobs.Script.Config;
-using Microsoft.Azure.WebJobs.Script.Description;
-using Microsoft.Azure.WebJobs.Script.Diagnostics;
-using Microsoft.Azure.WebJobs.Script.Eventing;
-using Microsoft.Azure.WebJobs.Script.Extensions;
-using Microsoft.Azure.WebJobs.Script.Grpc.Eventing;
-using Microsoft.Azure.WebJobs.Script.Grpc.Extensions;
-using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
-using Microsoft.Azure.WebJobs.Script.ManagedDependencies;
-using Microsoft.Azure.WebJobs.Script.Workers;
-using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
-using Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Yarp.ReverseProxy.Forwarder;
-
-using static Microsoft.Azure.WebJobs.Script.Grpc.Messages.RpcLog.Types;
 using FunctionMetadata = Microsoft.Azure.WebJobs.Script.Description.FunctionMetadata;
 using MsgType = Microsoft.Azure.WebJobs.Script.Grpc.Messages.StreamingMessage.ContentOneofCase;
 using ParameterBindingType = Microsoft.Azure.WebJobs.Script.Grpc.Messages.ParameterBinding.RpcDataOneofCase;

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -1,6 +1,38 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using Google.Protobuf.Collections;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.Extensions;
+using Microsoft.Azure.WebJobs.Script.Grpc.Eventing;
+using Microsoft.Azure.WebJobs.Script.Grpc.Extensions;
+using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using Microsoft.Azure.WebJobs.Script.ManagedDependencies;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Yarp.ReverseProxy.Forwarder;
+using static Microsoft.Azure.WebJobs.Script.Grpc.Messages.RpcLog.Types;
 using FunctionMetadata = Microsoft.Azure.WebJobs.Script.Description.FunctionMetadata;
 using MsgType = Microsoft.Azure.WebJobs.Script.Grpc.Messages.StreamingMessage.ContentOneofCase;
 using ParameterBindingType = Microsoft.Azure.WebJobs.Script.Grpc.Messages.ParameterBinding.RpcDataOneofCase;
@@ -18,6 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         private readonly List<TimeSpan> _workerStatusLatencyHistory = new List<TimeSpan>();
         private readonly IOptions<WorkerConcurrencyOptions> _workerConcurrencyOptions;
         private readonly WaitCallback _processInbound;
+        private readonly IInvocationMessageDispatcherFactory _messageDispatcherFactory;
         private readonly object _syncLock = new object();
         private readonly object _metadataLock = new object();
         private readonly Dictionary<MsgType, Queue<PendingItem>> _pendingActions = new();
@@ -32,7 +65,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         private RpcWorkerChannelState _state;
         private IDictionary<string, Exception> _functionLoadErrors = new Dictionary<string, Exception>();
         private IDictionary<string, Exception> _metadataRequestErrors = new Dictionary<string, Exception>();
-        private ConcurrentDictionary<string, ScriptInvocationContext> _executingInvocations = new ConcurrentDictionary<string, ScriptInvocationContext>();
+        private ConcurrentDictionary<string, ExecutingInvocation> _executingInvocations = new();
         private IDictionary<string, BufferBlock<ScriptInvocationContext>> _functionInputBuffers = new ConcurrentDictionary<string, BufferBlock<ScriptInvocationContext>>();
         private ConcurrentDictionary<string, TaskCompletionSource<bool>> _workerStatusRequests = new ConcurrentDictionary<string, TaskCompletionSource<bool>>();
         private List<IDisposable> _inputLinks = new List<IDisposable>();
@@ -104,6 +137,9 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             _startLatencyMetric = metricsLogger?.LatencyEvent(string.Format(MetricEventNames.WorkerInitializeLatency, workerConfig.Description.Language, attemptCount));
 
             _state = RpcWorkerChannelState.Default;
+
+            // Temporary switch to allow fully testing new algorithm in production
+            _messageDispatcherFactory = GetProcessorFactory();
         }
 
         private bool IsHttpProxyingWorker => _httpProxyEndpoint is not null;
@@ -115,6 +151,23 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         public IWorkerProcess WorkerProcess => _rpcWorkerProcess;
 
         public RpcWorkerConfig WorkerConfig => _workerConfig;
+
+        // Temporary switch that allows us to move between the "old" ThreadPool-only processor
+        // and a "new" Channel processor (for proper ordering of messages).
+        private IInvocationMessageDispatcherFactory GetProcessorFactory()
+        {
+            if (_hostingConfigOptions.Value.EnableOrderedInvocationMessages ||
+                FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableOrderedInvocationmessages, _environment))
+            {
+                _workerChannelLogger.LogDebug($"Using {nameof(OrderedInvocationProcessorFactory)}.");
+                return new OrderedInvocationProcessorFactory(ProcessItem, _workerChannelLogger);
+            }
+            else
+            {
+                _workerChannelLogger.LogDebug($"Using {nameof(ThreadPoolInvocationProcessorFactory)}.");
+                return new ThreadPoolInvocationProcessorFactory(_processInbound);
+            }
+        }
 
         private void ProcessItem(InboundGrpcEvent msg)
         {
@@ -218,7 +271,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                         {
                             Logger.ChannelReceivedMessage(_workerChannelLogger, msg.WorkerId, msg.MessageType);
                         }
-                        ThreadPool.QueueUserWorkItem(_processInbound, msg);
+
+                        DispatchMessage(msg);
                     }
                 }
             }
@@ -230,6 +284,40 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             {
                 // we're not listening any more! shut down the channels
                 _eventManager.RemoveGrpcChannels(_workerId);
+            }
+        }
+
+        private void DispatchMessage(InboundGrpcEvent msg)
+        {
+            // RpcLog and InvocationResponse messages are special. They need to be handled by the InvocationMessageDispatcher
+            switch (msg.MessageType)
+            {
+                case MsgType.RpcLog when msg.Message.RpcLog.LogCategory == RpcLogCategory.User || msg.Message.RpcLog.LogCategory == RpcLogCategory.CustomMetric:
+                    if (_executingInvocations.TryGetValue(msg.Message.RpcLog.InvocationId, out var invocation))
+                    {
+                        invocation.Dispatcher.DispatchRpcLog(msg);
+                    }
+                    else
+                    {
+                        // We received a log outside of a invocation
+                        ThreadPool.QueueUserWorkItem(_processInbound, msg);
+                    }
+                    break;
+                case MsgType.InvocationResponse:
+                    if (_executingInvocations.TryGetValue(msg.Message.InvocationResponse.InvocationId, out invocation))
+                    {
+                        invocation.Dispatcher.DispatchInvocationResponse(msg);
+                    }
+                    else
+                    {
+                        // This should never happen, but if it does, just send it to the ThreadPool.
+                        ThreadPool.QueueUserWorkItem(_processInbound, msg);
+                    }
+                    break;
+                default:
+                    // All other messages can go to the thread pool.
+                    ThreadPool.QueueUserWorkItem(_processInbound, msg);
+                    break;
             }
         }
 
@@ -717,14 +805,14 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                 {
                     _workerChannelLogger.LogDebug("Function {functionName} failed to load", context.FunctionMetadata.Name);
                     context.ResultSource.TrySetException(_functionLoadErrors[context.FunctionMetadata.GetFunctionId()]);
-                    _executingInvocations.TryRemove(invocationId, out ScriptInvocationContext _);
+                    RemoveExecutingInvocation(invocationId);
                     return;
                 }
                 else if (_metadataRequestErrors.ContainsKey(context.FunctionMetadata.GetFunctionId()))
                 {
                     _workerChannelLogger.LogDebug("Worker failed to load metadata for {functionName}", context.FunctionMetadata.Name);
                     context.ResultSource.TrySetException(_metadataRequestErrors[context.FunctionMetadata.GetFunctionId()]);
-                    _executingInvocations.TryRemove(invocationId, out ScriptInvocationContext _);
+                    RemoveExecutingInvocation(invocationId);
                     return;
                 }
 
@@ -738,7 +826,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
                 var invocationRequest = await context.ToRpcInvocationRequest(_workerChannelLogger, _workerCapabilities, _isSharedMemoryDataTransferEnabled, _sharedMemoryManager);
                 AddAdditionalTraceContext(invocationRequest.TraceContext.Attributes, context);
-                _executingInvocations.TryAdd(invocationRequest.InvocationId, context);
+                _executingInvocations.TryAdd(invocationRequest.InvocationId, new(context, _messageDispatcherFactory.Create(invocationRequest.InvocationId)));
                 _metricsLogger.LogEvent(string.Format(MetricEventNames.WorkerInvoked, Id), functionName: Sanitizer.Sanitize(context.FunctionMetadata.Name));
 
                 await SendStreamingMessageAsync(new StreamingMessage
@@ -947,8 +1035,9 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             // Check if the worker supports logging user-code-thrown exceptions to app insights
             bool capabilityEnabled = !string.IsNullOrEmpty(_workerCapabilities.GetCapabilityState(RpcWorkerConstants.EnableUserCodeException));
 
-            if (_executingInvocations.TryRemove(invokeResponse.InvocationId, out ScriptInvocationContext context))
+            if (_executingInvocations.TryRemove(invokeResponse.InvocationId, out var invocation))
             {
+                var context = invocation.Context;
                 if (invokeResponse.Result.IsInvocationSuccess(context.ResultSource, capabilityEnabled))
                 {
                     _metricsLogger.LogEvent(string.Format(MetricEventNames.WorkerInvokeSucceeded, Id));
@@ -1018,6 +1107,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                             SendCloseSharedMemoryResourcesForInvocationRequest(outputMaps);
                         }
                     }
+
+                    invocation.Dispose();
                 }
                 else
                 {
@@ -1050,8 +1141,10 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         internal void Log(GrpcEvent msg)
         {
             var rpcLog = msg.Message.RpcLog;
-            if (_executingInvocations.TryGetValue(rpcLog.InvocationId, out ScriptInvocationContext context))
+            if (_executingInvocations.TryGetValue(rpcLog.InvocationId, out var invocation))
             {
+                var context = invocation.Context;
+
                 // Restore the execution context from the original invocation. This allows AsyncLocal state to flow to loggers.
                 System.Threading.ExecutionContext.Run(context.AsyncExecutionContext, static (state) =>
                 {
@@ -1240,12 +1333,25 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             }
         }
 
+        private void RemoveExecutingInvocation(string invocationId)
+        {
+            if (_executingInvocations.TryRemove(invocationId, out var invocation))
+            {
+                invocation.Dispose();
+            }
+        }
+
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)
             {
                 if (disposing)
                 {
+                    foreach (var id in _executingInvocations.Keys)
+                    {
+                        RemoveExecutingInvocation(id);
+                    }
+
                     _startLatencyMetric?.Dispose();
                     _workerInitTask?.TrySetCanceled();
                     _timer?.Dispose();
@@ -1333,9 +1439,9 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         public async Task DrainInvocationsAsync()
         {
             _workerChannelLogger.LogDebug("Count of in-buffer invocations waiting to be drained out: {invocationCount}", _executingInvocations.Count);
-            foreach (ScriptInvocationContext currContext in _executingInvocations.Values)
+            foreach (var invocation in _executingInvocations.Values)
             {
-                await currContext.ResultSource.Task;
+                await invocation.Context.ResultSource.Task;
             }
         }
 
@@ -1351,12 +1457,12 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                 return false;
             }
 
-            foreach (ScriptInvocationContext currContext in _executingInvocations?.Values)
+            foreach (var invocation in _executingInvocations?.Values)
             {
-                string invocationId = currContext?.ExecutionContext?.InvocationId.ToString();
+                string invocationId = invocation.Context?.ExecutionContext?.InvocationId.ToString();
                 _workerChannelLogger.LogDebug("Worker '{workerId}' encountered a fatal error. Failing invocation: '{invocationId}'", _workerId, invocationId);
-                currContext?.ResultSource?.TrySetException(workerException);
-                _executingInvocations.TryRemove(invocationId, out ScriptInvocationContext _);
+                invocation.Context?.ResultSource?.TrySetException(workerException);
+                RemoveExecutingInvocation(invocationId);
             }
             return true;
         }
@@ -1493,6 +1599,24 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                 {
                     attributes[ScriptConstants.OperationNameKey] = operationName;
                 }
+            }
+        }
+
+        private sealed class ExecutingInvocation : IDisposable
+        {
+            public ExecutingInvocation(ScriptInvocationContext context, IInvocationMessageDispatcher dispatcher)
+            {
+                Context = context;
+                Dispatcher = dispatcher;
+            }
+
+            public ScriptInvocationContext Context { get; }
+
+            public IInvocationMessageDispatcher Dispatcher { get; }
+
+            public void Dispose()
+            {
+                (Dispatcher as IDisposable)?.Dispose();
             }
         }
 

--- a/src/WebJobs.Script.Grpc/Channel/IInvocationMessageDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/Channel/IInvocationMessageDispatcher.cs
@@ -26,7 +26,7 @@ internal interface IInvocationMessageDispatcher
     /// <summary>
     /// Inspects the incoming RpcLog and dispatches to a Thread or background Task as quickly as possible. This method is
     /// called from a loop processing incoming grpc messages and any thread blocking will delay the processing of that loop.
-    /// It can be assumed that this thread will never be called from multiple threads simultaneously and thus does not need
+    /// It can be assumed that this method will never be called from multiple threads simultaneously and thus does not need
     /// to be thread-safe.
     /// </summary>
     /// <param name="msg">The RpcLog message. Implementors can assume that this message is an RpcLog.</param>
@@ -35,7 +35,7 @@ internal interface IInvocationMessageDispatcher
     /// <summary>
     /// Inspects an incoming InvocationResponse message and dispatches to a Thread or background Task as quickly as possible.
     /// This method is called from a loop processing incoming grpc messages and any thread blocking will delay the processing
-    /// of that loop. It can be assumed that this thread will never be called from multiple threads simultaneously and thus
+    /// of that loop. It can be assumed that this method will never be called from multiple threads simultaneously and thus
     /// does not need to be thread-safe.
     /// </summary>
     /// <param name="msg">The InvocationResponse message. Implementors can assume that this message is an InvocationResponse.</param>

--- a/src/WebJobs.Script.Grpc/Channel/IInvocationMessageDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/Channel/IInvocationMessageDispatcher.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading;
+using Microsoft.Azure.WebJobs.Script.Grpc.Eventing;
+
+namespace Microsoft.Azure.WebJobs.Script.Grpc;
+
+/// <summary>
+/// Interface for processing grpc messages that may come from the worker that are
+/// related to an invocation (RpcLog and InvocationResponse).
+/// </summary>
+internal interface IInvocationMessageDispatcher
+{
+    void DispatchRpcLog(InboundGrpcEvent msg);
+
+    void DispatchInvocationResponse(InboundGrpcEvent msg);
+}
+
+internal interface IInvocationMessageDispatcherFactory
+{
+    IInvocationMessageDispatcher Create(string invocationId);
+}
+
+internal class ThreadPoolInvocationProcessorFactory : IInvocationMessageDispatcher, IInvocationMessageDispatcherFactory
+{
+    private readonly WaitCallback _callback;
+
+    public ThreadPoolInvocationProcessorFactory(WaitCallback callback)
+    {
+        _callback = callback;
+    }
+
+    // always return a single instance
+    public IInvocationMessageDispatcher Create(string invocationId) => this;
+
+    public void DispatchRpcLog(InboundGrpcEvent msg) => ThreadPool.QueueUserWorkItem(_callback, msg);
+
+    public void DispatchInvocationResponse(InboundGrpcEvent msg) => ThreadPool.QueueUserWorkItem(_callback, msg);
+}

--- a/src/WebJobs.Script.Grpc/Channel/IInvocationMessageDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/Channel/IInvocationMessageDispatcher.cs
@@ -7,11 +7,37 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc;
 
 /// <summary>
 /// Interface for processing grpc messages that may come from the worker that are
-/// related to an invocation (RpcLog and InvocationResponse).
+/// related to an invocation (RpcLog and InvocationResponse). The contract here is as-follows:
+/// - The contract with a worker is that, during an invocation (i.e an InvocationRequest has been sent), there are only
+///   two messages that the worker can send us related to that invocation
+///   - one or many RpcLog messages
+///   - one final InvocationResponse that effectively ends the invocation. Once the InvocationResponse is received, no
+///     more RpcLog messages from this specific invocation will be processed.
+/// - The GrpcChannel is looping to dequeue grpc messages from a worker. When it finds one that is either an RpcLog
+///   or an InvocationResponse, it will will call the matching method on this interface (i.e. RpcLog -> DispatchRpcLog)
+///   from the same thread that is looping and dequeuing items from the grpc channel. The implementors of this interface
+///   must quickly dispatch the message to a background Task or Thread for handling, so as to not block the
+///   main loop from dequeuing more messages.
+/// - Because the methods on this interface are all on being called from the same thread, they do not need to be
+///   thread-safe. They can assume that they will not be called multiple times from different threads.
 /// </summary>
 internal interface IInvocationMessageDispatcher
 {
+    /// <summary>
+    /// Inspects the incoming RpcLog and dispatches to a Thread or background Task as quickly as possible. This method is
+    /// called from a loop processing incoming grpc messages and any thread blocking will delay the processing of that loop.
+    /// It can be assumed that this thread will never be called from multiple threads simultaneously and thus does not need
+    /// to be thread-safe.
+    /// </summary>
+    /// <param name="msg">The RpcLog message. Implementors can assume that this message is an RpcLog.</param>
     void DispatchRpcLog(InboundGrpcEvent msg);
 
+    /// <summary>
+    /// Inspects an incoming InvocationResponse message and dispatches to a Thread or background Task as quickly as possible.
+    /// This method is called from a loop processing incoming grpc messages and any thread blocking will delay the processing
+    /// of that loop. It can be assumed that this thread will never be called from multiple threads simultaneously and thus
+    /// does not need to be thread-safe.
+    /// </summary>
+    /// <param name="msg">The InvocationResponse message. Implementors can assume that this message is an InvocationResponse.</param>
     void DispatchInvocationResponse(InboundGrpcEvent msg);
 }

--- a/src/WebJobs.Script.Grpc/Channel/IInvocationMessageDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/Channel/IInvocationMessageDispatcher.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Threading;
 using Microsoft.Azure.WebJobs.Script.Grpc.Eventing;
 
 namespace Microsoft.Azure.WebJobs.Script.Grpc;
@@ -15,26 +14,4 @@ internal interface IInvocationMessageDispatcher
     void DispatchRpcLog(InboundGrpcEvent msg);
 
     void DispatchInvocationResponse(InboundGrpcEvent msg);
-}
-
-internal interface IInvocationMessageDispatcherFactory
-{
-    IInvocationMessageDispatcher Create(string invocationId);
-}
-
-internal class ThreadPoolInvocationProcessorFactory : IInvocationMessageDispatcher, IInvocationMessageDispatcherFactory
-{
-    private readonly WaitCallback _callback;
-
-    public ThreadPoolInvocationProcessorFactory(WaitCallback callback)
-    {
-        _callback = callback;
-    }
-
-    // always return a single instance
-    public IInvocationMessageDispatcher Create(string invocationId) => this;
-
-    public void DispatchRpcLog(InboundGrpcEvent msg) => ThreadPool.QueueUserWorkItem(_callback, msg);
-
-    public void DispatchInvocationResponse(InboundGrpcEvent msg) => ThreadPool.QueueUserWorkItem(_callback, msg);
 }

--- a/src/WebJobs.Script.Grpc/Channel/IInvocationMessageDispatcherFactory.cs
+++ b/src/WebJobs.Script.Grpc/Channel/IInvocationMessageDispatcherFactory.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script.Grpc;
+
+internal interface IInvocationMessageDispatcherFactory
+{
+    IInvocationMessageDispatcher Create(string invocationId);
+}

--- a/src/WebJobs.Script.Grpc/Channel/OrderedInvocationMessageDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/Channel/OrderedInvocationMessageDispatcher.cs
@@ -10,33 +10,56 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.Grpc;
 
+/// <summary>
+/// An implementation of <see cref="IInvocationMessageDispatcher"/> that internally uses a per-invocation <see cref="Channel{T}"/> to ensure
+/// ordering of messages is maintained. The calls to <see cref="DispatchRpcLog(InboundGrpcEvent)"/> and <see cref="DispatchInvocationResponse(InboundGrpcEvent)"/>
+/// both write messages to the same <see cref="Channel{T}"/>. Then, a background <see cref="Task"/> reads messages from this channel and invokes the
+/// <see cref="Action"/> provided in the constructor.
+///
+/// This dispatcher is created with the <see cref="OrderedInvocationMessageDispatcherFactory"/> to ensure that instances are created and disposed
+/// per-invocation. This means that every instance is only ever responsible for processing messages from a single invocation.
+/// </summary>
 internal sealed class OrderedInvocationMessageDispatcher : IInvocationMessageDispatcher, IDisposable
 {
     private readonly ILogger _logger;
     private readonly string _invocationId;
-    private readonly Action<InboundGrpcEvent> _dispatchWithChannel;
+    private readonly Action<InboundGrpcEvent> _processItemWithChannel;
 
     // Separated these out for easier testing of the flow.
-    private readonly Action<InboundGrpcEvent> _dispatchWithThreadPool;
+    private readonly Action<InboundGrpcEvent> _processItemWithThreadPool;
 
     private Channel<InboundGrpcEvent> _channel;
     private bool _isChannelInitialized = false;
     private bool _invocationComplete = false;
     private bool _disposed = false;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OrderedInvocationMessageDispatcher"/> class.
+    /// </summary>
+    /// <param name="invocationId">The function invocation id.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="processItem">A callback to be invoked when processing an item.</param>
     public OrderedInvocationMessageDispatcher(string invocationId, ILogger logger, Action<InboundGrpcEvent> processItem)
         : this(invocationId, logger, processItem, processItem)
     {
     }
 
-    // For testing
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OrderedInvocationMessageDispatcher"/> class. This constructor is only for testing purposes.
+    /// It allows a different action to be called when using the fallback ThreadPool dispatch behavior. This allows the tests to validate that
+    /// the fallback is correctly invoked.
+    /// </summary>
+    /// <param name="invocationId">The function invocation id.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="processItemWithChannel">A callback to be invoked when processing an item from the internal Channel.</param>
+    /// <param name="processItemWithThreadPool">A callback to be invoked when processing an item on the ThreadPool. This is a fallback scenario.</param>
     internal OrderedInvocationMessageDispatcher(string invocationId, ILogger logger, Action<InboundGrpcEvent> processItemWithChannel,
         Action<InboundGrpcEvent> processItemWithThreadPool)
     {
         _logger = logger;
         _invocationId = invocationId;
-        _dispatchWithChannel = processItemWithChannel;
-        _dispatchWithThreadPool = processItemWithThreadPool;
+        _processItemWithChannel = processItemWithChannel;
+        _processItemWithThreadPool = processItemWithThreadPool;
     }
 
     // For testing
@@ -52,11 +75,18 @@ internal sealed class OrderedInvocationMessageDispatcher : IInvocationMessageDis
 
     public void DispatchRpcLog(InboundGrpcEvent msg)
     {
-        // The channel is only needed if we use any logs. Otherwise, ordering doesn't matter.
         // This is not thread-safe, but it is always called in-order from the same thread, so no
         // need for locking.
-        // We also do not want to initialize the channel if we're receiving an out-of-order RpcLog and
-        // the invocation is already done.
+
+        // The channel is only needed if we receive any RpcLog messages before we receive an
+        // InvocationResponse message. If the only message we ever see is InvocationResponse, we know
+        // the invocation is already complete and there's no need to use a channel for ordering, so skip
+        // the initialization altogether. In DispatchToInvocationResponse, we'll fallback to use the ThreadPool
+        // if the channel is not initialized.
+
+        // We also do not want to initialize the channel if we're receiving an RpcLog after the invocation
+        // has completed. In this case, the RpcLog will be dropped anyway, so there's no need to maintain
+        // ordering with the channel.
         if (!_isChannelInitialized && !_invocationComplete)
         {
             _channel = InitializeChannel();
@@ -76,7 +106,7 @@ internal sealed class OrderedInvocationMessageDispatcher : IInvocationMessageDis
         {
             WriteToChannel(msg);
 
-            // This signals that we're done with this invocation.
+            // Receiving an InvocationResponse signals that we're done with this invocation.
             _channel.Writer.TryComplete();
         }
         else
@@ -97,7 +127,7 @@ internal sealed class OrderedInvocationMessageDispatcher : IInvocationMessageDis
     }
 
     private void DispatchToThreadPool(InboundGrpcEvent msg) =>
-        ThreadPool.QueueUserWorkItem(state => _dispatchWithThreadPool((InboundGrpcEvent)state), msg);
+        ThreadPool.QueueUserWorkItem(state => _processItemWithThreadPool((InboundGrpcEvent)state), msg);
 
     private async Task ReadMessagesAsync()
     {
@@ -106,7 +136,7 @@ internal sealed class OrderedInvocationMessageDispatcher : IInvocationMessageDis
             await foreach (InboundGrpcEvent msg in _channel.Reader.ReadAllAsync())
             {
                 // Assume the Action being called is already wrapped in a try/catch
-                _dispatchWithChannel(msg);
+                _processItemWithChannel(msg);
             }
         }
         catch (Exception ex)

--- a/src/WebJobs.Script.Grpc/Channel/OrderedInvocationMessageDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/Channel/OrderedInvocationMessageDispatcher.cs
@@ -128,18 +128,3 @@ internal sealed class OrderedInvocationMessageDispatcher : IInvocationMessageDis
         }
     }
 }
-
-internal class OrderedInvocationProcessorFactory : IInvocationMessageDispatcherFactory
-{
-    private readonly Action<InboundGrpcEvent> _processItem;
-    private readonly ILogger _logger;
-
-    public OrderedInvocationProcessorFactory(Action<InboundGrpcEvent> processItem, ILogger logger)
-    {
-        _processItem = processItem;
-        _logger = logger;
-    }
-
-    public IInvocationMessageDispatcher Create(string invocationId) =>
-        new OrderedInvocationMessageDispatcher(invocationId, _logger, _processItem);
-}

--- a/src/WebJobs.Script.Grpc/Channel/OrderedInvocationMessageDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/Channel/OrderedInvocationMessageDispatcher.cs
@@ -1,0 +1,145 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Grpc.Eventing;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.Grpc;
+
+internal sealed class OrderedInvocationMessageDispatcher : IInvocationMessageDispatcher, IDisposable
+{
+    private readonly ILogger _logger;
+    private readonly string _invocationId;
+    private readonly Action<InboundGrpcEvent> _dispatchWithChannel;
+
+    // Separated these out for easier testing of the flow.
+    private readonly Action<InboundGrpcEvent> _dispatchWithThreadPool;
+
+    private Channel<InboundGrpcEvent> _channel;
+    private bool _isChannelInitialized = false;
+    private bool _invocationComplete = false;
+    private bool _disposed = false;
+
+    public OrderedInvocationMessageDispatcher(string invocationId, ILogger logger, Action<InboundGrpcEvent> processItem)
+        : this(invocationId, logger, processItem, processItem)
+    {
+    }
+
+    // For testing
+    internal OrderedInvocationMessageDispatcher(string invocationId, ILogger logger, Action<InboundGrpcEvent> processItemWithChannel,
+        Action<InboundGrpcEvent> processItemWithThreadPool)
+    {
+        _logger = logger;
+        _invocationId = invocationId;
+        _dispatchWithChannel = processItemWithChannel;
+        _dispatchWithThreadPool = processItemWithThreadPool;
+    }
+
+    // For testing
+    internal Channel<InboundGrpcEvent> MessageChannel => _channel;
+
+    private static Channel<InboundGrpcEvent> InitializeChannel() =>
+        Channel.CreateUnbounded<InboundGrpcEvent>(
+            new UnboundedChannelOptions
+            {
+                SingleReader = true,
+                SingleWriter = true
+            });
+
+    public void DispatchRpcLog(InboundGrpcEvent msg)
+    {
+        // The channel is only needed if we use any logs. Otherwise, ordering doesn't matter.
+        // This is not thread-safe, but it is always called in-order from the same thread, so no
+        // need for locking.
+        // We also do not want to initialize the channel if we're receiving an out-of-order RpcLog and
+        // the invocation is already done.
+        if (!_isChannelInitialized && !_invocationComplete)
+        {
+            _channel = InitializeChannel();
+            _ = ReadMessagesAsync();
+            _isChannelInitialized = true;
+        }
+
+        WriteToChannel(msg);
+    }
+
+    public void DispatchInvocationResponse(InboundGrpcEvent msg)
+    {
+        // Any other messages that come here shouldn't use the Channel.
+        _invocationComplete = true;
+
+        if (_isChannelInitialized)
+        {
+            WriteToChannel(msg);
+
+            // This signals that we're done with this invocation.
+            _channel.Writer.TryComplete();
+        }
+        else
+        {
+            // Channel was never started. We must not have needed it. Send directly to ThreadPool.
+            DispatchToThreadPool(msg);
+        }
+    }
+
+    private void WriteToChannel(InboundGrpcEvent msg)
+    {
+        if (_channel is null || !_channel.Writer.TryWrite(msg))
+        {
+            // If this fails, fall back to the ThreadPool
+            _logger.LogDebug("Cannot write '{msgType}' to channel for InvocationId '{functionInvocationId}'. Dispatching message to the ThreadPool.", msg.MessageType, _invocationId);
+            DispatchToThreadPool(msg);
+        }
+    }
+
+    private void DispatchToThreadPool(InboundGrpcEvent msg) =>
+        ThreadPool.QueueUserWorkItem(state => _dispatchWithThreadPool((InboundGrpcEvent)state), msg);
+
+    private async Task ReadMessagesAsync()
+    {
+        try
+        {
+            await foreach (InboundGrpcEvent msg in _channel.Reader.ReadAllAsync())
+            {
+                // Assume the Action being called is already wrapped in a try/catch
+                _dispatchWithChannel(msg);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error while reading InvocationProcessor channel for InvocationId '{functionInvocationId}'.", _invocationId);
+
+            // Ensure nothing else will be written to the channel. There is a possibility
+            // that some messages are lost here.
+            _channel.Writer.TryComplete(ex);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (!_disposed)
+        {
+            _disposed = true;
+            _channel?.Writer.TryComplete();
+        }
+    }
+}
+
+internal class OrderedInvocationProcessorFactory : IInvocationMessageDispatcherFactory
+{
+    private readonly Action<InboundGrpcEvent> _processItem;
+    private readonly ILogger _logger;
+
+    public OrderedInvocationProcessorFactory(Action<InboundGrpcEvent> processItem, ILogger logger)
+    {
+        _processItem = processItem;
+        _logger = logger;
+    }
+
+    public IInvocationMessageDispatcher Create(string invocationId) =>
+        new OrderedInvocationMessageDispatcher(invocationId, _logger, _processItem);
+}

--- a/src/WebJobs.Script.Grpc/Channel/OrderedInvocationMessageDispatcherFactory.cs
+++ b/src/WebJobs.Script.Grpc/Channel/OrderedInvocationMessageDispatcherFactory.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Script.Grpc.Eventing;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.Grpc;
+
+internal class OrderedInvocationMessageDispatcherFactory : IInvocationMessageDispatcherFactory
+{
+    private readonly Action<InboundGrpcEvent> _processItem;
+    private readonly ILogger _logger;
+
+    public OrderedInvocationMessageDispatcherFactory(Action<InboundGrpcEvent> processItem, ILogger logger)
+    {
+        _processItem = processItem;
+        _logger = logger;
+    }
+
+    public IInvocationMessageDispatcher Create(string invocationId) =>
+        new OrderedInvocationMessageDispatcher(invocationId, _logger, _processItem);
+}

--- a/src/WebJobs.Script.Grpc/Channel/ThreadPoolInvocationProcessorFactory.cs
+++ b/src/WebJobs.Script.Grpc/Channel/ThreadPoolInvocationProcessorFactory.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading;
+using Microsoft.Azure.WebJobs.Script.Grpc.Eventing;
+
+namespace Microsoft.Azure.WebJobs.Script.Grpc;
+
+/// <summary>
+/// Temporary class that handles both creation of the processor and acts as the processor itself. Once we've
+/// confirmed that the OrderedInvocationMessageDispatcher works as expected, we will remove this.
+/// </summary>
+internal class ThreadPoolInvocationProcessorFactory : IInvocationMessageDispatcher, IInvocationMessageDispatcherFactory
+{
+    private readonly WaitCallback _callback;
+
+    public ThreadPoolInvocationProcessorFactory(WaitCallback callback)
+    {
+        _callback = callback;
+    }
+
+    // always return a single instance
+    public IInvocationMessageDispatcher Create(string invocationId) => this;
+
+    public void DispatchRpcLog(InboundGrpcEvent msg) => ThreadPool.QueueUserWorkItem(_callback, msg);
+
+    public void DispatchInvocationResponse(InboundGrpcEvent msg) => ThreadPool.QueueUserWorkItem(_callback, msg);
+}

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -113,6 +113,19 @@ namespace Microsoft.Azure.WebJobs.Script.Config
             }
         }
 
+        public bool EnableOrderedInvocationMessages
+        {
+            get
+            {
+                return GetFeature(ScriptConstants.FeatureFlagEnableOrderedInvocationmessages) == "1";
+            }
+
+            set
+            {
+                _features[ScriptConstants.FeatureFlagEnableOrderedInvocationmessages] = value ? "1" : "0";
+            }
+        }
+
         /// <summary>
         /// Gets the highest version of extension bundle v3 supported
         /// </summary>

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -128,6 +128,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FeatureFlagEnableWorkerIndexing = "EnableWorkerIndexing";
         public const string FeatureFlagEnableDebugTracing = "EnableDebugTracing";
         public const string FeatureFlagEnableProxies = "EnableProxies";
+        public const string FeatureFlagEnableOrderedInvocationmessages = "EnableOrderedInvocationMessages";
         public const string HostingConfigDisableLinuxAppServiceDetailedExecutionEvents = "DisableLinuxExecutionDetails";
         public const string HostingConfigDisableLinuxAppServiceExecutionEventLogBackoff = "DisableLinuxLogBackoff";
         public const string FeatureFlagEnableLegacyDurableVersionCheck = "EnableLegacyDurableVersionCheck";

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -1360,7 +1360,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         {
             // Without this feature flag, this test fails every time on multi-core machines as the logs will
             // be processed out-of-order
-            _testEnvironment.SetEnvironmentVariable("AzureWebJobsFeatureFlags", "EnableOrderedInvocationMessages");
+            _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagEnableOrderedInvocationmessages);
 
             await CreateDefaultWorkerChannel();
             _metricsLogger.ClearCollections();

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -1358,6 +1358,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         [Fact]
         public async Task Log_And_InvocationResult_OrderedCorrectly()
         {
+            // Without this feature flag, this test fails every time on multi-core machines as the logs will
+            // be processed out-of-order
+            _testEnvironment.SetEnvironmentVariable("AzureWebJobsFeatureFlags", "EnableOrderedInvocationMessages");
+
             await CreateDefaultWorkerChannel();
             _metricsLogger.ClearCollections();
 
@@ -1391,7 +1395,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             }
         }
 
-        private IEnumerable<FunctionMetadata> GetTestFunctionsList(string runtime, bool addWorkerProperties = false)
+        private static IEnumerable<FunctionMetadata> GetTestFunctionsList(string runtime, bool addWorkerProperties = false)
         {
             var metadata1 = new FunctionMetadata()
             {
@@ -1430,8 +1434,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             };
         }
 
-        private ScriptInvocationContext GetTestScriptInvocationContext(Guid invocationId, TaskCompletionSource<ScriptInvocationResult> resultSource,
-             CancellationToken? token = null, ILogger logger = null)
+        public static ScriptInvocationContext GetTestScriptInvocationContext(Guid invocationId, TaskCompletionSource<ScriptInvocationResult> resultSource,
+             CancellationToken? token = null, ILogger logger = null, string scriptRootPath = null)
         {
             return new ScriptInvocationContext()
             {
@@ -1440,8 +1444,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 {
                     InvocationId = invocationId,
                     FunctionName = "js1",
-                    FunctionAppDirectory = _scriptRootPath,
-                    FunctionDirectory = _scriptRootPath
+                    FunctionAppDirectory = scriptRootPath,
+                    FunctionDirectory = scriptRootPath
                 },
                 BindingData = new Dictionary<string, object>(),
                 Inputs = new List<(string Name, DataType Type, object Val)>(),

--- a/test/WebJobs.Script.Tests/Workers/Rpc/OrderedInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/OrderedInvocationDispatcherTests.cs
@@ -1,0 +1,147 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Grpc;
+using Microsoft.Azure.WebJobs.Script.Grpc.Eventing;
+using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
+{
+    public class OrderedInvocationDispatcherTests : IDisposable
+    {
+        private readonly TestLogger _logger = new TestLogger<OrderedInvocationDispatcherTests>();
+        private int _channelCount;
+        private int _threadCount;
+        private OrderedInvocationMessageDispatcher _dispatcher;
+
+        public OrderedInvocationDispatcherTests()
+        {
+            _dispatcher = new OrderedInvocationMessageDispatcher(Guid.NewGuid().ToString(), _logger, ProcessWithChannel, ProcessWithThreadPool);
+        }
+
+        [Fact]
+        public async Task Processor_WithLogs_UsesChannel()
+        {
+            _dispatcher.DispatchRpcLog(CreateRpcLog());
+            _dispatcher.DispatchRpcLog(CreateRpcLog());
+            _dispatcher.DispatchRpcLog(CreateRpcLog());
+            _dispatcher.DispatchInvocationResponse(CreateInvocationResponse());
+
+            await TestHelpers.Await(() => _channelCount == 4);
+
+            Assert.Empty(_logger.GetLogMessages());
+            Assert.Equal(0, _threadCount);
+            Assert.Equal(4, _channelCount);
+            Assert.NotNull(_dispatcher.MessageChannel);
+            Assert.True(_dispatcher.MessageChannel.Reader.Completion.IsCompletedSuccessfully);
+        }
+
+        [Fact]
+        public async Task Processor_OnDispose_ClosesWriterAndSendsToThreadPool()
+        {
+            _dispatcher.DispatchRpcLog(CreateRpcLog());
+
+            await TestHelpers.Await(() => _channelCount == 1);
+
+            _dispatcher.Dispose();
+
+            _dispatcher.DispatchInvocationResponse(CreateInvocationResponse());
+
+            // We still expect this to be run, but on the ThreadPool rather than via the channel.
+            await TestHelpers.Await(() => _threadCount == 1);
+
+            Assert.Collection(_logger.GetLogMessages(), m => Assert.StartsWith("Cannot write", m.FormattedMessage));
+            Assert.Equal(1, _channelCount);
+            Assert.Equal(1, _threadCount);
+            Assert.NotNull(_dispatcher.MessageChannel);
+            Assert.True(_dispatcher.MessageChannel.Reader.Completion.IsCompletedSuccessfully);
+        }
+
+        [Fact]
+        public async Task Processor_NoLogs_DoesNotUseChannel()
+        {
+            _dispatcher.DispatchInvocationResponse(CreateInvocationResponse());
+
+            await TestHelpers.Await(() => _threadCount == 1);
+
+            Assert.Equal(0, _channelCount);
+            Assert.Equal(1, _threadCount);
+            Assert.Null(_dispatcher.MessageChannel);
+        }
+
+        [Fact]
+        public async Task Processor_RpcLogAfterChannelCloses_UsesThreadPool()
+        {
+            // Use an RpcLog to initialize the channel, then close it, then try to log again.
+            _dispatcher.DispatchRpcLog(CreateRpcLog());
+            _dispatcher.DispatchInvocationResponse(CreateInvocationResponse());
+            _dispatcher.DispatchRpcLog(CreateRpcLog());
+
+            await TestHelpers.Await(() => _channelCount == 2);
+            await TestHelpers.Await(() => _threadCount == 1);
+
+            Assert.Equal(2, _channelCount);
+            Assert.Equal(1, _threadCount);
+            Assert.Collection(_logger.GetLogMessages(), m => Assert.StartsWith("Cannot write", m.FormattedMessage));
+            Assert.NotNull(_dispatcher.MessageChannel);
+            Assert.True(_dispatcher.MessageChannel.Reader.Completion.IsCompletedSuccessfully);
+        }
+
+        [Fact]
+        public async Task Processor_RpcLogAfterResponse_UsesThreadPool()
+        {
+            // If the Channel was never initialized and we've received an after-completion RpcLog,
+            // do not initialize the channel. Should fall back to ThreadPool and log.
+            _dispatcher.DispatchInvocationResponse(CreateInvocationResponse());
+            _dispatcher.DispatchRpcLog(CreateRpcLog());
+
+            await TestHelpers.Await(() => _threadCount == 2);
+
+            Assert.Equal(0, _channelCount);
+            Assert.Equal(2, _threadCount);
+            Assert.Collection(_logger.GetLogMessages(), m => Assert.StartsWith("Cannot write", m.FormattedMessage));
+            Assert.Null(_dispatcher.MessageChannel);
+        }
+
+        private static InboundGrpcEvent CreateRpcLog()
+        {
+            var msg = new StreamingMessage
+            {
+                RpcLog = new RpcLog
+                {
+                    Message = "test"
+                }
+            };
+
+            return new InboundGrpcEvent("worker_id", msg);
+        }
+
+        private static InboundGrpcEvent CreateInvocationResponse()
+        {
+            var msg = new StreamingMessage
+            {
+                InvocationResponse = new InvocationResponse()
+            };
+
+            return new InboundGrpcEvent("worker_id", msg);
+        }
+
+        private void ProcessWithChannel(InboundGrpcEvent msg)
+        {
+            _channelCount++;
+        }
+
+        private void ProcessWithThreadPool(InboundGrpcEvent msg)
+        {
+            _threadCount++;
+        }
+
+        public void Dispose()
+        {
+            _dispatcher.Dispose();
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Workers/Rpc/TestFunctionRpcService.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/TestFunctionRpcService.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Description;
-using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.Grpc.Eventing;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
@@ -267,6 +266,24 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             {
                 RpcLog = rpcLog
             };
+            Write(logMessage);
+        }
+
+        public void PublishLogEvent(string message, string invocationId)
+        {
+            RpcLog rpcLog = new RpcLog()
+            {
+                LogCategory = RpcLog.Types.RpcLogCategory.User,
+                Level = RpcLog.Types.Level.Information,
+                InvocationId = invocationId,
+                Message = message
+            };
+
+            StreamingMessage logMessage = new StreamingMessage()
+            {
+                RpcLog = rpcLog
+            };
+
             Write(logMessage);
         }
 


### PR DESCRIPTION
~_Note -- I have a few things left to cleanup, but this is ready for initial review while I make sure all tests pass CI._~

resolves #9238 

This issue was introduced back when the GrpcChannel pipeline was refactored back in #8281. This change changed some behavior such that every message that came from the worker to the host via grpc was quickly queued on the ThreadPool for the fastest possible processing. 

However, there are two message types that require ordering -- `RpcLog` and `InvocationResponse`:
- If these are out of order, you'll end up with out-of-order logs, which makes debugging and tracing difficult
- Once we receive an `InvocationResponse`, we consider that invocation complete and remove the tracking context we had been using. This means that if we process a log after this, we have no information that the `RpcLog` needs and we just drop it.

This change special-cases these "InvocationMessages" and puts them through a per-invocation dispatcher. Internally this sticks these messages into a Channel and processes them via a background Task. This processing ensures they are processed in order, at the expense of running as fast-as-possible on all Threads.

This is currently hidden behind both a stamp-level setting and a FeatureFlag. Once in, we can enable for entire stamps and gather perf numbers, etc, then slowly roll out once we're comfortable. Customers that want to try sooner can set the flag themselves for their app.

Once we're confident in the change, we'll remove this completely and everyone will use this new dispatcher method.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
