### PR TITLE
preventing worker process startup during host shutdown

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -565,7 +565,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                         }
                         else
                         {
-                            StopCurrentDispatcher(previousHost);
+                            NotifyHostStopping(previousHost);
                             startTask = UnsynchronizedStartHostAsync(activeOperation);
                             stopTask = Orphan(previousHost, cancellationToken);
                         }
@@ -593,10 +593,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
         }
 
-        private static void StopCurrentDispatcher(IHost previousHost)
+        // Because we fire-and-forget the host disposal, we cannot be guaranteed when it will be stopped
+        // or disposed. Use this method to explicitly stop any services in the host that may be
+        // problematic to run side-by-side with the new host that is starting.
+        private static void NotifyHostStopping(IHost previousHost)
         {
-            // It's important to prevent any new workers from starting on the orphaned host. Due to
-            // the multi-threaded flow and the fact that workers can exist at the WebHost-level, the
+            // It's important to prevent any new workers from starting on the orphaned host. The
             // only way to guarantee this is to signal to the dispatcher that it's done with process
             // creation before we begin a new host.
             var dispatcherFactory = previousHost?.Services?.GetService<IFunctionInvocationDispatcherFactory>();

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -603,7 +603,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             // creation before we begin a new host.
             var dispatcherFactory = previousHost?.Services?.GetService<IFunctionInvocationDispatcherFactory>();
             IFunctionInvocationDispatcher dispatcher = dispatcherFactory?.GetFunctionDispatcher();
-            // dispatcher?.PreShutdown();
+            dispatcher?.PreShutdown();
         }
 
         internal bool ShouldEnforceSequentialRestart()

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -601,7 +601,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             // creation before we begin a new host.
             var dispatcherFactory = previousHost?.Services?.GetService<IFunctionInvocationDispatcherFactory>();
             IFunctionInvocationDispatcher dispatcher = dispatcherFactory?.GetFunctionDispatcher();
-            dispatcher?.PreShutdown();
+            // dispatcher?.PreShutdown();
         }
 
         internal bool ShouldEnforceSequentialRestart()

--- a/src/WebJobs.Script/Workers/Http/HttpFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpFunctionInvocationDispatcher.cs
@@ -212,5 +212,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             await DisposeAndRestartWorkerChannel(_httpWorkerChannel.Id);    // Since there's only one channel for httpworker
             return true;
         }
+
+        public void PreShutdown()
+        {
+        }
     }
 }

--- a/src/WebJobs.Script/Workers/IFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/IFunctionInvocationDispatcher.cs
@@ -26,5 +26,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         Task<bool> RestartWorkerWithInvocationIdAsync(string invocationId);
 
         Task StartWorkerChannel();
+
+        void PreShutdown();
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -678,5 +678,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 }
             }
         }
