### PR TITLE
[pack] adding warning if FUNCTIONS_WORKER_RUNTIME is missing

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -12,3 +12,4 @@
   - If a worker supports CancellationTokens, cancelled invocations will now be sent to the worker by default
     - Customers can opt-out of this behavior by setting `SendCanceledInvocationsToWorker` to `false` in host.json
   - If a worker does not support CancellationTokens, cancelled invocations will not be sent to the worker
+- Warn when `FUNCTIONS_WORKER_RUNTIME` is not set (#9799)

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         public Dictionary<string, string> Features => _features;
 
         /// <summary>
-        /// Gets a value indicating whether worker concurency feature is enabled in the hosting config.
+        /// Gets a value indicating whether worker concurrency feature is enabled in the hosting config.
         /// </summary>
         public bool FunctionsWorkerDynamicConcurrencyEnabled
         {
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether Linux Appservice/EP Detailed Execution Event is disabled in the hosting config.
+        /// Gets or sets a value indicating whether Linux AppService/EP Detailed Execution Event is disabled in the hosting config.
         /// </summary>
         public bool DisableLinuxAppServiceExecutionDetails
         {
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         }
 
         /// <summary>
-        /// Gets the highest version of extension bundle v3 supported
+        /// Gets the highest version of extension bundle v3 supported.
         /// </summary>
         public string MaximumBundleV3Version
         {
@@ -138,7 +138,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         }
 
         /// <summary>
-        /// Gets the highest version of extension bundle v4 supported
+        /// Gets the highest version of extension bundle v4 supported.
         /// </summary>
         public string MaximumBundleV4Version
         {
@@ -149,9 +149,9 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         }
 
         /// <summary>
-        /// Gets a value indicating whether the host should revert the worker shutdown behavior in the webhostworkerchannelmanager.
+        /// Gets a value indicating whether the host should revert the worker shutdown behavior in the WebHostWorkerChannelManager.
         /// </summary>
-        public bool RevertWorkerShutdownBehaviour
+        public bool RevertWorkerShutdownBehavior
         {
             get
             {
@@ -159,11 +159,19 @@ namespace Microsoft.Azure.WebJobs.Script.Config
             }
         }
 
+        public bool ThrowOnMissingFunctionsWorkerRuntime
+        {
+            get
+            {
+                return GetFeature(RpcWorkerConstants.ThrowOnMissingFunctionsWorkerRuntime) == "1";
+            }
+        }
+
         /// <summary>
         /// Gets feature by name.
         /// </summary>
         /// <param name="name">Feature name.</param>
-        /// <returns>String value from hostig configuration.</returns>
+        /// <returns>String value from hosting configuration.</returns>
         public string GetFeature(string name)
         {
             if (_features.TryGetValue(name, out string value))
@@ -178,7 +186,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         /// </summary>
         /// <param name="name">Feature name.</param>
         /// <param name="defaultValue">The default value to use.</param>
-        /// <returns>String value from hostig configuration.</returns>
+        /// <returns>String value from hosting configuration.</returns>
         public string GetFeatureOrDefault(string name, string defaultValue)
         {
             return GetFeature(name) ?? defaultValue;

--- a/src/WebJobs.Script/Diagnostics/DiagnosticEventConstants.cs
+++ b/src/WebJobs.Script/Diagnostics/DiagnosticEventConstants.cs
@@ -25,5 +25,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public const string LinuxConsumptionTimeZoneErrorCode = "AZFD0010";
         public const string LinuxConsumptionTimeZoneErrorHelpLink = "https://go.microsoft.com/fwlink/?linkid=2250165";
+
+        public const string MissingFunctionsWorkerRuntimeErrorCode = "AZFD0011";
+        public const string MissingFunctionsWorkerRuntimeHelpLink = "https://go.microsoft.com/fwlink/?linkid=2257963";
     }
 }

--- a/src/WebJobs.Script/Diagnostics/DiagnosticEventLoggerExtensions.cs
+++ b/src/WebJobs.Script/Diagnostics/DiagnosticEventLoggerExtensions.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.Diagnostics
@@ -27,6 +25,12 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
         {
             int eventId = 0; // Dummy value - diagnostic events does not log an eventId.
             logger.LogDiagnosticEvent(LogLevel.Information, eventId, errorCode, message, helpLink, null);
+        }
+
+        public static void LogDiagnosticEventWarning(this ILogger logger, string errorCode, string message, string helpLink, Exception exception)
+        {
+            int eventId = 0; // Dummy value - diagnostic events does not log an eventId.
+            logger.LogDiagnosticEvent(LogLevel.Warning, eventId, errorCode, message, helpLink, exception);
         }
 
         public static void LogDiagnosticEventError(this ILogger logger, string errorCode, string message, string helpLink, Exception exception)

--- a/src/WebJobs.Script/Diagnostics/Extensions/ScriptHostLoggerExtension.cs
+++ b/src/WebJobs.Script/Diagnostics/Extensions/ScriptHostLoggerExtension.cs
@@ -130,12 +130,6 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
                 new EventId(420, nameof(ResolvedWorkerRuntimeFromMetadata)),
                 $"{EnvironmentSettingNames.FunctionWorkerRuntime} is null. Resolved worker runtime from function metadata: '{{workerRuntime}}'");
 
-        private static readonly Action<ILogger, string, Exception> _missingFunctionsWorkerRuntime =
-            LoggerMessage.Define<string>(
-                LogLevel.Warning,
-                new EventId(421, nameof(MissingFunctionsWorkerRuntime)),
-                "{message}");
-
         public static void HostIdIsSet(this ILogger logger)
         {
             _hostIdIsSet(logger, null);
@@ -242,11 +236,6 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
         public static void ResolvedWorkerRuntimeFromMetadata(this ILogger logger, string workerRuntime)
         {
             _resolvedWorkerRuntimeFromMetadata(logger, workerRuntime, null);
-        }
-
-        public static void MissingFunctionsWorkerRuntime(this ILogger logger, string message)
-        {
-            _missingFunctionsWorkerRuntime(logger, message, null);
         }
     }
 }

