### PR TITLE
preventing placeholder hosts from draining worker console logs

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -9,5 +9,6 @@
   - Includes fixes from 2.16.0
 - Migrated Scale Metrics to use `Azure.Data.Tables` SDK (#10276)
   - Added support for Identity-based connections
-- Skip validation of `FUNCTIONS_WORKER_RUNTIME` with funciton metadata in placeholder mode. (#10459)
+- Skip validation of `FUNCTIONS_WORKER_RUNTIME` with function metadata in placeholder mode. (#10459)
 - Sanitize exception logs (#10443)
+- Improving console log handling during specialization (#10345)

--- a/src/WebJobs.Script/Workers/Http/HttpWorkerProcess.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpWorkerProcess.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Script.Workers.Http
 {
@@ -30,8 +31,10 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
                                        IEnvironment environment,
                                        IMetricsLogger metricsLogger,
                                        IServiceProvider serviceProvider,
+                                       IOptionsMonitor<ScriptApplicationHostOptions> scriptApplicationHostOptions,
                                        ILoggerFactory loggerFactory)
-            : base(eventManager, processRegistry, workerProcessLogger, consoleLogSource, metricsLogger, serviceProvider, loggerFactory, environment, httpWorkerOptions.Description.UseStdErrorStreamForErrorsOnly)
+            : base(eventManager, processRegistry, workerProcessLogger, consoleLogSource, metricsLogger, serviceProvider, loggerFactory, environment,
+                  scriptApplicationHostOptions, httpWorkerOptions.Description.UseStdErrorStreamForErrorsOnly)
         {
             _processFactory = processFactory;
             _eventManager = eventManager;

--- a/src/WebJobs.Script/Workers/Http/HttpWorkerProcessFactory.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpWorkerProcessFactory.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Script.Workers.Http
 {
@@ -18,6 +19,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
         private readonly IEnvironment _environment;
         private readonly IMetricsLogger _metricsLogger;
         private readonly IServiceProvider _serviceProvider;
+        private readonly IOptionsMonitor<ScriptApplicationHostOptions> _scriptApplicationHostOptions;
 
         public HttpWorkerProcessFactory(IScriptEventManager eventManager,
                                        ILoggerFactory loggerFactory,
@@ -26,7 +28,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
                                        IWorkerConsoleLogSource consoleLogSource,
                                        IEnvironment environment,
                                        IMetricsLogger metricsLogger,
-                                       IServiceProvider serviceProvider)
+                                       IServiceProvider serviceProvider,
+                                       IOptionsMonitor<ScriptApplicationHostOptions> scriptApplicationHostOptions)
         {
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
             _eventManager = eventManager ?? throw new ArgumentNullException(nameof(eventManager));
@@ -36,12 +39,14 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
             _metricsLogger = metricsLogger ?? throw new ArgumentNullException(nameof(metricsLogger));
             _environment = environment;
             _serviceProvider = serviceProvider;
+            _scriptApplicationHostOptions = scriptApplicationHostOptions;
         }
 
         public IWorkerProcess Create(string workerId, string scriptRootPath, HttpWorkerOptions httpWorkerOptions)
         {
             ILogger workerProcessLogger = _loggerFactory.CreateLogger($"Worker.HttpWorkerProcess.{workerId}");
-            return new HttpWorkerProcess(workerId, scriptRootPath, httpWorkerOptions, _eventManager, _workerProcessFactory, _processRegistry, workerProcessLogger, _consoleLogSource, _environment, _metricsLogger, _serviceProvider, _loggerFactory);
+            return new HttpWorkerProcess(workerId, scriptRootPath, httpWorkerOptions, _eventManager, _workerProcessFactory, _processRegistry, workerProcessLogger,
+                _consoleLogSource, _environment, _metricsLogger, _serviceProvider, _scriptApplicationHostOptions, _loggerFactory);
         }
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerProcess.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerProcess.cs
@@ -39,8 +39,10 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                                        IServiceProvider serviceProvider,
                                        IOptions<FunctionsHostingConfigOptions> hostingConfigOptions,
                                        IEnvironment environment,
+                                       IOptionsMonitor<ScriptApplicationHostOptions> scriptApplicationHostOptions,
                                        ILoggerFactory loggerFactory)
-            : base(eventManager, processRegistry, workerProcessLogger, consoleLogSource, metricsLogger, serviceProvider, loggerFactory, environment, rpcWorkerConfig.Description.UseStdErrorStreamForErrorsOnly)
+            : base(eventManager, processRegistry, workerProcessLogger, consoleLogSource, metricsLogger, serviceProvider, loggerFactory, environment,
+                  scriptApplicationHostOptions, rpcWorkerConfig.Description.UseStdErrorStreamForErrorsOnly)
         {
             _runtime = runtime;
             _processFactory = processFactory;

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerProcessFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerProcessFactory.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         private readonly IServiceProvider _serviceProvider;
         private readonly IOptions<FunctionsHostingConfigOptions> _hostingConfigOptions;
         private readonly IEnvironment _environment;
+        private readonly IOptionsMonitor<ScriptApplicationHostOptions> _scriptApplicationHostOptions;
 
         public RpcWorkerProcessFactory(IRpcServer rpcServer,
                                        IScriptEventManager eventManager,
@@ -32,7 +33,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                                        IMetricsLogger metricsLogger,
                                        IServiceProvider serviceProvider,
                                        IOptions<FunctionsHostingConfigOptions> hostingConfigOptions,
-                                       IEnvironment environment)
+                                       IEnvironment environment,
+                                       IOptionsMonitor<ScriptApplicationHostOptions> scriptApplicationHostOptions)
         {
             _loggerFactory = loggerFactory;
             _eventManager = eventManager;
@@ -44,12 +46,14 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             _serviceProvider = serviceProvider;
             _hostingConfigOptions = hostingConfigOptions;
             _environment = environment;
+            _scriptApplicationHostOptions = scriptApplicationHostOptions;
         }
 
         public IWorkerProcess Create(string workerId, string runtime, string scriptRootPath, RpcWorkerConfig workerConfig)
         {
             ILogger workerProcessLogger = _loggerFactory.CreateLogger($"Worker.rpcWorkerProcess.{runtime}.{workerId}");
-            return new RpcWorkerProcess(runtime, workerId, scriptRootPath, _rpcServer.Uri, workerConfig, _eventManager, _workerProcessFactory, _processRegistry, workerProcessLogger, _consoleLogSource, _metricsLogger, _serviceProvider, _hostingConfigOptions, _environment, _loggerFactory);
+            return new RpcWorkerProcess(runtime, workerId, scriptRootPath, _rpcServer.Uri, workerConfig, _eventManager, _workerProcessFactory, _processRegistry,
+                workerProcessLogger, _consoleLogSource, _metricsLogger, _serviceProvider, _hostingConfigOptions, _environment, _scriptApplicationHostOptions, _loggerFactory);
         }
     }
 }

--- a/test/DotNetIsolated60/Program.cs
+++ b/test/DotNetIsolated60/Program.cs
@@ -1,5 +1,6 @@
-using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Hosting;
+
+Console.WriteLine("Console Out from worker on startup.");
 
 //Debugger.Launch();
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -1069,8 +1069,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             response = await client.GetAsync("api/HttpRequestDataFunction");
             response.EnsureSuccessStatusCode();
 
-            var placeholderLogger = perScriptHostLoggers.Where(p => p.IsPlaceholderMode).Single().Logger;
-            var userLogger = perScriptHostLoggers.Where(p => !p.IsPlaceholderMode).Single().Logger;
+            var placeholderLogger = perScriptHostLoggers.Single(p => p.IsPlaceholderMode).Logger;
+            var userLogger = perScriptHostLoggers.Single(p => !p.IsPlaceholderMode).Logger;
 
             Assert.DoesNotContain("Host.Function.Console", placeholderLogger.GetAllLogMessages().Select(p => p.Category));
             Assert.DoesNotContain("Console Out from worker on startup.", placeholderLogger.GetAllLogMessages().Select(p => p.FormattedMessage));

--- a/test/WebJobs.Script.Tests.Shared/TestOptionsMonitor.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestOptionsMonitor.cs
@@ -12,6 +12,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         private readonly Func<T> _optionsFactory;
         private Action<T, string> _listener;
 
+        public TestOptionsMonitor()
+            : this(() => new T())
+        {
+        }
+
         public TestOptionsMonitor(T options)
             : this(() => options ?? new T())
         {

--- a/test/WebJobs.Script.Tests/Workers/Http/HttpWorkerProcessTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Http/HttpWorkerProcessTests.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
         private readonly TestLogger _testLogger = new TestLogger("test");
         private readonly HttpWorkerOptions _httpWorkerOptions;
         private readonly Mock<IServiceProvider> _serviceProviderMock;
+        private readonly TestOptionsMonitor<ScriptApplicationHostOptions> _scriptApplicationHostOptions = new();
 
         public HttpWorkerProcessTests()
         {
@@ -58,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
                 {
                     Assert.Equal(Environment.GetEnvironmentVariable(HttpWorkerConstants.PortEnvVarName), processEnvValue);
                 }
-                HttpWorkerProcess httpWorkerProcess = new HttpWorkerProcess(_testWorkerId, _rootScriptPath, _httpWorkerOptions, _mockEventManager.Object, _defaultWorkerProcessFactory, _processRegistry, _testLogger, _languageWorkerConsoleLogSource.Object, new TestEnvironment(), new TestMetricsLogger(), _serviceProviderMock.Object, new LoggerFactory());
+                HttpWorkerProcess httpWorkerProcess = new HttpWorkerProcess(_testWorkerId, _rootScriptPath, _httpWorkerOptions, _mockEventManager.Object, _defaultWorkerProcessFactory, _processRegistry, _testLogger, _languageWorkerConsoleLogSource.Object, new TestEnvironment(), new TestMetricsLogger(), _serviceProviderMock.Object, _scriptApplicationHostOptions, new LoggerFactory());
                 Process childProcess = httpWorkerProcess.CreateWorkerProcess();
                 Assert.NotNull(childProcess.StartInfo.EnvironmentVariables);
                 Assert.Equal(childProcess.StartInfo.EnvironmentVariables[HttpWorkerConstants.PortEnvVarName], _workerPort.ToString());
@@ -77,7 +78,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
                 File.Create(_executablePath).Dispose();
                 TestEnvironment testEnvironment = new TestEnvironment();
                 testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "TestContainer");
-                var mockHttpWorkerProcess = new HttpWorkerProcess(_testWorkerId, _rootScriptPath, _httpWorkerOptions, _mockEventManager.Object, _defaultWorkerProcessFactory, _processRegistry, _testLogger, _languageWorkerConsoleLogSource.Object, testEnvironment, new TestMetricsLogger(), _serviceProviderMock.Object, new LoggerFactory());
+                var mockHttpWorkerProcess = new HttpWorkerProcess(_testWorkerId, _rootScriptPath, _httpWorkerOptions, _mockEventManager.Object, _defaultWorkerProcessFactory, _processRegistry, _testLogger, _languageWorkerConsoleLogSource.Object, testEnvironment, new TestMetricsLogger(), _serviceProviderMock.Object, _scriptApplicationHostOptions, new LoggerFactory());
 
                 try
                 {
@@ -104,7 +105,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
             File.Delete(_executablePath);
             TestEnvironment testEnvironment = new TestEnvironment();
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "TestContainer");
-            var mockHttpWorkerProcess = new HttpWorkerProcess(_testWorkerId, _rootScriptPath, _httpWorkerOptions, _mockEventManager.Object, _defaultWorkerProcessFactory, _processRegistry, _testLogger, _languageWorkerConsoleLogSource.Object, testEnvironment, new TestMetricsLogger(), _serviceProviderMock.Object, new LoggerFactory());
+            var mockHttpWorkerProcess = new HttpWorkerProcess(_testWorkerId, _rootScriptPath, _httpWorkerOptions, _mockEventManager.Object, _defaultWorkerProcessFactory, _processRegistry, _testLogger, _languageWorkerConsoleLogSource.Object, testEnvironment, new TestMetricsLogger(), _serviceProviderMock.Object, _scriptApplicationHostOptions, new LoggerFactory());
 
             try
             {
@@ -132,7 +133,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
                 File.Create(_executablePath).Dispose();
                 TestEnvironment testEnvironment = new TestEnvironment();
                 testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "TestContainer");
-                var mockHttpWorkerProcess = new HttpWorkerProcess(_testWorkerId, _rootScriptPath, _httpWorkerOptions, _mockEventManager.Object, _defaultWorkerProcessFactory, _processRegistry, _testLogger, _languageWorkerConsoleLogSource.Object, testEnvironment, new TestMetricsLogger(), _serviceProviderMock.Object, new LoggerFactory());
+                var mockHttpWorkerProcess = new HttpWorkerProcess(_testWorkerId, _rootScriptPath, _httpWorkerOptions, _mockEventManager.Object, _defaultWorkerProcessFactory, _processRegistry, _testLogger, _languageWorkerConsoleLogSource.Object, testEnvironment, new TestMetricsLogger(), _serviceProviderMock.Object, _scriptApplicationHostOptions, new LoggerFactory());
 
                 try
                 {

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerProcessTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerProcessTests.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             serviceProviderMock.Setup(p => p.GetService(typeof(IScriptHostManager))).Returns(scriptHostManagerMock.Object);
 
             _functionsHostingConfigOptions = Options.Create(new FunctionsHostingConfigOptions());
+            var scriptApplicationHostOptions = new TestOptionsMonitor<ScriptApplicationHostOptions>();
 
             _rpcWorkerProcess = new RpcWorkerProcess("node",
                 "testworkerId",
@@ -59,6 +60,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 serviceProviderMock.Object,
                 _functionsHostingConfigOptions,
                 testEnv,
+                scriptApplicationHostOptions,
                 new LoggerFactory());
         }
 

--- a/test/WebJobs.Script.Tests/Workers/TestWorkerProcess.cs
+++ b/test/WebJobs.Script.Tests/Workers/TestWorkerProcess.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers
     internal class TestWorkerProcess : WorkerProcess
     {
         internal TestWorkerProcess(IScriptEventManager eventManager, IProcessRegistry processRegistry, ILogger workerProcessLogger, IWorkerConsoleLogSource consoleLogSource, IMetricsLogger metricsLogger, IServiceProvider serviceProvider, ILoggerFactory loggerFactory, IEnvironment environment, bool useStdErrStreamForErrorsOnly = false)
-        : base(eventManager, processRegistry, workerProcessLogger, consoleLogSource, metricsLogger, serviceProvider, loggerFactory, environment, useStdErrStreamForErrorsOnly)
+        : base(eventManager, processRegistry, workerProcessLogger, consoleLogSource, metricsLogger, serviceProvider, loggerFactory, environment, new TestOptionsMonitor<ScriptApplicationHostOptions>(), useStdErrStreamForErrorsOnly)
         {
         }
 


### PR DESCRIPTION
### Issue describing the changes in this PR

Resolves #10222 and #9360

During specialization, there can be a race to process logs being generated by the placeholder worker. If a worker writes console output during startup (say, during a file load like the issue describes), the placeholder can dequeue these and log them, which effectively means they go nowhere.

This change prevents placeholder hosts from dequeuing these messages at all, so they are ready to be consumed by the user's host starting up.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)