### PR TITLE
Run benchmarking in dedicated agents (application and load)

### DIFF
--- a/eng/ci/host.benchmarks.yml
+++ b/eng/ci/host.benchmarks.yml
@@ -1,14 +1,14 @@
 # No triggers for code push to any branch.
-trigger:
-  batch: true
-  branches:
-    include:
-    - shkr/vanilla_agents
-
+trigger: none
 # No PR triggers for now
 pr: none
-
-
+schedules:
+  - cron: "0 0 * * *"
+    displayName: Nightly Build
+    branches:
+      include:
+      - dev
+    always: true
 resources:
   repositories:
   - repository: 1es

--- a/eng/ci/host.benchmarks.yml
+++ b/eng/ci/host.benchmarks.yml
@@ -1,16 +1,13 @@
 # No triggers for code push to any branch.
-trigger: none
+trigger:
+  batch: true
+  branches:
+    include:
+    - shkr/vanilla_agents
 
 # No PR triggers for now
 pr: none
 
-schedules:
-  - cron: "0 0 * * *"
-    displayName: Nightly Build
-    branches:
-      include:
-      - dev
-    always: true
 
 resources:
   repositories:
@@ -36,8 +33,8 @@ extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
   parameters:
     pool:
-      name: 1es-pool-azfunc-large
-      image: 1es-windows-2022
+      name: 1es-pool-azfunc-benchmarking-large
+      image: 1es-windows-2022-benchmark-runner-vanilla
       os: windows
 
     stages:

--- a/eng/ci/host.benchmarks.yml
+++ b/eng/ci/host.benchmarks.yml
@@ -1,7 +1,9 @@
 # No triggers for code push to any branch.
 trigger: none
+
 # No PR triggers for now
 pr: none
+
 schedules:
   - cron: "0 0 * * *"
     displayName: Nightly Build
@@ -9,6 +11,7 @@ schedules:
       include:
       - dev
     always: true
+
 resources:
   repositories:
   - repository: 1es

--- a/eng/ci/host.benchmarks.yml
+++ b/eng/ci/host.benchmarks.yml
@@ -1,12 +1,16 @@
 # No triggers for code push to any branch.
-trigger:
-  batch: true
-  branches:
-    include:
-    - shkr/vanilla_agents
+trigger: none
 
 # No PR triggers for now
 pr: none
+
+schedules:
+  - cron: "0 0 * * *"
+    displayName: Nightly Build
+    branches:
+      include:
+      - dev
+    always: true
 
 resources:
   repositories:

--- a/eng/ci/host.benchmarks.yml
+++ b/eng/ci/host.benchmarks.yml
@@ -51,7 +51,7 @@ extends:
 
     - stage: Run
       displayName: Run Benchmarks
-      dependsOn: [] 
+      dependsOn: [] # Force this stage to run independently and in parallel with other stages.
       jobs:
       - template: /eng/ci/templates/official/jobs/run-benchmarks.yml@self
         parameters:
@@ -60,7 +60,6 @@ extends:
           additionalCrankArgs: $(AdditionalCrankArguments)  # Pipeline variable to pass additional arguments to crank command.
           storeResultsInDatabase: ${{ variables.storeBenchmarkResultsInDatabase }}
           agentName: HelloHttpNet9_APP
-
       - template: /eng/ci/templates/official/jobs/run-benchmarks.yml@self
         parameters:
           description: .NET9 Worker Application

--- a/eng/ci/host.benchmarks.yml
+++ b/eng/ci/host.benchmarks.yml
@@ -1,16 +1,12 @@
 # No triggers for code push to any branch.
-trigger: none
+trigger:
+  batch: true
+  branches:
+    include:
+    - shkr/vanilla_agents
 
 # No PR triggers for now
 pr: none
-
-schedules:
-  - cron: "0 0 * * *"
-    displayName: Nightly Build
-    branches:
-      include:
-      - dev
-    always: true
 
 resources:
   repositories:
@@ -41,8 +37,21 @@ extends:
       os: windows
 
     stages:
-    - stage: HttpApps
+    - stage: Setup
+      displayName: Setup & start agents
+      jobs:
+      - template: /eng/ci/templates/official/jobs/setup-benchmark-agents.yml@self
+        parameters:
+          functionAppName: HelloHttpNet9 
+          agentName: HelloHttpNet9_APP
+      - template: /eng/ci/templates/official/jobs/setup-benchmark-agents.yml@self
+        parameters:
+          agentName: HelloHttpNet9NoProxy_APP
+          functionAppName: HelloHttpNet9NoProxy 
+
+    - stage: Run
       displayName: Run Benchmarks
