### PR TITLE
re-adding workers for net8 in-proc builds

### DIFF
--- a/src/WebJobs.Script.SiteExtension/WebJobs.Script.SiteExtension.csproj
+++ b/src/WebJobs.Script.SiteExtension/WebJobs.Script.SiteExtension.csproj
@@ -17,9 +17,8 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <SiteExtensionName>FunctionsInProc8</SiteExtensionName>
   </PropertyGroup>
-
-  <!-- Only .NET6 builds include workers. -->
-  <Import Project="$(WorkersProps)" Condition="'$(TargetFramework)' == 'net6.0'" />
+  
+  <Import Project="$(WorkersProps)" />
 
   <ItemGroup>
     <ProjectReference Include="../WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj" ReferenceOutputAssembly="false" />

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/DrainModeResumeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/DrainModeResumeEndToEndTests.cs
@@ -1,13 +1,11 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.WebJobs.Script.Tests;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using System;
-using System.IO;
-using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
@@ -27,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal(drainStatus.State, DrainModeState.Disabled);
 
             // Capture pre-drain instance ID
-            var originalInstanceId = this.HostInstanceId;
+            var originalInstanceId = await GetActiveHostInstanceIdAsync();
 
             // Validate ability to call HttpTrigger without issues
             response = await SamplesTestHelpers.InvokeHttpTrigger(this, "HttpTrigger");
@@ -62,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // Validate the instance ID has changed
-            Assert.NotEqual(originalInstanceId, this.HostInstanceId);
+            Assert.NotEqual(originalInstanceId, await GetActiveHostInstanceIdAsync());
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
@@ -83,7 +83,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public TestEventGenerator EventGenerator { get; private set; } = new TestEventGenerator();
 
-        public string HostInstanceId => Host.JobHostServices.GetService<IOptions<ScriptJobHostOptions>>().Value.InstanceId;
+        public async Task<string> GetActiveHostInstanceIdAsync()
+        {
+            // During restarts the ActiveHost can be null. Wait to see if it recovers.
+            await TestHelpers.Await(() => Host.JobHostServices is not null,
+                userMessageCallback: () => $"Timed out waiting for JobHostServices to be available. Logs:{Environment.NewLine}{Host.GetLog()}.");
+
+            return Host.JobHostServices.GetService<IOptions<ScriptJobHostOptions>>().Value.InstanceId;
+        }
 
         public string MasterKey { get; private set; }
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/FunctionsControllerEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/FunctionsControllerEndToEndTests.cs
@@ -1,10 +1,10 @@
-using Microsoft.Azure.WebJobs.Script.WebHost.Models;
-using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
-using Microsoft.WebJobs.Script.Tests;
 using System;
 using System.IO;
 using System.Net;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.WebJobs.Script.Tests;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         public async Task FunctionsController_GetAllFunctions_ReturnsOk()
         {
             // Capture original instance ID
-            var originalInstanceId = this.HostInstanceId;
+            var originalInstanceId = await GetActiveHostInstanceIdAsync();
 
             // Validate ability to call HttpTrigger without issues
             var response = await SamplesTestHelpers.InvokeHttpTrigger(this, "HttpTrigger");
@@ -32,14 +32,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // Validate the instance ID is still the same
-            Assert.Equal(originalInstanceId, this.HostInstanceId);
+            Assert.Equal(originalInstanceId, await GetActiveHostInstanceIdAsync());
         }
 
         [Fact]
         public async Task FunctionsController_GetSpecificFunction_ReturnsOk()
         {
             // Capture original instance ID
-            var originalInstanceId = this.HostInstanceId;
+            var originalInstanceId = await GetActiveHostInstanceIdAsync();
 
             // Validate ability to call HttpTrigger without issues
             var response = await SamplesTestHelpers.InvokeHttpTrigger(this, "HttpTrigger");
@@ -55,14 +55,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // Validate the instance ID is still the same
-            Assert.Equal(originalInstanceId, this.HostInstanceId);
+            Assert.Equal(originalInstanceId, await GetActiveHostInstanceIdAsync());
         }
 
         [Fact]
         public async Task FunctionsController_GetSpecificFunctionStatus_ReturnsOk()
         {
             // Capture original instance ID
-            var originalInstanceId = this.HostInstanceId;
+            var originalInstanceId = await GetActiveHostInstanceIdAsync();
 
             // Validate ability to call HttpTrigger without issues
             var response = await SamplesTestHelpers.InvokeHttpTrigger(this, "HttpTrigger");
@@ -77,14 +77,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // Validate the instance ID is still the same
-            Assert.Equal(originalInstanceId, this.HostInstanceId);
+            Assert.Equal(originalInstanceId, await GetActiveHostInstanceIdAsync());
         }
 
         [Fact]
         public async Task FunctionsController_CreateUpdate_NoFileChange_ReturnsCreated_NoRestart()
         {
             // Capture original instance ID
-            var originalInstanceId = this.HostInstanceId;
+            var originalInstanceId = await GetActiveHostInstanceIdAsync();
 
             // Validate ability to call HttpTrigger without issues
             var response = await SamplesTestHelpers.InvokeHttpTrigger(this, "HttpTrigger");
@@ -99,14 +99,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // Validate the instance ID is still the same
-            Assert.Equal(originalInstanceId, this.HostInstanceId);
+            Assert.Equal(originalInstanceId, await GetActiveHostInstanceIdAsync());
         }
 
         [Fact]
         public async Task FunctionsController_CreateUpdate_FileChange_ReturnsCreated_RestartsJobHost()
         {
             // Capture pre-restart instance ID
-            var originalInstanceId = this.HostInstanceId;
+            var originalInstanceId = await GetActiveHostInstanceIdAsync();
 
             // Validate ability to call HttpTrigger without issues
             var response = await SamplesTestHelpers.InvokeHttpTrigger(this, "HttpTrigger");
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // Validate the instance ID has changed
-            Assert.NotEqual(originalInstanceId, this.HostInstanceId);
+            Assert.NotEqual(originalInstanceId, await GetActiveHostInstanceIdAsync());
 
             // Reset config
             response = await SamplesTestHelpers.InvokeEndpointPut(this, "admin/functions/HttpTrigger", TestData());


### PR DESCRIPTION
Logic Apps needs workers in net8 (even for in-proc) as they're testing out moving customers off of net6. 

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)