### PR TITLE
Update PowerShell template

### DIFF
--- a/src/WebJobs.Script/FileProvisioning/PowerShell/profile.ps1
+++ b/src/WebJobs.Script/FileProvisioning/PowerShell/profile.ps1
@@ -9,6 +9,9 @@
 # You can define helper functions, run commands, or specify environment variables
 # NOTE: any variables defined that are not environment variables will get reset after the first execution
 
+# Set ErrorActionPreference to "Stop". This will cause any exception to terminate the function.
+$ErrorActionPreference = "Stop"
+
 # Authenticate with Azure PowerShell using MSI.
 # Remove this if you are not planning on using MSI or Azure PowerShell.
 if ($env:MSI_SECRET) {


### PR DESCRIPTION
- Set ErrorActionPreference to Stop in profile.ps1

<!-- Please provide all the information below.  -->

### Set ErrorActionPreference to Stop in profile.ps1 for new PowerShell apps

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
