### PR TITLE
Ensuring non http invocation responses are not processed by IHttpProxyService

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <MajorVersion>4</MajorVersion>    
     <MinorVersion>1033</MinorVersion>
-    <PatchVersion>4</PatchVersion>
+    <PatchVersion>5</PatchVersion>
     <BuildNumber Condition="'$(BuildNumber)' == '' ">0</BuildNumber>
     <PreviewVersion></PreviewVersion>
     

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,4 +3,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-- Adjust Metrics Granularity for On-Demand (#9976)
+- Fixed a bug where non HTTP invocation responses were processed by `IHttpProxyService` when HTTP proxying capability is enabled (#9984)

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -1100,7 +1100,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
                 try
                 {
-                    if (IsHttpProxyingWorker)
+                    if (IsHttpProxyingWorker && context.FunctionMetadata.IsHttpTriggerFunction())
                     {
                         await _httpProxyService.EnsureSuccessfulForwardingAsync(context);
                     }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -1397,6 +1397,36 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
+        public async Task EnsureSuccessfulForwardingAsync_Is_Invoked_OnlyForHttpInvocationResponses()
+        {
+            await CreateDefaultWorkerChannel(capabilities: new Dictionary<string, string>() { { RpcWorkerConstants.HttpUri, "http://localhost:1234" } });
+
+            var httpInvocationId = Guid.NewGuid();
+            ScriptInvocationContext httpInvocationContext = GetTestScriptInvocationContext(httpInvocationId, new TaskCompletionSource<ScriptInvocationResult>(), logger: _logger);
+            httpInvocationContext.FunctionMetadata = BuildFunctionMetadataForHttpTrigger("httpTrigger");
+            await _workerChannel.SendInvocationRequest(httpInvocationContext);
+
+            var timerInvocationId = Guid.NewGuid();
+            ScriptInvocationContext timerInvocationContext = GetTestScriptInvocationContext(timerInvocationId, new TaskCompletionSource<ScriptInvocationResult>(), logger: _logger);
+            timerInvocationContext.FunctionMetadata = BuildFunctionMetadataForTimerTrigger("timerTrigger");
+
+            // Send http trigger and timer trigger invocation invocation requests.
+            await _workerChannel.SendInvocationRequest(httpInvocationContext);
+            await _workerChannel.SendInvocationRequest(timerInvocationContext);
+
+            // Send http trigger and timer trigger invocation responses.
+            await _workerChannel.InvokeResponse(BuildISuccessfulnvocationResponse(timerInvocationId.ToString()));
+            await _workerChannel.InvokeResponse(BuildISuccessfulnvocationResponse(httpInvocationId.ToString()));
+
+            LogMessage[] logs = _logger.GetLogMessages().ToArray();
+            Assert.True(logs.Count(m => m.FormattedMessage.Contains($"InvocationResponse received for invocation: '{timerInvocationId}'")) == 1);
+            Assert.True(logs.Count(m => m.FormattedMessage.Contains($"InvocationResponse received for invocation: '{httpInvocationId}'")) == 1);
+
+            // IHttpProxyService.EnsureSuccessfulForwardingAsync method should be invoked only for http invocation response.
+            _mockHttpProxyService.Verify(m => m.EnsureSuccessfulForwardingAsync(It.IsAny<ScriptInvocationContext>()), Times.Once);
+        }
+
+        [Fact]
         public async Task Log_And_InvocationResult_OrderedCorrectly()
         {
             // Without this feature flag, this test fails every time on multi-core machines as the logs will
@@ -1573,6 +1603,50 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             // Send worker init request and enable the capabilities
             return CreateDefaultWorkerChannel(capabilities: capabilities);
+        }
+
+        private static InvocationResponse BuildISuccessfulnvocationResponse(string invocationId)
+        {
+            return new InvocationResponse
+            {
+                InvocationId = invocationId,
+                Result = new StatusResult
+                {
+                    Status = StatusResult.Types.Status.Success
+                },
+            };
+        }
+
+        private static FunctionMetadata BuildFunctionMetadataForHttpTrigger(string name, string language = null)
+        {
+            var functionMetadata = new FunctionMetadata() { Name = name, Language = language };
+            functionMetadata.Bindings.Add(new BindingMetadata()
+            {
+                Type = "httpTrigger",
+                Direction = BindingDirection.In,
+                Name = "req"
+            });
+            functionMetadata.Bindings.Add(new BindingMetadata()
+            {
+                Type = "http",
+                Direction = BindingDirection.Out,
+                Name = "$return"
+            });
+
+            return functionMetadata;
+        }
+
+        private static FunctionMetadata BuildFunctionMetadataForTimerTrigger(string name, string language = null)
+        {
+            var functionMetadata = new FunctionMetadata() { Name = name, Language = language };
+            functionMetadata.Bindings.Add(new BindingMetadata()
+            {
+                Type = "timerTrigger",
+                Direction = BindingDirection.In,
+                Name = "myTimer"
+            });
+
+            return functionMetadata;
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -1415,8 +1415,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             await _workerChannel.SendInvocationRequest(timerInvocationContext);
 
             // Send http trigger and timer trigger invocation responses.
-            await _workerChannel.InvokeResponse(BuildISuccessfulnvocationResponse(timerInvocationId.ToString()));
-            await _workerChannel.InvokeResponse(BuildISuccessfulnvocationResponse(httpInvocationId.ToString()));
+            await _workerChannel.InvokeResponse(BuildSuccessfulInvocationResponse(timerInvocationId.ToString()));
+            await _workerChannel.InvokeResponse(BuildSuccessfulInvocationResponse(httpInvocationId.ToString()));
 
             LogMessage[] logs = _logger.GetLogMessages().ToArray();
             Assert.True(logs.Count(m => m.FormattedMessage.Contains($"InvocationResponse received for invocation: '{timerInvocationId}'")) == 1);
@@ -1605,7 +1605,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             return CreateDefaultWorkerChannel(capabilities: capabilities);
         }
 
-        private static InvocationResponse BuildISuccessfulnvocationResponse(string invocationId)
+        private static InvocationResponse BuildSuccessfulInvocationResponse(string invocationId)
         {
             return new InvocationResponse
             {

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -1397,14 +1397,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
-        public async Task EnsureSuccessfulForwardingAsync_Is_Invoked_OnlyForHttpInvocationResponses()
+        public async Task Ensure_SuccessfulForwardingAsync_Is_Invoked_OnlyFor_HttpInvocationResponses()
         {
             await CreateDefaultWorkerChannel(capabilities: new Dictionary<string, string>() { { RpcWorkerConstants.HttpUri, "http://localhost:1234" } });
 
             var httpInvocationId = Guid.NewGuid();
             ScriptInvocationContext httpInvocationContext = GetTestScriptInvocationContext(httpInvocationId, new TaskCompletionSource<ScriptInvocationResult>(), logger: _logger);
             httpInvocationContext.FunctionMetadata = BuildFunctionMetadataForHttpTrigger("httpTrigger");
-            await _workerChannel.SendInvocationRequest(httpInvocationContext);
 
             var timerInvocationId = Guid.NewGuid();
             ScriptInvocationContext timerInvocationContext = GetTestScriptInvocationContext(timerInvocationId, new TaskCompletionSource<ScriptInvocationResult>(), logger: _logger);
@@ -1418,9 +1417,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             await _workerChannel.InvokeResponse(BuildISuccessfulnvocationResponse(timerInvocationId.ToString()));
             await _workerChannel.InvokeResponse(BuildISuccessfulnvocationResponse(httpInvocationId.ToString()));
 
-            LogMessage[] logs = _logger.GetLogMessages().ToArray();
-            Assert.True(logs.Count(m => m.FormattedMessage.Contains($"InvocationResponse received for invocation: '{timerInvocationId}'")) == 1);
-            Assert.True(logs.Count(m => m.FormattedMessage.Contains($"InvocationResponse received for invocation: '{httpInvocationId}'")) == 1);
+            var logs = _logger.GetLogMessages().ToArray();
+            Assert.Single(logs.Where(m => m.FormattedMessage.Contains($"InvocationResponse received for invocation: '{timerInvocationId}'")));
+            Assert.Single(logs.Where(m => m.FormattedMessage.Contains($"InvocationResponse received for invocation: '{httpInvocationId}'")));
 
             // IHttpProxyService.EnsureSuccessfulForwardingAsync method should be invoked only for http invocation response.
             _mockHttpProxyService.Verify(m => m.EnsureSuccessfulForwardingAsync(It.IsAny<ScriptInvocationContext>()), Times.Once);


### PR DESCRIPTION
Fixed a bug where non-HTTP invocation responses were processed by `IHttpProxyService` when HTTP proxying capability is enabled.  The bug caused non http invocation responses to throw "**_System.InvalidOperationException : The function invocation context is missing the forwarding task property_**" exception, when HTTP proxying is enabled.

Also bumped version as we will create a new tag for flex.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.
No need to backport this change as the relevant change which caused the issue is not in in-proc branch. This happens only in oop worker code path.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)


