### PR TITLE
Fixed incorrect function count in the log message when getting function metadata from providers

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -16,3 +16,4 @@
 - Fixed an issue leading to a race when invocation responses returned prior to HTTP requests being sent in proxied scenarios.
 - Language worker channels will not be started during placeholder mode if we are in-process (#10161)
 - Ordered invocations are now the default (#10201)
+- Fixed incorrect function count in the log message.(#10220)

--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -223,11 +223,12 @@ namespace Microsoft.Azure.WebJobs.Script
             }
 
             var functionMetadataListArray = Task.WhenAll(functionProviderTasks).GetAwaiter().GetResult();
+            var totalFunctionsCount = functionMetadataListArray.Sum(metadataArray => metadataArray.Length);
 
             // This is used to make sure no duplicates are registered
             var distinctFunctionNames = new HashSet<string>(functionMetadataList.Select(m => m.Name));
 
-            _logger.FunctionsReturnedByProvider(functionMetadataListArray.Length, _metadataProviderName);
+            _logger.FunctionsReturnedByProvider(totalFunctionsCount, _metadataProviderName);
 
             foreach (var metadataArray in functionMetadataListArray)
             {

--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Azure.WebJobs.Script
             }
 
             var providerFunctionMetadataResults = Task.WhenAll(functionProviderTasks).GetAwaiter().GetResult();
-            var totalFunctionsCount = providerFunctionMetadataResults.Sum(metadataArray => metadataArray.Length);
+            var totalFunctionsCount = providerFunctionMetadataResults.Where(metadataArray => !metadataArray.IsDefaultOrEmpty).Sum(metadataArray => metadataArray.Length);
 
             // This is used to make sure no duplicates are registered
             var distinctFunctionNames = new HashSet<string>(functionMetadataList.Select(m => m.Name));

--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -222,15 +222,15 @@ namespace Microsoft.Azure.WebJobs.Script
                 functionProviderTasks.Add(functionProvider.GetFunctionMetadataAsync());
             }
 
-            var functionMetadataListArray = Task.WhenAll(functionProviderTasks).GetAwaiter().GetResult();
-            var totalFunctionsCount = functionMetadataListArray.Sum(metadataArray => metadataArray.Length);
+            var providerFunctionMetadataResults = Task.WhenAll(functionProviderTasks).GetAwaiter().GetResult();
+            var totalFunctionsCount = providerFunctionMetadataResults.Sum(metadataArray => metadataArray.Length);
 
             // This is used to make sure no duplicates are registered
             var distinctFunctionNames = new HashSet<string>(functionMetadataList.Select(m => m.Name));
 
             _logger.FunctionsReturnedByProvider(totalFunctionsCount, _metadataProviderName);
 
-            foreach (var metadataArray in functionMetadataListArray)
+            foreach (var metadataArray in providerFunctionMetadataResults)
             {
                 if (!metadataArray.IsDefaultOrEmpty)
                 {

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
@@ -278,7 +278,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
             Assert.True(traces.Length == expectedCount, $"Expected {expectedCount} messages, but found {traces.Length}. Actual logs:{Environment.NewLine}{string.Join(Environment.NewLine, traces.Select(t => t.Message))}");
 
             int idx = 0;
-            ValidateTrace(traces[idx++], "1 functions found", LogCategories.Startup);
+            ValidateTrace(traces[idx++], "0 functions found", LogCategories.Startup);
             ValidateTrace(traces[idx++], "2 functions loaded", LogCategories.Startup);
             ValidateTrace(traces[idx++], "A function allow list has been specified", LogCategories.Startup);
             ValidateTrace(traces[idx++], "Found the following functions:\r\n", LogCategories.Startup);


### PR DESCRIPTION
resolves #10220 

Fixing incorrect function count in the log message when getting function metadata from providers. Previously we were logging the length of the result array instead of the actual function count (stored in that array).

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR - https://github.com/Azure/azure-functions-host/pull/10223
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #10223 
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
