### PR TITLE
[in-proc] Update Microsoft.Azure.WebJobs to 3.0.41 and Microsoft.Azure.WebJobs.Host.Storage to 5.0.1

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -15,3 +15,8 @@
 - Sanitize worker arguments before logging (#10260)
 - Fix race condition on startup with extension RPC endpoints not being available. (#10282)
 - Adding a timeout when retrieving function metadata from metadata providers (#10219)
+- Upgraded the following package versions (#10288):
+  - `Microsoft.Azure.WebJobs` updated to 3.0.41
+  - `Microsoft.Azure.WebJobs.Host.Storage` updated to 5.0.1
+  - `Microsoft.Extensions.Azure` updated to 1.7.1
+  - `Azure.Storage.Blobs` updated to 12.19.1

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -76,8 +76,8 @@
     <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.8" />
     <PackageReference Include="Microsoft.Azure.Storage.File" Version="11.1.7" />
 
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.41-11331" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.0-beta.2-11957" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.41" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.1" />
     <PackageReference Include="Microsoft.Azure.WebSites.DataProtection" Version="2.1.91-alpha" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="$(IdentityDependencyVersion)" />
     <PackageReference Include="Microsoft.Security.Utilities" Version="1.3.0" />

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -46,7 +46,7 @@
     <!-- Dependencies needed for Storage Providers -->
     <PackageReference Include="Azure.Core" Version="1.38.0" />
     <PackageReference Include="Azure.Identity" Version="1.11.4" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.22.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.21.0" />
@@ -54,9 +54,9 @@
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.9" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.41-11331" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.0-beta.2-11957" />
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.41" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.1" />
 
     <!-- Workers -->
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.2.20220831.41" />

--- a/test/WebJobs.Script.Tests/DepsFiles/net6.0/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
+++ b/test/WebJobs.Script.Tests/DepsFiles/net6.0/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
@@ -6,7 +6,7 @@
   "compilationOptions": {},
   "targets": {
     ".NETCoreApp,Version=v6.0": {
-      "Microsoft.Azure.WebJobs.Script.WebHost/4.34.0": {
+      "Microsoft.Azure.WebJobs.Script.WebHost/4.35.0": {
         "dependencies": {
           "Azure.Data.Tables": "12.8.3",
           "Azure.Identity": "1.11.4",
@@ -22,17 +22,16 @@
           "Microsoft.Azure.AppService.Middleware.Functions": "1.5.4",
           "Microsoft.Azure.AppService.Proxy.Client": "2.2.20220831.41",
           "Microsoft.Azure.Cosmos.Table": "1.0.8",
-          "Microsoft.Azure.Functions.PythonWorker": "4.28.1",
+          "Microsoft.Azure.Functions.PythonWorker": "4.29.0",
           "Microsoft.Azure.Storage.File": "11.1.7",
-          "Microsoft.Azure.WebJobs": "3.0.41-11331",
-          "Microsoft.Azure.WebJobs.Host.Storage": "5.0.0-beta.2-11957",
-          "Microsoft.Azure.WebJobs.Script": "4.34.0",
-          "Microsoft.Azure.WebJobs.Script.Grpc": "4.34.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Azure.WebJobs.Host.Storage": "5.0.1",
+          "Microsoft.Azure.WebJobs.Script": "4.35.0",
+          "Microsoft.Azure.WebJobs.Script.Grpc": "4.35.0",
           "Microsoft.Azure.WebSites.DataProtection": "2.1.91-alpha",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.35.0",
           "Microsoft.IdentityModel.Tokens": "6.35.0",
           "Microsoft.Security.Utilities": "1.3.0",
-          "Microsoft.SourceLink.GitHub": "1.0.0",
           "Newtonsoft.Json": "13.0.3",
           "StyleCop.Analyzers": "1.2.0-beta.435",
           "System.IO.FileSystem.AccessControl": "5.0.0",
@@ -41,8 +40,8 @@
           "System.Private.Uri": "4.3.2",
           "System.Security.Cryptography.Xml": "4.7.1",
           "System.Text.RegularExpressions": "4.3.1",
-          "Microsoft.Azure.WebJobs.Script.Reference": "4.34.0.0",
-          "Microsoft.Azure.WebJobs.Script.Grpc.Reference": "4.34.0.0"
+          "Microsoft.Azure.WebJobs.Script.Reference": "4.35.0.0",
+          "Microsoft.Azure.WebJobs.Script.Grpc.Reference": "4.35.0.0"
         },
         "runtime": {
           "Microsoft.Azure.WebJobs.Script.WebHost.dll": {}
@@ -121,27 +120,27 @@
           }
         }
       },
-      "Azure.Storage.Blobs/12.13.0": {
+      "Azure.Storage.Blobs/12.19.1": {
         "dependencies": {
-          "Azure.Storage.Common": "12.12.0",
+          "Azure.Storage.Common": "12.18.1",
           "System.Text.Json": "6.0.9"
         },
         "runtime": {
-          "lib/netstandard2.1/Azure.Storage.Blobs.dll": {
-            "assemblyVersion": "12.13.0.0",
-            "fileVersion": "12.1300.22.35704"
+          "lib/net6.0/Azure.Storage.Blobs.dll": {
+            "assemblyVersion": "12.19.1.0",
+            "fileVersion": "12.1900.123.56305"
           }
         }
       },
-      "Azure.Storage.Common/12.12.0": {
+      "Azure.Storage.Common/12.18.1": {
         "dependencies": {
           "Azure.Core": "1.38.0",
           "System.IO.Hashing": "7.0.0"
         },
         "runtime": {
-          "lib/netstandard2.0/Azure.Storage.Common.dll": {
-            "assemblyVersion": "12.12.0.0",
-            "fileVersion": "12.1200.22.35704"
+          "lib/net6.0/Azure.Storage.Common.dll": {
+            "assemblyVersion": "12.18.1.0",
+            "fileVersion": "12.1800.123.56305"
           }
         }
       },
@@ -861,13 +860,13 @@
           }
         }
       },
-      "Microsoft.Azure.Functions.DotNetIsolatedNativeHost/1.0.8": {},
+      "Microsoft.Azure.Functions.DotNetIsolatedNativeHost/1.0.9": {},
       "Microsoft.Azure.Functions.JavaWorker/2.14.0": {},
       "Microsoft.Azure.Functions.NodeJsWorker/3.10.0": {},
       "Microsoft.Azure.Functions.PowerShellWorker.PS7.0/4.0.3148": {},
       "Microsoft.Azure.Functions.PowerShellWorker.PS7.2/4.0.3220": {},
       "Microsoft.Azure.Functions.PowerShellWorker.PS7.4/4.0.3219": {},
-      "Microsoft.Azure.Functions.PythonWorker/4.28.1": {},
+      "Microsoft.Azure.Functions.PythonWorker/4.29.0": {},
       "Microsoft.Azure.KeyVault.Core/2.0.4": {
         "dependencies": {
           "System.Runtime": "4.3.1",
@@ -905,9 +904,9 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs/3.0.41-11331": {
+      "Microsoft.Azure.WebJobs/3.0.41": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Core": "3.0.41-11331",
+          "Microsoft.Azure.WebJobs.Core": "3.0.41",
           "Microsoft.Extensions.Configuration": "6.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "6.0.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "2.1.1",
@@ -927,7 +926,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Core/3.0.41-11331": {
+      "Microsoft.Azure.WebJobs.Core/3.0.41": {
         "dependencies": {
           "System.ComponentModel.Annotations": "4.5.0",
           "System.Diagnostics.TraceSource": "4.3.0",
@@ -942,7 +941,7 @@
       },
       "Microsoft.Azure.WebJobs.Extensions/5.0.0-beta.2-10879": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.41-11331",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "NCrontab.Signed": "3.3.2"
         },
         "runtime": {
@@ -959,7 +958,7 @@
           "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.2.0",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
           "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.Azure.WebJobs": "3.0.41-11331"
+          "Microsoft.Azure.WebJobs": "3.0.41"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Http.dll": {
@@ -970,9 +969,9 @@
       },
       "Microsoft.Azure.WebJobs.Extensions.Timers.Storage/1.0.0-beta.1": {
         "dependencies": {
-          "Azure.Storage.Blobs": "12.13.0",
+          "Azure.Storage.Blobs": "12.19.1",
           "Microsoft.Azure.WebJobs.Extensions": "5.0.0-beta.2-10879",
-          "Microsoft.Azure.WebJobs.Host.Storage": "5.0.0-beta.2-11957"
+          "Microsoft.Azure.WebJobs.Host.Storage": "5.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Timers.Storage.dll": {
@@ -981,16 +980,16 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Host.Storage/5.0.0-beta.2-11957": {
+      "Microsoft.Azure.WebJobs.Host.Storage/5.0.1": {
         "dependencies": {
-          "Azure.Storage.Blobs": "12.13.0",
-          "Microsoft.Azure.WebJobs": "3.0.41-11331",
-          "Microsoft.Extensions.Azure": "1.7.0"
+          "Azure.Storage.Blobs": "12.19.1",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.7.1"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Host.Storage.dll": {
-            "assemblyVersion": "5.0.0.0",
-            "fileVersion": "5.0.0.0"
+            "assemblyVersion": "5.0.1.0",
+            "fileVersion": "5.0.1.0"
           }
         }
       },
@@ -1006,7 +1005,7 @@
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.Azure.WebJobs": "3.0.41-11331",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
           "System.Diagnostics.TraceSource": "4.3.0",
           "System.Threading": "4.3.0",
@@ -1021,7 +1020,7 @@
       },
       "Microsoft.Azure.WebJobs.Rpc.Core/3.0.37": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.41-11331"
+          "Microsoft.Azure.WebJobs": "3.0.41"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Rpc.Core.dll": {
@@ -1043,7 +1042,7 @@
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Script.Abstractions.dll": {
             "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.19706.0"
+            "fileVersion": "1.0.21220.0"
           }
         }
       },
@@ -1068,7 +1067,6 @@
           }
         }
       },
-      "Microsoft.Build.Tasks.Git/1.0.0": {},
       "Microsoft.CodeAnalysis.Analyzers/2.9.4": {},
       "Microsoft.CodeAnalysis.Common/3.3.1": {
         "dependencies": {
@@ -1319,7 +1317,7 @@
           }
         }
       },
-      "Microsoft.Extensions.Azure/1.7.0": {
+      "Microsoft.Extensions.Azure/1.7.1": {
         "dependencies": {
           "Azure.Core": "1.38.0",
           "Azure.Identity": "1.11.4",
@@ -1331,8 +1329,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Extensions.Azure.dll": {
-            "assemblyVersion": "1.7.0.0",
-            "fileVersion": "1.700.23.40801"
+            "assemblyVersion": "1.7.1.0",
+            "fileVersion": "1.700.123.52701"
           }
         }
       },
@@ -1668,13 +1666,6 @@
             "assemblyVersion": "1.3.0.0",
             "fileVersion": "1.3.0.2"
           }
-        }
-      },
-      "Microsoft.SourceLink.Common/1.0.0": {},
-      "Microsoft.SourceLink.GitHub/1.0.0": {
-        "dependencies": {
-          "Microsoft.Build.Tasks.Git": "1.0.0",
-          "Microsoft.SourceLink.Common": "1.0.0"
         }
       },
       "Microsoft.Spatial/7.6.4": {
@@ -3025,11 +3016,11 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Script/4.34.0": {
+      "Microsoft.Azure.WebJobs.Script/4.35.0": {
         "dependencies": {
           "Azure.Core": "1.38.0",
           "Azure.Identity": "1.11.4",
-          "Azure.Storage.Blobs": "12.13.0",
+          "Azure.Storage.Blobs": "12.19.1",
           "Microsoft.ApplicationInsights": "2.22.0",
           "Microsoft.ApplicationInsights.AspNetCore": "2.21.0",
           "Microsoft.ApplicationInsights.DependencyCollector": "2.21.0",
@@ -3037,21 +3028,21 @@
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
           "Microsoft.Azure.AppService.Proxy.Client": "2.2.20220831.41",
-          "Microsoft.Azure.Functions.DotNetIsolatedNativeHost": "1.0.8",
+          "Microsoft.Azure.Functions.DotNetIsolatedNativeHost": "1.0.9",
           "Microsoft.Azure.Functions.JavaWorker": "2.14.0",
           "Microsoft.Azure.Functions.NodeJsWorker": "3.10.0",
           "Microsoft.Azure.Functions.PowerShellWorker.PS7.0": "4.0.3148",
           "Microsoft.Azure.Functions.PowerShellWorker.PS7.2": "4.0.3220",
           "Microsoft.Azure.Functions.PowerShellWorker.PS7.4": "4.0.3219",
-          "Microsoft.Azure.WebJobs": "3.0.41-11331",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions": "5.0.0-beta.2-10879",
           "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.0",
           "Microsoft.Azure.WebJobs.Extensions.Timers.Storage": "1.0.0-beta.1",
-          "Microsoft.Azure.WebJobs.Host.Storage": "5.0.0-beta.2-11957",
+          "Microsoft.Azure.WebJobs.Host.Storage": "5.0.1",
           "Microsoft.Azure.WebJobs.Logging.ApplicationInsights": "3.0.41-11321",
           "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.4-preview",
           "Microsoft.CodeAnalysis.CSharp.Scripting": "3.3.1",
-          "Microsoft.Extensions.Azure": "1.7.0",
+          "Microsoft.Extensions.Azure": "1.7.1",
           "Microsoft.Extensions.Hosting.Abstractions": "6.0.0",
           "Microsoft.Extensions.Logging.Console": "6.0.0",
           "Mono.Posix.NETStandard": "1.0.0",
@@ -3065,10 +3056,13 @@
           "System.Text.Json": "6.0.9"
         },
         "runtime": {
-          "Microsoft.Azure.WebJobs.Script.dll": {}
+          "Microsoft.Azure.WebJobs.Script.dll": {
+            "assemblyVersion": "4.35.0",
+            "fileVersion": ""
+          }
         }
       },
-      "Microsoft.Azure.WebJobs.Script.Grpc/4.34.0": {
+      "Microsoft.Azure.WebJobs.Script.Grpc/4.35.0": {
         "dependencies": {
           "Grpc.AspNetCore": "2.55.0",
           "Microsoft.ApplicationInsights": "2.22.0",
@@ -3077,35 +3071,38 @@
           "Microsoft.ApplicationInsights.WindowsServer": "2.21.0",
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
           "Microsoft.Azure.WebJobs.Rpc.Core": "3.0.37",
-          "Microsoft.Azure.WebJobs.Script": "4.34.0",
+          "Microsoft.Azure.WebJobs.Script": "4.35.0",
           "System.IO.FileSystem.Primitives": "4.3.0",
           "System.Threading.Channels": "6.0.0",
           "Yarp.ReverseProxy": "2.0.1"
         },
         "runtime": {
-          "Microsoft.Azure.WebJobs.Script.Grpc.dll": {}
-        }
-      },
-      "Microsoft.Azure.WebJobs.Script.Reference/4.34.0.0": {
-        "runtime": {
-          "Microsoft.Azure.WebJobs.Script.dll": {
-            "assemblyVersion": "4.34.0.0",
-            "fileVersion": "4.34.0.0"
+          "Microsoft.Azure.WebJobs.Script.Grpc.dll": {
+            "assemblyVersion": "4.35.0",
+            "fileVersion": ""
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Script.Grpc.Reference/4.34.0.0": {
+      "Microsoft.Azure.WebJobs.Script.Reference/4.35.0.0": {
+        "runtime": {
+          "Microsoft.Azure.WebJobs.Script.dll": {
+            "assemblyVersion": "4.35.0.0",
+            "fileVersion": "4.35.0.0"
+          }
+        }
+      },
+      "Microsoft.Azure.WebJobs.Script.Grpc.Reference/4.35.0.0": {
         "runtime": {
           "Microsoft.Azure.WebJobs.Script.Grpc.dll": {
-            "assemblyVersion": "4.34.0.0",
-            "fileVersion": "4.34.0.0"
+            "assemblyVersion": "4.35.0.0",
+            "fileVersion": "4.35.0.0"
           }
         }
       }
     }
   },
   "libraries": {
-    "Microsoft.Azure.WebJobs.Script.WebHost/4.34.0": {
+    "Microsoft.Azure.WebJobs.Script.WebHost/4.35.0": {
       "type": "project",
       "serviceable": false,
       "sha512": ""
@@ -3145,19 +3142,19 @@
       "path": "azure.security.keyvault.secrets/4.2.0",
       "hashPath": "azure.security.keyvault.secrets.4.2.0.nupkg.sha512"
     },
-    "Azure.Storage.Blobs/12.13.0": {
+    "Azure.Storage.Blobs/12.19.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-h5ZxRwmS/U1NOFwd+MuHJe4To1hEPu/yeBIKS1cbAHTDc+7RBZEjPf1VFeUZsIIuHvU/AzXtcRaph9BHuPRNMQ==",
-      "path": "azure.storage.blobs/12.13.0",
-      "hashPath": "azure.storage.blobs.12.13.0.nupkg.sha512"
+      "sha512": "sha512-x43hWFJ4sPQ23TD4piCwT+KlQpZT8pNDAzqj6yUCqh+WJ2qcQa17e1gh6ZOeT2QNFQTTDSuR56fm2bIV7i11/w==",
+      "path": "azure.storage.blobs/12.19.1",
+      "hashPath": "azure.storage.blobs.12.19.1.nupkg.sha512"
     },
-    "Azure.Storage.Common/12.12.0": {
+    "Azure.Storage.Common/12.18.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Ms0XsZ/D9Pcudfbqj+rWeCkhx/ITEq8isY0jkor9JFmDAEHsItFa2XrWkzP3vmJU6EsXQrk4snH63HkW/Jksvg==",
-      "path": "azure.storage.common/12.12.0",
-      "hashPath": "azure.storage.common.12.12.0.nupkg.sha512"
+      "sha512": "sha512-ohCslqP9yDKIn+DVjBEOBuieB1QwsUCz+BwHYNaJ3lcIsTSiI4Evnq81HcKe8CqM8qvdModbipVQKpnxpbdWqA==",
+      "path": "azure.storage.common/12.18.1",
+      "hashPath": "azure.storage.common.12.18.1.nupkg.sha512"
     },
     "Google.Protobuf/3.23.1": {
       "type": "package",
@@ -3656,12 +3653,12 @@
       "path": "microsoft.azure.documentdb.core/2.11.2",
       "hashPath": "microsoft.azure.documentdb.core.2.11.2.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.DotNetIsolatedNativeHost/1.0.8": {
+    "Microsoft.Azure.Functions.DotNetIsolatedNativeHost/1.0.9": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-FBpjBzsruWBEwy9YtIb9FMtpQi2rSSpK+xXIkqFh31YnhI8jj86yuXt0X5Q0pZ3xd3jojmKDo2tu96tRlHY5rQ==",
-      "path": "microsoft.azure.functions.dotnetisolatednativehost/1.0.8",
-      "hashPath": "microsoft.azure.functions.dotnetisolatednativehost.1.0.8.nupkg.sha512"
+      "sha512": "sha512-lWM6jWUkcxzhQGDmO7gAkA9ErRibO8TH4ABDaf5rmte8tkewxlPYperknkZ/OS4kr7wnMKgjwqs48OyS7YmoYA==",
+      "path": "microsoft.azure.functions.dotnetisolatednativehost/1.0.9",
+      "hashPath": "microsoft.azure.functions.dotnetisolatednativehost.1.0.9.nupkg.sha512"
     },
     "Microsoft.Azure.Functions.JavaWorker/2.14.0": {
       "type": "package",
@@ -3698,12 +3695,12 @@
       "path": "microsoft.azure.functions.powershellworker.ps7.4/4.0.3219",
       "hashPath": "microsoft.azure.functions.powershellworker.ps7.4.4.0.3219.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.PythonWorker/4.28.1": {
+    "Microsoft.Azure.Functions.PythonWorker/4.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-59F7OULiqJOlAj07KpV/dbDr9oYZX9EHuEYbm4ysbVilKC4xZafrVpmCW9FLpzdQJVnIa73CRp6L4vQgKxy4Kw==",
-      "path": "microsoft.azure.functions.pythonworker/4.28.1",
-      "hashPath": "microsoft.azure.functions.pythonworker.4.28.1.nupkg.sha512"
+      "sha512": "sha512-42UtQ5TP6ITYt7jS0wY8YReFBi9TBGHqrmw0CRRnvaPlEy6DvxuHlgAcAx/YCNCGzjQYFJ+4QIlEI5sSVjOOjA==",
+      "path": "microsoft.azure.functions.pythonworker/4.29.0",
+      "hashPath": "microsoft.azure.functions.pythonworker.4.29.0.nupkg.sha512"
     },
     "Microsoft.Azure.KeyVault.Core/2.0.4": {
       "type": "package",
@@ -3726,19 +3723,19 @@
       "path": "microsoft.azure.storage.file/11.1.7",
       "hashPath": "microsoft.azure.storage.file.11.1.7.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs/3.0.41-11331": {
+    "Microsoft.Azure.WebJobs/3.0.41": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-cd5kFxuKLSnzWtnaTC8RytYBmZKT6BaTcajsqEtpcL8yQJnKnKRaMTyjyePYRd16dJFmO0EboIjvTtX3PBNl7w==",
-      "path": "microsoft.azure.webjobs/3.0.41-11331",
-      "hashPath": "microsoft.azure.webjobs.3.0.41-11331.nupkg.sha512"
+      "sha512": "sha512-nprqeSOAkhFrpIW1KVkXQb6BZCbnS8d1ytq0nUzIYnpkmbvmfkcQlJE9zp3Dbo26Q/0h0JdPSQ3BaVVBNPOUZg==",
+      "path": "microsoft.azure.webjobs/3.0.41",
+      "hashPath": "microsoft.azure.webjobs.3.0.41.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Core/3.0.41-11331": {
+    "Microsoft.Azure.WebJobs.Core/3.0.41": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-vNGTeRSRptH1xIn1XgpAKEVP81sS/mAuFUU5Kkc0vYYJYhQtI0eAmaZtvYQmBXRg9qPKKmkfMvkTnvTrHBkL2Q==",
-      "path": "microsoft.azure.webjobs.core/3.0.41-11331",
-      "hashPath": "microsoft.azure.webjobs.core.3.0.41-11331.nupkg.sha512"
+      "sha512": "sha512-nNW4I8m5GEhOxxD/NVZGjT6ZARGSy7wi8q+ihvKDin4IY4zYLpTy/GakZeGgbi7vPxcPHL5Z65n9DAV+goasqA==",
+      "path": "microsoft.azure.webjobs.core/3.0.41",
+      "hashPath": "microsoft.azure.webjobs.core.3.0.41.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions/5.0.0-beta.2-10879": {
       "type": "package",
@@ -3761,12 +3758,12 @@
       "path": "microsoft.azure.webjobs.extensions.timers.storage/1.0.0-beta.1",
       "hashPath": "microsoft.azure.webjobs.extensions.timers.storage.1.0.0-beta.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Host.Storage/5.0.0-beta.2-11957": {
+    "Microsoft.Azure.WebJobs.Host.Storage/5.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Oq0rRfl/MPfyUW0Tdue3osfXZxiKxMltSfF+rB2VurYHAlw1cHXuX9diMd8nCyYSjUFYkVi/mRS3lYJK9jdzqA==",
-      "path": "microsoft.azure.webjobs.host.storage/5.0.0-beta.2-11957",
-      "hashPath": "microsoft.azure.webjobs.host.storage.5.0.0-beta.2-11957.nupkg.sha512"
+      "sha512": "sha512-eO/sX41oaGkDiXHpT7y/F1F5Wvzm7e1QqFmd4GGMJOMdLOHGvwOvZR82AfR7rjvpqQZWyKjRHqxAVcntq+ZYwQ==",
+      "path": "microsoft.azure.webjobs.host.storage/5.0.1",
+      "hashPath": "microsoft.azure.webjobs.host.storage.5.0.1.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Logging.ApplicationInsights/3.0.41-11321": {
       "type": "package",
@@ -3785,7 +3782,7 @@
     "Microsoft.Azure.WebJobs.Script.Abstractions/1.0.4-preview": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-mvgXnFKwh4/Gw8BXc99ZJd2iQ8DQJTCotvY9PZ9Y2UHa4KiOsYaEW4kuZ5RFBD9KqGO2vXG56w3wMFVyxmaA2g==",
+      "sha512": "sha512-+f2iWeAdES4X4HtvgWoIHPXfTxXeX7UlQDbWMkSuxWdt1vHVJf164IEUZxG7Gtfh42ircV9jy7F1zPhuaWNamQ==",
       "path": "microsoft.azure.webjobs.script.abstractions/1.0.4-preview",
       "hashPath": "microsoft.azure.webjobs.script.abstractions.1.0.4-preview.nupkg.sha512"
     },
@@ -3802,13 +3799,6 @@
       "sha512": "sha512-yuvf07qFWFqtK3P/MRkEKLhn5r2UbSpVueRziSqj0yJQIKFwG1pq9mOayK3zE5qZCTs0CbrwL9M6R8VwqyGy2w==",
       "path": "microsoft.bcl.asyncinterfaces/1.1.1",
       "hashPath": "microsoft.bcl.asyncinterfaces.1.1.1.nupkg.sha512"
-    },
-    "Microsoft.Build.Tasks.Git/1.0.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-z2fpmmt+1Jfl+ZnBki9nSP08S1/tbEOxFdsK1rSR+LBehIJz1Xv9/6qOOoGNqlwnAGGVGis1Oj6S8Kt9COEYlQ==",
-      "path": "microsoft.build.tasks.git/1.0.0",
-      "hashPath": "microsoft.build.tasks.git.1.0.0.nupkg.sha512"
     },
     "Microsoft.CodeAnalysis.Analyzers/2.9.4": {
       "type": "package",
@@ -3866,12 +3856,12 @@
       "path": "microsoft.dotnet.platformabstractions/2.1.0",
       "hashPath": "microsoft.dotnet.platformabstractions.2.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Azure/1.7.0": {
+    "Microsoft.Extensions.Azure/1.7.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-lusJX7qm2eK4cDMQzgDt6M2qGqSvZKzirATCJvgYHrARFH/L5H9cJ4/i8v83OI8USKt3IOkyTFtuuExAGh6pUQ==",
-      "path": "microsoft.extensions.azure/1.7.0",
-      "hashPath": "microsoft.extensions.azure.1.7.0.nupkg.sha512"
+      "sha512": "sha512-mS4uBCrUz6eWLZUgkSQKNM97rRMOTFMhi3rdehNJmmnaCQd0mbsrWYkOG9ZVF93zFuvpHlqRUuTGCsHNvMCVPQ==",
+      "path": "microsoft.extensions.azure/1.7.1",
+      "hashPath": "microsoft.extensions.azure.1.7.1.nupkg.sha512"
     },
     "Microsoft.Extensions.Caching.Abstractions/5.0.0": {
       "type": "package",
@@ -4187,20 +4177,6 @@
       "sha512": "sha512-98YtlfblGO4Bu23GYj6FEHS0HNEzcxOGgQ27zvEnr+hzPiSNWm9phYuqyjoxnApFAWn8vxUvioQaJCC8QELRSg==",
       "path": "microsoft.security.utilities/1.3.0",
       "hashPath": "microsoft.security.utilities.1.3.0.nupkg.sha512"
-    },
-    "Microsoft.SourceLink.Common/1.0.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-G8DuQY8/DK5NN+3jm5wcMcd9QYD90UV7MiLmdljSJixi3U/vNaeBKmmXUqI4DJCOeWizIUEh4ALhSt58mR+5eg==",
-      "path": "microsoft.sourcelink.common/1.0.0",
-      "hashPath": "microsoft.sourcelink.common.1.0.0.nupkg.sha512"
-    },
-    "Microsoft.SourceLink.GitHub/1.0.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-aZyGyGg2nFSxix+xMkPmlmZSsnGQ3w+mIG23LTxJZHN+GPwTQ5FpPgDo7RMOq+Kcf5D4hFWfXkGhoGstawX13Q==",
-      "path": "microsoft.sourcelink.github/1.0.0",
-      "hashPath": "microsoft.sourcelink.github.1.0.0.nupkg.sha512"
     },
     "Microsoft.Spatial/7.6.4": {
       "type": "package",
@@ -5168,22 +5144,22 @@
       "path": "yarp.reverseproxy/2.0.1",
       "hashPath": "yarp.reverseproxy.2.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Script/4.34.0": {
+    "Microsoft.Azure.WebJobs.Script/4.35.0": {
       "type": "project",
       "serviceable": false,
       "sha512": ""
     },
-    "Microsoft.Azure.WebJobs.Script.Grpc/4.34.0": {
+    "Microsoft.Azure.WebJobs.Script.Grpc/4.35.0": {
       "type": "project",
       "serviceable": false,
       "sha512": ""
     },
-    "Microsoft.Azure.WebJobs.Script.Reference/4.34.0.0": {
+    "Microsoft.Azure.WebJobs.Script.Reference/4.35.0.0": {
       "type": "reference",
       "serviceable": false,
       "sha512": ""
     },
-    "Microsoft.Azure.WebJobs.Script.Grpc.Reference/4.34.0.0": {
+    "Microsoft.Azure.WebJobs.Script.Grpc.Reference/4.35.0.0": {
       "type": "reference",
       "serviceable": false,
       "sha512": ""

--- a/test/WebJobs.Script.Tests/DepsFiles/net8.0/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
+++ b/test/WebJobs.Script.Tests/DepsFiles/net8.0/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
@@ -6,7 +6,7 @@
   "compilationOptions": {},
   "targets": {
     ".NETCoreApp,Version=v8.0": {
-      "Microsoft.Azure.WebJobs.Script.WebHost/4.34.0": {
+      "Microsoft.Azure.WebJobs.Script.WebHost/4.35.0": {
         "dependencies": {
           "Azure.Data.Tables": "12.8.3",
           "Azure.Identity": "1.11.4",
@@ -22,17 +22,16 @@
           "Microsoft.Azure.AppService.Middleware.Functions": "1.5.4",
           "Microsoft.Azure.AppService.Proxy.Client": "2.3.20240307.67",
           "Microsoft.Azure.Cosmos.Table": "1.0.8",
-          "Microsoft.Azure.Functions.PythonWorker": "4.28.1",
+          "Microsoft.Azure.Functions.PythonWorker": "4.29.0",
           "Microsoft.Azure.Storage.File": "11.1.7",
-          "Microsoft.Azure.WebJobs": "3.0.41-11331",
-          "Microsoft.Azure.WebJobs.Host.Storage": "5.0.0-beta.2-11957",
-          "Microsoft.Azure.WebJobs.Script": "4.34.0",
-          "Microsoft.Azure.WebJobs.Script.Grpc": "4.34.0",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Azure.WebJobs.Host.Storage": "5.0.1",
+          "Microsoft.Azure.WebJobs.Script": "4.35.0",
+          "Microsoft.Azure.WebJobs.Script.Grpc": "4.35.0",
           "Microsoft.Azure.WebSites.DataProtection": "2.1.91-alpha",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "7.1.2",
           "Microsoft.IdentityModel.Tokens": "7.1.2",
           "Microsoft.Security.Utilities": "1.3.0",
-          "Microsoft.SourceLink.GitHub": "1.0.0",
           "Newtonsoft.Json": "13.0.3",
           "StyleCop.Analyzers": "1.2.0-beta.435",
           "System.IO.FileSystem.AccessControl": "5.0.0",
@@ -41,8 +40,8 @@
           "System.Private.Uri": "4.3.2",
           "System.Security.Cryptography.Xml": "4.7.1",
           "System.Text.RegularExpressions": "4.3.1",
-          "Microsoft.Azure.WebJobs.Script.Reference": "4.34.0.0",
-          "Microsoft.Azure.WebJobs.Script.Grpc.Reference": "4.34.0.0"
+          "Microsoft.Azure.WebJobs.Script.Reference": "4.35.0.0",
+          "Microsoft.Azure.WebJobs.Script.Grpc.Reference": "4.35.0.0"
         },
         "runtime": {
           "Microsoft.Azure.WebJobs.Script.WebHost.dll": {}
@@ -121,27 +120,27 @@
           }
         }
       },
-      "Azure.Storage.Blobs/12.13.0": {
+      "Azure.Storage.Blobs/12.19.1": {
         "dependencies": {
-          "Azure.Storage.Common": "12.12.0",
+          "Azure.Storage.Common": "12.18.1",
           "System.Text.Json": "6.0.9"
         },
         "runtime": {
-          "lib/netstandard2.1/Azure.Storage.Blobs.dll": {
-            "assemblyVersion": "12.13.0.0",
-            "fileVersion": "12.1300.22.35704"
+          "lib/net6.0/Azure.Storage.Blobs.dll": {
+            "assemblyVersion": "12.19.1.0",
+            "fileVersion": "12.1900.123.56305"
           }
         }
       },
-      "Azure.Storage.Common/12.12.0": {
+      "Azure.Storage.Common/12.18.1": {
         "dependencies": {
           "Azure.Core": "1.38.0",
           "System.IO.Hashing": "7.0.0"
         },
         "runtime": {
-          "lib/netstandard2.0/Azure.Storage.Common.dll": {
-            "assemblyVersion": "12.12.0.0",
-            "fileVersion": "12.1200.22.35704"
+          "lib/net6.0/Azure.Storage.Common.dll": {
+            "assemblyVersion": "12.18.1.0",
+            "fileVersion": "12.1800.123.56305"
           }
         }
       },
@@ -861,13 +860,13 @@
           }
         }
       },
-      "Microsoft.Azure.Functions.DotNetIsolatedNativeHost/1.0.8": {},
+      "Microsoft.Azure.Functions.DotNetIsolatedNativeHost/1.0.9": {},
       "Microsoft.Azure.Functions.JavaWorker/2.14.0": {},
       "Microsoft.Azure.Functions.NodeJsWorker/3.10.0": {},
       "Microsoft.Azure.Functions.PowerShellWorker.PS7.0/4.0.3148": {},
       "Microsoft.Azure.Functions.PowerShellWorker.PS7.2/4.0.3220": {},
       "Microsoft.Azure.Functions.PowerShellWorker.PS7.4/4.0.3219": {},
-      "Microsoft.Azure.Functions.PythonWorker/4.28.1": {},
+      "Microsoft.Azure.Functions.PythonWorker/4.29.0": {},
       "Microsoft.Azure.KeyVault.Core/2.0.4": {
         "dependencies": {
           "System.Runtime": "4.3.1",
@@ -905,9 +904,9 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs/3.0.41-11331": {
+      "Microsoft.Azure.WebJobs/3.0.41": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Core": "3.0.41-11331",
+          "Microsoft.Azure.WebJobs.Core": "3.0.41",
           "Microsoft.Extensions.Configuration": "6.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "6.0.0",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "2.1.1",
@@ -927,7 +926,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Core/3.0.41-11331": {
+      "Microsoft.Azure.WebJobs.Core/3.0.41": {
         "dependencies": {
           "System.ComponentModel.Annotations": "4.5.0",
           "System.Diagnostics.TraceSource": "4.3.0",
@@ -942,7 +941,7 @@
       },
       "Microsoft.Azure.WebJobs.Extensions/5.0.0-beta.2-10879": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.41-11331",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "NCrontab.Signed": "3.3.2"
         },
         "runtime": {
@@ -959,7 +958,7 @@
           "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.2.0",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
           "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.Azure.WebJobs": "3.0.41-11331"
+          "Microsoft.Azure.WebJobs": "3.0.41"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Http.dll": {
@@ -970,9 +969,9 @@
       },
       "Microsoft.Azure.WebJobs.Extensions.Timers.Storage/1.0.0-beta.1": {
         "dependencies": {
-          "Azure.Storage.Blobs": "12.13.0",
+          "Azure.Storage.Blobs": "12.19.1",
           "Microsoft.Azure.WebJobs.Extensions": "5.0.0-beta.2-10879",
-          "Microsoft.Azure.WebJobs.Host.Storage": "5.0.0-beta.2-11957"
+          "Microsoft.Azure.WebJobs.Host.Storage": "5.0.1"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Timers.Storage.dll": {
@@ -981,16 +980,16 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Host.Storage/5.0.0-beta.2-11957": {
+      "Microsoft.Azure.WebJobs.Host.Storage/5.0.1": {
         "dependencies": {
-          "Azure.Storage.Blobs": "12.13.0",
-          "Microsoft.Azure.WebJobs": "3.0.41-11331",
-          "Microsoft.Extensions.Azure": "1.7.0"
+          "Azure.Storage.Blobs": "12.19.1",
+          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Extensions.Azure": "1.7.1"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Host.Storage.dll": {
-            "assemblyVersion": "5.0.0.0",
-            "fileVersion": "5.0.0.0"
+            "assemblyVersion": "5.0.1.0",
+            "fileVersion": "5.0.1.0"
           }
         }
       },
@@ -1006,7 +1005,7 @@
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.Azure.WebJobs": "3.0.41-11331",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
           "System.Diagnostics.TraceSource": "4.3.0",
           "System.Threading": "4.3.0",
@@ -1021,7 +1020,7 @@
       },
       "Microsoft.Azure.WebJobs.Rpc.Core/3.0.37": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.41-11331"
+          "Microsoft.Azure.WebJobs": "3.0.41"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Rpc.Core.dll": {
@@ -1043,7 +1042,7 @@
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Script.Abstractions.dll": {
             "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.19706.0"
+            "fileVersion": "1.0.21220.0"
           }
         }
       },
@@ -1068,7 +1067,6 @@
           }
         }
       },
-      "Microsoft.Build.Tasks.Git/1.0.0": {},
       "Microsoft.CodeAnalysis.Analyzers/2.9.4": {},
       "Microsoft.CodeAnalysis.Common/3.3.1": {
         "dependencies": {
@@ -1319,7 +1317,7 @@
           }
         }
       },
-      "Microsoft.Extensions.Azure/1.7.0": {
+      "Microsoft.Extensions.Azure/1.7.1": {
         "dependencies": {
           "Azure.Core": "1.38.0",
           "Azure.Identity": "1.11.4",
@@ -1331,8 +1329,8 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Extensions.Azure.dll": {
-            "assemblyVersion": "1.7.0.0",
-            "fileVersion": "1.700.23.40801"
+            "assemblyVersion": "1.7.1.0",
+            "fileVersion": "1.700.123.52701"
           }
         }
       },
@@ -1663,13 +1661,6 @@
             "assemblyVersion": "1.3.0.0",
             "fileVersion": "1.3.0.2"
           }
-        }
-      },
-      "Microsoft.SourceLink.Common/1.0.0": {},
-      "Microsoft.SourceLink.GitHub/1.0.0": {
-        "dependencies": {
-          "Microsoft.Build.Tasks.Git": "1.0.0",
-          "Microsoft.SourceLink.Common": "1.0.0"
         }
       },
       "Microsoft.Spatial/7.6.4": {
@@ -3008,11 +2999,11 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Script/4.34.0": {
+      "Microsoft.Azure.WebJobs.Script/4.35.0": {
         "dependencies": {
           "Azure.Core": "1.38.0",
           "Azure.Identity": "1.11.4",
-          "Azure.Storage.Blobs": "12.13.0",
+          "Azure.Storage.Blobs": "12.19.1",
           "Microsoft.ApplicationInsights": "2.22.0",
           "Microsoft.ApplicationInsights.AspNetCore": "2.21.0",
           "Microsoft.ApplicationInsights.DependencyCollector": "2.21.0",
@@ -3020,21 +3011,21 @@
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
           "Microsoft.Azure.AppService.Proxy.Client": "2.3.20240307.67",
-          "Microsoft.Azure.Functions.DotNetIsolatedNativeHost": "1.0.8",
+          "Microsoft.Azure.Functions.DotNetIsolatedNativeHost": "1.0.9",
           "Microsoft.Azure.Functions.JavaWorker": "2.14.0",
           "Microsoft.Azure.Functions.NodeJsWorker": "3.10.0",
           "Microsoft.Azure.Functions.PowerShellWorker.PS7.0": "4.0.3148",
           "Microsoft.Azure.Functions.PowerShellWorker.PS7.2": "4.0.3220",
           "Microsoft.Azure.Functions.PowerShellWorker.PS7.4": "4.0.3219",
-          "Microsoft.Azure.WebJobs": "3.0.41-11331",
+          "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions": "5.0.0-beta.2-10879",
           "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.0",
           "Microsoft.Azure.WebJobs.Extensions.Timers.Storage": "1.0.0-beta.1",
-          "Microsoft.Azure.WebJobs.Host.Storage": "5.0.0-beta.2-11957",
+          "Microsoft.Azure.WebJobs.Host.Storage": "5.0.1",
           "Microsoft.Azure.WebJobs.Logging.ApplicationInsights": "3.0.41-11321",
           "Microsoft.Azure.WebJobs.Script.Abstractions": "1.0.4-preview",
           "Microsoft.CodeAnalysis.CSharp.Scripting": "3.3.1",
-          "Microsoft.Extensions.Azure": "1.7.0",
+          "Microsoft.Extensions.Azure": "1.7.1",
           "Microsoft.Extensions.Hosting.Abstractions": "6.0.0",
           "Microsoft.Extensions.Logging.Console": "6.0.0",
           "Mono.Posix.NETStandard": "1.0.0",
@@ -3048,10 +3039,13 @@
           "System.Text.Json": "6.0.9"
         },
         "runtime": {
-          "Microsoft.Azure.WebJobs.Script.dll": {}
+          "Microsoft.Azure.WebJobs.Script.dll": {
+            "assemblyVersion": "4.35.0",
+            "fileVersion": ""
+          }
         }
       },
-      "Microsoft.Azure.WebJobs.Script.Grpc/4.34.0": {
+      "Microsoft.Azure.WebJobs.Script.Grpc/4.35.0": {
         "dependencies": {
           "Grpc.AspNetCore": "2.55.0",
           "Microsoft.ApplicationInsights": "2.22.0",
@@ -3060,35 +3054,38 @@
           "Microsoft.ApplicationInsights.WindowsServer": "2.21.0",
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.21.0",
           "Microsoft.Azure.WebJobs.Rpc.Core": "3.0.37",
-          "Microsoft.Azure.WebJobs.Script": "4.34.0",
+          "Microsoft.Azure.WebJobs.Script": "4.35.0",
           "System.IO.FileSystem.Primitives": "4.3.0",
           "System.Threading.Channels": "6.0.0",
           "Yarp.ReverseProxy": "2.0.1"
         },
         "runtime": {
-          "Microsoft.Azure.WebJobs.Script.Grpc.dll": {}
-        }
-      },
-      "Microsoft.Azure.WebJobs.Script.Reference/4.34.0.0": {
-        "runtime": {
-          "Microsoft.Azure.WebJobs.Script.dll": {
-            "assemblyVersion": "4.34.0.0",
-            "fileVersion": "4.34.0.0"
+          "Microsoft.Azure.WebJobs.Script.Grpc.dll": {
+            "assemblyVersion": "4.35.0",
+            "fileVersion": ""
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Script.Grpc.Reference/4.34.0.0": {
+      "Microsoft.Azure.WebJobs.Script.Reference/4.35.0.0": {
+        "runtime": {
+          "Microsoft.Azure.WebJobs.Script.dll": {
+            "assemblyVersion": "4.35.0.0",
+            "fileVersion": "4.35.0.0"
+          }
+        }
+      },
+      "Microsoft.Azure.WebJobs.Script.Grpc.Reference/4.35.0.0": {
         "runtime": {
           "Microsoft.Azure.WebJobs.Script.Grpc.dll": {
-            "assemblyVersion": "4.34.0.0",
-            "fileVersion": "4.34.0.0"
+            "assemblyVersion": "4.35.0.0",
+            "fileVersion": "4.35.0.0"
           }
         }
       }
     }
   },
   "libraries": {
-    "Microsoft.Azure.WebJobs.Script.WebHost/4.34.0": {
+    "Microsoft.Azure.WebJobs.Script.WebHost/4.35.0": {
       "type": "project",
       "serviceable": false,
       "sha512": ""
@@ -3128,19 +3125,19 @@
       "path": "azure.security.keyvault.secrets/4.2.0",
       "hashPath": "azure.security.keyvault.secrets.4.2.0.nupkg.sha512"
     },
-    "Azure.Storage.Blobs/12.13.0": {
+    "Azure.Storage.Blobs/12.19.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-h5ZxRwmS/U1NOFwd+MuHJe4To1hEPu/yeBIKS1cbAHTDc+7RBZEjPf1VFeUZsIIuHvU/AzXtcRaph9BHuPRNMQ==",
-      "path": "azure.storage.blobs/12.13.0",
-      "hashPath": "azure.storage.blobs.12.13.0.nupkg.sha512"
+      "sha512": "sha512-x43hWFJ4sPQ23TD4piCwT+KlQpZT8pNDAzqj6yUCqh+WJ2qcQa17e1gh6ZOeT2QNFQTTDSuR56fm2bIV7i11/w==",
+      "path": "azure.storage.blobs/12.19.1",
+      "hashPath": "azure.storage.blobs.12.19.1.nupkg.sha512"
     },
-    "Azure.Storage.Common/12.12.0": {
+    "Azure.Storage.Common/12.18.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Ms0XsZ/D9Pcudfbqj+rWeCkhx/ITEq8isY0jkor9JFmDAEHsItFa2XrWkzP3vmJU6EsXQrk4snH63HkW/Jksvg==",
-      "path": "azure.storage.common/12.12.0",
-      "hashPath": "azure.storage.common.12.12.0.nupkg.sha512"
+      "sha512": "sha512-ohCslqP9yDKIn+DVjBEOBuieB1QwsUCz+BwHYNaJ3lcIsTSiI4Evnq81HcKe8CqM8qvdModbipVQKpnxpbdWqA==",
+      "path": "azure.storage.common/12.18.1",
+      "hashPath": "azure.storage.common.12.18.1.nupkg.sha512"
     },
     "Google.Protobuf/3.23.1": {
       "type": "package",
@@ -3646,12 +3643,12 @@
       "path": "microsoft.azure.documentdb.core/2.11.2",
       "hashPath": "microsoft.azure.documentdb.core.2.11.2.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.DotNetIsolatedNativeHost/1.0.8": {
+    "Microsoft.Azure.Functions.DotNetIsolatedNativeHost/1.0.9": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-FBpjBzsruWBEwy9YtIb9FMtpQi2rSSpK+xXIkqFh31YnhI8jj86yuXt0X5Q0pZ3xd3jojmKDo2tu96tRlHY5rQ==",
-      "path": "microsoft.azure.functions.dotnetisolatednativehost/1.0.8",
-      "hashPath": "microsoft.azure.functions.dotnetisolatednativehost.1.0.8.nupkg.sha512"
+      "sha512": "sha512-lWM6jWUkcxzhQGDmO7gAkA9ErRibO8TH4ABDaf5rmte8tkewxlPYperknkZ/OS4kr7wnMKgjwqs48OyS7YmoYA==",
+      "path": "microsoft.azure.functions.dotnetisolatednativehost/1.0.9",
+      "hashPath": "microsoft.azure.functions.dotnetisolatednativehost.1.0.9.nupkg.sha512"
     },
     "Microsoft.Azure.Functions.JavaWorker/2.14.0": {
       "type": "package",
@@ -3688,12 +3685,12 @@
       "path": "microsoft.azure.functions.powershellworker.ps7.4/4.0.3219",
       "hashPath": "microsoft.azure.functions.powershellworker.ps7.4.4.0.3219.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.PythonWorker/4.28.1": {
+    "Microsoft.Azure.Functions.PythonWorker/4.29.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-59F7OULiqJOlAj07KpV/dbDr9oYZX9EHuEYbm4ysbVilKC4xZafrVpmCW9FLpzdQJVnIa73CRp6L4vQgKxy4Kw==",
-      "path": "microsoft.azure.functions.pythonworker/4.28.1",
-      "hashPath": "microsoft.azure.functions.pythonworker.4.28.1.nupkg.sha512"
+      "sha512": "sha512-42UtQ5TP6ITYt7jS0wY8YReFBi9TBGHqrmw0CRRnvaPlEy6DvxuHlgAcAx/YCNCGzjQYFJ+4QIlEI5sSVjOOjA==",
+      "path": "microsoft.azure.functions.pythonworker/4.29.0",
+      "hashPath": "microsoft.azure.functions.pythonworker.4.29.0.nupkg.sha512"
     },
     "Microsoft.Azure.KeyVault.Core/2.0.4": {
       "type": "package",
@@ -3716,19 +3713,19 @@
       "path": "microsoft.azure.storage.file/11.1.7",
       "hashPath": "microsoft.azure.storage.file.11.1.7.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs/3.0.41-11331": {
+    "Microsoft.Azure.WebJobs/3.0.41": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-cd5kFxuKLSnzWtnaTC8RytYBmZKT6BaTcajsqEtpcL8yQJnKnKRaMTyjyePYRd16dJFmO0EboIjvTtX3PBNl7w==",
-      "path": "microsoft.azure.webjobs/3.0.41-11331",
-      "hashPath": "microsoft.azure.webjobs.3.0.41-11331.nupkg.sha512"
+      "sha512": "sha512-nprqeSOAkhFrpIW1KVkXQb6BZCbnS8d1ytq0nUzIYnpkmbvmfkcQlJE9zp3Dbo26Q/0h0JdPSQ3BaVVBNPOUZg==",
+      "path": "microsoft.azure.webjobs/3.0.41",
+      "hashPath": "microsoft.azure.webjobs.3.0.41.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Core/3.0.41-11331": {
+    "Microsoft.Azure.WebJobs.Core/3.0.41": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-vNGTeRSRptH1xIn1XgpAKEVP81sS/mAuFUU5Kkc0vYYJYhQtI0eAmaZtvYQmBXRg9qPKKmkfMvkTnvTrHBkL2Q==",
-      "path": "microsoft.azure.webjobs.core/3.0.41-11331",
-      "hashPath": "microsoft.azure.webjobs.core.3.0.41-11331.nupkg.sha512"
+      "sha512": "sha512-nNW4I8m5GEhOxxD/NVZGjT6ZARGSy7wi8q+ihvKDin4IY4zYLpTy/GakZeGgbi7vPxcPHL5Z65n9DAV+goasqA==",
+      "path": "microsoft.azure.webjobs.core/3.0.41",
+      "hashPath": "microsoft.azure.webjobs.core.3.0.41.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions/5.0.0-beta.2-10879": {
       "type": "package",
@@ -3751,12 +3748,12 @@
       "path": "microsoft.azure.webjobs.extensions.timers.storage/1.0.0-beta.1",
       "hashPath": "microsoft.azure.webjobs.extensions.timers.storage.1.0.0-beta.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Host.Storage/5.0.0-beta.2-11957": {
+    "Microsoft.Azure.WebJobs.Host.Storage/5.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-Oq0rRfl/MPfyUW0Tdue3osfXZxiKxMltSfF+rB2VurYHAlw1cHXuX9diMd8nCyYSjUFYkVi/mRS3lYJK9jdzqA==",
-      "path": "microsoft.azure.webjobs.host.storage/5.0.0-beta.2-11957",
-      "hashPath": "microsoft.azure.webjobs.host.storage.5.0.0-beta.2-11957.nupkg.sha512"
+      "sha512": "sha512-eO/sX41oaGkDiXHpT7y/F1F5Wvzm7e1QqFmd4GGMJOMdLOHGvwOvZR82AfR7rjvpqQZWyKjRHqxAVcntq+ZYwQ==",
+      "path": "microsoft.azure.webjobs.host.storage/5.0.1",
+      "hashPath": "microsoft.azure.webjobs.host.storage.5.0.1.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Logging.ApplicationInsights/3.0.41-11321": {
       "type": "package",
@@ -3775,7 +3772,7 @@
     "Microsoft.Azure.WebJobs.Script.Abstractions/1.0.4-preview": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-mvgXnFKwh4/Gw8BXc99ZJd2iQ8DQJTCotvY9PZ9Y2UHa4KiOsYaEW4kuZ5RFBD9KqGO2vXG56w3wMFVyxmaA2g==",
+      "sha512": "sha512-+f2iWeAdES4X4HtvgWoIHPXfTxXeX7UlQDbWMkSuxWdt1vHVJf164IEUZxG7Gtfh42ircV9jy7F1zPhuaWNamQ==",
       "path": "microsoft.azure.webjobs.script.abstractions/1.0.4-preview",
       "hashPath": "microsoft.azure.webjobs.script.abstractions.1.0.4-preview.nupkg.sha512"
     },
@@ -3792,13 +3789,6 @@
       "sha512": "sha512-yuvf07qFWFqtK3P/MRkEKLhn5r2UbSpVueRziSqj0yJQIKFwG1pq9mOayK3zE5qZCTs0CbrwL9M6R8VwqyGy2w==",
       "path": "microsoft.bcl.asyncinterfaces/1.1.1",
       "hashPath": "microsoft.bcl.asyncinterfaces.1.1.1.nupkg.sha512"
-    },
-    "Microsoft.Build.Tasks.Git/1.0.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-z2fpmmt+1Jfl+ZnBki9nSP08S1/tbEOxFdsK1rSR+LBehIJz1Xv9/6qOOoGNqlwnAGGVGis1Oj6S8Kt9COEYlQ==",
-      "path": "microsoft.build.tasks.git/1.0.0",
-      "hashPath": "microsoft.build.tasks.git.1.0.0.nupkg.sha512"
     },
     "Microsoft.CodeAnalysis.Analyzers/2.9.4": {
       "type": "package",
@@ -3856,12 +3846,12 @@
       "path": "microsoft.dotnet.platformabstractions/2.1.0",
       "hashPath": "microsoft.dotnet.platformabstractions.2.1.0.nupkg.sha512"
     },
-    "Microsoft.Extensions.Azure/1.7.0": {
+    "Microsoft.Extensions.Azure/1.7.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-lusJX7qm2eK4cDMQzgDt6M2qGqSvZKzirATCJvgYHrARFH/L5H9cJ4/i8v83OI8USKt3IOkyTFtuuExAGh6pUQ==",
-      "path": "microsoft.extensions.azure/1.7.0",
-      "hashPath": "microsoft.extensions.azure.1.7.0.nupkg.sha512"
+      "sha512": "sha512-mS4uBCrUz6eWLZUgkSQKNM97rRMOTFMhi3rdehNJmmnaCQd0mbsrWYkOG9ZVF93zFuvpHlqRUuTGCsHNvMCVPQ==",
+      "path": "microsoft.extensions.azure/1.7.1",
+      "hashPath": "microsoft.extensions.azure.1.7.1.nupkg.sha512"
     },
     "Microsoft.Extensions.Caching.Abstractions/5.0.0": {
       "type": "package",
@@ -4177,20 +4167,6 @@
       "sha512": "sha512-98YtlfblGO4Bu23GYj6FEHS0HNEzcxOGgQ27zvEnr+hzPiSNWm9phYuqyjoxnApFAWn8vxUvioQaJCC8QELRSg==",
       "path": "microsoft.security.utilities/1.3.0",
       "hashPath": "microsoft.security.utilities.1.3.0.nupkg.sha512"
-    },
-    "Microsoft.SourceLink.Common/1.0.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-G8DuQY8/DK5NN+3jm5wcMcd9QYD90UV7MiLmdljSJixi3U/vNaeBKmmXUqI4DJCOeWizIUEh4ALhSt58mR+5eg==",
-      "path": "microsoft.sourcelink.common/1.0.0",
-      "hashPath": "microsoft.sourcelink.common.1.0.0.nupkg.sha512"
-    },
-    "Microsoft.SourceLink.GitHub/1.0.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "sha512-aZyGyGg2nFSxix+xMkPmlmZSsnGQ3w+mIG23LTxJZHN+GPwTQ5FpPgDo7RMOq+Kcf5D4hFWfXkGhoGstawX13Q==",
-      "path": "microsoft.sourcelink.github/1.0.0",
-      "hashPath": "microsoft.sourcelink.github.1.0.0.nupkg.sha512"
     },
     "Microsoft.Spatial/7.6.4": {
       "type": "package",
@@ -5158,22 +5134,22 @@
       "path": "yarp.reverseproxy/2.0.1",
       "hashPath": "yarp.reverseproxy.2.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Script/4.34.0": {
+    "Microsoft.Azure.WebJobs.Script/4.35.0": {
       "type": "project",
       "serviceable": false,
       "sha512": ""
     },
-    "Microsoft.Azure.WebJobs.Script.Grpc/4.34.0": {
+    "Microsoft.Azure.WebJobs.Script.Grpc/4.35.0": {
       "type": "project",
       "serviceable": false,
       "sha512": ""
     },
-    "Microsoft.Azure.WebJobs.Script.Reference/4.34.0.0": {
+    "Microsoft.Azure.WebJobs.Script.Reference/4.35.0.0": {
       "type": "reference",
       "serviceable": false,
       "sha512": ""
     },
-    "Microsoft.Azure.WebJobs.Script.Grpc.Reference/4.34.0.0": {
+    "Microsoft.Azure.WebJobs.Script.Grpc.Reference/4.35.0.0": {
       "type": "reference",
       "serviceable": false,
       "sha512": ""


### PR DESCRIPTION
in-proc backport of https://github.com/Azure/azure-functions-host/pull/10287

Upgraded the following package versions:
  - Microsoft.Azure.WebJobs updated to 3.0.41
  - Microsoft.Azure.WebJobs.Host.Storage updated to 5.0.1
  - Microsoft.Extensions.Azure updated to 1.7.1
  - Azure.Storage.Blobs updated to 12.19.1

Test failure (net8) before fixing the deps.json in tests.

```
Previous file: C:\Dev\OSS\azure-functions-host\out\bin\WebJobs.Script.Tests\debug_net8.0\Microsoft.Azure.WebJobs.Script.WebHost.deps.json
New file:      C:\Dev\OSS\azure-functions-host\out\bin\WebJobs.Script.WebHost\debug_net8.0\Microsoft.Azure.WebJobs.Script.WebHost.deps.json

  Changed:
    - Azure.Storage.Blobs.dll: 12.13.0.0/12.1300.22.35704 -> 12.19.1.0/12.1900.123.56305
    - Azure.Storage.Common.dll: 12.12.0.0/12.1200.22.35704 -> 12.18.1.0/12.1800.123.56305
    - Microsoft.Extensions.Azure.dll: 1.7.0.0/1.700.23.40801 -> 1.7.1.0/1.700.123.52701

  Removed:

  Added:

Expected: True
Actual:   False
```

Second commit in the PR fixes the deps.json files(net6,net8) in tests.