### PR TITLE
Update host metrics to get function target group after specialization

### DIFF
--- a/src/WebJobs.Script/Metrics/HostMetrics.cs
+++ b/src/WebJobs.Script/Metrics/HostMetrics.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 

--- a/src/WebJobs.Script/Metrics/HostMetrics.cs
+++ b/src/WebJobs.Script/Metrics/HostMetrics.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Azure.WebJobs.Script.Metrics
 {
     public class HostMetrics : IHostMetrics
     {
+        private readonly IEnvironment _environment;
+
         public const string MeterName = "Microsoft.Azure.WebJobs.Script.Host.Internal";
         public const string CloudPlatformName = "azure_functions";
         public const string AppFailureCount = "azure.functions.app_failures";
@@ -18,6 +20,8 @@ namespace Microsoft.Azure.WebJobs.Script.Metrics
         private Counter<long> _appFailureCount;
         private Counter<long> _startedInvocationCount;
 
+        private KeyValuePair<string, object>? _cachedFunctionGroupTag = null;
+
         public HostMetrics(IMeterFactory meterFactory, IEnvironment environment)
         {
             if (meterFactory == null)
@@ -25,17 +29,13 @@ namespace Microsoft.Azure.WebJobs.Script.Metrics
                 throw new ArgumentNullException(nameof(meterFactory));
             }
 
-            if (environment == null)
-            {
-                throw new ArgumentNullException(nameof(environment));
-            }
+            _environment = environment ?? throw new ArgumentNullException(nameof(environment));
 
+            var instanceId = environment.GetInstanceId();
             var cloudName = environment.GetEnvironmentVariableOrDefault(EnvironmentSettingNames.CloudName, string.Empty);
             var region = environment.GetEnvironmentVariableOrDefault(EnvironmentSettingNames.RegionName, string.Empty);
             var armResourceId = environment.GetEnvironmentVariableOrDefault(EnvironmentSettingNames.WebsiteArmResourceId, string.Empty);
-            var instanceId = environment.GetInstanceId();
             var appName = environment.GetEnvironmentVariableOrDefault(EnvironmentSettingNames.AzureWebsiteName, string.Empty);
-            var functionGroup = environment.GetEnvironmentVariableOrDefault(EnvironmentSettingNames.FunctionsTargetGroup, string.Empty);
 
             var hostMeterOptions = new MeterOptions(MeterName)
             {
@@ -47,8 +47,7 @@ namespace Microsoft.Azure.WebJobs.Script.Metrics
                     { TelemetryAttributes.CloudRegion, region },
                     { TelemetryAttributes.CloudResourceId, armResourceId },
                     { TelemetryAttributes.ServiceInstanceId, instanceId },
-                    { TelemetryAttributes.ServiceName, appName },
-                    { TelemetryAttributes.AzureFunctionsGroup, functionGroup }
+                    { TelemetryAttributes.ServiceName, appName }
                 }
             };
             var meter = meterFactory.Create(hostMeterOptions);
@@ -57,8 +56,34 @@ namespace Microsoft.Azure.WebJobs.Script.Metrics
             _startedInvocationCount = meter.CreateCounter<long>(StartedInvocationCount, "numeric", "Number of function invocations that have started.");
         }
 
-        public void AppFailure() => _appFailureCount.Add(1);
+        private KeyValuePair<string, object> FunctionGroupTag
+        {
+            get
+            {
+                if (_cachedFunctionGroupTag != null)
+                {
+                    return _cachedFunctionGroupTag.Value;
+                }
 
-        public void IncrementStartedInvocationCount() => _startedInvocationCount.Add(1);
+                var functionGroup = _environment.GetEnvironmentVariableOrDefault(EnvironmentSettingNames.FunctionsTargetGroup, string.Empty);
+                var functionGroupTag = new KeyValuePair<string, object>(TelemetryAttributes.AzureFunctionsGroup, functionGroup);
+
+                if (!string.IsNullOrEmpty(functionGroup))
+                {
+                    _cachedFunctionGroupTag = functionGroupTag;
+                }
+
+                return functionGroupTag;
+            }
+
+            set
+            {
+                _cachedFunctionGroupTag = value;
+            }
+        }
+
+        public void AppFailure() => _appFailureCount.Add(1, FunctionGroupTag);
+
+        public void IncrementStartedInvocationCount() => _startedInvocationCount.Add(1, FunctionGroupTag);
     }
 }

