### PR TITLE
Flex placeholder fix - always treat flex as zip deployment

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <MajorVersion>4</MajorVersion>    
-    <MinorVersion>1031</MinorVersion>
+    <MinorVersion>1033</MinorVersion>
     <PatchVersion>2</PatchVersion>
     <BuildNumber Condition="'$(BuildNumber)' == '' ">0</BuildNumber>
     <PreviewVersion></PreviewVersion>

--- a/src/WebJobs.Script.WebHost/Configuration/ScriptApplicationHostOptionsSetup.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/ScriptApplicationHostOptionsSetup.cs
@@ -71,6 +71,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
 
         private bool IsZipDeployment(out bool isScmRunFromPackage)
         {
+            // Flex consumption does not support mutable filesystems, and therefore always counts as zip deployment. It does not use scmRunFromPackage.
+            // TODO: revisit whether this flex consumption path should return false when in placeholder mode? Thats how it appears to work for other SKUs.
+            if (_environment.IsFlexConsumptionSku())
+            {
+                isScmRunFromPackage = false;
+                return true;
+            }
+
             // Check app settings for run from package.
             bool runFromPkgConfigured = Utility.IsValidZipSetting(_environment.GetEnvironmentVariable(AzureWebsiteZipDeployment)) ||
                 Utility.IsValidZipSetting(_environment.GetEnvironmentVariable(AzureWebsiteAltZipDeployment)) ||

--- a/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
                 if (!isReadOnlyAndNoCompat)
                 {
-                    _logger.LogInformation("App will not use placeholder channel - ReadOnly: {isReadOnly}. NoCompat: {noCompat}.", _applicationHostOptions.CurrentValue.IsFileSystemReadOnly, !_environment.IsV2CompatibleOnV3Extension());
+                    _logger.LogDebug("App will not use placeholder channel - ReadOnly: {isReadOnly}. NoCompat: {noCompat}.", _applicationHostOptions.CurrentValue.IsFileSystemReadOnly, !_environment.IsV2CompatibleOnV3Extension());
                 }
 
                 return isReadOnlyAndNoCompat;

--- a/test/WebJobs.Script.Tests/Configuration/ScriptApplicationHostOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ScriptApplicationHostOptionsSetupTests.cs
@@ -101,6 +101,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             Assert.Equal(options.IsFileSystemReadOnly, expectedOutcome);
         }
 
+        [Fact]
+        public void IsFileSystemReadOnly_AlwaysAppliesForFlex()
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, ScriptConstants.FlexConsumptionSku);
+
+            ScriptApplicationHostOptions options = new ScriptApplicationHostOptions();
+            ConfiguredOptions(options, inStandbyMode: false, environment);
+
+            Assert.Equal(options.IsFileSystemReadOnly, true);
+        }
+
         private void ConfiguredOptions(ScriptApplicationHostOptions options, bool inStandbyMode, IEnvironment environment = null, bool blobExists = false)
         {
             var builder = new ConfigurationBuilder();


### PR DESCRIPTION
Recent changes in the flex deployment codepath have removed the use of the SCM_RUN_FROM_PACKAGE setting. This causes the host to go down a codepath where it thinks the app content is mutable and avoid using the language worker placeholder. This impact cold start because it has to start a new language worker from scratch.

The fix takes advantage of the fact that app content is always readonly in the context of flex. 

I included a small logging improvement that should help us understand when we are specifically failing to use the placeholder channel for this reason.