### PR TITLE
Add benchmark result comparison support

### DIFF
--- a/eng/ci/host.benchmarks.yml
+++ b/eng/ci/host.benchmarks.yml
@@ -22,6 +22,11 @@ resources:
     type: git
     name: engineering
     ref: refs/tags/release
+  pipelines:
+  - pipeline: BaselineResult
+    source: host.benchmarks
+    tags:
+    - AzFunc.Perf.Baseline
 
 variables:
   - template: /eng/ci/templates/variables/benchmarks.yml@self

--- a/eng/ci/templates/official/jobs/run-benchmarks.yml
+++ b/eng/ci/templates/official/jobs/run-benchmarks.yml
@@ -16,12 +16,14 @@ jobs:
   variables:
     runDescription: ${{ parameters.description }}
     functionApp: ${{ parameters.functionAppName }}
+    benchmarkArtifactName: benchmark_results_$(functionApp)
     functionAppOutputPath: $(Build.ArtifactStagingDirectory)/FunctionApps/$(functionApp)
-    benchmarkResultsJsonPath: "$(Build.ArtifactStagingDirectory)/BenchmarkResults/$(buildNumber)_$(functionApp).json"
+    benchmarkResultsJsonPath: $(Build.ArtifactStagingDirectory)/BenchmarkResults/$(buildNumber)_$(functionApp).json
     functionsWorkerRuntime: 'dotnet-isolated'
-    crankAgentUrl: "http://localhost:5010"  # Default crank agent URL.
+    crankAgentUrl: "http://localhost:5010" # Default crank agent URL.
     configFilePath: "./eng/perf/http.benchmarks.yml"
     hostLocation: "./../../"
+    baselineBenchmarkResultFilePath: ''
 
   templateContext:
     outputParentDirectory: $(Build.ArtifactStagingDirectory)
@@ -29,7 +31,7 @@ jobs:
     - output: pipelineArtifact
       displayName: Publish benchmark results
       path: $(benchmarkResultsJsonPath)
-      artifact: 'BenchmarkResults_$(functionApp)'
+      artifact: $(benchmarkArtifactName)
 
   steps:
 
@@ -50,8 +52,7 @@ jobs:
     displayName: Start crank-agent
     inputs:
       targetType: 'inline'
-      script: |
-        Start-Process powershell -ArgumentList '-NoExit', '-Command', 'crank-agent'
+      script: Start-Process powershell -ArgumentList '-NoExit', '-Command', 'crank-agent'
 
   - task: CopyFiles@2
     displayName: Copy benchmark apps to temp location
@@ -76,11 +77,11 @@ jobs:
     displayName: Install Microsoft.Crank.Controller
 
   - task: PowerShell@2
-    displayName: Run crank-controller
+    displayName: Run Benchmark
     inputs:
       targetType: 'inline'
       script: |
-        $crankArgs = "--config $(configFilePath) --scenario hellohttp --profile win2022 --load.options.reuseBuild true --description `"$(runDescription)`" --command-line-property --no-metadata --no-measurements --json $(benchmarkResultsJsonPath) --property sourceVersion=$(sourceVersion) --property buildNumber=$(buildNumber) --property buildId=$(buildId) --variable FunctionsWorkerRuntime=$(functionsWorkerRuntime) --variable HostLocation=$(hostLocation) --variable FunctionAppPath=$(functionAppOutputPath)"
+        $crankArgs = "--config $(configFilePath) --scenario hellohttp --profile win2022 --load.options.reuseBuild true --description `"$(runDescription)`" --command-line-property --no-measurements --json $(benchmarkResultsJsonPath) --property sourceVersion=$(sourceVersion) --property buildNumber=$(buildNumber) --property buildId=$(buildId) --property sourceBranch=$(sourceBranch) --variable FunctionsWorkerRuntime=$(functionsWorkerRuntime) --variable HostLocation=$(hostLocation) --variable FunctionAppPath=$(functionAppOutputPath)"
         $crankArgs += " ${{ parameters.additionalCrankArgs }}"
         $command = "crank $crankArgs"
 
@@ -91,12 +92,55 @@ jobs:
         Write-Host "Running command: $command"
         Invoke-Expression $command
 
+  # Retrieve function host logs
   - task: PowerShell@2
