### PR TITLE
Bump Microsoft.Azure.WebJobs.Extensions

### DIFF
--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -54,7 +54,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.1" />
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.3.20240307.67" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="5.1.0-12067" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="5.1.0-12151" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Timers.Storage" Version="1.0.0-beta.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.Abstractions" Version="1.0.4-preview" />


### PR DESCRIPTION
Update Microsoft.Azure.WebJobs.Extensions to latest version with timer extension drain mode cancellation fix:

https://github.com/Azure/azure-webjobs-sdk-extensions/commit/79b55b2b7aa53aadf7d99b4c2bd13c7f51e81eb1