### PR TITLE
Return metadata provider task whether it is successful or not

### DIFF
--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -244,7 +244,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
                 var completedTask = Task.WhenAny(getFunctionMetadataFromProviderTask, delayTask).ContinueWith(t =>
                 {
-                    if (t.Result == getFunctionMetadataFromProviderTask && getFunctionMetadataFromProviderTask.IsCompletedSuccessfully)
+                    if (t.Result == getFunctionMetadataFromProviderTask)
                     {
                         return getFunctionMetadataFromProviderTask.Result;
                     }


### PR DESCRIPTION
With the current behaviour, even if the `getFunctionMetadataFromProviderTask` completes before the timeout period, we get a timeout exception if it is not successful. This is a bug and ignores potential failures from the task.