### PR TITLE
[pack] Implementation of host metrics meter and provider

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/FunctionInstanceLogCollectorProvider.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/FunctionInstanceLogCollectorProvider.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.Metrics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Storage;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -15,20 +16,22 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
     {
         private readonly IFunctionMetadataManager _metadataManager;
         private readonly IMetricsLogger _metrics;
+        private readonly IHostMetrics _hostMetrics;
         private readonly IConfiguration _configuration;
         private readonly ILoggerFactory _loggerFactory;
 
-        public FunctionInstanceLogCollectorProvider(IFunctionMetadataManager metadataManager, IMetricsLogger metrics, IConfiguration configuration, ILoggerFactory loggerFactory)
+        public FunctionInstanceLogCollectorProvider(IFunctionMetadataManager metadataManager, IMetricsLogger metrics, IHostMetrics hostMetrics, IConfiguration configuration, ILoggerFactory loggerFactory)
         {
             _metadataManager = metadataManager ?? throw new ArgumentNullException(nameof(metadataManager));
             _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
+            _hostMetrics = hostMetrics ?? throw new ArgumentNullException(nameof(hostMetrics));
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
         }
 
         public IAsyncCollector<FunctionInstanceLogEntry> Create()
         {
-            return new FunctionInstanceLogger(_metadataManager, _metrics, _configuration, _loggerFactory);
+            return new FunctionInstanceLogger(_metadataManager, _metrics, _hostMetrics, _configuration, _loggerFactory);
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Metrics/FlexConsumptionMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/FlexConsumptionMetricsPublisher.cs
@@ -9,10 +9,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions;
+using Microsoft.Azure.WebJobs.Script.Metrics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
 {
@@ -22,6 +24,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         private readonly FlexConsumptionMetricsPublisherOptions _options;
         private readonly IEnvironment _environment;
         private readonly ILogger<FlexConsumptionMetricsPublisher> _logger;
+        private readonly IHostMetricsProvider _metricsProvider;
         private readonly object _lock = new object();
         private readonly IFileSystem _fileSystem;
 
@@ -33,13 +36,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         private TimeSpan _metricPublishInterval;
         private TimeSpan _initialPublishDelay;
 
-        public FlexConsumptionMetricsPublisher(IEnvironment environment, IOptionsMonitor<StandbyOptions> standbyOptions, IOptions<FlexConsumptionMetricsPublisherOptions> options, ILogger<FlexConsumptionMetricsPublisher> logger, IFileSystem fileSystem)
+        public FlexConsumptionMetricsPublisher(IEnvironment environment, IOptionsMonitor<StandbyOptions> standbyOptions, IOptions<FlexConsumptionMetricsPublisherOptions> options,
+            ILogger<FlexConsumptionMetricsPublisher> logger, IFileSystem fileSystem, IHostMetricsProvider metricsProvider)
         {
             _standbyOptions = standbyOptions ?? throw new ArgumentNullException(nameof(standbyOptions));
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
             _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _fileSystem = fileSystem ?? new FileSystem();
+            _metricsProvider = metricsProvider ?? throw new ArgumentNullException(nameof(metricsProvider));
 
             if (_standbyOptions.CurrentValue.InStandbyMode)
             {
@@ -90,7 +95,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         {
             try
             {
-                if (FunctionExecutionCount == 0 && FunctionExecutionTimeMS == 0 && !IsAlwaysReady)
+                if (FunctionExecutionCount == 0 && FunctionExecutionTimeMS == 0 && !IsAlwaysReady && !_metricsProvider.HasMetrics())
                 {
                     // no activity to report
                     return;
@@ -108,6 +113,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
                         ExecutionTimeMS = FunctionExecutionTimeMS,
                         IsAlwaysReady = IsAlwaysReady
                     };
+
+                    var scaleMetrics = _metricsProvider.GetHostMetricsOrNull();
+                    if (scaleMetrics is not null)
+                    {
+                        metrics.InstanceId = _metricsProvider.InstanceId;
+                        metrics.FunctionGroup = _metricsProvider.FunctionGroup;
+                        metrics.AppFailureCount = scaleMetrics.TryGetValue(HostMetrics.AppFailureCount, out long appFailureCount) ? appFailureCount : 0;
+                        metrics.StartedInvocationCount = scaleMetrics.TryGetValue(HostMetrics.StartedInvocationCount, out long startedInvocationCount) ? startedInvocationCount : 0;
+                        metrics.ActiveInvocationCount = scaleMetrics.TryGetValue(HostMetrics.ActiveInvocationCount, out long activeInvocationCount) ? activeInvocationCount : 0;
+                    }
 
                     FunctionExecutionTimeMS = FunctionExecutionCount = 0;
                 }
@@ -296,6 +311,32 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             /// AlwaysReady.
             /// </summary>
             public bool IsAlwaysReady { get; set; }
+
+            /// <summary>
+            /// Gets or sets the instance Id.
+            /// </summary>
+            public string InstanceId { get; set; }
+
+            /// <summary>
+            /// Gets or sets the function group name. This can be either http, durable or
+            /// the name of a function.
+            /// </summary>
+            public string FunctionGroup { get; set; }
+
+            /// <summary>
+            /// Gets or sets the total number of permanent host failures.
+            /// </summary>
+            public long AppFailureCount { get; set; }
+
+            /// <summary>
+            /// Gets or sets the total number of in-progress function invocations.
+            /// </summary>
+            public long ActiveInvocationCount { get; set; }
+
+            /// <summary>
+            /// Gets or sets the total number of function invocations that have started.
+            /// </summary>
+            public long StartedInvocationCount { get; set; }
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Metrics/FlexConsumptionMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/FlexConsumptionMetricsPublisher.cs
@@ -111,14 +111,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
                         TotalTimeMS = (long)_intervalStopwatch.GetElapsedTime().TotalMilliseconds,
                         ExecutionCount = FunctionExecutionCount,
                         ExecutionTimeMS = FunctionExecutionTimeMS,
-                        IsAlwaysReady = IsAlwaysReady
+                        IsAlwaysReady = IsAlwaysReady,
+                        InstanceId = _metricsProvider.InstanceId,
+                        FunctionGroup = _metricsProvider.FunctionGroup
                     };
 
                     var scaleMetrics = _metricsProvider.GetHostMetricsOrNull();
                     if (scaleMetrics is not null)
                     {
-                        metrics.InstanceId = _metricsProvider.InstanceId;
-                        metrics.FunctionGroup = _metricsProvider.FunctionGroup;
                         metrics.AppFailureCount = scaleMetrics.TryGetValue(HostMetrics.AppFailureCount, out long appFailureCount) ? appFailureCount : 0;
                         metrics.StartedInvocationCount = scaleMetrics.TryGetValue(HostMetrics.StartedInvocationCount, out long startedInvocationCount) ? startedInvocationCount : 0;
                         metrics.ActiveInvocationCount = scaleMetrics.TryGetValue(HostMetrics.ActiveInvocationCount, out long activeInvocationCount) ? activeInvocationCount : 0;

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Grpc;
+using Microsoft.Azure.WebJobs.Script.Metrics;
 using Microsoft.Azure.WebJobs.Script.Middleware;
 using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
 using Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement;
@@ -90,6 +91,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.TryAddSingleton<IStandbyManager, StandbyManager>();
             services.TryAddSingleton<IServiceCollection>(services);
             services.TryAddSingleton<IScriptHostBuilder, DefaultScriptHostBuilder>();
+
+            // Metrics
+            services.AddSingleton<IHostMetricsProvider, HostMetricsProvider>();
+            services.AddSingleton<IHostMetrics, HostMetrics>();
 
             // Linux container services
             services.AddLinuxContainerServices();
@@ -271,7 +276,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     var options = s.GetService<IOptions<FlexConsumptionMetricsPublisherOptions>>();
                     var standbyOptions = s.GetService<IOptionsMonitor<StandbyOptions>>();
                     var logger = s.GetService<ILogger<FlexConsumptionMetricsPublisher>>();
-                    return new FlexConsumptionMetricsPublisher(environment, standbyOptions, options, logger, new FileSystem());
+                    var metricsProvider = s.GetService<IHostMetricsProvider>();
+                    return new FlexConsumptionMetricsPublisher(environment, standbyOptions, options, logger, new FileSystem(), metricsProvider);
                 }
                 else if (environment.IsLinuxMetricsPublishingEnabled())
                 {

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -437,7 +437,12 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             if (environment.IsAnyLinuxConsumption())
             {
-                return environment.GetEnvironmentVariableOrDefault(ContainerName, string.Empty);
+                var instanceId = environment.GetEnvironmentVariableOrDefault(WebsitePodName, string.Empty);
+                if (string.IsNullOrEmpty(instanceId))
+                {
+                    instanceId = environment.GetEnvironmentVariableOrDefault(ContainerName, string.Empty);
+                }
+                return instanceId;
             }
             else
             {

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -76,6 +76,8 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FunctionsAlwaysReadyInstance = "FUNCTIONS_ALWAYSREADY_INSTANCE";
         public const string FunctionsTimeZone = "TZ";
         public const string FunctionsWebsiteTimeZone = "WEBSITE_TIME_ZONE";
+        public const string FunctionsTargetGroup = "FUNCTIONS_TARGET_GROUP";
+        public const string WebsiteArmResourceId = "WEBSITE_ARM_RESOURCE_ID";
 
         //Function in Kubernetes
         public const string PodNamespace = "POD_NAMESPACE";

--- a/src/WebJobs.Script/Metrics/HostMetrics.cs
+++ b/src/WebJobs.Script/Metrics/HostMetrics.cs
@@ -1,0 +1,65 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Microsoft.Azure.WebJobs.Script.Metrics
+{
+    public class HostMetrics : IHostMetrics
+    {
+        public const string MeterName = "Microsoft.Azure.WebJobs.Script.Host.Internal";
+        public const string CloudPlatformName = "azure_functions";
+        public const string AppFailureCount = "azure.functions.app_failures";
+        public const string ActiveInvocationCount = "azure.functions.active_invocations";
+        public const string StartedInvocationCount = "azure.functions.started_invocations";
+
+        private Counter<long> _appFailureCount;
+        private Counter<long> _startedInvocationCount;
+
+        public HostMetrics(IMeterFactory meterFactory, IEnvironment environment)
+        {
+            if (meterFactory == null)
+            {
+                throw new ArgumentNullException(nameof(meterFactory));
+            }
+
+            if (environment == null)
+            {
+                throw new ArgumentNullException(nameof(environment));
+            }
+
+            var cloudName = environment.GetEnvironmentVariableOrDefault(EnvironmentSettingNames.CloudName, string.Empty);
+            var region = environment.GetEnvironmentVariableOrDefault(EnvironmentSettingNames.RegionName, string.Empty);
+            var armResourceId = environment.GetEnvironmentVariableOrDefault(EnvironmentSettingNames.WebsiteArmResourceId, string.Empty);
+            var instanceId = environment.GetInstanceId();
+            var appName = environment.GetEnvironmentVariableOrDefault(EnvironmentSettingNames.AzureWebsiteName, string.Empty);
+            var functionGroup = environment.GetEnvironmentVariableOrDefault(EnvironmentSettingNames.FunctionsTargetGroup, string.Empty);
+
+            var hostMeterOptions = new MeterOptions(MeterName)
+            {
+                Version = "1.0.0",
+                Tags = new TagList()
+                {
+                    { TelemetryAttributes.CloudProvider, cloudName },
+                    { TelemetryAttributes.CloudPlatform, CloudPlatformName },
+                    { TelemetryAttributes.CloudRegion, region },
+                    { TelemetryAttributes.CloudResourceId, armResourceId },
+                    { TelemetryAttributes.ServiceInstanceId, instanceId },
+                    { TelemetryAttributes.ServiceName, appName },
+                    { TelemetryAttributes.AzureFunctionsGroup, functionGroup }
+                }
+            };
+            var meter = meterFactory.Create(hostMeterOptions);
+
+            _appFailureCount = meter.CreateCounter<long>(AppFailureCount, "numeric", "Number of times the host has failed to start.");
+            _startedInvocationCount = meter.CreateCounter<long>(StartedInvocationCount, "numeric", "Number of function invocations that have started.");
+        }
+
+        public void AppFailure() => _appFailureCount.Add(1);
+
+        public void IncrementStartedInvocationCount() => _startedInvocationCount.Add(1);
+    }
+}

--- a/src/WebJobs.Script/Metrics/HostMetricsProvider.cs
+++ b/src/WebJobs.Script/Metrics/HostMetricsProvider.cs
@@ -1,0 +1,125 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+#nullable enable
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.Metrics
+{
+    public class HostMetricsProvider : IHostMetricsProvider, IDisposable
+    {
+        private readonly MeterListener _meterListener;
+        private readonly IServiceProvider _serviceProvider;
+        private ConcurrentDictionary<string, long> _metricsCache = new();
+
+        public HostMetricsProvider(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+            _meterListener = new();
+
+            Start();
+        }
+
+        public string FunctionGroup { get; private set; } = string.Empty;
+
+        public string InstanceId { get; private set; } = string.Empty;
+
+        public void Start()
+        {
+            _meterListener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name is HostMetrics.MeterName)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+
+                    var funcGroupTag = instrument.Meter.Tags.FirstOrDefault(t => t.Key == TelemetryAttributes.AzureFunctionsGroup);
+                    var instanceIdTag = instrument.Meter.Tags.FirstOrDefault(t => t.Key == TelemetryAttributes.ServiceInstanceId);
+                    FunctionGroup = funcGroupTag.Value?.ToString() ?? string.Empty;
+                    InstanceId = instanceIdTag.Value?.ToString() ?? string.Empty;
+                }
+            };
+
+            _meterListener.SetMeasurementEventCallback<long>(OnMeasurementRecordedLong);
+            _meterListener.Start();
+        }
+
+        internal void OnMeasurementRecordedLong(
+            Instrument instrument,
+            long measurement,
+            ReadOnlySpan<KeyValuePair<string, object?>> tags,
+            object? state)
+        {
+            if (instrument == null)
+            {
+                throw new ArgumentNullException(nameof(instrument));
+            }
+
+            AddOrUpdateMetricsCache(instrument.Name, measurement);
+        }
+
+        private void AddOrUpdateMetricsCache(string key, long value)
+        {
+            _metricsCache.AddOrUpdate(key,
+                (k) =>
+                {
+                    if (value < 0)
+                    {
+                        return 0;
+                    }
+                    return value;
+                },
+                (k, oldValue) =>
+                {
+                    long newValue = oldValue + value;
+                    if (newValue < 0)
+                    {
+                        return 0;
+                    }
+                    return newValue;
+                });
+        }
+
+        public IReadOnlyDictionary<string, long>? GetHostMetricsOrNull()
+        {
+            if (!HasMetrics())
+            {
+                return null;
+            }
+
+            try
+            {
+                var functionActivityStatusProvider = _serviceProvider.GetScriptHostServiceOrNull<IFunctionActivityStatusProvider>();
+                var functionActivityStatus = functionActivityStatusProvider.GetStatus();
+                AddOrUpdateMetricsCache(HostMetrics.ActiveInvocationCount, functionActivityStatus.OutstandingInvocations);
+
+                return _metricsCache;
+            }
+            finally
+            {
+                PurgeMetricsCache();
+            }
+        }
+
+        public bool HasMetrics()
+        {
+            return _metricsCache.Count > 0;
+        }
+
+        private void PurgeMetricsCache()
+        {
+            _metricsCache.Clear();
+        }
+
+        public void Dispose()
+        {
+            _meterListener?.Dispose();
+        }
+    }
+}

--- a/src/WebJobs.Script/Metrics/HostMetricsProvider.cs
+++ b/src/WebJobs.Script/Metrics/HostMetricsProvider.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.WebJobs.Script.Metrics
                 var functionActivityStatus = functionActivityStatusProvider.GetStatus();
                 AddOrUpdateMetricsCache(HostMetrics.ActiveInvocationCount, functionActivityStatus.OutstandingInvocations);
 
-                return _metricsCache;
+                return new Dictionary<string, long>(_metricsCache);
             }
             finally
             {

--- a/src/WebJobs.Script/Metrics/IHostMetrics.cs
+++ b/src/WebJobs.Script/Metrics/IHostMetrics.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Script.Metrics
+{
+    /// <summary>
+    /// Defines the host metric methods that are used to track host-level metrics.
+    /// </summary>
+    public interface IHostMetrics
+    {
+        /// <summary>
+        /// Increments the app failure count. This is used to track the number of times the host has failed to start
+        /// due to issues where customer action is required to resolve.
+        /// </summary>
+        public void AppFailure();
+
+        /// <summary>
+        /// Increments the started invocation count. This is used to track the total number of function invocations
+        /// that have started on a given instance.
+        /// </summary>
+        public void IncrementStartedInvocationCount();
+    }
+}

--- a/src/WebJobs.Script/Metrics/IHostMetricsProvider.cs
+++ b/src/WebJobs.Script/Metrics/IHostMetricsProvider.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Script.Metrics
+{
+    /// <summary>
+    /// Defines the methods that are required for a host metrics provider.
+    /// The provider is can be used to collects metrics from the
+    /// HostMetrics meter and makes them available as a HostMetricsPayload object.
+    /// </summary>
+    public interface IHostMetricsProvider
+    {
+        /// <summary>
+        /// Gets the instance ID.
+        /// </summary>
+        public string InstanceId { get; }
+
+        /// <summary>
+        /// Gets the name of the function group for this instance.
+        /// </summary>
+        public string FunctionGroup { get; }
+
+        /// <summary>
+        /// Retrieves a dictionary of available metrics, or null.
+        /// </summary>
+        public IReadOnlyDictionary<string, long>? GetHostMetricsOrNull();
+
+        /// <summary>
+        /// Determines whether the provider has any host metrics.
+        /// </summary>
+        public bool HasMetrics();
+    }
+}

--- a/src/WebJobs.Script/Metrics/TelemetryAttributes.cs
+++ b/src/WebJobs.Script/Metrics/TelemetryAttributes.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script.Metrics
+{
+    public class TelemetryAttributes
+    {
+        public const string CloudProvider = "cloud.provider";
+        public const string CloudPlatform = "cloud.platform";
+        public const string CloudRegion = "cloud.region";
+        public const string CloudResourceId = "cloud.resource_id";
+        public const string ServiceInstanceId = "service.instance.id";
+        public const string ServiceName = "service.name";
+        public const string AzureFunctionsGroup = "azure.functions.group";
+    }
+}

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -76,6 +76,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
     <PackageReference Include="System.IO.Abstractions" Version="2.1.0.227">
       <NoWarn>NU1701</NoWarn>

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -16,6 +17,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.Storage;
 using Microsoft.Azure.Storage.Blob;
 using Microsoft.Azure.WebJobs.Host.Storage;
+using Microsoft.Azure.WebJobs.Script.Metrics;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;

--- a/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.Metrics;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Host.Storage;
@@ -11,6 +12,7 @@ using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Grpc;
+using Microsoft.Azure.WebJobs.Script.Metrics;
 using Microsoft.Azure.WebJobs.Script.Tests;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
@@ -72,6 +74,7 @@ namespace Microsoft.WebJobs.Script.Tests
             services.AddWebJobsScriptHostRouting();
             services.AddLogging();
             services.AddFunctionMetadataManager();
+            services.AddHostMetrics();
 
             configureRootServices?.Invoke(services);
 
@@ -101,6 +104,13 @@ namespace Microsoft.WebJobs.Script.Tests
         {
             var mock = new Mock<T>();
             return services.AddSingleton<T>(mock.Object);
+        }
+
+        private static IServiceCollection AddHostMetrics(this IServiceCollection services)
+        {
+            services.AddMetrics();
+            services.AddSingleton<IHostMetrics, HostMetrics>();
+            return services;
         }
 
         private static IServiceCollection AddFunctionMetadataManager(this IServiceCollection services)

--- a/test/WebJobs.Script.Tests.Shared/TestTraits.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestTraits.cs
@@ -57,5 +57,7 @@ namespace Microsoft.WebJobs.Script.Tests
         public const string FunctionsControllerEndToEnd = "FunctionsControllerEndToEnd";
 
         public const string FlexConsumptionMetricsTests = "FlexConsumptionMetricsTests";
+
+        public const string HostMetricsTests = "HostMetricsTests";
     }
 }

--- a/test/WebJobs.Script.Tests/Description/FunctionDescriptorProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/FunctionDescriptorProviderTests.cs
@@ -4,12 +4,15 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.Metrics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Binding;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Extensibility;
+using Microsoft.Azure.WebJobs.Script.Metrics;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -40,7 +43,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     o.ScriptPath = rootPath;
                     o.LogPath = TestHelpers.GetHostLogFileDirectory().Parent.FullName;
                 })
