### PR TITLE
[1es] [CG] Fix/suppress cred scan hits in test files

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
@@ -69,7 +69,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             var instanceController = new InstanceController(environment, instanceManager, loggerFactory, startupContextProvider);
 
-            const string containerEncryptionKey = "/a/vXvWJ3Hzgx4PFxlDUJJhQm5QVyGiu0NNLFm/ZMMg=";
             var hostAssignmentContext = new HostAssignmentContext
             {
                 Environment = new Dictionary<string, string>(),
@@ -79,14 +78,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             hostAssignmentContext.Environment[EnvironmentSettingNames.MsiEndpoint] = "http://localhost:8081";
             hostAssignmentContext.Environment[EnvironmentSettingNames.MsiSecret] = "secret";
 
-            var encryptedHostAssignmentValue = SimpleWebTokenHelper.Encrypt(JsonConvert.SerializeObject(hostAssignmentContext), containerEncryptionKey.ToKeyBytes());
+            var encryptedHostAssignmentValue = SimpleWebTokenHelper.Encrypt(JsonConvert.SerializeObject(hostAssignmentContext), TestHelpers.FakeEncryptionKey.ToKeyBytes());
 
             var encryptedHostAssignmentContext = new EncryptedHostAssignmentContext()
             {
                 EncryptedContext = encryptedHostAssignmentValue
             };
 
-            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, containerEncryptionKey);
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, TestHelpers.FakeEncryptionKey);
 
             IActionResult result = await instanceController.Assign(encryptedHostAssignmentContext);
 
@@ -145,7 +144,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             var instanceController = new InstanceController(environment, instanceManager, loggerFactory, startupContextProvider);
 
-            const string containerEncryptionKey = "/a/vXvWJ3Hzgx4PFxlDUJJhQm5QVyGiu0NNLFm/ZMMg=";
             var hostAssignmentContext = new HostAssignmentContext
             {
                 Environment = new Dictionary<string, string>()
@@ -156,14 +154,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             hostAssignmentContext.Secrets = new FunctionAppSecrets();
             hostAssignmentContext.IsWarmupRequest = false; // non-warmup Request
 
-            var encryptedHostAssignmentValue = SimpleWebTokenHelper.Encrypt(JsonConvert.SerializeObject(hostAssignmentContext), containerEncryptionKey.ToKeyBytes());
+            var encryptedHostAssignmentValue = SimpleWebTokenHelper.Encrypt(JsonConvert.SerializeObject(hostAssignmentContext), TestHelpers.FakeEncryptionKey.ToKeyBytes());
 
             var encryptedHostAssignmentContext = new EncryptedHostAssignmentContext()
             {
                 EncryptedContext = encryptedHostAssignmentValue
             };
 
-            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, containerEncryptionKey);
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, TestHelpers.FakeEncryptionKey);
 
             await instanceController.Assign(encryptedHostAssignmentContext);
             Assert.NotNull(startupContextProvider.Context);
@@ -199,7 +197,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             var instanceController = new InstanceController(environment, instanceManager, loggerFactory, startupContextProvider);
 
-            const string containerEncryptionKey = "/a/vXvWJ3Hzgx4PFxlDUJJhQm5QVyGiu0NNLFm/ZMMg=";
             var hostAssignmentContext = new HostAssignmentContext
             {
                 Environment = new Dictionary<string, string>()
@@ -210,14 +207,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             hostAssignmentContext.Secrets = new FunctionAppSecrets();
             hostAssignmentContext.IsWarmupRequest = true; // Warmup Request
 
-            var encryptedHostAssignmentValue = SimpleWebTokenHelper.Encrypt(JsonConvert.SerializeObject(hostAssignmentContext), containerEncryptionKey.ToKeyBytes());
+            var encryptedHostAssignmentValue = SimpleWebTokenHelper.Encrypt(JsonConvert.SerializeObject(hostAssignmentContext), TestHelpers.FakeEncryptionKey.ToKeyBytes());
 
             var encryptedHostAssignmentContext = new EncryptedHostAssignmentContext()
             {
                 EncryptedContext = encryptedHostAssignmentValue
             };
 
-            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, containerEncryptionKey);
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, TestHelpers.FakeEncryptionKey);
 
             await instanceController.Assign(encryptedHostAssignmentContext);
             Assert.Null(startupContextProvider.Context);
@@ -243,7 +240,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             var instanceController = new InstanceController(environment, instanceManager.Object, loggerFactory,
                 startupContextProvider);
 
-            const string containerEncryptionKey = "/a/vXvWJ3Hzgx4PFxlDUJJhQm5QVyGiu0NNLFm/ZMMg=";
             var hostAssignmentContext = new HostAssignmentContext
             {
                 Environment = new Dictionary<string, string>()
@@ -252,14 +248,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             var encryptedHostAssignmentValue =
                 SimpleWebTokenHelper.Encrypt(JsonConvert.SerializeObject(hostAssignmentContext),
-                    containerEncryptionKey.ToKeyBytes());
+                    TestHelpers.FakeEncryptionKey.ToKeyBytes());
 
             var encryptedHostAssignmentContext = new EncryptedHostAssignmentContext()
             {
                 EncryptedContext = encryptedHostAssignmentValue
             };
 
-            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, containerEncryptionKey);
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, TestHelpers.FakeEncryptionKey);
             
             await instanceController.Assign(encryptedHostAssignmentContext);
 

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
@@ -78,14 +78,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             hostAssignmentContext.Environment[EnvironmentSettingNames.MsiEndpoint] = "http://localhost:8081";
             hostAssignmentContext.Environment[EnvironmentSettingNames.MsiSecret] = "secret";
 
