### PR TITLE
Configuration based whitelisting of /admin API internal auth

### DIFF
--- a/src/WebJobs.Script.WebHost/Security/Authorization/Policies/AuthorizationOptionsExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authorization/Policies/AuthorizationOptionsExtensions.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Script.Extensions;
 using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
+using Microsoft.Azure.WebJobs.Script.WebHost.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies
@@ -52,7 +53,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies
                             return false;
                         }
 
-                        if (filterContext.HttpContext.Request.IsAppServiceInternalRequest())
+                        if (filterContext.HttpContext.Request.IsAppServiceInternalRequest() &&
+                            filterContext.HttpContext.Request.IsInternalAuthAllowed())
                         {
                             return true;
                         }
@@ -74,7 +76,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies
                 {
                     if (c.Resource is AuthorizationFilterContext filterContext)
                     {
-                        if (filterContext.HttpContext.Request.IsAppServiceInternalRequest())
+                        if (filterContext.HttpContext.Request.IsAppServiceInternalRequest() &&
+                            filterContext.HttpContext.Request.IsInternalAuthAllowed())
                         {
                             return true;
                         }

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 
 namespace Microsoft.Azure.WebJobs.Script.Config
@@ -10,6 +12,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
     public class FunctionsHostingConfigOptions
     {
         private readonly Dictionary<string, string> _features;
+        private PathString[] _allowedInternalAuthApis;
 
         public FunctionsHostingConfigOptions()
         {
@@ -88,6 +91,24 @@ namespace Microsoft.Azure.WebJobs.Script.Config
             set
             {
                 _features[ScriptConstants.HostingConfigSwtIssuerEnabled] = value ? "1" : "0";
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a string delimited by '|' that contains a list of admin APIs that are allowed to
+        /// be invoked internally by platform components.
+        /// </summary>
+        internal string InternalAuthApisAllowList
+        {
+            get
+            {
+                return GetFeature(ScriptConstants.HostingConfigInternalAuthApisAllowList);
+            }
+
+            set
+            {
+                _allowedInternalAuthApis = null;
+                _features[ScriptConstants.HostingConfigInternalAuthApisAllowList] = value;
             }
         }
 
@@ -242,8 +263,34 @@ namespace Microsoft.Azure.WebJobs.Script.Config
             {
                 return parsedInt != 0;
             }
-
             return defaultValue;
+        }
+
+        internal bool CheckInternalAuthAllowList(HttpRequest httpRequest)
+        {
+            if (InternalAuthApisAllowList != null && _allowedInternalAuthApis == null)
+            {
+                // initialize our cached allow list on demand
+                _allowedInternalAuthApis = InternalAuthApisAllowList.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries).Select(p => new PathString(p)).ToArray();
+            }
+
+            if (_allowedInternalAuthApis != null)
+            {
+                // An allow list is configured, so we ensure that the current request
+                // matches any of the allowed APIs.
+                foreach (PathString ps in _allowedInternalAuthApis)
+                {
+                    if (httpRequest.Path.StartsWithSegments(ps, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            // no allow list configured
+            return true;
         }
     }
 }

--- a/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs
+++ b/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs
@@ -13,7 +13,9 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -100,6 +102,13 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
             var header = request.Headers[ScriptConstants.AntaresPlatformInternal];
             string value = header.FirstOrDefault();
             return string.Compare(value, "true", StringComparison.OrdinalIgnoreCase) == 0;
+        }
+
+        public static bool IsInternalAuthAllowed(this HttpRequest httpRequest)
+        {
+            // Check to see if the specific API is allowed based on any configured allow list
+            var options = httpRequest.HttpContext.RequestServices.GetService<IOptions<FunctionsHostingConfigOptions>>().Value;
+            return options.CheckInternalAuthAllowList(httpRequest);
         }
 
         private static IEnvironment GetEnvironment(HttpRequest request, IEnvironment environment = null)

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -143,6 +143,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FeatureFlagEnableLegacyDurableVersionCheck = "EnableLegacyDurableVersionCheck";
         public const string HostingConfigSwtAuthenticationEnabled = "SwtAuthenticationEnabled";
         public const string HostingConfigSwtIssuerEnabled = "SwtIssuerEnabled";
+        public const string HostingConfigInternalAuthApisAllowList = "InternalAuthApisAllowList";
 
         public const string SiteAzureFunctionsUriFormat = "https://{0}.azurewebsites.net/azurefunctions";
         public const string ScmSiteUriFormat = "https://{0}.scm.azurewebsites.net";

--- a/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
@@ -139,7 +139,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 (nameof(FunctionsHostingConfigOptions.ThrowOnMissingFunctionsWorkerRuntime), "THROW_ON_MISSING_FUNCTIONS_WORKER_RUNTIME=1", true),
                 (nameof(FunctionsHostingConfigOptions.WorkerIndexingDisabledApps), "WORKER_INDEXING_DISABLED_APPS=teststring", "teststring"),
                 (nameof(FunctionsHostingConfigOptions.WorkerIndexingEnabled), "WORKER_INDEXING_ENABLED=1", true),
-                (nameof(FunctionsHostingConfigOptions.WorkerRuntimeStrictValidationEnabled), "WORKER_RUNTIME_STRICT_VALIDATION_ENABLED=1", true)
+                (nameof(FunctionsHostingConfigOptions.WorkerRuntimeStrictValidationEnabled), "WORKER_RUNTIME_STRICT_VALIDATION_ENABLED=1", true),
+
+                (nameof(FunctionsHostingConfigOptions.InternalAuthApisAllowList), "InternalAuthApisAllowList=|", "|"),
+                (nameof(FunctionsHostingConfigOptions.InternalAuthApisAllowList), "InternalAuthApisAllowList=/admin/host/foo|/admin/host/bar", "/admin/host/foo|/admin/host/bar")
             };
 
             // use reflection to ensure that we have a test that uses every value exposed on FunctionsHostingConfigOptions
@@ -279,6 +282,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             // returns false when disabled
             options.Features[ScriptConstants.HostingConfigSwtIssuerEnabled] = "0";
             Assert.False(options.SwtIssuerEnabled);
+        }
+
+        [Fact]
+        public void InternalAuthApisAllowList_ReturnsExpectedValue()
+        {
+            FunctionsHostingConfigOptions options = new FunctionsHostingConfigOptions();
+
+            Assert.Null(options.InternalAuthApisAllowList);
+
+            options.InternalAuthApisAllowList = string.Empty;
+            Assert.Equal(string.Empty, options.InternalAuthApisAllowList);
+
+            options.InternalAuthApisAllowList = "/admin/host/synctriggers|/admin/host/status";
+            Assert.Equal("/admin/host/synctriggers|/admin/host/status", options.InternalAuthApisAllowList);
         }
 
         internal static IHostBuilder GetScriptHostBuilder(string fileName, string fileContent)


### PR DESCRIPTION
Today, nearly all internal platform components are using token based authentication for host interactions. These changes will allow us to restrict internal platform auth usage to only those remaining APIs requiring it. The near term goal is to completely remove this unnecessary authentication mechanism.

I'll backport these changes to in-proc as well.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * https://github.com/Azure/azure-functions-host/pull/10502
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
