### PR TITLE
Host Split Update host build pipeline to publish a new FunctionsInproc site extension

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 variables:
   buildNumber: $[ counter('constant', 13000) ]
   isReleaseBranch: $[contains(variables['Build.SourceBranch'], 'release/')]
-  ${{ if contains(variables['Build.SourceBranch'], 'inproc') }}:
+  ${{ if contains(variables['Build.SourceBranch'], 'release/inproc6/') }}:
     minorVersionPrefix: "6"
   DOTNET_NOLOGO: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
   dependsOn: InitializePipeline
   condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.InitializePipeline.outputs['Initialize.BuildArtifacts'], true)))
   variables:
-    ${{ if or( eq( variables['Build.Reason'], 'PullRequest' ), and( not( contains( variables['Build.SourceBranch'], 'release/4.' ) ), not( contains( variables['Build.SourceBranch'], 'release/ExtensionsMetadataGenerator/' ) ), not( contains( variables['Build.SourceBranch'], 'release/inproc6/4.' ) ) ) ) }}:
+    ${{ if or( eq( variables['Build.Reason'], 'PullRequest' ), and( not( contains( variables['Build.SourceBranch'], 'release/inproc6/4.' ) ), not( contains( variables['Build.SourceBranch'], 'release/4.' ) ), not( contains( variables['Build.SourceBranch'], 'release/ExtensionsMetadataGenerator/' ) ) ) ) }}:
       suffixTemp: $(buildNumber)
       packSuffixSwitchTemp: --version-suffix $(buildNumber)
       emgSuffixSwitchTemp: --version-suffix ci$(buildNumber)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,7 @@
 variables:
   buildNumber: $[ counter('constant', 13000) ]
   isReleaseBranch: $[contains(variables['Build.SourceBranch'], 'release/')]
+  minorVersionPrefix: "10"
   ${{ if contains(variables['Build.SourceBranch'], 'release/inproc6/') }}:
     minorVersionPrefix: "6"
   DOTNET_NOLOGO: 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@ variables:
     minorVersionPrefix: "6"
   {{ else }}:
     minorVersionPrefix: "10"
-  {{ endif }}
+  {{ end }}
   DOTNET_NOLOGO: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,11 +1,6 @@
 variables:
   buildNumber: $[ counter('constant', 13000) ]
   isReleaseBranch: $[contains(variables['Build.SourceBranch'], 'release/')]
-  ${{ if contains(variables['Build.SourceBranch'], 'release/inproc6/') }}:
-    minorVersionPrefix: "6"
-  ${{ else }}:
-    minorVersionPrefix: "10"
-  ${{ endif }}
   DOTNET_NOLOGO: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -48,6 +43,9 @@ jobs:
     suffix: $[variables.suffixTemp] # this resolves to an empty string if it is missing
     packSuffixSwitch: $[variables.packSuffixSwitchTemp]
     emgSuffixSwitch: $[variables.emgSuffixSwitchTemp]
+    ${{ if contains(variables['Build.SourceBranch'], 'release/inproc6/') }}:
+        minorVersionPrefix: "6"
+    minorVersionPrefix: $[variables.minorVersionPrefixTemp]
   pool:
     name: '1ES-Hosted-AzFunc'
     demands:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
   dependsOn: InitializePipeline
   condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.InitializePipeline.outputs['Initialize.BuildArtifacts'], true)))
   variables:
-    ${{ if or( eq( variables['Build.Reason'], 'PullRequest' ), and( not( contains( variables['Build.SourceBranch'], 'release/4.' ) ), not( contains( variables['Build.SourceBranch'], 'release/ExtensionsMetadataGenerator/' ) ) ) ) }}:
+    ${{ if or( eq( variables['Build.Reason'], 'PullRequest' ), and( not( contains( variables['Build.SourceBranch'], 'release/4.' ) ), not( contains( variables['Build.SourceBranch'], 'release/ExtensionsMetadataGenerator/' ) ) ), not( contains( variables['Build.SourceBranch'], 'release/inproc/4.' ) ) ) }}:
       suffixTemp: $(buildNumber)
       packSuffixSwitchTemp: --version-suffix $(buildNumber)
       emgSuffixSwitchTemp: --version-suffix ci$(buildNumber)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,9 @@ variables:
   isReleaseBranch: $[contains(variables['Build.SourceBranch'], 'release/')]
   ${{ if contains(variables['Build.SourceBranch'], 'release/inproc6/') }}:
     minorVersionPrefix: "6"
