### PR TITLE
fixing some test races (hopefully)

### DIFF
--- a/eng/ci/templates/official/jobs/run-integration-tests.yml
+++ b/eng/ci/templates/official/jobs/run-integration-tests.yml
@@ -46,6 +46,7 @@ jobs:
     inputs:
       azureSubscription: Azure-Functions-Host-CI-internal
       azurePowerShellVersion: 'LatestVersion'
+      pwsh: true
       ScriptPath: eng/script/checkout-secrets.ps1
 
   - task: AzureKeyVault@1
@@ -201,5 +202,6 @@ jobs:
     inputs:
       azureSubscription: Azure-Functions-Host-CI-internal
       azurePowerShellVersion: 'LatestVersion'
+      pwsh: true
       ScriptPath: eng/script/checkin-secrets.ps1
       ScriptArguments: '-leaseBlob $(LeaseBlob) -leaseToken $(LeaseToken)'

--- a/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
+++ b/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
@@ -34,6 +34,7 @@ jobs:
     inputs:
       azureSubscription: Azure-Functions-Host-CI-internal
       azurePowerShellVersion: 'LatestVersion'
+      pwsh: true
       ScriptPath: eng/script/checkout-secrets.ps1
 
   - task: AzureKeyVault@1
@@ -91,5 +92,6 @@ jobs:
     inputs:
       azureSubscription: Azure-Functions-Host-CI-internal
       azurePowerShellVersion: 'LatestVersion'
+      pwsh: true
       ScriptPath: eng/script/checkin-secrets.ps1
       ScriptArguments: '-leaseBlob $(LeaseBlob) -leaseToken $(LeaseToken)'

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/DrainModeResumeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/DrainModeResumeEndToEndTests.cs
@@ -1,13 +1,11 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.WebJobs.Script.Tests;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using System;
-using System.IO;
-using System.Net;
-using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
@@ -27,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal(drainStatus.State, DrainModeState.Disabled);
 
             // Capture pre-drain instance ID
-            var originalInstanceId = this.HostInstanceId;
+            var originalInstanceId = await GetActiveHostInstanceIdAsync();
 
             // Validate ability to call HttpTrigger without issues
             response = await SamplesTestHelpers.InvokeHttpTrigger(this, "HttpTrigger");
@@ -62,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // Validate the instance ID has changed
-            Assert.NotEqual(originalInstanceId, this.HostInstanceId);
+            Assert.NotEqual(originalInstanceId, await GetActiveHostInstanceIdAsync());
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
@@ -83,7 +83,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public TestEventGenerator EventGenerator { get; private set; } = new TestEventGenerator();
 
