### PR TITLE
Using hostMetadataProvider for CreateOrUpdate call in FunctionController

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,4 +4,4 @@
 - My change description (#PR)
 -->
 
-- Setting force refersh to false for CreateOrUpdate call (#10668)
+- Using hostMetadataProvider for CreateOrUpdate call in FunctionController (#10678)

--- a/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
@@ -11,6 +11,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Management.Models;
 using Microsoft.Azure.WebJobs.Script.WebHost.Extensions;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
@@ -27,8 +29,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         private readonly IFunctionsSyncManager _functionsSyncManager;
         private readonly HostNameProvider _hostNameProvider;
         private readonly IFunctionMetadataManager _functionMetadataManager;
+        private readonly IHostFunctionMetadataProvider _hostFunctionMetadataProvider;
+        private readonly IOptionsMonitor<LanguageWorkerOptions> _languageWorkerOptions;
 
-        public WebFunctionsManager(IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, ILoggerFactory loggerFactory, IHttpClientFactory httpClientFactory, ISecretManagerProvider secretManagerProvider, IFunctionsSyncManager functionsSyncManager, HostNameProvider hostNameProvider, IFunctionMetadataManager functionMetadataManager)
+        public WebFunctionsManager(IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, ILoggerFactory loggerFactory, IHttpClientFactory httpClientFactory, ISecretManagerProvider secretManagerProvider, IFunctionsSyncManager functionsSyncManager, HostNameProvider hostNameProvider, IFunctionMetadataManager functionMetadataManager, IHostFunctionMetadataProvider hostFunctionMetadataProvider,
+            IOptionsMonitor<LanguageWorkerOptions> languageWorkerOptions)
         {
             _applicationHostOptions = applicationHostOptions;
             _logger = loggerFactory?.CreateLogger(ScriptConstants.LogCategoryHostGeneral);
@@ -37,6 +42,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             _functionsSyncManager = functionsSyncManager;
             _hostNameProvider = hostNameProvider;
             _functionMetadataManager = functionMetadataManager;
+            _hostFunctionMetadataProvider = hostFunctionMetadataProvider;
+            _languageWorkerOptions = languageWorkerOptions;
         }
 
         public async Task<IEnumerable<FunctionMetadataResponse>> GetFunctionsMetadata(bool includeProxies)
@@ -144,11 +151,21 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 await FileUtility.WriteAsync(dataFilePath, functionMetadata.TestData);
             }
 
+            var metadata = (await _hostFunctionMetadataProvider.GetFunctionMetadataAsync(_languageWorkerOptions.CurrentValue.WorkerConfigs, configChanged))
+                .FirstOrDefault(metadata => Utility.FunctionNamesMatch(metadata.Name, name));
+
+            var success = false;
+            FunctionMetadataResponse functionMetadataResult = null;
+            if (functionMetadata != null)
+            {
+                string routePrefix = await GetRoutePrefix(hostOptions.RootScriptPath);
+                var baseUrl = $"{request.Scheme}://{request.Host}";
+                functionMetadataResult = await metadata.ToFunctionMetadataResponse(hostOptions, routePrefix, baseUrl);
+                success = true;
+            }
+
             // we need to sync triggers if config changed, or the files changed
             await _functionsSyncManager.TrySyncTriggersAsync();
-
-            // Setting force refresh to false as host restart causes a refersh already
-            (var success, var functionMetadataResult) = await TryGetFunction(name, request, false);
 
             return (success, configChanged, functionMetadataResult);
         }

--- a/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
@@ -151,23 +151,23 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 await FileUtility.WriteAsync(dataFilePath, functionMetadata.TestData);
             }
 
-            var metadata = (await _hostFunctionMetadataProvider.GetFunctionMetadataAsync(_languageWorkerOptions.CurrentValue.WorkerConfigs, configChanged))
+            var updatedFunctionMetadata = (await _hostFunctionMetadataProvider.GetFunctionMetadataAsync(_languageWorkerOptions.CurrentValue.WorkerConfigs, configChanged))
                 .FirstOrDefault(metadata => Utility.FunctionNamesMatch(metadata.Name, name));
 