+  {{ else }}:
+    minorVersionPrefix: "10"
+  {{ endif }}
   DOTNET_NOLOGO: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
   dependsOn: InitializePipeline
   condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.InitializePipeline.outputs['Initialize.BuildArtifacts'], true)))
   variables:
-    ${{ if or( eq( variables['Build.Reason'], 'PullRequest' ), and( not( contains( variables['Build.SourceBranch'], 'release/4.' ) ), not( contains( variables['Build.SourceBranch'], 'release/ExtensionsMetadataGenerator/' ) ) ), not( contains( variables['Build.SourceBranch'], 'release/inproc6/4.' ) ) ) }}:
+    ${{ if or( eq( variables['Build.Reason'], 'PullRequest' ), and( not( contains( variables['Build.SourceBranch'], 'release/4.' ) ), not( contains( variables['Build.SourceBranch'], 'release/ExtensionsMetadataGenerator/' ) ), not( contains( variables['Build.SourceBranch'], 'release/inproc6/4.' ) ) ) ) }}:
       suffixTemp: $(buildNumber)
       packSuffixSwitchTemp: --version-suffix $(buildNumber)
       emgSuffixSwitchTemp: --version-suffix ci$(buildNumber)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,9 +1,6 @@
 variables:
   buildNumber: $[ counter('constant', 13000) ]
   isReleaseBranch: $[contains(variables['Build.SourceBranch'], 'release/')]
-  minorVersionPrefix: "10"
-  ${{ if contains(variables['Build.SourceBranch'], 'release/inproc6/') }}:
-    minorVersionPrefix: "6"
   DOTNET_NOLOGO: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -43,6 +40,9 @@ jobs:
       suffixTemp: $(buildNumber)
       packSuffixSwitchTemp: --version-suffix $(buildNumber)
       emgSuffixSwitchTemp: --version-suffix ci$(buildNumber)
+    ${{ if contains(variables['Build.SourceBranch'], 'release/inproc6/') }}:
+      minorVersionPrefixTemp: "6"
+    minorVersionPrefix: $[variables.minorVersionPrefixTemp]
     suffix: $[variables.suffixTemp] # this resolves to an empty string if it is missing
     packSuffixSwitch: $[variables.packSuffixSwitchTemp]
     emgSuffixSwitch: $[variables.emgSuffixSwitchTemp]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ jobs:
     packSuffixSwitch: $[variables.packSuffixSwitchTemp]
     emgSuffixSwitch: $[variables.emgSuffixSwitchTemp]
     ${{ if contains(variables['Build.SourceBranch'], 'release/inproc6/') }}:
-        minorVersionPrefix: "6"
+        minorVersionPrefixTemp: "6"
     minorVersionPrefix: $[variables.minorVersionPrefixTemp]
   pool:
     name: '1ES-Hosted-AzFunc'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,9 +3,9 @@ variables:
   isReleaseBranch: $[contains(variables['Build.SourceBranch'], 'release/')]
   ${{ if contains(variables['Build.SourceBranch'], 'release/inproc6/') }}:
     minorVersionPrefix: "6"
-  {{ else }}:
+  ${{ else }}:
     minorVersionPrefix: "10"
-  {{ end }}
+  ${{ endif }}
   DOTNET_NOLOGO: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
   dependsOn: InitializePipeline
   condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.InitializePipeline.outputs['Initialize.BuildArtifacts'], true)))
   variables:
-    ${{ if or( eq( variables['Build.Reason'], 'PullRequest' ), and( not( contains( variables['Build.SourceBranch'], 'release/4.' ) ), not( contains( variables['Build.SourceBranch'], 'release/ExtensionsMetadataGenerator/' ) ) ), not( contains( variables['Build.SourceBranch'], 'release/inproc/4.' ) ) ) }}:
+    ${{ if or( eq( variables['Build.Reason'], 'PullRequest' ), and( not( contains( variables['Build.SourceBranch'], 'release/4.' ) ), not( contains( variables['Build.SourceBranch'], 'release/ExtensionsMetadataGenerator/' ) ) ), not( contains( variables['Build.SourceBranch'], 'release/inproc6/4.' ) ) ) }}:
       suffixTemp: $(buildNumber)
       packSuffixSwitchTemp: --version-suffix $(buildNumber)
       emgSuffixSwitchTemp: --version-suffix ci$(buildNumber)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ jobs:
     displayName: "Build artifacts"
     inputs:
       filePath: '$(Build.Repository.LocalPath)\build\build-extensions.ps1'
