### PR TITLE
Adjusting token auth failure logging

### DIFF
--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Extensions;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication;
 using Microsoft.Extensions.Logging;
@@ -155,6 +156,11 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static void LogAuthenticationFailure(AuthenticationFailedContext context)
         {
+            if (!context.Request.IsAdminRequest())
+            {
+                return;
+            }
+
             var loggerFactory = context.HttpContext.RequestServices.GetRequiredService<ILoggerFactory>();
             var logger = loggerFactory.CreateLogger(ScriptConstants.LogCategoryHostAuthentication);
 
@@ -172,7 +178,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     break;
             }
 
-            logger.LogError(context.Exception, message);
+            logger.LogDebug(context.Exception, message);
         }
     }
 }


### PR DESCRIPTION
In a recent PR https://github.com/Azure/azure-functions-host/pull/9678, I added logging for all token authentication failures. The problem is, this ends up producing a bunch of noise for customers who are sending their own tokens via the Authorization header. In these cases, our JWT handler will run on them and log validation failures (e.g. invalid issuer/audience, etc.). We only want this logging to happen for our /admin APIs.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Backport PR https://github.com/Azure/azure-functions-host/pull/9704
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
