### PR TITLE
[1ES] Fix Official and PR 1es builds

### DIFF
--- a/eng/ci/integration-tests.yml
+++ b/eng/ci/integration-tests.yml
@@ -9,8 +9,7 @@ pr:
     - dev
     - in-proc
     - release/4.*
-    - release/inproc6/4.*
-    - release/inproc8/4.*
+    - release/in-proc
 
 resources:
   repositories:
@@ -30,7 +29,6 @@ extends:
     stages:
     - stage: Test
       jobs:
-
       - template: /eng/ci/templates/jobs/initialize-pipeline.yml@self
       - template: /eng/ci/templates/official/jobs/run-non-e2e-tests.yml@self
       - template: /eng/ci/templates/official/jobs/run-integration-tests.yml@self

--- a/eng/ci/integration-tests.yml
+++ b/eng/ci/integration-tests.yml
@@ -1,8 +1,3 @@
-variables:
-  DOTNET_NOLOGO: 1
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  DOTNET_CLI_TELEMETRY_OPTOUT: 1
-
 pr:
   branches:
     include:
@@ -18,6 +13,9 @@ resources:
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
 
+variables:
+  - template: eng/ci/templates/variables/build.yml@self
+
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
   parameters:
@@ -29,6 +27,6 @@ extends:
     stages:
     - stage: Test
       jobs:
-      - template: /eng/ci/templates/jobs/initialize-pipeline.yml@self
-      - template: /eng/ci/templates/official/jobs/run-non-e2e-tests.yml@self
-      - template: /eng/ci/templates/official/jobs/run-integration-tests.yml@self
+      - template: eng/ci/templates/jobs/initialize-pipeline.yml@self
+      - template: eng/ci/templates/official/jobs/run-non-e2e-tests.yml@self
+      - template: eng/ci/templates/official/jobs/run-integration-tests.yml@self

--- a/eng/ci/integration-tests.yml
+++ b/eng/ci/integration-tests.yml
@@ -14,7 +14,7 @@ resources:
     ref: refs/tags/release
 
 variables:
-  - template: eng/ci/templates/variables/build.yml@self
+  - template: /eng/ci/templates/variables/build.yml@self
 
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
@@ -27,6 +27,6 @@ extends:
     stages:
     - stage: Test
       jobs:
-      - template: eng/ci/templates/jobs/initialize-pipeline.yml@self
-      - template: eng/ci/templates/official/jobs/run-non-e2e-tests.yml@self
-      - template: eng/ci/templates/official/jobs/run-integration-tests.yml@self
+      - template: /eng/ci/templates/jobs/initialize-pipeline.yml@self
+      - template: /eng/ci/templates/official/jobs/run-non-e2e-tests.yml@self
+      - template: /eng/ci/templates/official/jobs/run-integration-tests.yml@self

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -22,8 +22,8 @@ resources:
     ref: refs/tags/release
 
 variables:
-  - template: eng/ci/templates/variables/build.yml@self
-  - template: ci/variables/cfs.yml@eng
+  - template: /eng/ci/templates/variables/build.yml@self
+  - template: /ci/variables/cfs.yml@eng
   - name: buildNumber
     value: $[ counter('build', 23000) ] # 23000 selected to be ahead of current host build
 
@@ -39,19 +39,19 @@ extends:
     - stage: Initialize
 
       jobs:
-      - template: eng/ci/templates/jobs/initialize-pipeline.yml@self
+      - template: /eng/ci/templates/jobs/initialize-pipeline.yml@self
 
     - stage: Build
       dependsOn: Initialize
 
       jobs:
-      - template: eng/ci/templates/official/jobs/build-artifacts-windows.yml@self
-      - template: eng/ci/templates/official/jobs/build-artifacts-linux.yml@self
+      - template: /eng/ci/templates/official/jobs/build-artifacts-windows.yml@self
+      - template: /eng/ci/templates/official/jobs/build-artifacts-linux.yml@self
 
     - stage: Test
       dependsOn: Initialize
 
       jobs:
