### PR TITLE
Fallback behavior to ensure in-proc payload compatibility with `dotnet-isolated` as the `FUNCTIONS_WORKER_RUNTIME` value

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -19,4 +19,4 @@
 - Worker termination path updated with sanitized logging (#10367)
 - Avoid redundant DiagnosticEvents error message (#10395)
 - Added logic to shim older versions of the .NET Worker JsonFunctionProvider to ensure backwards compatibility (#10410)
-- Added fallback behavior when FUNCTIONS_WORKER_RUNTIME does not match with metadata from deployed app payload.
+- Added fallback behavior to ensure in-proc payload compatibility with "dotnet-isolated" as the `FUNCTIONS_WORKER_RUNTIME` value (#10439)

--- a/release_notes.md
+++ b/release_notes.md
@@ -19,3 +19,4 @@
 - Worker termination path updated with sanitized logging (#10367)
 - Avoid redundant DiagnosticEvents error message (#10395)
 - Added logic to shim older versions of the .NET Worker JsonFunctionProvider to ensure backwards compatibility (#10410)
+- Added fallback behavior when FUNCTIONS_WORKER_RUNTIME does not match with metadata from deployed app payload.

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -183,6 +183,14 @@ namespace Microsoft.Azure.WebJobs.Script.Config
             }
         }
 
+        internal bool ThrowOnFunctionsWorkerRuntimeMismatchWithMetadataFromPayload
+        {
+            get
+            {
+                return GetFeature(RpcWorkerConstants.ThrowOnFunctionsWorkerRuntimeMismatchWithMetadataFromPayload) == "1";
+            }
+        }
+
         /// <summary>
         /// Gets feature by name.
         /// </summary>

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -183,11 +183,11 @@ namespace Microsoft.Azure.WebJobs.Script.Config
             }
         }
 
-        internal bool ThrowOnFunctionsWorkerRuntimeMismatchWithMetadataFromPayload
+        internal bool WorkerRuntimeStrictValidationEnabled
         {
             get
             {
-                return GetFeatureAsBooleanOrDefault(RpcWorkerConstants.ThrowOnFunctionsWorkerRuntimeMismatchWithMetadataFromPayload, false);
+                return GetFeatureAsBooleanOrDefault(RpcWorkerConstants.WorkerRuntimeStrictValidationEnabled, false);
             }
         }
 

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         {
             get
             {
-                return GetFeature(RpcWorkerConstants.ThrowOnFunctionsWorkerRuntimeMismatchWithMetadataFromPayload) == "1";
+                return GetFeatureAsBooleanOrDefault(RpcWorkerConstants.ThrowOnFunctionsWorkerRuntimeMismatchWithMetadataFromPayload, false);
             }
         }
 

--- a/src/WebJobs.Script/Diagnostics/DiagnosticEventConstants.cs
+++ b/src/WebJobs.Script/Diagnostics/DiagnosticEventConstants.cs
@@ -31,5 +31,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public const string NonHISSecretLoaded = "AZFD0012";
         public const string NonHISSecretLoadedHelpLink = "https://aka.ms/functions-non-his-secrets";
+
+        public const string WorkerRuntimeDoesNotMatchWithFunctionMetadataErrorCode = "AZFD0013";
+        public const string WorkerRuntimeDoesNotMatchWithFunctionMetadataHelpLink = "https://aka.ms/functions-invalid-worker-runtime";
     }
 }

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -776,7 +776,7 @@ namespace Microsoft.Azure.WebJobs.Script
         // Ensure customer deployed application payload matches with the worker runtime configured for the function app and log a warning if not.
         // If a customer has "dotnet-isolated" worker runtime configured for the function app, and then they deploy an in-proc app payload, this will warn/error
         // If there is a mismatch, the method will return false, else true.
-        internal static bool ValidateAndLogRuntimeMismatch(IEnumerable<FunctionMetadata> functionMetadata, string workerRuntime, IOptions<FunctionsHostingConfigOptions> hostingConfigOptions, ILogger logger)
+        private static bool ValidateAndLogRuntimeMismatch(IEnumerable<FunctionMetadata> functionMetadata, string workerRuntime, IOptions<FunctionsHostingConfigOptions> hostingConfigOptions, ILogger logger)
         {
             if (functionMetadata != null && functionMetadata.Any() && !Utility.ContainsAnyFunctionMatchingWorkerRuntime(functionMetadata, workerRuntime))
             {
@@ -805,8 +805,8 @@ namespace Microsoft.Azure.WebJobs.Script
                 // this dotnet isolated specific logic is temporary to ensure in-proc payload compatibility with "dotnet-isolated" as the FUNCTIONS_WORKER_RUNTIME value.
                 if (string.Equals(workerRuntime, RpcWorkerConstants.DotNetIsolatedLanguageWorkerName, StringComparison.OrdinalIgnoreCase))
                 {
-                    bool isDotnetIsolatedRuntimeWithValidPayload = ValidateAndLogRuntimeMismatch(functions, workerRuntime, _hostingConfigOptions, _logger);
-                    if (!isDotnetIsolatedRuntimeWithValidPayload)
+                    bool payloadMatchesWorkerRuntime = ValidateAndLogRuntimeMismatch(functions, workerRuntime, _hostingConfigOptions, _logger);
+                    if (!payloadMatchesWorkerRuntime)
                     {
                         UpdateFunctionMetadataLanguageForDotnetAssembly(functions, workerRuntime);
                         throwOnWorkerRuntimeAndPayloadMetadataMismatch = false; // we do not want to throw an exception in this case

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -780,15 +780,16 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             if (functionMetadata != null && functionMetadata.Any() && !Utility.ContainsAnyFunctionMatchingWorkerRuntime(functionMetadata, workerRuntime))
             {
-                string baseMessage = $"The '{EnvironmentSettingNames.FunctionWorkerRuntime}' is set to '{workerRuntime}', which does not match the worker runtime metadata found in the deployed function app artifacts. See {DiagnosticEventConstants.WorkerRuntimeDoesNotMatchWithFunctionMetadataHelpLink} for more information.";
+                var languages = string.Join(", ", functionMetadata.Select(f => f.Language).Distinct()).Replace(DotNetScriptTypes.DotNetAssembly, RpcWorkerConstants.DotNetLanguageWorkerName);
+                var baseMessage = $"The '{EnvironmentSettingNames.FunctionWorkerRuntime}' is set to '{workerRuntime}', which does not match the worker runtime metadata found in the deployed function app artifacts. The deployed artifacts are for '{languages}'. See {DiagnosticEventConstants.WorkerRuntimeDoesNotMatchWithFunctionMetadataHelpLink} for more information.";
 
-                if (hostingConfigOptions.Value.ThrowOnFunctionsWorkerRuntimeMismatchWithMetadataFromPayload)
+                if (hostingConfigOptions.Value.WorkerRuntimeStrictValidationEnabled)
                 {
                     logger.LogDiagnosticEventError(DiagnosticEventConstants.WorkerRuntimeDoesNotMatchWithFunctionMetadataErrorCode, baseMessage, DiagnosticEventConstants.WorkerRuntimeDoesNotMatchWithFunctionMetadataHelpLink, null);
                     throw new HostInitializationException(baseMessage);
                 }
 
-                string warningMessage = baseMessage + " The application will continue to run, but may throw an exception in the future.";
+                var warningMessage = baseMessage + " The application will continue to run, but may throw an exception in the future.";
                 logger.LogDiagnosticEventWarning(DiagnosticEventConstants.WorkerRuntimeDoesNotMatchWithFunctionMetadataErrorCode, warningMessage, DiagnosticEventConstants.WorkerRuntimeDoesNotMatchWithFunctionMetadataHelpLink, null);
                 return false;
             }

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -644,12 +644,12 @@ namespace Microsoft.Azure.WebJobs.Script
                 {
                     throw new HostInitializationException($"Found functions with more than one language. Select a language for your function app by specifying {RpcWorkerConstants.FunctionWorkerRuntimeSettingName} AppSetting");
                 }
-            }
-            else
-            {
-                if (throwOnMismatch)
+                else
                 {
-                    throw new HostInitializationException($"Did not find functions with language [{workerRuntime}].");
+                    if (throwOnMismatch)
+                    {
+                        throw new HostInitializationException($"Did not find functions with language [{workerRuntime}].");
+                    }
                 }
             }
         }

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -629,7 +629,7 @@ namespace Microsoft.Azure.WebJobs.Script
             return true;
         }
 
-        internal static void VerifyFunctionsMatchSpecifiedLanguage(IEnumerable<FunctionMetadata> functions, string workerRuntime, bool isPlaceholderMode, bool isHttpWorker, CancellationToken cancellationToken)
+        internal static void VerifyFunctionsMatchSpecifiedLanguage(IEnumerable<FunctionMetadata> functions, string workerRuntime, bool isPlaceholderMode, bool isHttpWorker, CancellationToken cancellationToken, bool throwOnMismatch = true)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -643,6 +643,13 @@ namespace Microsoft.Azure.WebJobs.Script
                 if (string.IsNullOrEmpty(workerRuntime))
                 {
                     throw new HostInitializationException($"Found functions with more than one language. Select a language for your function app by specifying {RpcWorkerConstants.FunctionWorkerRuntimeSettingName} AppSetting");
+                }
+            }
+            else
+            {
+                if (throwOnMismatch)
+                {
+                    throw new HostInitializationException($"Did not find functions with language [{workerRuntime}].");
                 }
             }
         }
