### PR TITLE
Use IsPackable for ZipPublish.targets

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,7 @@
     <ArtifactsPath>$(MSBuildThisFileDirectory)out</ArtifactsPath>
     <ArtifactsPublishOutputName>pub</ArtifactsPublishOutputName>
     <ArtifactsPackageOutputName>pkg</ArtifactsPackageOutputName>
+    <IsPackable>false</IsPackable> <!-- default false -->
   </PropertyGroup>
 
   <!-- paths -->

--- a/eng/build/ZipPublish.targets
+++ b/eng/build/ZipPublish.targets
@@ -32,7 +32,7 @@
   <Target Name="ZipPublishArtifacts"
     AfterTargets="Publish"
     DependsOnTargets="PrepareZipArtifacts"
-    Condition="'$(ZipArtifactsPath)' != '' AND '@(ZipArtifact)' != '' AND '$(IsCrossTargetingBuild)' != 'true' AND '$(IsZippable)' == 'true'">
+    Condition="'$(ZipArtifactsPath)' != '' AND '@(ZipArtifact)' != '' AND '$(IsCrossTargetingBuild)' != 'true' AND '$(IsPackable)' == 'true'">
     <ItemGroup Condition="'$(ZipArtifactsPath)' != ''">
       <ZipArtifact Condition="'%(TargetPath)' == '' AND '%(TargetName)' != ''">
         <TargetPath>$([MSBuild]::EnsureTrailingSlash('$(ZipArtifactsPath)'))%(TargetName)</TargetPath>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"
+          Condition="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')) != ''" />
+
+  <!-- artifacts -->
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/src/WebJobs.Script.SiteExtension/WebJobs.Script.SiteExtension.csproj
+++ b/src/WebJobs.Script.SiteExtension/WebJobs.Script.SiteExtension.csproj
@@ -7,7 +7,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifier>win</RuntimeIdentifier>
     <SiteExtensionName>Functions</SiteExtensionName>
-    <IsZippable>true</IsZippable>
     <CustomAfterNoTargets Condition="'$(TargetFramework)' != ''">$(MSBuildThisFileDirectory)Publish.SingleTFM.targets</CustomAfterNoTargets>
     <CustomAfterNoTargets Condition="'$(TargetFramework)' == ''">$(MSBuildThisFileDirectory)Publish.MultiTFM.targets</CustomAfterNoTargets>
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>

--- a/test/WebJobs.Script.Abstractions/WebJobs.Script.Tests.Abstractions.csproj
+++ b/test/WebJobs.Script.Abstractions/WebJobs.Script.Tests.Abstractions.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
-    <IsPackable>false</IsPackable>
     <AssemblyName>Microsoft.Azure.WebJobs.Script.Tests.Abstractions</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Script.Tests.Abstractions</RootNamespace>
   </PropertyGroup>

--- a/test/WebJobs.Script.Tests.Analyzers/WebJobs.Script.Tests.Analyzers.csproj
+++ b/test/WebJobs.Script.Tests.Analyzers/WebJobs.Script.Tests.Analyzers.csproj
@@ -2,11 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-
-    <IsPackable>false</IsPackable>
-
     <SignAssembly>true</SignAssembly>
-
     <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 

--- a/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
+++ b/test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj
@@ -2,7 +2,6 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <IsPackable>false</IsPackable>
     <AssemblyName>Microsoft.Azure.WebJobs.Script.Tests.Integration</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Script.Tests.Integration</RootNamespace>
     <!-- Allow BinaryFormatter for tests -->

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <IsTestProject>true</IsTestProject>
-    <IsPackable>false</IsPackable>
     <AssemblyName>Microsoft.Azure.WebJobs.Script.Tests</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Script.Tests</RootNamespace>
     <LangVersion>preview</LangVersion>


### PR DESCRIPTION
Quick follow up to #10168 to address linux artifacts not packing.

Using `IsZippable` was a last-minute change to avoid zipping up samples. This goes back to using `IsPackable`, but suppresses zipping up unintended projects by defaulting `IsPackable=false` for the repo, and opting in only shipping projects to `true`.