### PR TITLE
Adding a timeout to `IFunctionProvider.GetFunctionMetadataAsync` 

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -17,4 +17,4 @@
 - Ordered invocations are now the default (#10201)
 - Skip worker description if none of the profile conditions are met (#9932)
 - Fixed incorrect function count in the log message.(#10220)
-- Adding a timeout to `GetFunctionMetadataAsync` to prevent deadlocks (#10219)
+- Adding a timeout when retrieving function metadata from metadata providers (#10219)

--- a/release_notes.md
+++ b/release_notes.md
@@ -17,3 +17,4 @@
 - Ordered invocations are now the default (#10201)
 - Skip worker description if none of the profile conditions are met (#9932)
 - Fixed incorrect function count in the log message.(#10220)
+- Adding a timeout to `GetFunctionMetadataAsync` to prevent deadlocks (#10219)

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AppInsightsAgent = "APPLICATIONINSIGHTS_ENABLE_AGENT";
         public const string FunctionsExtensionVersion = "FUNCTIONS_EXTENSION_VERSION";
         public const string FunctionWorkerRuntime = "FUNCTIONS_WORKER_RUNTIME";
+        public const string MetadataProviderTimeoutInSeconds = "METADATA_PROVIDER_TIMEOUT_IN_SECONDS";
         public const string ContainerName = "CONTAINER_NAME";
         public const string WebsitePodName = "WEBSITE_POD_NAME";
         public const string LegionServiceHost = "LEGION_SERVICE_HOST";

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AppInsightsAgent = "APPLICATIONINSIGHTS_ENABLE_AGENT";
         public const string FunctionsExtensionVersion = "FUNCTIONS_EXTENSION_VERSION";
         public const string FunctionWorkerRuntime = "FUNCTIONS_WORKER_RUNTIME";
-        public const string MetadataProviderTimeoutInSeconds = "METADATA_PROVIDER_TIMEOUT_IN_SECONDS";
         public const string ContainerName = "CONTAINER_NAME";
         public const string WebsitePodName = "WEBSITE_POD_NAME";
         public const string LegionServiceHost = "LEGION_SERVICE_HOST";

--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Azure.WebJobs.Script
             };
         }
 
+        // Property is settable for testing purposes.
         internal int MetadataProviderTimeoutInSeconds { get; set; } = DefaultMetadataProviderTimeoutInSeconds;
 
         public ImmutableDictionary<string, ImmutableArray<string>> Errors { get; private set; }

--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -57,6 +57,8 @@ namespace Microsoft.Azure.WebJobs.Script
             };
         }
 
+        internal int MetadataProviderTimeoutInSeconds { get; set; } = DefaultMetadataProviderTimeoutInSeconds;
+
         public ImmutableDictionary<string, ImmutableArray<string>> Errors { get; private set; }
 
         public bool TryGetFunctionMetadata(string functionName, out FunctionMetadata functionMetadata, bool forceRefresh)
@@ -219,15 +221,10 @@ namespace Microsoft.Azure.WebJobs.Script
 
             var functionProviderTasks = new List<Task<ImmutableArray<FunctionMetadata>>>();
 
-            if (!int.TryParse(_environment.GetEnvironmentVariable(EnvironmentSettingNames.MetadataProviderTimeoutInSeconds), out int metadataProviderTimeoutInSeconds))
-            {
-                metadataProviderTimeoutInSeconds = DefaultMetadataProviderTimeoutInSeconds;
-            }
-
             foreach (var functionProvider in functionProviders)
             {
                 var getFunctionMetadataFromProviderTask = functionProvider.GetFunctionMetadataAsync();
-                Task delayTask = Task.Delay(TimeSpan.FromSeconds(metadataProviderTimeoutInSeconds));
+                var delayTask = Task.Delay(TimeSpan.FromSeconds(MetadataProviderTimeoutInSeconds));
 
                 var completedTask = Task.WhenAny(getFunctionMetadataFromProviderTask, delayTask).ContinueWith(t =>
                 {

--- a/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 mockFunctionMetadataProvider.Object, new List<IFunctionProvider>() { goodFunctionMetadataProvider.Object, badFunctionMetadataProvider.Object }, new OptionsWrapper<HttpWorkerOptions>(_defaultHttpWorkerOptions), loggerFactory, new TestOptionsMonitor<LanguageWorkerOptions>(TestHelpers.GetTestLanguageWorkerOptions()));
 
             // Set the timeout to 1 second for the test.
-            SystemEnvironment.Instance.SetEnvironmentVariable(EnvironmentSettingNames.MetadataProviderTimeoutInSeconds, "1");
+            testFunctionMetadataManager.MetadataProviderTimeoutInSeconds = 1;
 
             // Run LoadFunctionMetadata in a separate Task to avoid blocking the test thread
             var loadFunctionMetadataTask = Task.Run(() => testFunctionMetadataManager.LoadFunctionMetadata());


### PR DESCRIPTION
resolves #10219 

The fix is to wrap the `GetFunctionMetadataAsync` with a timeout task so that if the `GetFunctionMetadataAsync` does not return within a specific time, we throw a timeout exception which the caller will handle.

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR : https://github.com/Azure/azure-functions-host/pull/10273
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #issue_or_pr - https://github.com/Azure/azure-functions-host/pull/10273
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

