### PR TITLE
[in-proc] Update Node.js Worker Version to 3.10.1

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -19,3 +19,4 @@
 - Added fallback behavior to ensure in-proc payload compatibility with "dotnet-isolated" as the `FUNCTIONS_WORKER_RUNTIME` value (#10439)
 - Migrated Scale Metrics to use `Azure.Data.Tables` SDK (#10276)
   - Added support for Identity-based connections
+- Update Node.js Worker Version to [3.10.1](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.10.1)

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -62,7 +62,7 @@
     <!-- Workers -->
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.2.20220831.41" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.17.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.10.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.10.1" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" Version="4.0.3148" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" Version="4.0.4020" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" Version="4.0.4021" />

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.0" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.11.2" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.10.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.10.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.5-11874" />
     <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.17.0" />
     <PackageReference Include="Microsoft.Azure.Mobile.Client" Version="4.0.2" />


### PR DESCRIPTION
### Issue describing the changes in this PR

[Release notes](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.10.1)

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR: That's this PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)