### PR TITLE
Emit permanent app failure count after a couple retries

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -415,8 +415,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     logger.ErrorOccurredInactive(activeOperation.Id, exc);
                 }
 
-                _hostMetrics.AppFailure();
                 attemptCount++;
+
+                if (attemptCount > 3)
+                {
+                    _hostMetrics.AppFailure();
+                }
 
                 if (ShutdownHostIfUnhealthy())
                 {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Change based on discussion with @balag0; we want to have some way to avoid scaling down to 0 if there is a transient failure, so we will start to emit the permanent app failure count after 3 retries. If 3 is too low, we can increase this number to something more reasonable.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
