### PR TITLE
removing call to Configure() for FunctionsHostingConfigOptions

### DIFF
--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -208,13 +208,25 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.ConfigureOptionsWithChangeTokenSource<HttpBodyControlOptions, HttpBodyControlOptionsSetup, SpecializationChangeTokenSource<HttpBodyControlOptions>>();
             services.ConfigureOptions<FlexConsumptionMetricsPublisherOptionsSetup>();
             services.ConfigureOptions<ConsoleLoggingOptionsSetup>();
-            services.ConfigureOptions<FunctionsHostingConfigOptionsSetup>();
+            services.AddHostingConfigOptions(configuration);
 
             services.TryAddSingleton<IDependencyValidator, DependencyValidator>();
             services.TryAddSingleton<IJobHostMiddlewarePipeline>(s => DefaultMiddlewarePipeline.Empty);
 
             // Add AzureBlobStorageProvider to WebHost (also needed for ScriptHost)
             services.AddAzureBlobStorageProvider();
+        }
+
+        internal static void AddHostingConfigOptions(this IServiceCollection services, IConfiguration configuration)
+        {
+            services.ConfigureOptions<FunctionsHostingConfigOptionsSetup>();
+
+            if (configuration != null)
+            {
+                // Refresh IOptionsMonitor<FunctionsHostingConfigOptions> when the config section changes
+                var configSection = configuration.GetSection(ScriptConstants.FunctionsHostingConfigSectionName);
+                services.AddSingleton<IOptionsChangeTokenSource<FunctionsHostingConfigOptions>>(new ConfigurationChangeTokenSource<FunctionsHostingConfigOptions>(configSection));
+            }
         }
 
         private static void AddStandbyServices(this IServiceCollection services)

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -209,10 +209,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.ConfigureOptions<FlexConsumptionMetricsPublisherOptionsSetup>();
             services.ConfigureOptions<ConsoleLoggingOptionsSetup>();
             services.ConfigureOptions<FunctionsHostingConfigOptionsSetup>();
