### PR TITLE
Update runtime site handling for token audiences

### DIFF
--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class ScriptJwtBearerExtensions
     {
+        private const string DeploymentSlotSeparator = "__";
         private static double _specialized = 0;
 
         public static AuthenticationBuilder AddScriptJwtBearer(this AuthenticationBuilder builder)
@@ -110,15 +111,26 @@ namespace Microsoft.Extensions.DependencyInjection
             string runtimeSiteName = ScriptSettingsManager.Instance.GetSetting(AzureWebsiteRuntimeSiteName);
             var audiences = new List<string>
             {
-                string.Format(SiteAzureFunctionsUriFormat, siteName),
-                string.Format(SiteUriFormat, siteName)
+                string.Format(SiteUriFormat, siteName),
+                string.Format(SiteAzureFunctionsUriFormat, siteName)
             };
 
-            if (!string.IsNullOrEmpty(runtimeSiteName) && !string.Equals(siteName, runtimeSiteName, StringComparison.OrdinalIgnoreCase))
+            if (TryGetNormalizedSiteName(siteName, out string normalizedSiteName))
             {
-                // on a non-production slot, the runtime site name will differ from the site name
-                // we allow both for audience
-                audiences.Add(string.Format(SiteUriFormat, runtimeSiteName));
+                // If we're dealing with a runtime site name (e.g. https://test__5bb5.azurewebsites.net)
+                // we want to add a normalized version (e.g. https://test.azurewebsites.net).
+                audiences.Add(string.Format(SiteUriFormat, normalizedSiteName));
+            }
+
+            if (!string.IsNullOrEmpty(runtimeSiteName))
+            {
+                // In slots scenarios the runtime site name can differ from the site name
+                // we allow both for audience.
+                string audience = string.Format(SiteUriFormat, runtimeSiteName);
+                if (!audiences.Contains(audience, StringComparer.OrdinalIgnoreCase))
+                {
+                    audiences.Add(audience);
+                }
             }
 
             return audiences;
@@ -158,12 +170,61 @@ namespace Microsoft.Extensions.DependencyInjection
             return issuer;
         }
 
-        private static bool AudienceValidator(IEnumerable<string> audiences, SecurityToken securityToken, TokenValidationParameters validationParameters)
+        internal static bool AudienceValidator(IEnumerable<string> audiences, SecurityToken securityToken, TokenValidationParameters validationParameters)
         {
             foreach (string audience in audiences)
             {
+                // First see if we have an exact match.
                 if (validationParameters.ValidAudiences.Any(p => string.Equals(audience, p, StringComparison.OrdinalIgnoreCase)))
                 {
+                    return true;
+                }
+
+                // In slots scenarios, the hostname of the incoming audience may include a runtime
+                // site name slot component (e.g. https://test__5bb5.azurewebsites.net). We normalize
+                // this by removing the slot component (e.g. "__5bb5") and check again.
+                if (TryGetNormalizedAudience(audience, out string normalizedAudience) &&
+                    validationParameters.ValidAudiences.Any(p => string.Equals(normalizedAudience, p, StringComparison.OrdinalIgnoreCase)))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool TryGetNormalizedAudience(string audience, out string normalizedAudience)
+        {
+            normalizedAudience = null;
+
+            if (!string.IsNullOrEmpty(audience))
+            {
+                int left = audience.IndexOf(DeploymentSlotSeparator);
+                if (left != -1)
+                {
+                    int right = audience.IndexOf('.', left);
+                    int length = right - left;
+                    if (length > 0)
+                    {
+                        normalizedAudience = audience.Remove(left, length);
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static bool TryGetNormalizedSiteName(string siteName, out string normalizedSiteName)
+        {
+            normalizedSiteName = null;
+
+            if (!string.IsNullOrEmpty(siteName))
+            {
+                int idx = siteName.IndexOf(DeploymentSlotSeparator);
+                if (idx != -1)
+                {
+                    normalizedSiteName = siteName.Substring(0, idx);
                     return true;
                 }
             }


### PR DESCRIPTION
The previous fix I made in this area in https://github.com/Azure/azure-functions-host/pull/10183 works for most SKUs. However, it turns out that for Linux EP LWAS doesn't set WEBSITE_DEPLOYMENT_ID so we don't end up adding the runtime site name to audiences on that SKU. This came up in recent CRI https://portal.microsofticm.com/imp/v5/incidents/details/534693023. Example query showing that on the latest host version with the previous fix, we still get audience validation failures:

```
All("FunctionsLogs")
| where PreciseTimeStamp > ago(1h)
| where SourceNamespace == "LWAWS"
| where Source == "Host.Authentication"
| where Summary contains "Token audience validation failed for audience"
| where HostVersion == "4.1036.2.2"
| project PreciseTimeStamp, SourceNamespace, AppName, Summary
| take 10
```


This PR addresses this by performing a normalization on incoming audience values, removing any slot component and checking for an audience match again.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * https://github.com/Azure/azure-functions-host/pull/10544
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
