### PR TITLE
Update Java Worker Version to 2.16.0

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,7 +3,8 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-- Update Java Worker Version to [2.16.0](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.16.0)
+- Update Java Worker Version to [2.16.0](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.16.0):
+  - Fix thread context classloader for middleware chain
 
 - Upgraded the following package versions (#10325):
   - `Azure.Security.KeyVault.Secrets` updated to 4.6.0
@@ -13,3 +14,4 @@
 - Update PowerShell 7.4 worker to [4.0.4021](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.4021)
 - Updated dotnet-isolated worker to [1.0.10](https://github.com/Azure/azure-functions-dotnet-worker/pull/2629) (#10340)
 - Update Java Worker Version to [2.15.0](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.15.0)
+  - Update grpc-protobuf to 1.64.0 and application insights agent version to 3.5.2

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,6 +3,7 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Update Java Worker Version to [2.16.0](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.16.0)
 
 - Upgraded the following package versions (#10325):
   - `Azure.Security.KeyVault.Secrets` updated to 4.6.0

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -55,7 +55,7 @@
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.1" />
 
     <!-- Workers -->
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.15.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.16.0" />
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.3.20240307.67" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.10.0" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" Version="4.0.3148" />

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.10.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.5-11874" />
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.15.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.16.0" />
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.2.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />


### PR DESCRIPTION
### Issue describing the changes in this PR

Update Java Worker Version to 2.16.0

Java Worker Release note [2.16.0](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.16.0)

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the in-proc branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the in-proc branch is not required
    * [x] Otherwise: [Link to backporting PR](https://github.com/Azure/azure-functions-host/pull/10377)
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to release_notes.md
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)