### PR TITLE
[in-proc] Updating DotNetIsolatedNativeHost package to 1.0.11

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -4,7 +4,7 @@
     <LangVersion>latest</LangVersion>
     <MajorVersion>4</MajorVersion>
     <MinorVersion>$(MinorVersionPrefix)35</MinorVersion>
-    <PatchVersion>3</PatchVersion>
+    <PatchVersion>4</PatchVersion>
     <BuildNumber Condition="'$(BuildNumber)' == '' ">0</BuildNumber>
     <PreviewVersion></PreviewVersion>
     

--- a/release_notes.md
+++ b/release_notes.md
@@ -20,7 +20,7 @@
   - `Microsoft.Azure.WebJobs.Host.Storage` updated to 5.0.1
   - `Microsoft.Extensions.Azure` updated to 1.7.1
   - `Azure.Storage.Blobs` updated to 12.19.1
-- [in-proc] Updating FunctionsNetHost (dotnet isolated worker) to 1.0.10 (#10340)
+- [in-proc] Updating FunctionsNetHost (dotnet isolated worker) to 1.0.11 (#10379)
 - Upgraded the following package versions (#10326):
   - `Azure.Security.KeyVault.Secrets` updated to 4.6.0
   - `System.Format.Asn1` updated to 6.0.1

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer" Version="2.21.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" NoWarn="NU1701" />
-    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.10" />
+    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.11" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.41" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.1" />


### PR DESCRIPTION
in-proc backport of https://github.com/Azure/azure-functions-host/pull/10379



