### PR TITLE
Updating Microsoft.Azure.Functions.DotNetIsolatedNativeHost to 1.0.8.

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,3 +7,8 @@
 - Update PowerShell worker 7.0 to 4.0.3148 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.3148)
 - Update PowerShell worker 7.2 to 4.0.3131 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.3131)
 - Update PowerShell worker 7.4 to 4.0.3147 [Release Note](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.3147)
+- Updated `Microsoft.Azure.Functions.DotNetIsolatedNativeHost` version to 1.0.8 (#9936)
+	- [Improvements to NetHost logging & worker.config](https://github.com/Azure/azure-functions-dotnet-worker/pull/2315)
+	- [Pre-launching a minimal .NET app during placeholder mode](https://github.com/Azure/azure-functions-dotnet-worker/pull/2324)
+	- [Reverting the worker.config change made in #2315 (checking for INITIALIZED_FROM_PLACEHOLDER environment variable)](https://github.com/Azure/azure-functions-dotnet-worker/pull/2351)
+

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.21.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.6" />
+    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.8" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.39" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.0-beta.2-11957" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.0" />


### PR DESCRIPTION
Updating Microsoft.Azure.Functions.DotNetIsolatedNativeHost to 1.0.8, from 1.0.6.

This version includes the below change(s):.
 * https://github.com/Azure/azure-functions-dotnet-worker/pull/2315
 * https://github.com/Azure/azure-functions-dotnet-worker/pull/2324
 * https://github.com/Azure/azure-functions-dotnet-worker/pull/2351

1.0.7 was used for the PR I previously created (https://github.com/Azure/azure-functions-host/pull/9931) and later abandoned (after running into issues which lead to the creation of #9932 )

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)
