### PR TITLE
Add metadata provider timeout host config (#10526)

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,6 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Implement host configuration property to allow configuration of the metadata provider timeout period (#10526)
+  - The value can be set via `metadataProviderTimeout` in host.json and defaults to "00:00:30" (30 seconds).
+  - For logic apps, unless configured via the host.json, the timeout is disabled by default.

--- a/src/WebJobs.Script/Config/ConfigurationSectionNames.cs
+++ b/src/WebJobs.Script/Config/ConfigurationSectionNames.cs
@@ -24,5 +24,6 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
         public const string Retry = "retry";
         public const string SequentialJobHostRestart = JobHost + ":sequentialRestart";
         public const string SendCanceledInvocationsToWorker = "sendCanceledInvocationsToWorker";
+        public const string MetadataProviderTimeout = "metadataProviderTimeout";
     }
 }

--- a/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
@@ -51,7 +51,8 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             {
                 "version", "functionTimeout", "retry", "functions", "http", "watchDirectories", "watchFiles", "queues", "serviceBus",
                 "eventHub", "singleton", "logging", "aggregator", "healthMonitor", "extensionBundle", "managedDependencies",
-                "customHandler", "httpWorker", "extensions", "concurrency", ConfigurationSectionNames.SendCanceledInvocationsToWorker
+                "customHandler", "httpWorker", "extensions", "concurrency", ConfigurationSectionNames.SendCanceledInvocationsToWorker,
+                ConfigurationSectionNames.MetadataProviderTimeout
             };
 
             private readonly HostJsonFileConfigurationSource _configurationSource;

--- a/src/WebJobs.Script/Config/ScriptJobHostOptions.cs
+++ b/src/WebJobs.Script/Config/ScriptJobHostOptions.cs
@@ -129,5 +129,10 @@ namespace Microsoft.Azure.WebJobs.Script
         /// invocation to the worker.
         /// </summary>
         public bool SendCanceledInvocationsToWorker { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating the timeout duration for the function metadata provider.
+        /// </summary>
+        public TimeSpan MetadataProviderTimeout { get; set; } = TimeSpan.Zero;
     }
 }

--- a/src/WebJobs.Script/Config/ScriptJobHostOptionsSetup.cs
+++ b/src/WebJobs.Script/Config/ScriptJobHostOptionsSetup.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 
@@ -17,6 +18,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
         internal static readonly TimeSpan DefaultConsumptionFunctionTimeout = TimeSpan.FromMinutes(5);
         internal static readonly TimeSpan MaxFunctionTimeoutDynamic = TimeSpan.FromMinutes(10);
         internal static readonly TimeSpan DefaultFunctionTimeout = TimeSpan.FromMinutes(30);
+        internal static readonly TimeSpan DefaultMetadataProviderTimeout = TimeSpan.FromSeconds(30);
 
         public ScriptJobHostOptionsSetup(IConfiguration configuration, IEnvironment environment, IOptions<ScriptApplicationHostOptions> applicationHostOptions)
         {
@@ -58,6 +60,12 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             // FunctionTimeout
             ConfigureFunctionTimeout(options);
 
+            if (options.MetadataProviderTimeout == TimeSpan.Zero)
+            {
+                // If the timeout value is not configured and we are running in a logic app, we want to disable the timeout
+                options.MetadataProviderTimeout = _environment.IsLogicApp() ? Timeout.InfiniteTimeSpan : DefaultMetadataProviderTimeout;
+            }
+
             // If we have a read only file system, override any configuration and
             // disable file watching
             if (_applicationHostOptions.Value.IsFileSystemReadOnly)
@@ -77,7 +85,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
 
         private void ConfigureFunctionTimeout(ScriptJobHostOptions options)
         {
-            if (options.FunctionTimeout == null)
+            if (options.FunctionTimeout is null)
             {
                 options.FunctionTimeout = _environment.IsConsumptionSku() ? DefaultConsumptionFunctionTimeout : DefaultFunctionTimeout;
             }

--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Description;
@@ -21,9 +22,8 @@ namespace Microsoft.Azure.WebJobs.Script
 {
     public class FunctionMetadataManager : IFunctionMetadataManager
     {
-        private const string FunctionConfigurationErrorMessage = "Unable to determine the primary function script.Make sure atleast one script file is present.Try renaming your entry point script to 'run' or alternatively you can specify the name of the entry point script explicitly by adding a 'scriptFile' property to your function metadata.";
+        private const string FunctionConfigurationErrorMessage = "Unable to determine the primary function script. Make sure at least one script file is present. Try renaming your entry point script to 'run' or alternatively you can specify the name of the entry point script explicitly by adding a 'scriptFile' property to your function metadata.";
         private const string MetadataProviderName = "Custom";
-        private const int DefaultMetadataProviderTimeoutInSeconds = 30;
         private readonly IServiceProvider _serviceProvider;
         private IFunctionMetadataProvider _functionMetadataProvider;
         private bool _isHttpWorker;
@@ -56,9 +56,6 @@ namespace Microsoft.Azure.WebJobs.Script
                 }
             };
         }
-
-        // Property is settable for testing purposes.
-        internal int MetadataProviderTimeoutInSeconds { get; set; } = DefaultMetadataProviderTimeoutInSeconds;
 
         public ImmutableDictionary<string, ImmutableArray<string>> Errors { get; private set; }
 
@@ -221,11 +218,12 @@ namespace Microsoft.Azure.WebJobs.Script
             _logger.ReadingFunctionMetadataFromProvider(MetadataProviderName);
 
             var functionProviderTasks = new List<Task<ImmutableArray<FunctionMetadata>>>();
+            var metadataProviderTimeout = _scriptOptions.Value.MetadataProviderTimeout;
 
             foreach (var functionProvider in functionProviders)
             {
                 var getFunctionMetadataFromProviderTask = functionProvider.GetFunctionMetadataAsync();
-                var delayTask = Task.Delay(TimeSpan.FromSeconds(MetadataProviderTimeoutInSeconds));
+                var delayTask = Task.Delay(metadataProviderTimeout);
 
                 var completedTask = Task.WhenAny(getFunctionMetadataFromProviderTask, delayTask).ContinueWith(t =>
                 {
@@ -235,7 +233,7 @@ namespace Microsoft.Azure.WebJobs.Script
                     }
 
                     // Timeout case.
-                    throw new TimeoutException($"Timeout occurred while retrieving metadata from provider '{functionProvider.GetType().FullName}'. The operation exceeded the configured timeout of {MetadataProviderTimeoutInSeconds} seconds.");
+                    throw new TimeoutException($"Timeout occurred while retrieving metadata from provider '{functionProvider.GetType().FullName}'. The operation exceeded the configured timeout of {metadataProviderTimeout.TotalSeconds} seconds.");
                 });
 
                 functionProviderTasks.Add(completedTask);

--- a/test/WebJobs.Script.Tests/Configuration/ScriptJobHostOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ScriptJobHostOptionsSetupTests.cs
@@ -313,6 +313,38 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             Assert.Equal(expected, options.SendCanceledInvocationsToWorker);
         }
 
