### PR TITLE
Fix flaky test `TestDelay_StartProcess` by restructuring task model

### DIFF
--- a/src/WebJobs.Script/Extensions/TaskExtensions.cs
+++ b/src/WebJobs.Script/Extensions/TaskExtensions.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Script.Extensions
+{
+    internal static class TaskExtensions
+    {
+        /// <summary>
+        /// Forgets the task. This method is used to indicating not awaiting a task is intentional.
+        /// </summary>
+        /// <param name="task">The task to forget.</param>
+        public static void Forget(this Task task)
+        {
+            // No op - this method is used to suppress the compiler warning.
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Workers/Http/HttpFunctionInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Http/HttpFunctionInvocationDispatcherTests.cs
@@ -49,7 +49,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
             {
             }
 
-            await Task.Delay(TimeSpan.FromMilliseconds(500));
             if (startWorkerProcessResult)
             {
                 Assert.Equal(dispatcher.State, FunctionInvocationDispatcherState.Initialized);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR -- TODO
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Fixes the flaky test:

https://github.com/Azure/azure-functions-host/blob/1bf081347aa0ff3fa02e846802ae330611d192ff/test/WebJobs.Script.Tests/Workers/Http/HttpFunctionInvocationDispatcherTests.cs#L23

This is done by restructuring the system under test. Specifically, the continuation model from `InitializeHttpWorkerChannelAsync` is replaced with `await`. The desired fire & forget behavior is moved to the calling code. A `.Forget()` helper method is added to show fire & forget is intentional behavior.
