### PR TITLE
Updating Otel nuget packages.

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -76,6 +76,8 @@
     <PackageReference Include="NuGet.ProjectModel" Version="5.11.6" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
+++ b/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
@@ -98,8 +98,8 @@
           "Azure.Monitor.OpenTelemetry.Exporter": "1.3.0-beta.1",
           "Azure.Monitor.OpenTelemetry.LiveMetrics": "1.0.0-beta.3",
           "OpenTelemetry.Extensions.Hosting": "1.8.0",
-          "OpenTelemetry.Instrumentation.AspNetCore": "1.7.0",
-          "OpenTelemetry.Instrumentation.Http": "1.7.0"
+          "OpenTelemetry.Instrumentation.AspNetCore": "1.8.1",
+          "OpenTelemetry.Instrumentation.Http": "1.8.1"
         },
         "runtime": {
           "lib/net6.0/Azure.Monitor.OpenTelemetry.AspNetCore.dll": {
@@ -2055,26 +2055,27 @@
           }
         }
       },
-      "OpenTelemetry.Instrumentation.AspNetCore/1.7.0": {
+      "OpenTelemetry.Instrumentation.AspNetCore/1.8.1": {
         "dependencies": {
           "OpenTelemetry.Api.ProviderBuilderExtensions": "1.8.0"
         },
         "runtime": {
           "lib/net8.0/OpenTelemetry.Instrumentation.AspNetCore.dll": {
             "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.7.0.1114"
+            "fileVersion": "1.8.1.1245"
           }
         }
       },
-      "OpenTelemetry.Instrumentation.Http/1.7.0": {
+      "OpenTelemetry.Instrumentation.Http/1.8.1": {
         "dependencies": {
+          "Microsoft.Extensions.Configuration": "8.0.0",
           "Microsoft.Extensions.Options": "8.0.0",
           "OpenTelemetry.Api.ProviderBuilderExtensions": "1.8.0"
         },
         "runtime": {
           "lib/net8.0/OpenTelemetry.Instrumentation.Http.dll": {
             "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.7.0.1114"
+            "fileVersion": "1.8.1.1245"
           }
         }
       },
@@ -3162,6 +3163,8 @@
           "NuGet.ProjectModel": "5.11.6",
           "OpenTelemetry.Exporter.OpenTelemetryProtocol": "1.8.0",
           "OpenTelemetry.Extensions.Hosting": "1.8.0",
+          "OpenTelemetry.Instrumentation.AspNetCore": "1.8.1",
+          "OpenTelemetry.Instrumentation.Http": "1.8.1",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Drawing.Common": "8.0.0",
           "System.IO.Abstractions": "2.1.0.227",
@@ -4504,19 +4507,19 @@
       "path": "opentelemetry.extensions.hosting/1.8.0",
       "hashPath": "opentelemetry.extensions.hosting.1.8.0.nupkg.sha512"
     },
-    "OpenTelemetry.Instrumentation.AspNetCore/1.7.0": {
+    "OpenTelemetry.Instrumentation.AspNetCore/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-K/mjCmuR9zgrL6fMC6sbnX/y6BOJJFI3hp42O+tz8nT/w6sxbfjrLcU+fVwfct3lsnohSKdPfrq6fSrxAF5ezw==",
-      "path": "opentelemetry.instrumentation.aspnetcore/1.7.0",
-      "hashPath": "opentelemetry.instrumentation.aspnetcore.1.7.0.nupkg.sha512"
+      "sha512": "sha512-dRb1LEXSH95LGEubk96kYyBmGuny9/qycH9KqL8FXcOv446Xi53EW56TVE4wTMv4HPfn+rL3B9pPQ5RX7zD4Yw==",
+      "path": "opentelemetry.instrumentation.aspnetcore/1.8.1",
+      "hashPath": "opentelemetry.instrumentation.aspnetcore.1.8.1.nupkg.sha512"
     },
-    "OpenTelemetry.Instrumentation.Http/1.7.0": {
+    "OpenTelemetry.Instrumentation.Http/1.8.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-0pM1EHx/85DsUmtffysYNVZBNkenuYd++ZMgNB0oGLdhIK5EJEmz8+Yi+sjHajU5XvAUtOXPL6Ocd3dZWRQIAw==",
-      "path": "opentelemetry.instrumentation.http/1.7.0",
-      "hashPath": "opentelemetry.instrumentation.http.1.7.0.nupkg.sha512"
+      "sha512": "sha512-l1KaO1U+v11X/kfZ8tcONc5l1qoP6nPk6yPrXBJNH0Wb6NEBTdEgI1dtJBbqOnjOrI2XS09le0ZGooh9ZVkZ3Q==",
+      "path": "opentelemetry.instrumentation.http/1.8.1",
+      "hashPath": "opentelemetry.instrumentation.http.1.8.1.nupkg.sha512"
     },
     "OpenTelemetry.PersistentStorage.Abstractions/1.0.0": {
       "type": "package",


### PR DESCRIPTION
The build is failing because of a security vulnerability in OpenTelemetry.Instrumentation.AspNetCore and OpenTelemetry.Instrumentation.Http. These packages are not direct references; they are included because of Azure.Monitor.OpenTelemetry.AspNetCore. We are updating these two packages to their latest versions since the new AzMon Distro package has not been released yet.

   Transitive Package                              Resolved   Severity   Advisory URL                                     
   > OpenTelemetry.Instrumentation.AspNetCore      1.7.0      Moderate   https://github.com/advisories/GHSA-vh2m-22xx-q94f
   > OpenTelemetry.Instrumentation.Http            1.7.0      Moderate   https://github.com/advisories/GHSA-vh2m-22xx-q94f

https://github.com/open-telemetry/opentelemetry-dotnet/security/advisories/GHSA-vh2m-22xx-q94f

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
