### PR TITLE
Adding explict Function Invoke claim for non-Platform tokens

### DIFF
--- a/sample/CSharp/HttpTrigger-AnonymousLevel/function.json
+++ b/sample/CSharp/HttpTrigger-AnonymousLevel/function.json
@@ -1,0 +1,16 @@
+{
+  "bindings": [
+    {
+      "type": "httpTrigger",
+      "name": "req",
+      "direction": "in",
+      "methods": [ "get" ],
+      "authLevel": "anonymous"
+    },
+    {
+      "type": "http",
+      "name": "$return",
+      "direction": "out"
+    }
+  ]
+}

--- a/sample/CSharp/HttpTrigger-AnonymousLevel/run.csx
+++ b/sample/CSharp/HttpTrigger-AnonymousLevel/run.csx
@@ -1,0 +1,15 @@
+﻿using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
+
+public static IActionResult Run(HttpRequest req, TraceWriter log)
+{
+    log.Info("C# HTTP trigger function processed a request.");
+
+    if (req.Query.TryGetValue("name", out StringValues value))
+    {
+        return new OkObjectResult($"Hello {value.ToString()}");
+    }
+
+    return new BadRequestObjectResult("Please pass a name on the query string or in the request body");
+}

--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -53,10 +53,16 @@ namespace Microsoft.Extensions.DependencyInjection
                     },
                     OnTokenValidated = c =>
                     {
-                        c.Principal.AddIdentity(new ClaimsIdentity(new Claim[]
+                        var claims = new List<Claim>
                         {
                             new Claim(SecurityConstants.AuthLevelClaimType, AuthorizationLevel.Admin.ToString())
-                        }));
+                        };
+                        if (!string.Equals(c.SecurityToken.Issuer, ScriptConstants.AppServiceCoreUri, StringComparison.OrdinalIgnoreCase))
+                        {
+                            claims.Add(new Claim(SecurityConstants.InvokeClaimType, "true"));
+                        }
+
+                        c.Principal.AddIdentity(new ClaimsIdentity(claims));
 
                         c.Success();
 

--- a/src/WebJobs.Script.WebHost/Security/Authentication/Keys/AuthenticationLevelHandler.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Keys/AuthenticationLevelHandler.cs
@@ -59,7 +59,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Authentication
             {
                 var claims = new List<Claim>
                 {
-                    new Claim(SecurityConstants.AuthLevelClaimType, requestAuthorizationLevel.ToString())
+                    new Claim(SecurityConstants.AuthLevelClaimType, requestAuthorizationLevel.ToString()),
+                    new Claim(SecurityConstants.InvokeClaimType, "true")
                 };
 
                 if (!string.IsNullOrEmpty(name))

--- a/src/WebJobs.Script.WebHost/Security/Authentication/SecurityConstants.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/SecurityConstants.cs
@@ -13,5 +13,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication
     {
         public const string AuthLevelClaimType = "http://schemas.microsoft.com/2017/07/functions/claims/authlevel";
         public const string AuthLevelKeyNameClaimType = "http://schemas.microsoft.com/2017/07/functions/claims/keyid";
+
+        /// <summary>
+        /// Claim indicating whether a principal is authorized to invoke an http triggered function via a direct http
+        /// request to the function. Note that this claim will not be required for invocations triggered via the
+        /// /admin/functions/{function} API.
+        /// </summary>
+        public const string InvokeClaimType = "http://schemas.microsoft.com/2017/07/functions/claims/invoke";
     }
 }

--- a/src/WebJobs.Script.WebHost/Security/Authorization/AuthUtility.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authorization/AuthUtility.cs
@@ -58,5 +58,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization
 
             return false;
         }
+
+        public static bool PrincipalHasInvokeClaim(ClaimsPrincipal principal, AuthorizationLevel requiredLevel)
+        {
+            // If the required auth level is anonymous, the requirement is met
+            if (requiredLevel == AuthorizationLevel.Anonymous)
+            {
+                return true;
+            }
+
+            return principal.HasClaim(SecurityConstants.InvokeClaimType, "true");
+        }
     }
 }

