### PR TITLE
Migrate EndToEnd integration tests to Azure.Data.Tables

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/ScriptHostEndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/ScriptHostEndToEndTestFixture.cs
@@ -3,32 +3,31 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Http;
+using Azure;
+using Azure.Data.Tables;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Azure.Storage.Blob;
+using Microsoft.Azure.Storage.Queue;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.Metrics;
+using Microsoft.Azure.WebJobs.Script.WebHost.Helpers;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.WebJobs.Script.Tests;
-using Microsoft.Azure.Storage;
-using Microsoft.Azure.Storage.Blob;
-using Microsoft.Azure.Storage.Queue;
-using Microsoft.Azure.Cosmos.Table;
 using Moq;
 using Xunit;
 using CloudStorageAccount = Microsoft.Azure.Storage.CloudStorageAccount;
-using TableStorageAccount = Microsoft.Azure.Cosmos.Table.CloudStorageAccount;
 using IApplicationLifetime = Microsoft.AspNetCore.Hosting.IApplicationLifetime;
-using Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer;
-using System.Runtime.InteropServices;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
@@ -73,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public CloudQueueClient QueueClient { get; private set; }
 
-        public CloudTableClient TableClient { get; private set; }
+        public TableServiceClient TableServiceClient { get; private set; }
 
         public CloudBlobClient BlobClient { get; private set; }
 
@@ -81,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public CloudQueue MobileTablesQueue { get; private set; }
 
-        public CloudTable TestTable { get; private set; }
+        public TableClient TestTable { get; private set; }
 
         public ScriptHost JobHost { get; private set; }
 
@@ -109,8 +108,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             QueueClient = storageAccount.CreateCloudQueueClient();
             BlobClient = storageAccount.CreateCloudBlobClient();
 
-            TableStorageAccount tableStorageAccount = TableStorageAccount.Parse(connectionString);
-            TableClient = tableStorageAccount.CreateCloudTableClient();
+            TableServiceClient = new TableServiceClient(connectionString);
 
             await CreateTestStorageEntities();
 
@@ -219,50 +217,56 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             await TestOutputContainer.CreateIfNotExistsAsync();
             await TestHelpers.ClearContainerAsync(TestOutputContainer);
 
-            TestTable = TableClient.GetTableReference("test");
+            TestTable = TableServiceClient.GetTableClient("test");
             await TestTable.CreateIfNotExistsAsync();
 
-            await DeleteEntities(TestTable, "AAA");
-            await DeleteEntities(TestTable, "BBB");
+            await DeleteEntities(TestTable, TableServiceClient, "AAA");
+            await DeleteEntities(TestTable, TableServiceClient, "BBB");
 
-            var batch = new TableBatchOperation();
-            batch.Insert(new TestEntity { PartitionKey = "AAA", RowKey = "001", Region = "West", Name = "Test Entity 1", Status = 0 });
-            batch.Insert(new TestEntity { PartitionKey = "AAA", RowKey = "002", Region = "East", Name = "Test Entity 2", Status = 1 });
-            batch.Insert(new TestEntity { PartitionKey = "AAA", RowKey = "003", Region = "West", Name = "Test Entity 3", Status = 1 });
-            batch.Insert(new TestEntity { PartitionKey = "AAA", RowKey = "004", Region = "West", Name = "Test Entity 4", Status = 1 });
-            batch.Insert(new TestEntity { PartitionKey = "AAA", RowKey = "005", Region = "East", Name = "Test Entity 5", Status = 0 });
-            await TestTable.ExecuteBatchAsync(batch);
+            var batch = new List<TableTransactionAction>
+            {
+                new TableTransactionAction(TableTransactionActionType.Add, new TestEntity { PartitionKey = "AAA", RowKey = "001", Region = "West", Name = "Test Entity 1", Status = 0 }),
+                new TableTransactionAction(TableTransactionActionType.Add, new TestEntity { PartitionKey = "AAA", RowKey = "002", Region = "East", Name = "Test Entity 2", Status = 1 }),
+                new TableTransactionAction (TableTransactionActionType.Add, new TestEntity { PartitionKey = "AAA", RowKey = "003", Region = "West", Name = "Test Entity 3", Status = 1 }),
+                new TableTransactionAction (TableTransactionActionType.Add, new TestEntity { PartitionKey = "AAA", RowKey = "004", Region = "West", Name = "Test Entity 4", Status = 1 }),
+                new TableTransactionAction (TableTransactionActionType.Add, new TestEntity { PartitionKey = "AAA", RowKey = "005", Region = "East", Name = "Test Entity 5", Status = 0 })
+            };
+            await TestTable.SubmitTransactionAsync(batch);
 