-            var success = false;
+            bool getFunctionMetadataSuccessful = false;
             FunctionMetadataResponse functionMetadataResult = null;
-            if (functionMetadata != null)
+            if (updatedFunctionMetadata != null)
             {
                 string routePrefix = await GetRoutePrefix(hostOptions.RootScriptPath);
                 var baseUrl = $"{request.Scheme}://{request.Host}";
-                functionMetadataResult = await metadata.ToFunctionMetadataResponse(hostOptions, routePrefix, baseUrl);
-                success = true;
+                functionMetadataResult = await updatedFunctionMetadata.ToFunctionMetadataResponse(hostOptions, routePrefix, baseUrl);
+                getFunctionMetadataSuccessful = true;
             }
 
             // we need to sync triggers if config changed, or the files changed
             await _functionsSyncManager.TrySyncTriggersAsync();
 
-            return (success, configChanged, functionMetadataResult);
+            return (getFunctionMetadataSuccessful, configChanged, functionMetadataResult);
         }
 
         /// <summary>

--- a/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
@@ -7,6 +7,8 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Azure;
+using Azure.Core;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Management.Models;
@@ -151,23 +153,22 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 await FileUtility.WriteAsync(dataFilePath, functionMetadata.TestData);
             }
 
-            var updatedFunctionMetadata = (await _hostFunctionMetadataProvider.GetFunctionMetadataAsync(_languageWorkerOptions.CurrentValue.WorkerConfigs, configChanged))
+            // Using HostFunctionMetadataProvider instead of IFunctionMetadataManager. More details logged here https://github.com/Azure/azure-functions-host/issues/10691
+            var metadata = (await _hostFunctionMetadataProvider.GetFunctionMetadataAsync(_languageWorkerOptions.CurrentValue.WorkerConfigs, true))
                 .FirstOrDefault(metadata => Utility.FunctionNamesMatch(metadata.Name, name));
 
-            bool getFunctionMetadataSuccessful = false;
+            bool success = false;
             FunctionMetadataResponse functionMetadataResult = null;
-            if (updatedFunctionMetadata != null)
+            if (metadata != null)
             {
-                string routePrefix = await GetRoutePrefix(hostOptions.RootScriptPath);
-                var baseUrl = $"{request.Scheme}://{request.Host}";
-                functionMetadataResult = await updatedFunctionMetadata.ToFunctionMetadataResponse(hostOptions, routePrefix, baseUrl);
-                getFunctionMetadataSuccessful = true;
+                functionMetadataResult = await GetFunctionMetadataResponseAsync(metadata, hostOptions, request);
+                success = true;
             }
 
             // we need to sync triggers if config changed, or the files changed
             await _functionsSyncManager.TrySyncTriggersAsync();
 
-            return (getFunctionMetadataSuccessful, configChanged, functionMetadataResult);
+            return (success, configChanged, functionMetadataResult);
         }
 
         /// <summary>
@@ -196,9 +197,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
             if (functionMetadata != null)
             {
-                string routePrefix = await GetRoutePrefix(hostOptions.RootScriptPath);
-                var baseUrl = $"{request.Scheme}://{request.Host}";
-                return (true, await functionMetadata.ToFunctionMetadataResponse(hostOptions, routePrefix, baseUrl));
+                var functionMetadataResponse = await GetFunctionMetadataResponseAsync(functionMetadata, hostOptions, request);
+                return (true, functionMetadataResponse);
             }
             else
             {
@@ -243,6 +243,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             {
                 FileUtility.DeleteFileSafe(testDataPath);
             }
+        }
+
+        private static async Task<FunctionMetadataResponse> GetFunctionMetadataResponseAsync(FunctionMetadata functionMetadata, ScriptJobHostOptions hostOptions, HttpRequest request)
+        {
+            string routePrefix = await GetRoutePrefix(hostOptions.RootScriptPath);
+            var baseUrl = $"{request.Scheme}://{request.Host}";
+            return await functionMetadata.ToFunctionMetadataResponse(hostOptions, routePrefix, baseUrl);
         }
 
         // TODO : Due to lifetime scoping issues (this service lifetime is longer than the lifetime