+                .ConfigureServices((context, services) =>
+                {
+                    services.AddMetrics();
+                    services.AddSingleton<IEnvironment>(new TestEnvironment());
+                    services.AddSingleton<IHostMetrics, HostMetrics>();
+                })
                 .Build();
+
             _scriptHost = _host.GetScriptHost();
             _scriptHost.InitializeAsync().GetAwaiter().GetResult();
             var serviceBindingProviders = _host.Services.GetService<IEnumerable<IScriptBindingProvider>>().ToArray();

--- a/test/WebJobs.Script.Tests/Description/Worker/WorkerFunctionDescriptorProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Description/Worker/WorkerFunctionDescriptorProviderTests.cs
@@ -3,12 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Metrics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Binding;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Extensibility;
+using Microsoft.Azure.WebJobs.Script.Metrics;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -42,6 +44,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 o.ScriptPath = rootPath;
                 o.LogPath = TestHelpers.GetHostLogFileDirectory().Parent.FullName;
+            })
+            .ConfigureServices((context, services) =>
+            {
+                services.AddMetrics();
+                services.AddSingleton<IEnvironment>(new TestEnvironment());
+                services.AddSingleton<IHostMetrics, HostMetrics>();
             })
             .Build();
 

--- a/test/WebJobs.Script.Tests/Description/Worker/WorkerFunctionInvokerTests.cs
+++ b/test/WebJobs.Script.Tests/Description/Worker/WorkerFunctionInvokerTests.cs
@@ -3,10 +3,14 @@
 
 using System;
 using System.Collections.ObjectModel;