--- a/src/WebJobs.Script/Metrics/HostMetrics.cs
+++ b/src/WebJobs.Script/Metrics/HostMetrics.cs
@@ -5,12 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.Metrics
 {
     public class HostMetrics : IHostMetrics
     {
         private readonly IEnvironment _environment;
+        private readonly ILogger _logger;
 
         public const string MeterName = "Microsoft.Azure.WebJobs.Script.Host.Internal";
         public const string CloudPlatformName = "azure_functions";
@@ -23,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Script.Metrics
 
         private KeyValuePair<string, object>? _cachedFunctionGroupTag = null;
 
-        public HostMetrics(IMeterFactory meterFactory, IEnvironment environment)
+        public HostMetrics(IMeterFactory meterFactory, IEnvironment environment, ILogger<HostMetrics> logger)
         {
             if (meterFactory == null)
             {
@@ -31,6 +33,7 @@ namespace Microsoft.Azure.WebJobs.Script.Metrics
             }
 
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
             var instanceId = environment.GetInstanceId();
             var cloudName = environment.GetEnvironmentVariableOrDefault(EnvironmentSettingNames.CloudName, string.Empty);
@@ -72,6 +75,10 @@ namespace Microsoft.Azure.WebJobs.Script.Metrics
                 if (!string.IsNullOrEmpty(functionGroup))
                 {
                     _cachedFunctionGroupTag = functionGroupTag;
+                }
+                else
+                {
+                    _logger.LogDebug("Unable to resolve {tagName}, {funcGroup} is null or empty.", nameof(FunctionGroupTag), EnvironmentSettingNames.FunctionsTargetGroup);
                 }
 
                 return functionGroupTag;

--- a/test/WebJobs.Script.Tests/Metrics/FlexConsumptionMetricsPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/FlexConsumptionMetricsPublisherTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             _logger = new TestLogger<FlexConsumptionMetricsPublisher>();
             var serviceProvider = new Mock<IServiceProvider>();
             var hostMetricsLogger = new TestLogger<HostMetricsProvider>();
-            _metricsProvider = new HostMetricsProvider(serviceProvider.Object, _standbyOptionsMonitor, hostMetricsLogger);
+            _metricsProvider = new HostMetricsProvider(serviceProvider.Object, _standbyOptionsMonitor, hostMetricsLogger, _environment);
             var publisher = new FlexConsumptionMetricsPublisher(_environment, _standbyOptionsMonitor, optionsWrapper, _logger, new FileSystem(), _metricsProvider);
 
             return publisher;

--- a/test/WebJobs.Script.Tests/Metrics/HostMetricsProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/HostMetricsProviderTests.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddMetrics();
+            serviceCollection.AddFakeLogging();
             serviceCollection.AddSingleton<IEnvironment>(new TestEnvironment());
             serviceCollection.AddSingleton<IHostMetrics, HostMetrics>();
 

--- a/test/WebJobs.Script.Tests/Metrics/HostMetricsTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/HostMetricsTests.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddMetrics();
+            serviceCollection.AddFakeLogging();
             serviceCollection.AddSingleton<IEnvironment>(new TestEnvironment());
             serviceCollection.AddSingleton<IHostMetrics, HostMetrics>();
             _serviceProvider = serviceCollection.BuildServiceProvider();


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Bug found where the FunctionGroup being emitted by metrics is empty. This is because the FUNCTIONS_TARGET_GROUP environment variable is only set after specialization. The changes in this PR are two parts:

1. Within HostMetrics, instead of making FunctionGroup a global tag, it is now a tag added to each metric. The reason for this is that we cannot update a tag list once the meter is created. The only other alternative here is to have HostMetrics.cs listen for specialization which would require moving this class to the WebHost project amongst other changes - this doesn't feel right to me but I am open to feedback on it.

2. Within the HostMetricsProducer, instead of getting the FunctionGroup value from the meter tag list (which is created pre-specialization), we now just get this value directly from the environment. The producer is initialized after specialization so this ensures we have the updated post-specialization value for the function group. Eventually we will remove the producer in favour of using an OTel exporter, so I think this is the best change for now.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
