### PR TITLE
Moving WebJobs.Script to .NET 8

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -10,3 +10,4 @@
   - [Added net9 prelaunch app.](https://github.com/Azure/azure-functions-dotnet-worker/pull/2898)
 - Update the `DefaultHttpProxyService` to better handle client disconnect scenarios (#10688)
   - Replaced `InvalidOperationException` with `HttpForwardingException` when there is a ForwarderError
+- Updated `WebJobs.Script` to target .NET 8 (instead of .NET Standard 2.1)

--- a/src/WebJobs.Script/Binding/Http/RawScriptResult.cs
+++ b/src/WebJobs.Script/Binding/Http/RawScriptResult.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
                         }
                         else
                         {
-                            response.Headers.Add(header.Key, header.Value.ToString() ?? string.Empty);
+                            response.Headers.Append(header.Key, header.Value.ToString() ?? string.Empty);
                         }
                     }
                 }

--- a/src/WebJobs.Script/Binding/Http/ScriptObjectResult.cs
+++ b/src/WebJobs.Script/Binding/Http/ScriptObjectResult.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
                     }
                     else
                     {
-                        response.Headers.Add(header.Key, header.Value.ToString() ?? string.Empty);
+                        response.Headers.Append(header.Key, header.Value.ToString() ?? string.Empty);
                     }
                 }
             }

--- a/src/WebJobs.Script/Description/Compilation/CompilationServiceException.cs
+++ b/src/WebJobs.Script/Description/Compilation/CompilationServiceException.cs
@@ -11,7 +11,6 @@ using Microsoft.CodeAnalysis.Scripting;
 
 namespace Microsoft.Azure.WebJobs.Script.Description
 {
-    [Serializable]
     public sealed class CompilationServiceException : Exception
     {
         public CompilationServiceException()
@@ -23,10 +22,6 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         }
 
         public CompilationServiceException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-
-        private CompilationServiceException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/src/WebJobs.Script/Extensions/AssemblyExtensions.cs
+++ b/src/WebJobs.Script/Extensions/AssemblyExtensions.cs
@@ -25,7 +25,9 @@ namespace Microsoft.Azure.WebJobs.Script
                 return codeBase;
             }
 
+#pragma warning disable SYSLIB0012 // Type or member is obsolete
             return assembly.CodeBase;
+#pragma warning restore SYSLIB0012 // Type or member is obsolete
         }
     }
 }

--- a/src/WebJobs.Script/ExternalStartupException.cs
+++ b/src/WebJobs.Script/ExternalStartupException.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Azure.WebJobs.Script
     /// An exception that indicates an issue calling into an external Startup class. This will
     /// prevent the host from starting.
     /// </summary>