@@ -749,7 +756,7 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
-        /// Inspect the functions metadata to determine if atleast one function is of the specified worker runtime.
+        /// Inspect the functions metadata to determine if at least one function is of the specified worker runtime.
         /// </summary>
         internal static bool ContainsAnyFunctionMatchingWorkerRuntime(IEnumerable<FunctionMetadata> functions, string workerRuntime)
         {

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -644,10 +644,6 @@ namespace Microsoft.Azure.WebJobs.Script
                 {
                     throw new HostInitializationException($"Found functions with more than one language. Select a language for your function app by specifying {RpcWorkerConstants.FunctionWorkerRuntimeSettingName} AppSetting");
                 }
-                else
-                {
-                    throw new HostInitializationException($"Did not find functions with language [{workerRuntime}].");
-                }
             }
         }
 
@@ -748,10 +744,20 @@ namespace Microsoft.Azure.WebJobs.Script
             {
                 return functions.Any(f => dotNetLanguages.Any(l => l.Equals(f.Language, StringComparison.OrdinalIgnoreCase)));
             }
+
+            return ContainsAnyFunctionMatchingWorkerRuntime(functions, workerRuntime);
+        }
+
+        /// <summary>
+        /// Inspect the functions metadata to determine if atleast one function is of the specified worker runtime.
+        /// </summary>
+        internal static bool ContainsAnyFunctionMatchingWorkerRuntime(IEnumerable<FunctionMetadata> functions, string workerRuntime)
+        {
             if (functions != null && functions.Any())
             {
                 return functions.Any(f => !string.IsNullOrEmpty(f.Language) && f.Language.Equals(workerRuntime, StringComparison.OrdinalIgnoreCase));
             }
+
             return false;
         }
 

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -317,13 +317,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             }
             ErrorEventsThreshold = 3 * await _maxProcessCount.Value;
 
