### PR TITLE
Updating Host CI lease access

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -313,17 +313,12 @@ jobs:
       targetType: 'inline'
       script: 'Install-Module -Name Az.Storage -RequiredVersion 1.11.0 -Scope CurrentUser -Force -AllowClobber'
 
-  - task: AzureKeyVault@1
-    inputs:
-      # Note: This is actually a Service Connection in DevOps, not an Azure subscription name
-      azureSubscription: 'Azure-Functions-Host-CI'
-      keyVaultName: 'azure-functions-host-ci'
-      secretsFilter: '*'
-  - task: PowerShell@2
+  - task: AzurePowerShell@5
     displayName: 'Checkout secrets'
     inputs:
-      filePath: '$(Build.Repository.LocalPath)\build\checkout-secrets.ps1'
-      arguments: '-connectionString ''$(Storage-azurefunctionshostci0)'''
+      azureSubscription: Azure-Functions-Host-CI
+      ScriptPath: '$(Build.Repository.LocalPath)\build\checkout-secrets.ps1'
+      azurePowerShellVersion: 'LatestVersion'
   - task: AzureKeyVault@1
     inputs:
       # Note: This is actually a Service Connection in DevOps, not an Azure subscription name
@@ -348,12 +343,14 @@ jobs:
       AzureWebJobsSecretStorageKeyVaultTenantId: $(AzureTenantId)
       AzureWebJobsSecretStorageKeyVaultClientId: $(AzureClientId)
       AzureWebJobsSecretStorageKeyVaultClientSecret: $(AzureClientSecret)
-  - task: PowerShell@2
+  - task: AzurePowerShell@5
     condition: always()
     displayName: 'Checkin secrets'
     inputs:
-      filePath: '$(Build.Repository.LocalPath)\build\checkin-secrets.ps1'
-      arguments: '-connectionString ''$(Storage-azurefunctionshostci0)'' -leaseBlob $(LeaseBlob) -leaseToken $(LeaseToken)'
+      azureSubscription: Azure-Functions-Host-CI
+      ScriptPath: '$(Build.Repository.LocalPath)\build\checkin-secrets.ps1'
+      arguments: '-leaseBlob $(LeaseBlob) -leaseToken $(LeaseToken)'
+      azurePowerShellVersion: 'LatestVersion'
 
 - job: RunIntegrationTests
   pool:
@@ -385,11 +382,12 @@ jobs:
       azureSubscription: 'Azure-Functions-Host-CI'
       keyVaultName: 'azure-functions-host-ci'
       secretsFilter: '*'
-  - task: PowerShell@2
+  - task: AzurePowerShell@5
     displayName: 'Checkout secrets'
     inputs:
-      filePath: '$(Build.Repository.LocalPath)\build\checkout-secrets.ps1'
-      arguments: '-connectionString ''$(Storage-azurefunctionshostci0)'''
+      azureSubscription: Azure-Functions-Host-CI
+      ScriptPath: '$(Build.Repository.LocalPath)\build\checkout-secrets.ps1'
+      azurePowerShellVersion: 'LatestVersion'
   - task: AzureKeyVault@1
     inputs:
       # Note: This is actually a Service Connection in DevOps, not an Azure subscription name
@@ -535,9 +533,11 @@ jobs:
       arguments: '--filter "Group=ReleaseTests" --no-build'
       projects: |
         **\WebJobs.Script.Tests.Integration.csproj
-  - task: PowerShell@2
+  - task: AzurePowerShell@5
     condition: always()
     displayName: 'Checkin secrets'
     inputs:
-      filePath: '$(Build.Repository.LocalPath)\build\checkin-secrets.ps1'
-      arguments: '-connectionString ''$(Storage-azurefunctionshostci0)'' -leaseBlob $(LeaseBlob) -leaseToken $(LeaseToken)'
+      azureSubscription: Azure-Functions-Host-CI
+      ScriptPath: '$(Build.Repository.LocalPath)\build\checkin-secrets.ps1'
+      arguments: '-leaseBlob $(LeaseBlob) -leaseToken $(LeaseToken)'
+      azurePowerShellVersion: 'LatestVersion'

--- a/build/checkin-secrets.ps1
+++ b/build/checkin-secrets.ps1
@@ -1,5 +1,4 @@
 param (
-  [string]$connectionString = "",
   [string]$leaseBlob = "",
   [string]$leaseToken = ""
 )
