### PR TITLE
pinning sdk to 6.0.419

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.101",
+    "version": "6.0.419",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {


### PR DESCRIPTION
Pinning this SDK version to net8 had downstream effects on our Linux builds. Moving this back to 6.0.x until we can come up with a solution long-term.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)