### PR TITLE
adding support for net8 assembly list in emg

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -319,9 +319,16 @@ jobs:
       testRunTitle: 'Unit Tests'
       arguments: '-v n -f $(targetFramework)'
       projects: |
-        **\ExtensionsMetadataGeneratorTests.csproj
         **\WebJobs.Script.Scaling.Tests.csproj
-        **\WebJobs.Script.Tests.csproj  
+        **\WebJobs.Script.Tests.csproj
+  - task: DotNetCoreCLI@2
+    displayName: 'ExtensionsMetadataGenerator Unit Tests'
+    inputs:
+      command: 'test'
+      testRunTitle: 'EGM Unit Tests'
+      arguments: '-v n'
+      projects: |
+        **\ExtensionsMetadataGeneratorTests.csproj
 
 - job: RunNonE2EIntegrationTests
   strategy: 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -319,16 +319,9 @@ jobs:
       testRunTitle: 'Unit Tests'
       arguments: '-v n -f $(targetFramework)'
       projects: |
-        **\WebJobs.Script.Scaling.Tests.csproj
-        **\WebJobs.Script.Tests.csproj
-  - task: DotNetCoreCLI@2
-    displayName: 'EGM Unit Tests'
-    inputs:
-      command: 'test'
-      testRunTitle: 'EGM Unit Tests'
-      arguments: '-v n'
-      projects: |
         **\ExtensionsMetadataGeneratorTests.csproj
+        **\WebJobs.Script.Scaling.Tests.csproj
+        **\WebJobs.Script.Tests.csproj  
 
 - job: RunNonE2EIntegrationTests
   strategy: 

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/BuildTasks/RemoveRuntimeDependencies.cs
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/BuildTasks/RemoveRuntimeDependencies.cs
@@ -18,9 +18,21 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.BuildTasks
         private const string Net6File = ".runtimeAssemblies-net6.txt";
         private const string Net8File = ".runtimeAssemblies-net8.txt";
 
