### PR TITLE
Add official build queue-time parameters for test builds

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -7,6 +7,10 @@ parameters:
   displayName: Run tests (ignored for official branches)
   type: boolean
   default: true
+- name: signFiles
+  displayName: Sign files (ignored for official branches)
+  type: boolean
+  default: false
 
 trigger:
   batch: true
@@ -51,11 +55,12 @@ variables:
     value: false
 - name: '1ESTemplate'
   # force official to be true if an official branch. Otherwise respect the official parameter.
-  ${{ if or(eq(variables.OfficialBranch, true), eq(parameters.forceOfficial, 'true')) }}:
+  ${{ if or(eq(variables.OfficialBranch, true), eq(parameters.forceOfficial, true)) }}:
     value: 'v1/1ES.Official.PipelineTemplate.yml@1es'
-  # 'default'
   ${{ else }}:
     value: 'v1/1ES.Unofficial.PipelineTemplate.yml@1es'
+- name: SignFiles # variable for access in other templates
+  value: ${{ or(eq(variables.OfficialBranch, true), eq(parameters.signFiles, true)) }}
 
 extends:
   template: ${{ variables['1ESTemplate'] }}
@@ -77,11 +82,11 @@ extends:
       - template: /eng/ci/templates/official/jobs/build-artifacts-linux.yml@self
 
     # tests are always ran for official branches
-    - ${{ if or(eq(variables.OfficialBranch, true), eq(parameters.runTests, true)) }}:
-      - stage: Test
-        dependsOn: ''
+    - stage: Test
+      condition: ${{ or(eq(variables.OfficialBranch, true), eq(parameters.runTests, true)) }}
+      dependsOn: ''
 
-        jobs:
-        - template: /eng/ci/templates/jobs/run-unit-tests.yml@self
-        - template: /eng/ci/templates/official/jobs/run-non-e2e-tests.yml@self
-        - template: /eng/ci/templates/official/jobs/run-integration-tests.yml@self
+      jobs:
+      - template: /eng/ci/templates/jobs/run-unit-tests.yml@self
+      - template: /eng/ci/templates/official/jobs/run-non-e2e-tests.yml@self
+      - template: /eng/ci/templates/official/jobs/run-integration-tests.yml@self

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -1,14 +1,10 @@
 parameters:
-- name: official # this is used for testing the official CI from non-official branches.
-  displayName: Official Build
-  type: string
-  default: default
-  values:
-  - default
-  - 'true'
-  - 'false'
-- name: runTests # only respected if official is false
-  displayName: Run Tests
+- name: forceOfficial # this is used for testing the official CI from non-official branches.
+  displayName: Use official templates for non-official branches
+  type: boolean
+  default: false
+- name: runTests
+  displayName: Run tests (ignored for official branches)
   type: boolean
   default: true
 
@@ -55,7 +51,7 @@ variables:
     value: false
 - name: '1ESTemplate'
   # force official to be true if an official branch. Otherwise respect the official parameter.
-  ${{ if or(eq(variables.OfficialBranch, true), eq(parameters.official, 'true')) }}:
+  ${{ if or(eq(variables.OfficialBranch, true), eq(parameters.forceOfficial, 'true')) }}:
     value: 'v1/1ES.Official.PipelineTemplate.yml@1es'
   # 'default'
   ${{ else }}:

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -82,7 +82,7 @@ extends:
 
     - stage: Test
       # tests are always ran for official branches
-      condition: or(eq(variables.OfficialBranch, true), ${{ if eq(parameters.runTests, true) }})
+      condition: ${{ if or(eq(variables.OfficialBranch, true), eq(parameters.runTests, true)) }}
       dependsOn: ''
 
       jobs:

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -45,7 +45,7 @@ variables:
 - template: /eng/ci/templates/variables/build.yml@self
 - template: /ci/variables/cfs.yml@eng
 - name: OfficialBranch
-  ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/dev'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
+  ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/dev'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/')) }}:
     value: true
   ${{ else }}:
     value: false

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -80,12 +80,12 @@ extends:
       - template: /eng/ci/templates/official/jobs/build-artifacts-windows.yml@self
       - template: /eng/ci/templates/official/jobs/build-artifacts-linux.yml@self
 
-    - stage: Test
-      # tests are always ran for official branches
-      condition: ${{ if or(eq(variables.OfficialBranch, true), eq(parameters.runTests, true)) }}
-      dependsOn: ''
+    # tests are always ran for official branches
+    - ${{ if or(eq(variables.OfficialBranch, true), eq(parameters.runTests, true)) }}:
+      - stage: Test
+        dependsOn: ''
 
-      jobs:
-      - template: /eng/ci/templates/jobs/run-unit-tests.yml@self
-      - template: /eng/ci/templates/official/jobs/run-non-e2e-tests.yml@self
-      - template: /eng/ci/templates/official/jobs/run-integration-tests.yml@self
+        jobs:
+        - template: /eng/ci/templates/jobs/run-unit-tests.yml@self
+        - template: /eng/ci/templates/official/jobs/run-non-e2e-tests.yml@self
+        - template: /eng/ci/templates/official/jobs/run-integration-tests.yml@self

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -55,7 +55,7 @@ variables:
     value: 'v1/1ES.Official.PipelineTemplate.yml@1es'
   # 'default'
   ${{ else }}:
-    value: 'v1/1ES.UnOfficial.PipelineTemplate.yml@1es'
+    value: 'v1/1ES.Unofficial.PipelineTemplate.yml@1es'
 
 extends:
   template: ${{ variables['1ESTemplate'] }}

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -1,3 +1,17 @@
+parameters:
+- name: official # this is used for testing the official CI from non-official branches.
+  displayName: Official Build
+  type: string
+  default: default
+  values:
+  - default
+  - 'true'
+  - 'false'
+- name: runTests # only respected if official is false
+  displayName: Run Tests
+  type: boolean
+  default: true
+
 trigger:
   batch: true
   branches:
@@ -34,11 +48,21 @@ resources:
 variables:
 - template: /eng/ci/templates/variables/build.yml@self
 - template: /ci/variables/cfs.yml@eng
-- name: buildNumber
-  value: $[ counter('build', 23000) ] # 23000 selected to be ahead of current host build
+- name: OfficialBranch
+  ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/dev'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')) }}:
+    value: true
+  ${{ else }}:
+    value: false
+- name: '1ESTemplate'
+  # force official to be true if an official branch. Otherwise respect the official parameter.
+  ${{ if or(eq(variables.OfficialBranch, true), eq(parameters.official, 'true')) }}:
+    value: 'v1/1ES.Official.PipelineTemplate.yml@1es'
+  # 'default'
+  ${{ else }}:
+    value: 'v1/1ES.UnOfficial.PipelineTemplate.yml@1es'
 
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1es
+  template: ${{ variables['1ESTemplate'] }}
   parameters:
     pool:
       name: 1es-pool-azfunc
@@ -57,6 +81,8 @@ extends:
       - template: /eng/ci/templates/official/jobs/build-artifacts-linux.yml@self
 
     - stage: Test
+      # tests are always ran for official branches
+      condition: or(eq(variables.OfficialBranch, true), ${{ if eq(parameters.runTests, true) }})
       dependsOn: ''
 
       jobs:

--- a/eng/ci/templates/official/jobs/build-artifacts-windows.yml
+++ b/eng/ci/templates/official/jobs/build-artifacts-windows.yml
@@ -61,12 +61,13 @@ jobs:
         **/ExtensionsMetadataGenerator.csproj
         **/WebJobs.Script.Abstractions.csproj
 
-  - template: ci/sign-files.yml@eng
-    parameters:
-      displayName: Sign Abstractions assemblies
-      folderPath: out/bin/WebJobs.Script.Abstractions/release
-      pattern: Microsoft.Azure.WebJobs.Script.Abstractions*.dll
-      signType: dll
+  - ${{ if eq(variables.SignFiles, true) }}:
+    - template: ci/sign-files.yml@eng
+      parameters:
+        displayName: Sign Abstractions assemblies
+        folderPath: out/bin/WebJobs.Script.Abstractions/release
+        pattern: Microsoft.Azure.WebJobs.Script.Abstractions*.dll
+        signType: dll
 
   - task: DotNetCoreCLI@2
     displayName: Pack Abstractions
@@ -77,12 +78,13 @@ jobs:
       projects: |
         **/WebJobs.Script.Abstractions.csproj
 
-  - template: ci/sign-files.yml@eng
-    parameters:
-      displayName: Sign ExtensionsMetadataGenerator assemblies
-      folderPath: out/bin/ExtensionsMetadataGenerator
-      pattern: Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator*.dll
-      signType: dll-strong-name
+  - ${{ if eq(variables.SignFiles, true) }}:
+    - template: ci/sign-files.yml@eng
+      parameters:
+        displayName: Sign ExtensionsMetadataGenerator assemblies
+        folderPath: out/bin/ExtensionsMetadataGenerator
+        pattern: Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator*.dll
+        signType: dll-strong-name
 
   - task: DotNetCoreCLI@2
     displayName: Pack ExtensionsMetadataGenerator
@@ -93,19 +95,20 @@ jobs:
       projects: |
         **/ExtensionsMetadataGenerator.csproj
 
-  - template: ci/sign-files.yml@eng
-    parameters:
-      displayName: Sign NugetPackages
-      folderPath: $(nuget_package_path)
-      pattern: '*.nupkg'
-      signType: nuget
+  - ${{ if eq(variables.SignFiles, true) }}:
+    - template: ci/sign-files.yml@eng
+      parameters:
+        displayName: Sign NugetPackages
+        folderPath: $(nuget_package_path)
+        pattern: '*.nupkg'
+        signType: nuget
 
-  - task: DeleteFiles@1
-    displayName: Delete CodeSignSummary files
-    inputs:
-      contents: '**/CodeSignSummary-*.md'
+    - task: DeleteFiles@1
+      displayName: Delete CodeSignSummary files
+      inputs:
+        contents: '**/CodeSignSummary-*.md'
 
-  - task: DeleteFiles@1
-    displayName: Delete CodeSignSummary files
-    inputs:
-      contents: '$(nuget_package_path)/**/CodeSignSummary-*.md'
+    - task: DeleteFiles@1
+      displayName: Delete CodeSignSummary files
+      inputs:
+        contents: '$(nuget_package_path)/**/CodeSignSummary-*.md'


### PR DESCRIPTION
### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required -- TODO
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Adds parameters to official-build.yml to streamline testing the build itself. This PR introduces a concept of 'official branches' (dev, in-proc, release/*, internal/release/*) - these are branches which the rest of the changes in this PR are ignored. For _non_-official branches, this PR adds the following:

1. Uses unofficial 1ES templates
2. Adds queue time param to skip running tests
3. Adds queue time param to skip signing files

These changes streamline testing CI changes from other branches and avoids resource contention with actual official builds (integration test locks for example)