### PR TITLE
Adding nightly runs for benchmarks.

### DIFF
--- a/eng/ci/benchmarkconfigs/hellohttp-net9.yml
+++ b/eng/ci/benchmarkconfigs/hellohttp-net9.yml
@@ -1,0 +1,54 @@
+imports:
+  - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
+
+jobs:
+  server:
+    sources:
+      functionshost:
+        repository: https://github.com/Azure/azure-functions-host
+        branchOrCommit: dev
+    project: functionshost/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+    readyStateText: "Application started."
+    environmentVariables:
+      AzureWebJobsScriptRoot: "C:\\FunctionApps\\HelloHttp9"
+      FUNCTIONS_WORKER_RUNTIME: dotnet-isolated
+  servernoproxy:
+    sources:
+      functionshost:
+        repository: https://github.com/Azure/azure-functions-host
+        branchOrCommit: dev
+    project: functionshost/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+    readyStateText: "Application started."
+    environmentVariables:
+      AzureWebJobsScriptRoot: "C:\\FunctionApps\\HelloHttp9NoProxy"
+      FUNCTIONS_WORKER_RUNTIME: dotnet-isolated
+
+scenarios:
+  helloHttp:
+    hostruntime:
+      job: server
+    load:
+      job: bombardier
+      variables:
+        serverPort: 5000
+        path: /api/Hello
+  helloHttpnoproxy:
+    hostruntime:
+      job: servernoproxy
+    load:
+      job: bombardier
+      variables:
+        serverPort: 5000
+        path: /api/HelloHttp
+
+profiles:
+  windows2022azure:
+    variables:
+      serverAddress: localhost
+    jobs:
+      hostruntime:
+        endpoints:
+          - http://localhost:5010
+      load:
+        endpoints:
+          - http://localhost:5010

--- a/eng/ci/host.benchmarks.yml
+++ b/eng/ci/host.benchmarks.yml
@@ -1,0 +1,50 @@
+# No triggers for code push to any branch.
+trigger: none
+
+# No PR triggers for now
+pr: none
+
+schedules:
+  - cron: "0 0 * * *"
+    displayName: "Nightly run"
+    always: true
+    branches:
+      include:
+      - dev
+
+resources:
+  repositories:
+  - repository: 1es
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+variables:  
+  - template: /eng/ci/templates/variables/benchmarkrun-arguments.yml@self
+  - name: buildId
+    value: $(Build.BuildId)
+  - name: buildNumber
+    value: $(Build.BuildNumber)
+  - name: sourceVersion
+    value: $(Build.SourceVersion)
+
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
+  parameters:
+    pool:
+      name: 1es-pool-azfunc
+      image: 1es-windows-2022
+      os: windows
+    stages:
+    - stage: RunBenchmarks
+      jobs: 
+      - job: HTTPBenchmarks
+        displayName: ".NET9 Isolated app load test"
+        pool: server
+        steps:
+        - template: /eng/ci/templates/steps/benchmarks/http-scenarios.yml@self
+          parameters:
+            connection: $(connection)
+            serviceBusQueueName: crank-jobs
+            serviceBusNamespace: azure-functions-host-perf
+            arguments: "$(helloHttp9) "

--- a/eng/ci/templates/steps/benchmarks/http-scenarios.yml
+++ b/eng/ci/templates/steps/benchmarks/http-scenarios.yml
@@ -1,5 +1,3 @@
-# Proxy scenarios
-
 parameters:
 - name: arguments
   type: string

--- a/eng/ci/templates/steps/benchmarks/http-scenarios.yml
+++ b/eng/ci/templates/steps/benchmarks/http-scenarios.yml
@@ -1,0 +1,46 @@
+# Proxy scenarios
+
+parameters:
+- name: arguments
+  type: string
+  default: ''
+- name: connection
+  type: string
+  default: ''
+- name: serviceBusQueueName
+  type: string
+  default: ''
+- name: serviceBusNamespace
+  type: string
+  default: ''
+
+# Scenarios
+- name: scenarios
+  type: object
+  default:
+  # HTTP Functions
+  - displayName: Hello Http HttpProxying
+    arguments: --scenario helloHttp --property scenario=helloHttp --description net9hellohttp 
+  - displayName: Hello Http No HttpProxying
+    arguments: --scenario helloHttpnoproxy --property scenario=helloHttpnoproxy --description net9hellohttpproxy 
+
+steps:
+  - ${{ each s in parameters.scenarios }}:
+    - task: PublishToAzureServiceBus@2
+      condition: succeededOrFailed()
+      displayName: ${{ s.displayName }}
+      timeoutInMinutes: 10
+      inputs:
+        connectedServiceName: ${{ parameters.connection }}
+        serviceBusQueueName: ${{ parameters.serviceBusQueueName }}
+        serviceBusNamespace: ${{ parameters.serviceBusNamespace }}
+        waitForCompletion: true
+        useDataContractSerializer: "false"
+        messageBody: |
+          {
+            "name": "crank",
+            "retries": 1,
+            "args": [ "${{ parameters.arguments }} ${{ s.arguments }} --load.options.reuseBuild true  --command-line-property --table HttpBenchmarks --sql SQL_CONNECTION_STRING --chart --no-metadata --no-measurements --property buildId=\"$(buildId)\" --property sourceVersion=\"$(sourceVersion)\" --property buildNumber=\"$(buildNumber)\"" ]
+          }
+
+

--- a/eng/ci/templates/variables/benchmarkrun-arguments.yml
+++ b/eng/ci/templates/variables/benchmarkrun-arguments.yml
@@ -1,0 +1,3 @@
+variables:
+- name: helloHttp9
+  value: --config https://raw.githubusercontent.com/Azure/azure-functions-host/refs/heads/dev/eng/ci/benchmarkconfigs/hellohttp-net9.yml --profile windows2022azure


### PR DESCRIPTION
Adding pipeline changes to enable nightly benchmark runs. This is the v1 version and we will continue to iterate. Currently this trigger a run at 9 PM. 

[Here ](https://dev.azure.com/azfunc/internal/_build/results?buildId=195771&view=results)is a sample run from my current (temp) pipeline which was using code from private branch. Once this version is checked in I will make a minor adjustment to that to use the new(renamed) yml file.


**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)