--- a/src/WebJobs.Script/Diagnostics/Extensions/ScriptHostLoggerExtension.cs
+++ b/src/WebJobs.Script/Diagnostics/Extensions/ScriptHostLoggerExtension.cs
@@ -130,6 +130,12 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
                 new EventId(420, nameof(ResolvedWorkerRuntimeFromMetadata)),
                 $"{EnvironmentSettingNames.FunctionWorkerRuntime} is null. Resolved worker runtime from function metadata: '{{workerRuntime}}'");
 
+        private static readonly Action<ILogger, string, Exception> _missingFunctionsWorkerRuntime =
+            LoggerMessage.Define<string>(
+                LogLevel.Warning,
+                new EventId(421, nameof(MissingFunctionsWorkerRuntime)),
+                "{message}");
+
         public static void HostIdIsSet(this ILogger logger)
         {
             _hostIdIsSet(logger, null);
@@ -236,6 +242,11 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
         public static void ResolvedWorkerRuntimeFromMetadata(this ILogger logger, string workerRuntime)
         {
             _resolvedWorkerRuntimeFromMetadata(logger, workerRuntime, null);
+        }
+
+        public static void MissingFunctionsWorkerRuntime(this ILogger logger, string message)
+        {
+            _missingFunctionsWorkerRuntime(logger, message, null);
         }
     }
 }

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -446,20 +446,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 }
             }
 
