### PR TITLE
Introduce versioning for DiagnosticEvent

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEvent.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEvent.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 {
     public class DiagnosticEvent : TableEntity
     {
+        internal const string CurrentEventVersion = "2024-05-01";
+
         public DiagnosticEvent() { }
 
         public DiagnosticEvent(string hostId, DateTime timestamp)
@@ -18,7 +20,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             RowKey = TableStorageHelpers.GetRowKey(timestamp);
             PartitionKey = $"{hostId}-{timestamp:yyyyMMdd}";
             Timestamp = timestamp;
+            EventVersion = CurrentEventVersion;
         }
+
+        public string EventVersion { get; set; }
 
         public int HitCount { get; set; }
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * [x] Otherwise: Link to backporting PR- TODO
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

The changes implement a versioning mechanism for DiagnosticEvent entries stored in Azure Table Storage. This ensures that only the latest version of each event is retained, preventing the accumulation of outdated or redundant data.​

#### Key Changes

- Event Versioning: Introduced a Version property to the DiagnosticEvent class to track the version of each event.​
- Purge Mechanism: Implemented a method to purge older versions of events, ensuring that only the most recent version is stored.​
- Deletion Delay Handling: Added a 30-second delay when a table is deleted to handle eventual consistency in Azure Table Storage.​
- Host State Provider Retrieval: Modified the retrieval of IPrimaryHostStateProvider to obtain it via the script host, ensuring accurate host state information.​
- Caching Behavior: Adjusted the caching behavior to avoid caching the IPrimaryHostStateProvider, ensuring that the latest state is always retrieved.