--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
             ImmutableArray<FunctionMetadata> immutableFunctionMetadata;
 
-            immutableFunctionMetadata = _functionMetadataProvider.GetFunctionMetadataAsync(workerConfigs, _environment, forceRefresh).GetAwaiter().GetResult();
+            immutableFunctionMetadata = _functionMetadataProvider.GetFunctionMetadataAsync(workerConfigs, forceRefresh).GetAwaiter().GetResult();
 
             var functionMetadataList = new List<FunctionMetadata>();
             _functionErrors = new Dictionary<string, ICollection<string>>();

--- a/src/WebJobs.Script/Host/FunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataProvider.cs
@@ -32,12 +32,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         public ImmutableDictionary<string, ImmutableArray<string>> FunctionErrors { get; private set; }
 
-        public async Task<ImmutableArray<FunctionMetadata>> GetFunctionMetadataAsync(IEnumerable<RpcWorkerConfig> workerConfigs, IEnvironment environment, bool forceRefresh = false)
+        public async Task<ImmutableArray<FunctionMetadata>> GetFunctionMetadataAsync(IEnumerable<RpcWorkerConfig> workerConfigs, bool forceRefresh = false)
         {
             bool workerIndexing = Utility.CanWorkerIndex(workerConfigs, _environment, _functionsHostingConfigOptions);
             if (!workerIndexing)
             {
-                return await GetMetadataFromHostProvider(workerConfigs, environment, forceRefresh);
+                return await GetMetadataFromHostProvider(workerConfigs, forceRefresh);
             }
 
             _logger.LogInformation("Worker indexing is enabled");
@@ -48,15 +48,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             if (functionMetadataResult.UseDefaultMetadataIndexing)
             {
                 _logger.LogDebug("Fallback to host indexing as worker denied indexing");
-                return await GetMetadataFromHostProvider(workerConfigs, environment, forceRefresh);
+                return await GetMetadataFromHostProvider(workerConfigs, forceRefresh);
             }
 
             return functionMetadataResult.Functions;
         }
 
-        private async Task<ImmutableArray<FunctionMetadata>> GetMetadataFromHostProvider(IEnumerable<RpcWorkerConfig> workerConfigs, IEnvironment environment, bool forceRefresh = false)
+        private async Task<ImmutableArray<FunctionMetadata>> GetMetadataFromHostProvider(IEnumerable<RpcWorkerConfig> workerConfigs,  bool forceRefresh = false)
         {
-            var functions = await _hostFunctionMetadataProvider?.GetFunctionMetadataAsync(workerConfigs, environment, forceRefresh);
+            var functions = await _hostFunctionMetadataProvider?.GetFunctionMetadataAsync(workerConfigs, forceRefresh);
             FunctionErrors = _hostFunctionMetadataProvider.FunctionErrors;
             return functions;
         }

--- a/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/HostFunctionMetadataProvider.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public ImmutableDictionary<string, ImmutableArray<string>> FunctionErrors
            => _functionErrors.ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray());
 