+using System.Diagnostics.Metrics;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Binding;
 using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Metrics;
 using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.WebJobs.Script.Tests;
@@ -33,7 +37,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 {
                     o.ScriptPath = TestHelpers.FunctionsTestDirectory;
                     o.LogPath = TestHelpers.GetHostLogFileDirectory().Parent.FullName;
+                })
+                .ConfigureServices((context, services) =>
+                {
+                    services.AddMetrics();
+                    services.AddSingleton<IEnvironment>(new TestEnvironment());
+                    services.AddSingleton<IHostMetrics, HostMetrics>();
                 });
+
             var host = hostBuilder.Build();
 
             var sc = host.GetScriptHost();

--- a/test/WebJobs.Script.Tests/Diagnostics/FunctionInstanceLoggerTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/FunctionInstanceLoggerTests.cs
@@ -21,8 +21,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         public FunctionInstanceLoggerTests()
         {
             var metadataManager = new Mock<IFunctionMetadataManager>(MockBehavior.Strict);
-            var meterFactory = new Mock<IMeterFactory>(MockBehavior.Strict);
-            var environment = new Mock<IEnvironment>(MockBehavior.Strict);
+            var meterFactory = new Mock<IMeterFactory>();
+            var environment = new Mock<IEnvironment>();
             var hostMetrics = new HostMetrics(meterFactory.Object, environment.Object);
 
             _metrics = new TestMetricsLogger();

--- a/test/WebJobs.Script.Tests/Diagnostics/FunctionInstanceLoggerTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/FunctionInstanceLoggerTests.cs
@@ -21,12 +21,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         public FunctionInstanceLoggerTests()
         {
             var metadataManager = new Mock<IFunctionMetadataManager>(MockBehavior.Strict);
-            var meterFactory = new Mock<IMeterFactory>();
-            var environment = new Mock<IEnvironment>();
-            var hostMetrics = new HostMetrics(meterFactory.Object, environment.Object);
+            var hostMetricsMock = new Mock<IHostMetrics>();
 
             _metrics = new TestMetricsLogger();
-            _functionInstanceLogger = new FunctionInstanceLogger(metadataManager.Object, _metrics, hostMetrics);
+            _functionInstanceLogger = new FunctionInstanceLogger(metadataManager.Object, _metrics, hostMetricsMock.Object);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Diagnostics/FunctionInstanceLoggerTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/FunctionInstanceLoggerTests.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Diagnostics.Metrics;
 using System.Linq;
+using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.Metrics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Moq;
 using Xunit;
@@ -18,8 +21,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         public FunctionInstanceLoggerTests()
         {
             var metadataManager = new Mock<IFunctionMetadataManager>(MockBehavior.Strict);
+            var meterFactory = new Mock<IMeterFactory>(MockBehavior.Strict);
+            var environment = new Mock<IEnvironment>(MockBehavior.Strict);
+            var hostMetrics = new HostMetrics(meterFactory.Object, environment.Object);
+
             _metrics = new TestMetricsLogger();
-            _functionInstanceLogger = new FunctionInstanceLogger(metadataManager.Object, _metrics);
+            _functionInstanceLogger = new FunctionInstanceLogger(metadataManager.Object, _metrics, hostMetrics);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Metrics/FlexConsumptionMetricsPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/FlexConsumptionMetricsPublisherTests.cs
@@ -8,12 +8,14 @@ using System.IO.Abstractions;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Metrics;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
 using Microsoft.Azure.WebJobs.Script.WebHost.Metrics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
+using Moq;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -28,6 +30,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
         private TestOptionsMonitor<StandbyOptions> _standbyOptionsMonitor;
         private FlexConsumptionMetricsPublisherOptions _options;
         private TestLogger<FlexConsumptionMetricsPublisher> _logger;
+        private HostMetricsProvider _metricsProvider;
 
         public FlexConsumptionMetricsPublisherTests()
         {
@@ -78,7 +81,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             }
             var optionsWrapper = new OptionsWrapper<FlexConsumptionMetricsPublisherOptions>(_options);
             _logger = new TestLogger<FlexConsumptionMetricsPublisher>();
-            var publisher = new FlexConsumptionMetricsPublisher(_environment, _standbyOptionsMonitor, optionsWrapper, _logger, new FileSystem());
+            var scriptHostManager = new Mock<IScriptHostManager>();
+            _metricsProvider = new HostMetricsProvider(scriptHostManager.Object);
+            var publisher = new FlexConsumptionMetricsPublisher(_environment, _standbyOptionsMonitor, optionsWrapper, _logger, new FileSystem(), _metricsProvider);
 
             return publisher;
         }

--- a/test/WebJobs.Script.Tests/Metrics/FlexConsumptionMetricsPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/FlexConsumptionMetricsPublisherTests.cs
@@ -81,8 +81,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             }
             var optionsWrapper = new OptionsWrapper<FlexConsumptionMetricsPublisherOptions>(_options);
             _logger = new TestLogger<FlexConsumptionMetricsPublisher>();
-            var scriptHostManager = new Mock<IScriptHostManager>();
-            _metricsProvider = new HostMetricsProvider(scriptHostManager.Object);
+            var serviceProvider = new Mock<IServiceProvider>();
+            _metricsProvider = new HostMetricsProvider(serviceProvider.Object);
             var publisher = new FlexConsumptionMetricsPublisher(_environment, _standbyOptionsMonitor, optionsWrapper, _logger, new FileSystem(), _metricsProvider);
 
             return publisher;

--- a/test/WebJobs.Script.Tests/Metrics/HostMetricsProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/HostMetricsProviderTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Metrics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -24,6 +26,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             serviceCollection.AddSingleton<IEnvironment>(new TestEnvironment());
             serviceCollection.AddSingleton<IHostMetrics, HostMetrics>();
 
+            // Mock the function activity status provider to return a single outstanding invocation
+            var mockStatusProvider = new Mock<IFunctionActivityStatusProvider>();
+            var activityStatus = new FunctionActivityStatus() { OutstandingInvocations = 1 };
+            mockStatusProvider.Setup(p => p.GetStatus()).Returns(activityStatus);
+            serviceCollection.AddSingleton<IFunctionActivityStatusProvider>(mockStatusProvider.Object);
+
+            // Mock the script host manager to return the mock status provider
+            var scriptHostManagerMock = new Mock<IScriptHostManager>(MockBehavior.Strict);
+            var serviceProviderMock = scriptHostManagerMock.As<IServiceProvider>();
+            serviceProviderMock.Setup(p => p.GetService(typeof(IFunctionActivityStatusProvider))).Returns(mockStatusProvider.Object);
+            serviceCollection.AddSingleton<IScriptHostManager>(scriptHostManagerMock.Object);
+
             _serviceProvider = serviceCollection.BuildServiceProvider();
             _hostMetricsProvider = new HostMetricsProvider(_serviceProvider);
         }