-      - template: eng/ci/templates/jobs/run-unit-tests.yml@self
-      - template: eng/ci/templates/official/jobs/run-non-e2e-tests.yml@self
-      - template: eng/ci/templates/official/jobs/run-integration-tests.yml@self
+      - template: /eng/ci/templates/jobs/run-unit-tests.yml@self
+      - template: /eng/ci/templates/official/jobs/run-non-e2e-tests.yml@self
+      - template: /eng/ci/templates/official/jobs/run-integration-tests.yml@self

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -22,7 +22,7 @@ resources:
     ref: refs/tags/release
 
 variables:
-  - template: ci/variables/build.yml@eng
+  - template: eng/ci/templates/variables/build.yml@self
   - template: ci/variables/cfs.yml@eng
   - name: buildNumber
     value: $[ counter('build', 23000) ] # 23000 selected to be ahead of current host build
@@ -39,19 +39,19 @@ extends:
     - stage: Initialize
 
       jobs:
-      - template: /eng/ci/templates/jobs/initialize-pipeline.yml@self
+      - template: eng/ci/templates/jobs/initialize-pipeline.yml@self
 
     - stage: Build
       dependsOn: Initialize
 
       jobs:
-      - template: /eng/ci/templates/official/jobs/build-artifacts-windows.yml@self
-      - template: /eng/ci/templates/official/jobs/build-artifacts-linux.yml@self
+      - template: eng/ci/templates/official/jobs/build-artifacts-windows.yml@self
+      - template: eng/ci/templates/official/jobs/build-artifacts-linux.yml@self
 
     - stage: Test
       dependsOn: Initialize
 
       jobs:
-      - template: /eng/ci/templates/jobs/run-unit-tests.yml@self
-      - template: /eng/ci/templates/official/jobs/run-non-e2e-tests.yml@self
-      - template: /eng/ci/templates/official/jobs/run-integration-tests.yml@self
+      - template: eng/ci/templates/jobs/run-unit-tests.yml@self
+      - template: eng/ci/templates/official/jobs/run-non-e2e-tests.yml@self
+      - template: eng/ci/templates/official/jobs/run-integration-tests.yml@self

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -38,7 +38,7 @@ extends:
       os: windows
 
     stages:
-    - stage: Run Tests
+    - stage: Test
       jobs:
       - template: /eng/ci/templates/jobs/initialize-pipeline.yml@self
       - template: /eng/ci/templates/jobs/run-unit-tests.yml@self

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -1,10 +1,5 @@
 # This build is used for public PR and CI builds.
 
-variables:
-  DOTNET_NOLOGO: 1
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  DOTNET_CLI_TELEMETRY_OPTOUT: 1
-
 trigger:
   batch: true
   branches:
@@ -29,6 +24,9 @@ resources:
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
 
+variables:
+  - template: eng/ci/templates/variables/build.yml@self
+
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
   parameters:
@@ -40,5 +38,5 @@ extends:
     stages:
     - stage: Test
       jobs:
-      - template: /eng/ci/templates/jobs/initialize-pipeline.yml@self
-      - template: /eng/ci/templates/jobs/run-unit-tests.yml@self
+      - template: eng/ci/templates/jobs/initialize-pipeline.yml@self
+      - template: eng/ci/templates/jobs/run-unit-tests.yml@self

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -25,7 +25,7 @@ resources:
     ref: refs/tags/release
 
 variables:
-  - template: eng/ci/templates/variables/build.yml@self
+  - template: /eng/ci/templates/variables/build.yml@self
 
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
@@ -38,5 +38,5 @@ extends:
     stages:
     - stage: Test
       jobs:
-      - template: eng/ci/templates/jobs/initialize-pipeline.yml@self
-      - template: eng/ci/templates/jobs/run-unit-tests.yml@self
+      - template: /eng/ci/templates/jobs/initialize-pipeline.yml@self
+      - template: /eng/ci/templates/jobs/run-unit-tests.yml@self

