### PR TITLE
Use auth to decrypt signature and use container name for audience

### DIFF
--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -57,6 +57,11 @@ namespace Microsoft.Extensions.DependencyInjection
                         }));
                         c.Success();
                         return Task.CompletedTask;
+                    },
+                    OnAuthenticationFailed = c =>
+                    {
+                        LogAuthenticationFailure(c);
+                        return Task.CompletedTask;
                     }
                 };
                 o.TokenValidationParameters = CreateTokenValidationParameters();
@@ -93,8 +98,8 @@ namespace Microsoft.Extensions.DependencyInjection
             if (signingKeys.Length > 0)
             {
                 result.IssuerSigningKeys = signingKeys;
-                result.ValidateAudience = true;
-                result.ValidateIssuer = true;
+                result.AudienceValidator = AudienceValidator;
+                result.IssuerValidator = IssuerValidator;
                 result.ValidAudiences = GetValidAudiences();
                 result.ValidIssuers = new string[]
                 {

--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -70,12 +70,12 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static string[] GetValidAudiences()
         {
-            if (SystemEnvironment.Instance.IsPlaceholderModeEnabled() &&
-                SystemEnvironment.Instance.IsLinuxConsumptionOnLegion())
+             if (SystemEnvironment.Instance.IsPlaceholderModeEnabled()
+                && SystemEnvironment.Instance.IsLinuxConsumptionOnAtlas())
             {
                 return new string[]
                 {
-                    ScriptSettingsManager.Instance.GetSetting(WebsitePodName)
+                    ScriptSettingsManager.Instance.GetSetting(ContainerName)
                 };
             }
 

--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -29,50 +29,56 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static AuthenticationBuilder AddScriptJwtBearer(this AuthenticationBuilder builder)
             => builder.AddJwtBearer(o =>
-            {
-                o.Events = new JwtBearerEvents()
-                {
-                    OnMessageReceived = c =>
-                    {
-                        // By default, tokens are passed via the standard Authorization Bearer header. However we also support
-                        // passing tokens via the x-ms-site-token header.
-                        if (c.Request.Headers.TryGetValue(ScriptConstants.SiteTokenHeaderName, out StringValues values))
                         {
-                            // the token we set here will be the one used - Authorization header won't be checked.
-                            c.Token = values.FirstOrDefault();
-                        }
+                            o.Events = new JwtBearerEvents()
+                            {
+                                OnMessageReceived = c =>
+                                {
+                                    // By default, tokens are passed via the standard Authorization Bearer header. However we also support
+                                    // passing tokens via the x-ms-site-token header.
+                                    if (c.Request.Headers.TryGetValue(ScriptConstants.SiteTokenHeaderName, out StringValues values))
+                                    {
+                                        // the token we set here will be the one used - Authorization header won't be checked.
+                                        c.Token = values.FirstOrDefault();
+                                    }
 
-                        // Temporary: Tactical fix to address specialization issues. This should likely be moved to a token validator
-                        // TODO: DI (FACAVAL) This will be fixed once the permanent fix is in place
-                        if (_specialized == 0 && !SystemEnvironment.Instance.IsPlaceholderModeEnabled() && Interlocked.CompareExchange(ref _specialized, 1, 0) == 0)
-                        {
+                                    // Temporary: Tactical fix to address specialization issues. This should likely be moved to a token validator
+                                    // TODO: DI (FACAVAL) This will be fixed once the permanent fix is in place
+                                    if (_specialized == 0 && !SystemEnvironment.Instance.IsPlaceholderModeEnabled() && Interlocked.CompareExchange(ref _specialized, 1, 0) == 0)
+                                    {
+                                        o.TokenValidationParameters = CreateTokenValidationParameters();
+                                    }
+
+                                    return Task.CompletedTask;
+                                },
+                                OnTokenValidated = c =>
+                                {
+                                    c.Principal.AddIdentity(new ClaimsIdentity(new Claim[]
+                                    {
+                                        new Claim(SecurityConstants.AuthLevelClaimType, AuthorizationLevel.Admin.ToString())
+                                    }));
+
+                                    c.Success();
+
+                                    return Task.CompletedTask;
+                                },
+                                OnAuthenticationFailed = c =>
+                                {
+                                    LogAuthenticationFailure(c);
+
+                                    return Task.CompletedTask;
+                                }
+                            };
+
                             o.TokenValidationParameters = CreateTokenValidationParameters();
-                        }
-                        return Task.CompletedTask;
-                    },
-                    OnTokenValidated = c =>
-                    {
-                        c.Principal.AddIdentity(new ClaimsIdentity(new Claim[]
-                        {
-                            new Claim(SecurityConstants.AuthLevelClaimType, AuthorizationLevel.Admin.ToString())
-                        }));
-                        c.Success();
-                        return Task.CompletedTask;
-                    },
-                    OnAuthenticationFailed = c =>
-                    {
-                        LogAuthenticationFailure(c);
-                        return Task.CompletedTask;
-                    }
-                };
-                o.TokenValidationParameters = CreateTokenValidationParameters();
-                // TODO: DI (FACAVAL) Remove this once the work above is completed.
-                if (!SystemEnvironment.Instance.IsPlaceholderModeEnabled())
-                {
-                    // We're not in standby mode, so flag as specialized
-                    _specialized = 1;
-                }
-            });
+
+                            // TODO: DI (FACAVAL) Remove this once the work above is completed.
+                            if (!SystemEnvironment.Instance.IsPlaceholderModeEnabled())
+                            {
+                                // We're not in standby mode, so flag as specialized
+                                _specialized = 1;
+                            }
+                        });
 
         private static string[] GetValidAudiences()
         {

--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static AuthenticationBuilder AddScriptJwtBearer(this AuthenticationBuilder builder)
             => builder.AddJwtBearer(o =>
-                        {
+            {
                 o.Events = new JwtBearerEvents()
                 {
                     OnMessageReceived = c =>
@@ -41,6 +41,7 @@ namespace Microsoft.Extensions.DependencyInjection
                             // the token we set here will be the one used - Authorization header won't be checked.
                             c.Token = values.FirstOrDefault();
                         }
+
                         // Temporary: Tactical fix to address specialization issues. This should likely be moved to a token validator
                         // TODO: DI (FACAVAL) This will be fixed once the permanent fix is in place
                         if (_specialized == 0 && !SystemEnvironment.Instance.IsPlaceholderModeEnabled() && Interlocked.CompareExchange(ref _specialized, 1, 0) == 0)

--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -30,70 +30,72 @@ namespace Microsoft.Extensions.DependencyInjection
         public static AuthenticationBuilder AddScriptJwtBearer(this AuthenticationBuilder builder)
             => builder.AddJwtBearer(o =>
                         {
-                            o.Events = new JwtBearerEvents()
-                            {
-                                OnMessageReceived = c =>
-                                {
-                                    // By default, tokens are passed via the standard Authorization Bearer header. However we also support
-                                    // passing tokens via the x-ms-site-token header.
-                                    if (c.Request.Headers.TryGetValue(ScriptConstants.SiteTokenHeaderName, out StringValues values))
-                                    {
-                                        // the token we set here will be the one used - Authorization header won't be checked.
-                                        c.Token = values.FirstOrDefault();
-                                    }
-
-                                    // Temporary: Tactical fix to address specialization issues. This should likely be moved to a token validator
-                                    // TODO: DI (FACAVAL) This will be fixed once the permanent fix is in place
-                                    if (_specialized == 0 && !SystemEnvironment.Instance.IsPlaceholderModeEnabled() && Interlocked.CompareExchange(ref _specialized, 1, 0) == 0)
-                                    {
-                                        o.TokenValidationParameters = CreateTokenValidationParameters();
-                                    }
-
-                                    return Task.CompletedTask;
-                                },
-                                OnTokenValidated = c =>
-                                {
-                                    c.Principal.AddIdentity(new ClaimsIdentity(new Claim[]
-                                    {
-                                        new Claim(SecurityConstants.AuthLevelClaimType, AuthorizationLevel.Admin.ToString())
-                                    }));
-
-                                    c.Success();
-
-                                    return Task.CompletedTask;
-                                },
-                                OnAuthenticationFailed = c =>
-                                {
-                                    LogAuthenticationFailure(c);
-
-                                    return Task.CompletedTask;
-                                }
-                            };
-
+                o.Events = new JwtBearerEvents()
+                {
+                    OnMessageReceived = c =>
+                    {
+                        // By default, tokens are passed via the standard Authorization Bearer header. However we also support
+                        // passing tokens via the x-ms-site-token header.
+                        if (c.Request.Headers.TryGetValue(ScriptConstants.SiteTokenHeaderName, out StringValues values))
+                        {
+                            // the token we set here will be the one used - Authorization header won't be checked.
+                            c.Token = values.FirstOrDefault();
+                        }
+                        // Temporary: Tactical fix to address specialization issues. This should likely be moved to a token validator
+                        // TODO: DI (FACAVAL) This will be fixed once the permanent fix is in place
+                        if (_specialized == 0 && !SystemEnvironment.Instance.IsPlaceholderModeEnabled() && Interlocked.CompareExchange(ref _specialized, 1, 0) == 0)
+                        {
                             o.TokenValidationParameters = CreateTokenValidationParameters();
+                        }
+                        return Task.CompletedTask;
+                    },
+                    OnTokenValidated = c =>
+                    {
+                        c.Principal.AddIdentity(new ClaimsIdentity(new Claim[]
+                        {
+                            new Claim(SecurityConstants.AuthLevelClaimType, AuthorizationLevel.Admin.ToString())
+                        }));
+                        c.Success();
+                        return Task.CompletedTask;
+                    }
+                };
+                o.TokenValidationParameters = CreateTokenValidationParameters();
+                // TODO: DI (FACAVAL) Remove this once the work above is completed.
+                if (!SystemEnvironment.Instance.IsPlaceholderModeEnabled())
+                {
+                    // We're not in standby mode, so flag as specialized
+                    _specialized = 1;
+                }
+            });
 
-                            // TODO: DI (FACAVAL) Remove this once the work above is completed.
-                            if (!SystemEnvironment.Instance.IsPlaceholderModeEnabled())
-                            {
-                                // We're not in standby mode, so flag as specialized
-                                _specialized = 1;
-                            }
-                        });
+        private static string[] GetValidAudiences()
+        {
+            if (SystemEnvironment.Instance.IsPlaceholderModeEnabled() &&
+                SystemEnvironment.Instance.IsLinuxConsumptionOnLegion())
+            {
+                return new string[]
+                {
+                    ScriptSettingsManager.Instance.GetSetting(WebsitePodName)
+                };
+            }
 
-        private static TokenValidationParameters CreateTokenValidationParameters()
+            return new string[]
+            {
+                string.Format(SiteAzureFunctionsUriFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName)),
+                string.Format(SiteUriFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName))
+            };
+        }
+
+        public static TokenValidationParameters CreateTokenValidationParameters()
         {
             var signingKeys = SecretsUtility.GetTokenIssuerSigningKeys();
             var result = new TokenValidationParameters();
             if (signingKeys.Length > 0)
             {
                 result.IssuerSigningKeys = signingKeys;
-                result.AudienceValidator = AudienceValidator;
-                result.IssuerValidator = IssuerValidator;
-                result.ValidAudiences = new string[]
-                {
-                    string.Format(SiteAzureFunctionsUriFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName)),
-                    string.Format(SiteUriFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName))
-                };
+                result.ValidateAudience = true;
+                result.ValidateIssuer = true;
+                result.ValidAudiences = GetValidAudiences();
                 result.ValidIssuers = new string[]
                 {
                     AppServiceCoreUri,

--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static string[] GetValidAudiences()
         {
-             if (SystemEnvironment.Instance.IsPlaceholderModeEnabled()
+            if (SystemEnvironment.Instance.IsPlaceholderModeEnabled()
                 && SystemEnvironment.Instance.IsLinuxConsumptionOnAtlas())
             {
                 return new string[]

--- a/src/WebJobs.Script.WebHost/Security/SimpleWebTokenHelper.cs
+++ b/src/WebJobs.Script.WebHost/Security/SimpleWebTokenHelper.cs
@@ -84,7 +84,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security
                         binaryWriter.Write(data, 0, data.Length);
                     }
 
-                    return Encoding.UTF8.GetString(ms.ToArray());
+                    var input = ms.ToArray();
+                    if (signature != null && !signature.SequenceEqual(ComputeHMACSHA256(encryptionKey, input)))
+                    {
+                        throw new InvalidOperationException("Signature mismatches!");
+                    }
+
+                    return Encoding.UTF8.GetString(input);
                 }
             }
         }

--- a/test/WebJobs.Script.Tests/Extensions/ScriptJwtBearerExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/ScriptJwtBearerExtensionsTests.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using static Microsoft.Azure.WebJobs.Script.EnvironmentSettingNames;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
+{
+    public class ScriptJwtBearerExtensionsTests
+    {
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void CreateTokenValidationParameters_HasExpectedAudience(bool isPlaceholderModeEnabled, bool isLinuxConsumptionOnAtlas)
+        {
+            var containerName = "RandomContainerName";
+            var siteName = "RandomSiteName";
+            ScriptSettingsManager.Instance.SetSetting(AzureWebsiteName, siteName);
+
+            var expectedWithSiteName = new string[]
+            {
+                string.Format(ScriptConstants.SiteAzureFunctionsUriFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName)),
+                string.Format(ScriptConstants.SiteUriFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName))
+            };
+            var expectedWithContainerName = new string[]
+            {
+                containerName
+            };
+
+            var testData = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            if (isPlaceholderModeEnabled)
+            {
+                testData[AzureWebsitePlaceholderMode] = "1";
+            }
+
+            if (isLinuxConsumptionOnAtlas)
+            {
+                testData[AzureWebsiteInstanceId] = string.Empty;
+                testData[ContainerName] = containerName;
+            }
+
+            testData[ContainerEncryptionKey] = Convert.ToBase64String(TestHelpers.GenerateKeyBytes());
+            using (new TestScopedEnvironmentVariable(testData))
+            {
+                var tokenValidationParameters = ScriptJwtBearerExtensions.CreateTokenValidationParameters();
+                var audiences = tokenValidationParameters.ValidAudiences.ToList();
+
+                if (isPlaceholderModeEnabled &&
+                    isLinuxConsumptionOnAtlas)
+                {
+                    Assert.Equal(audiences.Count, expectedWithContainerName.Length);
+                    Assert.Equal(audiences[0], expectedWithContainerName[0]);
+                }
+                else
+                {
+                    Assert.Equal(audiences.Count, expectedWithSiteName.Length);
+                    Assert.True(audiences.Contains(expectedWithSiteName[0]));
+                    Assert.True(audiences.Contains(expectedWithSiteName[1]));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Backporting parts of #9325 and #9348 

### Issue describing the changes in this PR
Uses Container name as the valid audience for placeholders in Linux Consumption because sitename are not present when in placeholder mode. This PR also includes changes to accept signature as part of the token for container assignment.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)