### PR TITLE
Initial block for .NET in-proc indexing in the OOP host.

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -17,3 +17,4 @@
 - Added support for identity-based connections to Diagnostic Events (#10438)
 - Updating Microsoft.Azure.WebJobs.Logging.ApplicationInsights to 3.0.42-12121
 - Updated retry logic in Worker HTTP proxy to allow for longer worker HTTP listener initialization times (#10566).
+- Introduced proper handling in environments where .NET in-proc is not supported.

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Script.Workers.Http;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 
 namespace Microsoft.Azure.WebJobs.Script.Config
@@ -209,6 +210,14 @@ namespace Microsoft.Azure.WebJobs.Script.Config
             get
             {
                 return GetFeatureAsBooleanOrDefault(RpcWorkerConstants.WorkerRuntimeStrictValidationEnabled, false);
+            }
+        }
+
+        internal bool IsDotNetInProcDisabled
+        {
+            get
+            {
+                return GetFeatureAsBooleanOrDefault(ScriptConstants.HostingConfigDotNetInProcDisabled, false);
             }
         }
 

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -115,6 +115,12 @@ namespace Microsoft.Azure.WebJobs.Script
                    !string.IsNullOrEmpty(environment.GetEnvironmentVariable(AzureFilesContentShare));
         }
 
+        public static bool IsDotNetInProcSupported(this IEnvironment environment)
+        {
+            return !IsFlexConsumptionSku(environment)
+                   && !string.Equals(environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsDisableInProc), "1", StringComparison.OrdinalIgnoreCase);
+        }
+
         public static string GetAzureWebsiteHomePath(this IEnvironment environment)
         {
             return environment.GetEnvironmentVariable(AzureWebsiteHomePath);

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -83,6 +83,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FunctionsWebsiteTimeZone = "WEBSITE_TIME_ZONE";
         public const string FunctionsTargetGroup = "FUNCTIONS_TARGET_GROUP";
         public const string WebsiteArmResourceId = "WEBSITE_ARM_RESOURCE_ID";
+        public const string FunctionsDisableInProc = "FUNCTIONS_DISABLE_INPROC";
 
         //Function in Kubernetes
         public const string PodNamespace = "POD_NAMESPACE";

--- a/src/WebJobs.Script/Extensions/FunctionMetadataExtensions.cs
+++ b/src/WebJobs.Script/Extensions/FunctionMetadataExtensions.cs
@@ -124,6 +124,14 @@ namespace Microsoft.Azure.WebJobs.Script
             return result;
         }
 
+        public static bool IsDotNetInProc(this FunctionMetadata metadata)
+        {
+            return metadata.IsDirect()
+                   || (string.Equals(metadata.Language, DotNetScriptTypes.CSharp, StringComparison.OrdinalIgnoreCase)
+                       || string.Equals(metadata.Language, DotNetScriptTypes.DotNetAssembly, StringComparison.OrdinalIgnoreCase)
+                       || string.Equals(metadata.Language, DotNetScriptTypes.RawDotNetAssembly, StringComparison.OrdinalIgnoreCase));
+        }
+
         public static bool IsDisabled(this FunctionMetadata metadata)
         {
             Utility.TryReadAsBool(metadata.Properties, IsDisabledKey, out bool result);

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -144,6 +144,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string HostingConfigSwtAuthenticationEnabled = "SwtAuthenticationEnabled";
         public const string HostingConfigSwtIssuerEnabled = "SwtIssuerEnabled";
         public const string HostingConfigInternalAuthApisAllowList = "InternalAuthApisAllowList";
+        public const string HostingConfigDotNetInProcDisabled = "DotNetInProcDisabled";
 
         public const string SiteAzureFunctionsUriFormat = "https://{0}.azurewebsites.net/azurefunctions";
         public const string ScmSiteUriFormat = "https://{0}.scm.azurewebsites.net";

--- a/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
@@ -142,7 +142,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 (nameof(FunctionsHostingConfigOptions.WorkerRuntimeStrictValidationEnabled), "WORKER_RUNTIME_STRICT_VALIDATION_ENABLED=1", true),
 
                 (nameof(FunctionsHostingConfigOptions.InternalAuthApisAllowList), "InternalAuthApisAllowList=|", "|"),
-                (nameof(FunctionsHostingConfigOptions.InternalAuthApisAllowList), "InternalAuthApisAllowList=/admin/host/foo|/admin/host/bar", "/admin/host/foo|/admin/host/bar")
+                (nameof(FunctionsHostingConfigOptions.InternalAuthApisAllowList), "InternalAuthApisAllowList=/admin/host/foo|/admin/host/bar", "/admin/host/foo|/admin/host/bar"),
+
+                (nameof(FunctionsHostingConfigOptions.IsDotNetInProcDisabled), "DotNetInProcDisabled=False", false),
+                (nameof(FunctionsHostingConfigOptions.IsDotNetInProcDisabled), "DotNetInProcDisabled=True", true),
+                (nameof(FunctionsHostingConfigOptions.IsDotNetInProcDisabled), "DotNetInProcDisabled=1", true),
+                (nameof(FunctionsHostingConfigOptions.IsDotNetInProcDisabled), "DotNetInProcDisabled=0", false),
             };
 
             // use reflection to ensure that we have a test that uses every value exposed on FunctionsHostingConfigOptions


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Immediate fix to ensure proper handling of in-proc payloads in environments where it isn't supported. This defaults to Flex consumption today, with support for hosting configuration.

This currently ignores restrictions for placeholders to avoid potential impact to cold start. The downside is that it misses the opportunity to reduce memory consumption in those cases, but that enhancement will came in #10504 

### Issue describing the changes in this PR

resolves #10481 

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