--- a/eng/ci/templates/jobs/run-unit-tests.yml
+++ b/eng/ci/templates/jobs/run-unit-tests.yml
@@ -3,7 +3,7 @@ jobs:
   displayName: Run Unit Tests
 
   steps:
-  - template: /eng/ci/templates/install-dotnet.yml@self
+  - template: eng/ci/templates/install-dotnet.yml@self
 
   - task: DotNetCoreCLI@2
     displayName: Unit Tests

--- a/eng/ci/templates/jobs/run-unit-tests.yml
+++ b/eng/ci/templates/jobs/run-unit-tests.yml
@@ -3,7 +3,7 @@ jobs:
   displayName: Run Unit Tests
 
   steps:
-  - template: eng/ci/templates/install-dotnet.yml@self
+  - template: /eng/ci/templates/install-dotnet.yml@self
 
   - task: DotNetCoreCLI@2
     displayName: Unit Tests

--- a/eng/ci/templates/jobs/run-unit-tests.yml
+++ b/eng/ci/templates/jobs/run-unit-tests.yml
@@ -3,9 +3,6 @@ jobs:
   displayName: Run Unit Tests
 
   steps:
-  - task: NuGetAuthenticate@1
-    displayName: NuGet Authenticate
-
   - template: /eng/ci/templates/install-dotnet.yml@self
 
   - task: DotNetCoreCLI@2

--- a/eng/ci/templates/official/jobs/build-artifacts-linux.yml
+++ b/eng/ci/templates/official/jobs/build-artifacts-linux.yml
@@ -32,7 +32,7 @@ jobs:
     os: linux
 
   steps:
-  - template: /eng/ci/templates/install-dotnet.yml@self
+  - template: eng/ci/templates/install-dotnet.yml@self
 
   - task: DotNetCoreCLI@2
     displayName: Restore

--- a/eng/ci/templates/official/jobs/build-artifacts-linux.yml
+++ b/eng/ci/templates/official/jobs/build-artifacts-linux.yml
@@ -7,7 +7,7 @@ jobs:
     configuration: release
     runtime: linux-x64
     log_dir: $(Build.ArtifactStagingDirectory)/log
-    build_args: '-v m -c $(configuration) -r $(runtime) --self-contained true -p:BuildNumber=$(buildNumber) -p:MinorVersionPrefix=$(minorVersionPrefix) -p:IsPackable=false'
+    build_args: '-v m -c $(configuration) -r $(runtime) --self-contained true -p:BuildNumber=$(buildNumber) -p:IsPackable=false'
     publish_zip_dir: $(Build.ArtifactStagingDirectory)/Linux
 
   templateContext:

--- a/eng/ci/templates/official/jobs/build-artifacts-linux.yml
+++ b/eng/ci/templates/official/jobs/build-artifacts-linux.yml
@@ -32,7 +32,7 @@ jobs:
     os: linux
 
   steps:
-  - template: eng/ci/templates/install-dotnet.yml@self
+  - template: /eng/ci/templates/install-dotnet.yml@self
 
   - task: DotNetCoreCLI@2
     displayName: Restore

--- a/eng/ci/templates/official/jobs/build-artifacts-windows.yml
+++ b/eng/ci/templates/official/jobs/build-artifacts-windows.yml
@@ -37,7 +37,7 @@ jobs:
     emgSuffixSwitch: $[variables.emgSuffixSwitchTemp]
 
   steps:
-  - template: eng/ci/templates/install-dotnet.yml@self
+  - template: /eng/ci/templates/install-dotnet.yml@self
 
   - task: PowerShell@2
     displayName: Build artifacts

--- a/eng/ci/templates/official/jobs/build-artifacts-windows.yml
+++ b/eng/ci/templates/official/jobs/build-artifacts-windows.yml
@@ -43,7 +43,7 @@ jobs:
     displayName: Build artifacts
     inputs:
       filePath: build/build-extensions.ps1
