### PR TITLE
Logging function name from FunctionException

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/SystemLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/SystemLogger.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Indexers;
+using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.Eventing;
@@ -175,6 +176,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 if (string.IsNullOrEmpty(functionName) && exception is FunctionInvocationException fex)
                 {
                     functionName = string.IsNullOrEmpty(fex.MethodName) ? string.Empty : fex.MethodName.Replace("Host.Functions.", string.Empty);
+                }
+                else if (string.IsNullOrEmpty(functionName) && exception is FunctionListenerException flex)
+                {
+                    functionName = string.IsNullOrEmpty(flex.MethodName) ? string.Empty : Utility.GetFunctionShortName(flex.MethodName);
                 }
 
                 (innerExceptionType, innerExceptionMessage, details) = exception.GetExceptionDetails();

--- a/src/WebJobs.Script.WebHost/Diagnostics/SystemLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/SystemLogger.cs
@@ -173,13 +173,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             if (exception != null)
             {
                 // Populate details from the exception.
-                if (string.IsNullOrEmpty(functionName) && exception is FunctionInvocationException fex)
+                if (string.IsNullOrEmpty(functionName) && exception is FunctionException fex)
                 {
                     functionName = string.IsNullOrEmpty(fex.MethodName) ? string.Empty : fex.MethodName.Replace("Host.Functions.", string.Empty);
-                }
-                else if (string.IsNullOrEmpty(functionName) && exception is FunctionListenerException flex)
-                {
-                    functionName = string.IsNullOrEmpty(flex.MethodName) ? string.Empty : Utility.GetFunctionShortName(flex.MethodName);
                 }
 
                 (innerExceptionType, innerExceptionMessage, details) = exception.GetExceptionDetails();


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
This PR covers the scenario where as part of a listener start failure, FunctionListenerException is thrown. The function name is extracted from the exception, where WebJobs is setting the ShortName: https://github.com/Azure/azure-webjobs-sdk/blob/f1d6728283ce5a93f6f81858a9e1c81145742ad6/src/Microsoft.Azure.WebJobs.Host/Listeners/FunctionListener.cs#L73

resolves #5171

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