-            var encryptedHostAssignmentValue = SimpleWebTokenHelper.Encrypt(JsonConvert.SerializeObject(hostAssignmentContext), TestHelpers.FakeEncryptionKey.ToKeyBytes());
+            var encryptedHostAssignmentValue = SimpleWebTokenHelper.Encrypt(JsonConvert.SerializeObject(hostAssignmentContext), TestHelpers.EncryptionKey.ToKeyBytes());
 
             var encryptedHostAssignmentContext = new EncryptedHostAssignmentContext()
             {
                 EncryptedContext = encryptedHostAssignmentValue
             };
 
-            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, TestHelpers.FakeEncryptionKey);
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, TestHelpers.EncryptionKey);
 
             IActionResult result = await instanceController.Assign(encryptedHostAssignmentContext);
 
@@ -154,14 +154,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             hostAssignmentContext.Secrets = new FunctionAppSecrets();
             hostAssignmentContext.IsWarmupRequest = false; // non-warmup Request
 
-            var encryptedHostAssignmentValue = SimpleWebTokenHelper.Encrypt(JsonConvert.SerializeObject(hostAssignmentContext), TestHelpers.FakeEncryptionKey.ToKeyBytes());
+            var encryptedHostAssignmentValue = SimpleWebTokenHelper.Encrypt(JsonConvert.SerializeObject(hostAssignmentContext), TestHelpers.EncryptionKey.ToKeyBytes());
 
             var encryptedHostAssignmentContext = new EncryptedHostAssignmentContext()
             {
                 EncryptedContext = encryptedHostAssignmentValue
             };
 
-            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, TestHelpers.FakeEncryptionKey);
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, TestHelpers.EncryptionKey);
 
             await instanceController.Assign(encryptedHostAssignmentContext);
             Assert.NotNull(startupContextProvider.Context);
@@ -207,14 +207,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             hostAssignmentContext.Secrets = new FunctionAppSecrets();
             hostAssignmentContext.IsWarmupRequest = true; // Warmup Request
 
-            var encryptedHostAssignmentValue = SimpleWebTokenHelper.Encrypt(JsonConvert.SerializeObject(hostAssignmentContext), TestHelpers.FakeEncryptionKey.ToKeyBytes());
+            var encryptedHostAssignmentValue = SimpleWebTokenHelper.Encrypt(JsonConvert.SerializeObject(hostAssignmentContext), TestHelpers.EncryptionKey.ToKeyBytes());
 
             var encryptedHostAssignmentContext = new EncryptedHostAssignmentContext()
             {
                 EncryptedContext = encryptedHostAssignmentValue
             };
 
-            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, TestHelpers.FakeEncryptionKey);
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, TestHelpers.EncryptionKey);
 
             await instanceController.Assign(encryptedHostAssignmentContext);
             Assert.Null(startupContextProvider.Context);
@@ -248,14 +248,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             var encryptedHostAssignmentValue =
                 SimpleWebTokenHelper.Encrypt(JsonConvert.SerializeObject(hostAssignmentContext),
-                    TestHelpers.FakeEncryptionKey.ToKeyBytes());
+                    TestHelpers.EncryptionKey.ToKeyBytes());
 
             var encryptedHostAssignmentContext = new EncryptedHostAssignmentContext()
             {
                 EncryptedContext = encryptedHostAssignmentValue
             };
 