+      dependsOn: [] 
       jobs:
       - template: /eng/ci/templates/official/jobs/run-benchmarks.yml@self
         parameters:
@@ -50,9 +59,12 @@ extends:
           functionAppName: HelloHttpNet9  # App with ASP.NET Integration
           additionalCrankArgs: $(AdditionalCrankArguments)  # Pipeline variable to pass additional arguments to crank command.
           storeResultsInDatabase: ${{ variables.storeBenchmarkResultsInDatabase }}
+          agentName: HelloHttpNet9_APP
+
       - template: /eng/ci/templates/official/jobs/run-benchmarks.yml@self
         parameters:
           description: .NET9 Worker Application
           functionAppName: HelloHttpNet9NoProxy # App without ASP.NET Integration
           additionalCrankArgs: $(AdditionalCrankArguments)
           storeResultsInDatabase: ${{ variables.storeBenchmarkResultsInDatabase }}
+          agentName: HelloHttpNet9NoProxy_APP

--- a/eng/ci/templates/official/jobs/run-benchmarks.yml
+++ b/eng/ci/templates/official/jobs/run-benchmarks.yml
@@ -59,10 +59,10 @@ jobs:
     displayName: Install Microsoft.Crank.Agent tool
 
   - script: dotnet tool install -g Microsoft.Crank.Controller --version "0.2.0-*"
-    displayName: Install Microsoft.Crank.Controller
+    displayName: Install Microsoft.Crank.Controller tool
 
   - pwsh: Start-Process powershell -ArgumentList '-NoExit', '-Command', 'crank-agent'
-    displayName: 'Start crank-agent'
+    displayName: Start crank-agent
 
   - task: CopyFiles@2
     displayName: Copy benchmark apps to temp location
@@ -90,6 +90,9 @@ jobs:
       scriptType: pscore
       scriptLocation: inlineScript
       inlineScript: |
+        $maxAttempts = 60
+        $attempt = 0
+
         do {
           $Entity = az storage entity show `
             --account-name $(StorageAccount) `
@@ -106,6 +109,12 @@ jobs:
           } else {
             Write-Host "Entity not found. Retrying in 30 seconds..."
             Start-Sleep -Seconds 30
+            $attempt++
+          }
+
+          if ($attempt -ge $maxAttempts) {
+            Write-Host "Maximum attempts reached. Exiting..."
+            exit 1
           }
         } while (-not $Entity)
 
@@ -158,4 +167,3 @@ jobs:
       crank compare "$(baselineBenchmarkResultFilePath)" "$(benchmarkResultsJsonPath)"
     condition: and(succeeded(), ne(variables['baselineBenchmarkResultFilePath'], ''))
     displayName: 'Compare Results with Baseline'
-    

--- a/eng/ci/templates/official/jobs/run-benchmarks.yml
+++ b/eng/ci/templates/official/jobs/run-benchmarks.yml
@@ -120,7 +120,7 @@ jobs:
         }
 
         Write-Host "Running command: $command"
-        Invoke-Expression $command -ErrorAction Stop
+        Invoke-Expression $command
     displayName: 'Run Benchmark'
 
   # Retrieve function host logs

--- a/eng/ci/templates/official/jobs/run-benchmarks.yml
+++ b/eng/ci/templates/official/jobs/run-benchmarks.yml
@@ -9,22 +9,25 @@ parameters:
 - name: additionalCrankArgs
   type: string
   default: ''
+- name: agentName
+  type: string
 
 jobs:
 - job: ${{ parameters.functionAppName }}
 
   variables:
+    agentName: ${{ parameters.agentName }}
     runDescription: ${{ parameters.description }}
     functionApp: ${{ parameters.functionAppName }}
     benchmarkArtifactName: benchmark_results_$(functionApp)
     functionAppOutputPath: $(Build.ArtifactStagingDirectory)/FunctionApps/$(functionApp)
     benchmarkResultsJsonPath: $(Build.ArtifactStagingDirectory)/BenchmarkResults/$(Build.BuildNumber)_$(functionApp).json
     functionsWorkerRuntime: 'dotnet-isolated'
-    crankAgentUrl: "http://localhost:5010" # Default crank agent URL.
     configFilePath: "./eng/perf/http.benchmarks.yml"
     hostLocation: "./../../"
     baselineBenchmarkResultFilePath: ''
     baselineBenchmarkResultsDownloadDir: $(Pipeline.Workspace)/BenchmarkBaselineResult