-            // If the configured worker runtime is "dotnet-isolated" and no worker config is found, we should assume that this was caused by
-            //  1. App did not start in placeholder mode (so that the dotnet-isolated worker config was not initialized because of https://github.com/Azure/azure-functions-dotnet-worker/pull/2552)
-            //  2. App payload deployed is not "dotnet-isolated" (but "in-proc")
-            // In this case, we want to go ahead and initialize a language worker channel for the runtime.
-            var missingWorkerConfigForDotnetIsolated = !_workerConfigs.Any() && _workerRuntime == RpcWorkerConstants.DotNetIsolatedLanguageWorkerName;
-
-            if (missingWorkerConfigForDotnetIsolated || Utility.IsSupportedRuntime(_workerRuntime, _workerConfigs) || _environment.IsMultiLanguageRuntimeEnvironment())
+            if (Utility.IsSupportedRuntime(_workerRuntime, _workerConfigs) || _environment.IsMultiLanguageRuntimeEnvironment())
             {
                 State = FunctionInvocationDispatcherState.Initializing;
                 IDictionary<string, TaskCompletionSource<IRpcWorkerChannel>> webhostLanguageWorkerChannels = _webHostLanguageWorkerChannelManager.GetChannels(_workerRuntime);

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
@@ -93,6 +93,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public const string RevertWorkerShutdownBehavior = "REVERT_WORKER_SHUTDOWN_BEHAVIOR";
         public const string ShutdownWebhostWorkerChannelsOnHostShutdown = "ShutdownWebhostWorkerChannelsOnHostShutdown";
         public const string ThrowOnMissingFunctionsWorkerRuntime = "THROW_ON_MISSING_FUNCTIONS_WORKER_RUNTIME";
-        public const string ThrowOnFunctionsWorkerRuntimeMismatchWithMetadataFromPayload = "THROW_ON_FUNCTIONS_WORKER_RUNTIME_MISMATCH_WITH_PAYLOAD";
+        public const string WorkerRuntimeStrictValidationEnabled = "WORKER_RUNTIME_STRICT_VALIDATION_ENABLED";
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
@@ -93,5 +93,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public const string RevertWorkerShutdownBehavior = "REVERT_WORKER_SHUTDOWN_BEHAVIOR";
         public const string ShutdownWebhostWorkerChannelsOnHostShutdown = "ShutdownWebhostWorkerChannelsOnHostShutdown";
         public const string ThrowOnMissingFunctionsWorkerRuntime = "THROW_ON_MISSING_FUNCTIONS_WORKER_RUNTIME";
+        public const string ThrowOnFunctionsWorkerRuntimeMismatchWithMetadataFromPayload = "THROW_ON_FUNCTIONS_WORKER_RUNTIME_MISMATCH_WITH_PAYLOAD";
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebJobsStartupEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebJobsStartupEndToEndTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -29,6 +30,27 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
         {
             // We need different fixture setup for each test.
             var fixture = new CSharpPrecompiledEndToEndTestFixture(_projectName, _envVars);
+            try
+            {
+                await fixture.InitializeAsync();
+                var client = fixture.Host.HttpClient;
+
+                var response = await client.GetAsync($"api/Function1");
+
+                // The function does all the validation internally.
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            }
+            finally
+            {
+                await fixture.DisposeAsync();
+            }
+        }
+
+        [Fact]
+        public async Task InProcAppsWorkWithDotnetIsolatedAsFunctionWorkerRuntimeValue()
+        {
+            // test uses an in-proc app, but we are setting "dotnet-isolated" as functions worker runtime value.
+            var fixture = new CSharpPrecompiledEndToEndTestFixture(_projectName, _envVars, functionWorkerRuntime: RpcWorkerConstants.DotNetIsolatedLanguageWorkerName);
             try
             {
                 await fixture.InitializeAsync();

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebJobsStartupEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebJobsStartupEndToEndTests.cs
@@ -60,6 +60,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
 
                 // The function does all the validation internally.
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                const string expectedLogEntry =
+                    "The 'FUNCTIONS_WORKER_RUNTIME' is set to 'dotnet-isolated', " +
+                    "which does not match the worker runtime metadata found in the deployed function app artifacts. " +
+                    "The deployed artifacts are for 'dotnet'. See https://aka.ms/functions-invalid-worker-runtime " +
+                    "for more information. The application will continue to run, but may throw an exception in the future.";
+                Assert.Single(fixture.Host.GetScriptHostLogMessages(), p => p.FormattedMessage != null && p.FormattedMessage.EndsWith(expectedLogEntry));
             }
             finally
             {

--- a/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 (nameof(FunctionsHostingConfigOptions.ThrowOnMissingFunctionsWorkerRuntime), "THROW_ON_MISSING_FUNCTIONS_WORKER_RUNTIME=1", true),
                 (nameof(FunctionsHostingConfigOptions.WorkerIndexingDisabledApps), "WORKER_INDEXING_DISABLED_APPS=teststring", "teststring"),
                 (nameof(FunctionsHostingConfigOptions.WorkerIndexingEnabled), "WORKER_INDEXING_ENABLED=1", true),
-                (nameof(FunctionsHostingConfigOptions.WorkerRuntimeStrictValidationEnabled), "THROW_ON_FUNCTIONS_WORKER_RUNTIME_MISMATCH_WITH_PAYLOAD=1", true)
+                (nameof(FunctionsHostingConfigOptions.WorkerRuntimeStrictValidationEnabled), "WORKER_RUNTIME_STRICT_VALIDATION_ENABLED=1", true)
             };
 
             // use reflection to ensure that we have a test that uses every value exposed on FunctionsHostingConfigOptions

--- a/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 (nameof(FunctionsHostingConfigOptions.ThrowOnMissingFunctionsWorkerRuntime), "THROW_ON_MISSING_FUNCTIONS_WORKER_RUNTIME=1", true),
                 (nameof(FunctionsHostingConfigOptions.WorkerIndexingDisabledApps), "WORKER_INDEXING_DISABLED_APPS=teststring", "teststring"),
                 (nameof(FunctionsHostingConfigOptions.WorkerIndexingEnabled), "WORKER_INDEXING_ENABLED=1", true),
-                (nameof(FunctionsHostingConfigOptions.ThrowOnFunctionsWorkerRuntimeMismatchWithMetadataFromPayload), "THROW_ON_FUNCTIONS_WORKER_RUNTIME_MISMATCH_WITH_PAYLOAD=1", true)
+                (nameof(FunctionsHostingConfigOptions.WorkerRuntimeStrictValidationEnabled), "THROW_ON_FUNCTIONS_WORKER_RUNTIME_MISMATCH_WITH_PAYLOAD=1", true)
             };
 
             // use reflection to ensure that we have a test that uses every value exposed on FunctionsHostingConfigOptions

--- a/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
@@ -138,7 +138,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 
                 (nameof(FunctionsHostingConfigOptions.ThrowOnMissingFunctionsWorkerRuntime), "THROW_ON_MISSING_FUNCTIONS_WORKER_RUNTIME=1", true),
                 (nameof(FunctionsHostingConfigOptions.WorkerIndexingDisabledApps), "WORKER_INDEXING_DISABLED_APPS=teststring", "teststring"),
-                (nameof(FunctionsHostingConfigOptions.WorkerIndexingEnabled), "WORKER_INDEXING_ENABLED=1", true)
+                (nameof(FunctionsHostingConfigOptions.WorkerIndexingEnabled), "WORKER_INDEXING_ENABLED=1", true),
+                (nameof(FunctionsHostingConfigOptions.ThrowOnFunctionsWorkerRuntimeMismatchWithMetadataFromPayload), "THROW_ON_FUNCTIONS_WORKER_RUNTIME_MISMATCH_WITH_PAYLOAD=1", true)
             };
 
             // use reflection to ensure that we have a test that uses every value exposed on FunctionsHostingConfigOptions