-      arguments: '-buildNumber "$(buildNumber)" -suffix "$(suffix)"'
+      arguments: '-buildNumber "$(buildNumber)" -suffix "$(suffix)" -minorVersionPrefix "$(minorVersionPrefix)"'
   - task: PowerShell@2
     displayName: "Check for security vulnerabilities"
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,10 @@
 variables:
   buildNumber: $[ counter('constant', 13000) ]
   isReleaseBranch: $[contains(variables['Build.SourceBranch'], 'release/')]
+  ${{ if contains(variables['Build.SourceBranch'], 'release/inproc6/') }}:
+    minorVersionPrefix: "6"
+  ${{ else }}:
+    minorVersionPrefix: "10"
   DOTNET_NOLOGO: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -40,9 +44,6 @@ jobs:
       suffixTemp: $(buildNumber)
       packSuffixSwitchTemp: --version-suffix $(buildNumber)
       emgSuffixSwitchTemp: --version-suffix ci$(buildNumber)
-    ${{ if contains(variables['Build.SourceBranch'], 'release/inproc6/') }}:
-      minorVersionPrefixTemp: "6"
-    minorVersionPrefix: $[variables.minorVersionPrefixTemp]
     suffix: $[variables.suffixTemp] # this resolves to an empty string if it is missing
     packSuffixSwitch: $[variables.packSuffixSwitchTemp]
     emgSuffixSwitch: $[variables.emgSuffixSwitchTemp]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,8 @@
 variables:
   buildNumber: $[ counter('constant', 13000) ]
   isReleaseBranch: $[contains(variables['Build.SourceBranch'], 'release/')]
+  ${{ if contains(variables['Build.SourceBranch'], 'release/inproc6/') }}:
+    minorVersionPrefix: "6"
   DOTNET_NOLOGO: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,9 +43,6 @@ jobs:
     suffix: $[variables.suffixTemp] # this resolves to an empty string if it is missing
     packSuffixSwitch: $[variables.packSuffixSwitchTemp]
     emgSuffixSwitch: $[variables.emgSuffixSwitchTemp]
-    ${{ if contains(variables['Build.SourceBranch'], 'release/inproc6/') }}:
-        minorVersionPrefixTemp: "6"
-    minorVersionPrefix: $[variables.minorVersionPrefixTemp]
   pool:
     name: '1ES-Hosted-AzFunc'
     demands:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,8 @@
 variables:
   buildNumber: $[ counter('constant', 13000) ]
   isReleaseBranch: $[contains(variables['Build.SourceBranch'], 'release/')]
+  ${{ if contains(variables['Build.SourceBranch'], 'inproc') }}:
+    minorVersionPrefix: "6"
   DOTNET_NOLOGO: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -10,12 +12,14 @@ pr:
     include:
     - dev
     - release/4.*
+    - release/inproc6/4.*
 
 trigger:
   branches:
     include:
     - dev
     - release/4.*
+    - release/inproc6/4.*
 
 jobs:
 - job: InitializePipeline