-        public string HostInstanceId => Host.JobHostServices.GetService<IOptions<ScriptJobHostOptions>>().Value.InstanceId;
+        public async Task<string> GetActiveHostInstanceIdAsync()
+        {
+            // During restarts the ActiveHost can be null. Wait to see if it recovers.
+            await TestHelpers.Await(() => Host.JobHostServices is not null,
+                userMessageCallback: () => $"Timed out waiting for JobHostServices to be available. Logs:{Environment.NewLine}{Host.GetLog()}.");
+
+            return Host.JobHostServices.GetService<IOptions<ScriptJobHostOptions>>().Value.InstanceId;
+        }
 
         public string MasterKey { get; private set; }
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/FunctionsControllerEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/FunctionsControllerEndToEndTests.cs
@@ -1,10 +1,10 @@
-using Microsoft.Azure.WebJobs.Script.WebHost.Models;
-using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
-using Microsoft.WebJobs.Script.Tests;
 using System;
 using System.IO;
 using System.Net;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.WebJobs.Script.Tests;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         public async Task FunctionsController_GetAllFunctions_ReturnsOk()
         {
             // Capture original instance ID
-            var originalInstanceId = this.HostInstanceId;
+            var originalInstanceId = await GetActiveHostInstanceIdAsync();
 
             // Validate ability to call HttpTrigger without issues
             var response = await SamplesTestHelpers.InvokeHttpTrigger(this, "HttpTrigger");
@@ -32,14 +32,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // Validate the instance ID is still the same
-            Assert.Equal(originalInstanceId, this.HostInstanceId);
+            Assert.Equal(originalInstanceId, await GetActiveHostInstanceIdAsync());
         }
 
         [Fact]
         public async Task FunctionsController_GetSpecificFunction_ReturnsOk()
         {
             // Capture original instance ID
-            var originalInstanceId = this.HostInstanceId;
+            var originalInstanceId = await GetActiveHostInstanceIdAsync();
 
             // Validate ability to call HttpTrigger without issues
             var response = await SamplesTestHelpers.InvokeHttpTrigger(this, "HttpTrigger");
@@ -55,14 +55,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // Validate the instance ID is still the same
-            Assert.Equal(originalInstanceId, this.HostInstanceId);
+            Assert.Equal(originalInstanceId, await GetActiveHostInstanceIdAsync());
         }
 
         [Fact]
         public async Task FunctionsController_GetSpecificFunctionStatus_ReturnsOk()
         {
             // Capture original instance ID
-            var originalInstanceId = this.HostInstanceId;
+            var originalInstanceId = await GetActiveHostInstanceIdAsync();
 
             // Validate ability to call HttpTrigger without issues
             var response = await SamplesTestHelpers.InvokeHttpTrigger(this, "HttpTrigger");
@@ -77,14 +77,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // Validate the instance ID is still the same
-            Assert.Equal(originalInstanceId, this.HostInstanceId);
+            Assert.Equal(originalInstanceId, await GetActiveHostInstanceIdAsync());
         }
 
         [Fact]
         public async Task FunctionsController_CreateUpdate_NoFileChange_ReturnsCreated_NoRestart()
         {
             // Capture original instance ID
-            var originalInstanceId = this.HostInstanceId;
+            var originalInstanceId = await GetActiveHostInstanceIdAsync();
 
             // Validate ability to call HttpTrigger without issues
             var response = await SamplesTestHelpers.InvokeHttpTrigger(this, "HttpTrigger");
@@ -99,14 +99,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // Validate the instance ID is still the same
-            Assert.Equal(originalInstanceId, this.HostInstanceId);
+            Assert.Equal(originalInstanceId, await GetActiveHostInstanceIdAsync());
         }
 
         [Fact]
         public async Task FunctionsController_CreateUpdate_FileChange_ReturnsCreated_RestartsJobHost()
         {
             // Capture pre-restart instance ID
-            var originalInstanceId = this.HostInstanceId;
+            var originalInstanceId = await GetActiveHostInstanceIdAsync();
 
             // Validate ability to call HttpTrigger without issues
             var response = await SamplesTestHelpers.InvokeHttpTrigger(this, "HttpTrigger");
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
             // Validate the instance ID has changed
-            Assert.NotEqual(originalInstanceId, this.HostInstanceId);
+            Assert.NotEqual(originalInstanceId, await GetActiveHostInstanceIdAsync());
 
             // Reset config
             response = await SamplesTestHelpers.InvokeEndpointPut(this, "admin/functions/HttpTrigger", TestData());

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcesses.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcesses.cs
@@ -56,14 +56,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 
         private async Task<IEnumerable<int>> WaitAndGetAllNodeProcesses(int expectedProcessCount)
         {
-            IEnumerable<int> nodeProcessesBeforeHostRestart = Process.GetProcessesByName("node").Select(p => p.Id);
+            var nodeProcessesBeforeHostRestart = Process.GetProcessesByName("node");
             while (nodeProcessesBeforeHostRestart.Count() < expectedProcessCount)
             {
                 await Task.Delay(TimeSpan.FromSeconds(5));
-                nodeProcessesBeforeHostRestart = Process.GetProcessesByName("node").Select(p => p.Id);
+                nodeProcessesBeforeHostRestart = Process.GetProcessesByName("node");
             }
 
-            return nodeProcessesBeforeHostRestart;
+            foreach (var p in nodeProcessesBeforeHostRestart)
+            {
+                Console.WriteLine($"node {p.Id}: {p.StartInfo.Arguments}");
+            }
+
+            return nodeProcessesBeforeHostRestart.Select(p => p.Id);
         }
 
         [Fact]
@@ -96,14 +101,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                 Assert.Equal(HttpStatusCode.InternalServerError, timeoutResult.StatusCode);  // Confirm response code after timeout (10 seconds)
             }
 