-        public async Task<ImmutableArray<FunctionMetadata>> GetFunctionMetadataAsync(IEnumerable<RpcWorkerConfig> workerConfigs, IEnvironment environment, bool forceRefresh)
+        public async Task<ImmutableArray<FunctionMetadata>> GetFunctionMetadataAsync(IEnumerable<RpcWorkerConfig> workerConfigs, bool forceRefresh)
         {
             _functions = default(ImmutableArray<FunctionMetadata>);
 

--- a/src/WebJobs.Script/Host/IFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/IFunctionMetadataProvider.cs
@@ -13,6 +13,6 @@ namespace Microsoft.Azure.WebJobs.Script
     {
         ImmutableDictionary<string, ImmutableArray<string>> FunctionErrors { get; }
 
-        Task<ImmutableArray<FunctionMetadata>> GetFunctionMetadataAsync(IEnumerable<RpcWorkerConfig> workerConfigs, IEnvironment environment, bool forceRefresh = false);
+        Task<ImmutableArray<FunctionMetadata>> GetFunctionMetadataAsync(IEnumerable<RpcWorkerConfig> workerConfigs, bool forceRefresh = false);
     }
 }

--- a/src/WebJobs.Script/Host/IHostFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/IHostFunctionMetadataProvider.cs
@@ -12,13 +12,13 @@ namespace Microsoft.Azure.WebJobs.Script
     /// <summary>
     /// Defines an interface for fetching function metadata from function.json files
     /// </summary>
-    internal interface IHostFunctionMetadataProvider
+    public interface IHostFunctionMetadataProvider
     {
         ImmutableDictionary<string, ImmutableArray<string>> FunctionErrors { get; }
 
         /// <summary>
         /// Reads function metadata from function.json files present along with each function
         /// </summary>
-        Task<ImmutableArray<FunctionMetadata>> GetFunctionMetadataAsync(IEnumerable<RpcWorkerConfig> workerConfigs, IEnvironment environment, bool forceRefresh = false);
+        Task<ImmutableArray<FunctionMetadata>> GetFunctionMetadataAsync(IEnumerable<RpcWorkerConfig> workerConfigs, bool forceRefresh = false);
     }
 }

--- a/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             ImmutableDictionary<string, ImmutableArray<string>> mockFunctionErrors = new Dictionary<string, ICollection<string>>().ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray());
             Mock<IFunctionMetadataProvider> mockFunctionMetadataProvider = new Mock<IFunctionMetadataProvider>();
-            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), SystemEnvironment.Instance, false)).Returns(Task.FromResult(functionMetadataCollection.ToImmutableArray()));
+            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), false)).Returns(Task.FromResult(functionMetadataCollection.ToImmutableArray()));
             mockFunctionMetadataProvider.Setup(m => m.FunctionErrors).Returns(mockFunctionErrors);
 
             var managerMock = new Mock<IScriptHostManager>();
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var mockFunctionProvider = new Mock<IFunctionProvider>();
             var workerConfigs = TestHelpers.GetTestWorkerConfigs();
 
-            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, SystemEnvironment.Instance, false)).Returns(Task.FromResult(new Collection<FunctionMetadata>().ToImmutableArray()));
+            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, false)).Returns(Task.FromResult(new Collection<FunctionMetadata>().ToImmutableArray()));
             mockFunctionMetadataProvider.Setup(m => m.FunctionErrors).Returns(new Dictionary<string, ICollection<string>>().ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray()));
 
             functionMetadataCollection.Add(GetTestFunctionMetadata(scriptFile));
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var expectedTotalFunctionsCount = functionMetadataCollection1.Count + functionMetadataCollection2.Count;
 
             var mockFunctionMetadataProvider = new Mock<IFunctionMetadataProvider>();
-            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), It.IsAny<SystemEnvironment>(), It.IsAny<bool>()))
+            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), It.IsAny<bool>()))
                 .Returns(Task.FromResult(new Collection<FunctionMetadata>().ToImmutableArray()));
             mockFunctionMetadataProvider.Setup(m => m.FunctionErrors)
                 .Returns(new Dictionary<string, ICollection<string>>().ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray()));
@@ -200,7 +200,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(testLoggerProvider);
 
