### PR TITLE
[in-proc backport] Fix CI branches and missing 'minorVersionPrefix'

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,18 +14,20 @@ variables:
 pr:
   branches:
     include:
+    - dev
+    - in-proc
     - release/4.*
     - release/inproc6/4.*
     - release/inproc8/4.*
-    - in-proc
 
 trigger:
   branches:
     include:
+    - dev
+    - in-proc
     - release/4.*
     - release/inproc6/4.*
     - release/inproc8/4.*
-    - in-proc
 
 jobs:
 - job: InitializePipeline


### PR DESCRIPTION
Backport of #9995 