--- a/src/WebJobs.Script.WebHost/Security/Authorization/FunctionAuthorizationHandler.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authorization/FunctionAuthorizationHandler.cs
@@ -13,7 +13,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization
         protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, FunctionAuthorizationRequirement requirement, FunctionDescriptor resource)
         {
             var httpTrigger = resource.HttpTriggerAttribute;
-            if (httpTrigger != null && PrincipalHasAuthLevelClaim(context.User, httpTrigger.AuthLevel))
+            if (httpTrigger != null &&
+                PrincipalHasInvokeClaim(context.User, httpTrigger.AuthLevel) &&
+                PrincipalHasAuthLevelClaim(context.User, httpTrigger.AuthLevel))
             {
                 context.Succeed(requirement);
             }

--- a/test/WebJobs.Script.Tests/Security/Authorization/FunctionAuthorizationHandlerTests.cs
+++ b/test/WebJobs.Script.Tests/Security/Authorization/FunctionAuthorizationHandlerTests.cs
@@ -1,15 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Security.Claims;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Azure.WebJobs.Extensions.Http;
-using Microsoft.Azure.WebJobs.Script.Binding;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization;
@@ -23,13 +19,28 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security.Authorization
         [Fact]
         public async Task Authorization_WithExpectedAuthLevelMatch_Succeeds()
         {
-            await TestAuthorizationAsync(claimAuthLevel: AuthorizationLevel.Function, requiredFunctionLevel: AuthorizationLevel.Function);
+            await TestAuthorizationAsync(claimAuthLevel: AuthorizationLevel.Function, requiredFunctionLevel: AuthorizationLevel.Function, invokeClaimValue: "true");
         }
 
         [Fact]
         public async Task Authorization_WithAdminAuthLevel_Succeeds()
         {
-            await TestAuthorizationAsync(claimAuthLevel: AuthorizationLevel.Admin, requiredFunctionLevel: AuthorizationLevel.Function);
+            await TestAuthorizationAsync(claimAuthLevel: AuthorizationLevel.Admin, requiredFunctionLevel: AuthorizationLevel.Function, invokeClaimValue: "true");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("invalid")]
+        [InlineData("False")]
+        public async Task Authorization_WithoutInvokeClaim_Fails(string invokeClaimValue)
+        {
+            await TestAuthorizationAsync(claimAuthLevel: AuthorizationLevel.Function, requiredFunctionLevel: AuthorizationLevel.Function, invokeClaimValue: invokeClaimValue, expectSuccess: false);
+        }
+
+        [Fact]
+        public async Task Authorization_Anonymous_WithoutInvokeClaim_Succeeds()
+        {
+            await TestAuthorizationAsync(claimAuthLevel: AuthorizationLevel.Anonymous, requiredFunctionLevel: AuthorizationLevel.Anonymous, invokeClaimValue: null);
         }
 
         [Fact]
@@ -38,6 +49,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security.Authorization
             await TestAuthorizationAsync(
                 claimAuthLevel: AuthorizationLevel.Function,
                 requiredFunctionLevel: AuthorizationLevel.Function,
+                invokeClaimValue: bool.TrueString,
                 descriptor: new Mock<FunctionDescriptor>(),
                 expectSuccess: false);
         }
@@ -45,6 +57,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security.Authorization
         private async Task TestAuthorizationAsync(
             AuthorizationLevel claimAuthLevel,
             AuthorizationLevel requiredFunctionLevel,
+            string invokeClaimValue,
             bool expectSuccess = true,
             Mock<FunctionDescriptor> descriptor = null)
         {
@@ -54,9 +67,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security.Authorization
 
             var requirements = new IAuthorizationRequirement[] { new FunctionAuthorizationRequirement() };
             var claims = new List<Claim>
-                {
-                    new Claim(SecurityConstants.AuthLevelClaimType, claimAuthLevel.ToString())
-                };
+            {
+                new Claim(SecurityConstants.AuthLevelClaimType, claimAuthLevel.ToString())
+            };
+            if (invokeClaimValue != null)
+            {
+                claims.Add(new Claim(SecurityConstants.InvokeClaimType, invokeClaimValue));
+            }
 
             var user = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
 


### PR DESCRIPTION
Adding a new custom claim for direct http invocations. The auth requirements used by the function invocation middleware will require this claim to be present.

Our existing auth handlers for Keys and JWTs have been updated to add the claim to the principle, since those are the only auth schemes supported by the [DefaultFunctionPolicy](https://github.com/Azure/azure-functions-host/blob/171e5b1d15fef60ced61dc6831de38d86f45e152/src/WebJobs.Script.WebHost/Security/Authorization/AuthUtility.cs#L19).

Only need to backport to v3. In v1, ONLY key auth is supported for http function invocations.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] v3 backport: https://github.com/Azure/azure-functions-host/pull/9819
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
