### PR TITLE
Avoid using HttpRequest from log scope

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/SystemLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/SystemLogger.cs
@@ -146,10 +146,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
                 // For Http function invocations we want to stamp invocation logs with
                 // the request ID for easy correlation with incoming Http request logs.
-                if (scopeProps.TryGetValue(ScriptConstants.LoggerHttpRequest, out scopeValue))
+                if (scopeProps.TryGetValue(ScriptConstants.AzureFunctionsRequestIdKey, out scopeValue))
                 {
-                    var httpRequest = (HttpRequest)scopeValue;
-                    scopeActivityId = httpRequest.GetRequestId();
+                    scopeActivityId = scopeValue as string;
                 }
             }
 

--- a/src/WebJobs.Script.WebHost/Middleware/FunctionInvocationMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/FunctionInvocationMiddleware.cs
@@ -136,6 +136,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
                 var scopeState = new Dictionary<string, object>()
                 {
                     [ScriptConstants.LoggerHttpRequest] = context.Request,
+                    [ScriptConstants.AzureFunctionsRequestIdKey] = context.Request.GetRequestId(),
                 };
 
                 using (logger.BeginScope(scopeState))

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using NuGet.Versioning;
 
@@ -46,6 +47,10 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string TraceSourceHttpHandler = "HttpRequestTraceHandler";
         public const string TraceSourceHttpThrottleMiddleware = "HttpThrottleMiddleware";
 
+        // We have been using this to insert the full HttpRequest into the logger scope. This is not a good practice
+        // as it will worsen any execution context leaks. If logger scope is leaked, now HTTP request will be leaked as well.
+        // We will not remove it from the logger scope just yet, but we will remove all of our own usage of it.
+        [Obsolete("Do not access the HTTP request from the logger scope, this will be removed in a future version.")]
         public const string LoggerHttpRequest = "MS_HttpRequest";
 
         public const string LogCategoryHostController = "Host.Controllers.Host";


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR -- will cherry-pick after this PR is complete.
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Fix potential `ObjectDisposedException` when logging due to scope capturing `HttpRequest` (and the logger scope being captured & used after HTTP request finishes).
