### PR TITLE
[in-proc backport] Fix `JavaProcess_Different_AfterHostRestart` instability (#10200)

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Java.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Java.cs
@@ -12,7 +12,9 @@ using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.WebJobs.Script.Tests;
 using Xunit;
 
@@ -41,18 +43,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         [Fact]
         public async Task JavaProcess_Different_AfterHostRestart()
         {
-            IEnumerable<int> javaProcessesBefore = Process.GetProcessesByName("java").Select(p => p.Id);
-            Assert.True(javaProcessesBefore.Count() > 0);
+            IJobHostRpcWorkerChannelManager manager = _fixture.Host.JobHostServices.GetService<IJobHostRpcWorkerChannelManager>();
+            var channels = manager.GetChannels("java").ToList();
+            Assert.Equal(1, channels.Count);
+            int processId = channels[0].WorkerProcess.Id;
+
             // Trigger a restart
             await _fixture.Host.RestartAsync(CancellationToken.None);
             await HttpTrigger_Java_Get_Succeeds();
-            IEnumerable<int> javaProcessesAfter = Process.GetProcessesByName("java").Select(p => p.Id);
-            Assert.True(javaProcessesAfter.Count() > 0);
-            // Verify number of java processes before and after restart are the same.
-            Assert.Equal(javaProcessesBefore.Count(), javaProcessesAfter.Count());
-            // Verify Java different java process is used after host restart
-            var result = javaProcessesBefore.Where(pId1 => javaProcessesAfter.Any(pId2 => pId2 == pId1));
-            Assert.Equal(0, result.Count());
+
+            // Verify after restart we have only 1 java channel still, and the process ID has changed.
+            manager = _fixture.Host.JobHostServices.GetService<IJobHostRpcWorkerChannelManager>();
+            channels = manager.GetChannels("java").ToList();
+            Assert.Equal(1, channels.Count);
+            Assert.NotEqual(processId, channels[0].WorkerProcess.Id);
         }
 
         public class TestFixture : EndToEndTestFixture


### PR DESCRIPTION
Backport of #10200