### PR TITLE
Updating IsDotnetIsolatedApp to be more accurately captured

### DIFF
--- a/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs
+++ b/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs
@@ -81,16 +81,16 @@ namespace Microsoft.Azure.WebJobs.Script.DependencyInjection
             var bundleConfigured = _extensionBundleManager.IsExtensionBundleConfigured();
             bool isLegacyExtensionBundle = _extensionBundleManager.IsLegacyExtensionBundle();
             bool isPrecompiledFunctionApp = false;
-            bool isDotnetIsolatedApp = false;
 
             // dotnet app precompiled -> Do not use bundles
             var workerConfigs = _languageWorkerOptions.CurrentValue.WorkerConfigs;
+            ImmutableArray<FunctionMetadata> functionMetadataCollection = ImmutableArray.Create<FunctionMetadata>();
             if (bundleConfigured)
             {
                 ExtensionBundleDetails bundleDetails = await _extensionBundleManager.GetExtensionBundleDetails();
                 ValidateBundleRequirements(bundleDetails);
 
-                var functionMetadataCollection = _functionMetadataManager.GetFunctionMetadata(forceRefresh: true, includeCustomProviders: false, workerConfigs: workerConfigs);
+                functionMetadataCollection = _functionMetadataManager.GetFunctionMetadata(forceRefresh: true, includeCustomProviders: false, workerConfigs: workerConfigs);
                 bindingsSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
                 // Generate a Hashset of all the binding types used in the function app
@@ -102,10 +102,9 @@ namespace Microsoft.Azure.WebJobs.Script.DependencyInjection
                     }
                     isPrecompiledFunctionApp = isPrecompiledFunctionApp || functionMetadata.Language == DotNetScriptTypes.DotNetAssembly;
                 }
-
-                isDotnetIsolatedApp = IsDotnetIsolatedApp(functionMetadataCollection, SystemEnvironment.Instance);
             }
 
+            bool isDotnetIsolatedApp = IsDotnetIsolatedApp(functionMetadataCollection, SystemEnvironment.Instance);
             bool isDotnetApp = isPrecompiledFunctionApp || isDotnetIsolatedApp;
             var isLogicApp = SystemEnvironment.Instance.IsLogicApp();
 

--- a/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs
+++ b/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.WebJobs.Script.DependencyInjection
 
             // dotnet app precompiled -> Do not use bundles
             var workerConfigs = _languageWorkerOptions.CurrentValue.WorkerConfigs;
-            ImmutableArray<FunctionMetadata> functionMetadataCollection = ImmutableArray.Create<FunctionMetadata>();
+            ImmutableArray<FunctionMetadata> functionMetadataCollection = ImmutableArray<FunctionMetadata>.Empty;
             if (bundleConfigured)
             {
                 ExtensionBundleDetails bundleDetails = await _extensionBundleManager.GetExtensionBundleDetails();


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #9849

Making a change as a response to a comment (https://github.com/Azure/azure-functions-host/pull/9579#discussion_r1341677850) on a pervious PR. This would more accurately capture whether an app is dotnet isolated or not. Currently the log statement would sometimes say that isDotnetIsolated is false, even though in some cases it may be true. This does not affect the bundle selection logic, but the log statement would be in accurate under certain configurations.

The PR updates it so that we make use of all available information available at the time.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information