### PR TITLE
Updating FunctionsNetHost (dotnet isolated worker) to 1.0.9

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -17,4 +17,4 @@
 - Ordered invocations are now the default (#10201)
 - Skip worker description if none of the profile conditions are met (#9932)
 - Fixed incorrect function count in the log message.(#10220)
-- Updated dotnet-isolated worker to [1.0.9](https://github.com/Azure/azure-functions-dotnet-worker/pull/2552)
+- Updated dotnet-isolated worker to [1.0.9](https://github.com/Azure/azure-functions-dotnet-worker/pull/2552) (#10262)

--- a/release_notes.md
+++ b/release_notes.md
@@ -17,4 +17,4 @@
 - Ordered invocations are now the default (#10201)
 - Skip worker description if none of the profile conditions are met (#9932)
 - Fixed incorrect function count in the log message.(#10220)
-- Updated dotnet-isolated worker to [1.0.9](2552)
+- Updated dotnet-isolated worker to [1.0.9](https://github.com/Azure/azure-functions-dotnet-worker/pull/2552)

--- a/release_notes.md
+++ b/release_notes.md
@@ -17,3 +17,4 @@
 - Ordered invocations are now the default (#10201)
 - Skip worker description if none of the profile conditions are met (#9932)
 - Fixed incorrect function count in the log message.(#10220)
+- Updated dotnet-isolated worker to [1.0.9](2552)

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.22.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.22.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" NoWarn="NU1701" />
-    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.8" />
+    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.9" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.41-11331" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.0-beta.2-11957" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.0" />

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
@@ -275,7 +275,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
                 !t.Message.Contains("Skipping WorkerConfig for language")
             ).ToArray();
 
-            int expectedCount = 16;
+            int expectedCount = 18;
             Assert.True(traces.Length == expectedCount, $"Expected {expectedCount} messages, but found {traces.Length}. Actual logs:{Environment.NewLine}{string.Join(Environment.NewLine, traces.Select(t => t.Message))}");
 
             int idx = 0;
@@ -295,6 +295,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
             ValidateTrace(traces[idx++], "Job host started", LogCategories.Startup);
             ValidateTrace(traces[idx++], "Loading functions metadata", LogCategories.Startup);
             ValidateTrace(traces[idx++], "Reading functions metadata", LogCategories.Startup);
+
+            // The dotnet-isolated worker will not be loaded for this test as it is setup to run only in placeholder mode.
+            ValidateTrace(traces[idx++], "Skipping WorkerConfig for stack: dotnet-isolated since it is disabled.", LanguageWorkerConfigLogCategory);
+            // TO DO: Investigate why the message is logged twice. Tracking issue: https://github.com/Azure/azure-functions-host/issues/10268
+            ValidateTrace(traces[idx++], "Skipping WorkerConfig for stack: dotnet-isolated since it is disabled.", LanguageWorkerConfigLogCategory);
             ValidateTrace(traces[idx++], "Starting Host (HostId=", LogCategories.Startup);
         }
 

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
@@ -272,10 +272,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
             // in class LanguageWorkerOptionsSetup.cs -> Configure()
             // which is giving extra log lines for node worker
             traces = traces.Where(t =>
-                !t.Message.Contains("Skipping WorkerConfig for language")
+                !t.Message.Contains("Skipping WorkerConfig for language") && !t.Message.Contains("Skipping WorkerConfig for stack")
             ).ToArray();
 
-            int expectedCount = 18;
+            int expectedCount = 16;
+
             Assert.True(traces.Length == expectedCount, $"Expected {expectedCount} messages, but found {traces.Length}. Actual logs:{Environment.NewLine}{string.Join(Environment.NewLine, traces.Select(t => t.Message))}");
 
             int idx = 0;
@@ -295,11 +296,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
             ValidateTrace(traces[idx++], "Job host started", LogCategories.Startup);
             ValidateTrace(traces[idx++], "Loading functions metadata", LogCategories.Startup);
             ValidateTrace(traces[idx++], "Reading functions metadata", LogCategories.Startup);
-
-            // The dotnet-isolated worker will not be loaded for this test as it is setup to run only in placeholder mode.
-            ValidateTrace(traces[idx++], "Skipping WorkerConfig for stack: dotnet-isolated since it is disabled.", LanguageWorkerConfigLogCategory);
-            // TO DO: Investigate why the message is logged twice. Tracking issue: https://github.com/Azure/azure-functions-host/issues/10268
-            ValidateTrace(traces[idx++], "Skipping WorkerConfig for stack: dotnet-isolated since it is disabled.", LanguageWorkerConfigLogCategory);
             ValidateTrace(traces[idx++], "Starting Host (HostId=", LogCategories.Startup);
         }
 

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
     public abstract class ApplicationInsightsEndToEndTestsBase<TTestFixture>
         : IClassFixture<TTestFixture> where TTestFixture : ApplicationInsightsTestFixture, new()
     {
+        private const string LanguageWorkerConfigLogCategory = "Host.LanguageWorkerConfig";
         private ApplicationInsightsTestFixture _fixture;
 
         public ApplicationInsightsEndToEndTestsBase(ApplicationInsightsTestFixture fixture)
@@ -274,7 +275,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
                 !t.Message.Contains("Skipping WorkerConfig for language")
             ).ToArray();
 
-            int expectedCount = 16;
+            int expectedCount = 18;
             Assert.True(traces.Length == expectedCount, $"Expected {expectedCount} messages, but found {traces.Length}. Actual logs:{Environment.NewLine}{string.Join(Environment.NewLine, traces.Select(t => t.Message))}");
 
             int idx = 0;
@@ -294,6 +295,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
             ValidateTrace(traces[idx++], "Job host started", LogCategories.Startup);
             ValidateTrace(traces[idx++], "Loading functions metadata", LogCategories.Startup);
             ValidateTrace(traces[idx++], "Reading functions metadata", LogCategories.Startup);
+
+            // The dotnet-isolated worker will not be loaded for this test as it is setup to run only in placeholder mode.
+            ValidateTrace(traces[idx++], "Skipping WorkerConfig for stack: dotnet-isolated since it is disabled.", LanguageWorkerConfigLogCategory);
+            // TO DO: Investigate why the message is logged twice. Tracking issue: https://github.com/Azure/azure-functions-host/issues/10268
+            ValidateTrace(traces[idx++], "Skipping WorkerConfig for stack: dotnet-isolated since it is disabled.", LanguageWorkerConfigLogCategory);
             ValidateTrace(traces[idx++], "Starting Host (HostId=", LogCategories.Startup);
         }
 

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
@@ -275,7 +275,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
                 !t.Message.Contains("Skipping WorkerConfig for language")
             ).ToArray();
 
-            int expectedCount = 18;
+            int expectedCount = 16;
             Assert.True(traces.Length == expectedCount, $"Expected {expectedCount} messages, but found {traces.Length}. Actual logs:{Environment.NewLine}{string.Join(Environment.NewLine, traces.Select(t => t.Message))}");
 
             int idx = 0;
@@ -295,11 +295,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
             ValidateTrace(traces[idx++], "Job host started", LogCategories.Startup);
             ValidateTrace(traces[idx++], "Loading functions metadata", LogCategories.Startup);
             ValidateTrace(traces[idx++], "Reading functions metadata", LogCategories.Startup);
-
-            // The dotnet-isolated worker will not be loaded for this test as it is setup to run only in placeholder mode.
-            ValidateTrace(traces[idx++], "Skipping WorkerConfig for stack: dotnet-isolated since it is disabled.", LanguageWorkerConfigLogCategory);
-            // TO DO: Investigate why the message is logged twice. Tracking issue: https://github.com/Azure/azure-functions-host/issues/10268
-            ValidateTrace(traces[idx++], "Skipping WorkerConfig for stack: dotnet-isolated since it is disabled.", LanguageWorkerConfigLogCategory);
             ValidateTrace(traces[idx++], "Starting Host (HostId=", LogCategories.Startup);
         }
 

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
     public abstract class ApplicationInsightsEndToEndTestsBase<TTestFixture>
         : IClassFixture<TTestFixture> where TTestFixture : ApplicationInsightsTestFixture, new()
     {
-        private const string LanguageWorkerConfigLogCategory = "Host.LanguageWorkerConfig";
         private ApplicationInsightsTestFixture _fixture;
 
         public ApplicationInsightsEndToEndTestsBase(ApplicationInsightsTestFixture fixture)
@@ -276,7 +275,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
             ).ToArray();
 
             int expectedCount = 16;
-
             Assert.True(traces.Length == expectedCount, $"Expected {expectedCount} messages, but found {traces.Length}. Actual logs:{Environment.NewLine}{string.Join(Environment.NewLine, traces.Select(t => t.Message))}");
 
             int idx = 0;

--- a/test/WebJobs.Script.Tests/Configuration/LanguageWorkerOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/LanguageWorkerOptionsSetupTests.cs
@@ -33,14 +33,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             }
             else
             {
-                // dotnet-isolated worker config requires placehoolder mode env variable to be set to 1.
+                // The dotnet-isolated worker only runs in placeholder mode. Setting the placeholder environment to 1 for the test.
                 testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
             }
 
             testProfileManager.Setup(pm => pm.LoadWorkerDescriptionFromProfiles(It.IsAny<RpcWorkerDescription>(), out It.Ref<RpcWorkerDescription>.IsAny))
                 .Callback((RpcWorkerDescription defaultDescription, out RpcWorkerDescription outDescription) =>
                 {
-                    // dotnet-isolated worker config does not have "DefaultExecutablePath" in the parent level.So we should set it from a profile.
+                    // dotnet-isolated worker config does not have "DefaultExecutablePath" in the parent level.So, we should set it from a profile.
                     if (defaultDescription.Language == "dotnet-isolated")
                     {
                         outDescription = new RpcWorkerDescription() { DefaultExecutablePath = "testPath", Language = "dotnet-isolated" };

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -1600,7 +1600,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         [Theory]
         [InlineData("python", "main.py", "python", "python")]
-        [InlineData("dotnet-isolated", "app.dll", "dotnet-isolated", "dotnet-isolated")]
         [InlineData("dotnet", "app.dll", "dotnet", DotNetScriptTypes.DotNetAssembly)]
         [InlineData(null, "app.dll", "dotnet", DotNetScriptTypes.DotNetAssembly)] // if FUNCTIONS_WORKER_RUNTIME is missing, assume dotnet
         public async Task Initialize_MissingWorkerRuntime_SetsCorrectRuntimeFromFunctionMetadata(string functionsWorkerRuntime, string scriptFile, string expectedMetricLanguage, string expectedMetadataLanguage)

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
@@ -153,6 +153,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var config = configBuilder.Build();
             var scriptSettingsManager = new ScriptSettingsManager(config);
             var testLogger = new TestLogger("test");
+            _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
             using (var variables = new TestScopedSettings(scriptSettingsManager, testEnvVariables))
             {
                 var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger(), _testWorkerProfileManager);


### PR DESCRIPTION
Updating FunctionsNetHost (dotnet isolated worker) to 1.0.9. https://github.com/Azure/azure-functions-dotnet-worker/pull/2552
Updated a test(which uses the actual worker configs) to reflect this change.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR -https://github.com/Azure/azure-functions-host/pull/10263
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR https://github.com/Azure/azure-functions-host/pull/10263
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
