### PR TITLE
Add hosting config support to control 3.x log disablement

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,3 +5,4 @@
 *Please note we have reached end-of-life (EOL) support for v3.x.* For more information on supported runtime versions, please see [here.](https://learn.microsoft.com/en-us/azure/azure-functions/functions-versions?tabs=v4&pivots=programming-language-csharp)
 
 - Disable all non host startup logs for v3.x (#10399)
+- Add hosting config (`DisableHostLogs`) to enable/disable v3.x logs (#10552)

--- a/src/WebJobs.Script.WebHost/Diagnostics/ILoggingBuilderExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/ILoggingBuilderExtensions.cs
@@ -8,12 +8,12 @@ namespace Microsoft.Extensions.Logging
 {
     public static class ILoggingBuilderExtensions
     {
-        public static void AddWebJobsSystem<T>(this ILoggingBuilder builder) where T : SystemLoggerProvider
+        public static void AddWebJobsSystem<T>(this ILoggingBuilder builder, bool restrictHostLogs = false) where T : SystemLoggerProvider
         {
             builder.Services.AddSingleton<ILoggerProvider, T>();
 
             // Log all logs to SystemLogger
-            builder.AddDefaultWebJobsFilters<T>(LogLevel.Trace);
+            builder.AddDefaultWebJobsFilters<T>(LogLevel.Trace, restrictHostLogs);
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -75,9 +75,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 })
                 .ConfigureLogging(loggingBuilder =>
                 {
-                    loggingBuilder.Services.AddSingleton<ILoggerFactory, ScriptLoggerFactory>();
+                    var hostingConfigOptions = rootServiceProvider.GetService<IOptions<FunctionsHostingConfigOptions>>();
+                    var restrictHostLogs = RestrictHostLogs(hostingConfigOptions.Value);
 
-                    loggingBuilder.AddWebJobsSystem<SystemLoggerProvider>();
+                    loggingBuilder.Services.AddSingleton<ILoggerFactory, ScriptLoggerFactory>();
+                    loggingBuilder.AddDefaultWebJobsFilters(restrictHostLogs);
+                    loggingBuilder.AddWebJobsSystem<SystemLoggerProvider>(restrictHostLogs);
+
                     if (environment.IsAzureMonitorEnabled())
                     {
                         loggingBuilder.Services.AddSingleton<ILoggerProvider, AzureMonitorDiagnosticLoggerProvider>();
@@ -168,6 +172,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             {
                 configureBuilder.Configure(builder);
             }
+        }
+
+        private static bool RestrictHostLogs(FunctionsHostingConfigOptions options)
+        {
+            // Feature flag should take precedence over the host configuration
+            return !FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableHostLogs) && options.RestrictHostLogs;
         }
 
         /// <summary>

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -79,7 +79,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     var restrictHostLogs = RestrictHostLogs(hostingConfigOptions.Value);
 
                     loggingBuilder.Services.AddSingleton<ILoggerFactory, ScriptLoggerFactory>();
-                    loggingBuilder.AddDefaultWebJobsFilters(restrictHostLogs);
                     loggingBuilder.AddWebJobsSystem<SystemLoggerProvider>(restrictHostLogs);
 
                     if (environment.IsAzureMonitorEnabled())

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -86,6 +86,22 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether non-critical logs should be disabled in the host.
+        /// </summary>
+        public bool RestrictHostLogs
+        {
+            get
+            {
+                return GetFeatureOrDefault(ScriptConstants.HostingConfigRestrictHostLogs, "1") == "1";
+            }
+
+            set
+            {
+                _features[ScriptConstants.HostingConfigRestrictHostLogs] = value ? "1" : "0";
+            }
+        }
+
+        /// <summary>
         /// Gets feature by name.
         /// </summary>
         /// <param name="name">Feature name.</param>

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         {
             get
             {
-                return GetFeatureOrDefault(ScriptConstants.HostingConfigRestrictHostLogs, "1") == "1";
+                return GetFeatureOrDefault(ScriptConstants.HostingConfigRestrictHostLogs, "0") == "1";
             }
 
             set

--- a/src/WebJobs.Script/Extensions/ScriptLoggingBuilderExtensions.cs
+++ b/src/WebJobs.Script/Extensions/ScriptLoggingBuilderExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.Logging
     public static class ScriptLoggingBuilderExtensions
     {
         private static ConcurrentDictionary<string, bool> _filteredCategoryCache = new ();
-        private static ImmutableArray<string> _allowedLogCategoryPrefixes = new ();
+        private static ImmutableArray<string> _allowedLogCategoryPrefixes = ImmutableArray<string>.Empty;
 
         // For testing only
         internal static ImmutableArray<string> AllowedSystemLogPrefixes => _allowedLogCategoryPrefixes;

--- a/src/WebJobs.Script/Extensions/ScriptLoggingBuilderExtensions.cs
+++ b/src/WebJobs.Script/Extensions/ScriptLoggingBuilderExtensions.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Azure.WebJobs.Script;
-using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
@@ -16,16 +15,24 @@ namespace Microsoft.Extensions.Logging
     public static class ScriptLoggingBuilderExtensions
     {
         private static ConcurrentDictionary<string, bool> _filteredCategoryCache = new ConcurrentDictionary<string, bool>();
+        private static ImmutableArray<string> _allowedLogCategoryPrefixes = ScriptConstants.SystemLogCategoryPrefixes;
 
-        public static ILoggingBuilder AddDefaultWebJobsFilters(this ILoggingBuilder builder)
+        // For testing only
+        internal static ImmutableArray<string> AllowedSystemLogPrefixes => _allowedLogCategoryPrefixes;
+
+        public static ILoggingBuilder AddDefaultWebJobsFilters(this ILoggingBuilder builder, bool restrictHostLogs = false)
         {
+            SetSystemLogCategoryPrefixes(restrictHostLogs);
+
             builder.SetMinimumLevel(LogLevel.None);
             builder.AddFilter((c, l) => Filter(c, l, LogLevel.Information));
             return builder;
         }
 
-        public static ILoggingBuilder AddDefaultWebJobsFilters<T>(this ILoggingBuilder builder, LogLevel level) where T : ILoggerProvider
+        public static ILoggingBuilder AddDefaultWebJobsFilters<T>(this ILoggingBuilder builder, LogLevel level, bool restrictHostLogs = false) where T : ILoggerProvider
         {
+            SetSystemLogCategoryPrefixes(restrictHostLogs);
+
             builder.AddFilter<T>(null, LogLevel.None);
             builder.AddFilter<T>((c, l) => Filter(c, l, level));
             return builder;
@@ -38,11 +45,17 @@ namespace Microsoft.Extensions.Logging
 
         private static bool IsFiltered(string category)
         {
-            ImmutableArray<string> systemLogCategoryPrefixes = FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableHostLogs)
-                                                                ? ScriptConstants.SystemLogCategoryPrefixes
-                                                                : ScriptConstants.RestrictedSystemLogCategoryPrefixes;
+            return _filteredCategoryCache.GetOrAdd(category, c => _allowedLogCategoryPrefixes.Any(p => c.StartsWith(p)));
+        }
 
-            return _filteredCategoryCache.GetOrAdd(category, c => systemLogCategoryPrefixes.Any(p => category.StartsWith(p)));
+        private static void SetSystemLogCategoryPrefixes(bool restrictHostLogs)
+        {
+            // Once restrictHostLogs is set to true, it stays true for the rest of the application's lifetime
+            // Set _allowedLogCategoryPrefixes to the restricted prefixes and clear the filter cache
+            if (restrictHostLogs)
+            {
+                _allowedLogCategoryPrefixes = ScriptConstants.RestrictedSystemLogCategoryPrefixes;
+            }
         }
 
         public static void AddConsoleIfEnabled(this ILoggingBuilder builder, HostBuilderContext context)

--- a/src/WebJobs.Script/Extensions/ScriptLoggingBuilderExtensions.cs
+++ b/src/WebJobs.Script/Extensions/ScriptLoggingBuilderExtensions.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Extensions.Logging
 {
     public static class ScriptLoggingBuilderExtensions
     {
-        private static ConcurrentDictionary<string, bool> _filteredCategoryCache = new ConcurrentDictionary<string, bool>();
-        private static ImmutableArray<string> _allowedLogCategoryPrefixes = ScriptConstants.SystemLogCategoryPrefixes;
+        private static ConcurrentDictionary<string, bool> _filteredCategoryCache = new ();
+        private static ImmutableArray<string> _allowedLogCategoryPrefixes = new ();
 
         // For testing only
         internal static ImmutableArray<string> AllowedSystemLogPrefixes => _allowedLogCategoryPrefixes;
@@ -50,12 +50,7 @@ namespace Microsoft.Extensions.Logging
 
         private static void SetSystemLogCategoryPrefixes(bool restrictHostLogs)
         {
-            // Once restrictHostLogs is set to true, it stays true for the rest of the application's lifetime
-            // Set _allowedLogCategoryPrefixes to the restricted prefixes and clear the filter cache
-            if (restrictHostLogs)
-            {
-                _allowedLogCategoryPrefixes = ScriptConstants.RestrictedSystemLogCategoryPrefixes;
-            }
+            _allowedLogCategoryPrefixes = restrictHostLogs ? ScriptConstants.RestrictedSystemLogCategoryPrefixes : ScriptConstants.SystemLogCategoryPrefixes;
         }
 
         public static void AddConsoleIfEnabled(this ILoggingBuilder builder, HostBuilderContext context)

--- a/src/WebJobs.Script/Extensions/ScriptLoggingBuilderExtensions.cs
+++ b/src/WebJobs.Script/Extensions/ScriptLoggingBuilderExtensions.cs
@@ -50,7 +50,13 @@ namespace Microsoft.Extensions.Logging
 
         private static void SetSystemLogCategoryPrefixes(bool restrictHostLogs)
         {
+            var previous = _allowedLogCategoryPrefixes;
             _allowedLogCategoryPrefixes = restrictHostLogs ? ScriptConstants.RestrictedSystemLogCategoryPrefixes : ScriptConstants.SystemLogCategoryPrefixes;
+
+            if (!previous.IsDefault && !previous.SequenceEqual(_allowedLogCategoryPrefixes))
+            {
+                _filteredCategoryCache.Clear();
+            }
         }
 
         public static void AddConsoleIfEnabled(this ILoggingBuilder builder, HostBuilderContext context)

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public static readonly long DefaultMaxRequestBodySize = 104857600;
 
         public static readonly ImmutableArray<string> SystemLogCategoryPrefixes = ImmutableArray.Create("Microsoft.Azure.WebJobs.", "Function.", "Worker.", "Host.");
-        public static readonly ImmutableArray<string> RestrictedSystemLogCategoryPrefixes = ImmutableArray.Create("Host.Startup.");
+        public static readonly ImmutableArray<string> RestrictedSystemLogCategoryPrefixes = ImmutableArray.Create("Host.Startup");
 
         public static readonly string FunctionsHostingConfigSectionName = "FunctionsHostingConfig";
         public static readonly string MaximumSupportedBundleV3Version = "FunctionRuntimeV3MaxBundleV3Version";

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -127,6 +127,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FeatureFlagEnableHostLogs = "EnableHostLogs";
         public const string HostingConfigSwtAuthenticationEnabled = "SwtAuthenticationEnabled";
         public const string HostingConfigSwtIssuerEnabled = "SwtIssuerEnabled";
+        public const string HostingConfigRestrictHostLogs = "RestrictHostLogs";
 
         public const string SiteAzureFunctionsUriFormat = "https://{0}.azurewebsites.net/azurefunctions";
         public const string ScmSiteUriFormat = "https://{0}.scm.azurewebsites.net";
@@ -215,7 +216,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public static readonly long DefaultMaxRequestBodySize = 104857600;
 
         public static readonly ImmutableArray<string> SystemLogCategoryPrefixes = ImmutableArray.Create("Microsoft.Azure.WebJobs.", "Function.", "Worker.", "Host.");
-        public static readonly ImmutableArray<string> RestrictedSystemLogCategoryPrefixes = ImmutableArray.Create("Host.Startup");
+        public static readonly ImmutableArray<string> RestrictedSystemLogCategoryPrefixes = ImmutableArray.Create("Host.Startup.");
 
         public static readonly string FunctionsHostingConfigSectionName = "FunctionsHostingConfig";
         public static readonly string MaximumSupportedBundleV3Version = "FunctionRuntimeV3MaxBundleV3Version";

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -81,9 +81,7 @@ namespace Microsoft.Azure.WebJobs.Script
             // Host configuration
             builder.ConfigureLogging((context, loggingBuilder) =>
             {
-                var hostingConfigOptions = applicationOptions.RootServiceProvider.GetService<IOptions<FunctionsHostingConfigOptions>>();
-                var restrictHostLogs = RestrictHostLogs(hostingConfigOptions.Value, SystemEnvironment.Instance);
-                loggingBuilder.AddDefaultWebJobsFilters(restrictHostLogs);
+                loggingBuilder.AddDefaultWebJobsFilters();
 
                 string loggingPath = ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "Logging");
                 loggingBuilder.AddConfiguration(context.Configuration.GetSection(loggingPath));
@@ -492,12 +490,6 @@ namespace Microsoft.Azure.WebJobs.Script
                 logger.LogDebug("Using InMemoryDistributedLockManager in Functions Host.");
                 return new InMemoryDistributedLockManager();
             }
-        }
-
-        private static bool RestrictHostLogs(FunctionsHostingConfigOptions options, IEnvironment environment)
-        {
-            // Feature flag should take precedence over the host configuration
-            return !FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableHostLogs, environment) && options.RestrictHostLogs;
         }
 
         /// <summary>

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -81,7 +81,9 @@ namespace Microsoft.Azure.WebJobs.Script
             // Host configuration
             builder.ConfigureLogging((context, loggingBuilder) =>
             {
-                loggingBuilder.AddDefaultWebJobsFilters();
+                var hostingConfigOptions = applicationOptions.RootServiceProvider.GetService<IOptions<FunctionsHostingConfigOptions>>();
+                var restrictHostLogs = RestrictHostLogs(hostingConfigOptions.Value, SystemEnvironment.Instance);
+                loggingBuilder.AddDefaultWebJobsFilters(restrictHostLogs);
 
                 string loggingPath = ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "Logging");
                 loggingBuilder.AddConfiguration(context.Configuration.GetSection(loggingPath));
@@ -490,6 +492,12 @@ namespace Microsoft.Azure.WebJobs.Script
                 logger.LogDebug("Using InMemoryDistributedLockManager in Functions Host.");
                 return new InMemoryDistributedLockManager();
             }
+        }
+
+        private static bool RestrictHostLogs(FunctionsHostingConfigOptions options, IEnvironment environment)
+        {
+            // Feature flag should take precedence over the host configuration
+            return !FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableHostLogs, environment) && options.RestrictHostLogs;
         }
 
         /// <summary>

--- a/test/TestFunctions/TestFunctions.csproj
+++ b/test/TestFunctions/TestFunctions.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
   </PropertyGroup>
 

--- a/test/WebJobs.Script.Tests.Integration/EventHubs/EventHubsEndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/EventHubs/EventHubsEndToEndTestsBase.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.EventHubs
             _fixture = fixture;
         }
 
-        [Fact]
+        [Fact(Skip = "SAS authentication has been disabled for the namespace.")]
         public async Task EventHub()
         {
             // Event Hub needs the following environment vars:

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
@@ -356,7 +356,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         {
             var environmentSettings = new Dictionary<string, string>()
             {
-                { EnvironmentSettingNames.AzureWebsiteZipDeployment, "http://invalid.com/invalid/dne" }
+                { EnvironmentSettingNames.AzureWebsiteZipDeployment, "http://invalid.test/invalid/dne" }
             };
 
             var environment = new TestEnvironment();
@@ -439,7 +439,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         {
             var environment = new Dictionary<string, string>()
             {
-                { EnvironmentSettingNames.AzureWebsiteZipDeployment, "http://microsoft.com" }
+                { EnvironmentSettingNames.AzureWebsiteZipDeployment, "https://valid-zip.test" }
             };
             var assignmentContext = new HostAssignmentContext
             {
@@ -449,7 +449,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 IsWarmupRequest = false
             };
 
-            string error = await _instanceManager.ValidateContext(assignmentContext);
+            var handlerMock = new Mock<HttpMessageHandler>();
+            handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                });
+
+            var instanceManager = new InstanceManager(_optionsFactory, TestHelpers.CreateHttpClientFactory(handlerMock.Object).CreateClient(),
+                _scriptWebEnvironment, _environment, _loggerFactory.CreateLogger<InstanceManager>(),
+                new TestMetricsLogger(), null, _runFromPackageHandler, _packageDownloadHandler.Object);
+
+            string error = await instanceManager.ValidateContext(assignmentContext);
             Assert.Null(error);
 
             string[] expectedOutputLines =
@@ -539,8 +551,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         {
             var environment = new Dictionary<string, string>()
             {
-                { EnvironmentSettingNames.AzureWebsiteZipDeployment, "http://microsoft.com" },
-                { EnvironmentSettingNames.ScmRunFromPackage, "http://microsoft.com" }
+                { EnvironmentSettingNames.AzureWebsiteZipDeployment, "https://valid.test" },
+                { EnvironmentSettingNames.ScmRunFromPackage, "https://valid.tests" }
             };
             var assignmentContext = new HostAssignmentContext
             {
@@ -550,7 +562,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 IsWarmupRequest = false
             };
 
-            string error = await _instanceManager.ValidateContext(assignmentContext);
+            var handlerMock = new Mock<HttpMessageHandler>();
+            handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                });
+
+            var instanceManager = new InstanceManager(_optionsFactory, TestHelpers.CreateHttpClientFactory(handlerMock.Object).CreateClient(),
+                _scriptWebEnvironment, _environment, _loggerFactory.CreateLogger<InstanceManager>(),
+                new TestMetricsLogger(), null, _runFromPackageHandler, _packageDownloadHandler.Object);
+
+            string error = await instanceManager.ValidateContext(assignmentContext);
             Assert.Null(error);
 
             string[] expectedOutputLines =

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             _settingsManager = ScriptSettingsManager.Instance;
         }
 
-        [Fact]
+        [Fact(Skip = "SAS authentication has been disabled for the namespace.")]
         public async Task EventHubTrigger()
         {
             // write 3 events

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -23,6 +23,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
+using Moq;
 using Xunit.Abstractions;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
@@ -474,6 +475,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var azureStorageProvider = tempHost.Services.GetRequiredService<IAzureStorageProvider>();
             return azureStorageProvider;
+        }
+
+        /// <summary>
+        /// Mock an HttpClientFactory and its CreateClient functionality.
+        /// </summary>
+        /// <param name="handler">Some tests pass a mock HttpHandler into their HttpClient.</param>
+        /// <returns>IHttpClientFactory.</returns>
+        public static IHttpClientFactory CreateHttpClientFactory(HttpMessageHandler handler = null)
+        {
+            var httpClient = handler == null ? new HttpClient() : new HttpClient(handler);
+            var mockFactory = new Mock<IHttpClientFactory>();
+            mockFactory.Setup(m => m.CreateClient(It.IsAny<string>()))
+                 .Returns(httpClient);
+            return mockFactory.Object;
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
@@ -29,13 +29,13 @@ namespace Microsoft.WebJobs.Script.Tests
 {
     public static class TestHostBuilderExtensions
     {
-        public static IHostBuilder ConfigureDefaultTestWebScriptHost(this IHostBuilder builder, Action<ScriptApplicationHostOptions> configure = null, bool runStartupHostedServices = false)
+        public static IHostBuilder ConfigureDefaultTestWebScriptHost(this IHostBuilder builder, Action<ScriptApplicationHostOptions> configure = null, bool runStartupHostedServices = false, IEnvironment environment = null)
         {
-            return builder.ConfigureDefaultTestWebScriptHost(null, configure, runStartupHostedServices);
+            return builder.ConfigureDefaultTestWebScriptHost(null, configure, runStartupHostedServices, environment: environment);
         }
 
         public static IHostBuilder ConfigureDefaultTestWebScriptHost(this IHostBuilder builder, Action<IWebJobsBuilder> configureWebJobs,
-            Action<ScriptApplicationHostOptions> configure = null, bool runStartupHostedServices = false, Action<IServiceCollection> configureRootServices = null)
+            Action<ScriptApplicationHostOptions> configure = null, bool runStartupHostedServices = false, Action<IServiceCollection> configureRootServices = null, IEnvironment environment = null)
         {
             var webHostOptions = new ScriptApplicationHostOptions()
             {
@@ -48,9 +48,18 @@ namespace Microsoft.WebJobs.Script.Tests
 
             // Register root services
             var services = new ServiceCollection();
+
+            if (environment is not null)
+            {
+                services.AddSingleton<IEnvironment>(environment);
+            }
+            else
+            {
+                AddMockedSingleton<IEnvironment>(services);
+            }
+
             AddMockedSingleton<IDebugStateProvider>(services);
             AddMockedSingleton<IScriptHostManager>(services);
-            AddMockedSingleton<IEnvironment>(services);
             AddMockedSingleton<IScriptWebHostEnvironment>(services);
             AddMockedSingleton<IEventGenerator>(services);
             AddMockedSingleton<IFunctionInvocationDispatcherFactory>(services);

--- a/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.WebJobs.Script.Tests
             }
             else
             {
-                AddMockedSingleton<IEnvironment>(services);
+                services.AddSingleton<IEnvironment>(SystemEnvironment.Instance);
             }
 
             AddMockedSingleton<IDebugStateProvider>(services);

--- a/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
@@ -140,8 +140,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         {
             FunctionsHostingConfigOptions options = new FunctionsHostingConfigOptions();
 
-            // defaults to true
-            Assert.True(options.RestrictHostLogs);
+            // defaults to false
+            Assert.False(options.RestrictHostLogs);
 
             // returns true when explicitly enabled
             options.Features[ScriptConstants.HostingConfigRestrictHostLogs] = "1";

--- a/test/WebJobs.Script.Tests/Configuration/RestrictHostLogsTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/RestrictHostLogsTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
+using System.Collections.Immutable;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using WebJobs.Script.Tests;
 using Xunit;
+using static Microsoft.Azure.WebJobs.Script.Tests.Configuration.FunctionsHostingConfigOptionsTest;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 {
@@ -26,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             // Reset the static _allowedLogCategoryPrefixes field after each test to the default value
             typeof(ScriptLoggingBuilderExtensions)
                 .GetField("_allowedLogCategoryPrefixes", BindingFlags.Static | BindingFlags.NonPublic)
-                .SetValue(null, ScriptConstants.SystemLogCategoryPrefixes);
+                .SetValue(null, default(ImmutableArray<string>));
 
             SystemEnvironment.Instance.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, null);
             return Task.CompletedTask;
@@ -41,23 +42,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         {
             using (TempDirectory tempDir = new TempDirectory())
             {
-                var environment = SystemEnvironment.Instance;
                 string fileName = Path.Combine(tempDir.Path, "settings.txt");
                 string fileContent = restrictHostLogs ? string.Empty : $"{ScriptConstants.HostingConfigRestrictHostLogs}=false";
 
                 if (setFeatureFlag)
                 {
-                    environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagEnableHostLogs);
+                    SystemEnvironment.Instance.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagEnableHostLogs);
                 }
 
-                IHost host = FunctionsHostingConfigOptionsTest.GetScriptHostBuilder(fileName, fileContent, environment).Build();
-                var testService = host.Services.GetService<FunctionsHostingConfigOptionsTest.TestService>();
+                IHost host = GetScriptHostBuilder(fileName, fileContent).Build();
+                var testService = host.Services.GetService<TestService>();
 
                 await host.StartAsync();
                 await Task.Delay(1000);
 
                 Assert.Equal(restrictHostLogs, testService.Options.Value.RestrictHostLogs);
-                Assert.Equal(setFeatureFlag, FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableHostLogs, environment));
+                Assert.Equal(setFeatureFlag, FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableHostLogs, SystemEnvironment.Instance));
 
                 if (shouldResultInRestrictedSystemLogs)
                 {

--- a/test/WebJobs.Script.Tests/Configuration/RestrictHostLogsTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/RestrictHostLogsTests.cs
@@ -34,16 +34,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         }
 
         [Theory]
-        [InlineData(true, false, true)] // RestrictHostLogs is true, FeatureFlag is not set, should result in **restricted** logs. This is the default behaviour of the host.
-        [InlineData(false, true, false)] // RestrictHostLogs is false, FeatureFlag is set, should result in unrestricted logs
-        [InlineData(true, true, false)] // RestrictHostLogs is true, FeatureFlag is set, should result in unrestricted logs
-        [InlineData(false, false, false)] // RestrictHostLogs is false, FeatureFlag is not set, should result in unrestricted log
+        [InlineData(true, false, true)] // RestrictHostLogs is true, FeatureFlag is not set, should result in **restricted** logs.
+        [InlineData(false, true, false)] // RestrictHostLogs is false, FeatureFlag is set, should result in unrestricted logs.
+        [InlineData(true, true, false)] // RestrictHostLogs is true, FeatureFlag is set, should result in unrestricted logs.
+        [InlineData(false, false, false)] // RestrictHostLogs is false, FeatureFlag is not set, should result in unrestricted log. This is the default behaviour of the host.
         public async Task RestirctHostLogs_SetsCorrectSystemLogPrefix(bool restrictHostLogs, bool setFeatureFlag, bool shouldResultInRestrictedSystemLogs)
         {
             using (TempDirectory tempDir = new TempDirectory())
             {
                 string fileName = Path.Combine(tempDir.Path, "settings.txt");
-                string fileContent = restrictHostLogs ? string.Empty : $"{ScriptConstants.HostingConfigRestrictHostLogs}=false";
+                string fileContent = restrictHostLogs ? $"{ScriptConstants.HostingConfigRestrictHostLogs}=true" : string.Empty; // the default value is false
 
                 if (setFeatureFlag)
                 {

--- a/test/WebJobs.Script.Tests/Configuration/RestrictHostLogsTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/RestrictHostLogsTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using WebJobs.Script.Tests;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
+{
+    public class RestrictHostLogsTests : IAsyncLifetime
+    {
+        public Task InitializeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task DisposeAsync()
+        {
+            // Reset the static _allowedLogCategoryPrefixes field after each test to the default value
+            typeof(ScriptLoggingBuilderExtensions)
+                .GetField("_allowedLogCategoryPrefixes", BindingFlags.Static | BindingFlags.NonPublic)
+                .SetValue(null, ScriptConstants.SystemLogCategoryPrefixes);
+
+            SystemEnvironment.Instance.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, null);
+            return Task.CompletedTask;
+        }
+
+        [Theory]
+        [InlineData(true, false, true)] // RestrictHostLogs is true, FeatureFlag is not set, should result in **restricted** logs. This is the default behaviour of the host.
+        [InlineData(false, true, false)] // RestrictHostLogs is false, FeatureFlag is set, should result in unrestricted logs
+        [InlineData(true, true, false)] // RestrictHostLogs is true, FeatureFlag is set, should result in unrestricted logs
+        [InlineData(false, false, false)] // RestrictHostLogs is false, FeatureFlag is not set, should result in unrestricted log
+        public async Task RestirctHostLogs_SetsCorrectSystemLogPrefix(bool restrictHostLogs, bool setFeatureFlag, bool shouldResultInRestrictedSystemLogs)
+        {
+            using (TempDirectory tempDir = new TempDirectory())
+            {
+                var environment = SystemEnvironment.Instance;
+                string fileName = Path.Combine(tempDir.Path, "settings.txt");
+                string fileContent = restrictHostLogs ? string.Empty : $"{ScriptConstants.HostingConfigRestrictHostLogs}=false";
+
+                if (setFeatureFlag)
+                {
+                    environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagEnableHostLogs);
+                }
+
+                IHost host = FunctionsHostingConfigOptionsTest.GetScriptHostBuilder(fileName, fileContent, environment).Build();
+                var testService = host.Services.GetService<FunctionsHostingConfigOptionsTest.TestService>();
+
+                await host.StartAsync();
+                await Task.Delay(1000);
+
+                Assert.Equal(restrictHostLogs, testService.Options.Value.RestrictHostLogs);
+                Assert.Equal(setFeatureFlag, FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableHostLogs, environment));
+
+                if (shouldResultInRestrictedSystemLogs)
+                {
+                    Assert.Equal(ScriptConstants.RestrictedSystemLogCategoryPrefixes, ScriptLoggingBuilderExtensions.AllowedSystemLogPrefixes);
+                }
+                else
+                {
+                    Assert.Equal(ScriptConstants.SystemLogCategoryPrefixes, ScriptLoggingBuilderExtensions.AllowedSystemLogPrefixes);
+                }
+
+                await host.StopAsync();
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #10546

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Logs pre-configuration (during host startup) are unrestricted.

Post-configuration, the log prefixes are determined by the following settings:

- RestrictHostLogs is true, FeatureFlag is not set, **should result in restricted system log category prefixes**
    - This is the only setting that would result in restricted logs.
- RestrictHostLogs is true, FeatureFlag is set, should result in unrestricted system log category prefixes
- RestrictHostLogs is false, FeatureFlag is not set, should result in unrestricted system log category prefixes
    - This is the **Default** host state. 
- RestrictHostLogs is false, FeatureFlag is set, should result in unrestricted system log category prefixes