-            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, TestHelpers.FakeEncryptionKey);
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerEncryptionKey, TestHelpers.EncryptionKey);
             
             await instanceController.Assign(encryptedHostAssignmentContext);
 

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Abstractions;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -376,9 +375,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.NotFound
-            });
+                {
+                    StatusCode = HttpStatusCode.NotFound
+                });
 
             var instanceManager = new AtlasInstanceManager(_optionsFactory, TestHelpers.CreateHttpClientFactory(handlerMock.Object),
                 scriptWebEnvironment, environment, loggerFactory.CreateLogger<AtlasInstanceManager>(),
@@ -687,7 +686,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             var environment = new Dictionary<string, string>()
             {
                 { EnvironmentSettingNames.MsiEndpoint, "http://localhost:8081" },
-                { EnvironmentSettingNames.MsiSecret, "secret" }
+                { EnvironmentSettingNames.MsiSecret, "PLACEHOLDER" }
             };
             var assignmentContext = new HostAssignmentContext
             {
@@ -698,55 +697,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 MSIContext = new MSIContext()
                 {
                     SiteName = "TestSite",
-                    MSISecret = "TestSecret1234",
-                    Identities = new[] { new ManagedServiceIdentity() { 
-                        Type = ManagedServiceIdentityType.SystemAssigned, 
-                        ClientId = "identityClientId",
-                        TenantId = "identityTenantId",
-                        Thumbprint = "identityThumbprint",
-                        SecretUrl = "identitySecretUrl",
-                        ResourceId = "identityResourceId",
-                        Certificate = "identityCertificate",
-                        PrincipalId = "identityPrincipalId",
-                        AuthenticationEndpoint = "identityAuthEndpoint"
-                    } },
-                    SystemAssignedIdentity = new ManagedServiceIdentity()
-                    {
-                        Type = ManagedServiceIdentityType.SystemAssigned,
-                        ClientId = "saClientId",
-                        TenantId = "saTenantId",
-                        Thumbprint = "saThumbprint",
-                        SecretUrl = "saSecretUrl",
-                        ResourceId = "saResourceId",
-                        Certificate = "saCertificate",
-                        PrincipalId = "saPrincipalId",
-                        AuthenticationEndpoint = "saAuthEndpoint"
-                    },
-                    DelegatedIdentities = new[] { new ManagedServiceIdentity() {
-                        Type = ManagedServiceIdentityType.SystemAssigned,
-                        ClientId = "delegatedClientId",
-                        TenantId = "delegatedTenantId",
-                        Thumbprint = "delegatedThumbprint",
-                        SecretUrl = "delegatedSecretUrl",
-                        ResourceId = "delegatedResourceId",
-                        Certificate = "delegatedCertificate",
-                        PrincipalId = "delegatedPrincipalId",
-                        AuthenticationEndpoint = "delegatedAuthEndpoint"
-                    } },
-                    UserAssignedIdentities = new[] { new ManagedServiceIdentity() {
-                        Type = ManagedServiceIdentityType.UserAssigned,
-                        ClientId = "uaClientId",
-                        TenantId = "uaTenantId",
-                        Thumbprint = "uaThumbprint",
-                        SecretUrl = "uaSecretUrl",
-                        ResourceId = "uaResourceId",
-                        Certificate = "uaCertificate",
-                        PrincipalId = "uaPrincipalId",
-                        AuthenticationEndpoint = "uaAuthEndpoint"
-                    } },
+                    MSISecret = "PLACEHOLDER",
+                    Identities = new[] { TestHelpers.CreateMsi(ManagedServiceIdentityType.SystemAssigned, "identity") },
+                    SystemAssignedIdentity = TestHelpers.CreateMsi(ManagedServiceIdentityType.SystemAssigned, "sa"),
+                    DelegatedIdentities = new[] { TestHelpers.CreateMsi(ManagedServiceIdentityType.SystemAssigned, "delegated") },
+                    UserAssignedIdentities = new[] { TestHelpers.CreateMsi(ManagedServiceIdentityType.UserAssigned, "ua") },
                 }
             };
-            
+
             static void verifyMSIPropertiesHelper(ManagedServiceIdentity msi)
             {
                 Assert.NotNull(msi);
@@ -1160,7 +1118,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             var runFromPackageHandler = new Mock<IRunFromPackageHandler>(MockBehavior.Strict);
             runFromPackageHandler.Setup(r => r.MountAzureFileShare(context)).Returns(Task.FromResult(true));
-            
+
             runFromPackageHandler
                 .Setup(r => r.ApplyRunFromPackageContext(It.IsAny<RunFromPackageContext>(), It.IsAny<string>(), true,
                     false)).ReturnsAsync(false); // return false to trigger failure
@@ -1444,7 +1402,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
                 ItExpr.Is<HttpRequestMessage>(request => request.Method == HttpMethod.Post
-                                                         && (request.RequestUri.AbsoluteUri.Equals(msiEndpoint) 
+                                                         && (request.RequestUri.AbsoluteUri.Equals(msiEndpoint)
                                                             || request.RequestUri.AbsoluteUri.Equals(defaultEncryptedMsiEndpoint)
                                                             || request.RequestUri.AbsoluteUri.Equals(providedEncryptedMsiEndpoint))
                                                          && request.Content != null),

--- a/test/WebJobs.Script.Tests.Integration/Management/KubernetesPodControllerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/KubernetesPodControllerTests.cs
@@ -71,14 +71,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             hostAssignmentContext.IsWarmupRequest = false;
 
             var encryptedHostAssignmentValue = SimpleWebTokenHelper.Encrypt(
-                JsonConvert.SerializeObject(hostAssignmentContext), TestHelpers.FakeEncryptionKey.ToKeyBytes());
+                JsonConvert.SerializeObject(hostAssignmentContext), TestHelpers.EncryptionKey.ToKeyBytes());
 
             var encryptedHostAssignmentContext = new EncryptedHostAssignmentContext()
             {
                 EncryptedContext = encryptedHostAssignmentValue
             };
 
-            environment.SetEnvironmentVariable(EnvironmentSettingNames.PodEncryptionKey, TestHelpers.FakeEncryptionKey);
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.PodEncryptionKey, TestHelpers.EncryptionKey);
             environment.SetEnvironmentVariable(EnvironmentSettingNames.KubernetesServiceHost, "http://localhost:80");
             environment.SetEnvironmentVariable(EnvironmentSettingNames.PodNamespace, "k8se-apps");
 
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             hostAssignmentContext.IsWarmupRequest = false;
 
             var encryptedHostAssignmentValue = SimpleWebTokenHelper.Encrypt(
-                JsonConvert.SerializeObject(hostAssignmentContext), TestHelpers.FakeEncryptionKey.ToKeyBytes());
+                JsonConvert.SerializeObject(hostAssignmentContext), TestHelpers.EncryptionKey.ToKeyBytes());
 
             var encryptedHostAssignmentContext = new EncryptedHostAssignmentContext()
             {

--- a/test/WebJobs.Script.Tests.Integration/Management/KubernetesPodControllerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/KubernetesPodControllerTests.cs
@@ -60,7 +60,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             var podController = new KubernetesPodController(environment, instanceManager, loggerFactory, startupContextProvider);
 
-            const string podEncryptionKey = "/a/vXvWJ3Hzgx4PFxlDUJJhQm5QVyGiu0NNLFm/ZMMg=";
             var hostAssignmentContext = new HostAssignmentContext
             {
                 Environment = new Dictionary<string, string>()
@@ -71,14 +70,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             hostAssignmentContext.Secrets = new FunctionAppSecrets();
             hostAssignmentContext.IsWarmupRequest = false;
 
-            var encryptedHostAssignmentValue = SimpleWebTokenHelper.Encrypt(JsonConvert.SerializeObject(hostAssignmentContext), podEncryptionKey.ToKeyBytes());
+            var encryptedHostAssignmentValue = SimpleWebTokenHelper.Encrypt(
+                JsonConvert.SerializeObject(hostAssignmentContext), TestHelpers.FakeEncryptionKey.ToKeyBytes());
 
             var encryptedHostAssignmentContext = new EncryptedHostAssignmentContext()
             {
                 EncryptedContext = encryptedHostAssignmentValue
             };
 
-            environment.SetEnvironmentVariable(EnvironmentSettingNames.PodEncryptionKey, podEncryptionKey);
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.PodEncryptionKey, TestHelpers.FakeEncryptionKey);
             environment.SetEnvironmentVariable(EnvironmentSettingNames.KubernetesServiceHost, "http://localhost:80");
             environment.SetEnvironmentVariable(EnvironmentSettingNames.PodNamespace, "k8se-apps");
 
@@ -116,7 +116,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             instanceManager.Reset();
 
-            const string podEncryptionKey = "/a/vXvWJ3Hzgx4PFxlDUJJhQm5QVyGiu0NNLFm/ZMMg=";
             var podController = new KubernetesPodController(environment, instanceManager, loggerFactory, startupContextProvider);
 
             var hostAssignmentContext = new HostAssignmentContext
@@ -129,7 +128,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             hostAssignmentContext.Secrets = new FunctionAppSecrets();
             hostAssignmentContext.IsWarmupRequest = false;
 
-            var encryptedHostAssignmentValue = SimpleWebTokenHelper.Encrypt(JsonConvert.SerializeObject(hostAssignmentContext), podEncryptionKey.ToKeyBytes());
+            var encryptedHostAssignmentValue = SimpleWebTokenHelper.Encrypt(
+                JsonConvert.SerializeObject(hostAssignmentContext), TestHelpers.FakeEncryptionKey.ToKeyBytes());
 
             var encryptedHostAssignmentContext = new EncryptedHostAssignmentContext()
             {

--- a/test/WebJobs.Script.Tests.Integration/Management/MeshServiceClientTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/MeshServiceClientTests.cs
@@ -80,9 +80,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
                 StatusCode = HttpStatusCode.OK
             });
 
