### PR TITLE
 Fix for DryIoC causing a service type validation failure

### DIFF
--- a/src/WebJobs.Script.WebHost/DependencyInjection/DryIoc/Container.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/DryIoc/Container.cs
@@ -7132,6 +7132,7 @@ namespace DryIoc
                         implType, implType.GetGenericDefinitionOrNull());
 
                 else if (implType != serviceType && serviceType != typeof(object)
+                      && !implType.IsAssignableTo(serviceType)
                       && implType.GetImplementedTypes().IndexOf(t =>
                         t == serviceType || t.GetGenericDefinitionOrNull() == serviceType) == -1)
                     Throw.It(Error.RegisteringImplementationNotAssignableToServiceType, implType, serviceType);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

The change fixes an issue in DryIoC causing a service type validation failure.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