-            if (string.IsNullOrEmpty(_environment.GetFunctionsWorkerRuntime()))
-            {
-                string baseMessage = $"The '{EnvironmentSettingNames.FunctionWorkerRuntime}' setting is required. Please specify a valid value. See {DiagnosticEventConstants.MissingFunctionsWorkerRuntimeHelpLink} for more information.";
-
-                if (_hostingConfigOptions.Value.ThrowOnMissingFunctionsWorkerRuntime)
-                {
-                    _logger.LogDiagnosticEventError(DiagnosticEventConstants.MissingFunctionsWorkerRuntimeErrorCode, baseMessage, DiagnosticEventConstants.MissingFunctionsWorkerRuntimeHelpLink, null);
-                    throw new HostInitializationException(baseMessage);
-                }
-
-                string warningMessage = baseMessage + " The application will continue to run, but may throw an exception in a future release.";
-                _logger.LogDiagnosticEventWarning(DiagnosticEventConstants.MissingFunctionsWorkerRuntimeErrorCode, warningMessage, DiagnosticEventConstants.MissingFunctionsWorkerRuntimeHelpLink, null);
-                _logger.MissingFunctionsWorkerRuntime(warningMessage);
-            }
+            ValidateFunctionsWorkerRuntime(_environment, _hostingConfigOptions, _logger);
 
             // Log whether App Insights is enabled
             if (!string.IsNullOrEmpty(_settingsManager.ApplicationInsightsInstrumentationKey) || !string.IsNullOrEmpty(_settingsManager.ApplicationInsightsConnectionString))
@@ -472,6 +459,24 @@ namespace Microsoft.Azure.WebJobs.Script
             }
 
             InitializeFileSystem();
+        }
+
+        internal static void ValidateFunctionsWorkerRuntime(IEnvironment environment, IOptions<FunctionsHostingConfigOptions> hostingConfigOptions, ILogger logger)
+        {
+            if (string.IsNullOrEmpty(environment.GetFunctionsWorkerRuntime()))
+            {
+                string baseMessage = $"The '{EnvironmentSettingNames.FunctionWorkerRuntime}' setting is required. Please specify a valid value. See {DiagnosticEventConstants.MissingFunctionsWorkerRuntimeHelpLink} for more information.";
+
+                if (hostingConfigOptions.Value.ThrowOnMissingFunctionsWorkerRuntime)
+                {
+                    logger.LogDiagnosticEventError(DiagnosticEventConstants.MissingFunctionsWorkerRuntimeErrorCode, baseMessage, DiagnosticEventConstants.MissingFunctionsWorkerRuntimeHelpLink, null);
+                    throw new HostInitializationException(baseMessage);
+                }
+
+                string warningMessage = baseMessage + " The application will continue to run, but may throw an exception in a future release.";
+                logger.LogDiagnosticEventWarning(DiagnosticEventConstants.MissingFunctionsWorkerRuntimeErrorCode, warningMessage, DiagnosticEventConstants.MissingFunctionsWorkerRuntimeHelpLink, null);
+                logger.MissingFunctionsWorkerRuntime(warningMessage);
+            }
         }
 
         /// <summary>

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Azure.WebJobs.Script
         private readonly string _instanceId;
         private readonly IEnvironment _environment;
         private readonly IFunctionDataCache _functionDataCache;
+        private readonly IOptions<FunctionsHostingConfigOptions> _hostingConfigOptions;
         private readonly IOptionsMonitor<LanguageWorkerOptions> _languageWorkerOptions;
         private readonly ILogger _logger;
         private readonly IPrimaryHostStateProvider _primaryHostStateProvider;
@@ -106,6 +107,7 @@ namespace Microsoft.Azure.WebJobs.Script
             IExtensionBundleManager extensionBundleManager,
             IFunctionDataCache functionDataCache,
             IOptionsMonitor<LanguageWorkerOptions> languageWorkerOptions,
+            IOptions<FunctionsHostingConfigOptions> hostingConfigOptions,
             ScriptSettingsManager settingsManager = null)
             : base(options, jobHostContextFactory)
         {
@@ -153,6 +155,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 }));
 
             _functionDataCache = functionDataCache;
+            _hostingConfigOptions = hostingConfigOptions;
         }
 
         public event EventHandler HostInitializing;
@@ -441,6 +444,21 @@ namespace Microsoft.Azure.WebJobs.Script
                 {
                     _logger.VersionRecommendation(extensionVersion);
                 }
