### PR TITLE
Pass ARM ID header for Linux consumption metrics requests

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -13,3 +13,4 @@
 - Sanitize exception logs (#10443)
 - Improving console log handling during specialization (#10345)
 - Update Node.js Worker Version to [3.10.1](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.10.1)
+- Pass ARM ID header for Linux consumption metrics requests (#10476)

--- a/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         public const string ContainerNameHeader = "x-ms-functions-container-name";
         public const string HostNameHeader = "x-ms-functions-host-name";
         public const string StampNameHeader = "x-ms-site-home-stamp";
+        public const string ResourceIdHeader = "x-ms-site-arm-id";
 
         private const string _requestUriFormat = "https://{0}:31002/api/metrics";
         private const int _maxErrorLimit = 5;
@@ -63,6 +64,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         private Timer _metricsPublisherTimer;
         private int _errorCount = 0;
         private string _stampName;
+        private string _resourceId;
         private bool _initialized = false;
 
         public LinuxContainerMetricsPublisher(IEnvironment environment, IOptionsMonitor<StandbyOptions> standbyOptions, ILogger<LinuxContainerMetricsPublisher> logger, HostNameProvider hostNameProvider, IOptions<FunctionsHostingConfigOptions> functionsHostingConfigOptions, HttpClient httpClient = null)
@@ -247,6 +249,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         public void Initialize()
         {
             _stampName = _environment.GetEnvironmentVariable(EnvironmentSettingNames.WebSiteHomeStampName);
+            _resourceId = _environment.GetEnvironmentVariable(EnvironmentSettingNames.WebsiteArmResourceId);
             _tenant = _environment.GetEnvironmentVariable(EnvironmentSettingNames.WebSiteStampDeploymentId)?.ToLowerInvariant();
             _process = Process.GetCurrentProcess();
             _initialized = true;
@@ -291,6 +294,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             request.Headers.Add(ContainerNameHeader, _containerName);
             request.Headers.Add(HostNameHeader, _hostNameProvider.Value);
             request.Headers.Add(StampNameHeader, _stampName);
+            request.Headers.Add(ResourceIdHeader, _resourceId);
 
             if (_hostingConfigOptions.Value.SwtIssuerEnabled)
             {

--- a/test/WebJobs.Script.Tests/Metrics/LinuxContainerMetricsPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/LinuxContainerMetricsPublisherTests.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
         private const string _testIpAddress = "test-ip";
         private const string _testHostName = "test-host";
         private const string _testStampName = "test-stamp";
+        private const string _testResourceId = "test-resource-id";
         private const string _testTenant = "test-tenant";
         private readonly FunctionsHostingConfigOptions _hostingConfigOptions;
 
@@ -73,6 +74,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.LinuxNodeIpAddress)).Returns(_testIpAddress);
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName)).Returns(_testHostName);
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.WebSiteHomeStampName)).Returns(_testStampName);
+            mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.WebsiteArmResourceId)).Returns(_testResourceId);
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.WebSiteStampDeploymentId)).Returns(_testTenant);
 
             var websiteAuthEncryptionKey = TestHelpers.GenerateKeyBytes();
@@ -98,6 +100,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             Assert.Equal(request.Headers.GetValues(LinuxContainerMetricsPublisher.ContainerNameHeader).Single(), _containerName);
             Assert.Equal(request.Headers.GetValues(LinuxContainerMetricsPublisher.HostNameHeader).Single(), _testHostName);
             Assert.Equal(request.Headers.GetValues(LinuxContainerMetricsPublisher.StampNameHeader).Single(), _testStampName);
+            Assert.Equal(request.Headers.GetValues(LinuxContainerMetricsPublisher.ResourceIdHeader).Single(), _testResourceId);
 
             if (_hostingConfigOptions.SwtIssuerEnabled)
             {


### PR DESCRIPTION
This PR includes the Azure Resource Id of the function app as a header when publishing metrics for Linux Consumption. This change is required per the changes in internal dependencies.


**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise link to back port: #10477 
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

