### PR TITLE
Fixing Azure Powershell argument configuration

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -349,7 +349,7 @@ jobs:
     inputs:
       azureSubscription: Azure-Functions-Host-CI
       ScriptPath: '$(Build.Repository.LocalPath)\build\checkin-secrets.ps1'
-      arguments: '-leaseBlob $(LeaseBlob) -leaseToken $(LeaseToken)'
+      ScriptArguments: '-leaseBlob $(LeaseBlob) -leaseToken $(LeaseToken)'
       azurePowerShellVersion: 'LatestVersion'
 
 - job: RunIntegrationTests
@@ -539,5 +539,5 @@ jobs:
     inputs:
       azureSubscription: Azure-Functions-Host-CI
       ScriptPath: '$(Build.Repository.LocalPath)\build\checkin-secrets.ps1'
-      arguments: '-leaseBlob $(LeaseBlob) -leaseToken $(LeaseToken)'
+      ScriptArguments: '-leaseBlob $(LeaseBlob) -leaseToken $(LeaseToken)'
       azurePowerShellVersion: 'LatestVersion'

--- a/eng/ci/templates/official/jobs/run-integration-tests.yml
+++ b/eng/ci/templates/official/jobs/run-integration-tests.yml
@@ -202,4 +202,4 @@ jobs:
       azureSubscription: Azure-Functions-Host-CI-internal
       azurePowerShellVersion: 'LatestVersion'
       ScriptPath: build/checkin-secrets.ps1
-      arguments: '-leaseBlob $(LeaseBlob) -leaseToken $(LeaseToken)'
+      ScriptArguments: '-leaseBlob $(LeaseBlob) -leaseToken $(LeaseToken)'

--- a/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
+++ b/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
@@ -74,4 +74,4 @@ jobs:
       azureSubscription: Azure-Functions-Host-CI-internal
       azurePowerShellVersion: 'LatestVersion'
       ScriptPath: build/checkin-secrets.ps1
-      arguments: '-leaseBlob $(LeaseBlob) -leaseToken $(LeaseToken)'
+      ScriptArguments: '-leaseBlob $(LeaseBlob) -leaseToken $(LeaseToken)'


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Fixing arguments configuration in the Azure PowerShell task used to acquire test resources.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

