### PR TITLE
Fix CI branches and missing 'minorVersionPrefix'

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,12 @@
 variables:
   buildNumber: $[ counter('constant', 13000) ]
   isReleaseBranch: $[contains(variables['Build.SourceBranch'], 'release/')]
+  ${{ if contains(variables['Build.SourceBranch'], 'release/inproc6/') }}:
+    minorVersionPrefix: "6"
+  ${{ elseif contains(variables['Build.SourceBranch'], 'release/inproc8/') }}:
+    minorVersionPrefix: "8"
+  ${{ else }}:
+    minorVersionPrefix: ""
   DOTNET_NOLOGO: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -9,15 +15,19 @@ pr:
   branches:
     include:
     - dev
+    - in-proc
     - release/4.*
-    - feature/oop-host   
+    - release/inproc6/4.*
+    - release/inproc8/4.*
 
 trigger:
   branches:
     include:
     - dev
+    - in-proc
     - release/4.*
-    - feature/oop-host 
+    - release/inproc6/4.*
+    - release/inproc8/4.*
 
 jobs:
 - job: InitializePipeline


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR #9996 
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

`InitializePipelines` step was silently failing in dev branch due to missing `minorVersionPrefix` variable. Also adding triggers for in-proc here.
