### PR TITLE
Marking SyncTriggers [RequiresRunningHost] (#9904)

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -391,23 +391,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         [HttpPost]
         [Route("admin/host/synctriggers")]
         [Authorize(Policy = PolicyNames.AdminAuthLevelOrInternal)]
+        [RequiresRunningHost]
         public async Task<IActionResult> SyncTriggers()
         {
             _metricsLogger.LogEvent(MetricEventNames.SyncTriggersInvoked);
-
-            // TEMP: Collecting temporary metrics on the host state during SyncTrigger requests
-            if (!_scriptHostManager.HostIsInitialized())
-            {
-                _metricsLogger.LogEvent(MetricEventNames.SyncTriggersHostNotInitialized);
-            }
-
-            // TODO: We plan on making SyncTriggers RequiresRunningHost across the board,
-            // but for now only for Flex.
-            // https://github.com/Azure/azure-functions-host/issues/9904
-            if (_environment.IsFlexConsumptionSku())
-            {
-                await HttpContext.WaitForRunningHostAsync(_scriptHostManager, _applicationHostOptions.Value);
-            }
 
             var result = await _functionsSyncManager.TrySyncTriggersAsync();
 

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -316,17 +316,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             var triggersArray = new JArray(triggers);
             int count = triggersArray.Count;
 
+            // add host configuration
             JObject hostConfig = null;
-            if (_environment.IsFlexConsumptionSku())
+            if (Utility.TryGetHostService<IHostOptionsProvider>(_scriptHostManager, out IHostOptionsProvider hostOptionsProvider))
             {
-                // TODO: Only adding host configuration for Flex. Once SyncTriggers is marked RequiresRunningHost,
-                // we'll enable across the board.
-                // https://github.com/Azure/azure-functions-host/issues/9904
-                // If an active host is running, add host configuration.
-                if (Utility.TryGetHostService<IHostOptionsProvider>(_scriptHostManager, out IHostOptionsProvider hostOptionsProvider))
-                {
-                    hostConfig = hostOptionsProvider.GetOptions();
-                }
+                hostConfig = hostOptionsProvider.GetOptions();
             }
 
             // Form the base minimal result

--- a/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
+++ b/src/WebJobs.Script/Diagnostics/MetricEventNames.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics
         public const string HISStrictModeEnabled = "host.hismode.strict";
         public const string HISStrictModeWarn = "host.hismode.warn";
         public const string SyncTriggersInvoked = "host.synctriggers.invoke";
-        public const string SyncTriggersHostNotInitialized = "host.synctriggers.hostnotinitialized";
 
         // Script host level events
         public const string ScriptHostManagerBuildScriptHost = "scripthostmanager.buildscripthost.latency";

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -269,13 +269,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             }
         }
 
-        [Theory]
-        [InlineData(ScriptConstants.DynamicSku)]
-        [InlineData(ScriptConstants.FlexConsumptionSku)]
-        public async Task TrySyncTriggers_MaxSyncTriggersPayloadSize_Succeeds(string sku)
+        [Fact]
+        public async Task TrySyncTriggers_MaxSyncTriggersPayloadSize_Succeeds()
         {
-            _sku = sku;
-
             // create a dummy file that pushes us over size
             string maxString = new string('x', ScriptConstants.MaxTriggersStringLength + 1);
             _function1 = $"{{ bindings: [], test: '{maxString}'}}";
@@ -291,19 +287,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 Assert.True(syncString.Length < ScriptConstants.MaxTriggersStringLength);
                 var syncContent = JObject.Parse(syncString);
 
-                bool isFlexConsumptionSku = _mockEnvironment.Object.IsFlexConsumptionSku();
-                int expectedCount = isFlexConsumptionSku ? 3 : 2;
-                Assert.Equal(expectedCount, syncContent.Count);
+                Assert.Equal(3, syncContent.Count);
                 Assert.Equal("testhostid123", syncContent["hostId"]);
                 
                 JArray triggers = (JArray)syncContent["triggers"];
                 Assert.Equal(2, triggers.Count);
 
-                if (isFlexConsumptionSku)
-                {
-                    JObject hostConfig = (JObject)syncContent["hostConfig"];
-                    Assert.Equal(2, hostConfig.Count);
-                }
+                JObject hostConfig = (JObject)syncContent["hostConfig"];
+                Assert.Equal(2, hostConfig.Count);
             }
         }
 