-            IEnumerable<int> nodeProcessesAfter = Process.GetProcessesByName("node").Select(p => p.Id);
+            var nodeProcessesAfter = Process.GetProcessesByName("node");
+
+            foreach (var p in nodeProcessesAfter)
+            {
+                Console.WriteLine($"node {p.Id}: {p.StartInfo.Arguments}");
+            }
 
             // Confirm count remains the same
             Assert.Equal(nodeProcessesBeforeHostRestart.Count(), nodeProcessesAfter.Count());
 
-
             // Confirm all processes are different
-            Assert.Equal(3, nodeProcessesAfter.Except(nodeProcessesBeforeHostRestart).Count());
+            Assert.Equal(3, nodeProcessesAfter.Select(p => p.Id).Except(nodeProcessesBeforeHostRestart).Count());
 
             // Confirm host instance ids are the same
             Assert.Equal(oldHostInstanceId, await _fixture.GetActiveHostInstanceIdAsync());

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcesses.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcesses.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -11,7 +10,6 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.WebJobs.Script.Tests;
@@ -21,70 +19,52 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 {
     [Trait(TestTraits.Category, TestTraits.EndToEnd)]
     [Trait(TestTraits.Group, TestTraits.SamplesEndToEnd)]
-    public class SamplesEndToEndTests_Node_MultipleProcesses : IClassFixture<SamplesEndToEndTests_Node_MultipleProcesses.MultiplepleProcessesTestFixture>
+    public class SamplesEndToEndTests_Node_MultipleProcesses : IAsyncDisposable
     {
-        private readonly ScriptSettingsManager _settingsManager;
-        private MultiplepleProcessesTestFixture _fixture;
-        private IEnumerable<int> _nodeProcessesBeforeTestStarted;
+        private readonly MultiplepleProcessesTestFixture _fixture;
 
-        public SamplesEndToEndTests_Node_MultipleProcesses(MultiplepleProcessesTestFixture fixture)
+        public SamplesEndToEndTests_Node_MultipleProcesses()
         {
-            _fixture = fixture;
-            _nodeProcessesBeforeTestStarted = fixture.NodeProcessesBeforeTestStarted;
-            _settingsManager = ScriptSettingsManager.Instance;
+            // We want a new fixture for each test
+            _fixture = new MultiplepleProcessesTestFixture();
         }
 
         [Fact]
         public async Task NodeProcess_Different_AfterHostRestart()
         {
+            await _fixture.InitializeAsync();
+            await WaitForWebHostChannelCountAsync(3);
+
             await SamplesTestHelpers.InvokeAndValidateHttpTrigger(_fixture, "HttpTrigger");
-            IEnumerable<int> nodeProcessesBeforeHostRestart = Process.GetProcessesByName("node").Select(p => p.Id);
+            IEnumerable<int> nodeProcessesBeforeHostRestart = GetCurrentWorkerPids();
+
             // Trigger a restart
             await _fixture.Host.RestartAsync(CancellationToken.None);
 
             await SamplesTestHelpers.InvokeAndValidateHttpTrigger(_fixture, "HttpTrigger");
 
             // Wait for all the 3 process to start
-            await Task.Delay(TimeSpan.FromMinutes(1));
+            await WaitForWebHostChannelCountAsync(3);
 
-            IEnumerable<int> nodeProcessesAfter = Process.GetProcessesByName("node").Select(p => p.Id);
+            IEnumerable<int> nodeProcessesAfter = GetCurrentWorkerPids();
 
             // Verify node process is different after host restart
-            var result = nodeProcessesAfter.Where(pId1 => !nodeProcessesBeforeHostRestart.Any(pId2 => pId2 == pId1) && !_fixture.NodeProcessesBeforeTestStarted.Any(pId3 => pId3 == pId1));
+            var result = nodeProcessesAfter.Where(pId1 => !nodeProcessesBeforeHostRestart.Any(pId2 => pId2 == pId1) && !nodeProcessesBeforeHostRestart.Any(pId3 => pId3 == pId1));
             Assert.Equal(3, result.Count());
-        }
-
-        private async Task<IEnumerable<int>> WaitAndGetAllNodeProcesses(int expectedProcessCount)
-        {
-            var nodeProcessesBeforeHostRestart = Process.GetProcessesByName("node");
-            while (nodeProcessesBeforeHostRestart.Count() < expectedProcessCount)
-            {
-                await Task.Delay(TimeSpan.FromSeconds(5));
-                nodeProcessesBeforeHostRestart = Process.GetProcessesByName("node");
-            }
-
-            foreach (var p in nodeProcessesBeforeHostRestart)
-            {
-                Console.WriteLine($"node {p.Id}: {p.StartInfo.Arguments}");
-            }
-
-            return nodeProcessesBeforeHostRestart.Select(p => p.Id);
         }
 
         [Fact]
         public async Task NodeProcessCount_RemainsSame_AfterMultipleTimeouts()
         {
+            await _fixture.InitializeAsync();
+
             // Wait for all the 3 process to start
             List<Task<HttpResponseMessage>> timeoutTasks = new List<Task<HttpResponseMessage>>();
-            Task timeoutTask = Task.Delay(TimeSpan.FromMinutes(1));
-            Task<IEnumerable<int>> getNodeTask = WaitAndGetAllNodeProcesses(3);
-            Task result = await Task.WhenAny(getNodeTask, timeoutTask);
-            if (result.Equals(timeoutTask))
-            {
-                throw new Exception("Failed to start all 3 node processes");
-            }
+            await WaitForWebHostChannelCountAsync(3);
+            IEnumerable<int> nodeProcessesBeforeHostRestart = GetCurrentWorkerPids();
+
             var oldHostInstanceId = await _fixture.GetActiveHostInstanceIdAsync();
-            IEnumerable<int> nodeProcessesBeforeHostRestart = await getNodeTask;
+
             string functionKey = await _fixture.Host.GetFunctionSecretAsync("httptrigger-timeout");
             string uri = $"api/httptrigger-timeout?code={functionKey}&name=Yogi";
 
@@ -95,44 +75,70 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                 request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/plain"));
                 timeoutTasks.Add(_fixture.Host.HttpClient.SendAsync(request));
             }
+
             var results = await Task.WhenAll(timeoutTasks);
             foreach (var timeoutResult in results)
             {
                 Assert.Equal(HttpStatusCode.InternalServerError, timeoutResult.StatusCode);  // Confirm response code after timeout (10 seconds)
             }
 
-            var nodeProcessesAfter = Process.GetProcessesByName("node");
-
-            foreach (var p in nodeProcessesAfter)
-            {
-                Console.WriteLine($"node {p.Id}: {p.StartInfo.Arguments}");
-            }
+            // restarted workers run at JobHost level (?)
+            await WaitForJobHostChannelCountAsync(3);
+            var nodeProcessesAfter = GetCurrentWorkerPids();
 
             // Confirm count remains the same
             Assert.Equal(nodeProcessesBeforeHostRestart.Count(), nodeProcessesAfter.Count());
 
-            // Confirm all processes are different
-            Assert.Equal(3, nodeProcessesAfter.Select(p => p.Id).Except(nodeProcessesBeforeHostRestart).Count());
-
             // Confirm host instance ids are the same
             Assert.Equal(oldHostInstanceId, await _fixture.GetActiveHostInstanceIdAsync());
+
+            var result = nodeProcessesAfter.Where(pId1 => !nodeProcessesBeforeHostRestart.Any(pId2 => pId2 == pId1) && !nodeProcessesBeforeHostRestart.Any(pId3 => pId3 == pId1));
+            Assert.Equal(3, result.Count());
+        }
+
+        public async Task WaitForWebHostChannelCountAsync(int expectedCount)
+        {
+            await TestHelpers.Await(() =>
+            {
+                var channelManager = _fixture.Host.WebHostServices.GetService<IWebHostRpcWorkerChannelManager>();
+                var channels = channelManager.GetChannels("node");
+                return channels is not null && channels.Count == expectedCount;
+            }, pollingInterval: 1000, userMessageCallback: _fixture.Host.GetLog);
+        }
+
+        public async Task WaitForJobHostChannelCountAsync(int expectedCount)
+        {
+            await TestHelpers.Await(() =>
+            {
+                var channelManager = _fixture.Host.JobHostServices.GetService<IJobHostRpcWorkerChannelManager>();
+                var channels = channelManager.GetChannels("node");
+                return channels is not null && channels.Count() == expectedCount;
+            }, pollingInterval: 1000, userMessageCallback: _fixture.Host.GetLog);
+        }
+
+        public IEnumerable<int> GetCurrentWorkerPids()
+        {
+            var webHostChannelManager = _fixture.Host.WebHostServices.GetService<IWebHostRpcWorkerChannelManager>();
+            var webHostChannels = webHostChannelManager.GetChannels("node");
+            var webHostPids = webHostChannels.Select(c => c.Value.Task.Result.WorkerProcess.Id).ToArray();
+
+            var jobHostChannelManager = _fixture.Host.JobHostServices.GetService<IJobHostRpcWorkerChannelManager>();
+            var jobHostChannels = jobHostChannelManager.GetChannels("node");
+            var jobHostPids = jobHostChannels.Select(c => c.WorkerProcess.Id).ToArray();
+
+            return webHostPids.Concat(jobHostPids);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _fixture.DisposeAsync();
         }
 
         public class MultiplepleProcessesTestFixture : EndToEndTestFixture
         {
-            private IEnumerable<int> _nodeProcessesBeforeTestStarted;
-
-            public IEnumerable<int> NodeProcessesBeforeTestStarted => _nodeProcessesBeforeTestStarted;
-
-            static MultiplepleProcessesTestFixture()
-            {
-            }
-
             public MultiplepleProcessesTestFixture()
                 : base(Path.Combine(Environment.CurrentDirectory, @"..", "..", "..", "..", "sample", "node"), "samples", RpcWorkerConstants.NodeLanguageWorkerName, 3)
             {
-                _nodeProcessesBeforeTestStarted = Process.GetProcessesByName("node").Select(p => p.Id);
-                _nodeProcessesBeforeTestStarted = _nodeProcessesBeforeTestStarted ?? new List<int>();
             }
 
             public override void ConfigureScriptHost(IWebJobsBuilder webJobsBuilder)
@@ -140,12 +146,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                 base.ConfigureScriptHost(webJobsBuilder);
                 webJobsBuilder.Services.Configure<ScriptJobHostOptions>(o =>
                 {
-                    o.Functions = new[]
-                    {
+                    o.Functions =
+                    [
                         "HttpTrigger",
                         "HttpTrigger-Timeout",
-                    };
+                    ];
                 });
+
+                webJobsBuilder.Services.AddOptions<LanguageWorkerOptions>()
+                    .PostConfigure(o =>
+                    {
+                        var nodeConfig = o.WorkerConfigs.Single(c => c.Description.Language == "node");
+                        nodeConfig.CountOptions.ProcessStartupInterval = TimeSpan.FromSeconds(3);
+                    });
             }
         }
     }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesTestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesTestHelpers.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -21,7 +20,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/plain"));
 
             HttpResponseMessage response = await fixture.Host.HttpClient.SendAsync(request);
