### PR TITLE
Removing conditional exception handling from FileLogger

### DIFF
--- a/src/WebJobs.Script/Diagnostics/FileLogger.cs
+++ b/src/WebJobs.Script/Diagnostics/FileLogger.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
             {
                 _fileWriter.AppendLine(formattedMessage);
             }
-            catch (Exception ex) when (!ex.IsFatal())
+            catch (Exception)
             {
                 // Make sure the Logger doesn't throw if there are Exceptions (disk full, etc).
             }


### PR DESCRIPTION
Recent PR https://github.com/Azure/azure-functions-host/pull/9655 added a conditional catch block. We have evidence that this might be causing problems in some cases (not able to reproduce ourselves). We're seeing InvalidProgramExceptions coming from this method, and this is the only thing that has changed recently in this file. So we're reverting this to the previous behavior to see if it fixes things.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
