### PR TITLE
Updating FlexConsumption minimum metrics interval handling

### DIFF
--- a/src/WebJobs.Script.WebHost/Configuration/FlexConsumptionMetricsPublisherOptions.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/FlexConsumptionMetricsPublisherOptions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
     public class FlexConsumptionMetricsPublisherOptions
     {
         internal const int DefaultMetricsPublishIntervalMS = 5000;
-        internal const int DefaultMinimumActivityIntervalMS = 100;
+        internal const int DefaultMinimumActivityIntervalMS = 1000;
 
         public FlexConsumptionMetricsPublisherOptions()
         {

--- a/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/MetricsEventManager.cs
@@ -451,7 +451,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             }
 
             /// <summary>
-            /// Raise events for all current in progress functions
+            /// Raise events for all current in progress functions.
             /// </summary>
             private void RaiseFunctionMetricEvents()
             {


### PR DESCRIPTION
Based on discussions, we want to adjust the minimum activity interval. Also fixing how intervals are accumulated, ensuring that the accumulated duration for a metering interval is always less than the total interval. 

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