@@ -32,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
         public void GetHostMetricsOrNull_MetricsCaptured_ReturnsHostMetrics()
         {
             // Arrange
-            var metrics = _serviceProvider.GetRequiredService<HostMetrics>();
+            var metrics = _serviceProvider.GetRequiredService<IHostMetrics>();
 
             // Act
             metrics.IncrementStartedInvocationCount();
@@ -51,7 +65,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
         public void GetHostMetricsOrNull_NoMetricsCaptured_ReturnsNull()
         {
             // Arrange
-            var metrics = _serviceProvider.GetRequiredService<HostMetrics>();
+            var metrics = _serviceProvider.GetRequiredService<IHostMetrics>();
 
             // Assert
             var result = _hostMetricsProvider.GetHostMetricsOrNull();
@@ -62,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
         public void GetHostMetricsOrNull_PurgesMetricsCache()
         {
             // Arrange
-            var metrics = _serviceProvider.GetRequiredService<HostMetrics>();
+            var metrics = _serviceProvider.GetRequiredService<IHostMetrics>();
 
             // Act
             metrics.AppFailure();
@@ -79,7 +93,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
         public void HasMetrics_ReturnsExpectedResult(bool hasMetrics)
         {
             // Arrange
-            var metrics = _serviceProvider.GetRequiredService<HostMetrics>();
+            var metrics = _serviceProvider.GetRequiredService<IHostMetrics>();
 
             // Act
             if (hasMetrics)

--- a/test/WebJobs.Script.Tests/Metrics/HostMetricsProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/HostMetricsProviderTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Script.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.WebJobs.Script.Tests;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
+{
+    [Trait(TestTraits.Group, TestTraits.HostMetricsTests)]
+    public class HostMetricsProviderTests
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly IHostMetricsProvider _hostMetricsProvider;
+
+        public HostMetricsProviderTests()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddMetrics();
+            serviceCollection.AddSingleton<IEnvironment>(new TestEnvironment());
+            serviceCollection.AddSingleton<IHostMetrics, HostMetrics>();
+
+            _serviceProvider = serviceCollection.BuildServiceProvider();
+            _hostMetricsProvider = new HostMetricsProvider(_serviceProvider);
+        }
+
+        [Fact]
+        public void GetHostMetricsOrNull_MetricsCaptured_ReturnsHostMetrics()
+        {
+            // Arrange
+            var metrics = _serviceProvider.GetRequiredService<HostMetrics>();
+
+            // Act
+            metrics.IncrementStartedInvocationCount();
+            metrics.AppFailure();
+            metrics.AppFailure();
+
+            // Assert
+            var result = _hostMetricsProvider.GetHostMetricsOrNull();
+            result.TryGetValue(HostMetrics.StartedInvocationCount, out var startedInvocationCount);
+            result.TryGetValue(HostMetrics.AppFailureCount, out var appFailureCount);
+            Assert.Equal(1, startedInvocationCount);
+            Assert.Equal(2, appFailureCount);
+        }
+
+        [Fact]
+        public void GetHostMetricsOrNull_NoMetricsCaptured_ReturnsNull()
+        {
+            // Arrange
+            var metrics = _serviceProvider.GetRequiredService<HostMetrics>();
+
+            // Assert
+            var result = _hostMetricsProvider.GetHostMetricsOrNull();
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetHostMetricsOrNull_PurgesMetricsCache()
+        {
+            // Arrange
+            var metrics = _serviceProvider.GetRequiredService<HostMetrics>();
+
+            // Act
+            metrics.AppFailure();
+
+            // Assert
+            Assert.True(_hostMetricsProvider.HasMetrics());
+            _hostMetricsProvider.GetHostMetricsOrNull();
+            Assert.False(_hostMetricsProvider.HasMetrics());
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void HasMetrics_ReturnsExpectedResult(bool hasMetrics)
+        {
+            // Arrange
+            var metrics = _serviceProvider.GetRequiredService<HostMetrics>();
+
+            // Act
+            if (hasMetrics)
+            {
+                metrics.AppFailure();
+            }
+
+            // Assert
+            Assert.Equal(hasMetrics, _hostMetricsProvider.HasMetrics());
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Metrics/HostMetricsTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/HostMetricsTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
         public void AppFailure_Increments_AppFailureCount()
         {
             // Arrange
-            var metrics = _serviceProvider.GetRequiredService<HostMetrics>();
+            var metrics = _serviceProvider.GetRequiredService<IHostMetrics>();
             var meterFactory = _serviceProvider.GetRequiredService<IMeterFactory>();
             var collector = new MetricCollector<long>(meterFactory, HostMetrics.MeterName, HostMetrics.AppFailureCount);
 
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
         public void IncrementStartedInvocationCount_Increments_StartedInvocationCount()
         {
             // Arrange
-            var metrics = _serviceProvider.GetRequiredService<HostMetrics>();
+            var metrics = _serviceProvider.GetRequiredService<IHostMetrics>();
             var meterFactory = _serviceProvider.GetRequiredService<IMeterFactory>();
             var collector = new MetricCollector<long>(meterFactory, HostMetrics.MeterName, HostMetrics.StartedInvocationCount);
 

--- a/test/WebJobs.Script.Tests/Metrics/HostMetricsTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/HostMetricsTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics.Metrics;
+using Microsoft.Azure.WebJobs.Script.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.Metrics.Testing;
+using Microsoft.WebJobs.Script.Tests;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
+{
+    [Trait(TestTraits.Group, TestTraits.FlexConsumptionMetricsTests)]
+    public class HostMetricsTests
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public HostMetricsTests()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddMetrics();
+            serviceCollection.AddSingleton<IEnvironment>(new TestEnvironment());
+            serviceCollection.AddSingleton<IHostMetrics, HostMetrics>();
+            _serviceProvider = serviceCollection.BuildServiceProvider();
+        }
+
+        [Fact]
+        public void AppFailure_Increments_AppFailureCount()
+        {
+            // Arrange
+            var metrics = _serviceProvider.GetRequiredService<HostMetrics>();
+            var meterFactory = _serviceProvider.GetRequiredService<IMeterFactory>();
+            var collector = new MetricCollector<long>(meterFactory, HostMetrics.MeterName, HostMetrics.AppFailureCount);
+
+            // Act
+            metrics.AppFailure();
+            metrics.AppFailure();
+
+            // Assert
+            var measurements = collector.GetMeasurementSnapshot();
+            Assert.Equal(2, measurements.Count);
+            Assert.Equal(1, measurements[0].Value);
+        }
+
+        [Fact]
+        public void IncrementStartedInvocationCount_Increments_StartedInvocationCount()
+        {
+            // Arrange
+            var metrics = _serviceProvider.GetRequiredService<HostMetrics>();
+            var meterFactory = _serviceProvider.GetRequiredService<IMeterFactory>();
+            var collector = new MetricCollector<long>(meterFactory, HostMetrics.MeterName, HostMetrics.StartedInvocationCount);
+
+            // Act
+            metrics.IncrementStartedInvocationCount();
+
+            // Assert
+            var measurements = collector.GetMeasurementSnapshot();
+            Assert.Equal(1, measurements.Count);
+            Assert.Equal(1, measurements[0].Value);
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -59,6 +59,7 @@
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.24.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Moq" Version="4.9.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
@@ -66,6 +67,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.5-11874" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="2.1.0.227">
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
### Issue describing the changes in this PR

resolves #9763

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR (in progress)
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

Introduces the use of .NET Metrics to capture function host metrics, following OTel schematic standards. This PR also integrates with `FlexConsumptionMetricsPublisher` to capture these new host metrics into a file.