### PR TITLE
WIP: Update all logs to remove use of string interpolation

### DIFF
--- a/src/WebJobs.Script.Grpc/Server/AspNetCoreGrpcServer.cs
+++ b/src/WebJobs.Script.Grpc/Server/AspNetCoreGrpcServer.cs
@@ -48,10 +48,10 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             var addressFeature = server?.Features.Get<IServerAddressesFeature>();
             var address = addressFeature?.Addresses.SingleOrDefault();
 
-            if (!Uri.TryCreate(address, UriKind.Absolute, out Uri uri) ||
-                Uri != uri)
+            if (!Uri.TryCreate(address, UriKind.Absolute, out Uri actualUri) ||
+                Uri != actualUri)
             {
-                _logger.LogWarning($"Configured Uri ({Uri}) does not match actual Uri ({uri}).");
+                _logger.LogWarning("Configured Uri ({configuredUri}) does not match actual Uri ({actualUri}).", Uri, actualUri);
             }
 
             _logger.LogDebug($"Started {nameof(AspNetCoreGrpcServer)} on {address}.");

--- a/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
+++ b/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
             if (httpProxyTaskResult is not ForwarderError.None)
             {
-                _logger.LogDebug($"The function invocation failed to proxy the request with ForwarderError: {httpProxyTaskResult}");
+                _logger.LogDebug("The function invocation failed to proxy the request with ForwarderError: {forwarderErrorResult}", httpProxyTaskResult);
 
                 Exception forwarderException = null;
                 if (context.TryGetHttpRequest(out HttpRequest request))

--- a/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerActivityPublisher.cs
+++ b/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerActivityPublisher.cs
@@ -142,13 +142,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
                         {
                             if (_lastHeartBeatTime.AddMinutes(5) < DateTime.UtcNow)
                             {
-                                _logger.LogDebug($"Current activities count = {currentActivities.Count}");
+                                _logger.LogDebug("Current activities count = {currentActivitiesCount}", currentActivities.Count);
                                 _lastHeartBeatTime = DateTime.UtcNow;
                             }
 
                             if (currentActivities.Any())
                             {
-                                _logger.LogDebug($"Flushing {currentActivities.Count} function activities");
+                                _logger.LogDebug("Flushing {currentActivitiesCount} function activities", currentActivities.Count);
                                 await _meshServiceClient.PublishContainerActivity(currentActivities);
                             }
                         }
@@ -241,7 +241,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
             {
                 if (!PublishActivity(activity))
                 {
-                    _logger.LogWarning($"Failed to add activity {activity}");
+                    _logger.LogWarning("Failed to add activity {containerFunctionExecutionActivity}", activity);
                 }
             }
         }

--- a/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerInitializationHostedService.cs
+++ b/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerInitializationHostedService.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
                 await SpecializeMSISideCar(assignmentContext);
 
                 bool success = _instanceManager.StartAssignment(assignmentContext);
