### PR TITLE
making ordered invocations the default

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -15,3 +15,4 @@
 - Ensuring proxies are disabled, with a warning, when running in Flex Consumption. 
 - Fixed an issue leading to a race when invocation responses returned prior to HTTP requests being sent in proxied scenarios.
 - Language worker channels will not be started during placeholder mode if we are in-process (#10161)
+- Ordered invocations are now the default (#10201)

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         {
             // Ordered invocations is the default, but allow explicit disabling
             if (!_hostingConfigOptions.Value.EnableOrderedInvocationMessages ||
-                FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableOrderedInvocationmessages, _environment))
+                FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableOrderedInvocationMessages, _environment))
             {
                 _workerChannelLogger.LogDebug($"Using {nameof(ThreadPoolInvocationProcessorFactory)}.");
                 return new ThreadPoolInvocationProcessorFactory(_processInbound);

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -196,16 +196,17 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         // and a "new" Channel processor (for proper ordering of messages).
         private IInvocationMessageDispatcherFactory GetProcessorFactory()
         {
-            if (_hostingConfigOptions.Value.EnableOrderedInvocationMessages ||
-                FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableOrderedInvocationmessages, _environment))
-            {
-                _workerChannelLogger.LogDebug($"Using {nameof(OrderedInvocationMessageDispatcherFactory)}.");
-                return new OrderedInvocationMessageDispatcherFactory(ProcessItem, _workerChannelLogger);
-            }
-            else
+            // Ordered invocations is the default, but allow explicit disabling
+            if (!_hostingConfigOptions.Value.EnableOrderedInvocationMessages ||
+                FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableOrderedInvocationmessages, _environment))
             {
                 _workerChannelLogger.LogDebug($"Using {nameof(ThreadPoolInvocationProcessorFactory)}.");
                 return new ThreadPoolInvocationProcessorFactory(_processInbound);
+            }
+            else
+            {
+                _workerChannelLogger.LogDebug($"Using {nameof(OrderedInvocationMessageDispatcherFactory)}.");
+                return new OrderedInvocationMessageDispatcherFactory(ProcessItem, _workerChannelLogger);
             }
         }
 

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         {
             get
             {
-                return GetFeatureAsBooleanOrDefault(ScriptConstants.FeatureFlagEnableOrderedInvocationmessages, false);
+                return GetFeatureAsBooleanOrDefault(ScriptConstants.FeatureFlagEnableOrderedInvocationmessages, true);
             }
 
             set

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -137,6 +137,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FeatureFlagStrictHISModeEnabled = "StrictHISModeEnabled";
         public const string FeatureFlagStrictHISModeWarn = "StrictHISModeWarn";
         public const string FeatureFlagEnableOrderedInvocationmessages = "EnableOrderedInvocationMessages";
+        public const string FeatureFlagDisableOrderedInvocationmessages = "DisableOrderedInvocationMessages";
         public const string HostingConfigDisableLinuxAppServiceDetailedExecutionEvents = "DisableLinuxExecutionDetails";
         public const string HostingConfigDisableLinuxAppServiceExecutionEventLogBackoff = "DisableLinuxLogBackoff";
         public const string FeatureFlagEnableLegacyDurableVersionCheck = "EnableLegacyDurableVersionCheck";

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FeatureFlagStrictHISModeEnabled = "StrictHISModeEnabled";
         public const string FeatureFlagStrictHISModeWarn = "StrictHISModeWarn";
         public const string FeatureFlagEnableOrderedInvocationmessages = "EnableOrderedInvocationMessages";
-        public const string FeatureFlagDisableOrderedInvocationmessages = "DisableOrderedInvocationMessages";
+        public const string FeatureFlagDisableOrderedInvocationMessages = "DisableOrderedInvocationMessages";
         public const string HostingConfigDisableLinuxAppServiceDetailedExecutionEvents = "DisableLinuxExecutionDetails";
         public const string HostingConfigDisableLinuxAppServiceExecutionEventLogBackoff = "DisableLinuxLogBackoff";
         public const string FeatureFlagEnableLegacyDurableVersionCheck = "EnableLegacyDurableVersionCheck";

--- a/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
@@ -107,8 +107,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 // Supports True/False/1/0
                 (nameof(FunctionsHostingConfigOptions.EnableOrderedInvocationMessages), "EnableOrderedInvocationMessages=True", true),
                 (nameof(FunctionsHostingConfigOptions.EnableOrderedInvocationMessages), "EnableOrderedInvocationMessages=1", true),
-                (nameof(FunctionsHostingConfigOptions.EnableOrderedInvocationMessages), "EnableOrderedInvocationMessages=unparseable", false), // default
-                (nameof(FunctionsHostingConfigOptions.EnableOrderedInvocationMessages), string.Empty, false), // default
+                (nameof(FunctionsHostingConfigOptions.EnableOrderedInvocationMessages), "EnableOrderedInvocationMessages=unparseable", true), // default
+                (nameof(FunctionsHostingConfigOptions.EnableOrderedInvocationMessages), string.Empty, true), // default
 
                 (nameof(FunctionsHostingConfigOptions.FunctionsWorkerDynamicConcurrencyEnabled), "FUNCTIONS_WORKER_DYNAMIC_CONCURRENCY_ENABLED=1", true),
                 (nameof(FunctionsHostingConfigOptions.MaximumBundleV3Version), "FunctionRuntimeV4MaxBundleV3Version=teststring", "teststring"),

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -1426,12 +1426,34 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
+        public async Task DispatcherFactory_DefaultsToOrdered()
+        {
+            await CreateDefaultWorkerChannel();
+            var invocationFactoryMessage = _logger.GetLogMessages().Select(m => m.FormattedMessage).Single(m => m.Contains("Factory"));
+            Assert.Contains("OrderedInvocationMessageDispatcherFactory", invocationFactoryMessage);
+        }
+
+        [Fact]
+        public async Task DispatcherFactory_CanBeOverridden_WithAppSetting()
+        {
+            _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagDisableOrderedInvocationmessages);
+            await CreateDefaultWorkerChannel();
+            var invocationFactoryMessage = _logger.GetLogMessages().Select(m => m.FormattedMessage).Single(m => m.Contains("Factory"));
+            Assert.Contains("ThreadPoolInvocationProcessorFactory", invocationFactoryMessage);
+        }
+
+        [Fact]
+        public async Task DispatcherFactory_CanBeOverridden_WithHostingConfig()
+        {
+            _hostingConfigOptions.Value.EnableOrderedInvocationMessages = false;
+            await CreateDefaultWorkerChannel();
+            var invocationFactoryMessage = _logger.GetLogMessages().Select(m => m.FormattedMessage).Single(m => m.Contains("Factory"));
+            Assert.Contains("ThreadPoolInvocationProcessorFactory", invocationFactoryMessage);
+        }
+
+        [Fact]
         public async Task Log_And_InvocationResult_OrderedCorrectly()
         {
-            // Without this feature flag, this test fails every time on multi-core machines as the logs will
-            // be processed out-of-order
-            _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagEnableOrderedInvocationmessages);
-
             await CreateDefaultWorkerChannel();
             _metricsLogger.ClearCollections();
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -1436,7 +1436,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         [Fact]
         public async Task DispatcherFactory_CanBeOverridden_WithAppSetting()
         {
-            _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagDisableOrderedInvocationmessages);
+            _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagDisableOrderedInvocationMessages);
             await CreateDefaultWorkerChannel();
             var invocationFactoryMessage = _logger.GetLogMessages().Select(m => m.FormattedMessage).Single(m => m.Contains("Factory"));
             Assert.Contains("ThreadPoolInvocationProcessorFactory", invocationFactoryMessage);


### PR DESCRIPTION
This has been rolled out via hosting config to a majority of stamps for several months. Making this the default going forward, but allowing for disablement should something arise. Eventually we can remove that as well, but it's not as urgent.

The original PR that introduced it (for more context) is here: #9657

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR: #10207
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)