### PR TITLE
Fix branch naming check for suffix

### DIFF
--- a/build/initialize-pipeline.ps1
+++ b/build/initialize-pipeline.ps1
@@ -46,7 +46,7 @@ if ($buildReason -eq "PullRequest") {
 $buildNumber = ""
 
 $branch = $sourceBranch.ToLower();
-$isRelease = $branch.Contains("release/4") -or $branch.Contains("release/inproc6/4") -or $branch.Contains("release/inproc8/4")
+$isRelease = $branch.Contains("release/4") -or $branch.Contains("release/in-proc")
 
 if(($buildReason -eq "PullRequest") -or !$isRelease)
 {

--- a/eng/ci/templates/official/jobs/build-artifacts-windows.yml
+++ b/eng/ci/templates/official/jobs/build-artifacts-windows.yml
@@ -28,7 +28,7 @@ jobs:
     os: windows
 
   variables:
-    ${{ if or( eq( variables['Build.Reason'], 'PullRequest' ), and(not( contains( variables['Build.SourceBranch'], 'release/in-proc.' ) ), not( contains( variables['Build.SourceBranch'], 'release/4.' ) ), not( contains( variables['Build.SourceBranch'], 'release/ExtensionsMetadataGenerator/' ) ) ) ) }}:
+    ${{ if or( eq( variables['Build.Reason'], 'PullRequest' ), and(not( contains( variables['Build.SourceBranch'], 'release/in-proc' ) ), not( contains( variables['Build.SourceBranch'], 'release/4.' ) ), not( contains( variables['Build.SourceBranch'], 'release/ExtensionsMetadataGenerator/' ) ) ) ) }}:
         suffixTemp: $(buildNumber)
         packSuffixSwitchTemp: --version-suffix $(buildNumber)
         emgSuffixSwitchTemp: --version-suffix ci$(buildNumber)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This PR fixes releases from `release/in-proc` containing a version suffix. The root cause was a trailing '.' when updating branch names in our CI files. Additionally, `initialize-pipeline.ps1` had outdated branch checks (this only affected build numbering in ADO).
