### PR TITLE
Making JWT token audience/issuer validation case insensitive.

### DIFF
--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
@@ -13,6 +14,7 @@ using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Microsoft.IdentityModel.Tokens;
 using static Microsoft.Azure.WebJobs.Script.EnvironmentSettingNames;
@@ -56,6 +58,12 @@ namespace Microsoft.Extensions.DependencyInjection
                         }));
 
                         c.Success();
+
+                        return Task.CompletedTask;
+                    },
+                    OnAuthenticationFailed = c =>
+                    {
+                        LogAuthenticationFailure(c);
 
                         return Task.CompletedTask;
                     }
@@ -105,8 +113,8 @@ namespace Microsoft.Extensions.DependencyInjection
             if (signingKeys.Length > 0)
             {
                 result.IssuerSigningKeys = signingKeys;
-                result.ValidateAudience = true;
-                result.ValidateIssuer = true;
+                result.AudienceValidator = AudienceValidator;
+                result.IssuerValidator = IssuerValidator;
                 result.ValidAudiences = GetValidAudiences();
                 result.ValidIssuers = new string[]
                 {
@@ -117,6 +125,54 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             return result;
+        }
+
+        private static string IssuerValidator(string issuer, SecurityToken securityToken, TokenValidationParameters validationParameters)
+        {
+            if (!validationParameters.ValidIssuers.Any(p => string.Equals(issuer, p, StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new SecurityTokenInvalidIssuerException("IDX10205: Issuer validation failed.")
+                {
+                    InvalidIssuer = issuer,
+                };
+            }
+
+            return issuer;
+        }
+
+        private static bool AudienceValidator(IEnumerable<string> audiences, SecurityToken securityToken, TokenValidationParameters validationParameters)
+        {
+            foreach (string audience in audiences)
+            {
+                if (validationParameters.ValidAudiences.Any(p => string.Equals(audience, p, StringComparison.OrdinalIgnoreCase)))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static void LogAuthenticationFailure(AuthenticationFailedContext context)
+        {
+            var loggerFactory = context.HttpContext.RequestServices.GetRequiredService<ILoggerFactory>();
+            var logger = loggerFactory.CreateLogger(ScriptConstants.LogCategoryHostAuthentication);
+
+            string message = null;
+            switch (context.Exception)
+            {
+                case SecurityTokenInvalidIssuerException iex:
+                    message = $"Token issuer validation failed for issuer '{iex.InvalidIssuer}'.";
+                    break;
+                case SecurityTokenInvalidAudienceException iaex:
+                    message = $"Token audience validation failed for audience '{iaex.InvalidAudience}'.";
+                    break;
+                default:
+                    message = $"Token validation failed.";
+                    break;
+            }
+
+            logger.LogError(context.Exception, message);
         }
     }
 }

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string LogCategoryFunctionsController = "Host.Controllers.Functions";
         public const string LogCategoryInstanceController = "Host.Controllers.Instance";
         public const string LogCategoryKeysController = "Host.Controllers.Keys";
+        public const string LogCategoryHostAuthentication = "Host.Authentication";
         public const string LogCategoryHostGeneral = "Host.General";
         public const string LogCategoryHostMetrics = "Host.Metrics";
         public const string LogCategoryHost = "Host";


### PR DESCRIPTION
The App Service platform can sometimes send tokens with an Audience of varying case in some slot swap scenarios. Because our audience/issuer formats are URL based and casing is usually ignored when handling URLs, it's safe for us to make the checks case insensitive.

Backport PRs for v3 and v1 are below.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] V3 Backport https://github.com/Azure/azure-functions-host/pull/9681
    * [x] V1 Backport https://github.com/Azure/azure-functions-host/pull/9684
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
