### PR TITLE
Add metadata provider timeout host config

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -8,3 +8,5 @@
 - Improving console log handling during specialization (#10345)
 - Update Node.js Worker Version to [3.10.1](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.10.1)
 - Remove packages `Microsoft.Azure.Cosmos.Table` and `Microsoft.Azure.DocumentDB.Core` (#10503)
+- Implement host configuration property to all configuration of the metadata provider timeout (#10526)
+  - The value can be set via `metadataProviderTimeout` in host.json and defaults to "00:00:30" (30 seconds)

--- a/release_notes.md
+++ b/release_notes.md
@@ -8,5 +8,6 @@
 - Improving console log handling during specialization (#10345)
 - Update Node.js Worker Version to [3.10.1](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.10.1)
 - Remove packages `Microsoft.Azure.Cosmos.Table` and `Microsoft.Azure.DocumentDB.Core` (#10503)
-- Implement host configuration property to all configuration of the metadata provider timeout (#10526)
-  - The value can be set via `metadataProviderTimeout` in host.json and defaults to "00:00:30" (30 seconds)
+- Implement host configuration property to allow configuration of the metadata provider timeout period (#10526)
+  - The value can be set via `metadataProviderTimeout` in host.json and defaults to "00:00:30" (30 seconds).
+  - For logic apps, unless configured via the host.json, the timeout is disabled by default.

--- a/src/WebJobs.Script/Config/ConfigurationSectionNames.cs
+++ b/src/WebJobs.Script/Config/ConfigurationSectionNames.cs
@@ -25,5 +25,6 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
         public const string SequentialJobHostRestart = JobHost + ":sequentialRestart";
         public const string SendCanceledInvocationsToWorker = "sendCanceledInvocationsToWorker";
         public const string TelemetryMode = "telemetryMode";
+        public const string MetadataProviderTimeout = "metadataProviderTimeout";
     }
 }

--- a/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
@@ -51,7 +51,8 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             {
                 "version", "functionTimeout", "retry", "functions", "http", "watchDirectories", "watchFiles", "queues", "serviceBus",
                 "eventHub", "singleton", "logging", "aggregator", "healthMonitor", "extensionBundle", "managedDependencies",
-                "customHandler", "httpWorker", "extensions", "concurrency", ConfigurationSectionNames.SendCanceledInvocationsToWorker
+                "customHandler", "httpWorker", "extensions", "concurrency", ConfigurationSectionNames.SendCanceledInvocationsToWorker,
+                ConfigurationSectionNames.MetadataProviderTimeout
             };
 
             private readonly HostJsonFileConfigurationSource _configurationSource;

--- a/src/WebJobs.Script/Config/ScriptJobHostOptions.cs
+++ b/src/WebJobs.Script/Config/ScriptJobHostOptions.cs
@@ -135,5 +135,11 @@ namespace Microsoft.Azure.WebJobs.Script
         /// Gets or sets the telemetry mode.
         /// </summary>
         internal TelemetryMode TelemetryMode { get; set; } = TelemetryMode.ApplicationInsights;
+
+        /// <summary>
+        /// Gets or sets a value indicating the timeout duration for the function metadata provider.
+        /// Defaults to 30 seconds.
+        /// </summary>
+        public TimeSpan? MetadataProviderTimeout { get; set; }
     }
 }

--- a/src/WebJobs.Script/Config/ScriptJobHostOptions.cs
+++ b/src/WebJobs.Script/Config/ScriptJobHostOptions.cs
@@ -138,8 +138,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
         /// <summary>
         /// Gets or sets a value indicating the timeout duration for the function metadata provider.
-        /// Defaults to 30 seconds.
         /// </summary>
-        public TimeSpan MetadataProviderTimeout { get; set; } = TimeSpan.FromSeconds(30);
+        public TimeSpan MetadataProviderTimeout { get; set; } = TimeSpan.Zero;
     }
 }

--- a/src/WebJobs.Script/Config/ScriptJobHostOptions.cs
+++ b/src/WebJobs.Script/Config/ScriptJobHostOptions.cs
@@ -140,6 +140,6 @@ namespace Microsoft.Azure.WebJobs.Script
         /// Gets or sets a value indicating the timeout duration for the function metadata provider.
         /// Defaults to 30 seconds.
         /// </summary>
-        public TimeSpan? MetadataProviderTimeout { get; set; }
+        public TimeSpan MetadataProviderTimeout { get; set; } = TimeSpan.FromSeconds(30);
     }
 }

