### PR TITLE
Include HostId in SyncTriggers payload always

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -409,19 +409,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
         private JObject GetMinimalPayload(string hostId, JArray triggersArray)
         {
-            JObject result = new JObject
+            // When the HostId is sent, ScaleController will use it directly rather than compute it itself.
+            return new JObject
             {
-                { "triggers", triggersArray }
+                { "triggers", triggersArray },
+                { "hostId", hostId }
             };
-
-            if (_environment.IsFlexConsumptionSku())
-            {
-                // Currently we're only sending the HostId for Flex Consumption. Eventually we'll do this for all SKUs.
-                // When the HostId is sent, ScaleController will use it directly rather than compute it itself.
-                result["hostId"] = hostId;
-            }
-
-            return result;
         }
 
         internal static async Task<JObject> GetHostJsonExtensionsAsync(IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, ILogger logger)


### PR DESCRIPTION
Expanding inclusion of HostId in the SyncTriggers payload for all SKUs. Previously in https://github.com/Azure/azure-functions-host/pull/9157 this was scoped to Flex Consumption.

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