+        [Fact]
+        public void Configure_MetadataProviderTimeout_ValidateDefaultTimeoutValue()
+        {
+            var options = GetConfiguredOptions(new Dictionary<string, string>());
+
+            Assert.Equal(TimeSpan.FromSeconds(30), options.MetadataProviderTimeout);
+        }
+
+        [Fact]
+        public void Configure_MetadataProviderTimeout_IsLogicApp_SetTimeoutToInfinite()
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AppKind, "workflowapp");
+
+            var options = GetConfiguredOptions(new Dictionary<string, string>(), environment);
+
+            Assert.Equal(TimeSpan.FromMilliseconds(-1), options.MetadataProviderTimeout);
+        }
+
+        [Fact]
+        public void Configure_MetadataProviderTimeout_AppliesConfiguredTimeoutValue()
+        {
+            var settings = new Dictionary<string, string>
+            {
+                { ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "metadataProviderTimeout"), "00:00:43" }
+            };
+
+            var options = GetConfiguredOptions(settings);
+
+            Assert.Equal(TimeSpan.FromSeconds(43), options.MetadataProviderTimeout);
+        }
+
         private ScriptJobHostOptions GetConfiguredOptions(Dictionary<string, string> settings, IEnvironment environment = null)
         {
             ScriptJobHostOptionsSetup setup = CreateSetupWithConfiguration(settings, environment);

--- a/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
@@ -17,13 +17,12 @@ using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
 using Moq;
 using Xunit;
-using static Microsoft.Azure.AppService.Proxy.Common.Constants.WellKnownHttpHeaders;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class FunctionMetadataManagerTests
     {
-        private const string _expectedErrorMessage = "Unable to determine the primary function script.Make sure atleast one script file is present.Try renaming your entry point script to 'run' or alternatively you can specify the name of the entry point script explicitly by adding a 'scriptFile' property to your function metadata.";
+        private const string _expectedErrorMessage = "Unable to determine the primary function script. Make sure at least one script file is present. Try renaming your entry point script to 'run' or alternatively you can specify the name of the entry point script explicitly by adding a 'scriptFile' property to your function metadata.";
         private ScriptJobHostOptions _scriptJobHostOptions = new ScriptJobHostOptions();
         private Mock<IFunctionMetadataProvider> _mockFunctionMetadataProvider;
         private FunctionMetadataManager _testFunctionMetadataManager;
@@ -256,7 +255,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 mockFunctionMetadataProvider.Object, new List<IFunctionProvider>() { goodFunctionMetadataProvider.Object, badFunctionMetadataProvider.Object }, new OptionsWrapper<HttpWorkerOptions>(_defaultHttpWorkerOptions), loggerFactory, new TestOptionsMonitor<LanguageWorkerOptions>(TestHelpers.GetTestLanguageWorkerOptions()));
 
             // Set the timeout to 1 second for the test.
-            testFunctionMetadataManager.MetadataProviderTimeoutInSeconds = 1;
+            _scriptJobHostOptions.MetadataProviderTimeout = TimeSpan.FromSeconds(1);
 
             var exception = Assert.Throws<TimeoutException>(() => testFunctionMetadataManager.LoadFunctionMetadata());
             Assert.Contains($"Timeout occurred while retrieving metadata from provider '{badFunctionMetadataProvider.Object.GetType().FullName}'. The operation exceeded the configured timeout of 1 seconds.", exception.Message);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Cherry-pick https://github.com/Azure/azure-functions-host/pull/10545 into `release/in-proc-hotfix-v4.36.2`

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting 
* [x] My changes **do not** require documentation changes
    * [] Otherwise: Documentation issue linked to PR: **TODO:// Update host.json spec**
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [] Otherwise: 
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Adding a metadata provider timeout setting to the host.config to make this value configurable. For logic apps, we will not have a timeout limit.
