### PR TITLE
Flaky test: FunctionsSyncServiceTests: Increase test due time & add tsc callback

### DIFF
--- a/test/WebJobs.Script.Tests/FunctionsSyncServiceTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionsSyncServiceTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         private readonly Mock<IFunctionsSyncManager> _mockSyncManager;
         private readonly Mock<IScriptWebHostEnvironment> _mockWebHostEnvironment;
         private readonly Mock<IEnvironment> _mockEnvironment;
-        private readonly int _testDueTime = 250;
+        private readonly int _testDueTime = 1000;
 
         public FunctionsSyncServiceTests()
         {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Part of #10135

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Increasing the test due time to something more reasonable
