### PR TITLE
[in-proc8] Update GetWorkerProcessCount unit test to work on various machines

### DIFF
--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
@@ -204,6 +204,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 _testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionsWorkerProcessCountSettingName, "7");
             }
 
+            var expectedMaxProcessCount = (setProcessCountToNumberOfCpuCores && Environment.ProcessorCount > maxProcessCount)
+                                        ? Environment.ProcessorCount : maxProcessCount;
+
             var config = new ConfigurationBuilder().Build();
             var testLogger = new TestLogger("test");
 
@@ -237,7 +240,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             }
 
             Assert.Equal(TimeSpan.Parse(processStartupInterval), result.ProcessStartupInterval);
-            Assert.Equal(maxProcessCount, result.MaxProcessCount);
+            Assert.Equal(expectedMaxProcessCount, result.MaxProcessCount);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

#10044

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

The test today is hardcoded to whatever the CPU core value of our pipeline is, so this test fails locally.
Updating the test so that it works across different machines.


