### PR TITLE
[in-proc8] Fix IConfiguration mock behaviour

### DIFF
--- a/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             secretManagerMock.Setup(p => p.GetFunctionSecretsAsync("httptrigger", false)).ReturnsAsync(functionSecrets);
 
             var configurationMock = new Mock<IConfiguration>(MockBehavior.Strict);
+            configurationMock.Setup(p => p[It.IsAny<string>()]).Returns(It.IsAny<string>());
             configurationMock.Setup(p => p.GetReloadToken()).Returns(new Mock<IChangeToken>().Object);
 
             var hostIdProviderMock = new Mock<IHostIdProvider>(MockBehavior.Strict);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

#10044

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Fix use of IConfiguration in unit tests by setting up the `IConfiguration["SomeKey"]` mock
