### PR TITLE
Fix `JavaProcess_Different_AfterHostRestart` instability

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Java.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Java.cs
@@ -12,7 +12,9 @@ using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.WebJobs.Script.Tests;
 using Xunit;
 
@@ -41,18 +43,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         [Fact]
         public async Task JavaProcess_Different_AfterHostRestart()
         {
-            IEnumerable<int> javaProcessesBefore = Process.GetProcessesByName("java").Select(p => p.Id);
-            Assert.True(javaProcessesBefore.Count() > 0);
+            IJobHostRpcWorkerChannelManager manager = _fixture.Host.JobHostServices.GetService<IJobHostRpcWorkerChannelManager>();
+            var channels = manager.GetChannels("java").ToList();
+            Assert.Equal(1, channels.Count);
+            int processId = channels[0].WorkerProcess.Id;
+
             // Trigger a restart
             await _fixture.Host.RestartAsync(CancellationToken.None);
             await HttpTrigger_Java_Get_Succeeds();
-            IEnumerable<int> javaProcessesAfter = Process.GetProcessesByName("java").Select(p => p.Id);
-            Assert.True(javaProcessesAfter.Count() > 0);
-            // Verify number of java processes before and after restart are the same.
-            Assert.Equal(javaProcessesBefore.Count(), javaProcessesAfter.Count());
-            // Verify Java different java process is used after host restart
-            var result = javaProcessesBefore.Where(pId1 => javaProcessesAfter.Any(pId2 => pId2 == pId1));
-            Assert.Equal(0, result.Count());
+
+            // Verify after restart we have only 1 java channel still, and the process ID has changed.
+            channels = manager.GetChannels("java").ToList();
+            Assert.Equal(1, channels.Count);
+            Assert.NotEqual(processId, channels[0].WorkerProcess.Id);
         }
 
         public class TestFixture : EndToEndTestFixture

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Java.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Java.cs
@@ -53,6 +53,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             await HttpTrigger_Java_Get_Succeeds();
 
             // Verify after restart we have only 1 java channel still, and the process ID has changed.
+            manager = _fixture.Host.JobHostServices.GetService<IJobHostRpcWorkerChannelManager>();
             channels = manager.GetChannels("java").ToList();
             Assert.Equal(1, channels.Count);
             Assert.NotEqual(processId, channels[0].WorkerProcess.Id);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR -- TODO
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Refactors `JavaProcess_Different_AfterHostRestart` to improve stability. The previous test was checking the entire machine for java processes, which made it fail if any other Java process was running on the machine.
