### PR TITLE
Shim NetheriteProviderFactory DI to avoid .NET8 regression

### DIFF
--- a/src/WebJobs.Script.WebHost/DependencyInjection/JobHostScopedServiceProviderFactory.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/JobHostScopedServiceProviderFactory.cs
@@ -127,6 +127,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
                 }
             }
 
+            if (toReplace is null)
+            {
+                return;
+            }
+
             foreach ((ServiceDescriptor key, ServiceDescriptor value) in toReplace)
             {
                 services.Remove(key);

--- a/src/WebJobs.Script.WebHost/DependencyInjection/JobHostScopedServiceProviderFactory.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/JobHostScopedServiceProviderFactory.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #10271

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This PR addresses a breaking change in .NET 8 DI which impacts Netherite. Specifically, `ActivatorUtilitiesConstructorAttribute` no longer workers as expected, leading to an ambiguous constructor exception when trying to resolve `NetheriteProviderFactory`. The Netherite package has addressed this issue in a later version, but we are concerned about impact for customers not on latest netherite package. This PR aims to address that by looking for this impacted type and replacing the service descriptor with one explicitly targeting the preferred ctor.
