### PR TITLE
Skip validation of `FUNCTIONS_WORKER_RUNTIME` with function metadata in placeholder mode 

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -9,3 +9,4 @@
   - Includes fixes from 2.16.0
 - Migrated Scale Metrics to use `Azure.Data.Tables` SDK (#10276)
   - Added support for Identity-based connections
+- Excluding WarmUp function during placeholder mode when validating `FUNCTIONS_WORKER_RUNTIME` with funciton metadata. (#10459)

--- a/release_notes.md
+++ b/release_notes.md
@@ -9,4 +9,4 @@
   - Includes fixes from 2.16.0
 - Migrated Scale Metrics to use `Azure.Data.Tables` SDK (#10276)
   - Added support for Identity-based connections
-- Excluding WarmUp function during placeholder mode when validating `FUNCTIONS_WORKER_RUNTIME` with funciton metadata. (#10459)
+- Skip validation of `FUNCTIONS_WORKER_RUNTIME` with funciton metadata in placeholder mode. (#10459)

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -776,11 +776,19 @@ namespace Microsoft.Azure.WebJobs.Script
         // Ensure customer deployed application payload matches with the worker runtime configured for the function app and log a warning if not.
         // If a customer has "dotnet-isolated" worker runtime configured for the function app, and then they deploy an in-proc app payload, this will warn/error
         // If there is a mismatch, the method will return false, else true.
-        private static bool ValidateAndLogRuntimeMismatch(IEnumerable<FunctionMetadata> functionMetadata, string workerRuntime, IOptions<FunctionsHostingConfigOptions> hostingConfigOptions, ILogger logger)
+        private bool ValidateAndLogRuntimeMismatch(IEnumerable<FunctionMetadata> functionMetadata, string workerRuntime, IOptions<FunctionsHostingConfigOptions> hostingConfigOptions, ILogger logger)
         {
-            if (functionMetadata != null && functionMetadata.Any() && !Utility.ContainsAnyFunctionMatchingWorkerRuntime(functionMetadata, workerRuntime))
+            IEnumerable<FunctionMetadata> functionMetadataToCheck = functionMetadata ?? Enumerable.Empty<FunctionMetadata>();
+
+            // Placeholder mode will add "WarmUp" function of type CSharp. we should ignore this function for validating the metadata matching with worker runtime.
+            if (_environment.IsPlaceholderModeEnabled())
             {
-                var languages = string.Join(", ", functionMetadata.Select(f => f.Language).Distinct()).Replace(DotNetScriptTypes.DotNetAssembly, RpcWorkerConstants.DotNetLanguageWorkerName);
+                functionMetadataToCheck = functionMetadataToCheck.Where(f => !f.Name.Equals(ScriptJobHostExtensions.WarmupFunctionName, StringComparison.OrdinalIgnoreCase));
+            }
+
+            if (functionMetadataToCheck.Any() && !Utility.ContainsAnyFunctionMatchingWorkerRuntime(functionMetadataToCheck, workerRuntime))
+            {
+                var languages = string.Join(", ", functionMetadataToCheck.Select(f => f.Language).Distinct()).Replace(DotNetScriptTypes.DotNetAssembly, RpcWorkerConstants.DotNetLanguageWorkerName);
                 var baseMessage = $"The '{EnvironmentSettingNames.FunctionWorkerRuntime}' is set to '{workerRuntime}', which does not match the worker runtime metadata found in the deployed function app artifacts. The deployed artifacts are for '{languages}'. See {DiagnosticEventConstants.WorkerRuntimeDoesNotMatchWithFunctionMetadataHelpLink} for more information.";
 
                 if (hostingConfigOptions.Value.WorkerRuntimeStrictValidationEnabled)

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -776,8 +776,13 @@ namespace Microsoft.Azure.WebJobs.Script
         // Ensure customer deployed application payload matches with the worker runtime configured for the function app and log a warning if not.
         // If a customer has "dotnet-isolated" worker runtime configured for the function app, and then they deploy an in-proc app payload, this will warn/error
         // If there is a mismatch, the method will return false, else true.
-        private static bool ValidateAndLogRuntimeMismatch(IEnumerable<FunctionMetadata> functionMetadata, string workerRuntime, IOptions<FunctionsHostingConfigOptions> hostingConfigOptions, ILogger logger)
+        private bool ValidateAndLogRuntimeMismatch(IEnumerable<FunctionMetadata> functionMetadata, string workerRuntime, IOptions<FunctionsHostingConfigOptions> hostingConfigOptions, ILogger logger)
         {
+            if (_environment.IsPlaceholderModeEnabled())
+            {
+                throw new InvalidOperationException($"Validation of '{EnvironmentSettingNames.FunctionWorkerRuntime}' with deployed payload metadata should not occur in placeholder mode.");
+            }
+
             if (functionMetadata != null && functionMetadata.Any() && !Utility.ContainsAnyFunctionMatchingWorkerRuntime(functionMetadata, workerRuntime))
             {
                 var languages = string.Join(", ", functionMetadata.Select(f => f.Language).Distinct()).Replace(DotNetScriptTypes.DotNetAssembly, RpcWorkerConstants.DotNetLanguageWorkerName);

--- a/src/WebJobs.Script/Host/ScriptJobHostExtensions.cs
+++ b/src/WebJobs.Script/Host/ScriptJobHostExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.WebJobs.Script
 {
     public static class ScriptJobHostExtensions
     {
-        private const string WarmupFunctionName = "Warmup";
+        internal const string WarmupFunctionName = "Warmup";
         private const string WarmupTriggerName = "WarmupTrigger";
 
         /// <summary>

--- a/src/WebJobs.Script/Host/ScriptJobHostExtensions.cs
+++ b/src/WebJobs.Script/Host/ScriptJobHostExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.WebJobs.Script
 {
     public static class ScriptJobHostExtensions
     {
-        internal const string WarmupFunctionName = "Warmup";
+        private const string WarmupFunctionName = "Warmup";
         private const string WarmupTriggerName = "WarmupTrigger";
 
         /// <summary>

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Windows.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Windows.cs
@@ -106,8 +106,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(1, logLines.Count(p => p.Contains("StandbyMode placeholder function directory created")));
             Assert.Equal(1, logLines.Count(p => p.Contains("Host is in standby mode")));
 
-            // Validating Functions worker runtime with function metadata does not happen in placeholder mode.
-            Assert.Equal(0, logLines.Count(p => p.Contains("The 'FUNCTIONS_WORKER_RUNTIME' is set to 'dotnet-isolated', which does not match the worker runtime metadata found in the deployed function app artifacts. The deployed artifacts are for 'CSharp'")));
+            // Ensure no warning logs are present.
+            var warningLogEntries = _loggerProvider.GetAllLogMessages().Where(a => a.Level == Microsoft.Extensions.Logging.LogLevel.Warning);
+            Assert.True(!warningLogEntries.Any(), $"Warnings found in logs: {string.Join(Environment.NewLine, warningLogEntries.Select(e => e.FormattedMessage))}");
         }
 
         [Theory]

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Windows.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Windows.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(1, logLines.Count(p => p.Contains("StandbyMode placeholder function directory created")));
             Assert.Equal(1, logLines.Count(p => p.Contains("Host is in standby mode")));
 
-            // Worker runtime mismatch validation should not consider "Warmup" functions which are added in placeholder mode and have "CSharp" as language.
+            // Validating Functions worker runtime with function metadata does not happen in placeholder mode.
             Assert.Equal(0, logLines.Count(p => p.Contains("The 'FUNCTIONS_WORKER_RUNTIME' is set to 'dotnet-isolated', which does not match the worker runtime metadata found in the deployed function app artifacts. The deployed artifacts are for 'CSharp'")));
         }
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebJobsStartupEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebJobsStartupEndToEndTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                     "which does not match the worker runtime metadata found in the deployed function app artifacts. " +
                     "The deployed artifacts are for 'dotnet'. See https://aka.ms/functions-invalid-worker-runtime " +
                     "for more information. The application will continue to run, but may throw an exception in the future.";
-                Assert.Single(fixture.Host.GetScriptHostLogMessages(), p => p.FormattedMessage != null && p.FormattedMessage.EndsWith(expectedLogEntry));
+                Assert.Single(fixture.Host.GetScriptHostLogMessages().Where(a => a.Level == Microsoft.Extensions.Logging.LogLevel.Warning), p => p.FormattedMessage != null && p.FormattedMessage.EndsWith(expectedLogEntry));
             }
             finally
             {


### PR DESCRIPTION
Skip validation of `FUNCTIONS_WORKER_RUNTIME` with function metadata in placeholder mode (this validation was added in #10439)

Without this change, DNI apps in placeholder mode will log the error about runtime mismatch because the "WarmUp" function's Language is "CSharp".

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR - will follow
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