-            batch = new TableBatchOperation();
-            batch.Insert(new TestEntity { PartitionKey = "BBB", RowKey = "001", Region = "South", Name = "Test Entity 1", Status = 0 });
-            batch.Insert(new TestEntity { PartitionKey = "BBB", RowKey = "002", Region = "West", Name = "Test Entity 2", Status = 1 });
-            batch.Insert(new TestEntity { PartitionKey = "BBB", RowKey = "003", Region = "West", Name = "Test Entity 3", Status = 0 });
-            await TestTable.ExecuteBatchAsync(batch);
+            batch =
+            [
+                new TableTransactionAction(TableTransactionActionType.Add, new TestEntity { PartitionKey = "BBB", RowKey = "001", Region = "South", Name = "Test Entity 1", Status = 0 }),
+                new TableTransactionAction(TableTransactionActionType.Add, new TestEntity { PartitionKey = "BBB", RowKey = "002", Region = "West", Name = "Test Entity 2", Status = 1 }),
+                new TableTransactionAction(TableTransactionActionType.Add, new TestEntity { PartitionKey = "BBB", RowKey = "003", Region = "West", Name = "Test Entity 3", Status = 0 }),
+            ];
+            await TestTable.SubmitTransactionAsync(batch);
         }
 
-        public async Task DeleteEntities(CloudTable table, string partition = null)
+        public async Task DeleteEntities(TableClient table, TableServiceClient tableServiceClient, string partition = null)
         {
-            if (!await table.ExistsAsync())
+            if (!await TableStorageHelpers.TableExistAsync(table, tableServiceClient))
             {
                 return;
             }
 
-            TableQuery query = new TableQuery();
+            string query = string.Empty;
             if (partition != null)
             {
-                query.FilterString = string.Format("PartitionKey eq '{0}'", partition);
+                query = TableClient.CreateQueryFilter($"PartitionKey eq {partition}");
             }
 
-            var entities = await table.ExecuteQuerySegmentedAsync(query, null);
+            var entities = table.QueryAsync<TableEntity>(query, null);
 
-            if (entities.Any())
+
+            var batch = new List<TableTransactionAction>();
+            await foreach (var entity in entities)
             {
-                var batch = new TableBatchOperation();
-                foreach (var entity in entities)
-                {
-                    batch.Delete(entity);
-                }
-                await table.ExecuteBatchAsync(batch);
+                batch.Add(new TableTransactionAction(TableTransactionActionType.Delete, entity));
+            }
+
+            if(batch.Count != 0)
+            {
+                await table.SubmitTransactionAsync(batch);
             }
         }
 
@@ -282,13 +286,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Environment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName, string.Empty);
         }
 
-        private class TestEntity : TableEntity
+        private class TestEntity : ITableEntity
         {
             public string Name { get; set; }
 
             public string Region { get; set; }
 
             public int Status { get; set; }
+
+            public string PartitionKey { get; set; }
+
+            public string RowKey { get; set; }
+
+            public DateTimeOffset? Timestamp { get; set; }
+
+            public ETag ETag { get; set; }
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/ScriptHostEndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/ScriptHostEndToEndTestFixture.cs
@@ -264,7 +264,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 batch.Add(new TableTransactionAction(TableTransactionActionType.Delete, entity));
             }
 
-            if(batch.Count != 0)
+            if (batch.Count != 0)
             {
                 await table.SubmitTransactionAsync(batch);
             }


### PR DESCRIPTION
### Issue describing the changes in this PR

resolves #10354 

Migrates the end to end integration tests to use `Azure.Data.Tables`

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: #10362 
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