-            string connectionString = $"DefaultEndpointsProtocol=https;AccountName=storageaccount;AccountKey={TestHelpers.EmulatorAccountKey}";
-
-            await _meshServiceClient.MountCifs(connectionString, "sharename", "/data");
+            await _meshServiceClient.MountCifs(TestHelpers.StorageEmulatorConnectionString, "sharename", "/data");
 
             await Task.Delay(500);
 

--- a/test/WebJobs.Script.Tests.Integration/Management/MeshServiceClientTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/MeshServiceClientTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             });
 
             var connectionString =
-                "DefaultEndpointsProtocol=https;AccountName=storageaccount;AccountKey=whXtW6WP8QTh84TT5wdjgzeFTj7Vc1aOiCVjTXohpE+jALoKOQ9nlQpj5C5zpgseVJxEVbaAhptP5j5DpaLgtA==";
+                "DefaultEndpointsProtocol=https;AccountName=storageaccount;AccountKey=PLACEHOLDER";
 
             await _meshServiceClient.MountCifs(connectionString, "sharename", "/data");
 

--- a/test/WebJobs.Script.Tests.Integration/Management/MeshServiceClientTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/MeshServiceClientTests.cs
@@ -80,8 +80,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
                 StatusCode = HttpStatusCode.OK
             });
 
-            var connectionString =
-                "DefaultEndpointsProtocol=https;AccountName=storageaccount;AccountKey=PLACEHOLDER";
+            string connectionString = $"DefaultEndpointsProtocol=https;AccountName=storageaccount;AccountKey={TestHelpers.EmulatorAccountKey}";
 
             await _meshServiceClient.MountCifs(connectionString, "sharename", "/data");
 

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.Constants.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.Constants.cs
@@ -14,8 +14,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public static readonly string StorageEmulatorAccountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
         public static readonly string StorageEmulatorConnectionString = $"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey={StorageEmulatorAccountKey}";
 
-        public static readonly string EncryptionKey = _encryptionKey.Value;
-
         private static readonly Lazy<string> _encryptionKey = new Lazy<string>(
             () =>
             {
@@ -23,6 +21,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 aes.GenerateKey();
                 return Convert.ToBase64String(aes.Key);
             });
+
+        public static string EncryptionKey => _encryptionKey.Value;
 
         /// <summary>
         /// Gets the common root directory that functions tests create temporary directories under.

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.Constants.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.Constants.cs
@@ -10,10 +10,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public static partial class TestHelpers
     {
-        public static readonly string FakeEncryptionKey = CreateKey();
-
         [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification = "Well known account key for emulator. Used for testing.")]
         public static readonly string EmulatorAccountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+
+        public static readonly string EncryptionKey = _encryptionKey.Value;
+
+        private static readonly Lazy<string> _encryptionKey = new Lazy<string>(
+            () =>
+            {
+                using Aes aes = Aes.Create();
+                aes.GenerateKey();
+                return Convert.ToBase64String(aes.Key);
+            });
 
         /// <summary>
         /// Gets the common root directory that functions tests create temporary directories under.
@@ -25,13 +33,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 return Path.Combine(Path.GetTempPath(), "FunctionsTest");
             }
