### PR TITLE
Fix for unhealthy host restart

### DIFF
--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -44,6 +44,22 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         }
 
         /// <summary>
+        /// Gets or Sets a value indicating whether the host should shutdown webhost worker channels during shutdown.
+        /// </summary>
+        public bool ShutdownWebhostWorkerChannelsOnHostShutdown
+        {
+            get
+            {
+                return GetFeatureOrDefault(RpcWorkerConstants.ShutdownWebhostWorkerChannelsOnHostShutdown, "1") == "1";
+            }
+
+            set
+            {
+                _features[RpcWorkerConstants.ShutdownWebhostWorkerChannelsOnHostShutdown] = value ? "1" : "0";
+            }
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating whether SWT tokens should be accepted.
         /// </summary>
         public bool SwtAuthenticationEnabled

--- a/src/WebJobs.Script/Workers/FunctionInvocationDispatcherFactory.cs
+++ b/src/WebJobs.Script/Workers/FunctionInvocationDispatcherFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.ManagedDependencies;
@@ -31,7 +32,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             IJobHostRpcWorkerChannelManager jobHostLanguageWorkerChannelManager,
             IOptions<ManagedDependencyOptions> managedDependencyOptions,
             IRpcFunctionInvocationDispatcherLoadBalancer functionDispatcherLoadBalancer,
-            IOptions<WorkerConcurrencyOptions> workerConcurrencyOptions)
+            IOptions<WorkerConcurrencyOptions> workerConcurrencyOptions,
+            IOptions<FunctionsHostingConfigOptions> hostingConfigOptions)
         {
             if (httpWorkerOptions.Value == null)
             {
@@ -55,7 +57,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
                 jobHostLanguageWorkerChannelManager,
                 managedDependencyOptions,
                 functionDispatcherLoadBalancer,
-                workerConcurrencyOptions);
+                workerConcurrencyOptions,
+                hostingConfigOptions);
         }
 
         public IFunctionInvocationDispatcher GetFunctionDispatcher() => _functionDispatcher;

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
@@ -85,6 +85,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public const string WorkerIndexingEnabled = "WORKER_INDEXING_ENABLED";
         public const string WorkerIndexingDisabledApps = "WORKER_INDEXING_DISABLED_APPS";
         public const string RevertWorkerShutdownBehavior = "REVERT_WORKER_SHUTDOWN_BEHAVIOR";
+        public const string ShutdownWebhostWorkerChannelsOnHostShutdown = "ShutdownWebhostWorkerChannelsOnHostShutdown";
         public const string ThrowOnMissingFunctionsWorkerRuntime = "THROW_ON_MISSING_FUNCTIONS_WORKER_RUNTIME";
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcessesNoBundle.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcessesNoBundle.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             _settingsManager = ScriptSettingsManager.Instance;
         }
 
-        [Fact(Skip = "https://github.com/Azure/azure-functions-host/issues")]
+        [Fact]
         public async Task NodeProcessNoBundleConfigured_Different_AfterHostRestart()
         {
             await SamplesTestHelpers.InvokeAndValidateHttpTrigger(_fixture, "HttpTrigger");

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
@@ -696,7 +697,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 jobHostLanguageWorkerChannelManager,
                 new OptionsWrapper<ManagedDependencyOptions>(new ManagedDependencyOptions()),
                 mockFunctionDispatcherLoadBalancer.Object,
-                Options.Create(new WorkerConcurrencyOptions()));
+                Options.Create(new WorkerConcurrencyOptions()),
+                Options.Create(new FunctionsHostingConfigOptions()));
         }
 
         private async Task<int> WaitForJobhostWorkerChannelsToStartup(RpcFunctionInvocationDispatcher functionDispatcher, int expectedCount, bool allReadyForInvocations = true)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
With worker indexing enabled all of our worker channels are managed at the webhost level. In such a scenario, if the host becomes unhealthy we restart the script host here https://github.com/Azure/azure-functions-host/blob/af3687ddf6fc1849cb954defb1e9e300552aac30/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs#L724
However, as part of host restart we do not shutdown the workers started at the webhost level. Once the new host starts up specifically for dotnet-isolated, the request to load the same function is sent again. As the worker has not been restarted it throws an invalidOperation exception with the error. `Result: Failure Exception: System.InvalidOperationException: Unable to load Function '[Function name]'. A function with the id '[Function id]' name already exists`

### Additional PR information
The fix here was to make sure we shutdown the workers started at the webhost level on host shutdown. Except for when we specialize.

resolves [#2124](https://github.com/Azure/azure-functions-dotnet-worker/issues/2124)

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