-    displayName: Functions host logs
+    displayName: 'Fetch Function Host Logs'
     inputs:
       targetType: 'inline'
       script: |
         $url = "$(crankAgentUrl)/jobs/1/output"
-        Write-Host "Making GET request to: $url to get logs"
+        Write-Host "Fetching logs from: $url"
         $response = Invoke-WebRequest -Uri $url -Method GET -UseBasicParsing
         Write-Host $response.Content
+
+  # Tag the build as a baseline if it originates from the specified branch.
+  # Baseline builds serve as reference points for performance comparisons in future builds.
+  # The tag added here will help identify these builds in the pipeline.
+  - task: PowerShell@2
+    condition: and(succeeded(), eq(variables['sourceBranch'], variables['benchmarkBaselineBranch']))
+    displayName: 'Tag Build as Baseline'
+    inputs:
+      targetType: 'inline'
+      script: Write-Host "##vso[build.addbuildtag]$(benchmarkBaselineTagName)"
+
+  # Download baseline result
+  - download: BaselineResult
+    displayName: 'Download Baseline Benchmark Results'
+    artifact: '$(benchmarkArtifactName)'
+    continueOnError: true # Continue if baseline result artifact is not found
+
+  # Locate baseline benchmark result file
+  - task: PowerShell@2
+    displayName: 'Set Baseline Benchmark Result File Path'
+    inputs:
+      targetType: 'inline'
+      script: |
+        $baselineDir = "$(Pipeline.Workspace)/BaselineResult/$(benchmarkArtifactName)"
+        $fileNamePattern = "*_$(functionApp).json"
+        $baselineFile = Get-ChildItem -Path $baselineDir -Filter $fileNamePattern | Select-Object -First 1
+
+        if ($baselineFile) {
+          $baselineFilePath = $baselineFile.FullName
+          Write-Host "Found baseline benchmark result file: $baselineFilePath"
+          Write-Host "##vso[task.setvariable variable=baselineBenchmarkResultFilePath]$baselineFilePath"
+        } else {
+          Write-Host "No baseline benchmark result file found."
+        }
+
+  # Compare results with baseline
+  - task: PowerShell@2
+    condition: and(succeeded(), ne(variables['baselineBenchmarkResultFilePath'], ''))
+    displayName: 'Compare Results with Baseline'
+    inputs:
+      targetType: 'inline'
+      script: crank compare "$(baselineBenchmarkResultFilePath)" "$(benchmarkResultsJsonPath)"

--- a/eng/ci/templates/official/jobs/run-benchmarks.yml
+++ b/eng/ci/templates/official/jobs/run-benchmarks.yml
@@ -18,14 +18,21 @@ jobs:
     functionApp: ${{ parameters.functionAppName }}
     benchmarkArtifactName: benchmark_results_$(functionApp)
     functionAppOutputPath: $(Build.ArtifactStagingDirectory)/FunctionApps/$(functionApp)
-    benchmarkResultsJsonPath: $(Build.ArtifactStagingDirectory)/BenchmarkResults/$(buildNumber)_$(functionApp).json
+    benchmarkResultsJsonPath: $(Build.ArtifactStagingDirectory)/BenchmarkResults/$(Build.BuildNumber)_$(functionApp).json
     functionsWorkerRuntime: 'dotnet-isolated'
     crankAgentUrl: "http://localhost:5010" # Default crank agent URL.
     configFilePath: "./eng/perf/http.benchmarks.yml"
     hostLocation: "./../../"
     baselineBenchmarkResultFilePath: ''
+    baselineBenchmarkResultsDownloadDir: $(Pipeline.Workspace)/BenchmarkBaselineResult
 
   templateContext:
+    inputs:
+    - input: pipelineArtifact
+      artifactName: $(benchmarkArtifactName)
+      pipeline: BaselineResult
+      targetPath: $(baselineBenchmarkResultsDownloadDir)
+
     outputParentDirectory: $(Build.ArtifactStagingDirectory)
     outputs:
     - output: pipelineArtifact
@@ -48,11 +55,8 @@ jobs:
   - script: dotnet tool install -g Microsoft.Crank.Agent --version "0.2.0-*"
     displayName: Install Microsoft.Crank.Agent tool
 
