### PR TITLE
[in-proc] Updating FunctionsNetHost (dotnet isolated worker) to 1.0.9

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -15,4 +15,4 @@
 - Ordered invocations are now the default (#10201)
 - Skip worker description if none of the profile conditions are met (#9932)
 - Fixed incorrect function count in the log message.(#10220)
-- Updated dotnet-isolated worker to [1.0.9](2552)
+- Updated dotnet-isolated worker to [1.0.9](https://github.com/Azure/azure-functions-dotnet-worker/pull/2552) (#10263)

--- a/release_notes.md
+++ b/release_notes.md
@@ -15,3 +15,4 @@
 - Ordered invocations are now the default (#10201)
 - Skip worker description if none of the profile conditions are met (#9932)
 - Fixed incorrect function count in the log message.(#10220)
+- Updated dotnet-isolated worker to [1.0.9](2552)

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" NoWarn="NU1701" />
-    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.8" />
+    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.9" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.41-11331" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.0-beta.2-11957" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.0" />

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
     public abstract class ApplicationInsightsEndToEndTestsBase<TTestFixture>
         : IClassFixture<TTestFixture> where TTestFixture : ApplicationInsightsTestFixture, new()
     {
-        private const string LanguageWorkerConfigLogCategory = "Host.LanguageWorkerConfig";
         private ApplicationInsightsTestFixture _fixture;
 
         public ApplicationInsightsEndToEndTestsBase(ApplicationInsightsTestFixture fixture)
@@ -276,7 +275,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
             ).ToArray();
 
             int expectedCount = 16;
-
             Assert.True(traces.Length == expectedCount, $"Expected {expectedCount} messages, but found {traces.Length}. Actual logs:{Environment.NewLine}{string.Join(Environment.NewLine, traces.Select(t => t.Message))}");
 
             int idx = 0;

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsEndToEndTestsBase.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
     public abstract class ApplicationInsightsEndToEndTestsBase<TTestFixture>
         : IClassFixture<TTestFixture> where TTestFixture : ApplicationInsightsTestFixture, new()
     {
+        private const string LanguageWorkerConfigLogCategory = "Host.LanguageWorkerConfig";
         private ApplicationInsightsTestFixture _fixture;
 
         public ApplicationInsightsEndToEndTestsBase(ApplicationInsightsTestFixture fixture)
@@ -271,10 +272,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
             // in class LanguageWorkerOptionsSetup.cs -> Configure()
             // which is giving extra log lines for node worker
             traces = traces.Where(t =>
-                !t.Message.Contains("Skipping WorkerConfig for language")
+                !t.Message.Contains("Skipping WorkerConfig for language") && !t.Message.Contains("Skipping WorkerConfig for stack")
             ).ToArray();
 
             int expectedCount = 16;
+
             Assert.True(traces.Length == expectedCount, $"Expected {expectedCount} messages, but found {traces.Length}. Actual logs:{Environment.NewLine}{string.Join(Environment.NewLine, traces.Select(t => t.Message))}");
 
             int idx = 0;

--- a/test/WebJobs.Script.Tests/Configuration/LanguageWorkerOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/LanguageWorkerOptionsSetupTests.cs
@@ -31,6 +31,26 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             {
                 testEnvironment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, workerRuntime);
             }
+            else
+            {
+                // The dotnet-isolated worker only runs in placeholder mode. Setting the placeholder environment to 1 for the test.
+                testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
+            }
+
+            testProfileManager.Setup(pm => pm.LoadWorkerDescriptionFromProfiles(It.IsAny<RpcWorkerDescription>(), out It.Ref<RpcWorkerDescription>.IsAny))
+                .Callback((RpcWorkerDescription defaultDescription, out RpcWorkerDescription outDescription) =>
+                {
+                    // dotnet-isolated worker config does not have "DefaultExecutablePath" in the parent level.So, we should set it from a profile.
+                    if (defaultDescription.Language == "dotnet-isolated")
+                    {
+                        outDescription = new RpcWorkerDescription() { DefaultExecutablePath = "testPath", Language = "dotnet-isolated" };
+                    }
+                    else
+                    {
+                        // for other workers, we should return the default description as they have the "DefaultExecutablePath" in the parent level.
+                        outDescription = defaultDescription;
+                    }
+                });
 
             LanguageWorkerOptionsSetup setup = new LanguageWorkerOptionsSetup(configuration, NullLoggerFactory.Instance, testEnvironment, testMetricLogger, testProfileManager.Object);
             LanguageWorkerOptions options = new LanguageWorkerOptions();

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -1516,7 +1516,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         [Theory]
         [InlineData("python", "main.py", "python", "python")]
-        [InlineData("dotnet-isolated", "app.dll", "dotnet-isolated", "dotnet-isolated")]
         [InlineData("dotnet", "app.dll", "dotnet", DotNetScriptTypes.DotNetAssembly)]
         [InlineData(null, "app.dll", "dotnet", DotNetScriptTypes.DotNetAssembly)] // if FUNCTIONS_WORKER_RUNTIME is missing, assume dotnet
         public async Task Initialize_MissingWorkerRuntime_SetsCorrectRuntimeFromFunctionMetadata(string functionsWorkerRuntime, string scriptFile, string expectedMetricLanguage, string expectedMetadataLanguage)

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
@@ -153,6 +153,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var config = configBuilder.Build();
             var scriptSettingsManager = new ScriptSettingsManager(config);
             var testLogger = new TestLogger("test");
+            _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
             using (var variables = new TestScopedSettings(scriptSettingsManager, testEnvVariables))
             {
                 var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger(), _testWorkerProfileManager);


### PR DESCRIPTION
in-proc port of https://github.com/Azure/azure-functions-host/pull/10262
