### PR TITLE
Adding IKey and EndpointAddress in the ApplicationInsights Transmission Status log.

### DIFF
--- a/src/WebJobs.Script/Config/TransmissionStatusHandler.cs
+++ b/src/WebJobs.Script/Config/TransmissionStatusHandler.cs
@@ -44,6 +44,8 @@ namespace Microsoft.Azure.WebJobs.Script.Config
                             Count = n.Count()
                         });
 
+            // Log all the unique ikeys in the transmission, avoid storing the complete key.
+            IEnumerable<string> iKeys = transmission.TelemetryItems.GroupBy(n => n.Context.InstrumentationKey).Select(n => n.Key.Length > 24 ? n.Key.Substring(0, 24) : n.Key);
             IngestionServiceResponse response = null;
             if (!string.IsNullOrWhiteSpace(args?.Response?.Content))
             {
@@ -70,7 +72,9 @@ namespace Microsoft.Azure.WebJobs.Script.Config
                 ErrorMessage = topErrorMessage,
                 ErrorCode = topStatusCode,
                 ResponseTimeInMs = args?.ResponseDurationInMs,
-                RetryAfterHeader = args?.Response?.RetryAfterHeader
+                RetryAfterHeader = args?.Response?.RetryAfterHeader,
+                EndpointAddress = transmission.EndpointAddress.OriginalString,
+                IKeys = iKeys
             };
             return JsonSerializer.Serialize(log, LogMessageContext.Default.LogMessage);
         }
@@ -136,7 +140,11 @@ namespace Microsoft.Azure.WebJobs.Script.Config
 
         public string RetryAfterHeader { get; set; }
 
+        public string EndpointAddress { get; set; }
+
         public IEnumerable<TelemetryItem> Items { get; set; }
+
+        public IEnumerable<string> IKeys { get; set; }
     }
 
     internal class TelemetryItem

--- a/src/WebJobs.Script/Config/TransmissionStatusHandler.cs
+++ b/src/WebJobs.Script/Config/TransmissionStatusHandler.cs
@@ -45,8 +45,8 @@ namespace Microsoft.Azure.WebJobs.Script.Config
                         });
 
             // Log all the unique ikeys in the transmission, avoid storing the complete key.
-            IEnumerable<string> iKeys = transmission.TelemetryItems.GroupBy(n => n.Context.InstrumentationKey)
-                                        .Select(n => n.Key.Length > 24 ? string.Concat(n.Key.Substring(0, 24), "************") : n.Key);
+            IEnumerable<string> iKeys = transmission?.TelemetryItems.GroupBy(n => n.Context.InstrumentationKey)
+                                        .Select(n => n.Key.Length > 24 ? $"{n.Key[..24]}************" : n.Key);
 
             IngestionServiceResponse response = null;
             if (!string.IsNullOrWhiteSpace(args?.Response?.Content))

--- a/src/WebJobs.Script/Config/TransmissionStatusHandler.cs
+++ b/src/WebJobs.Script/Config/TransmissionStatusHandler.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
                 ErrorCode = topStatusCode,
                 ResponseTimeInMs = args?.ResponseDurationInMs,
                 RetryAfterHeader = args?.Response?.RetryAfterHeader,
-                EndpointAddress = transmission.EndpointAddress.OriginalString,
+                EndpointAddress = transmission?.EndpointAddress.OriginalString,
                 IKeys = iKeys
             };
             return JsonSerializer.Serialize(log, LogMessageContext.Default.LogMessage);

--- a/src/WebJobs.Script/Config/TransmissionStatusHandler.cs
+++ b/src/WebJobs.Script/Config/TransmissionStatusHandler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
 
             // Log all the unique ikeys in the transmission, avoid storing the complete key.
             IEnumerable<string> iKeys = transmission.TelemetryItems.GroupBy(n => n.Context.InstrumentationKey)
-                                        .Select(n => n.Key.Length > 24 ? n.Key.Substring(0, 24) : n.Key);
+                                        .Select(n => n.Key.Length > 24 ? string.Concat(n.Key.Substring(0, 24), "************") : n.Key);
 
             IngestionServiceResponse response = null;
             if (!string.IsNullOrWhiteSpace(args?.Response?.Content))

--- a/src/WebJobs.Script/Config/TransmissionStatusHandler.cs
+++ b/src/WebJobs.Script/Config/TransmissionStatusHandler.cs
@@ -45,7 +45,9 @@ namespace Microsoft.Azure.WebJobs.Script.Config
                         });
 
             // Log all the unique ikeys in the transmission, avoid storing the complete key.
-            IEnumerable<string> iKeys = transmission.TelemetryItems.GroupBy(n => n.Context.InstrumentationKey).Select(n => n.Key.Length > 24 ? n.Key.Substring(0, 24) : n.Key);
+            IEnumerable<string> iKeys = transmission.TelemetryItems.GroupBy(n => n.Context.InstrumentationKey)
+                                        .Select(n => n.Key.Length > 24 ? n.Key.Substring(0, 24) : n.Key);
+
             IngestionServiceResponse response = null;
             if (!string.IsNullOrWhiteSpace(args?.Response?.Content))
             {

--- a/test/WebJobs.Script.Tests/Configuration/TransmissionStatusHandlerTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/TransmissionStatusHandlerTest.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             Assert.Equal(3, log["iKeys"].Count());
             Assert.Null(log.Value<string>("errorMessage"));
             string keys = log["iKeys"].ToString();
-            Assert.True(keys.Contains("AAAAA-AAAAAAAAAA-AAAAAAA") && keys.Contains("BBBBB-BBBBBBBBB-BBBBBBBB") && keys.Contains("CCCCC-CCCCCCCCCCCCCCCCC-"));
+            Assert.True(keys.Contains("AAAAA-AAAAAAAAAA-AAAAAAA************") && keys.Contains("BBBBB-BBBBBBBBB-BBBBBBBB************") && keys.Contains("CCCCC-CCCCCCCCCCCCCCCCC-"));
         }
     }
 }


### PR DESCRIPTION
Adding EndpointAddress and all the unique IKeys in the transmission status log.  This will help us investigate issues where-in Function app was sending data to wrong ingestion endpoint after getting a 307 response from Breeze. We need to see which  Breeze endpoint this function app connected to when it got the 307 that redirected them to a different endpoint, and which Ikey the function app was using on that attempt. 

```
Diagnostic source 'Microsoft.Azure.Functions.Host.ApplicationInsights' emitted event 'TransmissionStatus': {
  "statusCode": 400,
  "statusDescription": "Bad Request",
  "id": "5kmhwqKFP8Y=",
  "responseTimeInMs": 1,
  "endpointAddress": "https://eastus-8.in.applicationinsights.azure.com/v2/track",
  "items": [
    {
      "count": 10,
      "type": "AppTraces"
    },
    {
      "count": 5,
      "type": "AppMetrics"
    }
  ],
  "iKeys": [
    "9e45c058-e012-4387-a6a4-************"
  ]
}
```

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