-        }
-
-        private static string CreateKey()
-        {
-            using Aes aes = Aes.Create();
-            aes.GenerateKey();
-            return Convert.ToBase64String(aes.Key);
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.Constants.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.Constants.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public static partial class TestHelpers
+    {
+        [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification = "Used for validating encryption behavior.")]
+        public const string FakeEncryptionKey = "/a/vXvWJ3Hzgx4PFxlDUJJhQm5QVyGiu0NNLFm/ZMMg=";
+
+        /// <summary>
+        /// Gets the common root directory that functions tests create temporary directories under.
+        /// This enables us to clean up test files by deleting this single directory.
+        /// </summary>
+        public static string FunctionsTestDirectory
+        {
+            get
+            {
+                return Path.Combine(Path.GetTempPath(), "FunctionsTest");
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.Constants.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.Constants.cs
@@ -11,7 +11,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
     public static partial class TestHelpers
     {
         [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification = "Well known account key for emulator. Used for testing.")]
-        public static readonly string EmulatorAccountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+        public static readonly string StorageEmulatorAccountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+        public static readonly string StorageEmulatorConnectionString = $"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey={StorageEmulatorAccountKey}";
 
         public static readonly string EncryptionKey = _encryptionKey.Value;
 

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.Constants.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.Constants.cs
@@ -1,15 +1,19 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Security.Cryptography;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public static partial class TestHelpers
     {
-        [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification = "Used for validating encryption behavior.")]
-        public const string FakeEncryptionKey = "/a/vXvWJ3Hzgx4PFxlDUJJhQm5QVyGiu0NNLFm/ZMMg=";
+        public static readonly string FakeEncryptionKey = CreateKey();
+
+        [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification = "Well known account key for emulator. Used for testing.")]
+        public static readonly string EmulatorAccountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
 
         /// <summary>
         /// Gets the common root directory that functions tests create temporary directories under.
@@ -21,6 +25,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 return Path.Combine(Path.GetTempPath(), "FunctionsTest");
             }
+        }
+
+        private static string CreateKey()
+        {
+            using Aes aes = Aes.Create();
+            aes.GenerateKey();
+            return Convert.ToBase64String(aes.Key);
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Metrics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -17,8 +16,8 @@ using System.Threading.Tasks;
 using Microsoft.Azure.Storage;
 using Microsoft.Azure.Storage.Blob;
 using Microsoft.Azure.WebJobs.Host.Storage;
-using Microsoft.Azure.WebJobs.Script.Metrics;
 using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.Azure;
@@ -35,18 +34,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
     {
         private const string Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
         private static readonly Random Random = new Random();
-
-        /// <summary>
-        /// Gets the common root directory that functions tests create temporary directories under.
-        /// This enables us to clean up test files by deleting this single directory.
-        /// </summary>
-        public static string FunctionsTestDirectory
-        {
-            get
-            {
-                return Path.Combine(Path.GetTempPath(), "FunctionsTest");
-            }
-        }
 
         public static Task WaitOneAsync(this WaitHandle waitHandle)
         {
@@ -116,8 +103,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     }
                     throw new ApplicationException(error);
                 }
-            }
         }
+            }
 
         public static async Task RetryFailedTest(Func<Task> test, int retries, ITestOutputHelper output = null)
         {
@@ -538,6 +525,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             mockFactory.Setup(m => m.CreateClient(It.IsAny<string>()))
                  .Returns(httpClient);
             return mockFactory.Object;
+        }
+
+        public static ManagedServiceIdentity CreateMsi(ManagedServiceIdentityType type, string prefix)
+        {
+            return new ManagedServiceIdentity
+            {
+                Type = type,
+                ClientId = $"{prefix}-clientId-placeholder",
+                PrincipalId = $"{prefix}-principalId-placeholder",
+                TenantId = $"{prefix}-tenantId-placeholder",
+                Thumbprint = $"{prefix}-thumbprint-placeholder",
+                SecretUrl = $"{prefix}-secretUrl-placeholder",
+                ResourceId = $"{prefix}-resourceId-placeholder",
+                Certificate = $"{prefix}-certificate-placeholder",
+                AuthenticationEndpoint = $"{prefix}-authenticationEndpoint-placeholder",
+            };
         }
 
         /// <summary>

--- a/test/WebJobs.Script.Tests.Shared/WebJobs.Script.Tests.Shared.projitems
+++ b/test/WebJobs.Script.Tests.Shared/WebJobs.Script.Tests.Shared.projitems
@@ -37,6 +37,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)TestTraits.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestHelpers.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestHelpers.Constants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestHelpers.Functions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestInvoker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestTelemetryChannel.cs" />

--- a/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
@@ -32,7 +32,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
     public class SecretManagerTests
     {
         private const int TestSentinelWatcherInitializationDelayMS = 50;
-        private const string TestEncryptionKey = "/a/vXvWJ3Hzgx4PFxlDUJJhQm5QVyGiu0NNLFm/ZMMg=";
         private readonly HostNameProvider _hostNameProvider;
         private readonly TestEnvironment _testEnvironment;
         private readonly TestLoggerProvider _loggerProvider;
@@ -63,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             {
                 string startupContextPath = Path.Combine(directory.Path, Guid.NewGuid().ToString());
                 _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteStartupContextCache, startupContextPath);
-                _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestEncryptionKey);
+                _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestHelpers.FakeEncryptionKey);
 
                 // Because we don't initialize any disk context, we can configure
                 // the secret manager to allocate fresh keys on start-up.
@@ -110,7 +109,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             {
                 string startupContextPath = Path.Combine(directory.Path, Guid.NewGuid().ToString());
                 _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteStartupContextCache, startupContextPath);
-                _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestEncryptionKey);
+                _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestHelpers.FakeEncryptionKey);
 
                 WriteStartContextCache(startupContextPath);
 
