### PR TITLE
Adding check for service and instances count.

### DIFF
--- a/src/WebJobs.Script.WebHost/DependencyInjection/ServiceProviderExtensions.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/ServiceProviderExtensions.cs
@@ -155,7 +155,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
                                   {string.Join(",\n\t", instancesArray.Select(i => i?.GetType()?.ToString() ?? "null"))}
                                 """;
 
-
                 throw new InvalidOperationException(message);
             }
         }

--- a/src/WebJobs.Script.WebHost/DependencyInjection/ServiceProviderExtensions.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/ServiceProviderExtensions.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -98,11 +99,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
                 else if (services.All(s => s.Lifetime == ServiceLifetime.Singleton))
                 {
                     // We can resolve them from the main container.
-                    var instances = serviceProvider.GetServices(services.Key);
+                    // Materialize services and instances to arrays once.
+                    var servicesArray = services.ToArray();
+                    var instancesArray = serviceProvider.GetServices(services.Key)?.ToArray() ?? Array.Empty<object>();
 
-                    for (var i = 0; i < services.Count(); i++)
+                    // Validate counts
+                    ValidateServiceAndInstanceCounts(servicesArray, instancesArray, services.Key);
+
+                    for (var i = 0; i < servicesArray.Length; i++)
                     {
-                        clonedCollection.CloneSingleton(services.ElementAt(i), instances.ElementAt(i));
+                        clonedCollection.CloneSingleton(servicesArray[i], instancesArray[i]);
                     }
                 }
 
@@ -112,24 +118,44 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
                     // We need a service scope to resolve them.
                     using var scope = serviceProvider.CreateScope();
 
-                    var instances = scope.ServiceProvider.GetServices(services.Key);
+                    // Materialize services and instances to arrays once.
+                    var servicesArray = services.ToArray();
+                    var instancesArray = scope.ServiceProvider.GetServices(services.Key)?.ToArray() ?? Array.Empty<object>();
+
+                    ValidateServiceAndInstanceCounts(servicesArray, instancesArray, services.Key);
 
                     // Then we only keep singleton instances.
-                    for (var i = 0; i < services.Count(); i++)
+                    for (var i = 0; i < servicesArray.Length; i++)
                     {
-                        if (services.ElementAt(i).Lifetime == ServiceLifetime.Singleton)
+                        if (servicesArray[i].Lifetime == ServiceLifetime.Singleton)
                         {
-                            clonedCollection.CloneSingleton(services.ElementAt(i), instances.ElementAt(i));
+                            clonedCollection.CloneSingleton(servicesArray[i], instancesArray[i]);
                         }
                         else
                         {
-                            clonedCollection.Add(services.ElementAt(i));
+                            clonedCollection.Add(servicesArray[i]);
                         }
                     }
                 }
             }
 
             return clonedCollection;
+        }
+
+        private static void ValidateServiceAndInstanceCounts<TService, TInstance>(TService[] servicesArray, TInstance[] instancesArray, Type serviceType)
+        {
+            if (servicesArray.Length != instancesArray.Length)
+            {
+                var messageBuilder = new StringBuilder()
+                    .AppendLine($"Mismatch detected for type {serviceType}:")
+                    .AppendLine($"services.Count = {servicesArray.Length}, instances.Count = {instancesArray.Length}")
+                    .Append("Services:\n\t")
+                    .Append(string.Join(",\n\t", servicesArray.Select(s => s.ToString())))
+                    .Append("\nInstances:\n\t")
+                    .AppendLine(string.Join(",\n\t", instancesArray.Select(i => i?.GetType()?.ToString() ?? "null")));
+                Console.WriteLine(messageBuilder.ToString());
+                throw new InvalidOperationException(messageBuilder.ToString());
+            }
         }
     }
 

--- a/src/WebJobs.Script.WebHost/DependencyInjection/ServiceProviderExtensions.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/ServiceProviderExtensions.cs
@@ -146,15 +146,17 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
         {
             if (servicesArray.Length != instancesArray.Length)
             {
-                var messageBuilder = new StringBuilder()
-                    .AppendLine($"Mismatch detected for type {serviceType}:")
-                    .AppendLine($"services.Count = {servicesArray.Length}, instances.Count = {instancesArray.Length}")
-                    .Append("Services:\n\t")
-                    .Append(string.Join(",\n\t", servicesArray.Select(s => s.ToString())))
-                    .Append("\nInstances:\n\t")
-                    .AppendLine(string.Join(",\n\t", instancesArray.Select(i => i?.GetType()?.ToString() ?? "null")));
-                Console.WriteLine(messageBuilder.ToString());
-                throw new InvalidOperationException(messageBuilder.ToString());
+                var message = $"""
+                                Mismatch detected for type {serviceType}:
+                                services.Count = {servicesArray.Length}, instances.Count = {instancesArray.Length}
+                                Services:
+                                  {string.Join(",\n\t", servicesArray.Select(s => s.ToString()))}
+                                Instances:
+                                  {string.Join(",\n\t", instancesArray.Select(i => i?.GetType()?.ToString() ?? "null"))}
+                                """;
+
+
+                throw new InvalidOperationException(message);
             }
         }
     }


### PR DESCRIPTION
Adding a check in the `CreateChildContainer` method to validate the counts of services and instances. Validation ensures that the number of services matches the number of instances, preventing runtime errors when processing them together. Some applications are encountering the following error, and this change will provide additional logs to aid in investigating the issue.

> System.ArgumentOutOfRangeException : Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
   at System.ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessException()
   at System.SZArrayHelper.get_Item[T](Int32 index)
   at System.Linq.Enumerable.ElementAt[TSource](IEnumerable`1 source,Int32 index)
   at Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection.ServiceProviderExtensions.CreateChildContainer(IServiceProvider serviceProvider,IServiceCollection serviceCollection)
   at Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection.JobHostScopedServiceProviderFactory.CreateServiceProvider(IServiceCollection services) 
   at /_/src/WebJobs.Script.WebHost/DependencyInjection/JobHostScopedServiceProviderFactory.cs : 68
   at Microsoft.Extensions.Hosting.HostBuilder.InitializeServiceProvider()
   at Microsoft.Extensions.Hosting.HostBuilder.Build()
   at async Microsoft.Azure.WebJobs.Script.WebHost.WebJobsScriptHostService.UnsynchronizedStartHostAsync(ScriptHostStartupOperation activeOperation,Int32 attemptCount,JobHostStartupMode startupMode) 
   at /_/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs : 346

**Sample log**
> Mismatch detected for type Microsoft.AspNetCore.Mvc.ApplicationModels.IPageApplicationModelProvider:
services.Count = 6, instances.Count = 5
Services:
        Microsoft.AspNetCore.Mvc.ApplicationModels.IPageApplicationModelProvider (Singleton),
         Microsoft.AspNetCore.Mvc.ApplicationModels.IPageApplicationModelProvider (Singleton),
         Microsoft.AspNetCore.Mvc.ApplicationModels.IPageApplicationModelProvider (Singleton),
         Microsoft.AspNetCore.Mvc.ApplicationModels.IPageApplicationModelProvider (Singleton),
         Microsoft.AspNetCore.Mvc.ApplicationModels.IPageApplicationModelProvider (Singleton),
         Microsoft.AspNetCore.Mvc.ApplicationModels.IPageApplicationModelProvider (Singleton)
Instances:
        Microsoft.AspNetCore.Mvc.ApplicationModels.DefaultPageApplicationModelProvider,
        Microsoft.AspNetCore.Mvc.ApplicationModels.AutoValidateAntiforgeryPageApplicationModelProvider,
        Microsoft.AspNetCore.Mvc.ApplicationModels.AuthorizationPageApplicationModelProvider,
        Microsoft.AspNetCore.Mvc.ApplicationModels.TempDataFilterPageApplicationModelProvider,
        Microsoft.AspNetCore.Mvc.ApplicationModels.ViewDataAttributePageApplicationModelProvider

This will help investigate 

### Issue describing the changes in this PR

resolves #10780 
### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
