### PR TITLE
4.35.2 release prep (4.35.1 + PR #10343 + Version update)

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -4,7 +4,7 @@
     <LangVersion>latest</LangVersion>
     <MajorVersion>4</MajorVersion>
     <MinorVersion>$(MinorVersionPrefix)35</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <PatchVersion>2</PatchVersion>
     <BuildNumber Condition="'$(BuildNumber)' == '' ">0</BuildNumber>
     <PreviewVersion></PreviewVersion>
     

--- a/release_notes.md
+++ b/release_notes.md
@@ -20,4 +20,4 @@
   - `Microsoft.Azure.WebJobs.Host.Storage` updated to 5.0.1
   - `Microsoft.Extensions.Azure` updated to 1.7.1
   - `Azure.Storage.Blobs` updated to 12.19.1
-- [in-proc] Updating FunctionsNetHost (dotnet isolated worker) to 1.0.9 (#10263)
+- [in-proc] Updating FunctionsNetHost (dotnet isolated worker) to 1.0.10 (#10340)

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" NoWarn="NU1701" />
-    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.9" />
+    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.10" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.41" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.1" />


### PR DESCRIPTION
Adding the below changes on top of4.35.1 (release/4.x is same as 4.35.1)

1. [Updating FunctionsNetHost (dotnet isolated worker) to 1.0.10](https://github.com/Azure/azure-functions-host/commit/fd76fee09ab6b396b226cb5030ae53ee88fdeeaa) - cherry picked
2. Bumped patch version to 2.