@@ -224,7 +223,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             {
                 string startupContextPath = Path.Combine(directory.Path, Guid.NewGuid().ToString());
                 _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteStartupContextCache, startupContextPath);
-                _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestEncryptionKey);
+                _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestHelpers.FakeEncryptionKey);
 
                 WriteStartContextCache(startupContextPath);
 
@@ -523,7 +522,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             {
                 string startupContextPath = Path.Combine(directory.Path, Guid.NewGuid().ToString());
                 _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteStartupContextCache, startupContextPath);
-                _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestEncryptionKey);
+                _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestHelpers.FakeEncryptionKey);
 
                 WriteStartContextCache(startupContextPath);
 
@@ -584,7 +583,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             };
 
             string json = JsonConvert.SerializeObject(context);
-            var encryptionKey = Convert.FromBase64String(TestEncryptionKey);
+            var encryptionKey = Convert.FromBase64String(TestHelpers.FakeEncryptionKey);
             string encryptedJson = SimpleWebTokenHelper.Encrypt(json, encryptionKey);
 
             File.WriteAllText(path, encryptedJson);
@@ -1286,7 +1285,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
         [Fact]
         public async Task SetMasterKey_WithProvidedKey_UsesProvidedKeyAndPersistsFile()
         {
-            string testSecret = "abcde0123456789abcde0123456789abcde0123456789";
+            string testSecret = "PLACEHOLDER";
             using (var directory = new TempDirectory())
             {
                 KeyOperationResult result;

--- a/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             {
                 string startupContextPath = Path.Combine(directory.Path, Guid.NewGuid().ToString());
                 _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteStartupContextCache, startupContextPath);
-                _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestHelpers.FakeEncryptionKey);
+                _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestHelpers.EncryptionKey);
 
                 // Because we don't initialize any disk context, we can configure
                 // the secret manager to allocate fresh keys on start-up.
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             {
                 string startupContextPath = Path.Combine(directory.Path, Guid.NewGuid().ToString());
                 _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteStartupContextCache, startupContextPath);
-                _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestHelpers.FakeEncryptionKey);
+                _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestHelpers.EncryptionKey);
 
                 WriteStartContextCache(startupContextPath);
 
@@ -223,7 +223,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             {
                 string startupContextPath = Path.Combine(directory.Path, Guid.NewGuid().ToString());
                 _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteStartupContextCache, startupContextPath);
-                _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestHelpers.FakeEncryptionKey);
+                _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestHelpers.EncryptionKey);
 
                 WriteStartContextCache(startupContextPath);
 
@@ -522,7 +522,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             {
                 string startupContextPath = Path.Combine(directory.Path, Guid.NewGuid().ToString());
                 _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteStartupContextCache, startupContextPath);
-                _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestHelpers.FakeEncryptionKey);
+                _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestHelpers.EncryptionKey);
 
                 WriteStartContextCache(startupContextPath);
 
@@ -583,7 +583,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             };
 
             string json = JsonConvert.SerializeObject(context);
-            var encryptionKey = Convert.FromBase64String(TestHelpers.FakeEncryptionKey);
+            var encryptionKey = Convert.FromBase64String(TestHelpers.EncryptionKey);
             string encryptedJson = SimpleWebTokenHelper.Encrypt(json, encryptionKey);
 
             File.WriteAllText(path, encryptedJson);

--- a/test/WebJobs.Script.Tests/StartupContextProviderTests.cs
+++ b/test/WebJobs.Script.Tests/StartupContextProviderTests.cs
@@ -19,8 +19,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class StartupContextProviderTests
     {
-        private const string TestEncryptionKey = "/a/vXvWJ3Hzgx4PFxlDUJJhQm5QVyGiu0NNLFm/ZMMg=";
-
         private readonly FunctionAppSecrets _secrets;
         private readonly StartupContextProvider _startupContextProvider;
         private readonly TestEnvironment _environment;
@@ -70,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _loggerProvider = new TestLoggerProvider();
             loggerFactory.AddProvider(_loggerProvider);
 
-            _environment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestEncryptionKey);
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestHelpers.FakeEncryptionKey);
 
             _startupContextProvider = new StartupContextProvider(_environment, loggerFactory.CreateLogger<StartupContextProvider>());
         }

--- a/test/WebJobs.Script.Tests/StartupContextProviderTests.cs
+++ b/test/WebJobs.Script.Tests/StartupContextProviderTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _loggerProvider = new TestLoggerProvider();
             loggerFactory.AddProvider(_loggerProvider);
 
-            _environment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestHelpers.FakeEncryptionKey);
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestHelpers.EncryptionKey);
 
             _startupContextProvider = new StartupContextProvider(_environment, loggerFactory.CreateLogger<StartupContextProvider>());
         }

--- a/test/WebJobs.Script.Tests/TokenExpirationServiceTests.cs
+++ b/test/WebJobs.Script.Tests/TokenExpirationServiceTests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Castle.Core.Logging;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Health;
 using Microsoft.Extensions.Logging;