-            if (configuration != null)
-            {
-                services.Configure<FunctionsHostingConfigOptions>(configuration.GetSection(ScriptConstants.FunctionsHostingConfigSectionName));
-            }
 
             services.TryAddSingleton<IDependencyValidator, DependencyValidator>();
             services.TryAddSingleton<IJobHostMiddlewarePipeline>(s => DefaultMiddlewarePipeline.Empty);

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         {
             get
             {
-                return GetFeatureAsBooleanOrDefault(RpcWorkerConstants.ShutdownWebhostWorkerChannelsOnHostShutdown, false);
+                return GetFeatureAsBooleanOrDefault(RpcWorkerConstants.ShutdownWebhostWorkerChannelsOnHostShutdown, true);
             }
 
             set

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         /// <summary>
         /// Gets a value indicating whether worker concurrency feature is enabled in the hosting config.
         /// </summary>
-        public bool FunctionsWorkerDynamicConcurrencyEnabled
+        internal bool FunctionsWorkerDynamicConcurrencyEnabled
         {
             get
             {
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         /// <summary>
         /// Gets a value indicating whether worker indexing feature is enabled in the hosting config.
         /// </summary>
-        public bool WorkerIndexingEnabled
+        internal bool WorkerIndexingEnabled
         {
             get
             {
@@ -46,11 +46,11 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         /// <summary>
         /// Gets or Sets a value indicating whether the host should shutdown webhost worker channels during shutdown.
         /// </summary>
-        public bool ShutdownWebhostWorkerChannelsOnHostShutdown
+        internal bool ShutdownWebhostWorkerChannelsOnHostShutdown
         {
             get
             {
-                return GetFeatureOrDefault(RpcWorkerConstants.ShutdownWebhostWorkerChannelsOnHostShutdown, "1") == "1";
+                return GetFeatureAsBooleanOrDefault(RpcWorkerConstants.ShutdownWebhostWorkerChannelsOnHostShutdown, false);
             }
 
             set
@@ -62,11 +62,11 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         /// <summary>
         /// Gets or sets a value indicating whether SWT tokens should be accepted.
         /// </summary>
-        public bool SwtAuthenticationEnabled
+        internal bool SwtAuthenticationEnabled
         {
             get
             {
-                return GetFeatureOrDefault(ScriptConstants.HostingConfigSwtAuthenticationEnabled, "1") == "1";
+                return GetFeatureAsBooleanOrDefault(ScriptConstants.HostingConfigSwtAuthenticationEnabled, true);
             }
 
             set
@@ -78,11 +78,11 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         /// <summary>
         /// Gets or sets a value indicating whether SWT tokens should be sent on outgoing requests.
         /// </summary>
-        public bool SwtIssuerEnabled
+        internal bool SwtIssuerEnabled
         {
             get
             {
-                return GetFeatureOrDefault(ScriptConstants.HostingConfigSwtIssuerEnabled, "1") == "1";
+                return GetFeatureAsBooleanOrDefault(ScriptConstants.HostingConfigSwtIssuerEnabled, true);
             }
 
             set
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         /// <summary>
         /// Gets a string delimited by '|' that contains the name of the apps with worker indexing disabled.
         /// </summary>
-        public string WorkerIndexingDisabledApps
+        internal string WorkerIndexingDisabledApps
         {
             get
             {
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         /// <summary>
         /// Gets a value indicating whether Linux Log Backoff is disabled in the hosting config.
         /// </summary>
-        public bool DisableLinuxAppServiceLogBackoff
+        internal bool DisableLinuxAppServiceLogBackoff
         {
             get
             {
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         /// <summary>
         /// Gets or sets a value indicating whether Linux AppService/EP Detailed Execution Event is disabled in the hosting config.
         /// </summary>
-        public bool DisableLinuxAppServiceExecutionDetails
+        internal bool DisableLinuxAppServiceExecutionDetails
         {
             get
             {
@@ -129,11 +129,11 @@ namespace Microsoft.Azure.WebJobs.Script.Config
             }
         }
 
-        public bool EnableOrderedInvocationMessages
+        internal bool EnableOrderedInvocationMessages
         {
             get
             {
-                return GetFeature(ScriptConstants.FeatureFlagEnableOrderedInvocationmessages) == "1";
+                return GetFeatureAsBooleanOrDefault(ScriptConstants.FeatureFlagEnableOrderedInvocationmessages, false);
             }
 
             set
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         /// <summary>
         /// Gets the highest version of extension bundle v3 supported.
         /// </summary>
-        public string MaximumBundleV3Version
+        internal string MaximumBundleV3Version
         {
             get
             {
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         /// <summary>
         /// Gets the highest version of extension bundle v4 supported.
         /// </summary>
-        public string MaximumBundleV4Version
+        internal string MaximumBundleV4Version
         {
             get
             {
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         /// <summary>
         /// Gets a value indicating whether the host should revert the worker shutdown behavior in the WebHostWorkerChannelManager.
         /// </summary>
-        public bool RevertWorkerShutdownBehavior
+        internal bool RevertWorkerShutdownBehavior
         {
             get
             {
@@ -175,7 +175,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
             }
         }
 
-        public bool ThrowOnMissingFunctionsWorkerRuntime
+        internal bool ThrowOnMissingFunctionsWorkerRuntime
         {
             get
             {
@@ -206,6 +206,36 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         public string GetFeatureOrDefault(string name, string defaultValue)
         {
             return GetFeature(name) ?? defaultValue;
+        }
+
+        /// <summary>
+        /// Gets a feature by name and attempts to parse it into a boolean.
+        /// Returns "True, False" or ints as booleans. Returns True for any non-zero integer.
+        /// If none of those (or empty), returns default.
+        /// </summary>
+        /// <param name="name">Feature name.</param>
+        /// <param name="defaultValue">The default value to return if the feature value cannot be parsed into a boolean.</param>
+        /// <returns>Boolean value if parse-able from hosting configuration. Otherwise, the defaultValue.</returns>
+        internal bool GetFeatureAsBooleanOrDefault(string name, bool defaultValue)
+        {
+            string featureValue = GetFeature(name);
+
+            if (string.IsNullOrWhiteSpace(featureValue))
+            {
+                return defaultValue;
+            }
+
+            if (bool.TryParse(featureValue, out bool parsedBool))
+            {
+                return parsedBool;
+            }
+
+            if (int.TryParse(featureValue, out int parsedInt))
+            {
+                return parsedInt != 0;
+            }
+
+            return defaultValue;
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcessesNoBundle.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcessesNoBundle.cs
@@ -6,9 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Config;
@@ -44,14 +41,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 
             await SamplesTestHelpers.InvokeAndValidateHttpTrigger(_fixture, "HttpTrigger");
 
+            Console.WriteLine("--- BEFORE: " + string.Join(",", nodeProcessesBeforeHostRestart));
+
             // Wait for all the 3 process to start
-            await Task.Delay(TimeSpan.FromMinutes(1));
-
-            IEnumerable<int> nodeProcessesAfter = Process.GetProcessesByName("node").Select(p => p.Id);
-
-            // Verify node process is different after host restart
-            var result = nodeProcessesAfter.Where(pId1 => !nodeProcessesBeforeHostRestart.Any(pId2 => pId2 == pId1) && !_fixture.NodeProcessesBeforeTestStarted.Any(pId3 => pId3 == pId1));
-            Assert.Equal(3, result.Count());
+            await TestHelpers.Await(() =>
+                {
+                    IEnumerable<int> nodeProcessesAfter = Process.GetProcessesByName("node").Select(p => p.Id);
+                    Console.WriteLine("--- AFTER: " + string.Join(", ", nodeProcessesAfter));
+                    // Verify node process is different after host restart
+                    var result = nodeProcessesAfter.Where(pId1 => !nodeProcessesBeforeHostRestart.Any(pId2 => pId2 == pId1) && !_fixture.NodeProcessesBeforeTestStarted.Any(pId3 => pId3 == pId1));
+                    bool success = result.Count() == 3;
+                    return success;
+                }, timeout: 120000, pollingInterval: 1000);
         }
 
         public class MultiplepleProcessesTestFixtureNoBundles : EndToEndTestFixture

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcessesNoBundle.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcessesNoBundle.cs
@@ -35,13 +35,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         public async Task NodeProcessNoBundleConfigured_Different_AfterHostRestart()
         {
             await SamplesTestHelpers.InvokeAndValidateHttpTrigger(_fixture, "HttpTrigger");
-            IEnumerable<int> nodeProcessesBeforeHostRestart = Process.GetProcessesByName("node").Select(p => p.Id);
+            IEnumerable<int> nodeProcessesBeforeHostRestart = Process.GetProcessesByName("node").Select(p => p.Id).ToArray();
             // Trigger a restart
             await _fixture.Host.RestartAsync(CancellationToken.None);
 
             await SamplesTestHelpers.InvokeAndValidateHttpTrigger(_fixture, "HttpTrigger");
 
-            Console.WriteLine("--- BEFORE: " + string.Join(",", nodeProcessesBeforeHostRestart));
+            Console.WriteLine("--- BEFORE1: " + string.Join(",", nodeProcessesBeforeHostRestart));
+            Console.WriteLine("--- BEFORE2: " + string.Join(",", _fixture.NodeProcessesBeforeTestStarted));
 
             // Wait for all the 3 process to start
             await TestHelpers.Await(() =>

--- a/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Extensions.DependencyInjection;
@@ -61,6 +65,120 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 
                 await host.RunAsync();
                 Assert.Equal(testService.Options.Value.GetFeature("feature1"), "value1");
+            }
+        }
+
+        [Theory]
+        [InlineData("True", false, true)]
+        [InlineData("False", true, false)]
+        [InlineData("tRuE", false, true)]
+        [InlineData(" true ", false, true)]
+        [InlineData("1", false, true)]
+        [InlineData("0", true, false)]
+        [InlineData("-2", false, true)] // any non-zero int is true
+        [InlineData("unparseable", false, false)]
+        [InlineData(null, true, true)]
+        public void GetFeatureAsBooleanOrDefault(string featureValue, bool defaultValue, bool expected)
+        {
+            string feature = "TestFeature";
+            var options = new FunctionsHostingConfigOptions();
+
+            if (featureValue != null)
+            {
+                options.Features.Add(feature, featureValue);
+            }
+
+            Assert.Equal(expected, options.GetFeatureAsBooleanOrDefault(feature, defaultValue));
+        }
+
+        [Fact]
+        public void Property_Validation()
+        {
+            // Doing this all in one test case (not using Theory) so that we can ensure we have at least one test for every property.
+            // Note: For legacy purposes (we used to call Configuration.Bind() on this object), some properties whose ScmHostingConfig key and
+            //       property name match exactly need to support "True/False".
+            //       It is recommended that new properties only look at "1/0" for their setting.
+            var testCases = new List<(string PropertyName, string ConfigValue, object Expected)>
+            {
+                (nameof(FunctionsHostingConfigOptions.DisableLinuxAppServiceExecutionDetails), "DisableLinuxExecutionDetails=1", true),
+                (nameof(FunctionsHostingConfigOptions.DisableLinuxAppServiceLogBackoff), "DisableLinuxLogBackoff=1", true),
+
+                // Supports True/False/1/0
+                (nameof(FunctionsHostingConfigOptions.EnableOrderedInvocationMessages), "EnableOrderedInvocationMessages=True", true),
+                (nameof(FunctionsHostingConfigOptions.EnableOrderedInvocationMessages), "EnableOrderedInvocationMessages=1", true),
+                (nameof(FunctionsHostingConfigOptions.EnableOrderedInvocationMessages), "EnableOrderedInvocationMessages=unparseable", false), // default
+                (nameof(FunctionsHostingConfigOptions.EnableOrderedInvocationMessages), string.Empty, false), // default
+
+                (nameof(FunctionsHostingConfigOptions.FunctionsWorkerDynamicConcurrencyEnabled), "FUNCTIONS_WORKER_DYNAMIC_CONCURRENCY_ENABLED=1", true),
+                (nameof(FunctionsHostingConfigOptions.MaximumBundleV3Version), "FunctionRuntimeV4MaxBundleV3Version=teststring", "teststring"),
+                (nameof(FunctionsHostingConfigOptions.MaximumBundleV4Version), "FunctionRuntimeV4MaxBundleV4Version=teststring", "teststring"),
+                (nameof(FunctionsHostingConfigOptions.RevertWorkerShutdownBehavior), "REVERT_WORKER_SHUTDOWN_BEHAVIOR=1", true),
+
+                // Supports True/False/1/0
+                (nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), "ShutdownWebhostWorkerChannelsOnHostShutdown=False", false),
+                (nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), "ShutdownWebhostWorkerChannelsOnHostShutdown=True", true),
+                (nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), "ShutdownWebhostWorkerChannelsOnHostShutdown=1", true),
+                (nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), "ShutdownWebhostWorkerChannelsOnHostShutdown=unparseable", false), // default
+                (nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), string.Empty, false), // default
+
+                // Supports True/False/1/0
+                (nameof(FunctionsHostingConfigOptions.SwtAuthenticationEnabled), "SwtAuthenticationEnabled=False", false),
+                (nameof(FunctionsHostingConfigOptions.SwtAuthenticationEnabled), "SwtAuthenticationEnabled=True", true),
+                (nameof(FunctionsHostingConfigOptions.SwtAuthenticationEnabled), "SwtAuthenticationEnabled=0", false),
+                (nameof(FunctionsHostingConfigOptions.SwtAuthenticationEnabled), "SwtAuthenticationEnabled=unparseable", true), // default
+                (nameof(FunctionsHostingConfigOptions.SwtAuthenticationEnabled), string.Empty, true), // default
+
+                // Supports True/False/1/0
+                (nameof(FunctionsHostingConfigOptions.SwtIssuerEnabled), "SwtIssuerEnabled=False", false),
+                (nameof(FunctionsHostingConfigOptions.SwtIssuerEnabled), "SwtIssuerEnabled=True", true),
+                (nameof(FunctionsHostingConfigOptions.SwtIssuerEnabled), "SwtIssuerEnabled=0", false),
+                (nameof(FunctionsHostingConfigOptions.SwtIssuerEnabled), "SwtIssuerEnabled=unparseable", true), //default
+                (nameof(FunctionsHostingConfigOptions.SwtIssuerEnabled), string.Empty, true), // default
+
+                (nameof(FunctionsHostingConfigOptions.ThrowOnMissingFunctionsWorkerRuntime), "THROW_ON_MISSING_FUNCTIONS_WORKER_RUNTIME=1", true),
+                (nameof(FunctionsHostingConfigOptions.WorkerIndexingDisabledApps), "WORKER_INDEXING_DISABLED_APPS=teststring", "teststring"),
+                (nameof(FunctionsHostingConfigOptions.WorkerIndexingEnabled), "WORKER_INDEXING_ENABLED=1", true)
+            };
+
+            // use reflection to ensure that we have a test that uses every value exposed on FunctionsHostingConfigOptions
+            // (except for Features, which does not get bound).
+            var props = typeof(FunctionsHostingConfigOptions).GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                        .Where(p => p.Name != nameof(FunctionsHostingConfigOptions.Features));
+
+            foreach (var prop in props)
+            {
+                // make sure all props are internal to prevent inadverntent binding in the future
+                if (prop.GetGetMethod() is not null || prop.GetSetMethod() is not null)
+                {
+                    throw new InvalidOperationException($"{prop.Name} is public. All properties on this object should be internal.");
+                }
+
+                // just make sure we have at least one test per prop
+                var expected = testCases.FirstOrDefault(p => p.PropertyName == prop.Name);
+                if (expected == default)
+                {
+                    throw new InvalidOperationException($"The property {prop.Name} is not set up to be validated. Please add at least one case in this test.");
+                }
+            }
+
+            foreach (var (propertyName, configValue, expected) in testCases)
+            {
+                using TempDirectory tempDir = new();
+
+                IHost host = GetScriptHostBuilder(Path.Combine(tempDir.Path, "settings.txt"), configValue).Build();
+                var testService = host.Services.GetService<TestService>();
+
+                var prop = props.Single(p => p.Name == propertyName);
+                var actual = prop.GetValue(testService.Options.Value);
+                try
+                {
+                    Assert.Equal(expected, actual);
+                }
+                catch (Exception)
+                {
+                    // provide a better failure message
+                    Assert.True(false, $"{prop.Name} failure ('{configValue}'). Expected: {expected}. Actual: {actual}.");
+                }
             }
         }
 
@@ -179,7 +297,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 .ConfigureServices((context, services) =>
                 {
                     services.ConfigureOptions<FunctionsHostingConfigOptionsSetup>();
-                    services.Configure<FunctionsHostingConfigOptions>(context.Configuration.GetSection(ScriptConstants.FunctionsHostingConfigSectionName));
                 }).Build();
 
             return new HostBuilder()

--- a/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
@@ -119,8 +119,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 (nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), "ShutdownWebhostWorkerChannelsOnHostShutdown=False", false),
                 (nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), "ShutdownWebhostWorkerChannelsOnHostShutdown=True", true),
                 (nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), "ShutdownWebhostWorkerChannelsOnHostShutdown=1", true),
-                (nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), "ShutdownWebhostWorkerChannelsOnHostShutdown=unparseable", false), // default
-                (nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), string.Empty, false), // default
+                (nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), "ShutdownWebhostWorkerChannelsOnHostShutdown=unparseable", true), // default
+                (nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), string.Empty, true), // default
 
                 // Supports True/False/1/0
                 (nameof(FunctionsHostingConfigOptions.SwtAuthenticationEnabled), "SwtAuthenticationEnabled=False", false),

--- a/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -296,7 +297,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 })
                 .ConfigureServices((context, services) =>
                 {
-                    services.ConfigureOptions<FunctionsHostingConfigOptionsSetup>();
+                    WebHostServiceCollectionExtensions.AddHostingConfigOptions(services, context.Configuration);
                 }).Build();
 
             return new HostBuilder()


### PR DESCRIPTION
Calling `Configure()` ultimately calls `IConfiguration.Bind(options)` on the specified `Options` object, This was problematic for this `FunctionsHostingConfigOptions` because several of us attempted to use ints (`myoption=1`) in the ScmHostingConfiguration file... which ended up throwing exceptions because ints are not parse-able into bools.

The longer-term approach here is that everything is driven by the `Features` dictionary, which is already populated by the `FunctionsHostingConfigOptionsSetup` class. There was no need to call `Configure()` so I'm removing it for safety going forward. As an extra precaution, I've move all properties to `internal` just in case this is re-introduced at any point.

Some other interesting notes:
- a bunch of properties do not have an exact match between what they use in ScmHostingConfigurations.txt and the property. This is why many don't see that issue (`WorkerIndexingEnabled`, for example).
- only when several of us added properties where the name exactly matches that in ScmHostingConfigurations.txt did we run into issues, which actually can cause outages.
- a few features have already rolled out using "True" or "False" as their string. So I've added a way to easily support "True/False/1/0". Ideally everyone going forward just uses "1/0".

I've also added a test to ensure that future additions here add new validation tests so we're all clear what is/isn't supported.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)