-            Console.WriteLine(fixture.Host.GetLog());
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             string body = await response.Content.ReadAsStringAsync();
             Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesTestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesTestHelpers.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
-using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/plain"));
 
             HttpResponseMessage response = await fixture.Host.HttpClient.SendAsync(request);
+            Console.WriteLine(fixture.Host.GetLog());
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             string body = await response.Content.ReadAsStringAsync();
             Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);


### PR DESCRIPTION
Hopefully fixing a handful of failures:

1. When asking for the HostInstanceId in tests that did restarts -- it would occasionally have a null ActiveHost, meaning there'd be some exception during DI service resolution. This adds a retry for a bit and a better error when this happens.
2. An error in Metrics tests with "InvocationId has already been used ". Looking through this, I saw that we manually call `Flush()` at the end of some tests as well as set the internal FlushTimer to 2 seconds. Sometimes these will happen simultaneously and it appears we flush the same event multiple times, leading to this weird error. Locking around this should fix it.
3. StackOverflow in one of our powershell scripts. There's a few issues (https://github.com/Azure/azure-powershell/issues/26623) on this around github. Most say switcing to `pwsh` fixes the issue, so giving that a try.
4. Some of our multi-process tests were very flaky. They're checking for all processes named "node" on the machine and not really waiting the right amount of time for processes to spin up, etc. I had recently taken a different approach in https://github.com/Azure/azure-functions-host/pull/9820 where, rather than check externally for processes to spin-up, I looked directly at the channels to be ready before continuing. This seems to be a lot more stable, so I re-wrote a few tests to use this pattern.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * [x] Otherwise:  https://github.com/Azure/azure-functions-host/pull/10818
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)