### PR TITLE
[CV2] Add AssistantSkillTrigger to known web hook triggers

### DIFF
--- a/src/WebJobs.Script/Extensions/BindingMetadataExtensions.cs
+++ b/src/WebJobs.Script/Extensions/BindingMetadataExtensions.cs
@@ -13,10 +13,18 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
         private const string HttpTrigger = "httpTrigger";
         private const string EventGridTrigger = "eventGridTrigger";
         private const string SignalRTrigger = "signalRTrigger";
+        public const string AssistantSkillTrigger = "assistantSkillTrigger";
         private const string BlobTrigger = "blobTrigger";
 
         private const string BlobSourceKey = "source";
         private const string EventGridSource = "eventGrid";
+
+        private static readonly HashSet<string> WebHookTriggers = new(StringComparer.OrdinalIgnoreCase)
+        {
+            EventGridTrigger,
+            SignalRTrigger,
+            AssistantSkillTrigger,
+        };
 
         private static readonly HashSet<string> DurableTriggers = new(StringComparer.OrdinalIgnoreCase)
         {
@@ -46,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
         /// <param name="binding">The binding metadata to check.</param>
         /// <returns><c>true</c> if a webhook trigger, <c>false</c> otherwise.</returns>
         /// <remarks>
-        /// Known webhook triggers includes SignalR, Event Grid triggers.
+        /// Known webhook triggers includes SignalR, Event Grid, and Assistant Skill triggers.
         /// </remarks>
         public static bool IsWebHookTrigger(this BindingMetadata binding)
         {
@@ -55,13 +63,7 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
                 throw new ArgumentNullException(nameof(binding));
             }
 
-            if (string.Equals(EventGridTrigger, binding.Type, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(SignalRTrigger, binding.Type, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            return false;
+            return WebHookTriggers.Contains(binding.Type);
         }
 
         /// <summary>

--- a/test/WebJobs.Script.Tests/Extensions/BindingMetadataExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/BindingMetadataExtensionsTests.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
         [Theory]
         [InlineData("eventGridTrigger", true)]
         [InlineData("signalRTrigger", true)]
+        [InlineData("assistantSkillTrigger", true)]
         [InlineData("blobTrigger", false, "eventGrid")]
         [InlineData("blobTrigger", false, "other")]
         [InlineData("httpTrigger", false)]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR -- TODO
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Adds "assistantSkillTrigger" as a known web hook trigger, allowing this trigger to be grouped with http instances.
