### PR TITLE
Added comments for HTTP response building code path

### DIFF
--- a/src/WebJobs.Script/Binding/Http/RawScriptResult.cs
+++ b/src/WebJobs.Script/Binding/Http/RawScriptResult.cs
@@ -79,10 +79,12 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
                 {
                     if (cookie.Item3 != null)
                     {
+                        // CodeQL [SM02373] This code path constructs the cookie collection based on what the out-of-process function app (where customers can set these cookies) sends to the host. Marking these cookies as "Secure" would introduce a breaking change for those customers.
                         response.Cookies.Append(cookie.Item1, cookie.Item2, cookie.Item3);
                     }
                     else
                     {
+                        // CodeQL [SM02373] This code path constructs the cookie collection based on what the out-of-process function app (where customers can set these cookies) sends to the host. Marking these cookies as "Secure" would introduce a breaking change for those customers.
                         response.Cookies.Append(cookie.Item1, cookie.Item2);
                     }
                 }

--- a/src/WebJobs.Script/Binding/Http/RawScriptResult.cs
+++ b/src/WebJobs.Script/Binding/Http/RawScriptResult.cs
@@ -79,12 +79,12 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
                 {
                     if (cookie.Item3 != null)
                     {
-                        // CodeQL [SM02373] This code path constructs the cookie collection based on what the out-of-process function app (where customers can set these cookies) sends to the host. Marking these cookies as "Secure" would introduce a breaking change for those customers.
+                        // CodeQL [SM02373] This code path constructs the cookie collection based on what the out-of-process function app (where customers can set these cookies) sends to the host. Overriding this behavior would introduce a breaking change for those customers.
                         response.Cookies.Append(cookie.Item1, cookie.Item2, cookie.Item3);
                     }
                     else
                     {
-                        // CodeQL [SM02373] This code path constructs the cookie collection based on what the out-of-process function app (where customers can set these cookies) sends to the host. Marking these cookies as "Secure" would introduce a breaking change for those customers.
+                        // CodeQL [SM02373] This code path constructs the cookie collection based on what the out-of-process function app (where customers can set these cookies) sends to the host. Overriding this behavior would introduce a breaking change for those customers.
                         response.Cookies.Append(cookie.Item1, cookie.Item2);
                     }
                 }


### PR DESCRIPTION
Resolves [link](https://github.com/orgs/Azure/projects/473/views/9?sliceBy%5Bvalue%5D=kshyju&pane=issue&itemId=80992817)

Added CodeQL suppression justification comments for out of process layer response handling code path.

Guidance for the changes is shared in Codeql links from Engineering hub [link](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/codeql-semmle)


### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

