### PR TITLE
[1ES] Disable broken linux integration test

### DIFF
--- a/eng/ci/templates/official/jobs/run-integration-tests.yml
+++ b/eng/ci/templates/official/jobs/run-integration-tests.yml
@@ -166,7 +166,7 @@ jobs:
       testRunTitle: Drain mode end to end tests
       arguments: '--filter "Group=DrainModeEndToEndTests" --no-build'
       projects: $(IntegrationProject)
-  
+
   - task: DotNetCoreCLI@2
     displayName: Standby mode end to end tests Windows
     condition: succeededOrFailed()
@@ -175,15 +175,16 @@ jobs:
       testRunTitle: Standby mode end to end tests Windows
       arguments: '--filter "Group=StandbyModeEndToEndTests_Windows" --no-build'
       projects: $(IntegrationProject)
-  
-  - task: DotNetCoreCLI@2
-    displayName: Standby mode end to end tests Linux
-    condition: succeededOrFailed()
-    inputs:
-      command: test
-      testRunTitle: Standby mode end to end tests Linux
-      arguments: '--filter "Group=StandbyModeEndToEndTests_Linux" --no-build'
-      projects: $(IntegrationProject)
+
+  # Disabled to unblock in 202401. Will fix shortly.
+  # - task: DotNetCoreCLI@2
+  #   displayName: Standby mode end to end tests Linux
+  #   condition: succeededOrFailed()
+  #   inputs:
+  #     command: test
+  #     testRunTitle: Standby mode end to end tests Linux
+  #     arguments: '--filter "Group=StandbyModeEndToEndTests_Linux" --no-build'
+  #     projects: $(IntegrationProject)
 
   - task: DotNetCoreCLI@2
     displayName: Linux container end to end tests Windows


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR -- TODO
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

These tests are disabled in current ci. Disabling here as well.

https://github.com/Azure/azure-functions-host/blob/1bf081347aa0ff3fa02e846802ae330611d192ff/azure-pipelines.yml#L512-L521