+            }
+
+            if (string.IsNullOrEmpty(_environment.GetFunctionsWorkerRuntime()))
+            {
+                string baseMessage = $"The '{EnvironmentSettingNames.FunctionWorkerRuntime}' setting is required. Please specify a valid value. See {DiagnosticEventConstants.MissingFunctionsWorkerRuntimeHelpLink} for more information.";
+
+                if (_hostingConfigOptions.Value.ThrowOnMissingFunctionsWorkerRuntime)
+                {
+                    _logger.LogDiagnosticEventError(DiagnosticEventConstants.MissingFunctionsWorkerRuntimeErrorCode, baseMessage, DiagnosticEventConstants.MissingFunctionsWorkerRuntimeHelpLink, null);
+                    throw new HostInitializationException(baseMessage);
+                }
+
+                string warningMessage = baseMessage + " The application will continue to run, but may throw an exception in a future release.";
+                _logger.LogDiagnosticEventWarning(DiagnosticEventConstants.MissingFunctionsWorkerRuntimeErrorCode, warningMessage, DiagnosticEventConstants.MissingFunctionsWorkerRuntimeHelpLink, null);
+                _logger.MissingFunctionsWorkerRuntime(warningMessage);
             }
 
             // Log whether App Insights is enabled

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -475,7 +475,6 @@ namespace Microsoft.Azure.WebJobs.Script
 
                 string warningMessage = baseMessage + " The application will continue to run, but may throw an exception in a future release.";
                 logger.LogDiagnosticEventWarning(DiagnosticEventConstants.MissingFunctionsWorkerRuntimeErrorCode, warningMessage, DiagnosticEventConstants.MissingFunctionsWorkerRuntimeHelpLink, null);
-                logger.MissingFunctionsWorkerRuntime(warningMessage);
             }
         }
 

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
@@ -85,5 +85,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public const string WorkerIndexingEnabled = "WORKER_INDEXING_ENABLED";
         public const string WorkerIndexingDisabledApps = "WORKER_INDEXING_DISABLED_APPS";
         public const string RevertWorkerShutdownBehavior = "REVERT_WORKER_SHUTDOWN_BEHAVIOR";
+        public const string ThrowOnMissingFunctionsWorkerRuntime = "THROW_ON_MISSING_FUNCTIONS_WORKER_RUNTIME";
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 throw new ArgumentNullException(nameof(language));
             }
 