-                _logger.LogDebug($"StartAssignment invoked (Success={success})");
+                _logger.LogDebug("StartAssignment invoked (Success={startInstanceAssignmnetResult})", success);
             }
             else
             {

--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
             {
                 ScriptHostState currentState = scriptHostManager.State;
 
-                _logger.LogDebug($"Received request to resume a draining host - host status: {currentState.ToString()}");
+                _logger.LogDebug("Received request to resume a draining host - host status: {currentHostStatus}", currentState);
 
                 if (currentState != ScriptHostState.Running
                     || !Utility.TryGetHostService(scriptHostManager, out IDrainModeManager drainModeManager))
@@ -285,7 +285,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                     return StatusCode(StatusCodes.Status409Conflict);
                 }
 
-                _logger.LogDebug($"Drain mode enabled: {drainModeManager.IsDrainModeEnabled}");
+                _logger.LogDebug("Drain mode enabled: {isDrainModeEnabled}", drainModeManager.IsDrainModeEnabled);
 
                 if (drainModeManager.IsDrainModeEnabled)
                 {

--- a/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         [Authorize(Policy = PolicyNames.AdminAuthLevel)]
         public async Task<IActionResult> Assign([FromBody] EncryptedHostAssignmentContext encryptedAssignmentContext)
         {
-            _logger.LogDebug($"Starting container assignment for host : {Request?.Host}. ContextLength is: {encryptedAssignmentContext.EncryptedContext?.Length}");
+            _logger.LogDebug("Starting container assignment for host : {hostId}. ContextLength is: {contextLength}", Request?.Host, encryptedAssignmentContext?.EncryptedContext?.Length);
 
             var assignmentContext = _startupContextProvider.SetContext(encryptedAssignmentContext);
 

--- a/src/WebJobs.Script.WebHost/Controllers/KubernetesPodController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/KubernetesPodController.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         [Route("admin/pod/assign")]
         public async Task<IActionResult> Assign([FromBody] EncryptedHostAssignmentContext encryptedAssignmentContext)
         {
-            _logger.LogDebug($"Starting container assignment for host : {Request?.Host}");
+            _logger.LogDebug("Starting container assignment for host : {hostId}", Request?.Host);
             var assignmentContext = _startupContextProvider.SetContext(encryptedAssignmentContext);
 
             string error = await _instanceManager.ValidateContext(assignmentContext);

--- a/src/WebJobs.Script.WebHost/FileMonitoringService.cs
+++ b/src/WebJobs.Script.WebHost/FileMonitoringService.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 }
                 catch (DirectoryNotFoundException)
                 {
-                    _logger.LogInformation($"Unable to get directory snapshot. No directory present at {_scriptOptions.RootScriptPath}");
+                    _logger.LogInformation("Unable to get directory snapshot. No directory present at {rootScriptPath}", _scriptOptions.RootScriptPath);
                 }
             }
             return ImmutableArray<string>.Empty;

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                     {
                         lastHash = reader.ReadToEnd();
                     }
-                    _logger.LogDebug($"SyncTriggers hash (Last='{lastHash}', Current='{currentHash}')");
+                    _logger.LogDebug("SyncTriggers hash (Last='{blobLastHash}', Current='{blobCurrentHash}')", lastHash, currentHash);
                 }
 
                 if (string.Compare(currentHash, lastHash) != 0)
@@ -282,7 +282,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 {
                     await hashBlobClient.UploadAsync(stream, overwrite: true);
                 }
-                _logger.LogDebug($"SyncTriggers hash updated to '{hash}'");
+                _logger.LogDebug("SyncTriggers hash updated to '{blobCurrentHash}'", hash);
             }
             catch (Exception ex)
             {
@@ -403,7 +403,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             {
                 // The settriggers call to the FE enforces a max request size limit.
                 // If we're over limit, revert to the minimal triggers format.
-                _logger.LogWarning($"SyncTriggers payload of length '{json.Length}' exceeds max length of '{ScriptConstants.MaxTriggersStringLength}'. Reverting to minimal format.");
+                _logger.LogWarning("SyncTriggers payload of length '{payloadLength}' exceeds max length of '{maxPayloadLength}'. Reverting to minimal format.", json.Length, ScriptConstants.MaxTriggersStringLength);
 
                 var minimalResult = GetMinimalPayload(hostId, triggersArray, hostConfig);
                 json = JsonConvert.SerializeObject(minimalResult);
@@ -768,7 +768,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                     request.Headers.Add(ScriptConstants.KubernetesManagedAppNamespace, _environment.GetEnvironmentVariable(EnvironmentSettingNames.PodNamespace));
                 }
 
-                _logger.LogDebug($"Making SyncTriggers request (RequestId={requestId}, Uri={request.RequestUri.ToString()}, Content={sanitizedContentString}).");
+                _logger.LogDebug("Making SyncTriggers request (RequestId={requestId}, Uri={requestUri}, Content={contentString}).", requestId, request.RequestUri.ToString(), sanitizedContentString);
 
                 var response = await _httpClient.SendAsync(request);
 

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/UnZipHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/UnZipHandler.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
         {
             using (_metricsLogger.LatencyEvent(MetricEventNames.LinuxContainerSpecializationZipExtract))
             {
-                _logger.LogDebug($"Extracting files to '{scriptPath}'");
+                _logger.LogDebug("Extracting files to '{unzipPackageScriptPath}'", scriptPath);
                 ZipFile.ExtractToDirectory(filePath, scriptPath, overwriteFiles: true);
                 _logger.LogDebug("Zip extraction complete");
             }

--- a/src/WebJobs.Script.WebHost/Management/MeshServiceClient.cs
+++ b/src/WebJobs.Script.WebHost/Management/MeshServiceClient.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
         public async Task MountFuse(string type, string filePath, string scriptPath)
         {
-            _logger.LogDebug($"Creating {type} mount from {filePath} to {scriptPath}");
+            _logger.LogDebug("Creating {type} mount from {filePath} to {scriptPath}", type, filePath, scriptPath);
 
             await SendAsync(new[]
             {
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
         public async Task PublishContainerActivity(IEnumerable<ContainerFunctionExecutionActivity> activities)
         {
-            _logger.LogDebug($"Publishing {activities.Count()} container activities");
+            _logger.LogDebug("Publishing {activitiesCount} container activities", activities.Count());
 
             try
             {
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
             var healthEventString = Serialize(healthEvent);
 
-            _logger.LogInformation($"Posting health event {healthEventString}");
+            _logger.LogInformation("Posting health event {healthEventString}", healthEventString);
 
             var responseMessage = await SendAsync(new[]
             {
@@ -107,12 +107,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 new KeyValuePair<string, string>("healthEvent", healthEventString),
             });
 
-            _logger.LogInformation($"Posted health event status: {responseMessage.StatusCode}");
+            _logger.LogInformation("Posted health event status: {responseMessageStatusCode}", responseMessage.StatusCode);
         }
 
         public async Task CreateBindMount(string sourcePath, string targetPath)
         {
-            _logger.LogDebug($"Creating bind mount from {sourcePath} to {targetPath}");
+            _logger.LogDebug("Creating bind mount from {bindSourcePath} to {bindTargetPath}", sourcePath, targetPath);
 
             var httpResponseMessage = await SendAsync(new[]
             {
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         private async Task PublishActivities(IEnumerable<ContainerFunctionExecutionActivity> activities)
         {
             // Log one of the activities being published for debugging.
-            _logger.LogDebug($"Publishing function execution activity {activities.FirstOrDefault()}");
+            _logger.LogDebug("Publishing function execution activity {containerFunctionExecutionActivities}", activities.FirstOrDefault());
 
             var operation = new[]
             {
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         private async Task<HttpResponseMessage> SendAsync(IEnumerable<KeyValuePair<string, string>> formData)
         {
             var operationName = formData.FirstOrDefault(f => string.Equals(f.Key, Operation)).Value;
-            _logger.LogDebug($"Sending mesh request {operationName}");
+            _logger.LogDebug("Sending mesh request {operationName}", operationName);
 
             var request = new HttpRequestMessage(HttpMethod.Post, _environment.GetEnvironmentVariable(EnvironmentSettingNames.MeshInitURI))
             {
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
             var res = await _client.SendAsync(request);
 
-            _logger.LogDebug($"Mesh response {res.StatusCode}");
+            _logger.LogDebug("Mesh response {statusCode}", res.StatusCode);
 
             return res;
         }

--- a/src/WebJobs.Script.WebHost/Metrics/FlexConsumptionMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/FlexConsumptionMetricsPublisher.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         {
             Initialize();
 
-            _logger.LogInformation($"Starting metrics publisher (AlwaysReady={IsAlwaysReady}, MetricsPath='{MetricsFilePath}').");
+            _logger.LogInformation("Starting metrics publisher (AlwaysReady={isAlwaysReady}, MetricsPath='{metricsFilePath}').", IsAlwaysReady, MetricsFilePath);
 
             _metricsPublisherTimer = new Timer(OnFunctionMetricsPublishTimer, null, _initialPublishDelay, _metricPublishInterval);
             _started = true;
@@ -206,7 +206,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             int numToDelete = files.Count - _options.MaxFileCount + 1;
             var filesToDelete = files.Take(numToDelete).ToArray();
 
-            _logger.LogDebug($"Deleting {filesToDelete.Length} metrics file(s).");
+            _logger.LogDebug("Deleting {filesToDeleteCount} metrics file(s).", filesToDelete.Length);
 
             foreach (var file in filesToDelete)
             {

--- a/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
@@ -122,11 +122,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             {
                 if (certificateChain.ChainStatus.Any(s => s.Status != X509ChainStatusFlags.NoError))
                 {
-                    _logger.LogError($"Failed to build remote certificate chain for {httpRequestMessage.RequestUri} with error {certificateChain.ChainStatus.First(chain => chain.Status != X509ChainStatusFlags.NoError).Status}");
+                    _logger.LogError("Failed to build remote certificate chain for {certificateChainRequestUri} with error {certificateChainError}",
+                        httpRequestMessage.RequestUri, certificateChain.ChainStatus.First(chain => chain.Status != X509ChainStatusFlags.NoError).Status);
                 }
                 else
                 {
-                    _logger.LogError($"Failed to validate certificate for {httpRequestMessage.RequestUri} with error {sslPolicyErrors}");
+                    _logger.LogError("Failed to validate certificate for {certificateChainRequestUri} with error {sslPolicyErrors}", httpRequestMessage.RequestUri, sslPolicyErrors);
                 }
             }
             return validateCertificateResult;
@@ -157,7 +158,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
 
             if (!_functionActivities.TryAdd(activity))
             {
-                _logger.LogWarning($"Buffer for function activities is full with {_functionActivities.Count} elements. Dropping current batch of function activities");
+                _logger.LogWarning("Buffer for function activities is full with {functionActivitiesCount} elements. Dropping current batch of function activities", _functionActivities.Count);
                 DrainActivities(_currentFunctionActivities, _functionActivities);
             }
         }
@@ -178,7 +179,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
 
             if (!_memoryActivities.TryAdd(memoryActivity))
             {
-                _logger.LogWarning($"Buffer for holding memory activities is full with {_memoryActivities.Count} elements.Dropping current batch of memory activities");
+                _logger.LogWarning("Buffer for holding memory activities is full with {memoryActivitiesCount} elements.Dropping current batch of memory activities", _memoryActivities.Count);
                 DrainActivities(_currentMemoryActivities, _memoryActivities);
             }
         }

--- a/src/WebJobs.Script.WebHost/Middleware/HttpThrottleMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/HttpThrottleMiddleware.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
                 _lastPerformanceCheck = DateTime.UtcNow;
                 if (_rejectRequests)
                 {
-                    _logger.LogWarning($"Thresholds for the following counters have been exceeded: [{string.Join(", ", exceededCounters)}]");
+                    _logger.LogWarning("Thresholds for the following counters have been exceeded: [{exceededPerformanceCounters}]", string.Join(", ", exceededCounters));
                 }
             }
 

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                     try
                     {
-                        _logger.LogDebug($"Loading secrets for function '{functionName}'");
+                        _logger.LogDebug("Loading secrets for function '{functionName}'", functionName);
 
                         FunctionSecrets secrets = await LoadFunctionSecretsAsync(functionName);
 
@@ -794,7 +794,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             {
                 if (!string.IsNullOrEmpty(functionName) && _functionSecrets.ContainsKey(functionName))
                 {
-                    _logger.LogInformation($"Function keys change detected. Clearing cache for function '{functionName}'.");
+                    _logger.LogInformation("Function keys change detected. Clearing cache for function '{functionName}'.", functionName);
                     _functionSecrets.TryRemove(functionName, out _);
                 }
                 else if (_functionSecrets.Any())

--- a/src/WebJobs.Script.WebHost/Standby/StandbyManager.cs
+++ b/src/WebJobs.Script.WebHost/Standby/StandbyManager.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
 
             string scriptPath = options.ScriptPath;
-            _logger.LogInformation($"Creating StandbyMode placeholder function directory ({scriptPath})");
+            _logger.LogInformation("Creating StandbyMode placeholder function directory ({scriptPath})", scriptPath);
 
             await FileUtility.DeleteDirectoryAsync(scriptPath, true);
             FileUtility.EnsureDirectoryExists(scriptPath);

--- a/src/WebJobs.Script.WebHost/StartupContextProvider.cs
+++ b/src/WebJobs.Script.WebHost/StartupContextProvider.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             {
                 var functionKeys = Context.Secrets.Function.ToDictionary(p => p.Name, p => p.Secrets);
 
-                _logger.LogDebug($"Loaded keys for {functionKeys.Keys.Count} functions from startup context");
+                _logger.LogDebug("Loaded keys for {functionKeysCount} functions from startup context", functionKeys.Keys.Count);
 
                 return functionKeys;
             }
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 try
                 {
                     contextPath = Environment.ExpandEnvironmentVariables(contextPath);
-                    _logger.LogDebug($"Loading startup context from {contextPath}");
+                    _logger.LogDebug("Loading startup context from {azureWebsiteStartupContextPath}", contextPath);
                     string content = File.ReadAllText(contextPath);
 
                     // Context files are onetime use. We delete after reading to ensure

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -755,13 +755,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             {
                 hisMode = "Strict";
                 _metricsLogger.LogEvent(MetricEventNames.HISStrictModeEnabled);
-                _logger.LogDebug($"HIS Strict mode enabled.");
+                _logger.LogDebug("HIS Strict mode enabled.");
             }
             else if (FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagStrictHISModeWarn))
             {
                 hisMode = "Warn";
                 _metricsLogger.LogEvent(MetricEventNames.HISStrictModeWarn);
-                _logger.LogDebug($"HIS Warn mode enabled.");
+                _logger.LogDebug("HIS Warn mode enabled.");
             }
 
             logger.LogHostInitializationSettings(_originalFunctionsWorkerRuntime, functionWorkerRuntime, _originalFunctionsWorkerRuntimeVersion, functionWorkerRuntimeVersion,

--- a/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
             if (!IsDispatcherReady())
             {
-                _logger.LogTrace($"FunctionDispatcher state: {_functionDispatcher.State}");
+                _logger.LogTrace("FunctionDispatcher state: {state}", _functionDispatcher.State);
                 bool result = await Utility.DelayAsync((_functionDispatcher.ErrorEventsThreshold + 1) * (int)_workerInitializationTimeout.TotalSeconds, WorkerConstants.WorkerReadyCheckPollingIntervalMilliseconds, () =>
                 {
                     return _functionDispatcher.State != FunctionInvocationDispatcherState.Initialized;
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
                 if (result)
                 {
-                    _logger.LogError($"Final functionDispatcher state: {_functionDispatcher.State}. Initialization timed out and host is shutting down");
+                    _logger.LogError("Final functionDispatcher state: {finalState}. Initialization timed out and host is shutting down", _functionDispatcher.State);
                     _applicationLifetime.StopApplication();
                 }
             }

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
             string bundlePath = Path.Combine(_options.DownloadPath, version);
             if (FileUtility.FileExists(bundleMetatdataFile))
             {
-                _logger.LogInformation($"Skipping bundle download since it already exists at path {bundlePath}");
+                _logger.LogInformation("Skipping bundle download since it already exists at path {bundlePath}", bundlePath);
                 return bundlePath;
             }
 

--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
             if (functionsAllowList != null)
             {
-                _logger.LogInformation($"A function allow list has been specified, excluding all but the following functions: [{string.Join(", ", functionsAllowList)}]");
+                _logger.LogInformation("A function allow list has been specified, excluding all but the following functions: [{functionsAllowList}]", string.Join(", ", functionsAllowList));
                 Errors = _functionErrors.Where(kvp => functionsAllowList.Any(functionName => functionName.Equals(kvp.Key, StringComparison.CurrentCultureIgnoreCase))).ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray());
             }
 

--- a/src/WebJobs.Script/Host/HostIdValidator.cs
+++ b/src/WebJobs.Script/Host/HostIdValidator.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 BinaryData data = BinaryData.FromObjectAsJson(hostIdInfo);
                 await blobClient.UploadAsync(data);
 
-                _logger.LogDebug($"Host ID record written (ID:{hostId}, HostName:{hostIdInfo.Hostname})");
+                _logger.LogDebug("Host ID record written (ID:{hostId}, HostName:{hostName})", hostId, hostIdInfo.Hostname);
             }
             catch (RequestFailedException rfex) when (rfex.Status == 409)
             {

--- a/src/WebJobs.Script/StorageProvider/HostAzureBlobStorageProvider.cs
+++ b/src/WebJobs.Script/StorageProvider/HostAzureBlobStorageProvider.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.Script
             if (_storageOptions?.CurrentValue.InternalSasBlobContainer != null)
             {
                 blobContainerClient = new BlobContainerClient(new Uri(_storageOptions.CurrentValue.InternalSasBlobContainer));
-                _logger.LogDebug($"Using storage account {blobContainerClient.AccountName} and container {blobContainerClient.Name} for hosting BlobContainerClient.");
+                _logger.LogDebug("Using storage account {blobAccountName} and container {blobContainerName} for hosting BlobContainerClient.", blobContainerClient.AccountName, blobContainerClient.Name);
                 return true;
             }
 

--- a/src/WebJobs.Script/Workers/Http/DefaultHttpWorkerService.cs
+++ b/src/WebJobs.Script/Workers/Http/DefaultHttpWorkerService.cs
@@ -315,7 +315,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
             try
             {
                 HttpResponseMessage response = await SendPingRequestAsync(requestUri, HttpMethod.Get);
-                _logger.LogDebug($"Response code while pinging uri '{requestUri}' is '{response.StatusCode}'");
+                _logger.LogDebug("Response code while pinging uri '{pingRequestUri}' is '{pingRequeststatusCode}'", requestUri, response.StatusCode);
             }
             catch (Exception ex)
             {

--- a/src/WebJobs.Script/Workers/Http/HttpFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpFunctionInvocationDispatcher.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
                     while (!_invokerErrors.IsEmpty)
                     {
                         _invokerErrors.TryPop(out HttpWorkerErrorEvent popped);
-                        _logger.LogDebug($"Popping out errorEvent createdAt:{popped.CreatedAt} workerId:{popped.WorkerId}");
+                        _logger.LogDebug("Popping out errorEvent createdAt:{httpWorkerErrorEventCreatedAt} workerId:{httpWorkerErrorEventWorkerId}", popped.CreatedAt, popped.WorkerId);
                     }
                 }
             }

--- a/src/WebJobs.Script/Workers/ProcessManagement/DefaultWorkerProcessFactory.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/DefaultWorkerProcessFactory.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             var matches = regex.Matches(envExpandedString);
             foreach (Match match in matches)
             {
-                _logger.LogDebug($"Environment variable:{match.Value} is not set");
+                _logger.LogDebug("Environment variable:{matchedEnvironmentVariableValue} is not set", match.Value);
                 envExpandedString = envExpandedString.Replace(match.Value, string.Empty);
             }
             return envExpandedString;

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -253,7 +253,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             cancellationToken.ThrowIfCancellationRequested();
 
             var placeholderModeEnabled = _environment.IsPlaceholderModeEnabled();
-            _logger.LogDebug($"Placeholder mode is enabled: {placeholderModeEnabled}");
+            _logger.LogDebug("Placeholder mode is enabled: {placeholderModeEnabled}", placeholderModeEnabled);
 
             if (placeholderModeEnabled)
             {
@@ -289,7 +289,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 // Only throw if workerConfig is null AND some functions have been found.
                 // With .NET out-of-proc, worker config comes from functions.
                 var allLanguageNamesFromWorkerConfigs = string.Join(",", _workerConfigs.Select(c => c.Description.Language));
-                _logger.LogDebug($"Languages present in WorkerConfig: {allLanguageNamesFromWorkerConfigs}");
+                _logger.LogDebug("Languages present in WorkerConfig: {allLanguageNamesFromWorkerConfigs}, allLanguageNamesFromWorkerConfigs");
 
                 throw new InvalidOperationException($"WorkerConfig for runtime: {_workerRuntime} not found");
             }
@@ -365,7 +365,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public async Task<IDictionary<string, WorkerStatus>> GetWorkerStatusesAsync()
         {
             var workerChannels = (await GetInitializedWorkerChannelsAsync()).ToArray();
-            _logger.LogDebug($"[HostMonitor] Checking worker statuses (Count={workerChannels.Length})");
+            _logger.LogDebug("[HostMonitor] Checking worker statuses (Count={currentWorkerChannelCount})", workerChannels.Length);
 
             // invoke the requests to each channel in parallel
             var workerStatuses = new Dictionary<string, WorkerStatus>(StringComparer.OrdinalIgnoreCase);
@@ -381,7 +381,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             {
                 var workerChannel = workerChannels[i];
                 var workerStatus = tasks[i].Result;
-                _logger.LogDebug($"[HostMonitor] Worker status: ID={workerChannel.Id}, Latency={Math.Round(workerStatus.Latency.TotalMilliseconds)}ms");
+                _logger.LogDebug("[HostMonitor] Worker status: ID={workerChannelId}, Latency={workerStatusLatencyMs}ms", workerChannel.Id, Math.Round(workerStatus.Latency.TotalMilliseconds));
                 workerStatuses.Add(workerChannel.Id, workerStatus);
             }
 
@@ -633,7 +633,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     while (!_languageWorkerErrors.IsEmpty)
                     {
                         _languageWorkerErrors.TryPop(out WorkerErrorEvent popped);
-                        _logger.LogDebug($"Popping out errorEvent createdAt: '{popped.CreatedAt}' workerId: '{popped.WorkerId}'");
+                        _logger.LogDebug("Popping out errorEvent createdAt: '{workerErrorEventCreatedAt}' workerId: '{workerErrorEventWorkerId}'", popped.CreatedAt, popped.WorkerId);
                     }
                 }
             }
@@ -680,7 +680,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             {
                 if (channel.IsExecutingInvocation(invocationId))
                 {
-                    _logger.LogDebug($"Restarting channel with workerId: '{channel.Id}' that is executing invocation: '{invocationId}' and timed out.");
+                    _logger.LogDebug("Restarting channel with workerId: '{restartedChannelId}' that is executing invocation: '{restartedInvocationId}' and timed out.", channel.Id, invocationId);
                     await DisposeAndRestartWorkerChannel(_workerRuntime, channel.Id);
                     return true;
                 }
@@ -703,7 +703,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         public void PreShutdown()
         {
-            _logger.LogDebug($"Preventing any new worker processes from starting during shutdown.");
+            _logger.LogDebug("Preventing any new worker processes from starting during shutdown.");
             _processStartCancellationToken.Cancel();
             if (_hostingConfigOptions.Value.ShutdownWebhostWorkerChannelsOnHostShutdown && !_scriptOptions.IsStandbyConfiguration)
             {

--- a/src/WebJobs.Script/Workers/WorkerConcurrencyManager.cs
+++ b/src/WebJobs.Script/Workers/WorkerConcurrencyManager.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
 
                     if (_functionInvocationDispatcher is HttpFunctionInvocationDispatcher)
                     {
-                        _logger.LogDebug($"Http dynamic worker concurrency is not supported.");
+                        _logger.LogDebug("Http dynamic worker concurrency is not supported.");
                         return Task.CompletedTask;
                     }
                     if (!string.IsNullOrEmpty(_environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionsWorkerProcessCountSettingName)))
@@ -82,12 +82,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
                     }
                     if (_environment.IsWorkerDynamicConcurrencyEnabled())
                     {
-                        _logger.LogDebug($"Dynamic worker concurrency monitoring is starting by app setting.");
+                        _logger.LogDebug("Dynamic worker concurrency monitoring is starting by app setting.");
                         Activate();
                     }
                     else if (_functionsHostingConfigOptionsMonitor.CurrentValue != null && _functionsHostingConfigOptionsMonitor.CurrentValue.FunctionsWorkerDynamicConcurrencyEnabled)
                     {
-                        _logger.LogDebug($"Dynamic worker concurrency monitoring is starting by hosting config.");
+                        _logger.LogDebug("Dynamic worker concurrency monitoring is starting by hosting config.");
                         Activate();
 
                         _hostingConfigOnChange = _functionsHostingConfigOptionsMonitor.OnChange(async (newOptions) =>
@@ -192,7 +192,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
                 {
                     if (workerStatuses.Count() < _workerConcurrencyOptions.Value.MaxWorkerCount)
                     {
-                        _logger.LogInformation($"A new worker will be added, overloaded workers = {overloadedCount}, initialized workers = {workerStatuses.Count()} ");
+                        _logger.LogInformation("A new worker will be added, overloaded workers = {overloadedWorkerCount}, initialized workers = {initializedWorkerCount} ", overloadedCount, workerStatuses.Count());
                         result = true;
                     }
                 }
@@ -276,7 +276,7 @@ LatencyHistory=({formattedLatencyHistory}), AvgLatency={latencyAvg}, MaxLatency=
             long currentMemoryConsumption = workerChannelSizes.Sum() + hostProcessSize;
             if (currentMemoryConsumption + maxWorkerSize > memoryLimit * 0.8)
             {
-                _logger.LogDebug($"Starting new language worker canceled: TotalMemory={memoryLimit}, MaxWorkerSize={maxWorkerSize}, CurrentMemoryConsumption={currentMemoryConsumption}");
+                _logger.LogDebug("Starting new language worker canceled: TotalMemory={totalMemoryLimit}, MaxWorkerSize={maxWorkerSize}, CurrentMemoryConsumption={currentMemoryConsumption}", memoryLimit, maxWorkerSize, currentMemoryConsumption);
                 return false;
             }
             return true;
@@ -294,7 +294,7 @@ LatencyHistory=({formattedLatencyHistory}), AvgLatency={latencyAvg}, MaxLatency=
             var nonReadyWorkerChannels = workerChannels.Where(x => x.IsChannelReadyForInvocations() == false);
             if (nonReadyWorkerChannels.Any())
             {
-                _logger.LogDebug($"Starting new language worker canceled as there is atleast one non ready channel: TotalChannels={workerChannels.Count()}, NonReadyChannels={nonReadyWorkerChannels.Count()}");
+                _logger.LogDebug("Starting new language worker canceled as there is atleast one non ready channel: TotalChannels={totalChannelWorkerCount}, NonReadyChannels={nonReadyWorkerChannelCount}", workerChannels.Count(), nonReadyWorkerChannels.Count());
                 return false;
             }
 
@@ -302,7 +302,7 @@ LatencyHistory=({formattedLatencyHistory}), AvgLatency={latencyAvg}, MaxLatency=
             int workersCount = workerChannels.Count();
             if (workersCount >= _workerConcurrencyOptions.Value.MaxWorkerCount)
             {
-                _logger.LogDebug($"Starting new language worker canceled as the count of total channels reaches the maximum limit: TotalChannels={workersCount}, MaxWorkerCount={_workerConcurrencyOptions.Value.MaxWorkerCount}");
+                _logger.LogDebug("Starting new language worker canceled as the count of total channels reaches the maximum limit: TotalChannels={currentWorkerCount}, MaxWorkerCount={concurrencyMaxWorkerCount}", workersCount, _workerConcurrencyOptions.Value.MaxWorkerCount);
                 return false;
             }
 
@@ -311,7 +311,7 @@ LatencyHistory=({formattedLatencyHistory}), AvgLatency={latencyAvg}, MaxLatency=
 
         private async Task StopApplication()
         {
-            _logger.LogDebug($"Dynamic worker concurrency monitoring is stopping on hosting config update. Shutting down Functions Host.");
+            _logger.LogDebug("Dynamic worker concurrency monitoring is stopping on hosting config update. Shutting down Functions Host.");
             await _functionInvocationDispatcher.ShutdownAsync();
             _applicationLifetime.StopApplication();
         }

--- a/test/DotNetIsolated60/QueueFunction.cs
+++ b/test/DotNetIsolated60/QueueFunction.cs
@@ -16,7 +16,7 @@ namespace DotNetIsolated60
         [Function("QueueFunction")]
         public void Run([QueueTrigger("myqueue-items", Connection = "AzureWebJobsStorage")] string myQueueItem)
         {
-            _logger.LogInformation($"C# Queue trigger function processed: {myQueueItem}");
+            _logger.LogInformation("C# Queue trigger function processed: {myQueueItem}", myQueueItem);
         }
     }
 }

--- a/test/DotNetIsolatedUnsupportedWorker/QueueFunction.cs
+++ b/test/DotNetIsolatedUnsupportedWorker/QueueFunction.cs
@@ -15,7 +15,7 @@ namespace DotNetIsolatedUnsupportedWorker
         [Function("QueueFunction")]
         public void Run([QueueTrigger("myqueue-items", Connection = "AzureWebJobsStorage")] string myQueueItem)
         {
-            _logger.LogInformation($"C# Queue trigger function processed: {myQueueItem}");
+            _logger.LogInformation("C# Queue trigger function processed: {myQueueItem}", myQueueItem);
         }
     }
 }


### PR DESCRIPTION
Updating logs to remove use of string interpolation. I know it's a lot of files, but the changes are very minimal.

I intentionally did not fix some formatting in these log messages to avoid breaking detectors and other items that depend on the current format. With the exception of things like:

`_logger.LogError($"Error reading previous start context: {e.ToString()}");`

Fixed to:

`_logger.LogError(e, "Error reading previous start context.");`

Is there are concerns about this, I can follow the same principal for this and keep the exception string in the message itself.

TODO: Update tests
