### PR TITLE
Avoid redundant DiagnosticEvents error message

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventLogger.cs
@@ -54,13 +54,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
         {
-            if (!IsEnabled(logLevel))
+            if (_diagnosticEventRepository is null || _diagnosticEventRepository.IsEnabled())
             {
-                return;
-            }
+                if (!IsEnabled(logLevel) || !(state is IDictionary<string, object> stateInfo && IsDiagnosticEvent(stateInfo)))
+                {
+                    return;
+                }
 
-            if (state is IDictionary<string, object> stateInfo && IsDiagnosticEvent(stateInfo))
-            {
                 string message = formatter(state, exception);
                 if (_diagnosticEventRepository == null)
                 {

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventNullRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventNullRepository.cs
@@ -2,13 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Azure.Cosmos.Table;
-using Microsoft.Azure.WebJobs.Host.Executors;
-using Microsoft.Azure.WebJobs.Script.WebHost.Helpers;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
@@ -16,5 +9,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
     public class DiagnosticEventNullRepository : IDiagnosticEventRepository
     {
         public void WriteDiagnosticEvent(DateTime timestamp, string errorCode, LogLevel level, string message, string helpLink, Exception exception) { }
+
+        public bool IsEnabled()
+        {
+            return false;
+        }
     }
 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         private bool _disposed = false;
         private bool _purged = false;
         private string _tableName;
+        private bool _isEnabled = true;
 
         internal DiagnosticEventTableStorageRepository(IConfiguration configuration, IHostIdProvider hostIdProvider, IEnvironment environment, IScriptHostManager scriptHostManager,
             ILogger<DiagnosticEventTableStorageRepository> logger, int logFlushInterval)
@@ -69,7 +70,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogError(ex, "Azure Storage connection string is empty or invalid. Unable to write diagnostic events.");
+                        _logger.LogError(ex, "The Azure Storage connection string is either empty or invalid. Unable to record diagnostic events, so the diagnostic logging service is being stopped.");
+                        _isEnabled = false;
+                        StopTimer();
                     }
                 }
 
@@ -267,6 +270,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                     _events[errorCode].HitCount++;
                 }
             }
+        }
+
+        public bool IsEnabled()
+        {
+            return _isEnabled;
         }
 
         private bool IsPrimaryHost()

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
@@ -67,6 +67,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                     try
                     {
                         _tableClient = new TableServiceClient(storageConnectionString);
+
+                        // The TableServiceClient only verifies the format of the connection string.
+                        // To ensure the storage account exists and supports Table storage, validate the connection string by retrieving the properties of the table service.
+                        _ = _tableClient.GetProperties();
                     }
                     catch (Exception ex)
                     {

--- a/src/WebJobs.Script.WebHost/Diagnostics/IDiagnosticEventRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/IDiagnosticEventRepository.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
@@ -11,5 +9,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
     public interface IDiagnosticEventRepository
     {
         void WriteDiagnosticEvent(DateTime timestamp, string errorCode, LogLevel level, string message, string helpLink, Exception exception);
+
+        bool IsEnabled();
     }
 }

--- a/test/WebJobs.Script.Tests.Shared/TestDiagnosticEventRepository.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestDiagnosticEventRepository.cs
@@ -35,4 +35,9 @@ public class TestDiagnosticEventRepository : IDiagnosticEventRepository
     {
         Events.Clear();
     }
+
+    public bool IsEnabled()
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
Adding a validation check for the storage connection string. If the connection string is null, empty, or invalid, diagnostic events will not be written to table storage, and the service will be disabled. This will help reduce noise in the FunctionsLogs table caused by exceptions thrown due to an invalid or empty connection string.

resolves #10163

### Pull request checklist


**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR #10396
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

