### PR TITLE
Add function group to metadata and sync triggers

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,3 +5,4 @@
 -->
 
 - Updated `Microsoft.Azure.Functions.DotNetIsolatedNativeHost` version to 1.0.5 (#9753)
+- Add function grouping information (#9735)

--- a/src/WebJobs.Script.WebHost/Extensions/FunctionMetadataExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Extensions/FunctionMetadataExtensions.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Extensions
         /// Maps FunctionMetadata to FunctionMetadataResponse.
         /// </summary>
         /// <param name="functionMetadata">FunctionMetadata to be mapped.</param>
-        /// <param name="hostOptions">The host options</param>
-        /// <returns>Promise of a FunctionMetadataResponse</returns>
+        /// <param name="hostOptions">The host options.</param>
+        /// <returns>Promise of a FunctionMetadataResponse.</returns>
         public static async Task<FunctionMetadataResponse> ToFunctionMetadataResponse(this FunctionMetadata functionMetadata, ScriptJobHostOptions hostOptions, string routePrefix, string baseUrl)
         {
             string functionPath = GetFunctionPathOrNull(hostOptions.RootScriptPath, functionMetadata.Name);
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Extensions
         /// </summary>
         /// <param name="functionMetadata">FunctionMetadata object to convert to a JObject.</param>
         /// <param name="config">ScriptHostConfiguration to read RootScriptPath from.</param>
-        /// <returns>JObject that represent the trigger for scale controller to consume</returns>
+        /// <returns>JObject that represent the trigger for scale controller to consume.</returns>
         public static async Task<JObject> ToFunctionTrigger(this FunctionMetadata functionMetadata, ScriptJobHostOptions config)
         {
             var functionPath = Path.Combine(config.RootScriptPath, functionMetadata.Name);
@@ -85,16 +85,22 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Extensions
             // Read function.json as a JObject
             var functionConfig = await GetFunctionConfig(functionMetadata, functionMetadataFilePath);
 
-            if (functionConfig.TryGetValue("bindings", out JToken value) &&
-                value is JArray)
+            if (functionConfig.TryGetValue("bindings", out JToken value) && value is JArray jArray)
             {
                 // Find the trigger and add functionName to it
-                foreach (JObject binding in (JArray)value)
+                foreach (JObject binding in jArray)
                 {
                     var type = (string)binding["type"];
                     if (type != null && type.EndsWith("Trigger", StringComparison.OrdinalIgnoreCase))
                     {
                         binding.Add("functionName", functionMetadata.Name);
+
+                        string group = functionMetadata.GetFunctionGroup();
+                        if (!string.IsNullOrEmpty(group))
+                        {
+                            binding.Add("functionGroup", group);
+                        }
+
                         return binding;
                     }
                 }

--- a/src/WebJobs.Script.WebHost/Extensions/FunctionMetadataExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Extensions/FunctionMetadataExtensions.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Extensions
         /// <param name="isFlexConsumption">True if this is for flex consumption, false otherwise.</param>
         /// <returns>JObject that represent the trigger for scale controller to consume.</returns>
         public static async Task<JObject> ToFunctionTrigger(
-            this FunctionMetadata functionMetadata, ScriptJobHostOptions config, bool isFlexConsumption)
+            this FunctionMetadata functionMetadata, ScriptJobHostOptions config, bool isFlexConsumption = false)
         {
             var functionPath = Path.Combine(config.RootScriptPath, functionMetadata.Name);
             var functionMetadataFilePath = Path.Combine(functionPath, ScriptConstants.FunctionMetadataFileName);

--- a/src/WebJobs.Script.WebHost/Extensions/FunctionMetadataExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Extensions/FunctionMetadataExtensions.cs
@@ -76,8 +76,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Extensions
         /// </summary>
         /// <param name="functionMetadata">FunctionMetadata object to convert to a JObject.</param>
         /// <param name="config">ScriptHostConfiguration to read RootScriptPath from.</param>
+        /// <param name="isFlexConsumption">True if this is for flex consumption, false otherwise.</param>
         /// <returns>JObject that represent the trigger for scale controller to consume.</returns>
-        public static async Task<JObject> ToFunctionTrigger(this FunctionMetadata functionMetadata, ScriptJobHostOptions config)
+        public static async Task<JObject> ToFunctionTrigger(
+            this FunctionMetadata functionMetadata, ScriptJobHostOptions config, bool isFlexConsumption)
         {
             var functionPath = Path.Combine(config.RootScriptPath, functionMetadata.Name);
             var functionMetadataFilePath = Path.Combine(functionPath, ScriptConstants.FunctionMetadataFileName);
@@ -95,10 +97,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Extensions
                     {
                         binding.Add("functionName", functionMetadata.Name);
 
-                        string group = functionMetadata.GetFunctionGroup();
-                        if (!string.IsNullOrEmpty(group))
+                        if (isFlexConsumption)
                         {
-                            binding.Add("functionGroup", group);
+                            string group = functionMetadata.GetFunctionGroup();
+                            if (!string.IsNullOrEmpty(group))
+                            {
+                                binding.Add("functionGroup", group);
+                            }
                         }
 
                         return binding;

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -449,7 +449,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         {
             var triggers = (await functionsMetadata
                 .Where(f => !f.IsProxy())
-                .Select(f => f.ToFunctionTrigger(hostOptions))
+                .Select(f => f.ToFunctionTrigger(hostOptions, _environment.IsFlexConsumptionSku()))
                 .WhenAll())
                 .Where(t => t != null);
 

--- a/src/WebJobs.Script/Extensions/BindingMetadataExtensions.cs
+++ b/src/WebJobs.Script/Extensions/BindingMetadataExtensions.cs
@@ -1,12 +1,53 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using Microsoft.Azure.WebJobs.Script.Description;
 
 namespace Microsoft.Azure.WebJobs.Script.Extensions
 {
     public static class BindingMetadataExtensions
     {
+        private const string HttpTriggerKey = "HttpTrigger";
+
+        private static readonly HashSet<string> DurableTriggers = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "EntityTrigger",
+            "ActivityTrigger",
+            "OrchestrationTrigger"
+        };
+
+        /// <summary>
+        /// Checks if a <see cref="BindingMetadata"/> represents an HTTP trigger.
+        /// </summary>
+        /// <param name="binding">The binding metadata to check.</param>
+        /// <returns><c>true</c> if an HTTP trigger, <c>false</c> otherwise.</returns>
+        public static bool IsHttpTrigger(this BindingMetadata binding)
+        {
+            if (binding is null)
+            {
+                throw new ArgumentNullException(nameof(binding));
+            }
+
+            return string.Equals(HttpTriggerKey, binding.Type, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Checks if a <see cref="BindingMetadata"/> represents a durable trigger (entity, orchestration, or activity).
+        /// </summary>
+        /// <param name="binding">The binding metadata to check.</param>
+        /// <returns><c>true</c> if a durable trigger, <c>false</c> otherwise.</returns>
+        public static bool IsDurableTrigger(this BindingMetadata binding)
+        {
+            if (binding is null)
+            {
+                throw new ArgumentNullException(nameof(binding));
+            }
+
+            return DurableTriggers.Contains(binding.Type);
+        }
+
         public static bool SupportsDeferredBinding(this BindingMetadata metadata)
         {
             Utility.TryReadAsBool(metadata.Properties, ScriptConstants.SupportsDeferredBindingKey, out bool result);

--- a/src/WebJobs.Script/Extensions/FunctionMetadataExtensions.cs
+++ b/src/WebJobs.Script/Extensions/FunctionMetadataExtensions.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.WebJobs.Script
             // Ensure http and durable triggers are grouped together.
             foreach (BindingMetadata binding in metadata.InputBindings)
             {
-                if (binding.IsHttpTrigger())
+                if (binding.IsHttpTrigger() || binding.IsWebHookTrigger())
                 {
                     return "http";
                 }

--- a/test/WebJobs.Script.Tests/Extensions/BindingMetadataExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/BindingMetadataExtensionsTests.cs
@@ -54,5 +54,36 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
             bool result = bindingMetadata.SkipDeferredBinding();
             Assert.False(result);
         }
+
+        [Theory]
+        [InlineData("httpTrigger", true)]
+        [InlineData("otherTrigger", false)]
+        [InlineData("http2Trigger", false)]
+        [InlineData("inputBinding", false)]
+        public void IsHttpTrigger_ReturnsExpectedValue(string type, bool expected)
+        {
+            var bindingMetadata = new BindingMetadata
+            {
+                Type = type,
+            };
+
+            Assert.Equal(expected, bindingMetadata.IsHttpTrigger());
+        }
+
+        [Theory]
+        [InlineData("orchestrationTrigger", true)]
+        [InlineData("activityTrigger", true)]
+        [InlineData("entityTrigger", true)]
+        [InlineData("httpTrigger", false)]
+        [InlineData("inputBinding", false)]
+        public void IsDurableTrigger_ReturnsExpectedValue(string type, bool expected)
+        {
+            var bindingMetadata = new BindingMetadata
+            {
+                Type = type,
+            };
+
+            Assert.Equal(expected, bindingMetadata.IsDurableTrigger());
+        }
     }
 }

--- a/test/WebJobs.Script.Tests/Extensions/BindingMetadataExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/BindingMetadataExtensionsTests.cs
@@ -71,6 +71,30 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
         }
 
         [Theory]
+        [InlineData("eventGridTrigger", true)]
+        [InlineData("blobTrigger", true, "eventGrid")]
+        [InlineData("blobTrigger", false, "other")]
+        [InlineData("httpTrigger", false)]
+        [InlineData("inputBinding", false)]
+        public void IsWebHookTrigger_ReturnsExpectedValue(string type, bool expected, string source = null)
+        {
+            var bindingMetadata = new BindingMetadata
+            {
+                Type = type,
+            };
+
+            if (source is not null)
+            {
+                bindingMetadata.Raw = new JObject
+                {
+                    ["source"] = source,
+                };
+            }
+
+            Assert.Equal(expected, bindingMetadata.IsHttpTrigger());
+        }
+
+        [Theory]
         [InlineData("orchestrationTrigger", true)]
         [InlineData("activityTrigger", true)]
         [InlineData("entityTrigger", true)]

--- a/test/WebJobs.Script.Tests/Extensions/BindingMetadataExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/BindingMetadataExtensionsTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
                 };
             }
 
-            Assert.Equal(expected, bindingMetadata.IsHttpTrigger());
+            Assert.Equal(expected, bindingMetadata.IsWebHookTrigger());
         }
 
         [Theory]

--- a/test/WebJobs.Script.Tests/Extensions/FunctionMetadataExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/FunctionMetadataExtensionsTests.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.WebHost.Extensions;
@@ -148,7 +146,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
                 RootScriptPath = _testRootScriptPath
             };
 
-            var result = await functionMetadata.ToFunctionTrigger(options);
+            var result = await functionMetadata.ToFunctionTrigger(options, isFlexConsumption: true);
             Assert.Equal("TestFunction1", result["functionName"].Value<string>());
             Assert.Equal(trigger, result["type"].Value<string>());
 
@@ -195,7 +193,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
                 RootScriptPath = _testRootScriptPath
             };
 
-            var result = await functionMetadata.ToFunctionTrigger(options);
+            var result = await functionMetadata.ToFunctionTrigger(options, isFlexConsumption: true);
             Assert.Equal("TestFunction1", result["functionName"].Value<string>());
             Assert.Equal(group, result["functionGroup"].Value<string>());
             Assert.Equal(trigger, result["type"].Value<string>());

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -35,6 +35,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Remove="Scale\**" />
+    <EmbeddedResource Remove="Scale\**" />
+    <None Remove="Scale\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="Description\DotNet\TestFiles\PackageReferences\ProjectWithLockMatch\function.proj">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -168,7 +174,6 @@
 
   <ItemGroup>
     <Folder Include="Description\DotNet\TestFiles\DepsFiles\" />
-    <Folder Include="Scale\" />
   </ItemGroup>
 
   <Import Project="..\..\build\GrpcTestFix.targets" />

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -35,12 +35,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove="Scale\**" />
-    <EmbeddedResource Remove="Scale\**" />
-    <None Remove="Scale\**" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="Description\DotNet\TestFiles\PackageReferences\ProjectWithLockMatch\function.proj">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -170,10 +164,6 @@
     <EmbeddedResource Include="Resources\FileProvisioning\PowerShell\profile.ps1">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </EmbeddedResource>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Description\DotNet\TestFiles\DepsFiles\" />
   </ItemGroup>
 
   <Import Project="..\..\build\GrpcTestFix.targets" />


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #9732

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This PR adds function grouping calculation as an extension method `FunctionMetadata.GetFunctonGroup()`. Function grouping is included in sync-triggers payload if it is non-null. Function grouping calculation works as follows:

1. If `FunctionMetadata.Properties["FunctionGroup"]` is present, return that.
2. Else, check if HTTP or Durable trigger. Return `http` or `durable` respectively.
3. Return `null` if none of the above checks succeed.

Some additional changes include binding & function metadata extensions refactoring.