+        // everything up until net6 maps to the net6 assembly list
+        // net8 only maps to the net8 assembly list
+        // anything else (such as future versions) are unsupported
         private static readonly IDictionary<string, string> _runtimeToAssemblyFileMap = new Dictionary<string, string>()
         {
+            { "netstandard2.0", Net6File },
+            { "netstandard2.1", Net6File },
+            { "netcoreapp2.1", Net6File },
+            { "netcoreapp2.2", Net6File },
+            { "netcoreapp3.0", Net6File },
+            { "netcoreapp2.0", Net6File },
+            { "netcoreapp3.1", Net6File },
+            { "net5.0", Net6File },
             { "net6.0", Net6File },
+
             { "net8.0", Net8File }
         };
 

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/BuildTasks/RemoveRuntimeDependencies.cs
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/BuildTasks/RemoveRuntimeDependencies.cs
@@ -25,14 +25,13 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.BuildTasks
         {
             { "netstandard2.0", Net6File },
             { "netstandard2.1", Net6File },
+            { "netcoreapp2.0", Net6File },
             { "netcoreapp2.1", Net6File },
             { "netcoreapp2.2", Net6File },
             { "netcoreapp3.0", Net6File },
-            { "netcoreapp2.0", Net6File },
             { "netcoreapp3.1", Net6File },
             { "net5.0", Net6File },
             { "net6.0", Net6File },
-
             { "net8.0", Net8File }
         };
 

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/BuildTasks/RemoveRuntimeDependencies.cs
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/BuildTasks/RemoveRuntimeDependencies.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Reflection;
-using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -18,11 +15,20 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.BuildTasks
     public class RemoveRuntimeDependencies : Task
 #endif
     {
+        private static readonly IDictionary<string, string> _runtimeToAssemblyFileMap = new Dictionary<string, string>()
+        {
+            { "net6.0", ".runtimeAssemblies-net6.txt" },
+            { "net8.0", ".runtimeAssemblies-net8.txt" }
+        };
+
         [Required]
         public string OutputPath { get; set; }
 
         [Required]
         public ITaskItem[] IgnoreFiles { get; set; }
+
+        [Required]
+        public string TargetFramework { get; set; }
 
         public override bool Execute()
         {
@@ -32,8 +38,14 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.BuildTasks
                 ignoreFilesSet.Add(item.ItemSpec);
             }
 
+            if (!_runtimeToAssemblyFileMap.TryGetValue(TargetFramework, out var assemblyListFileName))
+            {
+                Log.LogError($"The TargetFramework '{TargetFramework}' is not supported in this project.");
+                return false;
+            }
+
             Assembly assembly = typeof(RemoveRuntimeDependencies).Assembly;
-            using (Stream resource = assembly.GetManifestResourceStream(assembly.GetName().Name + ".runtimeassemblies-net6.txt"))
+            using (Stream resource = assembly.GetManifestResourceStream(assembly.GetName().Name + assemblyListFileName))
             using (var reader = new StreamReader(resource))
             {
                 string assemblyName = reader.ReadLine();

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/BuildTasks/RemoveRuntimeDependencies.cs
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/BuildTasks/RemoveRuntimeDependencies.cs
@@ -15,10 +15,13 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.BuildTasks
     public class RemoveRuntimeDependencies : Task
 #endif
     {
+        private const string Net6File = ".runtimeAssemblies-net6.txt";
+        private const string Net8File = ".runtimeAssemblies-net8.txt";
+
         private static readonly IDictionary<string, string> _runtimeToAssemblyFileMap = new Dictionary<string, string>()
         {
-            { "net6.0", ".runtimeAssemblies-net6.txt" },
-            { "net8.0", ".runtimeAssemblies-net8.txt" }
+            { "net6.0", Net6File },
+            { "net8.0", Net8File }
         };
 
         [Required]
@@ -40,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.BuildTasks
 
             if (!_runtimeToAssemblyFileMap.TryGetValue(TargetFramework, out var assemblyListFileName))
             {
-                Log.LogError($"The TargetFramework '{TargetFramework}' is not supported in this project.");
+                Log.LogError($"The TargetFramework '{TargetFramework}' is not supported in this project. Supported frameworks are: {string.Join(", ", _runtimeToAssemblyFileMap.Keys)}.");
                 return false;
             }
 

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.csproj
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.csproj
@@ -38,7 +38,7 @@
   <Target Name="PackReferenceAssemblies">
     <ItemGroup>
       <Content Include="$(ArtifactsPath)\bin\ExtensionsMetadataGenerator\release_netstandard2.0\generator\*">
-        <Pack>true</Pack>        
+        <Pack>true</Pack>
         <PackagePath>tools\netstandard2.0\generator</PackagePath>
       </Content>
       <Content Include="$(ArtifactsPath)\bin\ExtensionsMetadataGenerator\release_netstandard2.0\*.dll" Exclude="**\Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.dll">

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.csproj
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/ExtensionsMetadataGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" InitialTargets="UpdateRuntimeAssemblies">
   <Import Project="..\..\build\metadatagenerator.props" />
   <PropertyGroup>
-    <Version>4.0.2</Version>
+    <Version>4.0.3</Version>
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <AssemblyName>Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator</AssemblyName>
@@ -37,11 +37,11 @@
 
   <Target Name="PackReferenceAssemblies">
     <ItemGroup>
-      <Content Include="$(OutputPath)\netstandard2.0\generator\*">
-        <Pack>true</Pack>
+      <Content Include="$(ArtifactsPath)\bin\ExtensionsMetadataGenerator\release_netstandard2.0\generator\*">
+        <Pack>true</Pack>        
         <PackagePath>tools\netstandard2.0\generator</PackagePath>
       </Content>
-      <Content Include="$(OutputPath)\netstandard2.0\*.dll" Exclude="**\Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.dll">
+      <Content Include="$(ArtifactsPath)\bin\ExtensionsMetadataGenerator\release_netstandard2.0\*.dll" Exclude="**\Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.dll">
         <Pack>true</Pack>
         <PackagePath>tools\netstandard2.0\</PackagePath>
       </Content>

--- a/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets
+++ b/tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/Targets/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets
@@ -21,11 +21,11 @@
              AssemblyFile="$(_FunctionsExtensionsTaskAssemblyFullPath)"/>
 
   <Target Name="_FunctionsBuildCleanOutput" AfterTargets="_GenerateFunctionsExtensionsMetadataPostBuild" Condition="$(_FunctionsSkipCleanOutput) != 'true'" >
-    <RemoveRuntimeDependencies OutputPath="$(TargetDir)bin" IgnoreFiles="@(FunctionsPreservedDependencies)"/>
+    <RemoveRuntimeDependencies OutputPath="$(TargetDir)bin" IgnoreFiles="@(FunctionsPreservedDependencies)" TargetFramework="$(TargetFramework)" />
   </Target>
 
   <Target Name="_FunctionsPublishCleanOutput" AfterTargets="_GenerateFunctionsExtensionsMetadataPostPublish" Condition="$(_FunctionsSkipCleanOutput) != 'true'" >
-    <RemoveRuntimeDependencies OutputPath="$(PublishDir)bin" IgnoreFiles="@(FunctionsPreservedDependencies)"/>
+    <RemoveRuntimeDependencies OutputPath="$(PublishDir)bin" IgnoreFiles="@(FunctionsPreservedDependencies)" TargetFramework="$(TargetFramework)" />
   </Target>
 
   <UsingTask TaskName="GenerateFunctionsExtensionsMetadata"


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

resolves #10112

Adding support for separate assembly cleanup lists for net6 and net8 in ExtensionsMetadataGenerator.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)