### PR TITLE
Do not unregister extension endpoints on shutdown

### DIFF
--- a/src/WebJobs.Script.Grpc/Server/ExtensionsCompositeEndpointDataSource.cs
+++ b/src/WebJobs.Script.Grpc/Server/ExtensionsCompositeEndpointDataSource.cs
@@ -191,6 +191,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             lock (_lock)
             {
                 // Do not clear out endpoints when host changes to null, as functions may still be running.
+                // TODO: there are still edge cases where we will switch active hosts, leading to potential
+                // issues with draining invocations.
                 if (args?.NewHost?.Services is { } services)
                 {
                     _extensionServices = services;

--- a/src/WebJobs.Script.Grpc/Server/ExtensionsCompositeEndpointDataSource.cs
+++ b/src/WebJobs.Script.Grpc/Server/ExtensionsCompositeEndpointDataSource.cs
@@ -26,10 +26,11 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
     internal sealed class ExtensionsCompositeEndpointDataSource : EndpointDataSource, IDisposable
     {
         private readonly object _lock = new();
-        private readonly List<EndpointDataSource> _dataSources = new();
         private readonly IScriptHostManager _scriptHostManager;
         private readonly TaskCompletionSource _initialized = new();
+        private readonly ILogger _logger;
 
+        private IList<EndpointDataSource> _dataSources = Array.Empty<EndpointDataSource>();
         private IServiceProvider _extensionServices;
         private List<Endpoint> _endpoints;
         private IChangeToken _consumerChangeToken;
@@ -37,10 +38,13 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         private List<IDisposable> _changeTokenRegistrations;
         private bool _disposed;
 
-        public ExtensionsCompositeEndpointDataSource(IScriptHostManager scriptHostManager)
+        public ExtensionsCompositeEndpointDataSource(
+            IScriptHostManager scriptHostManager,
+            ILogger<ExtensionsCompositeEndpointDataSource> logger)
         {
             _scriptHostManager = scriptHostManager;
             _scriptHostManager.ActiveHostChanged += OnHostChanged;
+            _logger = logger;
         }
 
         /// <inheritdoc />
@@ -186,23 +190,19 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         {
             lock (_lock)
             {
-                _dataSources.Clear();
+                // Do not clear out endpoints when host changes to null, as functions may still be running.
                 if (args?.NewHost?.Services is { } services)
                 {
                     _extensionServices = services;
-                    IEnumerable<WebJobsRpcEndpointDataSource> sources = services
-                        .GetService<IEnumerable<WebJobsRpcEndpointDataSource>>()
-                        ?? Enumerable.Empty<WebJobsRpcEndpointDataSource>();
-                    _dataSources.AddRange(sources);
+                    IEnumerable<EndpointDataSource> sources = services.GetServices<WebJobsRpcEndpointDataSource>();
+                    _dataSources = sources.ToList();
+
+                    int totalEndpoints = _dataSources.Sum(x => x.Endpoints.Count);
+                    _logger.LogDebug("Host changed. Registering {ExtensionCount} extension data sources and {EndpointCount} total endpoints.", _dataSources.Count, totalEndpoints);
                     _initialized.TrySetResult(); // signal we have first initialized.
-                }
-                else
-                {
-                    _extensionServices = null;
+                    OnEndpointsChange(collectionChanged: true);
                 }
             }
-
-            OnEndpointsChange(collectionChanged: true);
         }
 
         private void OnEndpointsChange(bool collectionChanged)

--- a/src/WebJobs.Script/Host/IScriptHostManager.cs
+++ b/src/WebJobs.Script/Host/IScriptHostManager.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Script
         event EventHandler HostInitializing;
 
         /// <summary>
-        /// Evewnt raised when the active host managed by this instance changes.
+        /// Event raised when the active host managed by this instance changes.
         /// </summary>
         event EventHandler<ActiveHostChangedEventArgs> ActiveHostChanged;
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/ExtensionsCompositeEndpointDataSourceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/ExtensionsCompositeEndpointDataSourceTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
-        public void ActiveHostChanged_NullHost_NoEndpoints()
+        public void ActiveHostChanged_NullHost_EndpointsRemain()
         {
             Mock<IScriptHostManager> manager = new();
             ExtensionsCompositeEndpointDataSource dataSource = new(manager.Object, _dataSourceLogger);
@@ -43,8 +43,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             IChangeToken token = dataSource.GetChangeToken();
             Assert.False(token.HasChanged);
             manager.Raise(x => x.ActiveHostChanged += null, new ActiveHostChangedEventArgs(null, null));
-            Assert.True(token.HasChanged);
-            Assert.Empty(dataSource.Endpoints);
+            Assert.False(token.HasChanged);
+            Assert.NotEmpty(dataSource.Endpoints);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Workers/Rpc/ExtensionsCompositeEndpointDataSourceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/ExtensionsCompositeEndpointDataSourceTests.cs
@@ -44,7 +44,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.False(token.HasChanged);
             manager.Raise(x => x.ActiveHostChanged += null, new ActiveHostChangedEventArgs(null, null));
             Assert.False(token.HasChanged);
-            Assert.NotEmpty(dataSource.Endpoints);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #10251

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md` -- TODO
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Addresses an issue where on host shutdown gRPC extension endpoints would be unregistered before functions had finished draining. This could lead to gRPC "unimplemented" errors if those functions attempted to call a gRPC extension.

The fix is to _not_ unregister extension endpoints when active host changes to null. Instead, only non-null active host changes are processed.

#### Concerns

I am unsure if this is ever a possible scenario, but there is undefined behavior if we are transitioning from one non-null active host to another. We will still switch over to the new host's endpoints (if any) before old hosts' functions complete.

**UPDATE:** Synced with @fabiocav and there are definitely scenarios this fix will not cover (one JobHost draining while another spins up). However, this is still a net-improvement (solving the common host shutdown issue). Addressing the last issue is a **much** larger work item. To address this, I am going to explore moving gRPC extension server into the JobHost itself, which will completely solve the lifetime issue among others. I will explore this at a later time, proceeding with this improvement for now.