### PR TITLE
 Adding an app setting to allow CORS configuration

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -13,3 +13,4 @@
     - Customers can opt-out of this behavior by setting `SendCanceledInvocationsToWorker` to `false` in host.json
   - If a worker does not support CancellationTokens, cancelled invocations will not be sent to the worker
 - Warn when `FUNCTIONS_WORKER_RUNTIME` is not set (#9799)
+- Add an app setting to allow CORS configuration (#9846)

--- a/src/WebJobs.Script.WebHost/Configuration/CorsOptionsSetup.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/CorsOptionsSetup.cs
@@ -2,12 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Cors.Infrastructure;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
@@ -25,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
 
         public void Configure(CorsOptions options)
         {
-            if (_env.IsAnyLinuxConsumption() || _env.IsCorsConfigurationAllowed())
+            if (_env.IsAnyLinuxConsumption() || _env.IsCorsConfigurationEnabled())
             {
                 string[] allowedOrigins = _hostCorsOptions.Value.AllowedOrigins?.ToArray() ?? Array.Empty<string>();
                 var policyBuilder = new CorsPolicyBuilder(allowedOrigins);

--- a/src/WebJobs.Script.WebHost/Configuration/CorsOptionsSetup.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/CorsOptionsSetup.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
@@ -24,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
 
         public void Configure(CorsOptions options)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (_env.IsAnyLinuxConsumption() || _env.IsCorsConfigurationAllowed())
             {
                 string[] allowedOrigins = _hostCorsOptions.Value.AllowedOrigins?.ToArray() ?? Array.Empty<string>();
                 var policyBuilder = new CorsPolicyBuilder(allowedOrigins);

--- a/src/WebJobs.Script.WebHost/Configuration/CorsOptionsSetup.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/CorsOptionsSetup.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.Extensions.Options;
@@ -23,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
 
         public void Configure(CorsOptions options)
         {
-            if (_env.IsAnyLinuxConsumption())
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 string[] allowedOrigins = _hostCorsOptions.Value.AllowedOrigins?.ToArray() ?? Array.Empty<string>();
                 var policyBuilder = new CorsPolicyBuilder(allowedOrigins);

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobHostHttpMiddleware, CustomHttpHeadersMiddleware>());
                     services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobHostHttpMiddleware, HstsConfigurationMiddleware>());
 
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                    if (environment.IsAnyLinuxConsumption() || environment.IsCorsConfigurationAllowed())
                     {
                         services.AddSingleton<ICorsMiddlewareFactory, CorsMiddlewareFactory>();
                         services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobHostHttpMiddleware, JobHostCorsMiddleware>());

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Executors;
@@ -123,11 +124,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     services.TryAddSingleton<IJobHostMiddlewarePipeline, DefaultMiddlewarePipeline>();
                     services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobHostHttpMiddleware, CustomHttpHeadersMiddleware>());
                     services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobHostHttpMiddleware, HstsConfigurationMiddleware>());
-                    if (environment.IsAnyLinuxConsumption())
+
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                     {
                         services.AddSingleton<ICorsMiddlewareFactory, CorsMiddlewareFactory>();
                         services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobHostHttpMiddleware, JobHostCorsMiddleware>());
+                    }
 
+                    if (environment.IsAnyLinuxConsumption())
+                    {
                         // EasyAuth must go after CORS, as CORS preflight requests can happen before authentication
                         services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobHostHttpMiddleware, JobHostEasyAuthMiddleware>());
                     }

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -125,13 +125,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobHostHttpMiddleware, CustomHttpHeadersMiddleware>());
                     services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobHostHttpMiddleware, HstsConfigurationMiddleware>());
 
-                    if (environment.IsAnyLinuxConsumption() || environment.IsCorsConfigurationAllowed())
+                    bool isAnyLinuxConsumption = environment.IsAnyLinuxConsumption();
+
+                    if (isAnyLinuxConsumption || environment.IsCorsConfigurationEnabled())
                     {
                         services.AddSingleton<ICorsMiddlewareFactory, CorsMiddlewareFactory>();
                         services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobHostHttpMiddleware, JobHostCorsMiddleware>());
                     }
 
-                    if (environment.IsAnyLinuxConsumption())
+                    if (isAnyLinuxConsumption)
                     {
                         // EasyAuth must go after CORS, as CORS preflight requests can happen before authentication
                         services.TryAddEnumerable(ServiceDescriptor.Singleton<IJobHostHttpMiddleware, JobHostEasyAuthMiddleware>());

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -165,6 +165,14 @@ namespace Microsoft.Azure.WebJobs.Script
                 && runningInContainerValue;
         }
 
