### PR TITLE
Host release prep 4.35.3 (#10368)

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -4,7 +4,7 @@
     <LangVersion>latest</LangVersion>
     <MajorVersion>4</MajorVersion>
     <MinorVersion>$(MinorVersionPrefix)35</MinorVersion>
-    <PatchVersion>2</PatchVersion>
+    <PatchVersion>3</PatchVersion>
     <BuildNumber Condition="'$(BuildNumber)' == '' ">0</BuildNumber>
     <PreviewVersion></PreviewVersion>
     

--- a/release_notes.md
+++ b/release_notes.md
@@ -21,3 +21,4 @@
   - `Microsoft.Extensions.Azure` updated to 1.7.1
   - `Azure.Storage.Blobs` updated to 12.19.1
 - [in-proc] Updating FunctionsNetHost (dotnet isolated worker) to 1.0.10 (#10340)
+- Trim FunctionsNetHost artifacts (#10364)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->
Hotfix to reduce extension size for in-proc.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [X] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [X] I have added all required tests (Unit tests, E2E tests)

