### PR TITLE
Python worker hotfix 4.33.2

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <MajorVersion>4</MajorVersion>    
     <MinorVersion>$(MinorVersionPrefix)33</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <PatchVersion>2</PatchVersion>
     <BuildNumber Condition="'$(BuildNumber)' == '' ">0</BuildNumber>
     <PreviewVersion></PreviewVersion>
     

--- a/build/python.props
+++ b/build/python.props
@@ -1,5 +1,5 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.27.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.27.2" />
   </ItemGroup>
 </Project>

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,11 +3,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-- Update Python Worker Version to [4.27.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.27.0)
-- Update Java Worker Version to [2.14.0](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.14.0)
-- Update Python Worker Version to [4.26.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.26.0)
-- Updated `Microsoft.Azure.Functions.DotNetIsolatedNativeHost` version to 1.0.8 (#9936)
-	- [Improvements to NetHost logging & worker.config](https://github.com/Azure/azure-functions-dotnet-worker/pull/2315)
-	- [Pre-launching a minimal .NET app during placeholder mode](https://github.com/Azure/azure-functions-dotnet-worker/pull/2324)
-	- [Reverting the worker.config change made in #2315 (checking for INITIALIZED_FROM_PLACEHOLDER environment variable)](https://github.com/Azure/azure-functions-dotnet-worker/pull/2351)
-
+- Update Python Worker Version to [4.27.2](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.27.2)

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -58,7 +58,7 @@
     <PackageReference Include="appinsights.testlogger" Version="1.0.0" />
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.27.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.27.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Moq" Version="4.9.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">


### PR DESCRIPTION
<!-- Please provide all the information below.  -->
Updating python worker to 4.27.2

Fixes issues 
- Generic binding return types
- Indexing blueprint functions with worker process count>1
### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
