### PR TITLE
[pack] Ensuring JobHost restart suppresion aligns with request lifecycle

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,3 +6,4 @@
 - Introduced proper handling in environments where .NET in-proc is not supported.
 - Updated System.Memory.Data reference to 8.0.1
 - Address issue with HTTP proxying throwing `ArgumentException` (#10616)
+- Updated JobHost restart suppresion in functions APIs to align with request lifecycle (#10638)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### **NOTE:** Additional tests and private extension tests pending.

### Issue describing the changes in this PR

resolves #10631

This change aligns the restart suspension scope with the request lifecycle, ensuring that a JobHost restart triggered by changes to the functions does not resume before the request is complete, which could otherwise result in its services being disposed prematurely.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)