-            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, SystemEnvironment.Instance, false)).Returns(Task.FromResult(new Collection<FunctionMetadata>().ToImmutableArray()));
+            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, false)).Returns(Task.FromResult(new Collection<FunctionMetadata>().ToImmutableArray()));
             mockFunctionMetadataProvider.Setup(m => m.FunctionErrors).Returns(new Dictionary<string, ICollection<string>>().ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray()));
 
             // A good provider that returns 2 functions
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(testLoggerProvider);
 
-            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, SystemEnvironment.Instance, false)).Returns(Task.FromResult(new Collection<FunctionMetadata>().ToImmutableArray()));
+            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, false)).Returns(Task.FromResult(new Collection<FunctionMetadata>().ToImmutableArray()));
             mockFunctionMetadataProvider.Setup(m => m.FunctionErrors).Returns(new Dictionary<string, ICollection<string>>().ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray()));
 
             // A bad provider that returns a faulty task
@@ -264,7 +264,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(testLoggerProvider);
 
-            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, SystemEnvironment.Instance, false)).Returns(Task.FromResult(new Collection<FunctionMetadata>().ToImmutableArray()));
+            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, false)).Returns(Task.FromResult(new Collection<FunctionMetadata>().ToImmutableArray()));
             mockFunctionMetadataProvider.Setup(m => m.FunctionErrors).Returns(new Dictionary<string, ICollection<string>>().ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray()));
 
             // A good provider that returns 2 functions
@@ -306,7 +306,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(testLoggerProvider);
 
-            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, SystemEnvironment.Instance, false)).Returns(Task.FromResult(new Collection<FunctionMetadata>().ToImmutableArray()));
+            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, false)).Returns(Task.FromResult(new Collection<FunctionMetadata>().ToImmutableArray()));
             mockFunctionMetadataProvider.Setup(m => m.FunctionErrors).Returns(new Dictionary<string, ICollection<string>>().ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray()));
 
             functionMetadataCollection.Add(GetTestFunctionMetadata("somefile.dll", name: "anotherFunction"));
@@ -341,7 +341,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var mockFunctionProvider = new Mock<IFunctionProvider>();
             var workerConfigs = TestHelpers.GetTestWorkerConfigs();
 
-            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, SystemEnvironment.Instance, false)).Returns(Task.FromResult(new Collection<FunctionMetadata>().ToImmutableArray()));
+            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, false)).Returns(Task.FromResult(new Collection<FunctionMetadata>().ToImmutableArray()));
             mockFunctionMetadataProvider.Setup(m => m.FunctionErrors).Returns(new Dictionary<string, ICollection<string>>().ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray()));
 
             functionMetadataCollection.Add(GetTestFunctionMetadata("somefile.dll", name: "anotherFunction"));
@@ -365,7 +365,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var workerConfigs = TestHelpers.GetTestWorkerConfigs();
 
-            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, SystemEnvironment.Instance, false)).Returns(Task.FromResult(new Collection<FunctionMetadata>().ToImmutableArray()));
+            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, false)).Returns(Task.FromResult(new Collection<FunctionMetadata>().ToImmutableArray()));
             mockFunctionMetadataProvider.Setup(m => m.FunctionErrors).Returns(new Dictionary<string, ICollection<string>>().ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray()));
 
             const string aFunction = "aFunction";
@@ -402,7 +402,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var mockFunctionProviderDuplicate = new Mock<IFunctionProvider>();
             var workerConfigs = TestHelpers.GetTestWorkerConfigs();
 
-            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, SystemEnvironment.Instance, false)).Returns(Task.FromResult(new Collection<FunctionMetadata>().ToImmutableArray()));
+            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, false)).Returns(Task.FromResult(new Collection<FunctionMetadata>().ToImmutableArray()));
             mockFunctionMetadataProvider.Setup(m => m.FunctionErrors).Returns(new Dictionary<string, ICollection<string>>().ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray()));
 
             functionMetadataCollection.Add(GetTestFunctionMetadata("somefile.dll", name: "duplicateFunction"));
@@ -431,7 +431,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var mockFunctionProvider = new Mock<IFunctionProvider>();
             var workerConfigs = TestHelpers.GetTestWorkerConfigs();
 
