### PR TITLE
Special case EventGrid sourced blob triggers for grouping

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <MajorVersion>4</MajorVersion>    
     <MinorVersion>1033</MinorVersion>
-    <PatchVersion>5</PatchVersion>
+    <PatchVersion>6</PatchVersion>
     <BuildNumber Condition="'$(BuildNumber)' == '' ">0</BuildNumber>
     <PreviewVersion></PreviewVersion>
     

--- a/src/WebJobs.Script/Description/FunctionGroupListenerDecorator.cs
+++ b/src/WebJobs.Script/Description/FunctionGroupListenerDecorator.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
 
             string group = functionMetadata.GetFunctionGroup() ?? functionName;
-            if (IsFunctionTriggerMatch(targetGroup, group))
+            if (FunctionGroups.IsEnabled(targetGroup, group))
             {
                 _logger.LogDebug("Enabling function {functionName}", functionName);
                 return context.Listener;
@@ -59,26 +59,6 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             // By giving a no-op listener, we will prevent it from triggering without 'disabling' it.
             _logger.LogDebug("Function {functionName} is not part of group {functionGroup}. Listener will not be enabled.", functionName, targetGroup);
             return new NoOpListener(context.Listener);
-        }
-
-        private static bool IsFunctionTriggerMatch(string targetGroup, string triggerGroup)
-        {
-            if (string.Equals(targetGroup, triggerGroup, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            if (string.Equals(targetGroup, "http", StringComparison.OrdinalIgnoreCase)
-                && string.Equals(triggerGroup, "blob", StringComparison.OrdinalIgnoreCase))
-            {
-                // The blob group needs to be special cased as it is a two step process:
-                // 1. WebHook which enqueues a message to Azure Storage Queue.
-                // 2. Azure Storage Queue trigger which processes the message.
-                // So we need to run in both http and blob groups.
-                return true;
-            }
-
-            return false;
         }
 
         private class NoOpListener : IListener

--- a/src/WebJobs.Script/Description/FunctionGroupListenerDecorator.cs
+++ b/src/WebJobs.Script/Description/FunctionGroupListenerDecorator.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             }
 
             string group = functionMetadata.GetFunctionGroup() ?? functionName;
-            if (string.Equals(targetGroup, group, StringComparison.OrdinalIgnoreCase))
+            if (IsFunctionTriggerMatch(targetGroup, group))
             {
                 _logger.LogDebug("Enabling function {functionName}", functionName);
                 return context.Listener;
@@ -59,6 +59,26 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             // By giving a no-op listener, we will prevent it from triggering without 'disabling' it.
             _logger.LogDebug("Function {functionName} is not part of group {functionGroup}. Listener will not be enabled.", functionName, targetGroup);
             return new NoOpListener(context.Listener);
+        }
+
+        private static bool IsFunctionTriggerMatch(string targetGroup, string triggerGroup)
+        {
+            if (string.Equals(targetGroup, triggerGroup, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (string.Equals(targetGroup, "http", StringComparison.OrdinalIgnoreCase)
+                && string.Equals(triggerGroup, "blob", StringComparison.OrdinalIgnoreCase))
+            {
+                // The blob group needs to be special cased as it is a two step process:
+                // 1. WebHook which enqueues a message to Azure Storage Queue.
+                // 2. Azure Storage Queue trigger which processes the message.
+                // So we need to run in both http and blob groups.
+                return true;
+            }
+
+            return false;
         }
 
         private class NoOpListener : IListener

--- a/src/WebJobs.Script/Description/FunctionGroups.cs
+++ b/src/WebJobs.Script/Description/FunctionGroups.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Script.Description
+{
+    public static class FunctionGroups
+    {
+        public const string Http = "http";
+        public const string Durable = "durable";
+        public const string Blob = "blob";
+
+        public static string ForFunction(string function)
+        {
+            return $"function:{function}";
+        }
+
+        public static bool IsEnabled(string targetGroup, string triggerGroup)
+        {
+            if (string.Equals(targetGroup, triggerGroup, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (string.Equals(targetGroup, Http, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(triggerGroup, Blob, StringComparison.OrdinalIgnoreCase))
+            {
+                // The blob group needs to be special cased as it is a two step process:
+                // 1. WebHook which enqueues a message to Azure Storage Queue.
+                // 2. Azure Storage Queue trigger which processes the message.
+                // So we need to run in both http and blob groups.
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/WebJobs.Script/Extensions/BindingMetadataExtensions.cs
+++ b/src/WebJobs.Script/Extensions/BindingMetadataExtensions.cs
@@ -10,10 +10,13 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
 {
     public static class BindingMetadataExtensions
     {
-        private const string HttpTriggerKey = "httpTrigger";
-        private const string EventGridTriggerKey = "eventGridTrigger";
-        private const string SignalRTriggerKey = "signalRTrigger";
-        private const string BlobTriggerKey = "blobTrigger";
+        private const string HttpTrigger = "httpTrigger";
+        private const string EventGridTrigger = "eventGridTrigger";
+        private const string SignalRTrigger = "signalRTrigger";
+        private const string BlobTrigger = "blobTrigger";
+
+        private const string BlobSourceKey = "source";
+        private const string EventGridSource = "eventGrid";
 
         private static readonly HashSet<string> DurableTriggers = new(StringComparer.OrdinalIgnoreCase)
         {
@@ -34,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
                 throw new ArgumentNullException(nameof(binding));
             }
 
-            return string.Equals(HttpTriggerKey, binding.Type, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(HttpTrigger, binding.Type, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -52,8 +55,8 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
                 throw new ArgumentNullException(nameof(binding));
             }
 
-            if (string.Equals(EventGridTriggerKey, binding.Type, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(SignalRTriggerKey, binding.Type, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(EventGridTrigger, binding.Type, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(SignalRTrigger, binding.Type, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
@@ -88,13 +91,13 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
                 throw new ArgumentNullException(nameof(binding));
             }
 
-            if (string.Equals(BlobTriggerKey, binding.Type, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(BlobTrigger, binding.Type, StringComparison.OrdinalIgnoreCase))
             {
                 if (binding.Raw is { } obj)
                 {
-                    if (obj.TryGetValue("source", StringComparison.OrdinalIgnoreCase, out JToken token) && token is not null)
+                    if (obj.TryGetValue(BlobSourceKey, StringComparison.OrdinalIgnoreCase, out JToken token) && token is not null)
                     {
-                        return string.Equals(token.ToString(), "eventGrid", StringComparison.OrdinalIgnoreCase);
+                        return string.Equals(token.ToString(), EventGridSource, StringComparison.OrdinalIgnoreCase);
                     }
                 }
             }

--- a/src/WebJobs.Script/Extensions/BindingMetadataExtensions.cs
+++ b/src/WebJobs.Script/Extensions/BindingMetadataExtensions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
         /// <param name="binding">The binding metadata to check.</param>
         /// <returns><c>true</c> if a webhook trigger, <c>false</c> otherwise.</returns>
         /// <remarks>
-        /// Known webhook triggers includes SignalR, Event Grid and Event Grid sourced blob triggers.
+        /// Known webhook triggers includes SignalR, Event Grid triggers.
         /// </remarks>
         public static bool IsWebHookTrigger(this BindingMetadata binding)
         {
@@ -56,17 +56,6 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
                 || string.Equals(SignalRTriggerKey, binding.Type, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
-            }
-
-            if (string.Equals(BlobTriggerKey, binding.Type, StringComparison.OrdinalIgnoreCase))
-            {
-                if (binding.Raw is { } obj)
-                {
-                    if (obj.TryGetValue("source", StringComparison.OrdinalIgnoreCase, out JToken token) && token is not null)
-                    {
-                        return string.Equals(token.ToString(), "eventGrid", StringComparison.OrdinalIgnoreCase);
-                    }
-                }
             }
 
             return false;
@@ -85,6 +74,32 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
             }
 
             return DurableTriggers.Contains(binding.Type);
+        }
+
+        /// <summary>
+        /// Checks if a <see cref="BindingMetadata"/> represents an EventGrid sourced blob trigger.
+        /// </summary>
+        /// <param name="binding">The binding metadata to check.</param>
+        /// <returns><c>true</c> if a EventGrid sourced blob trigger, <c>false</c> otherwise.</returns>
+        public static bool IsEventGridBlobTrigger(this BindingMetadata binding)
+        {
+            if (binding is null)
+            {
+                throw new ArgumentNullException(nameof(binding));
+            }
+
+            if (string.Equals(BlobTriggerKey, binding.Type, StringComparison.OrdinalIgnoreCase))
+            {
+                if (binding.Raw is { } obj)
+                {
+                    if (obj.TryGetValue("source", StringComparison.OrdinalIgnoreCase, out JToken token) && token is not null)
+                    {
+                        return string.Equals(token.ToString(), "eventGrid", StringComparison.OrdinalIgnoreCase);
+                    }
+                }
+            }
+
+            return false;
         }
 
         public static bool SupportsDeferredBinding(this BindingMetadata metadata)

--- a/src/WebJobs.Script/Extensions/FunctionMetadataExtensions.cs
+++ b/src/WebJobs.Script/Extensions/FunctionMetadataExtensions.cs
@@ -78,22 +78,22 @@ namespace Microsoft.Azure.WebJobs.Script
             {
                 if (binding.IsHttpTrigger() || binding.IsWebHookTrigger())
                 {
-                    return "http";
+                    return FunctionGroups.Http;
                 }
 
                 if (binding.IsDurableTrigger())
                 {
-                    return "durable";
+                    return FunctionGroups.Durable;
                 }
 
                 if (binding.IsEventGridBlobTrigger())
                 {
-                    return "blob";
+                    return FunctionGroups.Blob;
                 }
             }
 
             // A function with no specified group will be assigned to a group of itself.
-            return $"function:{metadata.Name}";
+            return FunctionGroups.ForFunction(metadata.Name);
         }
 
         public static string GetFunctionId(this FunctionMetadata metadata)

--- a/src/WebJobs.Script/Extensions/FunctionMetadataExtensions.cs
+++ b/src/WebJobs.Script/Extensions/FunctionMetadataExtensions.cs
@@ -85,6 +85,11 @@ namespace Microsoft.Azure.WebJobs.Script
                 {
                     return "durable";
                 }
+
+                if (binding.IsEventGridBlobTrigger())
+                {
+                    return "blob";
+                }
             }
 
             // A function with no specified group will be assigned to a group of itself.

--- a/test/WebJobs.Script.Tests/Description/FunctionGroupListenerDecoratorTests.cs
+++ b/test/WebJobs.Script.Tests/Description/FunctionGroupListenerDecoratorTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description.Tests
             IFunctionDefinition definition = Mock.Of<IFunctionDefinition>();
             IListener original = Mock.Of<IListener>();
             IFunctionMetadataManager metadata = Mock.Of<IFunctionMetadataManager>();
-            IEnvironment environment = CreateEnvironment(FuncGroup.None);
+            IEnvironment environment = CreateEnvironment(null);
 
             var context = new ListenerDecoratorContext(definition, original.GetType(), original);
             var decorator = new FunctionGroupListenerDecorator(metadata, environment, _logger);
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description.Tests
             IFunctionDefinition definition = CreateDefinition("test");
             IListener original = Mock.Of<IListener>();
             IFunctionMetadataManager metadata = Mock.Of<IFunctionMetadataManager>();
-            IEnvironment environment = CreateEnvironment(FuncGroup.Http);
+            IEnvironment environment = CreateEnvironment("http");
 
             var context = new ListenerDecoratorContext(definition, original.GetType(), original);
             var decorator = new FunctionGroupListenerDecorator(metadata, environment, _logger);
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description.Tests
             IFunctionDefinition definition = CreateDefinition("test");
             IListener original = Mock.Of<IListener>();
             IFunctionMetadataManager metadata = CreateMetadataManager("test", true);
-            IEnvironment environment = CreateEnvironment(FuncGroup.Http);
+            IEnvironment environment = CreateEnvironment("http");
 
             var context = new ListenerDecoratorContext(definition, original.GetType(), original);
             var decorator = new FunctionGroupListenerDecorator(metadata, environment, _logger);
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description.Tests
             IFunctionDefinition definition = CreateDefinition("test");
             IListener original = Mock.Of<IListener>();
             IFunctionMetadataManager metadata = CreateMetadataManager("test", true);
-            IEnvironment environment = CreateEnvironment(FuncGroup.Other);
+            IEnvironment environment = CreateEnvironment("other");
 
             var context = new ListenerDecoratorContext(definition, original.GetType(), original);
             var decorator = new FunctionGroupListenerDecorator(metadata, environment, _logger);
@@ -100,8 +100,10 @@ namespace Microsoft.Azure.WebJobs.Script.Description.Tests
             Assert.NotSame(context.Listener, result);
         }
 
-        [Fact]
-        public void Decorate_BlobTrigger_EnabledForHttp()
+        [Theory]
+        [InlineData("http")]
+        [InlineData("blob")]
+        public void Decorate_BlobTrigger_EnabledForGroup(string targetGroup)
         {
             // Arrange
             IFunctionDefinition definition = CreateDefinition("test");
@@ -131,7 +133,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description.Tests
             var metadataMock = new Mock<IFunctionMetadataManager>();
             metadataMock.Setup(p => p.TryGetFunctionMetadata("test", out metadata, false)).Returns(true);
 
-            IEnvironment environment = CreateEnvironment(FuncGroup.Http);
+            IEnvironment environment = CreateEnvironment(targetGroup);
 
             var context = new ListenerDecoratorContext(definition, original.GetType(), original);
             var decorator = new FunctionGroupListenerDecorator(metadataMock.Object, environment, _logger);
@@ -177,17 +179,10 @@ namespace Microsoft.Azure.WebJobs.Script.Description.Tests
             return mock.Object;
         }
 
-        private static IEnvironment CreateEnvironment(FuncGroup group)
+        private static IEnvironment CreateEnvironment(string group)
         {
-            string groupStr = group switch
-            {
-                FuncGroup.Http => "http",
-                FuncGroup.Other => "other",
-                _ => null,
-            };
-
             var environment = new Mock<IEnvironment>(MockBehavior.Strict);
-            environment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsTargetGroup)).Returns(groupStr);
+            environment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsTargetGroup)).Returns(group);
             return environment.Object;
         }
     }

--- a/test/WebJobs.Script.Tests/Description/FunctionGroupListenerDecoratorTests.cs
+++ b/test/WebJobs.Script.Tests/Description/FunctionGroupListenerDecoratorTests.cs
@@ -100,6 +100,49 @@ namespace Microsoft.Azure.WebJobs.Script.Description.Tests
             Assert.NotSame(context.Listener, result);
         }
 
+        [Fact]
+        public void Decorate_BlobTrigger_EnabledForHttp()
+        {
+            // Arrange
+            IFunctionDefinition definition = CreateDefinition("test");
+            IListener original = Mock.Of<IListener>();
+
+            var metadata = new FunctionMetadata()
+            {
+                Name = "TestFunction1",
+                Bindings =
+                {
+                    new BindingMetadata
+                    {
+                        Name = "input",
+                        Type = "blobTrigger",
+                        Direction = BindingDirection.In,
+                        Raw = new JObject()
+                        {
+                            ["name"] = "input",
+                            ["type"] = "blobTrigger",
+                            ["direction"] = "in",
+                            ["source"] = "EventGrid",
+                        },
+                    }
+                }
+            };
+
+            var metadataMock = new Mock<IFunctionMetadataManager>();
+            metadataMock.Setup(p => p.TryGetFunctionMetadata("test", out metadata, false)).Returns(true);
+
+            IEnvironment environment = CreateEnvironment(FuncGroup.Http);
+
+            var context = new ListenerDecoratorContext(definition, original.GetType(), original);
+            var decorator = new FunctionGroupListenerDecorator(metadataMock.Object, environment, _logger);
+
+            // Act
+            var result = decorator.Decorate(context);
+
+            // Assert
+            Assert.Same(context.Listener, result);
+        }
+
         private static IFunctionDefinition CreateDefinition(string name)
         {
             var descriptor = new FuncDescriptor { LogName = name };

--- a/test/WebJobs.Script.Tests/Extensions/BindingMetadataExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/BindingMetadataExtensionsTests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
         [Theory]
         [InlineData("eventGridTrigger", true)]
         [InlineData("signalRTrigger", true)]
-        [InlineData("blobTrigger", true, "eventGrid")]
+        [InlineData("blobTrigger", false, "eventGrid")]
         [InlineData("blobTrigger", false, "other")]
         [InlineData("httpTrigger", false)]
         [InlineData("inputBinding", false)]
@@ -109,6 +109,31 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
             };
 
             Assert.Equal(expected, bindingMetadata.IsDurableTrigger());
+        }
+
+        [Theory]
+        [InlineData("blobTrigger", true, "eventGrid")]
+        [InlineData("blobTrigger", false, "other")]
+        [InlineData("blobTrigger", false, null)]
+        [InlineData("otherTrigger", false, "eventGrid")]
+        [InlineData("otherTrigger", false, "other")]
+        [InlineData("otherTrigger", false, null)]
+        public void IsEventGridBlobTrigger_ReturnsExpectedValue(string type, bool expected, string source)
+        {
+            var bindingMetadata = new BindingMetadata
+            {
+                Type = type,
+            };
+
+            if (source is not null)
+            {
+                bindingMetadata.Raw = new JObject
+                {
+                    ["source"] = source,
+                };
+            }
+
+            Assert.Equal(expected, bindingMetadata.IsEventGridBlobTrigger());
         }
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR


### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

In event grid sources blob triggers follow a 2 stage trigger process. First, a web hook from event grid which then sends a message to an Azure storage queue, which is then processed by the actual trigger. To support this with per-func scaling we need to do two things for blob:

1. They need to be grouped together as it is 1 queue for all triggers
2. They need to be in their own group _but also_ the `http` group so the webhook can run.
