### PR TITLE
Fix nuget audit settings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,9 +24,9 @@
   <PropertyGroup>
     <!-- Nuget audit as warnings only, even in TreatWarningsAsErrors. -->
     <!-- Except for in CI, critical will fail the build. -->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903</WarningsNotAsErrors>
-    <WarningsNotAsErrors Condition="'$(CI)' == 'false'">$(WarningsNotAsErrors)NU1904</WarningsNotAsErrors>
-    <WarningsAsErrors Condition="'$(CI)' == 'true'">$(WarningsAsErrors)NU1904</WarningsAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors)NU1901;NU1902;NU1903;</WarningsNotAsErrors>
+    <WarningsNotAsErrors Condition="'$(CI)' == 'false'">$(WarningsNotAsErrors)NU1904;</WarningsNotAsErrors>
+    <WarningsAsErrors Condition="'$(CI)' == 'true'">$(WarningsAsErrors)NU1904;</WarningsAsErrors>
     <NuGetAuditLevel>moderate</NuGetAuditLevel> <!-- warn on moderate severity only. -->
     <NuGetAuditMode>all</NuGetAuditMode> <!-- audit transitive dependencies. -->
   </PropertyGroup>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR #10662 
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Addresses a minor issue with nuget audit values
