### PR TITLE
Include route params in RpcHttp instance when http proxying is enabled.

### DIFF
--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         /// <summary>
         /// Indicates whether the RpcHttp request should include the route parameters when the request is being proxied to an HTTP worker.
         /// </summary>
-        public const string HandlesRouteParamsWhenHttpProxying = "HandlesRouteParamsWhenHttpProxying";
+        public const string RequiresRouteParameters = "RequiresRouteParameters";
 
         /// <summary>
         /// Indicates whether empty entries in the trigger message should be included when sending RpcInvocation data to OOP workers.

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
@@ -58,6 +58,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public const string WorkerOpenTelemetryEnabled = nameof(WorkerOpenTelemetryEnabled);
 
         /// <summary>
+        /// Indicates whether the RpcHttp request should include the route parameters when the request is being proxied to an HTTP worker.
+        /// </summary>
+        public const string HandlesRouteParamsWhenHttpProxying = "HandlesRouteParamsWhenHttpProxying";
+
+        /// <summary>
         /// Indicates whether empty entries in the trigger message should be included when sending RpcInvocation data to OOP workers.
         /// </summary>
         public const string IncludeEmptyEntriesInMessagePayload = "IncludeEmptyEntriesInMessagePayload";

--- a/test/WebJobs.Script.Tests/Workers/ScriptInvocationContextExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ScriptInvocationContextExtensionsTests.cs
@@ -351,7 +351,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
             var workerCapabilities = new Dictionary<string, string>()
             {
                 { RpcWorkerConstants.HttpUri, "http://localhost:1234" },
-                { RpcWorkerConstants.HandlesRouteParamsWhenHttpProxying, bool.TrueString }
+                { RpcWorkerConstants.RequiresRouteParameters, bool.TrueString }
             };
 
             var routeDataValues = new Dictionary<string, object>


### PR DESCRIPTION
Fixes #9840 
Adding support for workers to request route params data populated in the RpcHttp instance when Http proxying is enabled.
Worker needs to include "**RequiresRouteParameters**" capability in the capability list they send to host during init/env reload request for this to happen.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR - backport PR follows shortly.
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)