@@ -328,15 +319,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         }
 
         [Theory]
-        [InlineData(true, true, ScriptConstants.DynamicSku)]
-        [InlineData(true, true, ScriptConstants.FlexConsumptionSku)]
-        [InlineData(false, true, ScriptConstants.DynamicSku)]
-        [InlineData(false, true, ScriptConstants.FlexConsumptionSku)]
-        [InlineData(true, false, ScriptConstants.DynamicSku)]
-        public async Task TrySyncTriggers_PostsExpectedContent(bool cacheEnabled, bool swtIssuerEnabled, string sku)
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        public async Task TrySyncTriggers_PostsExpectedContent(bool cacheEnabled, bool swtIssuerEnabled)
         {
-            _sku = sku;
-
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteArmCacheEnabled)).Returns(cacheEnabled ? "1" : "0");
             _hostingConfigOptions.SwtIssuerEnabled = swtIssuerEnabled;
 
@@ -433,14 +420,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             Assert.Equal(expectedTriggersPayload, logObject["triggers"].ToString(Formatting.None));
             Assert.False(triggersLog.Contains("secrets"));
             
-            if (_mockEnvironment.Object.IsFlexConsumptionSku())
-            {
-                // verify hostConfig by spot checking a couple properties
-                var hostConfig = result["hostConfig"];
-                Assert.Equal(2, hostConfig["extensions"]["testExtension2"]["p2"]);
-                Assert.Equal("[Hidden Credential]", hostConfig["extensions"]["testExtension2"]["pwd"]);
-                Assert.Equal(0.85f, (float)hostConfig["concurrency"]["CPUThreshold"]);
-            }
+            // verify hostConfig by spot checking a couple properties
+            var hostConfig = result["hostConfig"];
+            Assert.Equal(2, hostConfig["extensions"]["testExtension2"]["p2"]);
+            Assert.Equal("[Hidden Credential]", hostConfig["extensions"]["testExtension2"]["pwd"]);
+            Assert.Equal(0.85f, (float)hostConfig["concurrency"]["CPUThreshold"]);
 
             return result;
         }

--- a/test/WebJobs.Script.Tests/Diagnostics/FileWriterTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/FileWriterTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 files = directory.GetFiles().OrderByDescending(p => p.LastWriteTime).ToArray();
                 return files.Length == 2;
-            }, timeout: 5000);
+            }, timeout: 10000);
 
             // expect only 2 files to remain - the new file we just created, as well
             // as the oversize file we just wrote to last (it has a new timestamp now so
@@ -194,6 +194,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 fileWriter.AppendLine($"Test message {Thread.CurrentThread.ManagedThreadId} {i}");
                 await Task.Delay(5);
             }
+
+            await Task.Delay(100);
 
             var directory = new DirectoryInfo(_logFilePath);
             int count = directory.EnumerateFiles().Count();


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-functions-host/issues/9904. Recently in PR https://github.com/Azure/azure-functions-host/pull/9898 we enforced a running host for FlexConsumption sync trigger operations, which allowed us to reliably include extended host config info in the sync payload. It was a TODO to address this for all SKUs after we reviewed the metrics we added in that PR (**host.synctriggers.hostnotinitialized**) to determine how safe the change would be.

The metric has been out for several releases now, and we now have data showing that about <ins>98% of sync operations are performed on a running host already</ins> (query below). 

Will backport to in-proc as well.

```
let _start = ago(3h);
let syncTriggersTotalCount = toscalar(All("FunctionsMetrics")
| where PreciseTimeStamp > _start
| where parse_version(HostVersion) >= parse_version("4.33.2.2")
| where EventName == "host.synctriggers.invoke"
| summarize sum(Count));
let nonInitializedSyncCount = toscalar(All("FunctionsMetrics")
| where PreciseTimeStamp > _start
| where EventName =~ "host.synctriggers.hostnotinitialized"
| summarize sum(Count));
print UnInitializedSyncPercentage=100*round((1.0*nonInitializedSyncCount)/syncTriggersTotalCount, 4);
```

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * [x] Backport PR: https://github.com/Azure/azure-functions-host/pull/10233
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)