-    [Serializable]
     public class ExternalStartupException : Exception
     {
         public ExternalStartupException() { }
@@ -17,9 +16,5 @@ namespace Microsoft.Azure.WebJobs.Script
         public ExternalStartupException(string message) : base(message) { }
 
         public ExternalStartupException(string message, Exception inner) : base(message, inner) { }
-
-        protected ExternalStartupException(
-          System.Runtime.Serialization.SerializationInfo info,
-          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/WebJobs.Script/FunctionConfigurationException.cs
+++ b/src/WebJobs.Script/FunctionConfigurationException.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Azure.WebJobs.Script
     /// An exception that indicates an issue with a function. These exceptions will be caught and
     /// logged, but not cause a host to restart.
     /// </summary>
-    [Serializable]
     public class FunctionConfigurationException : Exception
     {
         public FunctionConfigurationException() { }
@@ -17,9 +16,5 @@ namespace Microsoft.Azure.WebJobs.Script
         public FunctionConfigurationException(string message) : base(message) { }
 
         public FunctionConfigurationException(string message, Exception inner) : base(message, inner) { }
-
-        protected FunctionConfigurationException(
-          System.Runtime.Serialization.SerializationInfo info,
-          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/WebJobs.Script/Host/ProxyFunctionProvider.cs
+++ b/src/WebJobs.Script/Host/ProxyFunctionProvider.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.WebJobs.Script
             var functionErrors = new Dictionary<string, ICollection<string>>();
             Collection<ProxyFunctionMetadata> proxies = ReadProxyMetadata(_scriptOptions.Value.RootScriptPath, _logger, functionErrors);
 
-            ImmutableArray<FunctionMetadata> metadata;
+            ImmutableArray<FunctionMetadata> metadata = ImmutableArray<FunctionMetadata>.Empty;
             if (proxies != null && proxies.Any())
             {
                 metadata = proxies.ToImmutableArray<FunctionMetadata>();

--- a/src/WebJobs.Script/HostConfigurationException.cs
+++ b/src/WebJobs.Script/HostConfigurationException.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Azure.WebJobs.Script
     /// An exception that indicates an issue configuring a ScriptHost. This will
     /// prevent the host from starting.
     /// </summary>
-    [Serializable]
     public class HostConfigurationException : Exception
     {
         public HostConfigurationException() { }
@@ -17,9 +16,5 @@ namespace Microsoft.Azure.WebJobs.Script
         public HostConfigurationException(string message) : base(message) { }
 
         public HostConfigurationException(string message, Exception inner) : base(message, inner) { }
-
-        protected HostConfigurationException(
-          System.Runtime.Serialization.SerializationInfo info,
-          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/WebJobs.Script/HostDisposedException.cs
+++ b/src/WebJobs.Script/HostDisposedException.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Azure.WebJobs.Script
     /// <summary>
     /// An exception that indicates that a service was used on a disposed host.
     /// </summary>
-    [Serializable]
     public class HostDisposedException : ObjectDisposedException
     {
         // For this exception, we want a full stack trace to pinpoint the method
@@ -24,29 +23,11 @@ namespace Microsoft.Azure.WebJobs.Script
             _stackTraceString = GetStackTraceString();
         }
 
-        protected HostDisposedException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-            if (info == null)
-            {
-                throw new ArgumentNullException(nameof(info));
-            }
-
-            _stackTraceString = info.GetString("FullStackTraceString");
-        }
-
         public override string StackTrace => _stackTraceString;
 
         public string GetStackTraceString()
         {
             return new StackTrace(true).ToString();
-        }
-
-        public override void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            base.GetObjectData(info, context);
-
-            info.AddValue("FullStackTraceString", _stackTraceString);
         }
 
         private static string GetDefaultMessage(string disposedObjectName)

--- a/src/WebJobs.Script/HostInitializationException.cs
+++ b/src/WebJobs.Script/HostInitializationException.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.WebJobs.Script
     /// <summary>
     /// An exception that indicates an issue initializing a ScriptHost.
     /// </summary>
-    [Serializable]
     public class HostInitializationException : Exception
     {
         public HostInitializationException() { }
@@ -16,9 +15,5 @@ namespace Microsoft.Azure.WebJobs.Script
         public HostInitializationException(string message) : base(message) { }
 
         public HostInitializationException(string message, Exception inner) : base(message, inner) { }
-
-        protected HostInitializationException(
-          System.Runtime.Serialization.SerializationInfo info,
-          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/WebJobs.Script/InvalidHostServicesException.cs
+++ b/src/WebJobs.Script/InvalidHostServicesException.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Azure.WebJobs.Script
     /// An exception that indicates an issue with the registerd services for a ScriptHost. This will
     /// prevent the host from starting.
     /// </summary>
-    [Serializable]
     public class InvalidHostServicesException : Exception
     {
         public InvalidHostServicesException() { }
@@ -18,8 +17,5 @@ namespace Microsoft.Azure.WebJobs.Script
         public InvalidHostServicesException(string message) : base(message) { }
 
         public InvalidHostServicesException(string message, Exception inner) : base(message, inner) { }
-
-        protected InvalidHostServicesException(SerializationInfo info, StreamingContext context)
-            : base(info, context) { }
     }
 }

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackageId>Microsoft.Azure.WebJobs.Script</PackageId>
     <AssemblyName>Microsoft.Azure.WebJobs.Script</AssemblyName>
     <RootNamespace>Microsoft.Azure.WebJobs.Script</RootNamespace>

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -64,7 +64,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         internal static string GetDefaultWorkersDirectory(Func<string, bool> directoryExists)
         {
+#pragma warning disable SYSLIB0012 // Type or member is obsolete
             string assemblyLocalPath = Path.GetDirectoryName(new Uri(typeof(RpcWorkerConfigFactory).Assembly.CodeBase).LocalPath);
+#pragma warning restore SYSLIB0012 // Type or member is obsolete
             string workersDirPath = Path.Combine(assemblyLocalPath, RpcWorkerConstants.DefaultWorkersDirectoryName);
             if (!directoryExists(workersDirPath))
             {

--- a/src/WebJobs.Script/Workers/SharedMemoryDataTransfer/MemoryMappedFileAccessorWindows.cs
+++ b/src/WebJobs.Script/Workers/SharedMemoryDataTransfer/MemoryMappedFileAccessorWindows.cs
@@ -60,6 +60,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer
 
         public override bool TryOpen(string mapName, out MemoryMappedFile mmf)
         {
+            if (!OperatingSystem.IsWindows())
+            {
+                throw new PlatformNotSupportedException($"{nameof(TryOpen)} is not supported on the current platform.");
+            }
+
             mmf = null;
 
             try

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/HostDisposedExceptionTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/HostDisposedExceptionTests.cs
@@ -75,27 +75,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration
         //    Assert.Contains("CustomListener.RunAsync", ex.StackTrace);
         //}
 
-        [Fact]
-        public void Serialization()
-        {
-            HostDisposedException originalEx = new HostDisposedException("someObject", new ObjectDisposedException("someObject"));
-            HostDisposedException deserializedEx;
-
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-            BinaryFormatter bf = new BinaryFormatter();
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
-            using (MemoryStream ms = new MemoryStream())
-            {
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-                bf.Serialize(ms, originalEx);
-                ms.Seek(0, 0);
-                deserializedEx = (HostDisposedException)bf.Deserialize(ms);
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
-            }
-
-            Assert.Equal(originalEx.ToString(), deserializedEx.ToString());
-        }
-
         private class TestScriptLoggerFactory : ScriptLoggerFactory
         {
             public static bool ShouldWait { get; set; } = false;


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This change updates the target for the `WebJobs.Script` project to .NET 8, enabling us to take advantage of some of the APIs and newer .NET features we need. The .NET standard target is no longer relevant for this project and maintaining this has become a hinderance.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)


