### PR TITLE
Adding runtime site name to valid JWT audiences (slot scenarios)

### DIFF
--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 }
             });
 
-        private static string[] GetValidAudiences()
+        private static IEnumerable<string> GetValidAudiences()
         {
             if (SystemEnvironment.Instance.IsPlaceholderModeEnabled())
             {
@@ -106,11 +106,22 @@ namespace Microsoft.Extensions.DependencyInjection
                 }
             }
 
-            return new string[]
+            string siteName = ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName);
+            string runtimeSiteName = ScriptSettingsManager.Instance.GetSetting(AzureWebsiteRuntimeSiteName);
+            var audiences = new List<string>
             {
-                string.Format(SiteAzureFunctionsUriFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName)),
-                string.Format(SiteUriFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName))
+                string.Format(SiteAzureFunctionsUriFormat, siteName),
+                string.Format(SiteUriFormat, siteName)
             };
+
+            if (!string.IsNullOrEmpty(runtimeSiteName) && !string.Equals(siteName, runtimeSiteName, StringComparison.OrdinalIgnoreCase))
+            {
+                // on a non-production slot, the runtime site name will differ from the site name
+                // we allow both for audience
+                audiences.Add(string.Format(SiteUriFormat, runtimeSiteName));
+            }
+
+            return audiences;
         }
 
         public static TokenValidationParameters CreateTokenValidationParameters()

--- a/test/WebJobs.Script.Tests/Extensions/ScriptJwtBearerExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/ScriptJwtBearerExtensionsTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        public void CreateTokenValidationParameters_HasExpectedAudience(bool isPlaceholderModeEnabled, bool isLinuxConsumptionOnLegion)
+        public void CreateTokenValidationParameters_HasExpectedAudiences(bool isPlaceholderModeEnabled, bool isLinuxConsumptionOnLegion)
         {
             var podName = "RandomPodName";
             var containerName = "RandomContainerName";
@@ -79,6 +79,44 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
                     Assert.Equal(audiences.Count, expectedWithSiteName.Length);
                     Assert.True(audiences.Contains(expectedWithSiteName[0]));
                     Assert.True(audiences.Contains(expectedWithSiteName[1]));
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("testsite", "testsite")]
+        [InlineData("testsite", "testsite__5bb5")]
+        [InlineData("testsite", null)]
+        [InlineData("testsite", "")]
+        public void CreateTokenValidationParameters_NonProductionSlot_HasExpectedAudiences(string siteName, string runtimeSiteName)
+        {
+            string azFuncAudience = string.Format(ScriptConstants.SiteAzureFunctionsUriFormat, siteName);
+            string siteAudience = string.Format(ScriptConstants.SiteUriFormat, siteName);
+            string runtimeSiteAudience = string.Format(ScriptConstants.SiteUriFormat, runtimeSiteName);
+
+            var testEnv = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { EnvironmentSettingNames.AzureWebsiteName, siteName },
+                { EnvironmentSettingNames.AzureWebsiteRuntimeSiteName, runtimeSiteName },
+                { ContainerEncryptionKey, Convert.ToBase64String(TestHelpers.GenerateKeyBytes()) }
+            };
+
+            using (new TestScopedSettings(ScriptSettingsManager.Instance, testEnv))
+            {
+                var tokenValidationParameters = ScriptJwtBearerExtensions.CreateTokenValidationParameters();
+                var audiences = tokenValidationParameters.ValidAudiences.ToArray();
+
+                Assert.Equal(audiences[0], azFuncAudience);
+                Assert.Equal(audiences[1], siteAudience);
+
+                if (string.Compare(siteName, runtimeSiteName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    Assert.Equal(2, audiences.Length);
+                }
+                else if (!string.IsNullOrEmpty(runtimeSiteName))
+                {
+                    Assert.Equal(3, audiences.Length);
+                    Assert.Equal(audiences[2], runtimeSiteAudience);
                 }
             }
         }


### PR DESCRIPTION
Analysis of production logs reveal that in slot scenarios, audience validation for JWT tokens can fail, because platform components like DataRole and ScaleController when talking to non-production slots for the site will send an audience value using the **runtime site name**, so would use audience "https://testsite__5bb5.azurewebsites.net". Whereas, the normal production slot audience for this site is "https://testsite.azurewebsites.net".

I will be backporting this to v3 and v1.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * [x] in-proc backport: https://github.com/Azure/azure-functions-host/pull/10185
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Backport v3: https://github.com/Azure/azure-functions-host/pull/10186
    * [x] Backport v1: https://github.com/Azure/azure-functions-host/pull/10187
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
