### PR TITLE
Updating SyncTriggers to include host config

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -16,8 +16,10 @@ using Microsoft.AspNetCore.Mvc.WebApiCompatShim;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Scale;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.ExtensionBundle;
 using Microsoft.Azure.WebJobs.Script.Scale;
+using Microsoft.Azure.WebJobs.Script.WebHost.Extensions;
 using Microsoft.Azure.WebJobs.Script.WebHost.Filters;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
@@ -44,6 +46,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         private readonly IScriptHostManager _scriptHostManager;
         private readonly IFunctionsSyncManager _functionsSyncManager;
         private readonly HostPerformanceManager _performanceManager;
+        private readonly IMetricsLogger _metricsLogger;
         private static readonly SemaphoreSlim _drainSemaphore = new SemaphoreSlim(1, 1);
         private static readonly SemaphoreSlim _resumeSemaphore = new SemaphoreSlim(1, 1);
 
@@ -52,7 +55,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
             IEnvironment environment,
             IScriptHostManager scriptHostManager,
             IFunctionsSyncManager functionsSyncManager,
-            HostPerformanceManager performanceManager)
+            HostPerformanceManager performanceManager,
+            IMetricsLogger metricsLogger)
         {
             _applicationHostOptions = applicationHostOptions;
             _logger = loggerFactory.CreateLogger(ScriptConstants.LogCategoryHostController);
@@ -60,6 +64,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
             _scriptHostManager = scriptHostManager;
             _functionsSyncManager = functionsSyncManager;
             _performanceManager = performanceManager;
+            _metricsLogger = metricsLogger;
         }
 
         [HttpGet]
