### PR TITLE
[pack] adding more values to the log initialization output

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
@@ -331,7 +331,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
         }
 
         public static void LogHostInitializationSettings(this ILogger logger, string originalFunctionWorkerRuntime, string functionWorkerRuntime,
-            string originalFunctionWorkerRuntimeVersion, string functionsWorkerRuntimeVersion, string functionExtensionVersion, string siteExtensionDirectory,
+            string originalFunctionWorkerRuntimeVersion, string functionsWorkerRuntimeVersion, string functionExtensionVersion, string currentDirectory,
             bool inStandbyMode, bool hasBeenSpecialized, bool usePlaceholderDotNetIsolated, string websiteSku, string featureFlags,
             IDictionary<string, string> hostingConfig)
         {
@@ -344,7 +344,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
                 OriginalFunctionWorkerRuntimeVersion = originalFunctionWorkerRuntimeVersion,
                 FunctionsWorkerRuntimeVersion = functionsWorkerRuntimeVersion,
                 FunctionsExtensionVesion = functionExtensionVersion,
-                SiteExtensionDirectory = siteExtensionDirectory,
+                HostDirectory = currentDirectory,
                 InStandbyMode = inStandbyMode,
                 HasBeenSpecialized = hasBeenSpecialized,
                 UsePlaceholderDotNetIsolated = usePlaceholderDotNetIsolated,

--- a/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
@@ -331,7 +331,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
         }
 
         public static void LogHostInitializationSettings(this ILogger logger, string originalFunctionWorkerRuntime, string functionWorkerRuntime,
-            string originalFunctionWorkerRuntimeVersion, string functionsWorkerRuntimeVersion, string functionExtensionVersion, string currentDirectory,
+            string originalFunctionWorkerRuntimeVersion, string functionsWorkerRuntimeVersion, string functionExtensionVersion, string hostDirectory,
             bool inStandbyMode, bool hasBeenSpecialized, bool usePlaceholderDotNetIsolated, string websiteSku, string featureFlags,
             IDictionary<string, string> hostingConfig)
         {
@@ -344,7 +344,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
                 OriginalFunctionWorkerRuntimeVersion = originalFunctionWorkerRuntimeVersion,
                 FunctionsWorkerRuntimeVersion = functionsWorkerRuntimeVersion,
                 FunctionsExtensionVesion = functionExtensionVersion,
-                HostDirectory = currentDirectory,
+                HostDirectory = hostDirectory,
                 InStandbyMode = inStandbyMode,
                 HasBeenSpecialized = hasBeenSpecialized,
                 UsePlaceholderDotNetIsolated = usePlaceholderDotNetIsolated,

--- a/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
@@ -330,15 +330,18 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
             _scriptHostServiceRestartCanceledByRuntime(logger, null);
         }
 
-        public static void LogHostInitializationSettings(this ILogger logger, string functionWorkerRuntime, string functionsWorkerRuntimeVersion,
-            string functionExtensionVersion, string siteExtensionDirectory, bool inStandbyMode, bool hasBeenSpecialized, bool usePlaceholderDotNetIsolated,
-            string websiteSku, string featureFlags, IDictionary<string, string> hostingConfig)
+        public static void LogHostInitializationSettings(this ILogger logger, string originalFunctionWorkerRuntime, string functionWorkerRuntime,
+            string originalFunctionWorkerRuntimeVersion, string functionsWorkerRuntimeVersion, string functionExtensionVersion, string siteExtensionDirectory,
+            bool inStandbyMode, bool hasBeenSpecialized, bool usePlaceholderDotNetIsolated, string websiteSku, string featureFlags,
+            IDictionary<string, string> hostingConfig)
         {
             // This is a dump of values for telemetry right now, but eventually we will refactor this
             // into a proper Options object
             var initializationSettings = new
             {
+                OriginalFunctionWorkerRuntime = originalFunctionWorkerRuntime,
                 FunctionsWorkerRuntime = functionWorkerRuntime,
+                OriginalFunctionWorkerRuntimeVersion = originalFunctionWorkerRuntimeVersion,
                 FunctionsWorkerRuntimeVersion = functionsWorkerRuntimeVersion,
                 FunctionsExtensionVesion = functionExtensionVersion,
                 SiteExtensionDirectory = siteExtensionDirectory,

--- a/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.ApplicationInsights.AspNetCore;
-using Microsoft.Azure.Documents;
+using System.Collections.Generic;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
@@ -330,17 +330,30 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
             _scriptHostServiceRestartCanceledByRuntime(logger, null);
         }
 
-        public static void LogHostInitializationSettings(this ILogger logger, string functionWorkerRuntime, string functionExtensionVersion, string siteExtensionDirectory, bool inStandbyMode)
+        public static void LogHostInitializationSettings(this ILogger logger, string functionWorkerRuntime, string functionsWorkerRuntimeVersion,
+            string functionExtensionVersion, string siteExtensionDirectory, bool inStandbyMode, bool hasBeenSpecialized, bool usePlaceholderDotNetIsolated,
+            string websiteSku, string featureFlags, IDictionary<string, string> hostingConfig)
         {
-            var hostInitializationSettings = $@"{{
-    ""HostInitializationSettings"": {{
-        ""functionsWorkerRuntime"": ""{functionWorkerRuntime}"",
-        ""functionsExtensionVersion"": ""{functionExtensionVersion}"",
-        ""siteExtensionDirectory"": ""{siteExtensionDirectory}"",
-        ""inStandbyMode"": {inStandbyMode}
-    }}
-}}";
-            _logHostInitializationSettings(logger, hostInitializationSettings, null);
+            // This is a dump of values for telemetry right now, but eventually we will refactor this
+            // into a proper Options object
+            var initializationSettings = new
+            {
+                FunctionsWorkerRuntime = functionWorkerRuntime,
+                FunctionsWorkerRuntimeVersion = functionsWorkerRuntimeVersion,
+                FunctionsExtensionVesion = functionExtensionVersion,
+                SiteExtensionDirectory = siteExtensionDirectory,
+                InStandbyMode = inStandbyMode,
+                HasBeenSpecialized = hasBeenSpecialized,
+                UsePlaceholderDotNetIsolated = usePlaceholderDotNetIsolated,
+                WebSiteSku = websiteSku,
+                FeatureFlags = featureFlags,
+                HostingConfig = hostingConfig
+            };
+
+            var options = new JsonSerializerOptions { WriteIndented = true };
+            string settingsJson = JsonSerializer.Serialize(initializationSettings, options);
+
+            _logHostInitializationSettings(logger, settingsJson, null);
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -51,6 +51,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         private readonly Task _hostStarted;
         private readonly IOptions<FunctionsHostingConfigOptions> _hostingConfigOptions;
         private readonly bool _originalStandbyModeValue;