-            if (_hostingConfigOptions.Value.RevertWorkerShutdownBehaviour)
+            if (_hostingConfigOptions.Value.RevertWorkerShutdownBehavior)
             {
                 if (_workerChannels.TryRemove(language, out ConcurrentDictionary<string, TaskCompletionSource<IRpcWorkerChannel>> rpcWorkerChannels))
                 {

--- a/test/WebJobs.Script.Tests.Shared/TestDiagnosticEventRepository.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestDiagnosticEventRepository.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests;
+
+public class TestDiagnosticEventRepository : IDiagnosticEventRepository
+{
+    private readonly List<DiagnosticEvent> _events;
+
+    public TestDiagnosticEventRepository()
+    {
+        _events = new List<DiagnosticEvent>();
+    }
+
+    public List<DiagnosticEvent> Events => _events;
+
+    public void WriteDiagnosticEvent(DateTime timestamp, string errorCode, LogLevel level, string message, string helpLink, Exception exception)
+    {
+        _events.Add(new DiagnosticEvent("hostid", timestamp)
+        {
+            ErrorCode = errorCode,
+            LogLevel = level,
+            Message = message,
+            HelpLink = helpLink,
+            Details = exception?.Message
+        });
+    }
+
+    public void FlushLogs()
+    {
+        Events.Clear();
+    }
+}

--- a/test/WebJobs.Script.Tests.Shared/TestDiagnosticEventRepositoryFactory.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestDiagnosticEventRepositoryFactory.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests;
+
+public class TestDiagnosticEventRepositoryFactory : IDiagnosticEventRepositoryFactory
+{
+    private IDiagnosticEventRepository _repository;
+
+    public TestDiagnosticEventRepositoryFactory(IDiagnosticEventRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public IDiagnosticEventRepository Create()
+    {
+        return _repository;
+    }
+}

--- a/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
@@ -22,7 +22,6 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Moq;
-using static Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.DiagnosticEventLoggerTests;
 using IApplicationLifetime = Microsoft.AspNetCore.Hosting.IApplicationLifetime;
 
 namespace Microsoft.WebJobs.Script.Tests

--- a/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
@@ -22,6 +22,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Moq;
+using static Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.DiagnosticEventLoggerTests;
 using IApplicationLifetime = Microsoft.AspNetCore.Hosting.IApplicationLifetime;
 
 namespace Microsoft.WebJobs.Script.Tests
@@ -64,7 +65,8 @@ namespace Microsoft.WebJobs.Script.Tests
             AddMockedSingleton<IApplicationLifetime>(services);
             AddMockedSingleton<IDependencyValidator>(services);
             AddMockedSingleton<IAzureBlobStorageProvider>(services);
-            AddMockedSingleton<IDiagnosticEventRepositoryFactory>(services);
+            services.AddSingleton<IDiagnosticEventRepository, TestDiagnosticEventRepository>();
+            services.AddSingleton<IDiagnosticEventRepositoryFactory, TestDiagnosticEventRepositoryFactory>();
             services.AddSingleton<HostNameProvider>();
             services.AddSingleton<IMetricsLogger>(metricsLogger);
             services.AddWebJobsScriptHostRouting();

--- a/test/WebJobs.Script.Tests.Shared/WebJobs.Script.Tests.Shared.projitems
+++ b/test/WebJobs.Script.Tests.Shared/WebJobs.Script.Tests.Shared.projitems
@@ -17,6 +17,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)TempDirectory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestChangeTokenSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestConfigurationBuilderExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestDiagnosticEventRepository.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestDiagnosticEventRepositoryFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestEnvironment.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestEventGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestFunctionMetadataManager.cs" />

--- a/test/WebJobs.Script.Tests/Diagnostics/DiagnosticEventLoggerTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/DiagnosticEventLoggerTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost;
@@ -86,50 +84,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             }
 
             Assert.Empty(repository.Events);
-        }
-
-        public class TestDiagnosticEventRepositoryFactory : IDiagnosticEventRepositoryFactory
-        {
-            private IDiagnosticEventRepository _repository;
-
-            public TestDiagnosticEventRepositoryFactory(IDiagnosticEventRepository repository)
-            {
-                _repository = repository;
-            }
-
-            public IDiagnosticEventRepository Create()
-            {
-                return _repository;
-            }
-        }
-
-        public class TestDiagnosticEventRepository : IDiagnosticEventRepository
-        {
-            private readonly List<DiagnosticEvent> _events;
-
-            public TestDiagnosticEventRepository()
-            {
-                _events = new List<DiagnosticEvent>();
-            }
-
-            public List<DiagnosticEvent> Events => _events;
-
-            public void WriteDiagnosticEvent(DateTime timestamp, string errorCode, LogLevel level, string message, string helpLink, Exception exception)
-            {
-                _events.Add(new DiagnosticEvent("hostid", timestamp)
-                {
-                    ErrorCode = errorCode,
-                    LogLevel = level,
-                    Message = message,
-                    HelpLink = helpLink,
-                    Details = exception?.Message
-                });
-            }
-
-            public void FlushLogs()
-            {
-                Events.Clear();
-            }
         }
     }
 }

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -18,16 +18,20 @@ using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
 using Moq;
 using Newtonsoft.Json.Linq;
 using WebJobs.Script.Tests;
 using Xunit;
+using static Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.DiagnosticEventLoggerTests;
 using FunctionMetadata = Microsoft.Azure.WebJobs.Script.Description.FunctionMetadata;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
