### PR TITLE
Updating FunctionsNetHost (dotnet isolated worker) to 1.0.12

### DIFF
--- a/eng/build/Workers.Dotnet.props
+++ b/eng/build/Workers.Dotnet.props
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.11" />
+    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.12" />
   </ItemGroup>
 
   <Target Name="CleanDotnetWorkerFiles" BeforeTargets="AssignTargetPaths" Condition="$(RuntimeIdentifier.StartsWith(win))">

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,6 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Updated dotnet-isolated worker to 1.0.12.
+	- [Corrected the path for the prelaunch app location.](https://github.com/Azure/azure-functions-dotnet-worker/pull/2897)
+	- [Added net9 prelaunch app.](https://github.com/Azure/azure-functions-dotnet-worker/pull/2898)

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,5 +4,5 @@
 - My change description (#PR)
 -->
 - Updated dotnet-isolated worker to 1.0.12.
-	- [Corrected the path for the prelaunch app location.](https://github.com/Azure/azure-functions-dotnet-worker/pull/2897)
-	- [Added net9 prelaunch app.](https://github.com/Azure/azure-functions-dotnet-worker/pull/2898)
+  - [Corrected the path for the prelaunch app location.](https://github.com/Azure/azure-functions-dotnet-worker/pull/2897)
+  - [Added net9 prelaunch app.](https://github.com/Azure/azure-functions-dotnet-worker/pull/2898)


### PR DESCRIPTION
Updating FunctionsNetHost (dotnet isolated worker) to 1.0.12. This version includes the below changes:

1. [Corrected the path for the prelaunch app location.](https://github.com/Azure/azure-functions-dotnet-worker/pull/2897)
2. [Added net9 prelaunch app.](https://github.com/Azure/azure-functions-dotnet-worker/pull/2898)

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

