### PR TITLE
Removing unsupported tests

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
@@ -49,11 +49,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
+        // KeyVaultSecretRespository tests are no longer supported in host V3
         [InlineData(SecretsRepositoryType.BlobStorage, "Dedicated")]
         [InlineData(SecretsRepositoryType.BlobStorage, "Dynamic")]
         [InlineData(SecretsRepositoryType.BlobStorageSas, "Dedicated")]
         [InlineData(SecretsRepositoryType.FileSystem, "Dedicated")]
-        [InlineData(SecretsRepositoryType.KeyVault, "Dedicated")]
         public async Task Constructor_CreatesSecretPathIfNotExists(SecretsRepositoryType repositoryType, string sku)
         {
             string path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -84,14 +84,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
+        // KeyVaultSecretRespository tests are no longer supported in host V3
         [InlineData(SecretsRepositoryType.BlobStorage, ScriptSecretsType.Host)]
         [InlineData(SecretsRepositoryType.BlobStorage, ScriptSecretsType.Function)]
         [InlineData(SecretsRepositoryType.BlobStorageSas, ScriptSecretsType.Host)]
         [InlineData(SecretsRepositoryType.BlobStorageSas, ScriptSecretsType.Function)]
         [InlineData(SecretsRepositoryType.FileSystem, ScriptSecretsType.Host)]
         [InlineData(SecretsRepositoryType.FileSystem, ScriptSecretsType.Function)]
-        [InlineData(SecretsRepositoryType.KeyVault, ScriptSecretsType.Host)]
-        [InlineData(SecretsRepositoryType.KeyVault, ScriptSecretsType.Function)]
         public async Task ReadAsync_ReadsExpectedFile(SecretsRepositoryType repositoryType, ScriptSecretsType secretsType)
         {
             using (var directory = new TempDirectory())
@@ -140,9 +139,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
         }
 
-        [Theory] // Only for Key Vault to test paging over large number of secrets
-        [InlineData(SecretsRepositoryType.KeyVault, ScriptSecretsType.Host)]
-        [InlineData(SecretsRepositoryType.KeyVault, ScriptSecretsType.Function)]
+        // KeyVaultSecretRespository tests are no longer supported in host V3
         public async Task ReadAsync_ReadsExpectedKeyVaultPages(SecretsRepositoryType repositoryType, ScriptSecretsType secretsType)
         {
             using (var directory = new TempDirectory())
@@ -213,14 +210,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
 
         [Theory]
+        // KeyVaultSecretRespository tests are no longer supported in host V3
         [InlineData(SecretsRepositoryType.BlobStorage, ScriptSecretsType.Host)]
         [InlineData(SecretsRepositoryType.BlobStorage, ScriptSecretsType.Function)]
         [InlineData(SecretsRepositoryType.BlobStorageSas, ScriptSecretsType.Host)]
         [InlineData(SecretsRepositoryType.BlobStorageSas, ScriptSecretsType.Function)]
         [InlineData(SecretsRepositoryType.FileSystem, ScriptSecretsType.Host)]
         [InlineData(SecretsRepositoryType.FileSystem, ScriptSecretsType.Function)]
-        [InlineData(SecretsRepositoryType.KeyVault, ScriptSecretsType.Host)]
-        [InlineData(SecretsRepositoryType.KeyVault, ScriptSecretsType.Function)]
         public async Task WriteAsync_CreatesExpectedFile(SecretsRepositoryType repositoryType, ScriptSecretsType secretsType)
         {
             using (var directory = new TempDirectory())


### PR DESCRIPTION
V3 cannot be updated to support the same behavior as captured in https://github.com/Azure/azure-functions-host/pull/10309 and https://github.com/Azure/azure-functions-host/pull/10310.

In order to accommodate pipeline changes based on those, we need to remove these integration tests.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)