### PR TITLE
Temporarily run CodeQL on all jobs

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -47,7 +47,7 @@ extends:
     sdl:
       codeql:
         # Move codeql for source languages to source analysis stage
-        runSourceLanguagesInSourceAnalysis: true
+        # runSourceLanguagesInSourceAnalysis: true # temporary change to clean up stale python resuls
 
     stages:
     - stage: Initialize

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -46,7 +46,7 @@ extends:
       codeql:
         compiled:
           enabled: true
-        runSourceLanguagesInSourceAnalysis: true
+        # runSourceLanguagesInSourceAnalysis: true # temporary change to clean up stale python resuls
 
     settings:
       # PR's from forks do not have sufficient permissions to set tags.


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

CodeQL has stale results for Python scans due to them being from a job ID which no longer scans python and us since addressing the issues (configured CodeQL to ignore python libraries). To clear out the results we will run CodeQL for all languages in all jobs (with the fixes in place). This should clear out the scans and we can then revert this PR.
