### PR TITLE
[In proc] Add sync trigger support for container app connected environment

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -756,7 +756,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 string jwtToken = JwtTokenHelper.CreateToken(DateTime.UtcNow.AddMinutes(5));
                 request.Headers.Add(ScriptConstants.SiteTokenHeaderName, jwtToken);
 
-                if (_environment.IsManagedAppEnvironment() || _environment.IsConnectedAppEnvironment())
+                if (_environment.IsContainerAppEnvironment())
                 {
                     request.Headers.Add("K8SE-APP-NAME", _environment.GetEnvironmentVariable("CONTAINER_APP_NAME"));
                     request.Headers.Add("K8SE-APP-NAMESPACE", _environment.GetEnvironmentVariable("CONTAINER_APP_NAMESPACE"));

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -756,7 +756,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 string jwtToken = JwtTokenHelper.CreateToken(DateTime.UtcNow.AddMinutes(5));
                 request.Headers.Add(ScriptConstants.SiteTokenHeaderName, jwtToken);
 
-                if (_environment.IsManagedAppEnvironment())
+                if (_environment.IsManagedAppEnvironment() || _environment.IsConnectedAppEnvironment())
                 {
                     request.Headers.Add("K8SE-APP-NAME", _environment.GetEnvironmentVariable("CONTAINER_APP_NAME"));
                     request.Headers.Add("K8SE-APP-NAMESPACE", _environment.GetEnvironmentVariable("CONTAINER_APP_NAMESPACE"));

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -246,8 +246,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             if (string.IsNullOrEmpty(websiteRunFromPackageValue) &&
                 string.IsNullOrEmpty(scmRunFromPackageValue) &&
                 _environment.IsLinuxConsumptionOnAtlas() &&
-                !_environment.IsManagedAppEnvironment() &&
-                !_environment.IsConnectedAppEnvironment())
+                !_environment.IsContainerAppEnvironment())
             {
                 logger?.LogError($"Unable to load the functions payload since the app was not provisioned with valid {AzureWebJobsSecretStorage} connection string.");
             }

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -246,7 +246,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             if (string.IsNullOrEmpty(websiteRunFromPackageValue) &&
                 string.IsNullOrEmpty(scmRunFromPackageValue) &&
                 _environment.IsLinuxConsumptionOnAtlas() &&
-                !_environment.IsManagedAppEnvironment())
+                !_environment.IsManagedAppEnvironment() &&
+                !_environment.IsConnectedAppEnvironment())
             {
                 logger?.LogError($"Unable to load the functions payload since the app was not provisioned with valid {AzureWebJobsSecretStorage} connection string.");
             }

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -271,27 +271,17 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <returns><see cref="true"/> if running in Kubernetes environment; otherwise, false.</returns>
         public static bool IsAnyKubernetesEnvironment(this IEnvironment environment)
         {
-            return environment.IsKubernetesManagedHosting() || environment.IsManagedAppEnvironment() || environment.IsConnectedAppEnvironment();;
+            return environment.IsKubernetesManagedHosting() || environment.IsContainerAppEnvironment();
         }
 
         /// <summary>
-        /// Gets a value indicating whether the application is running in Managed App environment.
+        /// Gets a value indicating whether the application is running in Container App environment.
         /// </summary>
         /// <param name="environment">The environment to verify.</param>
