### PR TITLE
Update to .net9 sdk

### DIFF
--- a/eng/ci/templates/install-dotnet.yml
+++ b/eng/ci/templates/install-dotnet.yml
@@ -12,6 +12,12 @@ steps:
     packageType: sdk
     version: 6.x
 
+- task: UseDotNet@2 # Needed by our projects and CI steps
+  displayName: Install .NET 8
+  inputs:
+    packageType: sdk
+    version: 8.x
+
 - task: UseDotNet@2 # The pinned SDK we use to build
   displayName: Install .NET SDK from global.json
   inputs:

--- a/eng/ci/templates/steps/build-site-ext.yml
+++ b/eng/ci/templates/steps/build-site-ext.yml
@@ -4,14 +4,13 @@ parameters:
     default: src/WebJobs.Script.SiteExtension/WebJobs.Script.SiteExtension.csproj
 
 steps:
-  # Restore must be a separate step so we can pass in 'PublishReadyToRun=true'
   - task: DotNetCoreCLI@2
     displayName: Restore site extension
     inputs:
       command: custom
       custom: restore
       projects: ${{ parameters.project }}
-      arguments: '-v m -p:PublishReadyToRun=true -bl:$(log_dir)/site_ext.restore.binlog'
+      arguments: '-v m -bl:$(log_dir)/site_ext.restore.binlog'
 
   - task: DotNetCoreCLI@2
     displayName: Build site extension

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.101",
+    "version": "9.0.100",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {

--- a/src/WebJobs.Script.SiteExtension/readme.md
+++ b/src/WebJobs.Script.SiteExtension/readme.md
@@ -11,7 +11,7 @@ Like any MSBuild project, this can be restored, build, and published separately 
 dotnet publish -c {config}
 
 # Separately
-dotnet restore -p:PublishReadyToRun=true # needs to be set to true (fixed in .net9 SDK)
+dotnet restore
 dotnet build -c {config} --no-restore
 dotnet publish -c {config} --no-build
 ```

--- a/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
+++ b/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
@@ -21,6 +21,12 @@
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "8.0.1",
           "Microsoft.Azure.AppService.Middleware.Functions": "1.5.5",
           "Microsoft.Azure.AppService.Proxy.Client": "2.3.20240307.67",
+          "Microsoft.Azure.Functions.DotNetIsolatedNativeHost": "1.0.11",
+          "Microsoft.Azure.Functions.JavaWorker": "2.17.0",
+          "Microsoft.Azure.Functions.NodeJsWorker": "3.10.1",
+          "Microsoft.Azure.Functions.PowerShellWorker.PS7.0": "4.0.3148",
+          "Microsoft.Azure.Functions.PowerShellWorker.PS7.2": "4.0.4025",
+          "Microsoft.Azure.Functions.PowerShellWorker.PS7.4": "4.0.4026",
           "Microsoft.Azure.Functions.PythonWorker": "4.34.0",
           "Microsoft.Azure.Storage.File": "11.1.7",
           "Microsoft.Azure.WebJobs": "3.0.41",
@@ -37,7 +43,6 @@
           "System.IdentityModel.Tokens.Jwt": "6.35.0",
           "System.Memory.Data": "8.0.1",
           "System.Net.NameResolution": "4.3.0",
-          "System.Text.Json": "8.0.5",
           "Microsoft.Azure.WebJobs.Script.Reference": "4.1037.0.0",
           "Microsoft.Azure.WebJobs.Script.Grpc.Reference": "4.1037.0.0"
         },
@@ -1030,7 +1035,7 @@
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Script.Abstractions.dll": {
             "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.22000.0"
+            "fileVersion": "1.0.19706.0"
           }
         }
       },
@@ -2751,14 +2756,7 @@
         }
       },
       "System.Text.Encodings.Web/8.0.0": {},
-      "System.Text.Json/8.0.5": {
-        "runtime": {
-          "lib/net8.0/System.Text.Json.dll": {
-            "assemblyVersion": "8.0.0.0",
-            "fileVersion": "8.0.1024.46610"
-          }
-        }
-      },
+      "System.Text.Json/8.0.5": {},
       "System.Text.RegularExpressions/4.3.1": {
         "dependencies": {
           "System.Runtime": "4.3.1"
@@ -2883,12 +2881,6 @@
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.22.0",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
           "Microsoft.Azure.AppService.Proxy.Client": "2.3.20240307.67",
-          "Microsoft.Azure.Functions.DotNetIsolatedNativeHost": "1.0.11",
-          "Microsoft.Azure.Functions.JavaWorker": "2.17.0",
-          "Microsoft.Azure.Functions.NodeJsWorker": "3.10.1",
-          "Microsoft.Azure.Functions.PowerShellWorker.PS7.0": "4.0.3148",
-          "Microsoft.Azure.Functions.PowerShellWorker.PS7.2": "4.0.4025",
-          "Microsoft.Azure.Functions.PowerShellWorker.PS7.4": "4.0.4026",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Extensions": "5.1.0-12067",
           "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.0",
@@ -3607,14 +3599,14 @@
     "Microsoft.Azure.WebJobs/3.0.41": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-nprqeSOAkhFrpIW1KVkXQb6BZCbnS8d1ytq0nUzIYnpkmbvmfkcQlJE9zp3Dbo26Q/0h0JdPSQ3BaVVBNPOUZg==",
+      "sha512": "sha512-EOigHt+kjrpbg53s8SYn4dlTpZG9IgWPNrdmcdSG8c7U8qKZvcF4BwZtF7ETy3KGir2NtIpJaIc7dUm2+k9/GA==",
       "path": "microsoft.azure.webjobs/3.0.41",
       "hashPath": "microsoft.azure.webjobs.3.0.41.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Core/3.0.41": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-VtmzMUEMhhY7+lxhXxphPbn/1du+QFKU+VtH3UHzmn/sS2JwXJNtQNk/SiC+wad69GSGzgKH5x1aN2qTnEXh+Q==",
+      "sha512": "sha512-nNW4I8m5GEhOxxD/NVZGjT6ZARGSy7wi8q+ihvKDin4IY4zYLpTy/GakZeGgbi7vPxcPHL5Z65n9DAV+goasqA==",
       "path": "microsoft.azure.webjobs.core/3.0.41",
       "hashPath": "microsoft.azure.webjobs.core.3.0.41.nupkg.sha512"
     },
@@ -3642,7 +3634,7 @@
     "Microsoft.Azure.WebJobs.Host.Storage/5.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-eO/sX41oaGkDiXHpT7y/F1F5Wvzm7e1QqFmd4GGMJOMdLOHGvwOvZR82AfR7rjvpqQZWyKjRHqxAVcntq+ZYwQ==",
+      "sha512": "sha512-5fF88jDYdxUs4EdYZw3MqK7ghG4mZ5MsCt8MhKk38CiTK90VmoWtXbBYURohil+WJ8vB/i0UwQGg64y6TdvliA==",
       "path": "microsoft.azure.webjobs.host.storage/5.0.1",
       "hashPath": "microsoft.azure.webjobs.host.storage.5.0.1.nupkg.sha512"
     },
@@ -3663,7 +3655,7 @@
     "Microsoft.Azure.WebJobs.Script.Abstractions/1.0.4-preview": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-U/aVn/i0P9MdPsca9TrLmTlKuGOJ8okTdifrBeNviwd80Xbv/+dIM/GGReQXaVVtUM5/SlbUHRAhvA9w0yuEyA==",
+      "sha512": "sha512-mvgXnFKwh4/Gw8BXc99ZJd2iQ8DQJTCotvY9PZ9Y2UHa4KiOsYaEW4kuZ5RFBD9KqGO2vXG56w3wMFVyxmaA2g==",
       "path": "microsoft.azure.webjobs.script.abstractions/1.0.4-preview",
       "hashPath": "microsoft.azure.webjobs.script.abstractions.1.0.4-preview.nupkg.sha512"
     },


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

# DO NOT MERGE YET

The SDK change has a tangible impact to our artifacts. With `8.0.101` SDK we have some OOB packages pinned ahead of the runtime, which leads to those assemblies being explicitly included (example: System.Text.Json). When updating the SDK, the runtime is now ahead or same version as our package ref's and they are then excluded from our outputs. This will have a downstream impact if the hosted environments do not have a new enough runtime to match our requested OOB packages. We should first verify Antares and linux images have the latest .net8 runtime installed before merging this PR.

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR  -- TODO
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Updates to .net9 SDK which addresses a restore issue with r2r.

deps.json changes:
```
Previous file: C:\repos\func\host-2\out\bin\WebJobs.Script.Tests\debug\Microsoft.Azure.WebJobs.Script.WebHost.deps.json
New file:      C:\repos\func\host-2\out\bin\WebJobs.Script.WebHost\debug\Microsoft.Azure.WebJobs.Script.WebHost.deps.json

  Changed:

  Removed:
    - System.Text.Json.dll: 8.0.0.0/8.0.1024.46610

  Added:
```