+        public static bool IsCorsConfigurationAllowed(this IEnvironment environment)
+        {
+            var allowCorsConfiguration = environment.GetEnvironmentVariable(AllowCorsConfiguration);
+            return !string.IsNullOrEmpty(allowCorsConfiguration)
+                && bool.TryParse(allowCorsConfiguration, out bool allowCorsConfigurationValue)
+                && allowCorsConfigurationValue;
+        }
+
         public static bool IsPersistentFileSystemAvailable(this IEnvironment environment)
         {
             return environment.IsWindowsAzureManagedHosting()

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -165,12 +165,9 @@ namespace Microsoft.Azure.WebJobs.Script
                 && runningInContainerValue;
         }
 
-        public static bool IsCorsConfigurationAllowed(this IEnvironment environment)
+        public static bool IsCorsConfigurationEnabled(this IEnvironment environment)
         {
-            var allowCorsConfiguration = environment.GetEnvironmentVariable(AllowCorsConfiguration);
-            return !string.IsNullOrEmpty(allowCorsConfiguration)
-                && bool.TryParse(allowCorsConfiguration, out bool allowCorsConfigurationValue)
-                && allowCorsConfigurationValue;
+            return environment.GetEnvironmentVariable(EnableCorsConfiguration) == "1";
         }
 
         public static bool IsPersistentFileSystemAvailable(this IEnvironment environment)

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string LinuxAzureAppServiceStorage = "WEBSITES_ENABLE_APP_SERVICE_STORAGE";
         public const string CoreToolsEnvironment = "FUNCTIONS_CORETOOLS_ENVIRONMENT";
         public const string RunningInContainer = "DOTNET_RUNNING_IN_CONTAINER";
-        public const string AllowCorsConfiguration = "ALLOW_CORS_CONFIGURATION";
+        public const string EnableCorsConfiguration = "FUNCTIONS_ENABLE_CORS_CONFIGURATION";
 
         public const string ExtensionBundleSourceUri = "FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI";
 

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -112,6 +112,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string LinuxAzureAppServiceStorage = "WEBSITES_ENABLE_APP_SERVICE_STORAGE";
         public const string CoreToolsEnvironment = "FUNCTIONS_CORETOOLS_ENVIRONMENT";
         public const string RunningInContainer = "DOTNET_RUNNING_IN_CONTAINER";
+        public const string AllowCorsConfiguration = "ALLOW_CORS_CONFIGURATION";
 
         public const string ExtensionBundleSourceUri = "FUNCTIONS_EXTENSIONBUNDLE_SOURCE_URI";
 

