### PR TITLE
Update pipeline so that .NET 8 and .NET 6 artifacts are published

### DIFF
--- a/eng/ci/templates/official/jobs/build-artifacts-windows.yml
+++ b/eng/ci/templates/official/jobs/build-artifacts-windows.yml
@@ -52,7 +52,7 @@ jobs:
       TargetFolder: $(Build.ArtifactStagingDirectory)
 
   - task: PowerShell@2
-    displayName: Build artifacts (net 6)
+    displayName: Build artifacts (.NET 6)
     inputs:
       filePath: build/build-extensions.ps1
       arguments: '-buildNumber "$(buildNumber)" -suffix "$(suffix)" -minorVersionPrefix "6"'
@@ -64,7 +64,7 @@ jobs:
       TargetFolder: $(Build.ArtifactStagingDirectory)
 
   - task: PowerShell@2
-    displayName: Build artifacts (net 8)
+    displayName: Build artifacts (.NET 8)
     inputs:
       filePath: build/build-extensions.ps1
       arguments: '-buildNumber "$(buildNumber)" -suffix "$(suffix)" -minorVersionPrefix "8"'

--- a/eng/ci/templates/official/jobs/build-artifacts-windows.yml
+++ b/eng/ci/templates/official/jobs/build-artifacts-windows.yml
@@ -51,6 +51,30 @@ jobs:
       Contents: '**/*.zip'
       TargetFolder: $(Build.ArtifactStagingDirectory)
 
+  - task: PowerShell@2
+    displayName: Build artifacts (net 6)
+    inputs:
+      filePath: build/build-extensions.ps1
+      arguments: '-buildNumber "$(buildNumber)" -suffix "$(suffix)" -minorVersionPrefix "6"'
+
+  - task: CopyFiles@2
+    inputs:
+      SourceFolder: out/pub/WebJobs.Script.WebHost
+      Contents: '**/*.zip'
+      TargetFolder: $(Build.ArtifactStagingDirectory)
+
+  - task: PowerShell@2
+    displayName: Build artifacts (net 8)
+    inputs:
+      filePath: build/build-extensions.ps1
+      arguments: '-buildNumber "$(buildNumber)" -suffix "$(suffix)" -minorVersionPrefix "8"'
+
+  - task: CopyFiles@2
+    inputs:
+      SourceFolder: out/pub/WebJobs.Script.WebHost
+      Contents: '**/*.zip'
+      TargetFolder: $(Build.ArtifactStagingDirectory)
+
   - task: DotNetCoreCLI@2
     displayName: Build host packages
     inputs:


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
The 1ES pipeline wasn't building the .NET 6 and .NET 8 artifacts since the minorPrefixVersion was not specified. This PR fixes this step.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
