### PR TITLE
[pack] Setting force refresh to false for create update functions call

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,4 +4,4 @@
 - My change description (#PR)
 -->
 
-- Setting force refersh to false for CreateUpdate call (#)
+- Setting force refersh to false for CreateOrUpdate call (#10668)

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,3 +4,4 @@
 - My change description (#PR)
 -->
 
+- Setting force refersh to false for CreateUpdate call (#)

--- a/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
@@ -147,7 +147,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             // we need to sync triggers if config changed, or the files changed
             await _functionsSyncManager.TrySyncTriggersAsync();
 
-            (var success, var functionMetadataResult) = await TryGetFunction(name, request, configChanged);
+            // Setting force refresh to false as host restart causes a refersh already
+            (var success, var functionMetadataResult) = await TryGetFunction(name, request, false);
 
             return (success, configChanged, functionMetadataResult);
         }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Currently the create update call from function controller tries to get the latest metadata after create / update call has been made. To do that it passes in force refresh flag to true when config change has occurred. However, there is a race condition between the host restart and this call that causes the call to return 500. We don't really need the force refresh call on get metadata as the data is already latest from a host restart that has occurred before. Removing force refresh fixes the race condition.

resolves #10631

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
