### PR TITLE
Add SignalR to http group, always include group name

### DIFF
--- a/src/WebJobs.Script/Extensions/BindingMetadataExtensions.cs
+++ b/src/WebJobs.Script/Extensions/BindingMetadataExtensions.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
     {
         private const string HttpTriggerKey = "httpTrigger";
         private const string EventGridTriggerKey = "eventGridTrigger";
+        private const string SignalRTriggerKey = "signalRTrigger";
         private const string BlobTriggerKey = "blobTrigger";
 
         private static readonly HashSet<string> DurableTriggers = new(StringComparer.OrdinalIgnoreCase)
@@ -42,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
         /// <param name="binding">The binding metadata to check.</param>
         /// <returns><c>true</c> if a webhook trigger, <c>false</c> otherwise.</returns>
         /// <remarks>
-        /// Known webhook triggers includes Event Grid and Event Grid sourced blob triggers.
+        /// Known webhook triggers includes SignalR, Event Grid and Event Grid sourced blob triggers.
         /// </remarks>
         public static bool IsWebHookTrigger(this BindingMetadata binding)
         {
@@ -51,7 +52,8 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
                 throw new ArgumentNullException(nameof(binding));
             }
 
-            if (string.Equals(EventGridTriggerKey, binding.Type, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(EventGridTriggerKey, binding.Type, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(SignalRTriggerKey, binding.Type, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }

--- a/src/WebJobs.Script/Extensions/FunctionMetadataExtensions.cs
+++ b/src/WebJobs.Script/Extensions/FunctionMetadataExtensions.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// Gets the function group for the specified <see cref="FunctionMetadata"/>.
         /// </summary>
         /// <param name="metadata">The function metadata.</param>
-        /// <returns>The function group for this metadata or <c>null</c> if no group specified.</returns>
+        /// <returns>The function group for this metadata.</returns>
         public static string GetFunctionGroup(this FunctionMetadata metadata)
         {
             if (metadata == null)
@@ -92,7 +92,8 @@ namespace Microsoft.Azure.WebJobs.Script
                 }
             }
 
-            return null;
+            // A function with no specified group will be assigned to a group of itself.
+            return $"function__{metadata.Name}";
         }
 
         public static string GetFunctionId(this FunctionMetadata metadata)

--- a/src/WebJobs.Script/Extensions/FunctionMetadataExtensions.cs
+++ b/src/WebJobs.Script/Extensions/FunctionMetadataExtensions.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.WebJobs.Script
             }
 
             // A function with no specified group will be assigned to a group of itself.
-            return $"function__{metadata.Name}";
+            return $"function:{metadata.Name}";
         }
 
         public static string GetFunctionId(this FunctionMetadata metadata)

--- a/test/WebJobs.Script.Tests/Extensions/BindingMetadataExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/BindingMetadataExtensionsTests.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
 
         [Theory]
         [InlineData("eventGridTrigger", true)]
+        [InlineData("signalRTrigger", true)]
         [InlineData("blobTrigger", true, "eventGrid")]
         [InlineData("blobTrigger", false, "other")]
         [InlineData("httpTrigger", false)]

--- a/test/WebJobs.Script.Tests/Extensions/FunctionMetadataExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/FunctionMetadataExtensionsTests.cs
@@ -146,15 +146,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
                 RootScriptPath = _testRootScriptPath
             };
 
+            group ??= $"function__{functionMetadata.Name}";
             var result = await functionMetadata.ToFunctionTrigger(options, isFlexConsumption: true);
             Assert.Equal("TestFunction1", result["functionName"].Value<string>());
             Assert.Equal(trigger, result["type"].Value<string>());
 
-            Assert.Equal(group != null, result.TryGetValue("functionGroup", out JToken functionGroup));
-            if (functionGroup is not null)
-            {
-                Assert.Equal(group, functionGroup.Value<string>());
-            }
+            Assert.True(result.TryGetValue("functionGroup", out JToken functionGroup));
+            Assert.Equal(group, functionGroup.Value<string>());
         }
 
         [Theory]

--- a/test/WebJobs.Script.Tests/Extensions/FunctionMetadataExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/FunctionMetadataExtensionsTests.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
                 RootScriptPath = _testRootScriptPath
             };
 
-            group ??= $"function__{functionMetadata.Name}";
+            group ??= $"function:{functionMetadata.Name}";
             var result = await functionMetadata.ToFunctionTrigger(options, isFlexConsumption: true);
             Assert.Equal("TestFunction1", result["functionName"].Value<string>());
             Assert.Equal(trigger, result["type"].Value<string>());


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #9733

follow up to #9732

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

1. Add SignalR to be included in `http` function group, as it is a web hook.
2. Always return function group for non-grouped functions as `function__{name}`.
