### PR TITLE
Do not assign permissions when file does not exist

### DIFF
--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcess.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcess.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
@@ -324,6 +325,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
                 }
 
                 string filePath = p.StartInfo.FileName;
+                if (!File.Exists(filePath))
+                {
+                    _workerProcessLogger.LogDebug("File path does not exist, not assigning permissions: {filePath}", filePath);
+                    return;
+                }
+
                 UnixFileInfo fileInfo = new UnixFileInfo(filePath);
                 if (!fileInfo.FileAccessPermissions.HasFlag(FileAccessPermissions.UserExecute))
                 {

--- a/test/WebJobs.Script.Tests/Workers/Http/HttpWorkerProcessTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Http/HttpWorkerProcessTests.cs
@@ -101,6 +101,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
         [Fact]
         public async Task StartProcess_LinuxConsumption_TriesToAssignExecutePermissions_NotExists()
         {
+            File.Delete(_executablePath);
             TestEnvironment testEnvironment = new TestEnvironment();
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "TestContainer");
             var mockHttpWorkerProcess = new HttpWorkerProcess(_testWorkerId, _rootScriptPath, _httpWorkerOptions, _mockEventManager.Object, _defaultWorkerProcessFactory, _processRegistry, _testLogger, _languageWorkerConsoleLogSource.Object, testEnvironment, new TestMetricsLogger(), _serviceProviderMock.Object, new LoggerFactory());

--- a/test/WebJobs.Script.Tests/Workers/Http/HttpWorkerProcessTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Http/HttpWorkerProcessTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Eventing;
@@ -19,6 +20,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
         private const string _testWorkerId = "testId";
         private const string _rootScriptPath = "c:\\testDir";
         private const int _workerPort = 8090;
+
+        private readonly string _executablePath = System.IO.Path.GetTempFileName();
         private readonly ScriptSettingsManager _settingsManager;
         private readonly Mock<IScriptEventManager> _mockEventManager = new Mock<IScriptEventManager>();
         private readonly IWorkerProcessFactory _defaultWorkerProcessFactory = new DefaultWorkerProcessFactory(new TestEnvironment(), new LoggerFactory());
@@ -33,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
             _httpWorkerOptions = new HttpWorkerOptions()
             {
                 Port = _workerPort,
-                Arguments = new WorkerProcessArguments() { ExecutablePath = "test" },
+                Arguments = new WorkerProcessArguments() { ExecutablePath = _executablePath },
                 Description = new HttpWorkerDescription()
                 {
                     WorkingDirectory = @"c:\testDir"
@@ -67,7 +70,36 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
         }
 
         [Fact]
-        public async Task StartProcess_LinuxConsumption_TriesToAssignExecutePermissions()
+        public async Task StartProcess_LinuxConsumption_TriesToAssignExecutePermissions_Exists()
+        {
+            try
+            {
+                File.Create(_executablePath).Dispose();
+                TestEnvironment testEnvironment = new TestEnvironment();
+                testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "TestContainer");
+                var mockHttpWorkerProcess = new HttpWorkerProcess(_testWorkerId, _rootScriptPath, _httpWorkerOptions, _mockEventManager.Object, _defaultWorkerProcessFactory, _processRegistry, _testLogger, _languageWorkerConsoleLogSource.Object, testEnvironment, new TestMetricsLogger(), _serviceProviderMock.Object, new LoggerFactory());
+
+                try
+                {
+                    await mockHttpWorkerProcess.StartProcessAsync();
+                }
+                catch
+                {
+                    // expected to throw. Just verifying a log statement occurred before then.
+                }
+
+                // Verify method invocation
+                var testLogs = _testLogger.GetLogMessages();
+                Assert.Contains("Error while assigning execute permission", testLogs[0].FormattedMessage);
+            }
+            finally
+            {
+                File.Delete(_executablePath);
+            }
+        }
+
+        [Fact]
+        public async Task StartProcess_LinuxConsumption_TriesToAssignExecutePermissions_NotExists()
         {
             TestEnvironment testEnvironment = new TestEnvironment();
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "TestContainer");
@@ -79,12 +111,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
             }
             catch
             {
-                // expected to throw. Just verifying a log statement occured before then.
+                // expected to throw. Just verifying a log statement occurred before then.
             }
 
             // Verify method invocation
             var testLogs = _testLogger.GetLogMessages();
-            Assert.Contains("Error while assigning execute permission", testLogs[0].FormattedMessage);
+            Assert.Contains("File path does not exist, not assigning permissions", testLogs[0].FormattedMessage);
         }
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Avoids polluting logs with warning messages when the process path does not exist.
