### PR TITLE
Making JWT token audience/issuer validation case insensitive.

### DIFF
--- a/test/WebJobs.Script.Tests/Filters/JwtAuthenticationAttributeTests.cs
+++ b/test/WebJobs.Script.Tests/Filters/JwtAuthenticationAttributeTests.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Filters
         [InlineData(nameof(HttpRequestHeader.Authorization), "https://testsite.azurewebsites.net", "https://testsite.azurewebsites.net")]
         [InlineData(ScriptConstants.SiteTokenHeaderName)]
         [InlineData(ScriptConstants.SiteTokenHeaderName, "https://appservice.core.azurewebsites.net", "https://testsite.azurewebsites.net")]
+        [InlineData(ScriptConstants.SiteTokenHeaderName, "https://AppService.Core.Azurewebsites.net", "https://TestSite.Azurewebsites.net")]
         [InlineData(ScriptConstants.SiteTokenHeaderName, "https://appservice.core.azurewebsites.net", "https://testsite.azurewebsites.net/azurefunctions")]
         [InlineData(ScriptConstants.SiteTokenHeaderName, "https://testsite.scm.azurewebsites.net", "https://testsite.azurewebsites.net")]
         [InlineData(ScriptConstants.SiteTokenHeaderName, "https://testsite.scm.azurewebsites.net", "https://testsite.azurewebsites.net/azurefunctions")]


### PR DESCRIPTION
Backport of https://github.com/Azure/azure-functions-host/pull/9678. In the v1 port, I didn't carry the logging forward because the version of the token libraries we're using in v1 make it easy to log PII when logging token validation exceptions (e.g. will log the raw token). Later library versions being used in v3/v4 do not output PII.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