--- a/src/WebJobs.Script/Config/ScriptJobHostOptionsSetup.cs
+++ b/src/WebJobs.Script/Config/ScriptJobHostOptionsSetup.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 using Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
@@ -59,6 +60,12 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             // FunctionTimeout
             ConfigureFunctionTimeout(options);
 
+            if (_environment.IsLogicApp())
+            {
+                // Logic Apps requires no timeout
+                options.MetadataProviderTimeout = Timeout.InfiniteTimeSpan;
+            }
+
             // If we have a read only file system, override any configuration and
             // disable file watching
             if (_applicationHostOptions.Value.IsFileSystemReadOnly)
@@ -88,7 +95,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
 
         private void ConfigureFunctionTimeout(ScriptJobHostOptions options)
         {
-            if (options.FunctionTimeout == null)
+            if (options.FunctionTimeout is null)
             {
                 options.FunctionTimeout = (_environment.IsConsumptionSku() && !_environment.IsFlexConsumptionSku()) ? DefaultConsumptionFunctionTimeout : DefaultFunctionTimeout;
             }

--- a/src/WebJobs.Script/Config/ScriptJobHostOptionsSetup.cs
+++ b/src/WebJobs.Script/Config/ScriptJobHostOptionsSetup.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
         internal static readonly TimeSpan DefaultConsumptionFunctionTimeout = TimeSpan.FromMinutes(5);
         internal static readonly TimeSpan MaxFunctionTimeoutDynamic = TimeSpan.FromMinutes(10);
         internal static readonly TimeSpan DefaultFunctionTimeout = TimeSpan.FromMinutes(30);
+        internal static readonly TimeSpan DefaultMetadataProviderTimeout = TimeSpan.FromSeconds(30);
 
         public ScriptJobHostOptionsSetup(IConfiguration configuration, IEnvironment environment, IOptions<ScriptApplicationHostOptions> applicationHostOptions)
         {
@@ -60,10 +61,10 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             // FunctionTimeout
             ConfigureFunctionTimeout(options);
 
-            if (_environment.IsLogicApp())
+            if (options.MetadataProviderTimeout == TimeSpan.Zero)
             {
-                // Logic Apps requires no timeout
-                options.MetadataProviderTimeout = Timeout.InfiniteTimeSpan;
+                // If the timeout value is not configured and we are running in a logic app, we want to disable the timeout
+                options.MetadataProviderTimeout = _environment.IsLogicApp() ? Timeout.InfiniteTimeSpan : DefaultMetadataProviderTimeout;
             }
 
             // If we have a read only file system, override any configuration and

--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Script
 {
     public class FunctionMetadataManager : IFunctionMetadataManager
     {
-        private const string FunctionConfigurationErrorMessage = "Unable to determine the primary function script.Make sure atleast one script file is present.Try renaming your entry point script to 'run' or alternatively you can specify the name of the entry point script explicitly by adding a 'scriptFile' property to your function metadata.";
+        private const string FunctionConfigurationErrorMessage = "Unable to determine the primary function script. Make sure atleast one script file is present. Try renaming your entry point script to 'run' or alternatively you can specify the name of the entry point script explicitly by adding a 'scriptFile' property to your function metadata.";
         private const string MetadataProviderName = "Custom";
         private const int DefaultMetadataProviderTimeoutInSeconds = 30;
         private readonly IServiceProvider _serviceProvider;
@@ -39,12 +39,15 @@ namespace Microsoft.Azure.WebJobs.Script
             IOptions<HttpWorkerOptions> httpWorkerOptions, IScriptHostManager scriptHostManager, ILoggerFactory loggerFactory,
             IEnvironment environment)
         {
-            _scriptOptions = scriptOptions;
+            _scriptOptions = scriptOptions ?? throw new ArgumentNullException(nameof(scriptOptions));
             _serviceProvider = scriptHostManager as IServiceProvider;
             _functionMetadataProvider = functionMetadataProvider;
             _logger = loggerFactory.CreateLogger(LogCategories.Startup);
             _isHttpWorker = httpWorkerOptions?.Value?.Description != null;
             _environment = environment;
+
+            var metadataProviderTimeout = _scriptOptions.Value.MetadataProviderTimeout;
+            MetadataProviderTimeoutInSeconds = metadataProviderTimeout.HasValue ? metadataProviderTimeout.Value.TotalSeconds : DefaultMetadataProviderTimeoutInSeconds;
 
             // Every time script host is re-initializing, we also need to re-initialize
             // services that change with the scope of the script host.
@@ -58,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         // Property is settable for testing purposes.
-        internal int MetadataProviderTimeoutInSeconds { get; set; } = DefaultMetadataProviderTimeoutInSeconds;
+        internal int MetadataProviderTimeoutInSeconds { get; set; }
 
         public ImmutableDictionary<string, ImmutableArray<string>> Errors { get; private set; }
 

--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Script
 {
     public class FunctionMetadataManager : IFunctionMetadataManager
     {
-        private const string FunctionConfigurationErrorMessage = "Unable to determine the primary function script. Make sure atleast one script file is present. Try renaming your entry point script to 'run' or alternatively you can specify the name of the entry point script explicitly by adding a 'scriptFile' property to your function metadata.";
+        private const string FunctionConfigurationErrorMessage = "Unable to determine the primary function script. Make sure at least one script file is present. Try renaming your entry point script to 'run' or alternatively you can specify the name of the entry point script explicitly by adding a 'scriptFile' property to your function metadata.";
         private const string MetadataProviderName = "Custom";
         private readonly IServiceProvider _serviceProvider;
         private IFunctionMetadataProvider _functionMetadataProvider;

--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Script
             IOptions<HttpWorkerOptions> httpWorkerOptions, IScriptHostManager scriptHostManager, ILoggerFactory loggerFactory,
             IEnvironment environment)
         {
-            _scriptOptions = scriptOptions ?? throw new ArgumentNullException(nameof(scriptOptions));
+            _scriptOptions = scriptOptions;
             _serviceProvider = scriptHostManager as IServiceProvider;
             _functionMetadataProvider = functionMetadataProvider;
             _logger = loggerFactory.CreateLogger(LogCategories.Startup);

--- a/test/WebJobs.Script.Tests/Configuration/ScriptJobHostOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ScriptJobHostOptionsSetupTests.cs
@@ -334,6 +334,38 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             Assert.Equal(expectedMode, options.TelemetryMode.ToString());
         }
 
+        [Fact]
+        public void Configure_MetadataProviderTimeout_ValidateDefaultTimeoutValue()
+        {
+            var options = GetConfiguredOptions(new Dictionary<string, string>());
+
+            Assert.Equal(TimeSpan.FromSeconds(30), options.MetadataProviderTimeout);
+        }
+
+        [Fact]
+        public void Configure_MetadataProviderTimeout_IsLogicApp_SetTimeoutToInfinite()
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AppKind, "workflowapp");
+
+            var options = GetConfiguredOptions(new Dictionary<string, string>(), environment);
+
+            Assert.Equal(TimeSpan.FromMilliseconds(-1), options.MetadataProviderTimeout);
+        }
+
+        [Fact]
+        public void Configure_MetadataProviderTimeout_AppliesConfiguredTimeoutValue()
+        {
+            var settings = new Dictionary<string, string>
+            {
+                { ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "metadataProviderTimeout"), "00:00:43" }
+            };
+
+            var options = GetConfiguredOptions(settings);
+
+            Assert.Equal(TimeSpan.FromSeconds(43), options.MetadataProviderTimeout);
+        }
+
         private ScriptJobHostOptions GetConfiguredOptions(Dictionary<string, string> settings, IEnvironment environment = null)
         {
             ScriptJobHostOptionsSetup setup = CreateSetupWithConfiguration(settings, environment);

--- a/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 mockFunctionMetadataProvider.Object, new List<IFunctionProvider>() { goodFunctionMetadataProvider.Object, badFunctionMetadataProvider.Object }, new OptionsWrapper<HttpWorkerOptions>(_defaultHttpWorkerOptions), loggerFactory, new TestOptionsMonitor<LanguageWorkerOptions>(TestHelpers.GetTestLanguageWorkerOptions()));
 
             // Set the timeout to 1 second for the test.
-            testFunctionMetadataManager.MetadataProviderTimeoutInSeconds = 1;
+            testFunctionMetadataManager.MetadataProviderTimeout = TimeSpan.FromSeconds(1);
 
             var exception = Assert.Throws<TimeoutException>(() => testFunctionMetadataManager.LoadFunctionMetadata());
             Assert.Contains($"Timeout occurred while retrieving metadata from provider '{badFunctionMetadataProvider.Object.GetType().FullName}'. The operation exceeded the configured timeout of 1 seconds.", exception.Message);

--- a/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
@@ -17,13 +17,12 @@ using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
 using Moq;
 using Xunit;
-using static Microsoft.Azure.AppService.Proxy.Common.Constants.WellKnownHttpHeaders;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class FunctionMetadataManagerTests
     {
-        private const string _expectedErrorMessage = "Unable to determine the primary function script.Make sure atleast one script file is present.Try renaming your entry point script to 'run' or alternatively you can specify the name of the entry point script explicitly by adding a 'scriptFile' property to your function metadata.";
+        private const string _expectedErrorMessage = "Unable to determine the primary function script. Make sure at least one script file is present. Try renaming your entry point script to 'run' or alternatively you can specify the name of the entry point script explicitly by adding a 'scriptFile' property to your function metadata.";
         private ScriptJobHostOptions _scriptJobHostOptions = new ScriptJobHostOptions();
         private Mock<IFunctionMetadataProvider> _mockFunctionMetadataProvider;
         private FunctionMetadataManager _testFunctionMetadataManager;

--- a/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 mockFunctionMetadataProvider.Object, new List<IFunctionProvider>() { goodFunctionMetadataProvider.Object, badFunctionMetadataProvider.Object }, new OptionsWrapper<HttpWorkerOptions>(_defaultHttpWorkerOptions), loggerFactory, new TestOptionsMonitor<LanguageWorkerOptions>(TestHelpers.GetTestLanguageWorkerOptions()));
 
             // Set the timeout to 1 second for the test.
-            testFunctionMetadataManager.MetadataProviderTimeout = TimeSpan.FromSeconds(1);
+            _scriptJobHostOptions.MetadataProviderTimeout = TimeSpan.FromSeconds(1);
 
             var exception = Assert.Throws<TimeoutException>(() => testFunctionMetadataManager.LoadFunctionMetadata());
             Assert.Contains($"Timeout occurred while retrieving metadata from provider '{badFunctionMetadataProvider.Object.GetType().FullName}'. The operation exceeded the configured timeout of 1 seconds.", exception.Message);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #10529

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR: #10545
* [ ] My changes **do not** require documentation changes
    * [x] Otherwise: Documentation issue linked to PR: **TODO:// Update host.json spec**
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #10545
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Adding a metadata provider timeout setting to the host.config to make this value configurable. For logic apps, we will not have a timeout limit.
