### PR TITLE
Fixing an issue leading to a race when proxying HTTP requests to the worker.

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -13,3 +13,4 @@
 - Update PowerShell worker 7.2 to [4.0.3220](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.3220)
 - Update PowerShell worker 7.4 to [4.0.3219](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.3219)
 - Ensuring proxies are disabled, with a warning, when running in Flex Consumption. 
+- Fixed an issue leading to a race when invocation responses returned prior to HTTP requests being sent in proxied scenarios.

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -890,6 +890,14 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                 _executingInvocations.TryAdd(invocationRequest.InvocationId, new(context, _messageDispatcherFactory.Create(invocationRequest.InvocationId)));
                 _metricsLogger.LogEvent(string.Format(MetricEventNames.WorkerInvoked, Id), functionName: Sanitizer.Sanitize(context.FunctionMetadata.Name));
 
+                // If the worker supports HTTP proxying, ensure this request is forwarded prior
+                // to sending the invocation request to the worker, as this will ensure the context
+                // is properly set up.
+                if (IsHttpProxyingWorker && context.FunctionMetadata.IsHttpTriggerFunction())
+                {
+                    _httpProxyService.StartForwarding(context, _httpProxyEndpoint);
+                }
+
                 await SendStreamingMessageAsync(new StreamingMessage
                 {
                     InvocationRequest = invocationRequest
@@ -899,11 +907,6 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                 {
                     var cancellationCtr = context.CancellationToken.Register(() => SendInvocationCancel(invocationRequest.InvocationId));
                     context.Properties.Add(ScriptConstants.CancellationTokenRegistration, cancellationCtr);
-                }
-
-                if (IsHttpProxyingWorker && context.FunctionMetadata.IsHttpTriggerFunction())
-                {
-                    _ = _httpProxyService.ForwardAsync(context, _httpProxyEndpoint);
                 }
             }
             catch (Exception invokeEx)

--- a/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
+++ b/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             }
         }
 
-        public Task ForwardAsync(ScriptInvocationContext context, Uri httpUri)
+        public void StartForwarding(ScriptInvocationContext context, Uri httpUri)
         {
             ArgumentNullException.ThrowIfNull(context);
 
@@ -89,8 +89,6 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
             var forwardingTask = _httpForwarder.SendAsync(httpContext, httpUri.ToString(), _messageInvoker, _forwarderRequestConfig).AsTask();
             context.Properties.Add(ScriptConstants.HttpProxyTask, forwardingTask);
-
-            return forwardingTask;
         }
     }
 }

--- a/src/WebJobs.Script.Grpc/Server/IHttpProxyService.cs
+++ b/src/WebJobs.Script.Grpc/Server/IHttpProxyService.cs
@@ -11,6 +11,11 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
     {
         Task EnsureSuccessfulForwardingAsync(ScriptInvocationContext context);
 
-        Task ForwardAsync(ScriptInvocationContext context, Uri httpUri);
+        /// <summary>
+        /// Initiates a request forward and updates the current context to track forwarding operation.
+        /// </summary>
+        /// <param name="context">The <see cref="ScriptInvocationContext"/> for the HTTP invocation.</param>
+        /// <param name="httpUri">The target URI used for forwarding.</param>
+        void StartForwarding(ScriptInvocationContext context, Uri httpUri);
     }
 }


### PR DESCRIPTION
Fixing a race with the HTTP proxying flow that leads to request failures due to missing HTTP context association.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting [coming]
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
