### PR TITLE
Updating JwtTokenAuth tests to use more specific filter conditions.

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/JwtTokenAuthTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/JwtTokenAuthTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
             var response = await _fixture.Host.HttpClient.SendAsync(request);
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
 
-            var validationError = _fixture.Host.GetScriptHostLogMessages().Single(p => p.Level == LogLevel.Debug);
+            var validationError = _fixture.Host.GetScriptHostLogMessages().Single(p => p.Category == ScriptConstants.LogCategoryHostAuthentication && p.Level == LogLevel.Debug);
             Assert.Equal(ScriptConstants.LogCategoryHostAuthentication, validationError.Category);
             Assert.Equal("Token audience validation failed for audience 'invalid'.", validationError.FormattedMessage);
             Assert.True(validationError.Exception.Message.StartsWith("IDX10231: Audience validation failed."));
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
             var response = await _fixture.Host.HttpClient.SendAsync(request);
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
 
-            var validationError = _fixture.Host.GetScriptHostLogMessages().Single(p => p.Level == LogLevel.Debug);
+            var validationError = _fixture.Host.GetScriptHostLogMessages().Single(p => p.Category == ScriptConstants.LogCategoryHostAuthentication && p.Level == LogLevel.Debug);
             Assert.Equal(ScriptConstants.LogCategoryHostAuthentication, validationError.Category);
             Assert.Equal("Token issuer validation failed for issuer 'invalid'.", validationError.FormattedMessage);
             Assert.Equal("IDX10205: Issuer validation failed.", validationError.Exception.Message);
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
             var response = await _fixture.Host.HttpClient.SendAsync(request);
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
 
-            var validationError = _fixture.Host.GetScriptHostLogMessages().Single(p => p.Level == LogLevel.Debug);
+            var validationError = _fixture.Host.GetScriptHostLogMessages().Single(p => p.Category == ScriptConstants.LogCategoryHostAuthentication && p.Level == LogLevel.Debug);
             Assert.Equal(ScriptConstants.LogCategoryHostAuthentication, validationError.Category);
             Assert.Equal("Token validation failed.", validationError.FormattedMessage);
             Assert.True(validationError.Exception.Message.StartsWith("IDX10503: Signature validation failed."));


### PR DESCRIPTION
Updating JwtTokenAuth tests to use more specific filter conditions when getting the log messages to assert.


### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