-  - task: PowerShell@2
-    displayName: Start crank-agent
-    inputs:
-      targetType: 'inline'
-      script: Start-Process powershell -ArgumentList '-NoExit', '-Command', 'crank-agent'
+  - pwsh: Start-Process powershell -ArgumentList '-NoExit', '-Command', 'crank-agent'
+    displayName: 'Start crank-agent'
 
   - task: CopyFiles@2
     displayName: Copy benchmark apps to temp location
@@ -76,12 +80,8 @@ jobs:
   - script: dotnet tool install -g Microsoft.Crank.Controller --version "0.2.0-*"
     displayName: Install Microsoft.Crank.Controller
 
-  - task: PowerShell@2
-    displayName: Run Benchmark
-    inputs:
-      targetType: 'inline'
-      script: |
-        $crankArgs = "--config $(configFilePath) --scenario hellohttp --profile win2022 --load.options.reuseBuild true --description `"$(runDescription)`" --command-line-property --no-measurements --json $(benchmarkResultsJsonPath) --property sourceVersion=$(sourceVersion) --property buildNumber=$(buildNumber) --property buildId=$(buildId) --property sourceBranch=$(sourceBranch) --variable FunctionsWorkerRuntime=$(functionsWorkerRuntime) --variable HostLocation=$(hostLocation) --variable FunctionAppPath=$(functionAppOutputPath)"
+  - pwsh: |
+        $crankArgs = "--config $(configFilePath) --scenario hellohttp --profile win2022 --load.options.reuseBuild true --description `"$(runDescription)`" --command-line-property --no-measurements --json $(benchmarkResultsJsonPath) --property sourceVersion=$(Build.SourceVersion) --property buildNumber=$(Build.BuildNumber) --property buildId=$(Build.BuildId) --property sourceBranch=$(Build.SourceBranch) --variable FunctionsWorkerRuntime=$(functionsWorkerRuntime) --variable HostLocation=$(hostLocation) --variable FunctionAppPath=$(functionAppOutputPath)"
         $crankArgs += " ${{ parameters.additionalCrankArgs }}"
         $command = "crank $crankArgs"
 
@@ -91,56 +91,40 @@ jobs:
 
         Write-Host "Running command: $command"
         Invoke-Expression $command
+    displayName: 'Run Benchmark'
 
   # Retrieve function host logs
-  - task: PowerShell@2
+  - pwsh: |
+      $url = "$(crankAgentUrl)/jobs/1/output"
+      Write-Host "Fetching logs from: $url"
+      $response = Invoke-WebRequest -Uri $url -Method GET -UseBasicParsing
+      Write-Host $response.Content
     displayName: 'Fetch Function Host Logs'
-    inputs:
-      targetType: 'inline'
-      script: |
-        $url = "$(crankAgentUrl)/jobs/1/output"
-        Write-Host "Fetching logs from: $url"
-        $response = Invoke-WebRequest -Uri $url -Method GET -UseBasicParsing
-        Write-Host $response.Content
 
   # Tag the build as a baseline if it originates from the specified branch.
   # Baseline builds serve as reference points for performance comparisons in future builds.
   # The tag added here will help identify these builds in the pipeline.
-  - task: PowerShell@2
-    condition: and(succeeded(), eq(variables['sourceBranch'], variables['benchmarkBaselineBranch']))
+  - pwsh: |
+      Write-Host "##vso[build.addbuildtag]$(benchmarkBaselineTagName)"
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], variables['benchmarkBaselineBranch']))
     displayName: 'Tag Build as Baseline'
-    inputs:
-      targetType: 'inline'
-      script: Write-Host "##vso[build.addbuildtag]$(benchmarkBaselineTagName)"
 
-  # Download baseline result
-  - download: BaselineResult
-    displayName: 'Download Baseline Benchmark Results'
-    artifact: '$(benchmarkArtifactName)'
-    continueOnError: true # Continue if baseline result artifact is not found
+  # Locate baseline benchmark result file from the downloaded baseline artifact.
+  - pwsh: |
+      $baselineDir = "$(baselineBenchmarkResultsDownloadDir)"
+      $fileNamePattern = "*_$(functionApp).json"
+      $baselineFile = Get-ChildItem -Path $baselineDir -Filter $fileNamePattern | Select-Object -First 1
 