@@ -388,6 +393,22 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         [Authorize(Policy = PolicyNames.AdminAuthLevelOrInternal)]
         public async Task<IActionResult> SyncTriggers()
         {
+            _metricsLogger.LogEvent(MetricEventNames.SyncTriggersInvoked);
+
+            // TEMP: Collecting temporary metrics on the host state during SyncTrigger requests
+            if (!_scriptHostManager.HostIsInitialized())
+            {
+                _metricsLogger.LogEvent(MetricEventNames.SyncTriggersHostNotInitialized);
+            }
+
+            // TODO: We plan on making SyncTriggers RequiresRunningHost across the board,
+            // but for now only for Flex.
+            // https://github.com/Azure/azure-functions-host/issues/9904
+            if (_environment.IsFlexConsumptionSku())
+            {
+                await HttpContext.WaitForRunningHostAsync(_scriptHostManager, _applicationHostOptions.Value);
+            }
+
             var result = await _functionsSyncManager.TrySyncTriggersAsync();
 
             // Return a dummy body to make it valid in ARM template action evaluation

--- a/src/WebJobs.Script.WebHost/Extensions/HttpContextExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Extensions/HttpContextExtensions.cs
@@ -2,14 +2,41 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.IO;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Azure.WebJobs.Script.Extensions;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Extensions
 {
     internal static class HttpContextExtensions
     {
+        public static async Task WaitForRunningHostAsync(this HttpContext httpContext, IScriptHostManager hostManager, ScriptApplicationHostOptions applicationHostOptions, int timeoutSeconds = ScriptConstants.HostTimeoutSeconds, int pollingIntervalMilliseconds = ScriptConstants.HostPollingIntervalMilliseconds, ActionExecutionDelegate next = null)
+        {
+            if (hostManager.State == ScriptHostState.Offline)
+            {
+                await httpContext.SetOfflineResponseAsync(applicationHostOptions.ScriptPath);
+            }
+            else
+            {
+                // If the host is not ready, we'll wait a bit for it to initialize.
+                // This might happen if http requests come in while the host is starting
+                // up for the first time, or if it is restarting.
+                bool hostReady = await hostManager.DelayUntilHostReady(timeoutSeconds, pollingIntervalMilliseconds);
+
+                if (!hostReady)
+                {
+                    throw new HttpException(HttpStatusCode.ServiceUnavailable, "Function host is not running.");
+                }
+
+                if (next != null)
+                {
+                    await next();
+                }
+            }
+        }
+
         public static async Task SetOfflineResponseAsync(this HttpContext httpContext, string scriptPath)
         {
             httpContext.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;

--- a/src/WebJobs.Script.WebHost/Extensions/ScriptHostManagerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Extensions/ScriptHostManagerExtensions.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Script
@@ -12,7 +9,7 @@ namespace Microsoft.Azure.WebJobs.Script
     {
         public static async Task<bool> DelayUntilHostReady(this IScriptHostManager hostManager, int timeoutSeconds = ScriptConstants.HostTimeoutSeconds, int pollingIntervalMilliseconds = ScriptConstants.HostPollingIntervalMilliseconds)
         {
-            if (CanInvoke(hostManager))
+            if (HostIsInitialized(hostManager))
             {
                 return true;
             }
@@ -20,14 +17,19 @@ namespace Microsoft.Azure.WebJobs.Script
             {
                 await Utility.DelayAsync(timeoutSeconds, pollingIntervalMilliseconds, () =>
                 {
-                    return !CanInvoke(hostManager) && hostManager.State != ScriptHostState.Error;
+                    return !HostIsInitialized(hostManager) && hostManager.State != ScriptHostState.Error;
                 });
 
-                return CanInvoke(hostManager);
+                return HostIsInitialized(hostManager);
             }
         }
 
-        public static bool CanInvoke(this IScriptHostManager hostManager)
+        /// <summary>
+        /// Gets a value indicating whether the host in an initialized or running state.
+        /// </summary>
+        /// <param name="hostManager">The <see cref="IScriptHostManager"/> to check.</param>
+        /// <returns>True if the host is initialized or running, false otherwise.</returns>
+        public static bool HostIsInitialized(this IScriptHostManager hostManager)
         {
             return hostManager.State == ScriptHostState.Running || hostManager.State == ScriptHostState.Initialized;
         }

--- a/src/WebJobs.Script.WebHost/Middleware/HostAvailabilityCheckMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/HostAvailabilityCheckMiddleware.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
         {
             if (_scriptHostManager.State != ScriptHostState.Offline)
             {
-                if (!_scriptHostManager.CanInvoke())
+                if (!_scriptHostManager.HostIsInitialized())
                 {
                     // If we're not ready, take the slower/more expensive route and await being ready
                     return InvokeAwaitingHost(httpContext, _next, _logger, _scriptHostManager);

--- a/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
@@ -54,8 +54,6 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
                 "customHandler", "httpWorker", "extensions", "concurrency", ConfigurationSectionNames.SendCanceledInvocationsToWorker
             };
 
-            private static readonly string[] CredentialNameFragments = new[] { "password", "pwd", "key", "secret", "token", "sas" };
-
             private readonly HostJsonFileConfigurationSource _configurationSource;
             private readonly Stack<string> _path;
             private readonly ILogger _logger;
@@ -147,7 +145,10 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
                     string hostFilePath = Path.Combine(options.ScriptPath, ScriptConstants.HostMetadataFileName);
                     JObject hostConfigObject = LoadHostConfig(hostFilePath);
                     hostConfigObject = InitializeHostConfig(hostFilePath, hostConfigObject);
-                    string sanitizedJson = SanitizeHostJson(hostConfigObject);
+
+                    Func<string, bool> selector = (name) => WellKnownHostJsonProperties.Contains(name);
+                    var sanitizedHostConfigObject = Sanitizer.Sanitize(hostConfigObject, selector);
+                    string sanitizedJson = sanitizedHostConfigObject.ToString();
 
                     _logger.HostConfigApplied();
 
@@ -282,73 +283,6 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
                     _logger.AddingExtensionBundleConfiguration(bundleConfiguration);
                 }
                 return content;
-            }
-
-            internal static string SanitizeHostJson(JObject hostJsonObject)
-            {
-                static bool IsPotentialCredential(string name)
-                {
-                    foreach (string fragment in CredentialNameFragments)
-                    {
-                        if (name.Contains(fragment, StringComparison.OrdinalIgnoreCase))
-                        {
-                            return true;
-                        }
-                    }
-
-                    return false;
-                }
-
-                static JToken Sanitize(JToken token)
-                {
-                    if (token is JObject obj)
-                    {
-                        JObject sanitized = new JObject();
-                        foreach (var prop in obj)
-                        {
-                            if (IsPotentialCredential(prop.Key))
-                            {
-                                sanitized[prop.Key] = Sanitizer.SecretReplacement;
-                            }
-                            else
-                            {
-                                sanitized[prop.Key] = Sanitize(prop.Value);
-                            }
-                        }
-
-                        return sanitized;
-                    }
-
-                    if (token is JArray arr)
-                    {
-                        JArray sanitized = new JArray();
-                        foreach (var value in arr)
-                        {
-                            sanitized.Add(Sanitize(value));
-                        }
-
-                        return sanitized;
-                    }
-
-                    if (token.Type == JTokenType.String)
-                    {
-                        return Sanitizer.Sanitize(token.ToString());
-                    }
-
-                    return token;
-                }
-
-                JObject sanitizedObject = new JObject();
-                foreach (var propName in WellKnownHostJsonProperties)
-                {
-                    var propValue = hostJsonObject[propName];
-                    if (propValue != null)
-                    {
-                        sanitizedObject[propName] = Sanitize(propValue);
-                    }
-                }
-
-                return sanitizedObject.ToString();
             }
         }
     }

--- a/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
         public const string IdentifiableSecretLoaded = "host.secrets.identifiable";
         public const string HISStrictModeEnabled = "host.hismode.strict";
         public const string HISStrictModeWarn = "host.hismode.warn";
+        public const string SyncTriggersInvoked = "host.synctriggers.invoke";
+        public const string SyncTriggersHostNotInitialized = "host.synctriggers.hostnotinitialized";
 
         // Script host level events
         public const string ScriptHostManagerBuildScriptHost = "scripthostmanager.buildscripthost.latency";

--- a/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
@@ -93,9 +93,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             var defaultProvider = new FunctionMetadataProvider(NullLogger<FunctionMetadataProvider>.Instance, null, metadataProvider, new OptionsWrapper<FunctionsHostingConfigOptions>(new FunctionsHostingConfigOptions()), SystemEnvironment.Instance);
             var functionMetadataManager = TestFunctionMetadataManager.GetFunctionMetadataManager(new OptionsWrapper<ScriptJobHostOptions>(new ScriptJobHostOptions()), defaultProvider, null, new OptionsWrapper<HttpWorkerOptions>(new HttpWorkerOptions()), loggerFactory, new TestOptionsMonitor<LanguageWorkerOptions>(TestHelpers.GetTestLanguageWorkerOptions()));
 
+            var mockScriptHostManager = new Mock<IScriptHostManager>(MockBehavior.Strict);
+            var scriptHostManagerServiceProviderMock = mockScriptHostManager.As<IServiceProvider>();
+            scriptHostManagerServiceProviderMock.Setup(p => p.GetService(typeof(IHostOptionsProvider))).Returns(null);
+
             var emptyOptions = new JobHostInternalStorageOptions();
             var azureBlobStorageProvider = TestHelpers.GetAzureBlobStorageProvider(configurationMock.Object, storageOptions: emptyOptions);
-            var functionsSyncManager = new FunctionsSyncManager(hostIdProviderMock.Object, optionsMonitor, loggerFactory.CreateLogger<FunctionsSyncManager>(), httpClientFactory, secretManagerProviderMock.Object, mockWebHostEnvironment.Object, _mockEnvironment.Object, hostNameProvider, functionMetadataManager, azureBlobStorageProvider, hostingConfigOptionsWrapper);
+            var functionsSyncManager = new FunctionsSyncManager(hostIdProviderMock.Object, optionsMonitor, loggerFactory.CreateLogger<FunctionsSyncManager>(), httpClientFactory, secretManagerProviderMock.Object, mockWebHostEnvironment.Object, _mockEnvironment.Object, hostNameProvider, functionMetadataManager, azureBlobStorageProvider, hostingConfigOptionsWrapper, mockScriptHostManager.Object);
             _webFunctionsManager = new WebFunctionsManager(optionsMonitor, loggerFactory, httpClientFactory, secretManagerProviderMock.Object, functionsSyncManager, hostNameProvider, functionMetadataManager);
         }
 


### PR DESCRIPTION
Needed for Flex Consumption scaling. When there's an active host running during a sync triggers operation, we want to include host config info so it's persisted by the platform and accessible to other platform components like ScaleController.

Because the sync triggers payload will be different based on whether there's an active host or not, this means that the payload can oscillate from call to call.  Changes are being made in the FrontEnd to handle this and those changes must be complete before these host changes are active. The FE will correctly handle the presence/absence of the hostConfig portion of the payload by doing a merge operation with any existing sync value it has stored. 

Because the payload can oscillate based on presence of hostConfig, I was also thinking initially that for the background sync triggers hash check, we'd need to track 2 different hash values - one for an "active" sync where the hostConfig is present, and one for an "inactive" sync where hostConfig is not present. However, I don't think we need to make any changes there. A background sync is only ever done when there's an active host running (code [here](https://github.com/Azure/azure-functions-host/blob/937267a5d78b006456446be62ecb120d10c0208d/src/WebJobs.Script.WebHost/FunctionsSyncService.cs#L41)), so it should never (or very rarely in race condition cases) happen that we might make an extraneous call due to oscillation based on active/inactive host.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)