--- a/build/Get-AzureFunctionsVersion.psm1
+++ b/build/Get-AzureFunctionsVersion.psm1
@@ -1,7 +1,8 @@
 function Get-AzureFunctionsVersion {
   param(    
     [string] $buildNumber,
-    [string] $suffix
+    [string] $suffix,
+    [string] $minorVersionPrefix
   )
 
   $hasSuffix = ![string]::IsNullOrEmpty($suffix)
@@ -12,7 +13,7 @@ function Get-AzureFunctionsVersion {
   }
 
   # use the same logic as the projects to generate the site extension version
-  $cmd = "build", "$PSScriptRoot\common.props", "/t:EchoVersion", "-restore:False", "/p:BuildNumber=$buildNumber", $suffixCmd, "--nologo", "-clp:NoSummary"  
+  $cmd = "build", "$PSScriptRoot\common.props", "/t:EchoVersion", "-restore:False", "/p:BuildNumber=$buildNumber", "/p:MinorVersionPrefix=$minorVersionPrefix", $suffixCmd, "--nologo", "-clp:NoSummary"  
   $version = (& dotnet $cmd).Trim()
 
   return $version

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -1,7 +1,7 @@
 param (
   [string]$buildNumber = "0",  
   [string]$suffix = "",
-  [string]$minorVersionPrefix = "10",
+  [string]$minorVersionPrefix = "",
   [string]$hashesForHardlinksFile = "hashesForHardlinks.txt"
 )
 
@@ -245,7 +245,7 @@ function CreateSiteExtensions() {
     if ($minorVersionPrefix -eq "10") {
         ZipContent $siteExtensionPath "$zipOutput\Functions.$extensionVersion$runtimeSuffix.zip"
     } else {
-		ZipContent $siteExtensionPath "$zipOutput\FunctionsInProc.$extensionVersion$runtimeSuffix.zip"
+        ZipContent $siteExtensionPath "$zipOutput\FunctionsInProc.$extensionVersion$runtimeSuffix.zip"
 	}
 
     # Create directory for content even if there is no patch build. This makes artifact uploading easier.

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -242,13 +242,11 @@ function CreateSiteExtensions() {
     
     $zipOutput = "$buildOutput\SiteExtension"
     New-Item -Itemtype directory -path $zipOutput -Force > $null
-    if ($minorVersionPrefix -eq "6") {
-        ZipContent $siteExtensionPath "$zipOutput\FunctionsInProc.$extensionVersion$runtimeSuffix.zip"
-    } else {
+    if ($minorVersionPrefix -eq "10") {
         ZipContent $siteExtensionPath "$zipOutput\Functions.$extensionVersion$runtimeSuffix.zip"
     } else {
-		ZipContent $siteExtensionPath "$zipOutput\FunctionsInProc.$extensionVersion$runtimeSuffix.zip"
-	}
+        ZipContent $siteExtensionPath "$zipOutput\FunctionsInProc.$extensionVersion$runtimeSuffix.zip"
+    }
 
     # Create directory for content even if there is no patch build. This makes artifact uploading easier.
     $patchedContentDirectory = "$buildOutput\PatchedSiteExtension"

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -242,6 +242,7 @@ function CreateSiteExtensions() {
     $zipOutput = "$buildOutput\SiteExtension"
     New-Item -Itemtype directory -path $zipOutput -Force > $null
     ZipContent $siteExtensionPath "$zipOutput\Functions.$extensionVersion$runtimeSuffix.zip"
+    ZipContent $siteExtensionPath "$zipOutput\FunctionsInProc.$extensionVersion$runtimeSuffix.zip"
 
     # Create directory for content even if there is no patch build. This makes artifact uploading easier.
     $patchedContentDirectory = "$buildOutput\PatchedSiteExtension"

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -246,7 +246,7 @@ function CreateSiteExtensions() {
         ZipContent $siteExtensionPath "$zipOutput\Functions.$extensionVersion$runtimeSuffix.zip"
     } else {
         ZipContent $siteExtensionPath "$zipOutput\FunctionsInProc.$extensionVersion$runtimeSuffix.zip"
-	}
+    }
 
     # Create directory for content even if there is no patch build. This makes artifact uploading easier.
     $patchedContentDirectory = "$buildOutput\PatchedSiteExtension"

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -1,7 +1,7 @@
 param (
   [string]$buildNumber = "0",  
   [string]$suffix = "",
-  [string]$minorVersionPrefix = "10",
+  [string]$minorVersionPrefix = "",
   [string]$hashesForHardlinksFile = "hashesForHardlinks.txt"
 )
 

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -1,7 +1,7 @@
 param (
   [string]$buildNumber = "0",  
   [string]$suffix = "",
-  [string]$minorVersionPrefix = "",
+  [string]$minorVersionPrefix = "10",
   [string]$hashesForHardlinksFile = "hashesForHardlinks.txt"
 )
 

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -242,10 +242,10 @@ function CreateSiteExtensions() {
     
     $zipOutput = "$buildOutput\SiteExtension"
     New-Item -Itemtype directory -path $zipOutput -Force > $null
-    if ($minorVersionPrefix -eq "10") {
-        ZipContent $siteExtensionPath "$zipOutput\Functions.$extensionVersion$runtimeSuffix.zip"
-    } else {
+    if ($minorVersionPrefix -eq "6") {
         ZipContent $siteExtensionPath "$zipOutput\FunctionsInProc.$extensionVersion$runtimeSuffix.zip"
+    } else {
+        ZipContent $siteExtensionPath "$zipOutput\Functions.$extensionVersion$runtimeSuffix.zip"
     }
 
     # Create directory for content even if there is no patch build. This makes artifact uploading easier.

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -1,7 +1,7 @@
 param (
   [string]$buildNumber = "0",  
   [string]$suffix = "",
-  [string]$minorVersionPrefix = "",
+  [string]$minorVersionPrefix = "10",
   [string]$hashesForHardlinksFile = "hashesForHardlinks.txt"
 )
 
@@ -245,7 +245,7 @@ function CreateSiteExtensions() {
     if ($minorVersionPrefix -eq "10") {
         ZipContent $siteExtensionPath "$zipOutput\Functions.$extensionVersion$runtimeSuffix.zip"
     } else {
-        ZipContent $siteExtensionPath "$zipOutput\FunctionsInProc.$extensionVersion$runtimeSuffix.zip"
+		ZipContent $siteExtensionPath "$zipOutput\FunctionsInProc.$extensionVersion$runtimeSuffix.zip"
 	}
 
     # Create directory for content even if there is no patch build. This makes artifact uploading easier.

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -248,6 +248,7 @@ function CreateSiteExtensions() {
         ZipContent $siteExtensionPath "$zipOutput\FunctionsInProc.$extensionVersion$runtimeSuffix.zip"
     }
 
+
     # Create directory for content even if there is no patch build. This makes artifact uploading easier.
     $patchedContentDirectory = "$buildOutput\PatchedSiteExtension"
     New-Item -Itemtype directory -path $patchedContentDirectory -Force > $null

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -248,7 +248,6 @@ function CreateSiteExtensions() {
         ZipContent $siteExtensionPath "$zipOutput\FunctionsInProc.$extensionVersion$runtimeSuffix.zip"
     }
 
-
     # Create directory for content even if there is no patch build. This makes artifact uploading easier.
     $patchedContentDirectory = "$buildOutput\PatchedSiteExtension"
     New-Item -Itemtype directory -path $patchedContentDirectory -Force > $null

--- a/build/common.props
+++ b/build/common.props
@@ -4,7 +4,8 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <MajorVersion>4</MajorVersion>
-    <MinorVersion>30</MinorVersion>
+	<MinorVersionPrefix Condition="'$(MinorVersionPrefix)' == ''">10</MinorVersionPrefix>
+    <MinorVersion>$(MinorVersionPrefix)30</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <BuildNumber Condition="'$(BuildNumber)' == '' ">0</BuildNumber>
     <PreviewVersion></PreviewVersion>

--- a/build/common.props
+++ b/build/common.props
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <MajorVersion>4</MajorVersion>
-	  <MinorVersionPrefix Condition="'$(MinorVersionPrefix)' == ''">10</MinorVersionPrefix>
+	<MinorVersionPrefix Condition="'$(MinorVersionPrefix)' == ''">10</MinorVersionPrefix>
     <MinorVersion>$(MinorVersionPrefix)30</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <BuildNumber Condition="'$(BuildNumber)' == '' ">0</BuildNumber>

--- a/build/common.props
+++ b/build/common.props
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <MajorVersion>4</MajorVersion>
-	<MinorVersionPrefix Condition="'$(MinorVersionPrefix)' == ''">10</MinorVersionPrefix>
+	  <MinorVersionPrefix Condition="'$(MinorVersionPrefix)' == ''">10</MinorVersionPrefix>
     <MinorVersion>$(MinorVersionPrefix)30</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <BuildNumber Condition="'$(BuildNumber)' == '' ">0</BuildNumber>

--- a/build/common.props
+++ b/build/common.props
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <MajorVersion>4</MajorVersion>
-<MinorVersionPrefix Condition="'$(MinorVersionPrefix)' == ''">10</MinorVersionPrefix>
+    <MinorVersionPrefix Condition="'$(MinorVersionPrefix)' == ''">10</MinorVersionPrefix>
     <MinorVersion>$(MinorVersionPrefix)30</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <BuildNumber Condition="'$(BuildNumber)' == '' ">0</BuildNumber>

--- a/build/common.props
+++ b/build/common.props
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <MajorVersion>4</MajorVersion>
-	<MinorVersionPrefix Condition="'$(MinorVersionPrefix)' == ''">10</MinorVersionPrefix>
+<MinorVersionPrefix Condition="'$(MinorVersionPrefix)' == ''">10</MinorVersionPrefix>
     <MinorVersion>$(MinorVersionPrefix)30</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <BuildNumber Condition="'$(BuildNumber)' == '' ">0</BuildNumber>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #9722 

On a high level, the pipeline pushes the dev branch to `release/4.x` and `release/inproc6/4.x`. The first branch will generate an artifact called `Functions.4.1030.zip` and the second branch will generate an artifact called `FunctionsInProc.4.630.zip`.

We are calling in-proc `4.6xx` and OOP `4.10xx` to specify the host .NET version without having to make another query. So `4.6xx` means we're using .NET 6. We chose to add `10` to the minor prefix of the version since we want the version for isolated to be larger than the version for in-proc.

The following site extension is built when testing with `aishwarya/release/inproc6/4.99`:
![image](https://github.com/Azure/azure-functions-host/assets/37918412/40bf6000-dae9-4c48-8dfb-262f5d500144)


And the following site extension is built when testing with `aishwarya/release/4.99`:
![image](https://github.com/Azure/azure-functions-host/assets/37918412/2d14a70a-5a9b-44be-bac3-4c196c685f2d)


### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