+        private readonly string _originalFunctionsWorkerRuntime;
+        private readonly string _originalFunctionsWorkerRuntimeVersion;
         private IScriptEventManager _eventManager;
 
         private IHost _host;
@@ -102,8 +104,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
             _hostingConfigOptions = hostingConfigOptions;
 
-            // we'll use this to determine if this process has ever been specialized
+            // we'll use this to emit telemetry on if and how this process has been specialized
             _originalStandbyModeValue = _scriptWebHostEnvironment.InStandbyMode;
+            _originalFunctionsWorkerRuntime = _environment.GetFunctionsWorkerRuntime();
+            _originalFunctionsWorkerRuntimeVersion = _environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName);
         }
 
         public event EventHandler HostInitializing;
@@ -722,8 +726,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             var featureFlags = _environment.GetEnvironmentVariable(AzureWebJobsFeatureFlags);
             var hostingConfigDict = _hostingConfigOptions.Value.Features;
 
-            logger.LogHostInitializationSettings(functionWorkerRuntime, functionWorkerRuntimeVersion, functionExtensionVersion, currentDirectory, inStandbyMode,
-                hasBeenSpecialized, usePlaceholderDotNetIsolated, websiteSku, featureFlags, hostingConfigDict);
+            logger.LogHostInitializationSettings(_originalFunctionsWorkerRuntime, functionWorkerRuntime, _originalFunctionsWorkerRuntimeVersion, functionWorkerRuntimeVersion,
+                functionExtensionVersion, currentDirectory, inStandbyMode, hasBeenSpecialized, usePlaceholderDotNetIsolated, websiteSku, featureFlags, hostingConfigDict);
         }
 
         private void OnHostHealthCheckTimer(object state)

--- a/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class WebJobsScriptHostServiceTests
     {
+        private readonly OptionsWrapper<FunctionsHostingConfigOptions> _functionsHostingConfigOptions = new(new FunctionsHostingConfigOptions());
         private WebJobsScriptHostService _hostService;
         private ScriptApplicationHostOptionsMonitor _monitor;
         private TestLoggerProvider _webHostLoggerProvider = new TestLoggerProvider();
@@ -107,7 +108,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object,
                 _hostPerformanceManager, _healthMonitorOptions,
                 metricsLogger, new Mock<IApplicationLifetime>().Object,
-                _mockConfig, mockEventManager.Object);
+                _mockConfig, mockEventManager.Object, _functionsHostingConfigOptions);
 
             await _hostService.StartAsync(CancellationToken.None);
 
@@ -138,7 +139,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 _monitor, hostBuilder.Object, NullLoggerFactory.Instance,
                 _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object,
                 _hostPerformanceManager, _healthMonitorOptions, metricsLogger,
-                new Mock<IApplicationLifetime>().Object, _mockConfig, new TestScriptEventManager());
+                new Mock<IApplicationLifetime>().Object, _mockConfig, new TestScriptEventManager(), _functionsHostingConfigOptions);
 
             await _hostService.StartAsync(CancellationToken.None);
             Assert.True(AreRequiredMetricsGenerated(metricsLogger));