-      arguments: '-buildNumber "$(buildNumber)" -suffix "$(suffix)" -minorVersionPrefix "$(minorVersionPrefix)"'
+      arguments: '-buildNumber "$(buildNumber)" -suffix "$(suffix)"'
 
   - task: CopyFiles@2
     inputs:

--- a/eng/ci/templates/official/jobs/build-artifacts-windows.yml
+++ b/eng/ci/templates/official/jobs/build-artifacts-windows.yml
@@ -37,7 +37,7 @@ jobs:
     emgSuffixSwitch: $[variables.emgSuffixSwitchTemp]
 
   steps:
-  - template: /eng/ci/templates/install-dotnet.yml@self
+  - template: eng/ci/templates/install-dotnet.yml@self
 
   - task: PowerShell@2
     displayName: Build artifacts

--- a/eng/ci/templates/official/jobs/run-integration-tests.yml
+++ b/eng/ci/templates/official/jobs/run-integration-tests.yml
@@ -12,7 +12,7 @@ jobs:
     IsReleaseBranch: $[contains(variables['Build.SourceBranch'], 'release/')]
 
   steps:
-  - template: /eng/ci/templates/install-dotnet.yml@self
+  - template: eng/ci/templates/install-dotnet.yml@self
 
   - task: UseNode@1
     inputs:

--- a/eng/ci/templates/official/jobs/run-integration-tests.yml
+++ b/eng/ci/templates/official/jobs/run-integration-tests.yml
@@ -12,9 +12,6 @@ jobs:
     IsReleaseBranch: $[contains(variables['Build.SourceBranch'], 'release/')]
 
   steps:
-  - task: NuGetAuthenticate@1
-    displayName: NuGet Authenticate
-
   - template: /eng/ci/templates/install-dotnet.yml@self
 
   - task: UseNode@1

--- a/eng/ci/templates/official/jobs/run-integration-tests.yml
+++ b/eng/ci/templates/official/jobs/run-integration-tests.yml
@@ -12,7 +12,7 @@ jobs:
     IsReleaseBranch: $[contains(variables['Build.SourceBranch'], 'release/')]
 
   steps:
-  - template: eng/ci/templates/install-dotnet.yml@self
+  - template: /eng/ci/templates/install-dotnet.yml@self
 
   - task: UseNode@1
     inputs:

--- a/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
+++ b/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
@@ -11,7 +11,7 @@ jobs:
     IntegrationProject: test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
 
   steps:
-  - template: eng/ci/templates/install-dotnet.yml@self
+  - template: /eng/ci/templates/install-dotnet.yml@self
 
   - task: UseNode@1
     inputs:

--- a/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
+++ b/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
@@ -11,7 +11,7 @@ jobs:
     IntegrationProject: test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
 
   steps:
-  - template: /eng/ci/templates/install-dotnet.yml@self
+  - template: eng/ci/templates/install-dotnet.yml@self
 
   - task: UseNode@1
     inputs:

--- a/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
+++ b/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
@@ -11,9 +11,6 @@ jobs:
     IntegrationProject: test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
 
   steps:
-  - task: NuGetAuthenticate@1
-    displayName: NuGet Authenticate
-
   - template: /eng/ci/templates/install-dotnet.yml@self
 
   - task: UseNode@1

--- a/eng/ci/templates/variables/build.yml
+++ b/eng/ci/templates/variables/build.yml
@@ -1,0 +1,7 @@
+variables:
+  - name: DOTNET_NOLOGO
+    value: 1
+  - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
+    value: 1
+  - name: DOTNET_CLI_TELEMETRY_OPTOUT
+    value: 1


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR -- TODO
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Fixes the following CI and PR issues:

- Invalid stage name for 1ES PR build
- Removes unneeded `NugetAuthenticate` steps
- Removes uses of `$(minorVersionPrefix)`