@@ -1709,6 +1713,54 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 FileUtility.Instance = null;
                 EnvironmentExtensions.BaseDirectory = null;
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("node")]
+        public void Missing_FunctionsWorkerRuntime_LogsWarning(string functionsWorkerRuntime)
+        {
+            var environment = new TestEnvironment();
+            if (functionsWorkerRuntime != null)
+            {
+                environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, functionsWorkerRuntime);
+            }
+
+            var diagnosticEventRepository = new TestDiagnosticEventRepository();
+            var diagnosticEventRepositoryFactory = new TestDiagnosticEventRepositoryFactory(diagnosticEventRepository);
+            var standbyOptions = new StandbyOptions { InStandbyMode = false };
+            var mockStandbyOptionsMonitor = new Mock<IOptionsMonitor<StandbyOptions>>();
+            mockStandbyOptionsMonitor
+                .SetupGet(m => m.CurrentValue)
+                .Returns(standbyOptions);
+            var diagnosticEventLogger = new DiagnosticEventLoggerProvider(diagnosticEventRepositoryFactory, environment, mockStandbyOptionsMonitor.Object);
+
+            var loggerFactory = new LoggerFactory();
+            loggerFactory.AddTestLoggerProvider(out TestLoggerProvider testLoggerProvider);
+            loggerFactory.AddProvider(diagnosticEventLogger);
+
+            var configOptions = new OptionsWrapper<FunctionsHostingConfigOptions>(new FunctionsHostingConfigOptions());
+
+            ScriptHost.ValidateFunctionsWorkerRuntime(environment, configOptions, loggerFactory.CreateLogger<ScriptHost>());
+
+            if (string.IsNullOrEmpty(functionsWorkerRuntime))
+            {
+                var diagnosticEvent = diagnosticEventRepository.Events.Single();
+                Assert.Equal(diagnosticEvent.LogLevel, LogLevel.Warning);
+                Assert.NotNull(diagnosticEvent.Message);
+                Assert.NotNull(diagnosticEvent.HelpLink);
+
+                // The diagnostic event and the "normal" log will both be here
+                var warnings = testLoggerProvider.GetAllLogMessages().Where(m => m.Level == LogLevel.Warning);
+                Assert.Collection(warnings,
+                    m => Assert.Contains(DiagnosticEventConstants.MissingFunctionsWorkerRuntimeHelpLink, m.FormattedMessage),
+                    m => Assert.Contains(DiagnosticEventConstants.MissingFunctionsWorkerRuntimeHelpLink, m.FormattedMessage));
+            }
+            else
+            {
+                Assert.Empty(diagnosticEventRepository.Events);
+                Assert.Empty(testLoggerProvider.GetAllLogMessages().Where(m => m.Level == LogLevel.Warning));
             }
         }
 

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -31,7 +31,6 @@ using Moq;
 using Newtonsoft.Json.Linq;
 using WebJobs.Script.Tests;
 using Xunit;
-using static Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.DiagnosticEventLoggerTests;
 using FunctionMetadata = Microsoft.Azure.WebJobs.Script.Description.FunctionMetadata;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
@@ -1751,11 +1750,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Assert.NotNull(diagnosticEvent.Message);
                 Assert.NotNull(diagnosticEvent.HelpLink);
 
-                // The diagnostic event and the "normal" log will both be here
-                var warnings = testLoggerProvider.GetAllLogMessages().Where(m => m.Level == LogLevel.Warning);
-                Assert.Collection(warnings,
-                    m => Assert.Contains(DiagnosticEventConstants.MissingFunctionsWorkerRuntimeHelpLink, m.FormattedMessage),
-                    m => Assert.Contains(DiagnosticEventConstants.MissingFunctionsWorkerRuntimeHelpLink, m.FormattedMessage));
+                // Ensure it goes to App Insights as well
+                var log = testLoggerProvider.GetAllLogMessages().Single(m => m.Level == LogLevel.Warning);
+                Assert.Contains(DiagnosticEventConstants.MissingFunctionsWorkerRuntimeHelpLink, log.FormattedMessage);
             }
             else
             {


### PR DESCRIPTION
resolves #9801 

Begin warning if `FUNCTIONS_WORKER_RUNTIME` is null or empty. Changes coming in the future for both performance and reliability require that we have this set so we can guarantee we run the correct host version. Even though it's been in templates for quite a while, we still have some sites without it. There is a plan to gradually get the number of null `FUNCTIONS_WORKER_RUNTIME` values down to zero, and then enforcing that it is set. This is the first step towards that.

Documentation PR is here: https://github.com/MicrosoftDocs/azure-docs-pr/pull/264142

### Pull request checklist

* [ ] My changes **do not** require documentation changes
    * [x] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * [x] Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)