### PR TITLE
Disabling proxies in Flex Consumption

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -12,3 +12,4 @@
 - Update Node.js Worker Version to [3.10.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.10.0) (#9999)
 - Update PowerShell worker 7.2 to [4.0.3220](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.3220)
 - Update PowerShell worker 7.4 to [4.0.3219](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.3219)
+- Ensuring proxies are disabled, with a warning, when running in Flex Consumption. 

--- a/src/WebJobs.Script/Host/ProxyFunctionProvider.cs
+++ b/src/WebJobs.Script/Host/ProxyFunctionProvider.cs
@@ -41,6 +41,12 @@ namespace Microsoft.Azure.WebJobs.Script
             _logger = loggerFactory.CreateLogger(LogCategories.Startup);
             if (_environment.IsProxiesEnabled())
             {
+                if (_environment.IsFlexConsumptionSku())
+                {
+                    _logger.LogWarning("Proxies are not supported in Flex Consumption. Proxy definitions will be ignored.");
+                    return;
+                }
+
                 // note these are both null-checked; if they're left null (disabled) - that's fine
                 _metadata = new Lazy<ImmutableArray<FunctionMetadata>>(LoadFunctionMetadata);
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Small change to ensure proxies are not accidentally enabled in Flex Consumption and warnings are emitted when the flag is set.

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

