### PR TITLE
Remove "Warning As Error" for System.Text.Json

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -9,8 +9,6 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsAsErrors />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>


### PR DESCRIPTION
This change is part of a hotfix for Logic Apps. The build for this hotfix is failing with: `Error NU1903: Warning As Error: Package 'System.Text.Json' 6.0.9 has a known high severity vulnerability`. 

However, this severity was patched in v4.636.2. Due to the nature of this hotfix, it is based on v4.636.0. In order to minimize the number of changes that we are introducing, we have chosen not to add that same patch into this hotfix as well.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [X] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [X] I have added all required tests (Unit tests, E2E tests)