+
+        public void PreShutdown()
+        {
+            _logger.LogDebug($"Preventing any new worker processes from starting during shutdown.");
+            _processStartCancellationToken.Cancel();
+        }
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -389,7 +389,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         internal void SetInitializedWorkerChannel(string initializedRuntime, IRpcWorkerChannel initializedLanguageWorkerChannel)
         {
-            _logger.LogDebug("Adding webhost language worker channel for runtime: {language}. workerId:{id}", initializedRuntime, initializedLanguageWorkerChannel.Id);
+            _logger.LogDebug("Initializing webhost language worker channel for runtime: {language}. workerId:{id}", initializedRuntime, initializedLanguageWorkerChannel.Id);
             if (_workerChannels.TryGetValue(initializedRuntime, out ConcurrentDictionary<string, TaskCompletionSource<IRpcWorkerChannel>> channel))
             {
                 if (channel.TryGetValue(initializedLanguageWorkerChannel.Id, out TaskCompletionSource<IRpcWorkerChannel> value))

--- a/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/NodeScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/NodeScriptHostTests.cs
@@ -211,6 +211,64 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.True(logs.Any(l => l.Contains($"FunctionDirectory:{Path.Combine(Fixture.JobHost.ScriptOptions.RootScriptPath, "Scenarios")}")));
         }
 
+        [Fact]
+        public Task Repro()
+        {
+            return Task.CompletedTask;
+            //var fd = Fixture.JobHost.FunctionDispatcher as RpcFunctionInvocationDispatcher;
+
+            //List<Task<bool>> tasks = new();
+            //List<Thread> threads = new();
+            //Thread t = new(static (state) =>
+            //{
+            //    var (jobhost, tasks) = ((ScriptHost, List<Task>))state;
+            //    tasks.Add(jobhost.RestartAsync());
+            //    var dispatcher = jobhost.FunctionDispatcher as RpcFunctionInvocationDispatcher;
+            //    tasks.Add(WaitForJobhostWorkerChannelsToStartup(dispatcher, 3, false));
+
+            //});
+            //threads.Add(t);
+
+            //Thread t2 = new(static (state) =>
+            //{
+            //    var (jobhost, tasks) = ((ScriptHost, List<Task<int>>))state;
+            //    var dispatcher = jobhost.FunctionDispatcher as RpcFunctionInvocationDispatcher;
+            //    tasks.Add(WaitForJobhostWorkerChannelsToStartup(dispatcher, 3));
+            //});
+            //threads.Add(t2);
+
+            //foreach (Thread thread in threads)
+            //{
+            //    thread.Start((Fixture.JobHost, tasks));
+            //}
+
+            //// channels = await WaitForJobhostWorkerChannelsToStartup(fd, 3);
+
+            //// Invoke function, should fail
+            //string userAgent = "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.71 Safari/537.36";
+            //string accept = "text/html, application/xhtml+xml, application/xml; q=0.9, */*; q=0.8";
+            //string customHeader = "foo,bar,baz";
+            //string url = $"http://localhost/api/httptrigger?name=Mathew%20Charles&location=Seattle";
+            //var request = HttpTestHelpers.CreateHttpRequest(
+            //    "GET",
+            //    url,
+            //    new HeaderDictionary()
+            //    {
+            //        ["test-header"] = "Test Request Header",
+            //        ["user-agent"] = userAgent,
+            //        ["accept"] = accept,
+            //        ["custom-1"] = customHeader
+            //    });
+            //Dictionary<string, object> arguments = new Dictionary<string, object>
+            //{
+            //    { "request", request }
+            //};
+            //await Fixture.JobHost.CallAsync("HttpTrigger", arguments);
+            //var result = (IActionResult)request.HttpContext.Items[ScriptConstants.AzureFunctionsHttpResponseKey];
+            //var objResult = result as RawScriptResult;
+            //Assert.Equal(200, objResult.StatusCode);
+        }
+
         public class TestFixture : ScriptHostEndToEndTestFixture
         {
             static TestFixture()

--- a/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/NodeScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/NodeScriptHostTests.cs
@@ -211,64 +211,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.True(logs.Any(l => l.Contains($"FunctionDirectory:{Path.Combine(Fixture.JobHost.ScriptOptions.RootScriptPath, "Scenarios")}")));
         }
 
-        [Fact]
-        public Task Repro()
-        {
-            return Task.CompletedTask;
-            //var fd = Fixture.JobHost.FunctionDispatcher as RpcFunctionInvocationDispatcher;
-
-            //List<Task<bool>> tasks = new();
-            //List<Thread> threads = new();
-            //Thread t = new(static (state) =>
-            //{
-            //    var (jobhost, tasks) = ((ScriptHost, List<Task>))state;
-            //    tasks.Add(jobhost.RestartAsync());
-            //    var dispatcher = jobhost.FunctionDispatcher as RpcFunctionInvocationDispatcher;
-            //    tasks.Add(WaitForJobhostWorkerChannelsToStartup(dispatcher, 3, false));
-
-            //});
-            //threads.Add(t);
-
-            //Thread t2 = new(static (state) =>
-            //{
-            //    var (jobhost, tasks) = ((ScriptHost, List<Task<int>>))state;
-            //    var dispatcher = jobhost.FunctionDispatcher as RpcFunctionInvocationDispatcher;
-            //    tasks.Add(WaitForJobhostWorkerChannelsToStartup(dispatcher, 3));
-            //});
-            //threads.Add(t2);
-
-            //foreach (Thread thread in threads)
-            //{
-            //    thread.Start((Fixture.JobHost, tasks));
-            //}
-
-            //// channels = await WaitForJobhostWorkerChannelsToStartup(fd, 3);
-
-            //// Invoke function, should fail
-            //string userAgent = "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.71 Safari/537.36";
-            //string accept = "text/html, application/xhtml+xml, application/xml; q=0.9, */*; q=0.8";
-            //string customHeader = "foo,bar,baz";
-            //string url = $"http://localhost/api/httptrigger?name=Mathew%20Charles&location=Seattle";
-            //var request = HttpTestHelpers.CreateHttpRequest(
-            //    "GET",
-            //    url,
-            //    new HeaderDictionary()
-            //    {
-            //        ["test-header"] = "Test Request Header",
-            //        ["user-agent"] = userAgent,
-            //        ["accept"] = accept,
-            //        ["custom-1"] = customHeader
-            //    });
-            //Dictionary<string, object> arguments = new Dictionary<string, object>
-            //{
-            //    { "request", request }
-            //};
-            //await Fixture.JobHost.CallAsync("HttpTrigger", arguments);
-            //var result = (IActionResult)request.HttpContext.Items[ScriptConstants.AzureFunctionsHttpResponseKey];
-            //var objResult = result as RawScriptResult;
-            //Assert.Equal(200, objResult.StatusCode);
-        }
-
         public class TestFixture : ScriptHostEndToEndTestFixture
         {
             static TestFixture()

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/NodeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/NodeEndToEndTests.cs
@@ -10,7 +10,6 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Http;
 using Microsoft.Azure.Storage.Blob;
@@ -446,6 +445,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 
             HttpResponseMessage response = await Fixture.Host.HttpClient.SendAsync(request);
 
+            Assert.True(response.StatusCode == HttpStatusCode.OK, Fixture.Host.GetLog());
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             Assert.Equal("Test Response Header", response.Headers.GetValues("test-header").SingleOrDefault());
@@ -833,79 +833,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal("Test Entity 1, Test Entity 2", Utility.RemoveUtf8ByteOrderMark(blobContent.Trim()));
         }
 
-        [Fact]
-        // Confirms that a background timer to create new worker processes does not
-        // continue to fire after we've initiated a restart. This could lead to issues
-        // where we'd create too many processes and throw an exception.
-        // See https://github.com/Azure/azure-functions-host/pull/9820 for details.
-        public async Task JobHostRestart_StopsCreatingNewWorkers()
-        {
-            var cancelWait = new CancellationTokenSource();
-            var fixture = new WorkerProcessRestartTestFixture();
-
-            try
-            {
-                await fixture.InitializeAsync();
-                var channelManager = fixture.Host.WebHostServices.GetService<IWebHostRpcWorkerChannelManager>();
-                var scriptHostManager = fixture.Host.WebHostServices.GetService<IScriptHostManager>();
-                var appHostLifecycle = fixture.Host.JobHostServices.GetService<IApplicationLifetime>();
-
-                appHostLifecycle.ApplicationStopping.Register(() =>
-                {
-                    // pause here to prevent the original host from shutting down fully
-                    // this emulates scenarios in production where the disposal of an old host
-                    // can take a very long time
-                    TestHelpers.Await(() => cancelWait.IsCancellationRequested,
-                        pollingInterval: 500).GetAwaiter().GetResult();
-                });
-
-                await TestHelpers.Await(() =>
-                {
-                    var channels = channelManager.GetChannels("node");
-                    int? currentChannelCount = channels?.Count;
-                    return currentChannelCount == 2;
-                });
-
-                // Once we've hit 2, we have 10 seconds to trigger a restart.
-                _ = Task.Run(() => scriptHostManager.RestartHostAsync());
-
-                int delayInSeconds = 15;
-                DateTime start = DateTime.UtcNow;
-                await TestHelpers.Await(() =>
-                {
-                    var channels = channelManager.GetChannels("node");
-                    if (channels == null)
-                    {
-                        return false;
-                    }
-
-                    // If it hasn't started by now, we should be good.
-                    if (DateTime.UtcNow.AddSeconds(-delayInSeconds) > start)
-                    {
-                        return true;
-                    }
-
-                    return channels.Count(c => c.Value.Task.Status == TaskStatus.RanToCompletion) == 4;
-                });
-
-                // now that we've created all 3 from before... let the original shutdown continue
-                cancelWait.Cancel();
-
-                string key = await fixture.Host.GetFunctionSecretAsync("HttpTrigger");
-                var result = await fixture.Host.HttpClient.GetAsync($"/api/HttpTrigger?code={key}");
-
-                var errors = fixture.Host.GetScriptHostLogMessages()
-                    .Where(m => m.Level == LogLevel.Error)
-                    .Select(m => m.Exception);
-                Assert.Empty(errors);
-                Assert.Equal(HttpStatusCode.OK, result.StatusCode);
-            }
-            finally
-            {
-                await fixture.DisposeAsync();
-            }
-        }
-
 #if APIHUB
         [Fact( Skip = "unsupported" )]
         public async Task ApiHubTableEntityIn()
@@ -957,31 +884,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         }
         
 #endif
