### PR TITLE
FlexConsumptionMetricsPublisher : Ensure only full invocations are measured

### DIFF
--- a/src/WebJobs.Script.WebHost/Metrics/FlexConsumptionMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/FlexConsumptionMetricsPublisher.cs
@@ -268,6 +268,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
                 {
                     ActiveFunctionCount--;
                 }
+                else
+                {
+                    // We got a completion event without a corresponding start.
+                    // This might happen during specialization for example.
+                    // Ignore the event.
+                    return;
+                }
 
                 if (ActiveFunctionCount == 0)
                 {

--- a/test/WebJobs.Script.Tests/Metrics/FlexConsumptionMetricsPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/FlexConsumptionMetricsPublisherTests.cs
@@ -437,6 +437,27 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             Assert.Equal(4800, publisher.FunctionExecutionTimeMS);
         }
 
+        [Fact]
+        public void OnFunctionCompleted_NoOutstandingInvocations_IgnoresEvent()
+        {
+            var publisher = CreatePublisher(metricsPublishInterval: TimeSpan.FromHours(1), inStandbyMode: false);
+
+            Assert.Equal(1000, _options.MinimumActivityIntervalMS);
+            Assert.Equal(0, publisher.ActiveFunctionCount);
+            Assert.Equal(0, publisher.FunctionExecutionCount);
+            Assert.Equal(0, publisher.FunctionExecutionTimeMS);
+
+            DateTime now = DateTime.UtcNow;
+
+            // send a function completion without a corresponding start event
+            now += TimeSpan.FromMilliseconds(300);
+            publisher.OnFunctionCompleted("foo", "1", now);
+
+            Assert.Equal(0, publisher.ActiveFunctionCount);
+            Assert.Equal(0, publisher.FunctionExecutionCount);
+            Assert.Equal(0, publisher.FunctionExecutionTimeMS);
+        }
+
         public void CleanupMetricsFiles()
         {
             var directory = new DirectoryInfo(_metricsFilePath);


### PR DESCRIPTION
When specializing, it's possible for the following flow to occur:

1) Warmup function to starts execution while still in placeholder mode while specialization is in progress, BEFORE the FlexConsumptionMetricsPublisher is started
2) Specialization completes, then FlexConsumptionMetricsPublisher is started
3) The outstanding Warmup invocation completes

Because we never saw the begin event, _currentActivityIntervalStart was default(DateTime), resulting in an incorrect and super large interval calculation.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