@@ -16,7 +15,7 @@ if ($leaseToken -eq "") {
 
 Write-Host "Breaking lease for $leaseBlob."
 
-$storageContext = New-AzStorageContext -ConnectionString $connectionString
+$storageContext = New-AzStorageContext -StorageAccountName "azurefunctionshostci0" -UseConnectedAccount
 $blob = Get-AzStorageBlob -Context $storageContext -Container "ci-locks" -Blob $leaseBlob
 
 $accessCondition = New-Object -TypeName Microsoft.Azure.Storage.AccessCondition

--- a/build/checkout-secrets.ps1
+++ b/build/checkout-secrets.ps1
@@ -1,7 +1,3 @@
-param (
-  [string]$connectionString = ""
-)
-
 function AcquireLease($blob) {
   try {
     return $blob.ICloudBlob.AcquireLease($null, $null, $null, $null, $null)
@@ -14,15 +10,10 @@ function AcquireLease($blob) {
 # use this for tracking metadata in lease blobs
 $buildName = "3.0." + $env:buildNumber + "_" + $env:SYSTEM_JOBDISPLAYNAME
 
-$azVersion = "1.11.0"
 Import-Module Az.Storage
-$azModule = Get-Module -Name Az.Storage
-if ($azModule.Version -ne $azVersion) {
-  throw "Az.Storage module version $azVersion was not found. Current version: $($azModule.Version)"
-}
 
 # get a blob lease to prevent test overlap
-$storageContext = New-AzStorageContext -ConnectionString $connectionString
+$storageContext = New-AzStorageContext -StorageAccountName "azurefunctionshostci0" -UseConnectedAccount
 
 While($true) {
   $blobs = Get-AzStorageBlob -Context $storageContext -Container "ci-locks"

--- a/eng/ci/templates/official/jobs/run-integration-tests.yml
+++ b/eng/ci/templates/official/jobs/run-integration-tests.yml
@@ -41,18 +41,12 @@ jobs:
       command: ci
       workingDir: sample/CustomHandlerRetry
 
-  - task: AzureKeyVault@1
-    inputs:
-      # Note: This is actually a Service Connection in DevOps, not an Azure subscription name
-      azureSubscription: Azure-Functions-Host-CI-internal
-      keyVaultName: azure-functions-host-ci
-      secretsFilter: '*'
-
-  - task: PowerShell@2
+  - task: AzurePowerShell@5
     displayName: Checkout secrets
     inputs:
-      filePath: build/checkout-secrets.ps1
-      arguments: '-connectionString ''$(Storage-azurefunctionshostci0)'''
+      azureSubscription: Azure-Functions-Host-CI-internal
+      azurePowerShellVersion: 'LatestVersion'
+      ScriptPath: build/checkout-secrets.ps1
 
   - task: AzureKeyVault@1
     inputs:
@@ -201,9 +195,11 @@ jobs:
       arguments: '--filter "Group=ReleaseTests" --no-build'
       projects: $(IntegrationProject)
 
-  - task: PowerShell@2
+  - task: AzurePowerShell@5
     condition: always()
     displayName: Checkin secrets
     inputs:
-      filePath: build/checkin-secrets.ps1
-      arguments: '-connectionString ''$(Storage-azurefunctionshostci0)'' -leaseBlob $(LeaseBlob) -leaseToken $(LeaseToken)'
+      azureSubscription: Azure-Functions-Host-CI-internal
+      azurePowerShellVersion: 'LatestVersion'
+      ScriptPath: build/checkin-secrets.ps1
+      arguments: '-leaseBlob $(LeaseBlob) -leaseToken $(LeaseToken)'

--- a/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
+++ b/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
@@ -29,18 +29,12 @@ jobs:
       targetType: inline
       script: 'Install-Module -Name Az.Storage -RequiredVersion 1.11.0 -Scope CurrentUser -Force -AllowClobber'
 
-  - task: AzureKeyVault@1
-    inputs:
-      # Note: This is actually a Service Connection in DevOps, not an Azure subscription name
-      azureSubscription: Azure-Functions-Host-CI-internal
-      keyVaultName: azure-functions-host-ci
-      secretsFilter: '*'
-
-  - task: PowerShell@2
+  - task: AzurePowerShell@5
     displayName: Checkout secrets
     inputs:
-      filePath: build/checkout-secrets.ps1
-      arguments: '-connectionString ''$(Storage-azurefunctionshostci0)'''
+      azureSubscription: Azure-Functions-Host-CI-internal
+      azurePowerShellVersion: 'LatestVersion'
+      ScriptPath: build/checkout-secrets.ps1
 
   - task: AzureKeyVault@1
     inputs:
@@ -73,9 +67,11 @@ jobs:
       AzureWebJobsSecretStorageKeyVaultClientId: $(AzureClientId)
       AzureWebJobsSecretStorageKeyVaultClientSecret: $(AzureClientSecret)
 
-  - task: PowerShell@2
+  - task: AzurePowerShell@5
     condition: always()
     displayName: Checkin secrets
     inputs:
-      filePath: build/checkin-secrets.ps1
-      arguments: '-connectionString ''$(Storage-azurefunctionshostci0)'' -leaseBlob $(LeaseBlob) -leaseToken $(LeaseToken)'
+      azureSubscription: Azure-Functions-Host-CI-internal
+      azurePowerShellVersion: 'LatestVersion'
+      ScriptPath: build/checkin-secrets.ps1
+      arguments: '-leaseBlob $(LeaseBlob) -leaseToken $(LeaseToken)'


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Updating the CI resources lease acquisition/release process to use the connected account

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Coming after merge
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