-        /// <returns><see cref="true"/> if running in Managed App environment; otherwise, false.</returns>
-        public static bool IsManagedAppEnvironment(this IEnvironment environment)
+        /// <returns><see cref="true"/> if running in Container App environment; otherwise, false.</returns>
+        public static bool IsContainerAppEnvironment(this IEnvironment environment)
         {
-            return !string.IsNullOrEmpty(environment.GetEnvironmentVariable(ManagedEnvironment));
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether the application is running in Connected App environment.
-        /// </summary>
-        /// <param name="environment">The environment to verify.</param>
-        /// <returns><see cref="true"/> if running in Connected App environment; otherwise, false.</returns>
-        public static bool IsConnectedAppEnvironment(this IEnvironment environment)
-        {
-            return !string.IsNullOrEmpty(environment.GetEnvironmentVariable(ConnectedEnvironment));
+            return !string.IsNullOrEmpty(environment.GetEnvironmentVariable(ManagedEnvironment)) || !string.IsNullOrEmpty(environment.GetEnvironmentVariable(ConnectedEnvironment));
         }
 
         /// <summary>
@@ -302,7 +292,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <returns><see cref="true"/> if running in a Linux Consumption App Service app; otherwise, false.</returns>
         public static bool IsAnyLinuxConsumption(this IEnvironment environment)
         {
-            return (environment.IsLinuxConsumptionOnAtlas() || environment.IsLinuxConsumptionOnLegion()) && !environment.IsManagedAppEnvironment() && !environment.IsConnectedAppEnvironment();
+            return (environment.IsLinuxConsumptionOnAtlas() || environment.IsLinuxConsumptionOnLegion()) && !environment.IsContainerAppEnvironment();
         }
 
         public static bool IsLinuxConsumptionOnAtlas(this IEnvironment environment)
@@ -362,8 +352,7 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             return !string.IsNullOrEmpty(environment.GetEnvironmentVariable(KubernetesServiceHost))
             && !string.IsNullOrEmpty(environment.GetEnvironmentVariable(PodNamespace))
-            && !environment.IsManagedAppEnvironment()
-            && !environment.IsConnectedAppEnvironment();
+            && !environment.IsContainerAppEnvironment();
         }
 
         /// <summary>

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <returns><see cref="true"/> if running in Kubernetes environment; otherwise, false.</returns>
         public static bool IsAnyKubernetesEnvironment(this IEnvironment environment)
         {
-            return environment.IsKubernetesManagedHosting() || environment.IsManagedAppEnvironment();
+            return environment.IsKubernetesManagedHosting() || environment.IsManagedAppEnvironment() || environment.IsConnectedAppEnvironment();;
         }
 
         /// <summary>
@@ -285,6 +285,16 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
+        /// Gets a value indicating whether the application is running in Connected App environment.
+        /// </summary>
+        /// <param name="environment">The environment to verify.</param>
+        /// <returns><see cref="true"/> if running in Connected App environment; otherwise, false.</returns>
+        public static bool IsConnectedAppEnvironment(this IEnvironment environment)
+        {
+            return !string.IsNullOrEmpty(environment.GetEnvironmentVariable(ConnectedEnvironment));
+        }
+
+        /// <summary>
         /// Gets a value indicating whether the application is running in a Linux Consumption (dynamic)
         /// App Service environment.
         /// </summary>
@@ -292,7 +302,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <returns><see cref="true"/> if running in a Linux Consumption App Service app; otherwise, false.</returns>
         public static bool IsAnyLinuxConsumption(this IEnvironment environment)
         {
-            return (environment.IsLinuxConsumptionOnAtlas() || environment.IsLinuxConsumptionOnLegion()) && !environment.IsManagedAppEnvironment();
+            return (environment.IsLinuxConsumptionOnAtlas() || environment.IsLinuxConsumptionOnLegion()) && !environment.IsManagedAppEnvironment() && !environment.IsConnectedAppEnvironment();
         }
 
         public static bool IsLinuxConsumptionOnAtlas(this IEnvironment environment)
@@ -352,7 +362,8 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             return !string.IsNullOrEmpty(environment.GetEnvironmentVariable(KubernetesServiceHost))
             && !string.IsNullOrEmpty(environment.GetEnvironmentVariable(PodNamespace))
-            && !environment.IsManagedAppEnvironment();
+            && !environment.IsManagedAppEnvironment()
+            && !environment.IsConnectedAppEnvironment();
         }
 
         /// <summary>

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -86,6 +86,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string PodEncryptionKey = "POD_ENCRYPTION_KEY";
         public const string HttpLeaderEndpoint = "HTTP_LEADER_ENDPOINT";
         public const string ManagedEnvironment = "MANAGED_ENVIRONMENT";
+        public const string ConnectedEnvironment = "CONNECTED_ENVIRONMENT";
 
         /// <summary>
         /// Environment variable dynamically set by the platform when it is safe to

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -142,6 +142,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.KubernetesServiceHost)).Returns("");
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.PodNamespace)).Returns("");
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ManagedEnvironment)).Returns((string)null);
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ConnectedEnvironment)).Returns((string)null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)).Returns((string)null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSlotName)).Returns((string)null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags)).Returns((string)null);

--- a/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
@@ -177,14 +177,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
         }
 
         [Theory]
