### PR TITLE
Copy deps.json artifact only if failed

### DIFF
--- a/eng/ci/templates/jobs/run-unit-tests.yml
+++ b/eng/ci/templates/jobs/run-unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
       displayName: Publish deps.json
       path: $(Build.ArtifactStagingDirectory)
       artifact: WebHost_Deps
-      condition: always()
+      condition: failed()
 
   steps:
   - template: /eng/ci/templates/install-dotnet.yml@self
@@ -27,7 +27,7 @@ jobs:
 
   - task: CopyFiles@2
     displayName: Copy deps.json
-    condition: always()
+    condition: failed()
     inputs:
       SourceFolder: out/bin/WebJobs.Script.WebHost/debug
       Contents: '**/Microsoft.Azure.WebJobs.Script.WebHost.deps.json'


### PR DESCRIPTION
Quick change to CI pipeline to copy deps.json only if unit tests failed. This is to prevent pipeline re-runs from failing