-        internal class WorkerProcessRestartTestFixture : EndToEndTestFixture
-        {
-            private static string rootPath = Path.Combine("TestScripts", "Node");
-
-            public WorkerProcessRestartTestFixture()
-                : base(rootPath, "nodeWorkerRestart", RpcWorkerConstants.NodeLanguageWorkerName, workerProcessesCount: 3)
-            {
-            }
-
-            protected override Task CreateTestStorageEntities() => Task.CompletedTask;
-
-            public override void ConfigureScriptHost(IWebJobsBuilder webJobsBuilder)
-            {
-                base.ConfigureScriptHost(webJobsBuilder);
-
-                webJobsBuilder.AddAzureStorage()
-                    .Services.Configure<ScriptJobHostOptions>(o =>
-                    {
-                        o.Functions = new[]
-                        {
-                            "HttpTrigger"
-                        };
-                    });
-            }
-        }
 
         public class TestFixture : EndToEndTestFixture
         {

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/NodeHostRestartEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/NodeHostRestartEndToEndTests.cs
@@ -1,0 +1,126 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd;
+
+public class NodeHostRestartEndToEndTests
+{
+    [Fact]
+    // Confirms that a background timer to create new worker processes does not
+    // continue to fire after we've initiated a restart. This could lead to issues
+    // where we'd create too many processes and throw an exception.
+    // See https://github.com/Azure/azure-functions-host/pull/9820 for details.
+    public static async Task JobHostRestart_StopsCreatingNewWorkers()
+    {
+        CancellationTokenRegistration registration = default;
+        var fixture = new WorkerProcessRestartTestFixture();
+
+        try
+        {
+            await fixture.InitializeAsync();
+            var channelManager = fixture.Host.WebHostServices.GetService<IWebHostRpcWorkerChannelManager>();
+            var scriptHostManager = fixture.Host.WebHostServices.GetService<IScriptHostManager>();
+            var appHostLifecycle = fixture.Host.JobHostServices.GetService<IApplicationLifetime>();
+            var semaphore = new SemaphoreSlim(0, 1);
+            registration = appHostLifecycle.ApplicationStopping.Register(() =>
+            {
+                // pause here to prevent the original host from shutting down fully
+                // this emulates scenarios in production where the disposal of an old host
+                // can take a very long time
+                semaphore.Wait();
+            });
+
+            await TestHelpers.Await(() =>
+            {
+                var channels = channelManager.GetChannels("node");
+                int? currentChannelCount = channels?.Count;
+                return currentChannelCount == 2;
+            });
+
+            // Once we've hit 2, we have a couple seconds to trigger a restart.
+            _ = Task.Run(() => scriptHostManager.RestartHostAsync());
+
+            DateTime start = DateTime.UtcNow;
+            await TestHelpers.Await(() =>
+            {
+                var channels = channelManager.GetChannels("node");
+                if (channels == null)
+                {
+                    return false;
+                }
+
+                // If it hasn't started by now, we should be good.
+                var waitTime = WorkerProcessRestartTestFixture.ProcessStartupInterval.Add(TimeSpan.FromSeconds(2));
+                if (DateTime.UtcNow.AddSeconds(-waitTime.TotalSeconds) > start)
+                {
+                    return true;
+                }
+
+                return channels.Count(c => c.Value.Task.Status == TaskStatus.RanToCompletion) == 4;
+            });
+
+            // let the original shutdown continue
+            semaphore.Release();
+
+            string key = await fixture.Host.GetFunctionSecretAsync("HttpTrigger");
+            var result = await fixture.Host.HttpClient.GetAsync($"/api/HttpTrigger?code={key}");
+
+            var errors = fixture.Host.GetScriptHostLogMessages()
+                .Where(m => m.Level == LogLevel.Error)
+                .Select(m => m.Exception);
+            Assert.Empty(errors);
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+            (registration as IDisposable)?.Dispose();
+        }
+    }
+    private class WorkerProcessRestartTestFixture : EndToEndTestFixture
+    {
+        private static readonly string rootPath = Path.Combine("TestScripts", "Node");
+
+        public WorkerProcessRestartTestFixture()
+            : base(rootPath, "nodeWorkerRestart", RpcWorkerConstants.NodeLanguageWorkerName, workerProcessesCount: 3)
+        {
+        }
+
+        public static readonly TimeSpan ProcessStartupInterval = TimeSpan.FromSeconds(3);
+
+        protected override Task CreateTestStorageEntities() => Task.CompletedTask;
+
+        public override void ConfigureScriptHost(IWebJobsBuilder webJobsBuilder)
+        {
+            base.ConfigureScriptHost(webJobsBuilder);
+
+            webJobsBuilder.AddAzureStorage()
+                .Services.Configure<ScriptJobHostOptions>(o =>
+                {
+                    o.Functions = new[]
+                    {
+                        "HttpTrigger"
+                    };
+                });
+
+            webJobsBuilder.Services.AddOptions<LanguageWorkerOptions>()
+                .PostConfigure(o =>
+                {
+                    var nodeConfig = o.WorkerConfigs.Single(c => c.Description.Language == "node");
+                    nodeConfig.CountOptions.ProcessStartupInterval = ProcessStartupInterval;
+                });
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Shared/TestLogger.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestLogger.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public override string ToString()
         {
-            return $"[{Timestamp.ToString("HH:mm:ss.fff")}] [{Category}] {FormattedMessage}";
+            return $"[{Timestamp.ToString("HH:mm:ss.fff")}] [{Category}] {FormattedMessage} {Exception}";
         }
     }
 }

--- a/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
@@ -152,6 +152,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var metricsLogger = new TestMetricsLogger();
             _host.Setup(h => h.StartAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
+            _host.SetupGet(h => h.Services)
+                .Returns((IServiceProvider)null);
 
             var hostBuilder = new Mock<IScriptHostBuilder>();
             hostBuilder.Setup(b => b.BuildHost(It.IsAny<bool>(), It.IsAny<bool>()))


### PR DESCRIPTION
Resolves #9335 

During a host restart, we do not explicitly cancel the loop that is waiting 10 seconds to create new worker processes. While this does happen when that host is fully stopped/disposed this can take quite a long time on slower, single-core machines. We create workers every 10 seconds and we've seen it take 4->12 seconds sometimes to fully shut down. If this loop iterates during this time, you can end up with a rogue process that throws everything off.

The problem has been around for a while -- it only affects worker processes at the WebHost level -- which is now almost all workers due to Worker Indexing being the default.

This fixes the issue by explicitly signaling to the Dispatcher that it should stop the creation loop as it's about to shut down. It's a tactical fix that we can re-visit as we redo this layer in the coming months. I created a solid repro of the issue in production and tested with this change and saw no more occurrences.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)