-        [InlineData(true, false, false, true, false)]
-        [InlineData(false, true, false, true, false)]
-        [InlineData(false, true, false, true, true)]
-        [InlineData(true, true, false, true, false)]
-        [InlineData(true, true, false, true, true)]
-        [InlineData(false, false, false, false, false)]
-        [InlineData(false, false, true, false, false)]
-        public void IsAnyLinuxConsumption_ReturnsExpectedResult(bool isLinuxConsumptionOnAtlas, bool isLinuxConsumptionOnLegion, bool isManagedAppEnvironment, bool expectedValue, bool setPodName)
+        [InlineData(true, false, false, false, true, false)]
+        [InlineData(false, true, false, false, true, false)]
+        [InlineData(false, true, false, false, true, true)]
+        [InlineData(true, true, false, false, true, false)]
+        [InlineData(true, true, false, false, true, true)]
+        [InlineData(false, false, false, false, false, false)]
+        [InlineData(false, false, true, false, false, false)]
+        [InlineData(false, false, false, true, false, false)]
+        public void IsAnyLinuxConsumption_ReturnsExpectedResult(bool isLinuxConsumptionOnAtlas, bool isLinuxConsumptionOnLegion, bool isManagedAppEnvironment, bool isConnectedAppEnvironment, bool expectedValue, bool setPodName)
         {
             IEnvironment env = new TestEnvironment();
             if (isLinuxConsumptionOnAtlas)
@@ -210,14 +211,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
                 env.SetEnvironmentVariable(ManagedEnvironment, "true");
             }
 
+            if (isConnectedAppEnvironment)
+            {
+                env.SetEnvironmentVariable(ConnectedEnvironment, "true");
+            }
+
             Assert.Equal(expectedValue, env.IsAnyLinuxConsumption());
         }
 
         [Theory]
-        [InlineData(true, false, true)]
-        [InlineData(false, true, true)]
-        [InlineData(false, false, false)]
-        public void IsAnyKubernetesEnvironment_ReturnsExpectedResult(bool isKubernetesManagedHosting, bool isManagedAppEnvironment, bool expectedValue)
+        [InlineData(true, false, false, true)]
+        [InlineData(false, true, false, true)]
+        [InlineData(false, false, true, true)]
+        [InlineData(false, false, false, false)]
+        public void IsAnyKubernetesEnvironment_ReturnsExpectedResult(bool isKubernetesManagedHosting, bool isManagedAppEnvironment, bool isConnectedAppEnvironment, bool expectedValue)
         {
             IEnvironment env = new TestEnvironment();
             if (isKubernetesManagedHosting)
@@ -229,6 +236,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
             if (isManagedAppEnvironment)
             {
                 env.SetEnvironmentVariable(ManagedEnvironment, "true");
+            }
+
+            if (isConnectedAppEnvironment)
+            {
+                env.SetEnvironmentVariable(ConnectedEnvironment, "true");
             }
 
             Assert.Equal(expectedValue, env.IsAnyKubernetesEnvironment());
@@ -246,6 +258,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
             }
 
             Assert.Equal(expectedValue, env.IsManagedAppEnvironment());
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void IsConnectedAppEnvironment_ReturnsExpectedResult(bool isConnectedAppEnvironment, bool expectedValue)
+        {
+            IEnvironment env = new TestEnvironment();
+            if (isConnectedAppEnvironment)
+            {
+                env.SetEnvironmentVariable(EnvironmentSettingNames.ConnectedEnvironment, "true");
+            }
+
+            Assert.Equal(expectedValue, env.IsConnectedAppEnvironment());
         }
 
         [Theory]

--- a/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
@@ -250,7 +250,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
         [InlineData(true, false, true)]
         [InlineData(false, true, true)]
         [InlineData(false, false, false)]
-        public void IsManagedAppEnvironment_ReturnsExpectedResult(bool isManagedAppEnvironment, bool isConnectedAppEnvironment, bool expectedValue)
+        public void IsContainerAppEnvironment_ReturnsExpectedResult(bool isManagedAppEnvironment, bool isConnectedAppEnvironment, bool expectedValue)
         {
             IEnvironment env = new TestEnvironment();
             if (isManagedAppEnvironment)

--- a/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
@@ -247,9 +247,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
         }
 
         [Theory]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public void IsManagedAppEnvironment_ReturnsExpectedResult(bool isManagedAppEnvironment, bool expectedValue)
+        [InlineData(true, false, true)]
+        [InlineData(false, true, true)]
+        [InlineData(false, false, false)]
+        public void IsManagedAppEnvironment_ReturnsExpectedResult(bool isManagedAppEnvironment, bool isConnectedAppEnvironment, bool expectedValue)
         {
             IEnvironment env = new TestEnvironment();
             if (isManagedAppEnvironment)
@@ -257,21 +258,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
                 env.SetEnvironmentVariable(EnvironmentSettingNames.ManagedEnvironment, "true");
             }
 
