### PR TITLE
Set the MetadataProvider timeout to InfiniteTimeSpan for LA

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,4 +4,4 @@
 - My change description (#PR)
 -->
 - The base commit for the release branch is set to v4.636.0.
-- Set the MetadataProvider timeout to InfiniteTimeSpan for LA
+- Set the MetadataProvider timeout to InfiniteTimeSpan for LogicApps

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,3 +4,4 @@
 - My change description (#PR)
 -->
 - The base commit for the release branch is set to v4.636.0.
+- Set the MetadataProvider timeout to InfiniteTimeSpan for LA


### PR DESCRIPTION
Update the timeout period for the MetadataProvider so that it is set to InfiniteTimeSpan when the environment is a Logic App.