### PR TITLE
Add `IsDisabled` property to worker description and skip if the value is True

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -16,3 +16,4 @@
 - Fixed an issue leading to a race when invocation responses returned prior to HTTP requests being sent in proxied scenarios.
 - Language worker channels will not be started during placeholder mode if we are in-process (#10161)
 - Ordered invocations are now the default (#10201)
+- Skip worker description if none of the profile conditions are met (#9932)

--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerDescription.cs
@@ -46,10 +46,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         public abstract bool UseStdErrorStreamForErrorsOnly { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the worker description should be skipped if none of the profiles defined is applicable.
-        /// This happens when conditions defined for that profile is not met.
+        /// Gets or sets a value indicating whether the worker description is disabled.
         /// </summary>
-        public bool SkipWhenProfileConditionsUnmet { get; set; }
+        public bool? IsDisabled { get; set; }
 
         public abstract void ApplyDefaultsAndValidate(string workerDirectory, ILogger logger);
 

--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerDescription.cs
@@ -45,6 +45,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         /// </summary>
         public abstract bool UseStdErrorStreamForErrorsOnly { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the worker description should be skipped if none of the profiles defined is applicable.
+        /// This happens when conditions defined for that profile is not met.
+        /// </summary>
+        public bool SkipWhenProfileConditionsUnmet { get; set; }
+
         public abstract void ApplyDefaultsAndValidate(string workerDirectory, ILogger logger);
 
         internal void ThrowIfFileNotExists(string inputFile, string paramName)

--- a/src/WebJobs.Script/Workers/Profiles/IWorkerProfileManager.cs
+++ b/src/WebJobs.Script/Workers/Profiles/IWorkerProfileManager.cs
@@ -2,33 +2,33 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using Microsoft.Azure.WebJobs.Script.Workers.Profiles;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 
 namespace Microsoft.Azure.WebJobs.Script.Workers.Profiles
 {
     /// <summary>
-    /// Interface to regulate profile operations through the profile manager
+    /// Interface to regulate profile operations through the profile manager.
     /// </summary>
     public interface IWorkerProfileManager
     {
         /// <summary>
-        /// Creates profile condition using different condition descriptor properties
+        /// Creates profile condition using different condition descriptor properties.
         /// </summary>
         bool TryCreateWorkerProfileCondition(WorkerProfileConditionDescriptor conditionDescriptor, out IWorkerProfileCondition condition);
 
         /// <summary>
-        /// Set the different profiles for a given worker runtime language
+        /// Set the different profiles for a given worker runtime language.
         /// </summary>
         void SetWorkerDescriptionProfiles(List<WorkerDescriptionProfile> workerDescriptionProfiles, string language);
 
         /// <summary>
-        /// Load a profile that meets it's conditions
+        /// Attempts to load a worker profile that satisfies its conditions.
+        /// Returns true if a suitable profile is found and loaded, otherwise returns false.
         /// </summary>
-        void LoadWorkerDescriptionFromProfiles(RpcWorkerDescription defaultWorkerDescription, out RpcWorkerDescription workerDescription);
+        bool LoadWorkerDescriptionFromProfiles(RpcWorkerDescription defaultWorkerDescription, out RpcWorkerDescription workerDescription);
 
         /// <summary>
-        /// Verify if the current profile's conditions have changed
+        /// Verify if the current profile's conditions have changed.
         /// </summary>
         bool IsCorrectProfileLoaded(string workerRuntime);
     }

--- a/src/WebJobs.Script/Workers/Profiles/IWorkerProfileManager.cs
+++ b/src/WebJobs.Script/Workers/Profiles/IWorkerProfileManager.cs
@@ -2,33 +2,33 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Script.Workers.Profiles;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 
 namespace Microsoft.Azure.WebJobs.Script.Workers.Profiles
 {
     /// <summary>
-    /// Interface to regulate profile operations through the profile manager.
+    /// Interface to regulate profile operations through the profile manager
     /// </summary>
     public interface IWorkerProfileManager
     {
         /// <summary>
-        /// Creates profile condition using different condition descriptor properties.
+        /// Creates profile condition using different condition descriptor properties
         /// </summary>
         bool TryCreateWorkerProfileCondition(WorkerProfileConditionDescriptor conditionDescriptor, out IWorkerProfileCondition condition);
 
         /// <summary>
-        /// Set the different profiles for a given worker runtime language.
+        /// Set the different profiles for a given worker runtime language
         /// </summary>
         void SetWorkerDescriptionProfiles(List<WorkerDescriptionProfile> workerDescriptionProfiles, string language);
 
         /// <summary>
-        /// Attempts to load a worker profile that satisfies its conditions.
-        /// Returns true if a suitable profile is found and loaded, otherwise returns false.
+        /// Load a profile that meets it's conditions
         /// </summary>
-        bool LoadWorkerDescriptionFromProfiles(RpcWorkerDescription defaultWorkerDescription, out RpcWorkerDescription workerDescription);
+        void LoadWorkerDescriptionFromProfiles(RpcWorkerDescription defaultWorkerDescription, out RpcWorkerDescription workerDescription);
 
         /// <summary>
-        /// Verify if the current profile's conditions have changed.
+        /// Verify if the current profile's conditions have changed
         /// </summary>
         bool IsCorrectProfileLoaded(string workerRuntime);
     }

--- a/src/WebJobs.Script/Workers/Profiles/WorkerDescriptionProfile.cs
+++ b/src/WebJobs.Script/Workers/Profiles/WorkerDescriptionProfile.cs
@@ -81,6 +81,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Profiles
             updatedDescription.Extensions = UseProfileOrDefault(ProfileDescription.Extensions, defaultWorkerDescription.Extensions) as List<string>;
             updatedDescription.Language = UseProfileOrDefault(ProfileDescription.Language, defaultWorkerDescription.Language);
             updatedDescription.WorkerDirectory = UseProfileOrDefault(ProfileDescription.WorkerDirectory, defaultWorkerDescription.WorkerDirectory);
+            updatedDescription.IsDisabled = ProfileDescription.IsDisabled ?? defaultWorkerDescription.IsDisabled ?? false;
             return updatedDescription;
         }
 

--- a/src/WebJobs.Script/Workers/Profiles/WorkerProfileManager.cs
+++ b/src/WebJobs.Script/Workers/Profiles/WorkerProfileManager.cs
@@ -59,9 +59,10 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         }
 
         /// <inheritdoc />
-        public void LoadWorkerDescriptionFromProfiles(RpcWorkerDescription defaultWorkerDescription, out RpcWorkerDescription workerDescription)
+        public bool LoadWorkerDescriptionFromProfiles(RpcWorkerDescription defaultWorkerDescription, out RpcWorkerDescription workerDescription)
         {
-            if (GetEvaluatedProfile(defaultWorkerDescription.Language, out WorkerDescriptionProfile profile))
+            var validProfileFound = GetEvaluatedProfile(defaultWorkerDescription.Language, out WorkerDescriptionProfile profile);
+            if (validProfileFound)
             {
                 _logger?.LogInformation($"Worker initialized with profile - {profile.Name}, Profile ID {profile.ProfileId} from worker config.");
                 _activeProfiles[defaultWorkerDescription.Language] = profile.ProfileId;
@@ -71,6 +72,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             {
                 workerDescription = defaultWorkerDescription;
             }
+
+            return validProfileFound;
         }
 
         /// <inheritdoc />

--- a/src/WebJobs.Script/Workers/Profiles/WorkerProfileManager.cs
+++ b/src/WebJobs.Script/Workers/Profiles/WorkerProfileManager.cs
@@ -59,10 +59,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         }
 
         /// <inheritdoc />
-        public bool LoadWorkerDescriptionFromProfiles(RpcWorkerDescription defaultWorkerDescription, out RpcWorkerDescription workerDescription)
+        public void LoadWorkerDescriptionFromProfiles(RpcWorkerDescription defaultWorkerDescription, out RpcWorkerDescription workerDescription)
         {
-            var validProfileFound = GetEvaluatedProfile(defaultWorkerDescription.Language, out WorkerDescriptionProfile profile);
-            if (validProfileFound)
+            if (GetEvaluatedProfile(defaultWorkerDescription.Language, out WorkerDescriptionProfile profile))
             {
                 _logger?.LogInformation($"Worker initialized with profile - {profile.Name}, Profile ID {profile.ProfileId} from worker config.");
                 _activeProfiles[defaultWorkerDescription.Language] = profile.ProfileId;
@@ -72,8 +71,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             {
                 workerDescription = defaultWorkerDescription;
             }
-
-            return validProfileFound;
         }
 
         /// <inheritdoc />

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -138,7 +138,14 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                         if (workerDescriptionProfiles.Count > 0)
                         {
                             _profileManager.SetWorkerDescriptionProfiles(workerDescriptionProfiles, workerDescription.Language);
-                            _profileManager.LoadWorkerDescriptionFromProfiles(workerDescription, out workerDescription);
+                            var profileLoaded = _profileManager.LoadWorkerDescriptionFromProfiles(workerDescription, out workerDescription);
+
+                            // Skip the worker if SkipWhenProfileConditionsUnmet is true and none of the profiles were loaded.
+                            if (workerDescription.SkipWhenProfileConditionsUnmet && !profileLoaded)
+                            {
+                                _logger.LogInformation("Skipping WorkerConfig for language: {workerDescription.Language} since none of the profiles loaded and 'SkipWhenProfileConditionsUnmet' is true.", workerDescription.Language);
+                                return;
+                            }
                         }
                     }
 

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -138,14 +138,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                         if (workerDescriptionProfiles.Count > 0)
                         {
                             _profileManager.SetWorkerDescriptionProfiles(workerDescriptionProfiles, workerDescription.Language);
-                            var profileLoaded = _profileManager.LoadWorkerDescriptionFromProfiles(workerDescription, out workerDescription);
-
-                            // Skip the worker if SkipWhenProfileConditionsUnmet is true and none of the profiles were loaded.
-                            if (workerDescription.SkipWhenProfileConditionsUnmet && !profileLoaded)
-                            {
-                                _logger.LogInformation("Skipping WorkerConfig for language: {workerDescription.Language} since none of the profiles loaded and 'SkipWhenProfileConditionsUnmet' is true.", workerDescription.Language);
-                                return;
-                            }
+                            _profileManager.LoadWorkerDescriptionFromProfiles(workerDescription, out workerDescription);
                         }
                     }
 
@@ -157,6 +150,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
                     // Validate workerDescription
                     workerDescription.ApplyDefaultsAndValidate(Directory.GetCurrentDirectory(), _logger);
+
+                    if (workerDescription.IsDisabled == true)
+                    {
+                        _logger.LogInformation("Skipping WorkerConfig for stack: {language} since it is disabled.", workerDescription.Language);
+                        return;
+                    }
 
                     if (ShouldAddWorkerConfig(workerDescription.Language))
                     {

--- a/test/WebJobs.Script.Tests/TestWorkers/worker1/worker.config.json
+++ b/test/WebJobs.Script.Tests/TestWorkers/worker1/worker.config.json
@@ -1,0 +1,7 @@
+﻿{
+  "description": {
+    "language": "foo",
+    "defaultExecutablePath": "%FUNCTIONS_WORKER_DIRECTORY%/1.bat",
+    "defaultWorkerPath": "1.bat"
+  }
+}

--- a/test/WebJobs.Script.Tests/TestWorkers/worker2/worker.config.json
+++ b/test/WebJobs.Script.Tests/TestWorkers/worker2/worker.config.json
@@ -1,0 +1,36 @@
+﻿{
+  "description": {
+    "language": "bar",
+    "SkipWhenProfileConditionsUnmet": true
+  },
+  "profiles": [
+    {
+      "profileName": "Profile1",
+      "conditions": [
+        {
+          "conditionType": "environment",
+          "conditionName": "NON_EXISTING_ENV_VAR",
+          "conditionExpression": "(?i)true$"
+        }
+      ],
+      "description": {
+        "defaultExecutablePath": "%FUNCTIONS_WORKER_DIRECTORY%/2.bat",
+        "defaultWorkerPath": "bin/2.bat"
+      }
+    },
+    {
+      "profileName": "Profile2",
+      "conditions": [
+        {
+          "conditionType": "environment",
+          "conditionName": "NON_EXISTING_ENV_VAR",
+          "conditionExpression": "(?i)true$"
+        }
+      ],
+      "description": {
+        "defaultExecutablePath": "%FUNCTIONS_WORKER_DIRECTORY%/2.bat",
+        "defaultWorkerPath": "bin/2.bat"
+      }
+    }
+  ]
+}

--- a/test/WebJobs.Script.Tests/TestWorkers/worker2/worker.config.json
+++ b/test/WebJobs.Script.Tests/TestWorkers/worker2/worker.config.json
@@ -1,11 +1,10 @@
 ﻿{
   "description": {
-    "language": "bar",
-    "SkipWhenProfileConditionsUnmet": true
+    "language": "bar"
   },
   "profiles": [
     {
-      "profileName": "Profile1",
+      "profileName": "SpecificConditionProfile",
       "conditions": [
         {
           "conditionType": "environment",
@@ -15,21 +14,22 @@
       ],
       "description": {
         "defaultExecutablePath": "%FUNCTIONS_WORKER_DIRECTORY%/2.bat",
-        "defaultWorkerPath": "bin/2.bat"
+        "defaultWorkerPath": "2.bat"
       }
     },
     {
-      "profileName": "Profile2",
+      "profileName": "FallbackProfileToDisableWorker",
       "conditions": [
         {
           "conditionType": "environment",
-          "conditionName": "NON_EXISTING_ENV_VAR",
+          "conditionName": "ENV_VAR_BAR",
           "conditionExpression": "(?i)true$"
         }
       ],
       "description": {
         "defaultExecutablePath": "%FUNCTIONS_WORKER_DIRECTORY%/2.bat",
-        "defaultWorkerPath": "bin/2.bat"
+        "defaultWorkerPath": "2.bat",
+        "isDisabled": true
       }
     }
   ]

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -78,6 +78,7 @@
     <None Update="Microsoft.Azure.WebJobs.Script.WebHost.deps.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="TestFixture\HostOptionsProviderTests\*.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="Workers\Rpc\Resources\**" CopyToOutputDirectory="PreserveNewest" />
+    <None Update="TestWorkers\**" CopyToOutputDirectory="PreserveNewest" />
     <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
     <None Remove="Resources\FileProvisioning\PowerShell\*" />
   </ItemGroup>

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
@@ -93,10 +93,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
-        public void Skips_WorkerProfile_When_Conditions_Unmet()
+        public void WorkerDescription_Skipped_When_Profile_Disables_Worker()
         {
             // The "TestWorkers" directory has 2 workers: "worker1" and "worker2".
-            // Since "worker2" has "SkipWhenProfileConditionsUnmet" set to "True" and its profile conditions won't be met, it should be skipped.
+            // "worker2" has 2 profiles. The first profile will be skipped since the condition is not met.
+            // The second profile will be applied since the condition is met. The second profile updates
+            // the "IsDisabled" property to True and will cause the workerDescription to be skipped.
+
             var testPath = Path.GetDirectoryName(new Uri(typeof(RpcWorkerConfigFactoryTests).Assembly.Location).LocalPath);
             var testWorkersDirectory = Path.Combine(testPath, "TestWorkers");
             var testEnvVariables = new Dictionary<string, string>
@@ -108,13 +111,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var config = configBuilder.Build();
             var scriptSettingsManager = new ScriptSettingsManager(config);
             var testLogger = new TestLogger("test");
+            _testEnvironment.SetEnvironmentVariable("ENV_VAR_BAR", "True");
             var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger(), _testWorkerProfileManager);
 
             var workerConfigs = configFactory.GetConfigs();
 
             Assert.False(testLogger.GetLogMessages().Any(m => m.Exception != null), "There should not be an exception logged while executing GetConfigs method.");
             Assert.Equal(1, workerConfigs.Count);
-            Assert.EndsWith("worker1\\1.bat", workerConfigs.Single().Description.DefaultWorkerPath);
+            Assert.EndsWith("worker1\\1.bat", workerConfigs[0].Description.DefaultWorkerPath);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #9932 

Adding `IsDisabled` property to worker description. This allows language workers to enable/disable a worker based on profile conditions. This is an optional property. If not provided, the worker will not be skipped.

Here is a sample worker config which takes advantage of this property.

```json
{
  "description": {
    "language": "bar"
  },
  "profiles": [
    {
      "profileName": "SpecificConditionProfile",
      "conditions": [
        {
          "conditionType": "environment",
          "conditionName": "NON_EXISTING_ENV_VAR",
          "conditionExpression": "(?i)true$"
        }
      ],
      "description": {
        "defaultExecutablePath": "%FUNCTIONS_WORKER_DIRECTORY%/2.bat",
        "defaultWorkerPath": "2.bat"
      }
    },
    {
      "profileName": "FallbackProfileToDisableWorker",
      "conditions": [
        {
          "conditionType": "environment",
          "conditionName": "EXISTING_ENV_VAR",
          "conditionExpression": "(?i)true$"
        }
      ],
      "description": {
        "defaultExecutablePath": "%FUNCTIONS_WORKER_DIRECTORY%/2.bat",
        "defaultWorkerPath": "2.bat",
        "isDisabled": true
      }
    }
  ]
}
```

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * ~Will follow backport PR.~ https://github.com/Azure/azure-functions-host/pull/10250
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #issue_or_pr - https://github.com/Azure/azure-functions-host/pull/10250
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
