### PR TITLE
[Flex][Scaling] Allow for running only a specified group of functions

### DIFF
--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Loggers;
 using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Azure.WebJobs.Host.Storage;
@@ -13,6 +14,7 @@ using Microsoft.Azure.WebJobs.Host.Timers;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Configuration;
+using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Middleware;
 using Microsoft.Azure.WebJobs.Script.Scale;
@@ -130,6 +132,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                         // EasyAuth must go after CORS, as CORS preflight requests can happen before authentication
                         services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobHostHttpMiddleware, JobHostEasyAuthMiddleware>());
+                    }
+
+                    if (environment.IsFlexConsumptionSku())
+                    {
+                        services.TryAddEnumerable(ServiceDescriptor.Singleton<IListenerDecorator, FunctionGroupListenerDecorator>());
                     }
 
                     services.AddSingleton<IScaleMetricsRepository, TableStorageScaleMetricsRepository>();

--- a/src/WebJobs.Script/Description/FunctionGroupListenerDecorator.cs
+++ b/src/WebJobs.Script/Description/FunctionGroupListenerDecorator.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.Description
+{
+    internal class FunctionGroupListenerDecorator : IListenerDecorator
+    {
+        private static readonly NoOpListener _noOpListener = new();
+        private readonly IFunctionMetadataManager _metadata;
+        private readonly IEnvironment _environment; // TODO: replace options pattern
+        private readonly ILogger _logger;
+
+        public FunctionGroupListenerDecorator(
+            IFunctionMetadataManager metadata,
+            IEnvironment environment,
+            ILogger<FunctionGroupListenerDecorator> logger)
+        {
+            _metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
+            _environment = environment ?? throw new ArgumentNullException(nameof(environment));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public IListener Decorate(ListenerDecoratorContext context)
+        {
+            if (context is null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (!_environment.TryGetFunctionsTargetGroup(out string targetGroup))
+            {
+                // If no group configured, short-circuit.
+                return context.Listener;
+            }
+
+            _logger.LogInformation("Function group target is {targetGroup}", targetGroup);
+            string functionName = context.FunctionDefinition.Descriptor.ShortName;
+            if (!_metadata.TryGetFunctionMetadata(functionName, out FunctionMetadata m))
+            {
+                _logger.LogWarning("Unable to find function metadata for function {functionName}", functionName);
+                return context.Listener;
+            }
+
+            string group = m.GetFunctionGroup() ?? functionName;
+            if (string.Equals(targetGroup, group, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogDebug("Enabling function {functionName}", functionName);
+                return context.Listener;
+            }
+
+            // A target function group is configured and this function is not part of it.
+            // By giving a no-op listener, we will prevent it from triggering without 'disabling' it.
+            _logger.LogDebug("Disabling function {functionName}", functionName);
+            return _noOpListener;
+        }
+
+        private class NoOpListener : IListener
+        {
+            public void Cancel()
+            {
+            }
+
+            public void Dispose()
+            {
+            }
+
+            public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+            public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        }
+    }
+}

--- a/src/WebJobs.Script/Description/FunctionGroupListenerDecorator.cs
+++ b/src/WebJobs.Script/Description/FunctionGroupListenerDecorator.cs
@@ -41,13 +41,13 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
             _logger.LogInformation("Function group target is {targetGroup}", targetGroup);
             string functionName = context.FunctionDefinition.Descriptor.ShortName;
-            if (!_metadata.TryGetFunctionMetadata(functionName, out FunctionMetadata m))
+            if (!_metadata.TryGetFunctionMetadata(functionName, out FunctionMetadata functionMetadata))
             {
                 _logger.LogWarning("Unable to find function metadata for function {functionName}", functionName);
                 return context.Listener;
             }
 
-            string group = m.GetFunctionGroup() ?? functionName;
+            string group = functionMetadata.GetFunctionGroup() ?? functionName;
             if (string.Equals(targetGroup, group, StringComparison.OrdinalIgnoreCase))
             {
                 _logger.LogDebug("Enabling function {functionName}", functionName);
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
             // A target function group is configured and this function is not part of it.
             // By giving a no-op listener, we will prevent it from triggering without 'disabling' it.
-            _logger.LogDebug("Disabling function {functionName}", functionName);
+            _logger.LogDebug("Function {functionName} is not part of group {functionGroup}. Listener will not be enabled.", functionName, targetGroup);
             context.Listener?.Dispose(); // this will not be used, lets dispose it now.
             return _noOpListener;
         }

--- a/src/WebJobs.Script/Description/FunctionGroupListenerDecorator.cs
+++ b/src/WebJobs.Script/Description/FunctionGroupListenerDecorator.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             // A target function group is configured and this function is not part of it.
             // By giving a no-op listener, we will prevent it from triggering without 'disabling' it.
             _logger.LogDebug("Disabling function {functionName}", functionName);
+            context.Listener?.Dispose(); // this will not be used, lets dispose it now.
             return _noOpListener;
         }
 

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -650,5 +650,23 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             return !string.Equals(environment.GetEnvironmentVariable(TargetBaseScalingEnabled), "0");
         }
+
+        /// <summary>
+        /// Tries to get the target functions group to run, if any specified.
+        /// </summary>
+        /// <param name="environment">The environment to use.</param>
+        /// <param name="group">The target group, if any.</param>
+        /// <returns>True if group specified, false otherwise.</returns>
+        public static bool TryGetFunctionsTargetGroup(this IEnvironment environment, out string group)
+        {
+            group = environment.GetEnvironmentVariable(FunctionsTargetGroup);
+            if (group is "")
+            {
+                // standardize empty string to null
+                group = null;
+            }
+
+            return group is not null;
+        }
     }
 }

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FunctionsAlwaysReadyInstance = "FUNCTIONS_ALWAYSREADY_INSTANCE";
         public const string FunctionsTimeZone = "TZ";
         public const string FunctionsWebsiteTimeZone = "WEBSITE_TIME_ZONE";
