### PR TITLE
Ensure only full invocations are measured (#10177)

### DIFF
--- a/src/WebJobs.Script.WebHost/Metrics/FlexConsumptionMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/FlexConsumptionMetricsPublisher.cs
@@ -268,6 +268,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
                 {
                     ActiveFunctionCount--;
                 }
+                else
+                {
+                    // We got a completion event without a corresponding start.
+                    // This might happen during specialization for example.
+                    // Ignore the event.
+                    return;
+                }
 
                 if (ActiveFunctionCount == 0)
                 {

--- a/test/WebJobs.Script.Tests/Metrics/FlexConsumptionMetricsPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/FlexConsumptionMetricsPublisherTests.cs
@@ -437,6 +437,27 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             Assert.Equal(4800, publisher.FunctionExecutionTimeMS);
         }
 
+        [Fact]
+        public void OnFunctionCompleted_NoOutstandingInvocations_IgnoresEvent()
+        {
+            var publisher = CreatePublisher(metricsPublishInterval: TimeSpan.FromHours(1), inStandbyMode: false);
+
+            Assert.Equal(1000, _options.MinimumActivityIntervalMS);
+            Assert.Equal(0, publisher.ActiveFunctionCount);
+            Assert.Equal(0, publisher.FunctionExecutionCount);
+            Assert.Equal(0, publisher.FunctionExecutionTimeMS);
+
+            DateTime now = DateTime.UtcNow;
+
+            // send a function completion without a corresponding start event
+            now += TimeSpan.FromMilliseconds(300);
+            publisher.OnFunctionCompleted("foo", "1", now);
+
+            Assert.Equal(0, publisher.ActiveFunctionCount);
+            Assert.Equal(0, publisher.FunctionExecutionCount);
+            Assert.Equal(0, publisher.FunctionExecutionTimeMS);
+        }
+
         public void CleanupMetricsFiles()
         {
             var directory = new DirectoryInfo(_metricsFilePath);


### PR DESCRIPTION
Pulling commit https://github.com/Azure/azure-functions-host/commit/62c4472bbf7240ab17e8fd47d1319f158b7c68c3 into Flex