-            Assert.Equal(expectedValue, env.IsManagedAppEnvironment());
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public void IsConnectedAppEnvironment_ReturnsExpectedResult(bool isConnectedAppEnvironment, bool expectedValue)
-        {
-            IEnvironment env = new TestEnvironment();
             if (isConnectedAppEnvironment)
             {
                 env.SetEnvironmentVariable(EnvironmentSettingNames.ConnectedEnvironment, "true");
             }
 
-            Assert.Equal(expectedValue, env.IsConnectedAppEnvironment());
+            Assert.Equal(expectedValue, env.IsContainerAppEnvironment());
         }
 
         [Theory]

--- a/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
@@ -249,6 +249,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
         [Theory]
         [InlineData(true, false, true)]
         [InlineData(false, true, true)]
+        [InlineData(true, true, true)]
         [InlineData(false, false, false)]
         public void IsContainerAppEnvironment_ReturnsExpectedResult(bool isManagedAppEnvironment, bool isConnectedAppEnvironment, bool expectedValue)
         {

--- a/test/WebJobs.Script.Tests/FunctionsSyncServiceTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionsSyncServiceTests.cs
@@ -112,20 +112,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
-        [InlineData(true, true, false, false, true, true, false, false)] // in standby
-        [InlineData(true, true, false, false, true, false, false, false)] // in standby
-        [InlineData(true, true, false, true, true, false, true, false)] // in standby
-        [InlineData(true, true, false, false, false, true, false, true)]
-        [InlineData(false, true, true, false, false, false, false, false)] // container not ready
-        [InlineData(false, true, true, false, false, true, false, true)]
-        [InlineData(false, false, true, false, false, true, false, false)] // no encryption key
+        [InlineData(true, true, false, false, true, true, false, false, false)] // in standby
+        [InlineData(true, true, false, false, true, false, false, false, false)] // in standby
+        [InlineData(true, true, false, true, true, false, true, false, false)] // in standby
+        [InlineData(true, true, false, true, true, false, false, true, false)] // in standby
+        [InlineData(true, true, false, false, false, true, false, false, true)]
+        [InlineData(false, true, true, false, false, false, false, false, false)] // container not ready
+        [InlineData(false, true, true, false, false, true, false, false, true)]
+        [InlineData(false, false, true, false, false, true, false, false, false)] // no encryption key
         // note: normally linux dedicated would have AzureWebsiteInstanceId set.
         // However the test will always catch it as Windows because it checks the OS of the running process.
         // Setting AzureWebsiteInstanceId to null will make it fail the IsAppServiceWindows, and it shouldn't affect the check for dedicated linux
-        [InlineData(false, true, false, true, false, false, false, false)] // dedicated linux
-        [InlineData(false, true, false, false, false, false, false, true)] // dedicated linux
-        [InlineData(false, true, false, false, false, false, true, true)] // managed app environment
-        public void IsSyncTriggersEnvironment_StandbyMode_ReturnsExpectedResult(bool isAppService, bool hasEncryptionKey, bool isConsumptionLinuxOnAtlas, bool isConsumptionLinuxOnLegion, bool standbyMode, bool containerReady, bool isManagedAppEnvironment, bool expected)
+        [InlineData(false, true, false, true, false, false, false, false, false)] // dedicated linux
+        [InlineData(false, true, false, false, false, false, false, false, true)] // dedicated linux
+        [InlineData(false, true, false, false, false, false, true, false, true)] // managed app environment
+        [InlineData(false, true, false, false, false, false, false, true, true)] // connected app environment
+        public void IsSyncTriggersEnvironment_StandbyMode_ReturnsExpectedResult(bool isAppService, bool hasEncryptionKey, bool isConsumptionLinuxOnAtlas, bool isConsumptionLinuxOnLegion, bool standbyMode, bool containerReady, bool isManagedAppEnvironment, bool isConnectedAppEnvironment, bool expected)
         {
             _mockWebHostEnvironment.SetupGet(p => p.InStandbyMode).Returns(standbyMode);
 
@@ -136,6 +138,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.LegionServiceHost)).Returns(isConsumptionLinuxOnLegion ? "1" : null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady)).Returns(containerReady ? "1" : null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ManagedEnvironment)).Returns(isManagedAppEnvironment ? "1" : null);
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ConnectedEnvironment)).Returns(isConnectedAppEnvironment ? "1" : null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.WebsitePodName)).Returns(isConsumptionLinuxOnLegion ? "RandomPodName" : null);
 
             var result = FunctionsSyncManager.IsSyncTriggersEnvironment(_mockWebHostEnvironment.Object, _mockEnvironment.Object);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
Sync trigger api works when host is running on ContainerApp ManagedEnvironment.
However logic apps is running on ARC that has the concept of ConnectedEnvironment.
So adding the support of sync trigger for ConnectedEnvironment as well same as Managed Environment.

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