+        public const string FunctionsTargetGroup = "FUNCTIONS_TARGET_GROUP";
 
         //Function in Kubernetes
         public const string PodNamespace = "POD_NAMESPACE";

--- a/test/WebJobs.Script.Tests/Description/FunctionGroupListenerDecoratorTests.cs
+++ b/test/WebJobs.Script.Tests/Description/FunctionGroupListenerDecoratorTests.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Host.Indexers;
+using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using FuncDescriptor = Microsoft.Azure.WebJobs.Host.Protocols.FunctionDescriptor;
+
+namespace Microsoft.Azure.WebJobs.Script.Description.Tests
+{
+    public class FunctionGroupListenerDecoratorTests
+    {
+        private readonly ILogger<FunctionGroupListenerDecorator> _logger
+            = NullLogger<FunctionGroupListenerDecorator>.Instance;
+
+        [Fact]
+        public void Decorate_NoTargetGroupConfigured_ReturnsOriginalListener()
+        {
+            // Arrange
+            IFunctionDefinition definition = Mock.Of<IFunctionDefinition>();
+            IListener original = Mock.Of<IListener>();
+            IFunctionMetadataManager metadata = Mock.Of<IFunctionMetadataManager>();
+            IEnvironment environment = CreateEnvironment(null);
+
+            var context = new ListenerDecoratorContext(definition, original.GetType(), original);
+            var decorator = new FunctionGroupListenerDecorator(metadata, environment, _logger);
+
+            // Act
+            var result = decorator.Decorate(context);
+
+            // Assert
+            Assert.Same(context.Listener, result);
+        }
+
+        [Fact]
+        public void Decorate_MetadataNotFound_ReturnsOriginalListener()
+        {
+            // Arrange
+            IFunctionDefinition definition = CreateDefinition("test");
+            IListener original = Mock.Of<IListener>();
+            IFunctionMetadataManager metadata = Mock.Of<IFunctionMetadataManager>();
+            IEnvironment environment = CreateEnvironment("test-group");
+
+            var context = new ListenerDecoratorContext(definition, original.GetType(), original);
+            var decorator = new FunctionGroupListenerDecorator(metadata, environment, _logger);
+
+            // Act
+            var result = decorator.Decorate(context);
+
+            // Assert
+            Assert.Same(context.Listener, result);
+        }
+
+        [Fact]
+        public void Decorate_GroupMatch_ReturnsOriginalListener()
+        {
+            // Arrange
+            IFunctionDefinition definition = CreateDefinition("test");
+            IListener original = Mock.Of<IListener>();
+            IFunctionMetadataManager metadata = CreateMetadataManager("test", "test-group");
+            IEnvironment environment = CreateEnvironment("test-group");
+
+            var context = new ListenerDecoratorContext(definition, original.GetType(), original);
+            var decorator = new FunctionGroupListenerDecorator(metadata, environment, _logger);
+
+            // Act
+            var result = decorator.Decorate(context);
+
+            // Assert
+            Assert.Same(context.Listener, result);
+        }
+
+        [Fact]
+        public void Decorate_GroupDoesNotMatch_ReturnsNoOpListener()
+        {
+            // Arrange
+            IFunctionDefinition definition = CreateDefinition("test");
+            IListener original = Mock.Of<IListener>();
+            IFunctionMetadataManager metadata = CreateMetadataManager("test", "test-group");
+            IEnvironment environment = CreateEnvironment("other-group");
+
+            var context = new ListenerDecoratorContext(definition, original.GetType(), original);
+            var decorator = new FunctionGroupListenerDecorator(metadata, environment, _logger);
+
+            // Act
+            var result = decorator.Decorate(context);
+
+            // Assert
+            Assert.NotSame(context.Listener, result);
+        }
+
+        private static IFunctionDefinition CreateDefinition(string name)
+        {
+            var descriptor = new FuncDescriptor { LogName = name };
+            return Mock.Of<IFunctionDefinition>(m => m.Descriptor == descriptor);
+        }
+
+        private static IFunctionMetadataManager CreateMetadataManager(string name, string group)
+        {
+            var metadata = new FunctionMetadata()
+            {
+                Properties = { ["FunctionGroup"] = group },
+            };
+
+            var mock = new Mock<IFunctionMetadataManager>();
+            mock.Setup(p => p.TryGetFunctionMetadata(name, out metadata, false)).Returns(true);
+            return mock.Object;
+        }
+
+        private static IEnvironment CreateEnvironment(string group)
+        {
+            var environment = new Mock<IEnvironment>(MockBehavior.Strict);
+            environment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsTargetGroup)).Returns(group);
+            return environment.Object;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #9734

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This PR adds support for specifying and running a select function group in flex consumption only. This is accomplished by checking for the env variable `FUNCTIONS_TARGET_GROUP`. If it is available, we will enable _only_ functions that match that group. This is accomplished by doing the inverse: functions _not_ in the group have their listener suppressed by inserting a no-op listener ahead of it. This allows for the function to appear present in all other systems: not disabled, part of sync triggers, can be manually triggered. But its listener will never be started and thus the function is never automatically triggered.