-  # Locate baseline benchmark result file
-  - task: PowerShell@2
+      if ($baselineFile) {
+        Write-Host "Found baseline benchmark result file: $($baselineFile.FullName)"
+        Write-Host "##vso[task.setvariable variable=baselineBenchmarkResultFilePath]$($baselineFile.FullName)"
+      } else {
+        Write-Host "No baseline benchmark result file found."
+      }
     displayName: 'Set Baseline Benchmark Result File Path'
-    inputs:
-      targetType: 'inline'
-      script: |
-        $baselineDir = "$(Pipeline.Workspace)/BaselineResult/$(benchmarkArtifactName)"
-        $fileNamePattern = "*_$(functionApp).json"
-        $baselineFile = Get-ChildItem -Path $baselineDir -Filter $fileNamePattern | Select-Object -First 1
-
-        if ($baselineFile) {
-          $baselineFilePath = $baselineFile.FullName
-          Write-Host "Found baseline benchmark result file: $baselineFilePath"
-          Write-Host "##vso[task.setvariable variable=baselineBenchmarkResultFilePath]$baselineFilePath"
-        } else {
-          Write-Host "No baseline benchmark result file found."
-        }
 
   # Compare results with baseline
-  - task: PowerShell@2
+  - pwsh: |
+      crank compare "$(baselineBenchmarkResultFilePath)" "$(benchmarkResultsJsonPath)"
     condition: and(succeeded(), ne(variables['baselineBenchmarkResultFilePath'], ''))
     displayName: 'Compare Results with Baseline'
-    inputs:
-      targetType: 'inline'
-      script: crank compare "$(baselineBenchmarkResultFilePath)" "$(benchmarkResultsJsonPath)"

--- a/eng/ci/templates/variables/benchmarks.yml
+++ b/eng/ci/templates/variables/benchmarks.yml
@@ -13,4 +13,3 @@ variables:
   value: refs/heads/shkr/release4x
 - name: benchmarkBaselineTagName
   value: AzFunc.Perf.Baseline
-  

--- a/eng/ci/templates/variables/benchmarks.yml
+++ b/eng/ci/templates/variables/benchmarks.yml
@@ -10,6 +10,6 @@ variables:
 - name: sourceBranch
   value: $(Build.SourceBranch)
 - name: benchmarkBaselineBranch
-  value: refs/heads/shkr/release4x
+  value: refs/heads/release/4.x
 - name: benchmarkBaselineTagName
   value: AzFunc.Perf.Baseline

--- a/eng/ci/templates/variables/benchmarks.yml
+++ b/eng/ci/templates/variables/benchmarks.yml
@@ -1,14 +1,6 @@
 variables:
-- name: buildId
-  value: $(Build.BuildId)
-- name: buildNumber
-  value: $(Build.BuildNumber)
-- name: sourceVersion
-  value: $(Build.SourceVersion)
 - name: storeBenchmarkResultsInDatabase
   value: ${{ eq(variables['Build.Reason'], 'Schedule') }}
-- name: sourceBranch
-  value: $(Build.SourceBranch)
 - name: benchmarkBaselineBranch
   value: refs/heads/release/4.x
 - name: benchmarkBaselineTagName

--- a/eng/ci/templates/variables/benchmarks.yml
+++ b/eng/ci/templates/variables/benchmarks.yml
@@ -7,3 +7,10 @@ variables:
   value: $(Build.SourceVersion)
 - name: storeBenchmarkResultsInDatabase
   value: ${{ eq(variables['Build.Reason'], 'Schedule') }}
+- name: sourceBranch
+  value: $(Build.SourceBranch)
+- name: benchmarkBaselineBranch
+  value: refs/heads/shkr/release4x
+- name: benchmarkBaselineTagName
+  value: AzFunc.Perf.Baseline
+  


### PR DESCRIPTION
This PR introduces changes to enable benchmark result comparisons with a baseline version. The pipeline updates include tagging builds from specific branches (e.g., `release\4x`) with a designated tag. During a benchmark run, the pipeline will download the benchmark results from the latest build with this tag and compare the current run's results against the baseline.

Sample run using my private branch: https://azfunc.visualstudio.com/internal/_build/results?buildId=197569&view=logs&j=6b6a182f-f93d-525d-58f1-7dd940856fb8&t=db2ecd77-6a75-517c-c5ff-de4cbedea6d5&l=27

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

