### PR TITLE
Removing noisy log when ignoring an RpcLog

### DIFF
--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.Log.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.Log.cs
@@ -22,16 +22,9 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                 new EventId(821, nameof(InvocationResponseReceived)),
                 "InvocationResponse received for invocation: '{invocationId}'");
 
-            private static readonly Action<ILogger, string, Exception> _ignoringRpcLog = LoggerMessage.Define<string>(
-                LogLevel.Debug,
-                new EventId(822, nameof(IgnoringRpcLog)),
-                "Ignoring RpcLog from invocation '{invocationId}' because there is no matching ScriptInvocationContext.");
-
             internal static void ChannelReceivedMessage(ILogger logger, string workerId, ContentOneofCase msgType) => _channelReceivedMessage(logger, workerId, msgType, null);
 
             internal static void InvocationResponseReceived(ILogger logger, string invocationId) => _invocationResponseReceived(logger, invocationId, null);
-
-            internal static void IgnoringRpcLog(ILogger logger, string invocationId) => _ignoringRpcLog(logger, invocationId, null);
         }
     }
 }

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -1293,10 +1293,6 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     }
                 }, (context, rpcLog, _isWorkerApplicationInsightsLoggingEnabled));
             }
-            else
-            {
-                Logger.IgnoringRpcLog(_workerChannelLogger, rpcLog.InvocationId);
-            }
         }
 
         internal void SystemLog(GrpcEvent msg)


### PR DESCRIPTION
Fixes #10779 

This log was initially added when I realized we'd been ignoring RpcLogs for years without realizing it. It eventually led to me refactoring the invocation pipeline to ensure we caught them all (there was a race): https://github.com/Azure/azure-functions-host/pull/9657

I thought this would be a rare occurrence and once we saw these logs, we'd be able to fix them all. But it turns out that there's *tons* of RpcLogs written outside the context of a ScriptInvocationContext and it causes a flood of log messages that we won't act on.

This takes us back to ignoring these completely.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)