-            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, SystemEnvironment.Instance, false)).Returns(Task.FromResult(new Collection<FunctionMetadata>().ToImmutableArray()));
+            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, false)).Returns(Task.FromResult(new Collection<FunctionMetadata>().ToImmutableArray()));
             mockFunctionMetadataProvider.Setup(m => m.FunctionErrors).Returns(new Dictionary<string, ICollection<string>>().ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray()));
 
             functionMetadataCollection.Add(GetTestFunctionMetadata("somefile.dll", name: "myFunction"));
@@ -476,7 +476,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var expectedTotalFunctionsCount = 0;
 
             var mockFunctionMetadataProvider = new Mock<IFunctionMetadataProvider>();
-            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), It.IsAny<SystemEnvironment>(), It.IsAny<bool>()))
+            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), It.IsAny<bool>()))
                 .Returns(Task.FromResult(new Collection<FunctionMetadata>().ToImmutableArray()));
             mockFunctionMetadataProvider.Setup(m => m.FunctionErrors)
                 .Returns(new Dictionary<string, ICollection<string>>().ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray()));
@@ -513,7 +513,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var expectedTotalFunctionsCount = 0;
 
             var mockFunctionMetadataProvider = new Mock<IFunctionMetadataProvider>();
-            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), It.IsAny<SystemEnvironment>(), It.IsAny<bool>()))
+            mockFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), It.IsAny<bool>()))
                 .Returns(Task.FromResult(new Collection<FunctionMetadata>().ToImmutableArray()));
             mockFunctionMetadataProvider.Setup(m => m.FunctionErrors)
                 .Returns(new Dictionary<string, ICollection<string>>().ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray()));

--- a/test/WebJobs.Script.Tests/FunctionMetadataProviderTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionMetadataProviderTests.cs
@@ -54,10 +54,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             FunctionMetadataResult result = new FunctionMetadataResult(true, functionMetadataCollection.ToImmutableArray());
             _workerFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, false)).Returns(Task.FromResult(result));
-            _hostFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, environment, false)).Returns(Task.FromResult(functionMetadataCollection.ToImmutableArray()));
+            _hostFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, false)).Returns(Task.FromResult(functionMetadataCollection.ToImmutableArray()));
 
             // Act
-            var functions = defaultProvider.GetFunctionMetadataAsync(workerConfigs, environment, false).GetAwaiter().GetResult();
+            var functions = defaultProvider.GetFunctionMetadataAsync(workerConfigs, false).GetAwaiter().GetResult();
 
             // Assert
             Assert.Equal(1, functions.Length);
@@ -93,10 +93,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var defaultProvider = new FunctionMetadataProvider(_logger, workerMetadataProvider.Object, _hostFunctionMetadataProvider.Object, new OptionsWrapper<FunctionsHostingConfigOptions>(new FunctionsHostingConfigOptions()), SystemEnvironment.Instance);
 
             FunctionMetadataResult result = new FunctionMetadataResult(true, functionMetadataCollection.ToImmutableArray());
-            _hostFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, environment, false)).Returns(Task.FromResult(functionMetadataCollection.ToImmutableArray()));
+            _hostFunctionMetadataProvider.Setup(m => m.GetFunctionMetadataAsync(workerConfigs, false)).Returns(Task.FromResult(functionMetadataCollection.ToImmutableArray()));
 
             // Act
-            var functions = defaultProvider.GetFunctionMetadataAsync(workerConfigs, environment, false).GetAwaiter().GetResult();
+            var functions = defaultProvider.GetFunctionMetadataAsync(workerConfigs, false).GetAwaiter().GetResult();
 
             // Assert
             Assert.Equal(1, functions.Length);