@@ -34,14 +32,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
-        [InlineData("BlobEndpoint=https://storage.blob.core.windows.net;SharedAccessSignature=sv=2015-07-08&sig=f%2BGLvBih%2BoFuQvckBSHWKMXwqGJHlPkESmZh9pjnHuc%3D&spr=https&st=2016-04-12T03%3A24%3A31Z&se=2023-07-20T05:27:05Z&srt=s&ss=bf&sp=rwl", true, true)]
-        [InlineData("BlobEndpoint=https://storage.blob.core.windows.net;SharedAccessSignature=sv=2015-07-08&sig=f%2BGLvBih%2BoFuQvckBSHWKMXwqGJHlPkESmZh9pjnHuc%3D&spr=https&st=2016-04-12T03%3A24%3A31Z&srt=s&ss=bf&sp=rwl", true, false)]
+        [InlineData("BlobEndpoint=https://storage.blob.core.windows.net;SharedAccessSignature=sv=2015-07-08&sig=PLACEHOLDER&spr=https&st=2016-04-12T03%3A24%3A31Z&se=2023-07-20T05:27:05Z&srt=s&ss=bf&sp=rwl", true, true)]
+        [InlineData("BlobEndpoint=https://storage.blob.core.windows.net;SharedAccessSignature=sv=2015-07-08&sig=PLACEHOLDER&spr=https&st=2016-04-12T03%3A24%3A31Z&srt=s&ss=bf&sp=rwl", true, false)]
         [InlineData("https://storage.blob.core.windows.net/functions/func.zip", false, false)]
-        [InlineData("https://storage.blob.core.windows.net/func/func.zip?sp=r&st=2023-07-12T21:27:05Z&se=2023-07-20T05:27:05Z&spr=https&sv=2022-11-02&sr=b&sig=f%2BGLvBih%2BoFuQvckBSHWKMXwqGJHlPkESmZh9pjnHuc%3D", false, true)]
-        [InlineData("BlobEndpoint=https://storage.blob.core.windows.net;SharedAccessSignature=sv=2015-07-08&sig=f%2BGLvBih%2BoFuQvckBSHWKMXwqGJHlPkESmZh9pjnHuc%3D&spr=https&st=2016-04-12T03%3A24%3A31Z&se=9999-07-20T05:27:05Z&srt=s&ss=bf&sp=rwl", true, false)]
+        [InlineData("https://storage.blob.core.windows.net/func/func.zip?sp=r&st=2023-07-12T21:27:05Z&se=2023-07-20T05:27:05Z&spr=https&sv=2022-11-02&sr=b&sig=PLACEHOLDER", false, true)]
+        [InlineData("BlobEndpoint=https://storage.blob.core.windows.net;SharedAccessSignature=sv=2015-07-08&sig=PLACEHOLDER&spr=https&st=2016-04-12T03%3A24%3A31Z&se=9999-07-20T05:27:05Z&srt=s&ss=bf&sp=rwl", true, false)]
         [InlineData("UseDevelopmentStorage=true", true, false)]
-        [InlineData("BlobEndpoint=https://storage.blob.core.windows.net;TableEndpoint=https://table.core.windows.net;SharedAccessSignature=sv=2015-07-08&sig=f%2BGLvBih%2BoFuQvckBSHWKMXwqGJHlPkESmZh9pjnHuc%3D&spr=https&st=2016-04-12T03%3A24%3A31Z&srt=s&ss=bf&sp=rwl", true, false)]
-        [InlineData("BlobEndpoint=https://storage.blob.core.windows.net;TableEndpoint=https://table.core.windows.net;SharedAccessSignature=sv=2015-07-08&sig=f%2BGLvBih%2BoFuQvckBSHWKMXwqGJHlPkESmZh9pjnHuc%3D&spr=https&st=2016-04-12T03%3A24%3A31Z&se=2023-07-20T05:27:05Z&srt=s&ss=bf&sp=rwl", true, true)]
+        [InlineData("BlobEndpoint=https://storage.blob.core.windows.net;TableEndpoint=https://table.core.windows.net;SharedAccessSignature=sv=2015-07-08&sig=PLACEHOLDER&spr=https&st=2016-04-12T03%3A24%3A31Z&srt=s&ss=bf&sp=rwl", true, false)]
+        [InlineData("BlobEndpoint=https://storage.blob.core.windows.net;TableEndpoint=https://table.core.windows.net;SharedAccessSignature=sv=2015-07-08&sig=PLACEHOLDER&spr=https&st=2016-04-12T03%3A24%3A31Z&se=2023-07-20T05:27:05Z&srt=s&ss=bf&sp=rwl", true, true)]
         [InlineData("1", false, false)]
         public async Task StartAsync_Tests(string input, bool isAzureWebJobsStorage, bool shouldEmitEvent)
         {

--- a/test/WebJobs.Script.Tests/UtilityTests.cs
+++ b/test/WebJobs.Script.Tests/UtilityTests.cs
@@ -423,7 +423,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Theory]
         [InlineData("", null, false)]
         [InlineData(null, null, false)]