+    appAgentIpAddress: ''
 
   templateContext:
     inputs:
@@ -55,6 +58,9 @@ jobs:
   - script: dotnet tool install -g Microsoft.Crank.Agent --version "0.2.0-*"
     displayName: Install Microsoft.Crank.Agent tool
 
+  - script: dotnet tool install -g Microsoft.Crank.Controller --version "0.2.0-*"
+    displayName: Install Microsoft.Crank.Controller
+
   - pwsh: Start-Process powershell -ArgumentList '-NoExit', '-Command', 'crank-agent'
     displayName: 'Start crank-agent'
 
@@ -77,11 +83,35 @@ jobs:
       arguments: -c Release -o $(functionAppOutputPath) -f net9.0
       workingDirectory: $(Build.ArtifactStagingDirectory)/PerformanceTestApps/$(functionApp)
 
-  - script: dotnet tool install -g Microsoft.Crank.Controller --version "0.2.0-*"
-    displayName: Install Microsoft.Crank.Controller
+  - task: AzureCLI@2
+    displayName: Get Remote Agent IP Address
+    inputs:
+      azureSubscription: $(ServiceConnection)
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript: |
+        do {
+          $Entity = az storage entity show `
+            --account-name $(StorageAccount) `
+            --auth-mode login `
+            --table-name $(BenchmarkAgentInfoTableName) `
+            --partition-key $(Build.BuildNumber) `
+            --row-key $(agentName) `
+            --select AgentIPAddress
+
+          if ($Entity) {
+            $AgentIPAddress = ($Entity | ConvertFrom-Json).AgentIPAddress
+            Write-Host "##vso[task.setvariable variable=appAgentIpAddress]$AgentIPAddress"
+            break
+          } else {
+            Write-Host "Entity not found. Retrying in 30 seconds..."
+            Start-Sleep -Seconds 30
+          }
+        } while (-not $Entity)
 
   - pwsh: |
         $crankArgs = "--config $(configFilePath) --scenario hellohttp --profile win2022 --load.options.reuseBuild true --description `"$(runDescription)`" --command-line-property --no-measurements --json $(benchmarkResultsJsonPath) --property sourceVersion=$(Build.SourceVersion) --property buildNumber=$(Build.BuildNumber) --property buildId=$(Build.BuildId) --property sourceBranch=$(Build.SourceBranch) --variable FunctionsWorkerRuntime=$(functionsWorkerRuntime) --variable HostLocation=$(hostLocation) --variable FunctionAppPath=$(functionAppOutputPath)"
+        $crankArgs += " --variable CrankAgentAppVm=$(appAgentIpAddress) --variable CrankAgentLoadVm=localhost --variable AspNetUrls=http://$(appAgentIpAddress):5000"
         $crankArgs += " ${{ parameters.additionalCrankArgs }}"
         $command = "crank $crankArgs"
 
@@ -90,12 +120,12 @@ jobs:
         }
 
         Write-Host "Running command: $command"
-        Invoke-Expression $command
+        Invoke-Expression $command -ErrorAction Stop
     displayName: 'Run Benchmark'
 
   # Retrieve function host logs
   - pwsh: |
-      $url = "$(crankAgentUrl)/jobs/1/output"
+      $url = "http://$(appAgentIpAddress):5010/jobs/1/output"
       Write-Host "Fetching logs from: $url"
       $response = Invoke-WebRequest -Uri $url -Method GET -UseBasicParsing
       Write-Host $response.Content
@@ -128,3 +158,4 @@ jobs:
       crank compare "$(baselineBenchmarkResultFilePath)" "$(benchmarkResultsJsonPath)"
     condition: and(succeeded(), ne(variables['baselineBenchmarkResultFilePath'], ''))
     displayName: 'Compare Results with Baseline'
+    

--- a/eng/ci/templates/official/jobs/setup-benchmark-agents.yml
+++ b/eng/ci/templates/official/jobs/setup-benchmark-agents.yml
@@ -1,0 +1,107 @@
+parameters:
+- name: functionAppName
+  type: string
+- name: agentName
+  type: string
+jobs:
+- job: ${{ parameters.functionAppName }}
+
+  variables:
+    agentName: ${{ parameters.agentName }}
+    functionApp: ${{ parameters.functionAppName }}
+    functionAppOutputPath: $(Build.ArtifactStagingDirectory)/FunctionApps/$(functionApp)
+
+  steps:
+
+  - template: /eng/ci/templates/install-dotnet.yml@self
+
+  - script: dotnet tool install -g Microsoft.Crank.Agent --version "0.2.0-*"
+    displayName: Install crank agent
+
+  - pwsh: Start-Process powershell -ArgumentList '-NoExit', '-Command', 'crank-agent'
+    displayName: Start crank agent
+
+  - pwsh: |
+      dotnet --info
+    displayName: Print .NET info
+
+  - task: CopyFiles@2
+    displayName: Copy benchmark apps to temp location
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)/test/Performance/Apps'
+      Contents: '**/*'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)/PerformanceTestApps'
+      CleanTargetFolder: true
+
+  - task: DotNetCoreCLI@2
+    displayName: Publish benchmark app
+    inputs:
+      command: publish
+      publishWebProjects: false
+      zipAfterPublish: false
+      modifyOutputPath: false
+      projects: '$(Build.ArtifactStagingDirectory)/PerformanceTestApps/$(functionApp)/HelloHttp.csproj'
+      arguments: -c Release -o $(functionAppOutputPath) -f net9.0 -v n
+      workingDirectory: $(Build.ArtifactStagingDirectory)/PerformanceTestApps/$(functionApp)
+
+  - script: |
+      netsh advfirewall firewall add rule name="Open Port 5000" dir=in action=allow protocol=TCP localport=5000
+      netsh advfirewall firewall add rule name="Open Port 5010" dir=in action=allow protocol=TCP localport=5010
+    displayName: Open port 5000 and 5010
+
+  - task: PowerShell@2
+    displayName: Get Agent IP Address
+    inputs:
+      targetType: 'inline'
+      script: |
+        $ipAddress = (Test-Connection -ComputerName (hostname) -Count 1).IPv4Address.IPAddressToString
+        Write-Host "IP Address: $ipAddress"
+        Write-Host "##vso[task.setvariable variable=agentIp]$ipAddress"
+
+  - task: AzureCLI@2
+    displayName: Persist Agent IP Address
+    inputs:
+      azureSubscription: $(ServiceConnection)
+      scriptType: 'pscore'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
+        az storage entity insert `
+          --auth-mode login `
+          --account-name $(StorageAccount) `
+          --table-name $(BenchmarkAgentInfoTableName) `
+          --entity PartitionKey=$(Build.BuildNumber) RowKey=$(agentName) AgentName=$(agentName) AgentIPAddress=$(agentIp)
+
+  - pwsh: |
+      $url = "http://localhost:5010/jobs/all"
+      Write-Host "Calling $url to check benchmark job status"
+      while ($true) {
+          try {
+              $data = (Invoke-WebRequest -Uri $url -Method Get).Content | ConvertFrom-Json
+              $completedJobCount = ($data | Where-Object { $_.state -eq "Deleted" }).Count 
+
+              if ($completedJobCount -gt 0) { 
+                  Write-Host "Found at least 1 jobs with 'state' = 'Deleted'. Exiting task."
+                  exit 0
+              }
+          } catch {
+              Write-Host "Error querying the API: $_"
+              exit 1
+          }
+
+          Write-Host "No completed jobs found. Polling again in 30 seconds.."
+          Start-Sleep -Seconds 30
+      }
+    displayName: 'Wait for job completion'
+
+  - task: AzureCLI@2
+    displayName: Clean up storage
+    inputs:
+      azureSubscription: $(ServiceConnection)
+      scriptType: 'pscore'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
+        az storage entity delete `
+          --auth-mode login `
+          --account-name $(StorageAccount) `
+          --table-name $(BenchmarkAgentInfoTableName) `
+          --partition-key $(Build.BuildNumber) --row-key=$(agentName)

--- a/eng/ci/templates/official/jobs/setup-benchmark-agents.yml
+++ b/eng/ci/templates/official/jobs/setup-benchmark-agents.yml
@@ -75,23 +75,19 @@ jobs:
       $url = "http://localhost:5010/jobs/all"
       Write-Host "Calling $url to check benchmark job status"
       while ($true) {
-          try {
-              $data = (Invoke-WebRequest -Uri $url -Method Get).Content | ConvertFrom-Json
-              $completedJobCount = ($data | Where-Object { $_.state -eq "Deleted" }).Count 
+          $response = Invoke-WebRequest -Uri $url -Method Get -ErrorAction Stop
+          $data = $response.Content | ConvertFrom-Json
+          $completedJobCount = ($data | Where-Object { $_.state -eq "Deleted" }).Count 
 
-              if ($completedJobCount -gt 0) { 
-                  Write-Host "Found at least 1 jobs with 'state' = 'Deleted'. Exiting task."
-                  exit 0
-              }
-          } catch {
-              Write-Host "Error querying the API: $_"
-              exit 1
+          if ($completedJobCount -gt 0) { 
+              Write-Host "Found at least 1 job with 'state' = 'Deleted'. Exiting task."
+              exit 0
           }
 
-          Write-Host "No completed jobs found. Polling again in 30 seconds.."
+          Write-Host "No completed jobs found. Polling again in 30 seconds..."
           Start-Sleep -Seconds 30
       }
-    displayName: 'Wait for job completion'
+    displayName: Wait for job completion
 
   - task: AzureCLI@2
     displayName: Clean up storage

--- a/eng/ci/templates/official/jobs/setup-benchmark-agents.yml
+++ b/eng/ci/templates/official/jobs/setup-benchmark-agents.yml
@@ -16,7 +16,7 @@ jobs:
   - template: /eng/ci/templates/install-dotnet.yml@self
 
   - script: dotnet tool install -g Microsoft.Crank.Agent --version "0.2.0-*"
-    displayName: Install crank agent
+    displayName: Install Microsoft.Crank.Agent tool
 
   - pwsh: Start-Process powershell -ArgumentList '-NoExit', '-Command', 'crank-agent'
     displayName: Start crank agent
@@ -74,7 +74,10 @@ jobs:
   - pwsh: |
       $url = "http://localhost:5010/jobs/all"
       Write-Host "Calling $url to check benchmark job status"
-      while ($true) {
+      $maxAttempts = 60
+      $attempt = 0
+
+      while ($attempt -lt $maxAttempts) {
           $response = Invoke-WebRequest -Uri $url -Method Get -ErrorAction Stop
           $data = $response.Content | ConvertFrom-Json
           $completedJobCount = ($data | Where-Object { $_.state -eq "Deleted" }).Count 
@@ -86,11 +89,16 @@ jobs:
 
           Write-Host "No completed jobs found. Polling again in 30 seconds..."
           Start-Sleep -Seconds 30
+          $attempt++
       }
+
+      Write-Host "Maximum attempts reached. Exiting..."
+      exit 1
     displayName: Wait for job completion
 
   - task: AzureCLI@2
     displayName: Clean up storage
+    condition: always()
     inputs:
       azureSubscription: $(ServiceConnection)
       scriptType: 'pscore'

--- a/eng/perf/http.benchmarks.yml
+++ b/eng/perf/http.benchmarks.yml
@@ -27,11 +27,12 @@ scenarios:
 profiles:
   win2022:
     variables:
-      serverAddress: localhost
+      serverUri: http://{{ CrankAgentAppVm }}
+      serverPort: 5000
     jobs: 
       hostruntime:
         endpoints: 
-          - http://localhost:5010
+          - "http://{{ CrankAgentAppVm }}:5010"
       load:
         endpoints: 
-          - http://localhost:5010
+          - "http://{{ CrankAgentLoadVm }}:5010"

--- a/eng/perf/http.benchmarks.yml
+++ b/eng/perf/http.benchmarks.yml
@@ -33,7 +33,7 @@ profiles:
     jobs: 
       hostruntime:
         endpoints: 
-          - "http://{{ CrankAgentAppVm }}:5010"
+          - http://{{ CrankAgentAppVm }}:5010
       load:
         endpoints: 
-          - "http://{{ CrankAgentLoadVm }}:5010"
+          - http://{{ CrankAgentLoadVm }}:5010

--- a/eng/perf/http.benchmarks.yml
+++ b/eng/perf/http.benchmarks.yml
@@ -12,6 +12,7 @@ jobs:
     environmentVariables:
       FUNCTIONS_WORKER_RUNTIME: '{{FunctionsWorkerRuntime}}'
       AzureWebJobsScriptRoot: '{{FunctionAppPath}}'
+      ASPNETCORE_URLS: '{{ AspNetUrls }}'
 
 scenarios:
   hellohttp:


### PR DESCRIPTION
With this change, the application and load generators run on separate agents. To share the application agent's IP address with the load generator agent, we use Azure Table Storage. Job output variables are not suitable as they become available only after the job finishes, whereas we need the job (agent) to remain running.

Sample pipeline run: 
1. https://azfunc.visualstudio.com/internal/_build/results?buildId=199693&view=results

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)