@@ -168,7 +169,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object,
                 _hostPerformanceManager, _healthMonitorOptions,
                 metricsLogger, new Mock<IApplicationLifetime>().Object,
-                _mockConfig, new TestScriptEventManager());
+                _mockConfig, new TestScriptEventManager(), _functionsHostingConfigOptions);
 
             await _hostService.StartAsync(CancellationToken.None);
             Assert.True(AreRequiredMetricsGenerated(metricsLogger));
@@ -223,7 +224,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object,
                 _hostPerformanceManager, _healthMonitorOptions,
                 metricsLogger, new Mock<IApplicationLifetime>().Object,
-                _mockConfig, new TestScriptEventManager());
+                _mockConfig, new TestScriptEventManager(), _functionsHostingConfigOptions);
 
             TestLoggerProvider hostALogger = hostA.Object.GetTestLoggerProvider();
             TestLoggerProvider hostBLogger = hostB.Object.GetTestLoggerProvider();
@@ -299,7 +300,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object,
                 _hostPerformanceManager, _healthMonitorOptions,
                 metricsLogger, new Mock<IApplicationLifetime>().Object,
-                _mockConfig, new TestScriptEventManager());
+                _mockConfig, new TestScriptEventManager(), _functionsHostingConfigOptions);
 
             TestLoggerProvider hostALogger = hostA.Object.GetTestLoggerProvider();
 
@@ -368,7 +369,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                _monitor, hostBuilder.Object, NullLoggerFactory.Instance,
                _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object,
                _hostPerformanceManager, _healthMonitorOptions, metricsLogger,
-               new Mock<IApplicationLifetime>().Object, _mockConfig, new TestScriptEventManager());
+               new Mock<IApplicationLifetime>().Object, _mockConfig, new TestScriptEventManager(),
+               _functionsHostingConfigOptions);
 
             Task startTask = _hostService.StartAsync(CancellationToken.None);
 
@@ -419,7 +421,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object,
                 _hostPerformanceManager, _healthMonitorOptions,
                 metricsLogger, new Mock<IApplicationLifetime>().Object,
-                _mockConfig, new TestScriptEventManager());
+                _mockConfig, new TestScriptEventManager(), _functionsHostingConfigOptions);
 
             var hostLogger = host.Object.GetTestLoggerProvider();
 
@@ -456,7 +458,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                _monitor, hostBuilder.Object, _loggerFactory,
                _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object,
                _hostPerformanceManager, _healthMonitorOptions, metricsLogger,
-               new Mock<IApplicationLifetime>().Object, _mockConfig, new TestScriptEventManager());
+               new Mock<IApplicationLifetime>().Object, _mockConfig,
+               new TestScriptEventManager(), _functionsHostingConfigOptions);
 
             // Simulate a call to specialize coming from the PlaceholderSpecializationMiddleware. This
             // can happen before we ever start the service, which could create invalid state.
@@ -511,7 +514,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 _monitor, hostBuilder.Object, NullLoggerFactory.Instance,
                 _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object,
                 _hostPerformanceManager, _healthMonitorOptions, metricsLogger,
-                new Mock<IApplicationLifetime>().Object, config, new TestScriptEventManager());
+                new Mock<IApplicationLifetime>().Object, config, new TestScriptEventManager(),
+                _functionsHostingConfigOptions);
 
             Assert.Equal(expectedResult, _hostService.ShouldEnforceSequentialRestart());
         }
@@ -548,7 +552,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                             _monitor, scriptHostBuilder.Object, NullLoggerFactory.Instance,
                             _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object,
                             _hostPerformanceManager, _healthMonitorOptions, new TestMetricsLogger(),
-                            new Mock<IApplicationLifetime>().Object, _mockConfig, new TestScriptEventManager()))
+                            new Mock<IApplicationLifetime>().Object, _mockConfig, new TestScriptEventManager(),
+                            _functionsHostingConfigOptions))
             {
                 await _hostService.StartAsync(CancellationToken.None);
 


### PR DESCRIPTION
Expanding logging for telemetry during host-split and placeholder work. I've tested this on my private stamp and we can now see at-a-glance stuff like this (a dotnet-isolated 6.0 app was specialized onto a java 11 placeholder):

```
{
  "OriginalFunctionWorkerRuntime": "java",
  "FunctionsWorkerRuntime": "dotnet-isolated",
  "OriginalFunctionWorkerRuntimeVersion": "11",
  "FunctionsWorkerRuntimeVersion": "6.0",
  "FunctionsExtensionVesion": "~4",
  "SiteExtensionDirectory": "C:\\Program Files (x86)\\SiteExtensions\\Functions\\4.30.0\\64bit",
  "InStandbyMode": false,
  "HasBeenSpecialized": true,
  "UsePlaceholderDotNetIsolated": true,
  "WebSiteSku": "Dynamic",
  "FeatureFlags": null,
  "HostingConfig": {}
}
```

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)