--- a/test/WebJobs.Script.Tests/HostFunctionMetadataProviderTests.cs
+++ b/test/WebJobs.Script.Tests/HostFunctionMetadataProviderTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var metadataProvider = new HostFunctionMetadataProvider(optionsMonitor, logger, _testMetricsLogger, SystemEnvironment.Instance);
             var workerConfigs = TestHelpers.GetTestWorkerConfigs();
 
-            Assert.Equal(18, metadataProvider.GetFunctionMetadataAsync(workerConfigs, SystemEnvironment.Instance, false).Result.Length);
+            Assert.Equal(18, metadataProvider.GetFunctionMetadataAsync(workerConfigs, false).Result.Length);
             var traces = testLoggerProvider.GetAllLogMessages();
             Assert.True(AreRequiredMetricsEmitted(_testMetricsLogger));
 
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var optionsMonitor = TestHelpers.CreateOptionsMonitor(_scriptApplicationHostOptions);
             var metadataProvider = new HostFunctionMetadataProvider(optionsMonitor, NullLogger<HostFunctionMetadataProvider>.Instance, _testMetricsLogger, SystemEnvironment.Instance);
             var workerConfigs = TestHelpers.GetTestWorkerConfigs();
-            Assert.Equal(0, metadataProvider.GetFunctionMetadataAsync(workerConfigs, SystemEnvironment.Instance, false).Result.Length);
+            Assert.Equal(0, metadataProvider.GetFunctionMetadataAsync(workerConfigs, false).Result.Length);
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var optionsMonitor = TestHelpers.CreateOptionsMonitor(_scriptApplicationHostOptions);
             var metadataProvider = new HostFunctionMetadataProvider(optionsMonitor, NullLogger<HostFunctionMetadataProvider>.Instance, _testMetricsLogger, SystemEnvironment.Instance);
             var workerConfigs = TestHelpers.GetTestWorkerConfigs();
-            var functionMetadatas = metadataProvider.GetFunctionMetadataAsync(workerConfigs, SystemEnvironment.Instance, false).Result;
+            var functionMetadatas = metadataProvider.GetFunctionMetadataAsync(workerConfigs, false).Result;
 
             Assert.Equal(2, functionMetadatas.Length);
 

--- a/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             var emptyOptions = new JobHostInternalStorageOptions();
             var azureBlobStorageProvider = TestHelpers.GetAzureBlobStorageProvider(configurationMock.Object, storageOptions: emptyOptions);
             var functionsSyncManager = new FunctionsSyncManager(hostIdProviderMock.Object, optionsMonitor, loggerFactory.CreateLogger<FunctionsSyncManager>(), httpClientFactory, secretManagerProviderMock.Object, mockWebHostEnvironment.Object, _mockEnvironment.Object, hostNameProvider, functionMetadataManager, azureBlobStorageProvider, hostingConfigOptionsWrapper, mockScriptHostManager.Object);
-            _webFunctionsManager = new WebFunctionsManager(optionsMonitor, loggerFactory, httpClientFactory, secretManagerProviderMock.Object, functionsSyncManager, hostNameProvider, functionMetadataManager);
+            _webFunctionsManager = new WebFunctionsManager(optionsMonitor, loggerFactory, httpClientFactory, secretManagerProviderMock.Object, functionsSyncManager, hostNameProvider, functionMetadataManager, metadataProvider, new TestOptionsMonitor<LanguageWorkerOptions>(TestHelpers.GetTestLanguageWorkerOptions()));
         }
 
         [Theory]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

We encountered 500s from the CreateUpdate flow from FunctionController. This was caused because of multiple host restarts that used to happen during this flow. @fabiocav fixed host restarts in this [PR](https://github.com/Azure/azure-functions-host/pull/10638). However we still had one remaining when forceRefresh was set to true. This caused the function host to restart and resulted in 500s. The forceRefresh caused host restart while fetching the metadata from function workers. However in this flow we do not need to fetch the metadata from the workers. So to resolve this we are directly using HostMetadataProvider. This prevents the restart and still gives us fresh metadata as we reading the function files again.

Resolves  #10631 

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
