### PR TITLE
Remove whitespace in hashesForHardlinks.txt

### DIFF
--- a/src/WebJobs.Script.SiteExtension/Publish.SingleTFM.targets
+++ b/src/WebJobs.Script.SiteExtension/Publish.SingleTFM.targets
@@ -136,7 +136,7 @@
     <WriteLinesToFile
       Overwrite="true"
       File="$(SiteExtensionDir)hashesForHardlinks.txt"
-      Lines="@(_HashedFiles->'Hash: %(FileHash) FileName: %(RelativePath)')" />
+      Lines="@(_HashedFiles->'Hash:%(FileHash) FileName:%(RelativePath)')" />
   </Target>
 
   <Target Name="WriteReleaseJson">


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR: #10785
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

These spaces were not present in previous method of generating this file. Removing for consistency.
