### PR TITLE
[.NET 8 in-proc] Clean up to remove older release branches(inproc6,inproc8) from build YAML 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,8 +11,7 @@ pr:
     - dev
     - in-proc
     - release/4.*
-    - release/inproc6/4.*
-    - release/inproc8/4.*
+    - release/in-proc
 
 trigger:
   branches:
@@ -20,8 +19,7 @@ trigger:
     - dev
     - in-proc
     - release/4.*
-    - release/inproc6/4.*
-    - release/inproc8/4.*
+    - release/in-proc
 
 jobs:
 - job: InitializePipeline
@@ -53,7 +51,7 @@ jobs:
   dependsOn: InitializePipeline
   condition: and(succeeded(), or(ne(variables['Build.Reason'], 'PullRequest'), eq(dependencies.InitializePipeline.outputs['Initialize.BuildArtifacts'], true)))
   variables:
-    ${{ if or( eq( variables['Build.Reason'], 'PullRequest' ), and( not( contains( variables['Build.SourceBranch'], 'release/inproc6/4.' ) ), not( contains( variables['Build.SourceBranch'], 'release/inproc8/4.' ) ), not( contains( variables['Build.SourceBranch'], 'release/4.' ) ), not( contains( variables['Build.SourceBranch'], 'release/ExtensionsMetadataGenerator/' ) ) ) ) }}:
+    ${{ if or( eq( variables['Build.Reason'], 'PullRequest' ), and( not( contains( variables['Build.SourceBranch'], 'release/in-proc' ) ), not( contains( variables['Build.SourceBranch'], 'release/ExtensionsMetadataGenerator/' ) ) ) ) }}:
       suffixTemp: $(buildNumber)
       packSuffixSwitchTemp: --version-suffix $(buildNumber)
       emgSuffixSwitchTemp: --version-suffix ci$(buildNumber)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -295,7 +295,7 @@ jobs:
       BuildDropPath: 'out/pkg/release'
       Verbosity: 'Information'
   - publish: out/pkg/release
-    artifact: NugetPackages
+    artifact: _NugetPackages.net$(minorVersionPrefix)
 
 - job: RunUnitTests
   strategy: 
@@ -619,10 +619,10 @@ jobs:
       path: '$(Build.ArtifactStagingDirectory)/PrivateSiteExtension'
 
   - task: DownloadPipelineArtifact@2
-    displayName: 'Download _Packages.net8 Artifact'
+    displayName: 'Download _NugetPackages.net8 Artifact'
     inputs:
       buildType: 'current'
-      artifact: '_Packages.net8'
+      artifact: '_NugetPackages.net8'
       path: '$(Build.ArtifactStagingDirectory)/packages'
 
   - task: DownloadPipelineArtifact@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,17 +8,13 @@ variables:
 pr:
   branches:
     include:
-    - dev
     - in-proc
-    - release/4.*
     - release/in-proc
 
 trigger:
   branches:
     include:
-    - dev
     - in-proc
-    - release/4.*
     - release/in-proc
 
 jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,13 +8,17 @@ variables:
 pr:
   branches:
     include:
+    - dev
     - in-proc
+    - release/4.*
     - release/in-proc
 
 trigger:
   branches:
     include:
+    - dev
     - in-proc
+    - release/4.*
     - release/in-proc
 
 jobs:


### PR DESCRIPTION
Removing old TFM specific branch names.

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)
