### PR TITLE
[In-proc] Sanitize worker arguments before logging

### DIFF
--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcess.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerProcess.cs
@@ -81,8 +81,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
                     Process.OutputDataReceived += (sender, e) => OnOutputDataReceived(sender, e);
                     Process.Exited += (sender, e) => OnProcessExited(sender, e);
                     Process.EnableRaisingEvents = true;
+                    string sanitizedArguments = Sanitizer.Sanitize(Process.StartInfo.Arguments);
 
-                    _workerProcessLogger?.LogDebug($"Starting worker process with FileName:{Process.StartInfo.FileName} WorkingDirectory:{Process.StartInfo.WorkingDirectory} Arguments:{Process.StartInfo.Arguments}");
+                    _workerProcessLogger?.LogDebug($"Starting worker process with FileName:{Process.StartInfo.FileName} WorkingDirectory:{Process.StartInfo.WorkingDirectory} Arguments:{sanitizedArguments}");
                     Process.Start();
                     _workerProcessLogger?.LogDebug($"{Process.StartInfo.FileName} process with Id={Process.Id} started");
 

--- a/test/WebJobs.Script.Tests/Workers/Http/HttpWorkerProcessTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Http/HttpWorkerProcessTests.cs
@@ -119,5 +119,47 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
             var testLogs = _testLogger.GetLogMessages();
             Assert.Contains("File path does not exist, not assigning permissions", testLogs[0].FormattedMessage);
         }
+
+        [Theory]
+        [InlineData("AccountKey=abcde==", true)]
+        [InlineData("teststring", false)]
+        public async Task StartProcess_VerifySanitizedCredentialLogging(string input, bool isSecret)
+        {
+            try
+            {
+                _httpWorkerOptions.Arguments.WorkerArguments.Add(input);
+
+                File.Create(_executablePath).Dispose();
+                TestEnvironment testEnvironment = new TestEnvironment();
+                testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "TestContainer");
+                var mockHttpWorkerProcess = new HttpWorkerProcess(_testWorkerId, _rootScriptPath, _httpWorkerOptions, _mockEventManager.Object, _defaultWorkerProcessFactory, _processRegistry, _testLogger, _languageWorkerConsoleLogSource.Object, testEnvironment, new TestMetricsLogger(), _serviceProviderMock.Object, new LoggerFactory());
+
+                try
+                {
+                    await mockHttpWorkerProcess.StartProcessAsync();
+                }
+                catch
+                {
+                    // expected to throw. Just verifying a log statement occurred before then.
+                }
+
+                // Verify
+                var testLogs = _testLogger.GetLogMessages();
+
+                if (isSecret)
+                {
+                    Assert.DoesNotContain(input, testLogs[1].FormattedMessage);
+                    Assert.Contains($"Arguments: [Hidden Credential]", testLogs[1].FormattedMessage);
+                }
+                else
+                {
+                    Assert.Contains($"Arguments: {input}", testLogs[1].FormattedMessage);
+                }
+            }
+            finally
+            {
+                File.Delete(_executablePath);
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves - [link](https://github.com/orgs/Azure/projects/473/views/9?sliceBy%5Bvalue%5D=surgupta-msft&pane=issue&itemId=69050571)

Cherry picked commit from dev - [link](https://github.com/Azure/azure-functions-host/pull/10260)

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
