### PR TITLE
Pin to .NET8 SDK

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,7 @@ jobs:
     name: Initialize
     inputs:
       filePath: '$(Build.Repository.LocalPath)\build\initialize-pipeline.ps1'
+      showWarnings: true
 
 - job: BuildArtifacts
   dependsOn: InitializePipeline

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,11 @@ jobs:
     demands:
       - ImageOverride -equals MMS2019TLS
   steps:
+  - task: UseDotNet@2 # The pinned SDK we use to build
+    displayName: 'Install .NET SDK from global.json'
+    inputs:
+      packageType: sdk
+      useGlobalJson: true
   - task: PowerShell@2
     displayName: 'Initialize'
     name: Initialize

--- a/build/initialize-pipeline.ps1
+++ b/build/initialize-pipeline.ps1
@@ -5,13 +5,19 @@ Write-Host "BUILD_REASON: '$buildReason'"
 Write-Host "BUILD_SOURCEBRANCH: '$sourceBranch'"
 
 if ($buildReason -eq "PullRequest") {
-  # parse PR title to see if we should pack this
-  $response = Invoke-RestMethod api.github.com/repos/$env:BUILD_REPOSITORY_ID/pulls/$env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER
-  $title = $response.title.ToLowerInvariant()
-  Write-Host "Pull request '$title'"
-  if ($title.Contains("[pack]")) {
-    Write-Host "##vso[task.setvariable variable=BuildArtifacts;isOutput=true]true"
-    Write-Host "Setting 'BuildArtifacts' to true."
+  try {
+    # parse PR title to see if we should pack this
+    $response = Invoke-RestMethod api.github.com/repos/$env:BUILD_REPOSITORY_ID/pulls/$env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER
+    $title = $response.title.ToLowerInvariant()
+    Write-Host "Pull request '$title'"
+    if ($title.Contains("[pack]")) {
+      Write-Host "##vso[task.setvariable variable=BuildArtifacts;isOutput=true]true"
+      Write-Host "Setting 'BuildArtifacts' to true."
+    }
+  }
+  catch {
+    Write-Warning "Failed to get pull request title."
+    Write-Warning $_
   }
 }
 

--- a/build/initialize-pipeline.ps1
+++ b/build/initialize-pipeline.ps1
@@ -16,7 +16,7 @@ if ($buildReason -eq "PullRequest") {
     }
   }
   catch {
-    Write-Warning "Failed to get pull request title."
+    Write-Warning "Failed to get pull request title. Artifacts will not be built or packed."
     Write-Warning $_
   }
 }

--- a/build/install-dotnet.yml
+++ b/build/install-dotnet.yml
@@ -1,18 +1,16 @@
 steps:
-- task: PowerShell@2
-  displayName: 'Install .NET 3.1'
+- task: UseDotNet@2 # Needed by some of our test resources
+  displayName: 'Install .NET 3.1 runtime'
   inputs:
-    targetType: 'inline'
-    script: |
-      Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -OutFile 'dotnet-install.ps1'
-      ./dotnet-install.ps1 -InstallDir 'C:\Program Files\dotnet' -Verbose -Channel 3.1
-- task: PowerShell@2
-  displayName: 'Install .NET 6'
+    packageType: runtime
+    version: 3.1.x
+- task: UseDotNet@2 # Needed by our projects and CI steps
+  displayName: 'Install .NET 6 runtime'
   inputs:
-    targetType: 'inline'
-    script: |
-      Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -OutFile 'dotnet-install.ps1'
-      # Official release versions can be found at: https://dotnet.microsoft.com/download/dotnet/6.0
-      # Newer versions can be found at: https://github.com/dotnet/installer#installers-and-binaries
-      ./dotnet-install.ps1 -InstallDir 'C:\Program Files\dotnet' -Verbose -Channel 6.0
-      & dotnet --info
+    packageType: runtime
+    version: 6.x
+- task: UseDotNet@2 # The pinned SDK we use to build
+  displayName: 'Install .NET SDK'
+  inputs:
+    packageType: sdk
+    useGlobalJson: true

--- a/build/install-dotnet.yml
+++ b/build/install-dotnet.yml
@@ -1,16 +1,16 @@
 steps:
 - task: UseDotNet@2 # Needed by some of our test resources
-  displayName: 'Install .NET 3.1 runtime'
+  displayName: 'Install .NET 3.1'
   inputs:
-    packageType: runtime
+    packageType: sdk
     version: 3.1.x
 - task: UseDotNet@2 # Needed by our projects and CI steps
-  displayName: 'Install .NET 6 runtime'
+  displayName: 'Install .NET 6'
   inputs:
-    packageType: runtime
+    packageType: sdk
     version: 6.x
 - task: UseDotNet@2 # The pinned SDK we use to build
-  displayName: 'Install .NET SDK'
+  displayName: 'Install .NET SDK from global.json'
   inputs:
     packageType: sdk
     useGlobalJson: true

--- a/global.json
+++ b/global.json
@@ -1,0 +1,10 @@
+{
+  "sdk": {
+    "version": "8.0.101",
+    "rollForward": "latestFeature"
+  },
+  "msbuild-sdks": {
+    "Microsoft.Build.NoTargets": "3.7.56",
+    "Microsoft.Build.Traversal": "4.1.0"
+  }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Part of #9824

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Pins our SDK to .net8. This forces local builds and CI builds to align on the SDK used. Also updates `install-dotnet.yml` to use existing ADO task for runtime/sdk installed instead of powershell script. Note this does **not** affect the target framework of our built product, that is still .net6.0.
