### PR TITLE
Address 1ES CodeQL issues

### DIFF
--- a/eng/ci/integration-tests.yml
+++ b/eng/ci/integration-tests.yml
@@ -31,6 +31,13 @@ extends:
       image: 1es-windows-2022
       os: windows
 
+    sdl:
+      codeql:
+        runSourceLanguagesInSourceAnalysis: true
+        compiled:
+          enabled: false
+          justificationForDisabling: Covered by a separate pipeline.
+
     stages:
     - stage: Test
       jobs:

--- a/eng/ci/integration-tests.yml
+++ b/eng/ci/integration-tests.yml
@@ -31,13 +31,6 @@ extends:
       image: 1es-windows-2022
       os: windows
 
-    sdl:
-      codeql:
-        runSourceLanguagesInSourceAnalysis: true
-        compiled:
-          enabled: false
-          justificationForDisabling: Covered by a separate pipeline.
-
     stages:
     - stage: Test
       jobs:

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -7,6 +7,15 @@ trigger:
     - release/4.*
     - release/in-proc
 
+schedules:
+# Ensure we build at least once a week for SDL reporting purposes.
+- cron: "0 0 * * 0"
+  displayName: SDL Weekly Build
+  branches:
+    include:
+    - dev
+  always: true
+
 # CI only, does not trigger on PRs.
 pr: none
 
@@ -34,6 +43,10 @@ extends:
       name: 1es-pool-azfunc
       image: 1es-windows-2022
       os: windows
+    sdl:
+      codeql:
+        # Move codeql for source languages to source analysis stage
+        runSourceLanguagesInSourceAnalysis: true
 
     stages:
     - stage: Initialize

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -8,12 +8,13 @@ trigger:
     - release/in-proc
 
 schedules:
-# Ensure we build at least once a week for SDL reporting purposes.
-- cron: "0 0 * * 0"
-  displayName: SDL Weekly Build
+# Ensure we build nightly to catch any new CVEs and report SDL often.
+- cron: "0 0 * * *"
+  displayName: Nightly Build
   branches:
     include:
     - dev
+    - in-proc
   always: true
 
 # CI only, does not trigger on PRs.

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -9,6 +9,15 @@ trigger:
     - release/4.*
     - release/in-proc
 
+schedules:
+# Ensure we build at least once a week for SDL reporting purposes.
+- cron: "0 0 * * 0"
+  displayName: SDL Weekly Build
+  branches:
+    include:
+    - dev
+  always: true
+
 pr:
   branches:
     include:
@@ -34,6 +43,14 @@ extends:
       name: 1es-pool-azfunc-public
       image: 1es-windows-2022
       os: windows
+
+    # Enable CodeQL for the dev branch
+    ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/dev') }}:
+      sdl:
+        codeql:
+          compiled:
+            enabled: true
+          runSourceLanguagesInSourceAnalysis: true
 
     stages:
     - stage: Test

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -44,13 +44,11 @@ extends:
       image: 1es-windows-2022
       os: windows
 
-    # Enable CodeQL for the dev branch
-    ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/dev') }}:
-      sdl:
-        codeql:
-          compiled:
-            enabled: true
-          runSourceLanguagesInSourceAnalysis: true
+    sdl:
+      codeql:
+        compiled:
+          enabled: true
+        runSourceLanguagesInSourceAnalysis: true
 
     stages:
     - stage: Test

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -10,14 +10,14 @@ trigger:
     - release/in-proc
 
 schedules:
-# Ensure we build at least once a week for SDL reporting purposes.
-- cron: "0 0 * * 0"
-  displayName: SDL Weekly Build
-  branches:
-    include:
-    - dev
-  always: true
-
+  # Ensure we build nightly to catch any new CVEs and report SDL often.
+  - cron: "0 0 * * *"
+    displayName: Nightly Build
+    branches:
+      include:
+      - dev
+      - in-proc
+    always: true
 pr:
   branches:
     include:

--- a/eng/ci/templates/jobs/initialize-pipeline.yml
+++ b/eng/ci/templates/jobs/initialize-pipeline.yml
@@ -2,6 +2,12 @@ jobs:
   - job: InitializePipeline
     displayName: Initialize Pipeline
 
+    templateContext:
+      sdl:
+        codeql:
+          compiled:
+            enabled: false
+
     steps:
     - task: UseDotNet@2 # The pinned SDK we use to build
       displayName: 'Install .NET SDK from global.json'

--- a/sample/Java/HttpTrigger/Function.java.txt
+++ b/sample/Java/HttpTrigger/Function.java.txt
@@ -1,4 +1,5 @@
 // This is a .txt extension intentionally so CodeQL does not expect and wait for a java compilation step.
+// Real java function apps would have this as .java extension.
 
 package Microsoft.Azure.WebJobs.Script.Tests.EndToEnd;
 

--- a/sample/Java/HttpTrigger/Function.java.txt
+++ b/sample/Java/HttpTrigger/Function.java.txt
@@ -1,3 +1,5 @@
+// This is a .txt extension intentionally so CodeQL does not expect and wait for a java compilation step.
+
 package Microsoft.Azure.WebJobs.Script.Tests.EndToEnd;
 
 import java.util.*;
@@ -13,7 +15,7 @@ import com.microsoft.azure.functions.*;
  * Accept defaults for rest of the identifiers
  * Run mvn clean package
  */
-public class Function {   
+public class Function {
     @FunctionName("HttpTrigger")
     public HttpResponseMessage run(
             @HttpTrigger(name = "req", methods = {HttpMethod.GET, HttpMethod.POST}, authLevel = AuthorizationLevel.FUNCTION) HttpRequestMessage<Optional<String>> request,
@@ -23,12 +25,12 @@ public class Function {
         // Parse query parameter
         String query = request.getQueryParameters().get("name");
         String name = request.getBody().orElse(query);
-		String readEnv = System.getenv("AzureWebJobsStorage");
+        String readEnv = System.getenv("AzureWebJobsStorage");
 
         if (name == null) {
             return request.createResponseBuilder(HttpStatus.BAD_REQUEST).body("Please pass a name on the query string or in the request body").build();
         }
-		if (readEnv == null ) {
+        if (readEnv == null ) {
             return request.createResponseBuilder(HttpStatus.INTERNAL_SERVER_ERROR).body("AzureWebJobsStorage is empty").build();
         }
         return request.createResponseBuilder(HttpStatus.OK).body("Hello, " + name).build();


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR -- TODO
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

CodeQL in 1ES is detecting this `.java` file and expecting a build action for it (which it will then hook into and perform analysis). This never happens so CodeQL times out. Since this is a sample that is not production code, the fix is to change the extension so codeql no longer detects it.

Additional changes in this PR are:

1. Optimize CodeQL in our jobs
    - Move 'source' languages (js, ts, python) to SDL stage only
    - Skip compiled languages for initialize-pipeline job.
2. Enable CodeQL on public build.
    - Our official and public builds run against different repos (Azure Devops, GitHub respectively). So we need it to be reported for _both_.
    - Not enabled for PR builds (as `Build.SourceBranch` will never match)
3. Adds a scheduled build for once a week to ensure SDL is reported
