### PR TITLE
Adding HIS Enforcement feature flags and metrics logging

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/KeysController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/KeysController.cs
@@ -23,8 +23,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
     [ResourceContainsSecrets]
     public class KeysController : Controller
     {
-        private const string MasterKeyName = "_master";
-
         private static readonly Lazy<Dictionary<string, string>> EmptyKeys = new Lazy<Dictionary<string, string>>(() => new Dictionary<string, string>());
         private readonly ISecretManagerProvider _secretManagerProvider;
         private readonly ILogger _logger;
@@ -187,7 +185,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
             }
 
             KeyOperationResult operationResult;
-            if (secretsType == ScriptSecretsType.Host && string.Equals(keyName, MasterKeyName, StringComparison.OrdinalIgnoreCase))
+            if (secretsType == ScriptSecretsType.Host && string.Equals(keyName, ScriptConstants.MasterKeyName, StringComparison.OrdinalIgnoreCase))
             {
                 operationResult = await _secretManagerProvider.Current.SetMasterKeyAsync(value);
             }
@@ -216,6 +214,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                     return NotFound();
                 case OperationResult.Conflict:
                     return StatusCode(StatusCodes.Status409Conflict);
+                case OperationResult.BadRequest:
+                    return StatusCode(StatusCodes.Status400BadRequest);
                 default:
                     return StatusCode(StatusCodes.Status500InternalServerError);
             }
@@ -237,7 +237,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                 {
                     keys = new Dictionary<string, string>(keys)
                     {
-                        { MasterKeyName, hostSecrets.MasterKey }
+                        { ScriptConstants.MasterKeyName, hostSecrets.MasterKey }
                     };
                 }
 
@@ -276,7 +276,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
         internal bool IsBuiltInSystemKeyName(string keyName)
         {
-            if (keyName.Equals(MasterKeyName, StringComparison.OrdinalIgnoreCase))
+            if (keyName.Equals(ScriptConstants.MasterKeyName, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }

--- a/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
@@ -333,7 +333,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
         public static void LogHostInitializationSettings(this ILogger logger, string originalFunctionWorkerRuntime, string functionWorkerRuntime,
             string originalFunctionWorkerRuntimeVersion, string functionsWorkerRuntimeVersion, string functionExtensionVersion, string hostDirectory,
             bool inStandbyMode, bool hasBeenSpecialized, bool usePlaceholderDotNetIsolated, string websiteSku, string featureFlags,
-            IDictionary<string, string> hostingConfig)
+            IDictionary<string, string> hostingConfig, string hisMode)
         {
             // This is a dump of values for telemetry right now, but eventually we will refactor this
             // into a proper Options object
@@ -350,7 +350,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
                 UsePlaceholderDotNetIsolated = usePlaceholderDotNetIsolated,
                 WebSiteSku = websiteSku,
                 FeatureFlags = featureFlags,
-                HostingConfig = hostingConfig
+                HostingConfig = hostingConfig,
+                HISMode = hisMode
             };
 
             var options = new JsonSerializerOptions { WriteIndented = true };

--- a/src/WebJobs.Script.WebHost/OperationResult.cs
+++ b/src/WebJobs.Script.WebHost/OperationResult.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         Created,
         Updated,
         NotFound,
-        Conflict
+        Conflict,
+        BadRequest
     }
 }

--- a/src/WebJobs.Script.WebHost/Properties/Resources.Designer.cs
+++ b/src/WebJobs.Script.WebHost/Properties/Resources.Designer.cs
@@ -231,6 +231,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A non highly-identifiable secret has been loaded by the application: (KeyType:{0}, KeyName:{1}, FunctionName:{2})..
+        /// </summary>
+        internal static string NonHISSecret {
+            get {
+                return ResourceManager.GetString("NonHISSecret", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} secret &apos;{1}&apos; for &apos;{2}&apos; {3}..
         /// </summary>
         internal static string TraceAddOrUpdateFunctionSecret {

--- a/src/WebJobs.Script.WebHost/Properties/Resources.resx
+++ b/src/WebJobs.Script.WebHost/Properties/Resources.resx
@@ -283,6 +283,9 @@
   <data name="HostSpecializationTrace" xml:space="preserve">
     <value>Starting host specialization</value>
   </data>
+  <data name="NonHISSecret" xml:space="preserve">
+    <value>A non highly-identifiable secret has been loaded by the application: (KeyType:{0}, KeyName:{1}, FunctionName:{2}).</value>
+  </data>
   <data name="TraceAddOrUpdateFunctionSecret" xml:space="preserve">
     <value>{0} secret '{1}' for '{2}' {3}.</value>
   </data>

--- a/src/WebJobs.Script.WebHost/Security/SecretGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Security/SecretGenerator.cs
@@ -45,5 +45,22 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security
             // equal signs do not require encoding.
             return IdentifiableSecrets.GenerateUrlSafeBase64Key(seed, 40, AzureFunctionsSignature, elidePadding: false);
         }
+
+        internal static bool ValidateSecret(string key, ulong seed)
+        {
+            return IdentifiableSecrets.ValidateBase64Key(key, seed, AzureFunctionsSignature, encodeForUrl: true);
+        }
+
+        internal static bool TryValidateSecret(string key, ulong seed)
+        {
+            try
+            {
+                return ValidateSecret(key, seed);
+            }
+            catch
+            {
+                return false;
+            }
+        }
     }
 }

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -726,8 +726,22 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             var featureFlags = _environment.GetEnvironmentVariable(AzureWebJobsFeatureFlags);
             var hostingConfigDict = _hostingConfigOptions.Value.Features;
 
