### PR TITLE
Updating Microsoft.Azure.Functions.DotNetIsolatedNativeHost to 1.0.7

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,3 +7,7 @@
 - Update PowerShell worker 7.0 to 4.0.3148 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.3148)
 - Update PowerShell worker 7.2 to 4.0.3131 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.3131)
 - Update PowerShell worker 7.4 to 4.0.3147 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.3147)
+- Updated `Microsoft.Azure.Functions.DotNetIsolatedNativeHost` version to 1.0.7 (#9931)
+	- [Improvements to NetHost logging & worker.config](https://github.com/Azure/azure-functions-dotnet-worker/pull/2315)
+	- [Pre-launching a minimal .NET app during placeholder mode](https://github.com/Azure/azure-functions-dotnet-worker/pull/2324)
+

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.21.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.6" />
+    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.7" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.39" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.0-beta.2-11957" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.0" />

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
@@ -19,6 +19,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
+using Moq;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
 {
@@ -30,7 +31,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
         {
             string scriptPath = Path.Combine(Environment.CurrentDirectory, scriptRoot);
             string logPath = Path.Combine(Path.GetTempPath(), @"Functions");
-            Environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, testId);
+
+            var environmentMock = new Mock<IEnvironment>();
+            environmentMock.Setup(e => e.GetEnvironmentVariable(EnvironmentSettingNames.InitializedFromPlaceholder)).Returns(bool.TrueString);
+            environmentMock.Setup(e=> e.GetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime)).Returns(testId);
 
             WebHostOptions = new ScriptApplicationHostOptions
             {
@@ -67,6 +71,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
                     {
                         s.AddSingleton<IRpcWorkerChannelFactory, TestGrpcWorkerChannelFactory>();
                     }
+                    s.AddSingleton<IEnvironment>(environmentMock.Object);
                 });
 
             HttpClient = TestHost.HttpClient;

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 { EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1" },
                 { EnvironmentSettingNames.AzureWebsiteContainerReady, null },
+                { EnvironmentSettingNames.InitializedFromPlaceholder, bool.TrueString },
              };
 
             _environment = new TestEnvironment(settings);

--- a/test/WebJobs.Script.Tests/Configuration/LanguageWorkerOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/LanguageWorkerOptionsSetupTests.cs
@@ -25,14 +25,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             var configurationBuilder = new ConfigurationBuilder()
                 .Add(new ScriptEnvironmentVariablesConfigurationSource());
             var configuration = configurationBuilder.Build();
-            var testProfileManager = new Mock<IWorkerProfileManager>();
+            var workerProfileLogger = new TestLogger<Script.Workers.WorkerProfileManager>();
+            var workerProfileManager = new Script.Workers.WorkerProfileManager(workerProfileLogger, testEnvironment);
 
             if (!string.IsNullOrEmpty(workerRuntime))
             {
                 testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, workerRuntime);
             }
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.InitializedFromPlaceholder, bool.TrueString);
 
-            LanguageWorkerOptionsSetup setup = new LanguageWorkerOptionsSetup(configuration, NullLoggerFactory.Instance, testEnvironment, testMetricLogger, testProfileManager.Object);
+            LanguageWorkerOptionsSetup setup = new LanguageWorkerOptionsSetup(configuration, NullLoggerFactory.Instance, testEnvironment, testMetricLogger, workerProfileManager);
             LanguageWorkerOptions options = new LanguageWorkerOptions();
 
             setup.Configure(options);

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -1657,7 +1657,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 var metricsLogger = new TestMetricsLogger();
                 var environment = new TestEnvironment();
                 environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, functionsWorkerRuntime);
-
+                environment.SetEnvironmentVariable(EnvironmentSettingNames.InitializedFromPlaceholder, bool.TrueString);
                 FileUtility.Instance = CreateFileSystem(rootPath);
 
                 TaskCompletionSource<bool> processCreated = new();

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
@@ -124,6 +124,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var config = configBuilder.Build();
             var scriptSettingsManager = new ScriptSettingsManager(config);
             var testLogger = new TestLogger("test");
+            _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.InitializedFromPlaceholder, bool.TrueString);
             using (var variables = new TestScopedSettings(scriptSettingsManager, testEnvVariables))
             {
                 var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger(), _testWorkerProfileManager);


### PR DESCRIPTION
Updating Microsoft.Azure.Functions.DotNetIsolatedNativeHost to 1.0.7.

This version includes the below change(s):.
 * https://github.com/Azure/azure-functions-dotnet-worker/pull/2315
 * https://github.com/Azure/azure-functions-dotnet-worker/pull/2324

Changes were validated on both Linux and windows.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)
