### PR TITLE
Update Python Worker Version to 4.29.0

### DIFF
--- a/build/python.props
+++ b/build/python.props
@@ -1,5 +1,5 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.28.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.29.0" />
   </ItemGroup>
 </Project>

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,6 +3,7 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Update Python Worker Version to [4.29.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.29.0)
 - Update Python Worker Version to [4.28.1](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.28.1)
 - Update Python Worker Version to [4.28.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.28.0)
 - DotnetIsolated worker artifact clean up (#9976)

--- a/release_notes.md
+++ b/release_notes.md
@@ -17,7 +17,4 @@
 - Fixed an issue leading to a race when invocation responses returned prior to HTTP requests being sent in proxied scenarios.
 - Language worker channels will not be started during placeholder mode if we are in-process (#10161)
 - Ordered invocations are now the default (#10201)
-<<<<<<< python/4.29.0
-=======
 - Fixed incorrect function count in the log message.(#10220)
->>>>>>> dev

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,8 +4,6 @@
 - My change description (#PR)
 -->
 - Update Python Worker Version to [4.29.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.29.0)
-- Update Python Worker Version to [4.28.1](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.28.1)
-- Update Python Worker Version to [4.28.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.28.0)
 - DotnetIsolated worker artifact clean up (#9976)
   - Move symbols from dotnet-isolated worker to symbols package
   - Removed linux executables from dotnet-isolated worker.

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -44,7 +44,7 @@
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.28.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.29.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">


### PR DESCRIPTION
Python Worker Release note [4.29.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.29.0)

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * [X] InProc backport: https://github.com/Azure/azure-functions-host/pull/10234
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [X] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