--- a/test/WebJobs.Script.Tests/Middleware/CorsConfigurationMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Middleware/CorsConfigurationMiddlewareTests.cs
@@ -57,10 +57,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
         [Fact]
         public async Task Invoke_OriginAllowed_AddsExpectedHeaders()
         {
-            var envars = new Dictionary<string, string>()
-            {
-                { EnvironmentSettingNames.ContainerName, "foo" },
-            };
+            var envars = new Dictionary<string, string>() { };
             var testEnv = new TestEnvironment(envars);
             var testOrigin = "https://functions.azure.com";
             var hostCorsOptions = new HostCorsOptions
@@ -110,10 +107,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
         [Fact]
         public async Task Invoke_OriginNotAllowed_DoesNotAddHeaders()
         {
-            var envars = new Dictionary<string, string>()
-            {
-                { EnvironmentSettingNames.ContainerName, "foo" },
-            };
+            var envars = new Dictionary<string, string>() { };
             var testEnv = new TestEnvironment(envars);
             var badOrigin = "http://badorigin.com";
             var hostCorsOptions = new HostCorsOptions
@@ -164,10 +158,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
         [Fact]
         public async Task Invoke_Adds_AccessControlAllowMethods()
         {
-            var envars = new Dictionary<string, string>()
-            {
-                { EnvironmentSettingNames.ContainerName, "foo" },
-            };
+            var envars = new Dictionary<string, string>() { };
             var testEnv = new TestEnvironment(envars);
             var testOrigin = "https://functions.azure.com";
             var hostCorsOptions = new HostCorsOptions

--- a/test/WebJobs.Script.Tests/Middleware/CorsConfigurationMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Middleware/CorsConfigurationMiddlewareTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
 
         [Theory]
         [InlineData(EnvironmentSettingNames.ContainerName, "foo")]
-        [InlineData(EnvironmentSettingNames.AllowCorsConfiguration, "true")]
+        [InlineData(EnvironmentSettingNames.EnableCorsConfiguration, "1")]
         public async Task Invoke_OriginAllowed_AddsExpectedHeaders(string appSettingName, string appSettingValue)
         {
             var envars = new Dictionary<string, string>()
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
 
         [Theory]
         [InlineData(EnvironmentSettingNames.ContainerName, "foo")]
-        [InlineData(EnvironmentSettingNames.AllowCorsConfiguration, "true")]
+        [InlineData(EnvironmentSettingNames.EnableCorsConfiguration, "1")]
         public async Task Invoke_OriginNotAllowed_DoesNotAddHeaders(string appSettingName, string appSettingValue)
         {
             var envars = new Dictionary<string, string>()
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
 
         [Theory]
         [InlineData(EnvironmentSettingNames.ContainerName, "foo")]
-        [InlineData(EnvironmentSettingNames.AllowCorsConfiguration, "true")]
+        [InlineData(EnvironmentSettingNames.EnableCorsConfiguration, "1")]
         public async Task Invoke_Adds_AccessControlAllowMethods(string appSettingName, string appSettingValue)
         {
             var envars = new Dictionary<string, string>()

--- a/test/WebJobs.Script.Tests/Middleware/CorsConfigurationMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Middleware/CorsConfigurationMiddlewareTests.cs
@@ -54,10 +54,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
             Assert.True(nextInvoked);
         }
 
-        [Fact]
-        public async Task Invoke_OriginAllowed_AddsExpectedHeaders()
+        [Theory]
+        [InlineData(EnvironmentSettingNames.ContainerName, "foo")]
+        [InlineData(EnvironmentSettingNames.AllowCorsConfiguration, "true")]
+        public async Task Invoke_OriginAllowed_AddsExpectedHeaders(string appSettingName, string appSettingValue)
         {
-            var envars = new Dictionary<string, string>() { };
+            var envars = new Dictionary<string, string>()
+            {
+                { appSettingName, appSettingValue }
+            };
             var testEnv = new TestEnvironment(envars);
             var testOrigin = "https://functions.azure.com";
             var hostCorsOptions = new HostCorsOptions
@@ -104,10 +109,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
             Assert.Equal("true", allowCredsHeaderValues.FirstOrDefault());
         }
 
-        [Fact]
-        public async Task Invoke_OriginNotAllowed_DoesNotAddHeaders()
+        [Theory]
+        [InlineData(EnvironmentSettingNames.ContainerName, "foo")]
+        [InlineData(EnvironmentSettingNames.AllowCorsConfiguration, "true")]
+        public async Task Invoke_OriginNotAllowed_DoesNotAddHeaders(string appSettingName, string appSettingValue)
         {
-            var envars = new Dictionary<string, string>() { };
+            var envars = new Dictionary<string, string>()
+            {
+                { appSettingName, appSettingValue }
+            };
             var testEnv = new TestEnvironment(envars);
             var badOrigin = "http://badorigin.com";
             var hostCorsOptions = new HostCorsOptions
@@ -155,10 +165,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
             Assert.False(response.Headers.TryGetValues("Access-Control-Allow-Methods", out allowMethods));
         }
 
-        [Fact]
-        public async Task Invoke_Adds_AccessControlAllowMethods()
+        [Theory]
+        [InlineData(EnvironmentSettingNames.ContainerName, "foo")]
+        [InlineData(EnvironmentSettingNames.AllowCorsConfiguration, "true")]
+        public async Task Invoke_Adds_AccessControlAllowMethods(string appSettingName, string appSettingValue)
         {
-            var envars = new Dictionary<string, string>() { };
+            var envars = new Dictionary<string, string>()
+            {
+                { appSettingName, appSettingValue }
+            };
             var testEnv = new TestEnvironment(envars);
             var testOrigin = "https://functions.azure.com";
             var hostCorsOptions = new HostCorsOptions


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

resolves #8936

Host currently honors 'CORS_ALLOWED_ORIGINS' app setting only for linux consumption. Windows and linux app service go thorugh a seperate channel. However there are additional hosting scenarios that have no way of setting up CORS configuration. This change adds an app setting that allows customer to set up CORS configuration by setting `"FUNCTIONS_ENABLE_CORS_CONFIGURATION" = "true"`

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
