### PR TITLE
Defaulting SwtAuthenticationEnabled to False

### DIFF
--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         {
             get
             {
-                return GetFeatureAsBooleanOrDefault(ScriptConstants.HostingConfigSwtAuthenticationEnabled, true);
+                return GetFeatureAsBooleanOrDefault(ScriptConstants.HostingConfigSwtAuthenticationEnabled, false);
             }
 
             set

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
@@ -1391,6 +1391,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             {
                 base.ConfigureWebHost(services);
 
+                // SWT auth is disabled by default so we must enable to test
+                services.AddOptions<FunctionsHostingConfigOptions>()
+                    .Configure(o => o.SwtAuthenticationEnabled = true);
+
                 // The legacy http tests use sync IO so explicitly allow this
                 var environment = new TestEnvironment();
                 string testSiteName = "somewebsite";

--- a/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
@@ -126,8 +126,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 (nameof(FunctionsHostingConfigOptions.SwtAuthenticationEnabled), "SwtAuthenticationEnabled=False", false),
                 (nameof(FunctionsHostingConfigOptions.SwtAuthenticationEnabled), "SwtAuthenticationEnabled=True", true),
                 (nameof(FunctionsHostingConfigOptions.SwtAuthenticationEnabled), "SwtAuthenticationEnabled=0", false),
-                (nameof(FunctionsHostingConfigOptions.SwtAuthenticationEnabled), "SwtAuthenticationEnabled=unparseable", true), // default
-                (nameof(FunctionsHostingConfigOptions.SwtAuthenticationEnabled), string.Empty, true), // default
+                (nameof(FunctionsHostingConfigOptions.SwtAuthenticationEnabled), "SwtAuthenticationEnabled=unparseable", false), // default
+                (nameof(FunctionsHostingConfigOptions.SwtAuthenticationEnabled), string.Empty, false), // default
 
                 // Supports True/False/1/0
                 (nameof(FunctionsHostingConfigOptions.SwtIssuerEnabled), "SwtIssuerEnabled=False", false),
@@ -251,8 +251,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         {
             FunctionsHostingConfigOptions options = new FunctionsHostingConfigOptions();
 
-            // defaults to true
-            Assert.True(options.SwtAuthenticationEnabled);
+            // defaults to false
+            Assert.False(options.SwtAuthenticationEnabled);
 
             // returns true when explicitly enabled
             options.Features[ScriptConstants.HostingConfigSwtAuthenticationEnabled] = "1";

--- a/test/WebJobs.Script.Tests/Security/Authentication/ArmAuthenticationHandlerTests.cs
+++ b/test/WebJobs.Script.Tests/Security/Authentication/ArmAuthenticationHandlerTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,6 +20,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security.Authentication
         private static DefaultHttpContext GetContext()
         {
             var services = new ServiceCollection().AddLogging();
+
+            // SWT auth is disabled by default so we must enable to test
+            services.AddOptions<FunctionsHostingConfigOptions>()
+                .Configure(o => o.SwtAuthenticationEnabled = true);
+
             services.AddAuthentication(o =>
             {
                 o.DefaultScheme = ArmAuthenticationDefaults.AuthenticationScheme;


### PR DESCRIPTION
Changing the default for this hosting config. I've already configured this to False on nearly all public stamps, so now's the time to flip the default.

I'll be backporting this to v3/v1 as well as in-proc.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * [x] In-proc backport: https://github.com/Azure/azure-functions-host/pull/10195
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] v3 backport: https://github.com/Azure/azure-functions-host/pull/10196
    * [x] v1 backport: https://github.com/Azure/azure-functions-host/pull/10197
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
