### PR TITLE
Fixing thread safety issue in the GrpcWorkerChannel.LoadResponse method

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -12,3 +12,4 @@
 - Update PowerShell 7.4 worker to [4.0.4021](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.4021)
 - Updated dotnet-isolated worker to [1.0.10](https://github.com/Azure/azure-functions-dotnet-worker/pull/2629) (#10340)
 - Update Java Worker Version to [2.15.0](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.15.0)
+- Resolved thread safety issue in the `GrpcWorkerChannel.LoadResponse` method. (#10352)

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         private ConcurrentDictionary<string, ExecutingInvocation> _executingInvocations = new();
         private IDictionary<string, BufferBlock<ScriptInvocationContext>> _functionInputBuffers = new ConcurrentDictionary<string, BufferBlock<ScriptInvocationContext>>();
         private ConcurrentDictionary<string, TaskCompletionSource<bool>> _workerStatusRequests = new ConcurrentDictionary<string, TaskCompletionSource<bool>>();
-        private List<IDisposable> _inputLinks = new List<IDisposable>();
+        private ConcurrentBag<IDisposable> _inputLinks = new ConcurrentBag<IDisposable>();
         private List<IDisposable> _eventSubscriptions = new List<IDisposable>();
         private IDisposable _startLatencyMetric;
         private IEnumerable<FunctionMetadata> _functions;

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -966,8 +966,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 Task.Run(() => _testFunctionRpcService.PublishFunctionLoadResponseEvent(function.Id)));
 
             await Task.WhenAll(publishFunctionLoadResponseTasks);
-            // Give some time for the logs to be written.
-            await Task.Delay(TimeSpan.FromMilliseconds(500));
+
+            await TestHelpers.Await(() =>
+            {
+                return _logger.GetLogMessages().Count(m => m.FormattedMessage.StartsWith("Received FunctionLoadResponse")) == allFunctionIdsAndNames.Count;
+            });
 
             var traces = _logger.GetLogMessages();
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -940,6 +940,45 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
+        public async Task Receives_Individual_FunctionLoadResponses_Parallel()
+        {
+            await CreateDefaultWorkerChannel();
+
+            var startStreamMessage = new StreamingMessage()
+            {
+                StartStream = new StartStream()
+                {
+                    WorkerId = _workerId
+                }
+            };
+
+            var rpcEvent = new GrpcEvent(_workerId, startStreamMessage);
+            _workerChannel.SendWorkerInitRequest(rpcEvent);
+
+            var functionMetadataList = GetTestFunctionsList("node", numberOfFunctions: 250);
+            _workerChannel.SetupFunctionInvocationBuffers(functionMetadataList);
+            _workerChannel.SendFunctionLoadRequests(managedDependencyOptions: null, TimeSpan.FromSeconds(1));
+
+            var allFunctionIdsAndNames = functionMetadataList.Select(f => new { Id = f.Properties["FunctionId"].ToString(), f.Name }).ToList();
+
+            // Send function load responses for each function, not necessarily in the order the load requests were sent.
+            var publishFunctionLoadResponseTasks = allFunctionIdsAndNames.Select(function =>
+                Task.Run(() => _testFunctionRpcService.PublishFunctionLoadResponseEvent(function.Id)));
+
+            await Task.WhenAll(publishFunctionLoadResponseTasks);
+            // Give some time for the logs to be written.
+            await Task.Delay(TimeSpan.FromMilliseconds(500));
+
+            var traces = _logger.GetLogMessages();
+
+            foreach (var function in allFunctionIdsAndNames)
+            {
+                Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, $"Setting up FunctionInvocationBuffer for function: '{function.Name}' with functionId: '{function.Id}'")), $"setup {function.Id}");
+                Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, $"Received FunctionLoadResponse for function: '{function.Name}' with functionId: '{function.Id}'.")), $"FunctionLoadResponse {function.Id}");
+            }
+        }
+
+        [Fact]
         public async Task ReceivesInboundEvent_Failed_FunctionLoadResponses()
         {
             IDictionary<string, string> capabilities = new Dictionary<string, string>()
@@ -1489,41 +1528,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
         private static IEnumerable<FunctionMetadata> GetTestFunctionsList(string runtime, bool addWorkerProperties = false)
         {
-            var metadata1 = new FunctionMetadata()
-            {
-                Language = runtime,
-                Name = "js1"
-            };
-
-            metadata1.SetFunctionId("TestFunctionId1");
-            metadata1.Properties.Add(LogConstants.CategoryNameKey, "testcat1");
-            metadata1.Properties.Add(ScriptConstants.LogPropertyHostInstanceIdKey, "testhostId1");
-
-            if (addWorkerProperties)
-            {
-                metadata1.Properties.Add("worker.functionId", "fn1");
-            }
-
-            var metadata2 = new FunctionMetadata()
-            {
-                Language = runtime,
-                Name = "js2",
-            };
-
-            metadata2.SetFunctionId("TestFunctionId2");
-            metadata2.Properties.Add(LogConstants.CategoryNameKey, "testcat2");
-            metadata2.Properties.Add(ScriptConstants.LogPropertyHostInstanceIdKey, "testhostId2");
-
-            if (addWorkerProperties)
-            {
-                metadata2.Properties.Add("WORKER.functionId", "fn2");
-            }
-
-            return new List<FunctionMetadata>()
-            {
-                metadata1,
-                metadata2
-            };
+            return GetTestFunctionsList(runtime, numberOfFunctions: 2, addWorkerProperties);
         }
 
         public static ScriptInvocationContext GetTestScriptInvocationContext(Guid invocationId, TaskCompletionSource<ScriptInvocationResult> resultSource,
@@ -1546,6 +1551,33 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 AsyncExecutionContext = System.Threading.ExecutionContext.Capture(),
                 Logger = logger
             };
+        }
+
+        private static List<FunctionMetadata> GetTestFunctionsList(string runtime, int numberOfFunctions, bool addWorkerProperties = false)
+        {
+            var functions = new List<FunctionMetadata>();
+
+            for (int i = 1; i <= numberOfFunctions; i++)
+            {
+                var metadata = new FunctionMetadata()
+                {
+                    Language = runtime,
+                    Name = $"js{i}"
+                };
+
+                metadata.SetFunctionId($"TestFunctionId{i}");
+                metadata.Properties.Add(LogConstants.CategoryNameKey, $"testcat1");
+                metadata.Properties.Add(ScriptConstants.LogPropertyHostInstanceIdKey, $"testhostId1");
+
+                if (addWorkerProperties)
+                {
+                    metadata.Properties.Add("worker.functionId", $"fn{i}");
+                }
+
+                functions.Add(metadata);
+            }
+
+            return functions;
         }
 
         /// <summary>


### PR DESCRIPTION
- Fixed thread safety issue in the `GrpcWorkerChannel.LoadResponse` method. 
- Added a test to handle multiple individual LoadResponses, which was previously missing.

resolves #10352

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR - #10400
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #10400
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