-        [InlineData("http://storage.blob.core.windows.net/functions/func.zip?sr=c&si=policy&sig=f%2BGLvBih%2BoFuQvckBSHWKMXwqGJHlPkESmZh9pjnHuc%3D",
+        [InlineData("http://storage.blob.core.windows.net/functions/func.zip?sr=c&si=policy&sig=PLACEHOLDER",
             "http://storage.blob.core.windows.net/functions/func.zip...", true)]
         [InlineData("http://storage.blob.core.windows.net/functions/func.zip",
             "http://storage.blob.core.windows.net/functions/func.zip", true)]
@@ -441,7 +441,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Theory]
         [InlineData("", null, false)]
         [InlineData(null, null, false)]
-        [InlineData("http://storage.blob.core.windows.net/functions/func.zip?sr=c&si=policy&sig=f%2BGLvBih%2BoFuQvckBSHWKMXwqGJHlPkESmZh9pjnHuc%3D",
+        [InlineData("http://storage.blob.core.windows.net/functions/func.zip?sr=c&si=policy&sig=PLACEHOLDER",
             "http://storage.blob.core.windows.net", true)]
         [InlineData("http://storage.blob.core.windows.net/functions/func.zip",
             "http://storage.blob.core.windows.net", true)]
@@ -457,8 +457,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
-        [InlineData("http://storage.blob.core.windows.net/functions/func.zip?sr=c&si=policy&sig=f%2BGLvBih%2BoFuQvckBSHWKMXwqGJHlPkESmZh9pjnHuc%3D", true)]
-        [InlineData("http://storage.blob.core.windows.net/functions/func.zip?sr=c&si=policy&sv=abcd&sig=f%2BGLvBih%2BoFuQvckBSHWKMXwqGJHlPkESmZh9pjnHuc%3D", false)]
+        [InlineData("http://storage.blob.core.windows.net/functions/func.zip?sr=c&si=policy&sig=PLACEHOLDER", true)]
+        [InlineData("http://storage.blob.core.windows.net/functions/func.zip?sr=c&si=policy&sv=abcd&sig=PLACEHOLDER", false)]
         [InlineData("http://storage.blob.core.windows.net/functions/func.zip", true)]
         public void GetAccountNameFromDomain(string url, bool isUrlWithNoSas)
         {
@@ -466,12 +466,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
-        [InlineData("BlobEndpoint=https://storage.blob.core.windows.net;SharedAccessSignature=sv=2015-07-08&sig=f%2BGLvBih%2BoFuQvckBSHWKMXwqGJHlPkESmZh9pjnHuc%3D&spr=https&st=2016-04-12T03%3A24%3A31Z&se=2023-07-20T05:27:05Z&srt=s&ss=bf&sp=rwl", "2023-07-20T05:27:05Z", true)]
-        [InlineData("BlobEndpoint=https://storage.blob.core.windows.net;SharedAccessSignature=sv=2015-07-08&sig=f%2BGLvBih%2BoFuQvckBSHWKMXwqGJHlPkESmZh9pjnHuc%3D&spr=https&st=2016-04-12T03%3A24%3A31Z&srt=s&ss=bf&sp=rwl", null, true)]
-        [InlineData("BlobEndpoint=https://storage.blob.core.windows.net;TableEndpoint=https://table.core.windows.net;SharedAccessSignature=sv=2015-07-08&sig=f%2BGLvBih%2BoFuQvckBSHWKMXwqGJHlPkESmZh9pjnHuc%3D&spr=https&st=2016-04-12T03%3A24%3A31Z&srt=s&ss=bf&sp=rwl", null, true)]
-        [InlineData("BlobEndpoint=https://storage.blob.core.windows.net;TableEndpoint=https://table.core.windows.net;SharedAccessSignature=sv=2015-07-08&sig=f%2BGLvBih%2BoFuQvckBSHWKMXwqGJHlPkESmZh9pjnHuc%3D&spr=https&st=2016-04-12T03%3A24%3A31Z&se=2023-07-20T05:27:05Z&srt=s&ss=bf&sp=rwl", "2023-07-20T05:27:05Z", true)]
+        [InlineData("BlobEndpoint=https://storage.blob.core.windows.net;SharedAccessSignature=sv=2015-07-08&sig=PLACEHOLDER&spr=https&st=2016-04-12T03%3A24%3A31Z&se=2023-07-20T05:27:05Z&srt=s&ss=bf&sp=rwl", "2023-07-20T05:27:05Z", true)]
+        [InlineData("BlobEndpoint=https://storage.blob.core.windows.net;SharedAccessSignature=sv=2015-07-08&sig=PLACEHOLDER&spr=https&st=2016-04-12T03%3A24%3A31Z&srt=s&ss=bf&sp=rwl", null, true)]
+        [InlineData("BlobEndpoint=https://storage.blob.core.windows.net;TableEndpoint=https://table.core.windows.net;SharedAccessSignature=sv=2015-07-08&sig=PLACEHOLDER&spr=https&st=2016-04-12T03%3A24%3A31Z&srt=s&ss=bf&sp=rwl", null, true)]
+        [InlineData("BlobEndpoint=https://storage.blob.core.windows.net;TableEndpoint=https://table.core.windows.net;SharedAccessSignature=sv=2015-07-08&sig=PLACEHOLDER&spr=https&st=2016-04-12T03%3A24%3A31Z&se=2023-07-20T05:27:05Z&srt=s&ss=bf&sp=rwl", "2023-07-20T05:27:05Z", true)]
         [InlineData("UseDevelopmentStorage=true", null, true)]
-        [InlineData("https://storage.blob.core.windows.net/func/func.zip?sp=r&st=2023-07-12T21:27:05Z&se=2023-07-20T05:27:05Z&spr=https&sv=2022-11-02&sr=b&sig=f%2BGLvBih%2BoFuQvckBSHWKMXwqGJHlPkESmZh9pjnHuc%3D", "2023-07-20T05:27:05Z", false)]
+        [InlineData("https://storage.blob.core.windows.net/func/func.zip?sp=r&st=2023-07-12T21:27:05Z&se=2023-07-20T05:27:05Z&spr=https&sv=2022-11-02&sr=b&sig=PLACEHOLDER", "2023-07-20T05:27:05Z", false)]
         [InlineData("https://storage.blob.core.windows.net/functions/func.zip", null, false)]
         public void GetSasTokenExpirationDateFromSasSignature(string input, string expirationDate, bool isAzureWebJobsStorage)
         {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR - TODO
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Credscan in 1ES is flagging many of our test files. None of these are actual credentials, but the tool cannot tell that. This PR suppresses these through a variety of methods:

1. Using `PLACEHOLDER` literals - cred scan knows to ignore these.
2. Using in source suppressions with a justification (test needs a semantically correct key, but key is not for any real resource)
3. Generating keys as part of the test.
