### PR TITLE
Include all release/in-proc branches for PR checks

### DIFF
--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -24,7 +24,7 @@ pr:
     - dev
     - in-proc
     - release/4.*
-    - release/in-proc
+    - release/in-proc*
 
 resources:
   repositories:


### PR DESCRIPTION
This PR modifies our PR checks to run on all branches that begin with `release/in-proc`. Previously, we were only running checks on the `release/in-proc` branch, but we now have a `release/in-proc-hotfix` branch (as an example).