### PR TITLE
Add policy for issues with no activity in over 3 years

### DIFF
--- a/.github/policies/issue.flag-stale-no-activity-years.yml
+++ b/.github/policies/issue.flag-stale-no-activity-years.yml
@@ -1,4 +1,4 @@
-name: Flag stale issues due to no activity
+name: Flag stale issues
 description: Flag issues that have seen no activity in over three years.
 resource: repository
 configuration:
@@ -14,15 +14,9 @@ configuration:
       - noActivitySince:
           days: 1095 # 3 years
       - isNotLabeledWith:
-          label: no-recent-activity
+          label: 'Needs: Author Feedback'
       actions:
       - addLabel:
-          label: no-recent-activity
-      - addReply:
-          reply: >-
-            This issue has been automatically marked as stale because it has not seen any activity for **3 years**. It will be closed if no further activity occurs **within 3 days of this comment**.
-
-
-            If you are not the original author (${issueAuthor}) and believe this issue is not stale, please comment with `/bot not-stale` and I will not close it.
+          label: 'Needs: Author Feedback'
 onFailure:
 onSuccess:

--- a/.github/policies/issue.flag-stale-no-activity-years.yml
+++ b/.github/policies/issue.flag-stale-no-activity-years.yml
@@ -1,0 +1,28 @@
+name: Flag stale issues due to no activity
+description: Flag issues that have seen no activity in over three years.
+resource: repository
+configuration:
+  resourceManagementConfiguration:
+    scheduledSearches:
+      frequencies:
+      - weekday:
+          day: Monday
+          time: 10:00
+      filters:
+      - isIssue
+      - isOpen
+      - noActivitySince:
+          days: 1095 # 3 years
+      - isNotLabeledWith:
+          label: no-recent-activity
+      actions:
+      - addLabel:
+          label: no-recent-activity
+      - addReply:
+          reply: >-
+            This issue has been automatically marked as stale because it has not seen any activity for **3 years**. It will be closed if no further activity occurs **within 3 days of this comment**.
+
+
+            If you are not the original author (${issueAuthor}) and believe this issue is not stale, please comment with `/bot not-stale` and I will not close it.
+onFailure:
+onSuccess:

--- a/.github/policies/issue.flag-stale-no-activity-years.yml
+++ b/.github/policies/issue.flag-stale-no-activity-years.yml
@@ -4,7 +4,7 @@ resource: repository
 configuration:
   resourceManagementConfiguration:
     scheduledSearches:
-      frequencies:
+    - frequencies:
       - weekday:
           day: Monday
           time: 10:00

--- a/.github/policies/issue.flag-stale-no-activity-years.yml
+++ b/.github/policies/issue.flag-stale-no-activity-years.yml
@@ -18,5 +18,9 @@ configuration:
       actions:
       - addLabel:
           label: 'Needs: Author Feedback'
+      - addReply:
+          reply: >-
+            This issue has been automatically marked as stale because it has not seen any activity for **3 years**. It will be closed if no further activity occurs **within 5 days of this comment**.
+            If you believe this issue is still relevant, please leave a comment with details.
 onFailure:
 onSuccess:


### PR DESCRIPTION
Add 'Needs: Author Feedback' label to issues that have not been touched in 3 years. This policy runs every Monday at 10am.