### PR TITLE
[pack] reverting version prefix change for Functions build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ variables:
   ${{ elseif contains(variables['Build.SourceBranch'], 'release/inproc8/') }}:
     minorVersionPrefix: "8"
   ${{ else }}:
-    minorVersionPrefix: "10"
+    minorVersionPrefix: ""
   DOTNET_NOLOGO: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -1,7 +1,7 @@
 param (
   [string]$buildNumber = "0",    
   [string]$suffix = "",
-  [ValidateSet("6", "8", "10")][string]$minorVersionPrefix = "10",
+  [ValidateSet("6", "8")][string]$minorVersionPrefix = "",
   [string]$hashesForHardlinksFile = "hashesForHardlinks.txt"
 )
 
@@ -240,7 +240,7 @@ function CreateSiteExtensions() {
     $zipOutput = "$buildOutput\SiteExtension"
     $hashesForHardLinksPath = "$siteExtensionPath\$extensionVersion\$hashesForHardlinksFile"
     New-Item -Itemtype directory -path $zipOutput -Force > $null
-    if ($minorVersionPrefix -eq "10") {
+    if ($minorVersionPrefix -eq "") {
         ZipContent $siteExtensionPath "$zipOutput\Functions.$extensionVersion$runtimeSuffix.zip"
     } elseif ($minorVersionPrefix -eq "8") {
         # Only the "Functions" site extension supports hard links

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -1,7 +1,7 @@
 param (
   [string]$buildNumber = "0",    
   [string]$suffix = "",
-  [ValidateSet("6", "8")][string]$minorVersionPrefix = "",
+  [ValidateSet("6", "8", "")][string]$minorVersionPrefix = "",
   [string]$hashesForHardlinksFile = "hashesForHardlinks.txt"
 )
 

--- a/build/common.props
+++ b/build/common.props
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <MajorVersion>4</MajorVersion>
-    <MinorVersionPrefix Condition="'$(MinorVersionPrefix)' == ''">10</MinorVersionPrefix>
+    <MajorVersion>4</MajorVersion>    
     <MinorVersion>$(MinorVersionPrefix)31</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <BuildNumber Condition="'$(BuildNumber)' == '' ">0</BuildNumber>


### PR DESCRIPTION
In #9817 we bumped the version of functions to start with "10". We decided we shouldn't do this just yet, so reverting that part of the change.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)