### PR TITLE
updating build number in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,7 @@ jobs:
     name: Initialize
     inputs:
       filePath: '$(Build.Repository.LocalPath)\build\initialize-pipeline.ps1'
+      arguments: -minorVersionPrefix "$(minorVersionPrefix)"
       showWarnings: true
 
 - job: BuildArtifacts

--- a/build/build-extensions.ps1
+++ b/build/build-extensions.ps1
@@ -243,20 +243,26 @@ function CreateSiteExtensions() {
     if ($minorVersionPrefix -eq "") {
         ZipContent $siteExtensionPath "$zipOutput\Functions.$extensionVersion$runtimeSuffix.zip"
     } elseif ($minorVersionPrefix -eq "8") {
+        Write-Host "======================================"
         # Only the "Functions" site extension supports hard links
-        Write-Host "Removing $hashesForHardLinksPath before zipping."
+        Write-Host "MinorVersionPrefix is '8'. Removing $hashesForHardLinksPath before zipping."
         Remove-Item -Force "$hashesForHardLinksPath" -ErrorAction Stop
         # The .NET 8 host doesn't require any workers. Doing this to save space.
         Write-Host "Removing workers before zipping."
-        Remove-Item -Recurse -Force "$siteExtensionPath\$extensionVersion$runtimeSuffix\workers" -ErrorAction Stop
-        # The host requires that this folder exists, even if it's empty
-        New-Item -Itemtype directory -path $siteExtensionPath\$extensionVersion$runtimeSuffix\workers > $null 
+        # The host requires that this folder exists and it cannot be empty
+        Remove-Item -Recurse -Force "$siteExtensionPath\$extensionVersion$runtimeSuffix\workers" -ErrorAction Stop 
+        New-Item -Path "$siteExtensionPath\$extensionVersion$runtimeSuffix" -Name "workers" -ItemType Directory -ErrorAction Stop | Out-Null
+        Set-Content -Force -Path "$siteExtensionPath\$extensionVersion$runtimeSuffix\workers\this_folder_intentionally_empty.txt" -Value ".NET 8 builds do not have workers. However, this folder must contain at least one file." -ErrorAction Stop
+        Write-Host "======================================"
         Write-Host
         ZipContent $siteExtensionPath "$zipOutput\FunctionsInProc8.$extensionVersion$runtimeSuffix.zip"
     } elseif ($minorVersionPrefix -eq "6") {
         # Only the "Functions" site extension supports hard links
-        Write-Host "Removing $hashesForHardLinksPath before zipping."
+        Write-Host "======================================"
+        Write-Host "MinorVersionPrefix is '6'. Removing $hashesForHardLinksPath before zipping."
         Remove-Item -Force "$hashesForHardLinksPath" -ErrorAction Stop
+        Write-Host "======================================"
+        Write-Host
         ZipContent $siteExtensionPath "$zipOutput\FunctionsInProc.$extensionVersion$runtimeSuffix.zip"
     }
 
@@ -309,7 +315,7 @@ Write-Host
 Write-Host "Output directory: $buildOutput"
 if (Test-Path $buildOutput) {
     Write-Host "  Existing build output found. Deleting."
-    Remove-Item $buildOutput -Recurse -Force
+    Remove-Item $buildOutput -Recurse -Force -ErrorAction Stop
 }
 Write-Host "Extensions version: $extensionVersion"
 Write-Host ""

--- a/build/initialize-pipeline.ps1
+++ b/build/initialize-pipeline.ps1
@@ -1,3 +1,7 @@
+param (
+  [ValidateSet("6", "8", "")][string]$minorVersionPrefix = ""
+)
+
 $buildReason = $env:BUILD_REASON
 $sourceBranch = $env:BUILD_SOURCEBRANCH
 
@@ -23,14 +27,21 @@ if ($buildReason -eq "PullRequest") {
 
 $buildNumber = ""
 
-if(($buildReason -eq "PullRequest") -or !($sourceBranch.ToLower().Contains("release/4.")))
+$branch = $sourceBranch.ToLower();
+$isRelease = $branch.Contains("release/4") -or $branch.Contains("release/inproc6/4") -or $branch.Contains("release/inproc8/4")
+
+if(($buildReason -eq "PullRequest") -or !$isRelease)
 {
   $buildNumber = $env:buildNumber
   Write-Host "BuildNumber: '$buildNumber'"
 }
+else 
+{
+  Write-Host "Release build; Not using a build number."
+}
 
 Import-Module $PSScriptRoot\Get-AzureFunctionsVersion -Force
-$version = Get-AzureFunctionsVersion $buildNumber $buildNumber
+$version = Get-AzureFunctionsVersion $buildNumber $buildNumber $minorVersionPrefix
 
 Write-Host "Site extension version: $version"
 Write-Host "##vso[build.updatebuildnumber]$version"


### PR DESCRIPTION
Our new inproc6/inproc8 builds weren't properly setting up the DevOps build number. This is mostly cosmetic, but it is actually used in one of our automated release steps (tagging/releasing on github). So, we'll have to do that manually until next release.

I tested that this works here: https://azfunc.visualstudio.com/Azure%20Functions/_build/results?buildId=161766&view=logs&j=2f7c43da-a38c-5369-068a-fe2a49031931&t=77a37c01-da68-5015-8d70-6932cf872bf8. 

-- notice the build number is 4.631.0 rather than 4.31.0 as before.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
