### PR TITLE
Adding PUT to the list of supported WebHook verbs

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -454,7 +454,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
             return Accepted();
         }
 
-        [AcceptVerbs("GET", "POST", "DELETE", "OPTIONS")]
+        [AcceptVerbs("GET", "PUT", "POST", "DELETE", "OPTIONS")]
         [Authorize(Policy = PolicyNames.SystemKeyAuthLevel)]
         [Route("runtime/webhooks/{extensionName}/{*extra}")]
         [RequiresRunningHost]

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
@@ -164,11 +164,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             _fixture.MockWebHookProvider.Setup(p => p.TryGetHandler("test", out handler)).Returns(true);
             _fixture.MockWebHookProvider.Setup(p => p.TryGetHandler("invalid", out handler)).Returns(false);
 
-            // successful request
+            // successful request for all supported verbs
             string uri = "runtime/webhooks/test?code=SystemValue3";
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
-            HttpResponseMessage response = await _fixture.Host.HttpClient.SendAsync(request);
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            HttpRequestMessage request = null;
+            HttpResponseMessage response = null;
+            var httpMethods = new HttpMethod[] { HttpMethod.Get, HttpMethod.Put, HttpMethod.Post, HttpMethod.Delete, HttpMethod.Options };
+            foreach (var httpMethod in httpMethods)
+            {
+                uri = "runtime/webhooks/test?code=SystemValue3";
+                request = new HttpRequestMessage(httpMethod, uri);
+                response = await _fixture.Host.HttpClient.SendAsync(request);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            }
 
             // invalid system key value - no key match
             uri = "runtime/webhooks/test?code=invalid";


### PR DESCRIPTION
I think this was just an oversight - no reason we can't let extension WebHook handlers support PUT as well. The ask is coming from @apranaseth for Workflow scenarios.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

