### PR TITLE
FlexConsumption Non-Encrypted Assign Endpoint for Legion

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -28,4 +28,5 @@
    - Azure.Core (1.34.0 to 1.35.0)
 - Bug fix: Comparisons in the Azure Key Vault Secrets Repository are now case insensitive (#9644)
   - This fixes a bug where keys could be automatically recreated if they had been manually added to Key Vault with all lowercase secret names
+- Adding non-encrypted assign endpoint for legion pods (#9675)
 - Update DotNetIsolatedNativeHost version to 1.0.3 (#9671)

--- a/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         [HttpPost]
         [Route("admin/instance/legion-assign")]
         [Authorize(Policy = PolicyNames.AdminAuthLevel)]
-        public async Task<IActionResult> LegionAssign([FromBody] HostAssignmentContext hostAssignmentContext)
+        public IActionResult LegionAssign([FromBody] HostAssignmentContext hostAssignmentContext)
         {
             _logger.LogDebug($"Starting legion container assignment for host : {Request?.Host}");
 

--- a/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
@@ -64,6 +64,27 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                 : StatusCode(StatusCodes.Status409Conflict, "Instance already assigned");
         }
 
+        [HttpPost]
+        [Route("admin/instance/legion-assign")]
+        [Authorize(Policy = PolicyNames.AdminAuthLevel)]
+        public async Task<IActionResult> LegionAssign([FromBody] HostAssignmentContext hostAssignmentContext)
+        {
+            _logger.LogDebug($"Starting legion container assignment for host : {Request?.Host}");
+
+            if (!_environment.IsFlexConsumptionSku())
+            {
+                return StatusCode(StatusCodes.Status403Forbidden, "Legion assignment is not allowed on this instance");
+            }
+
+            _startupContextProvider.SetLegionContext(hostAssignmentContext);
+
+            var succeeded = _instanceManager.StartAssignment(hostAssignmentContext);
+
+            return succeeded
+                ? Accepted()
+                : StatusCode(StatusCodes.Status409Conflict, "Instance already assigned");
+        }
+
         [HttpGet]
         [Route("admin/instance/info")]
         [Authorize(Policy = PolicyNames.AdminAuthLevel)]

--- a/src/WebJobs.Script.WebHost/StartupContextProvider.cs
+++ b/src/WebJobs.Script.WebHost/StartupContextProvider.cs
@@ -155,6 +155,24 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             return hostAssignmentContext;
         }
 
+        /// <summary>
+        /// Decrypt and deserialize the specified context, and apply values from it to the
+        /// startup cache context.
+        /// </summary>
+        /// <param name="hostAssignmentContext">The encrypted assignment context.</param>
+        public virtual void SetLegionContext(HostAssignmentContext hostAssignmentContext)
+        {
+            // Don't update StartupContext for warmup requests
+            if (!hostAssignmentContext.IsWarmupRequest)
+            {
+                // apply values from the context to our cached context
+                Context = new StartupContext
+                {
+                    Secrets = hostAssignmentContext.Secrets
+                };
+            }
+        }
+
         public class StartupContext
         {
             [JsonProperty("secrets")]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #9674 

Adding a new /admin/instance/assign endpoint to accept non-encrypted content for Legion hosts. Encrypting host context is not needed for legion hosts because the AIP's are not publicly accessible outside of the nested vm's

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
