### PR TITLE
Added support for checking sync trigger hash from file storage

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/BlobSyncTriggerHashClient.cs
+++ b/src/WebJobs.Script.WebHost/Management/BlobSyncTriggerHashClient.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
+{
+    public class BlobSyncTriggerHashClient : ISyncTriggerHashClient
+    {
+        private readonly BlobClient _blobClient;
+        private readonly ILogger _logger;
+
+        public BlobSyncTriggerHashClient(BlobClient blobClient, ILogger logger)
+        {
+            _blobClient = blobClient;
+            _logger = logger;
+        }
+
+        public async Task<string> CheckHashAsync(string content)
+        {
+            try
+            {
+                // compute the current hash value and compare it with
+                // the last stored value
+                string currentHash = null;
+                using (var sha256 = SHA256.Create())
+                {
+                    byte[] hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(content));
+                    currentHash = hash
+                        .Aggregate(new StringBuilder(), (a, b) => a.Append(b.ToString("x2")))
+                        .ToString();
+                }
+
+                // get the last hash value if present
+                string lastHash = null;
+                if (await _blobClient.ExistsAsync())
+                {
+                    var downloadResponse = await _blobClient.DownloadAsync();
+                    using (StreamReader reader = new StreamReader(downloadResponse.Value.Content))
+                    {
+                        lastHash = reader.ReadToEnd();
+                    }
+                    _logger.LogDebug($"SyncTriggers hash (Last='{lastHash}', Current='{currentHash}')");
+                }
+
+                if (string.Compare(currentHash, lastHash) != 0)
+                {
+                    // hash will need to be updated - return the
+                    // new hash value
+                    return currentHash;
+                }
+            }
+            catch (Exception ex)
+            {
+                // best effort
+                _logger.LogError(ex, "Error checking SyncTriggers hash");
+            }
+
+            // if the last and current hash values are the same,
+            // or if any error occurs, return null
+            return null;
+        }
+
+        public async Task UpdateHashAsync(string hash)
+        {
+            try
+            {
+                // hash value has changed or was not yet stored
+                // update the last hash value in storage
+                using (Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(hash)))
+                {
+                    await _blobClient.UploadAsync(stream, overwrite: true);
+                }
+                _logger.LogDebug($"SyncTriggers hash updated to '{hash}'");
+            }
+            catch (Exception ex)
+            {
+                // best effort
+                _logger.LogError(ex, "Error updating SyncTriggers hash");
+            }
+        }
+
+        public async Task DeleteIfExistsAsync()
+        {
+            await _blobClient.DeleteIfExistsAsync();
+        }
+
+        public async Task<bool> ExistsAsync() => await _blobClient.ExistsAsync();
+
+        public async Task<string> GetHashAsync()
+        {
+            string result = string.Empty;
+            var downloadResponse = await _blobClient.DownloadAsync();
+            using (StreamReader reader = new StreamReader(downloadResponse.Value.Content))
+            {
+                result = reader.ReadToEnd();
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Management/FileStorageSyncTriggerHashClient.cs
+++ b/src/WebJobs.Script.WebHost/Management/FileStorageSyncTriggerHashClient.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
+{
+    public class FileStorageSyncTriggerHashClient : ISyncTriggerHashClient
+    {
+        private readonly string _filePath;
+        private readonly ILogger _logger;
+
+        public FileStorageSyncTriggerHashClient(string filePath, ILogger logger)
+        {
+            _filePath = filePath;
+            _logger = logger;
+        }
+
+        public async Task<string> CheckHashAsync(string content)
+        {
+            try
+            {
+                // compute the current hash value and compare it with
+                // the last stored value
+                string currentHash = null;
+                using (var sha256 = SHA256.Create())
+                {
+                    byte[] hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(content));
+                    currentHash = hash
+                        .Aggregate(new StringBuilder(), (a, b) => a.Append(b.ToString("x2")))
+                        .ToString();
+                }
+
+                // get the last hash value if present
+                string lastHash = null;
+                if (File.Exists(_filePath))
+                {
+                    lastHash = await File.ReadAllTextAsync(_filePath);
+                    _logger.LogDebug($"SyncTriggers hash (Last='{lastHash}', Current='{currentHash}')");
+                }
+
+                if (string.Compare(currentHash, lastHash) != 0)
+                {
+                    // hash will need to be updated - return the
+                    // new hash value
+                    return currentHash;
+                }
+            }
+            catch (Exception ex)
+            {
+                // best effort
+                _logger.LogError(ex, "Error checking SyncTriggers hash");
+            }
+
+            // if the last and current hash values are the same,
+            // or if any error occurs, return null
+            return null;
+        }
+
+        public async Task UpdateHashAsync(string hash)
+        {
+            try
+            {
+                if (!File.Exists(_filePath))
+                {
+                    string directoryPath = Path.GetDirectoryName(_filePath);
+                    if (!Directory.Exists(directoryPath))
+                    {
+                        Directory.CreateDirectory(directoryPath);
+                    }
+                }
+
+                await File.WriteAllTextAsync(_filePath, hash);
+                _logger.LogDebug($"SyncTriggers hash updated to '{hash}'");
+            }
+            catch (Exception ex)
+            {
+                // best effort
+                _logger.LogError(ex, "Error updating SyncTriggers hash");
+            }
+        }
+
+        public async Task DeleteIfExistsAsync()
+        {
+            await Task.Run(() =>
+            {
+                if (File.Exists(_filePath))
+                {
+                    File.Delete(_filePath);
+                }
+            });
+        }
+
+        public async Task<bool> ExistsAsync() => await Task.Run(() => File.Exists(_filePath));
+
+        public async Task<string> GetHashAsync()
+        {
+            string result = string.Empty;
+            if (File.Exists(_filePath))
+            {
+                result = await File.ReadAllTextAsync(_filePath);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Management/ISyncTriggerHashClient.cs
+++ b/src/WebJobs.Script.WebHost/Management/ISyncTriggerHashClient.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
+{
+    public interface ISyncTriggerHashClient
+    {
+        Task<string> CheckHashAsync(string content);
+
+        Task UpdateHashAsync(string hash);
+
+        Task DeleteIfExistsAsync();
+
+        Task<bool> ExistsAsync();
+
+        Task<string> GetHashAsync();
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->
Functions host saves some last hash of the trigger synced.
This fails when AzureWebJobsStorage is not set. because it always tries to save the hash on blob.

LogicApps hybrid does not use Azure for runtime as dataplane itself can be at any customer location disconnected from internet.
We use `AzureWebJobsSecretStorageType` = `files` , so that all the secrets are generated on file storage.
same can be used for storing synctrigger last hash.

Added support for checking sync trigger hash from file storage

### Issue describing the changes in this PR
https://github.com/Azure/azure-functions-host/issues/10341

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
    * https://github.com/Azure/azure-functions-host/pull/10361
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
