### PR TITLE
Adding additional WebJobs assemblies to deps validation exclusion

### DIFF
--- a/test/WebJobs.Script.Tests/DependencyTests.cs
+++ b/test/WebJobs.Script.Tests/DependencyTests.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             "Microsoft.Azure.WebJobs.Script.Grpc.dll",
             "Microsoft.Azure.WebJobs.Script.WebHost.dll",
             "Microsoft.Azure.WebJobs.dll",
+            "Microsoft.Azure.WebJobs.Script.dll",
+            "Microsoft.Azure.WebJobs.Script.Grpc.dll",
             "Microsoft.Azure.WebJobs.Host.dll",
             "Microsoft.Azure.WebJobs.Logging.ApplicationInsights.dll",
             "Microsoft.Azure.WebJobs.Script.Abstractions.dll",


### PR DESCRIPTION
This change addresses an issue impacting the deps generation, primarily for 3.x. The new behavior is causing assemblies we should be ignoring to be flagged as changed. 


* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #9796 
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
