### PR TITLE
Supporting WorkloadIdentityCredential in KeyVaultSecretsRespository (in-proc)

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
@@ -626,7 +626,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 }
                 else
                 {
-                    return new KeyVaultSecretsRepository(SecretsDirectory, KeyVaultUri, KeyVaultClientId, KeyVaultClientSecret, KeyVaultTenantId, logger, Environment);
+                    return new KeyVaultSecretsRepository(SecretsDirectory, KeyVaultUri, KeyVaultClientId, KeyVaultClientSecret, KeyVaultTenantId, logger, Environment, new WorkloadIdentityCredential());
                 }
             }
 


### PR DESCRIPTION
(in-proc backport of https://github.com/Azure/azure-functions-host/pull/10309)

Existing behavior can't be leveraged in CI without secrets or in alternative hosting environments. This PR expands the last fallback option to include `WorkloadIdentityCredential`.

### Pull request checklist

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)