### PR TITLE
Do not set tags for PRs from forks

### DIFF
--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -52,7 +52,7 @@ extends:
 
     settings:
       # PR's from forks do not have sufficient permissions to set tags.
-      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullReqest.IsFork'] }}
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullRequest.IsFork'] }}
 
     stages:
     - stage: Test

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -52,7 +52,7 @@ extends:
 
     settings:
       # PR's from forks do not have sufficient permissions to set tags.
-      skipBuildTagsForGitHubPullRequests: ${{ eq(variables['System.PullReqest.IsFork'], 'true') }}
+      skipBuildTagsForGitHubPullRequests: ${{ variables['System.PullReqest.IsFork'] }}
 
     stages:
     - stage: Test

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -50,6 +50,10 @@ extends:
           enabled: true
         runSourceLanguagesInSourceAnalysis: true
 
+    settings:
+      # PR's from forks do not have sufficient permissions to set tags.
+      skipBuildTagsForGitHubPullRequests: ${{ eq(variables['System.PullReqest.IsFork'], 'true') }}
+
     stages:
     - stage: Test
       jobs:


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR -- TODO
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Skip setting build tags for PRs from forks due to insufficient permissions.