+            string hisMode = "Disabled";
+            if (FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagStrictHISModeEnabled))
+            {
+                hisMode = "Strict";
+                _metricsLogger.LogEvent(MetricEventNames.HISStrictModeEnabled);
+                _logger.LogDebug($"HIS Strict mode enabled.");
+            }
+            else if (FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagStrictHISModeWarn))
+            {
+                hisMode = "Warn";
+                _metricsLogger.LogEvent(MetricEventNames.HISStrictModeWarn);
+                _logger.LogDebug($"HIS Warn mode enabled.");
+            }
+
             logger.LogHostInitializationSettings(_originalFunctionsWorkerRuntime, functionWorkerRuntime, _originalFunctionsWorkerRuntimeVersion, functionWorkerRuntimeVersion,
-                functionExtensionVersion, currentDirectory, inStandbyMode, hasBeenSpecialized, usePlaceholderDotNetIsolated, websiteSku, featureFlags, hostingConfigDict);
+                functionExtensionVersion, currentDirectory, inStandbyMode, hasBeenSpecialized, usePlaceholderDotNetIsolated, websiteSku, featureFlags, hostingConfigDict, hisMode);
         }
 
         private void OnHostHealthCheckTimer(object state)

--- a/src/WebJobs.Script/Diagnostics/DiagnosticEventConstants.cs
+++ b/src/WebJobs.Script/Diagnostics/DiagnosticEventConstants.cs
@@ -28,5 +28,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public const string MissingFunctionsWorkerRuntimeErrorCode = "AZFD0011";
         public const string MissingFunctionsWorkerRuntimeHelpLink = "https://go.microsoft.com/fwlink/?linkid=2257963";
+
+        public const string NonHISSecretLoaded = "AZFD0012";
+        public const string NonHISSecretLoadedHelpLink = "https://aka.ms/functions-non-his-secrets";
     }
 }

--- a/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
@@ -16,6 +16,10 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
         public const string HostStartupGetFunctionDescriptorsLatency = "host.startup.getfunctiondescriptors.latency";
         public const string HostStartupGrpcServerLatency = "host.startup.outofproc.grpcserver.initialize.latency";
         public const string HostStartupRuntimeLanguage = "host.startup.runtime.language.{0}";
+        public const string NonIdentifiableSecretLoaded = "host.secrets.nonidentifiable";
+        public const string IdentifiableSecretLoaded = "host.secrets.identifiable";
+        public const string HISStrictModeEnabled = "host.hismode.strict";
+        public const string HISStrictModeWarn = "host.hismode.warn";
 
         // Script host level events
         public const string ScriptHostManagerBuildScriptHost = "scripthostmanager.buildscripthost.latency";

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -128,6 +128,8 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FeatureFlagEnableWorkerIndexing = "EnableWorkerIndexing";
         public const string FeatureFlagEnableDebugTracing = "EnableDebugTracing";
         public const string FeatureFlagEnableProxies = "EnableProxies";
+        public const string FeatureFlagStrictHISModeEnabled = "StrictHISModeEnabled";
+        public const string FeatureFlagStrictHISModeWarn = "StrictHISModeWarn";
         public const string FeatureFlagEnableOrderedInvocationmessages = "EnableOrderedInvocationMessages";
         public const string HostingConfigDisableLinuxAppServiceDetailedExecutionEvents = "DisableLinuxExecutionDetails";
         public const string HostingConfigDisableLinuxAppServiceExecutionEventLogBackoff = "DisableLinuxLogBackoff";
@@ -245,5 +247,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public static readonly string OperationNameKey = "OperationName";
 
         public static readonly string CancellationTokenRegistration = "CancellationTokenRegistration";
+
+        internal const string MasterKeyName = "_master";
     }
 }

--- a/test/WebJobs.Script.Tests.Shared/TestEnvironment.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestEnvironment.cs
@@ -14,8 +14,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         private readonly IDictionary<string, string> _variables;
         private bool _is64BitProcess;
 
-        public TestEnvironment()
-    : this(new Dictionary<string, string>())
+        public TestEnvironment() : this(new Dictionary<string, string>())
         {
         }
 

--- a/test/WebJobs.Script.Tests.Shared/TestTraits.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestTraits.cs
@@ -57,5 +57,7 @@ namespace Microsoft.WebJobs.Script.Tests
         public const string FunctionsControllerEndToEnd = "FunctionsControllerEndToEnd";
 
         public const string FlexConsumptionMetricsTests = "FlexConsumptionMetricsTests";
+
+        public const string HISSecretsTests = "HISSecretsTests";
     }
 }


### PR DESCRIPTION
These changes add new capabilities to the host for both logging HIS (highly identifiable secret) status for loaded keys, as well as allowing the host to be put in strict/warn modes for HIS enforcement.

Related to the work we did a couple years ago in https://github.com/Azure/azure-functions-host/pull/8071. After those changes, all keys the platform generates are HIS. However, any keys generated before that remain non-HIS. The changes in this PR enable customers to identify legacy keys (and rotate them) via the Warn mode, as well as enforce that no non-HIS keys can be added/used in the future via the Strict mode.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