### PR DESCRIPTION
This update addresses the issue of running a function app where the `FUNCTIONS_WORKER_RUNTIME` setting does not match the function metadata from the deployed code. For example, if a function app is configured with `"dotnet-isolated"` as the `FUNCTIONS_WORKER_RUNTIME` but has an in-process (in-proc) app payload deployed, this scenario previously worked in version 4.34.

However, in version 4.35, a change was introduced (see [this PR](https://github.com/Azure/azure-functions-dotnet-worker/pull/2552)) that restricts the use of the dotnet-isolated worker configuration to only when the app is running in placeholder mode. This change was intentional to ensure that `FunctionsNetHost` starts only in placeholder mode. However, it inadvertently caused issues for incorrectly configured apps (i.e., those with an in-proc payload and a `"dotnet-isolated"` `FUNCTIONS_WORKER_RUNTIME` value), as this new behavior prevents the creation of the worker configuration instance, thereby stopping the function app from running.

This PR includes changes to temporarily support this use case while also emitting a diagnostic warning to customers. The intention is to remove this support in a future release.

#### Why it works in 4.34

The reason it works in 4.34 is we update the "Language" property of function metadata to "dotnet-isolated" (the language present in the workerconfig instance). Code [here](https://github.com/Azure/azure-functions-host/blob/ff0dea77c3de615a9a19f000595dc56262f47ad4/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs#L166) and [here](https://github.com/Azure/azure-functions-host/blob/ff0dea77c3de615a9a19f000595dc56262f47ad4/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs#L200-L204)). Having this change (Language in function metadata entries matching with FUNCTIONS_WORKER_RUNTIME
) and having at least one workerconfig instance to match the worker runtime value (dotnet-isolated) make things works. 
### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR - https://github.com/Azure/azure-functions-host/pull/10449
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x ] Otherwise: Backport tracked by issue/PR #issue_or_pr - will follow
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: Added diag event. will work on docs change.
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
