### PR TITLE
Address unit test timing and setting Console.Out

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/BufferedConsoleWriter.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/BufferedConsoleWriter.cs
@@ -111,12 +111,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                             }
 
                             _writeResetEvent.Set();
-                            Writer.Write(builder.ToString());
+                            await Writer.WriteAsync(builder.ToString());
                             builder.Clear();
                         }
                         else
                         {
-                            Writer.WriteLine(line1);
+                            await Writer.WriteLineAsync(line1);
                         }
                     }
                 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/BufferedConsoleWriter.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/BufferedConsoleWriter.cs
@@ -53,19 +53,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public TextWriter Writer { get; init; } = Console.Out;
 
-        /// <summary>
-        /// Primarily for testing. Do not call in production.
-        /// </summary>
-        /// <remarks>
-        /// Not called 'FlushAsync' because this does stop processing messages.
-        /// </remarks>
-        /// <returns>A task that completes when all buffered messages are drained.</returns>
-        public Task CompleteAsync()
-        {
-            _consoleBuffer.Writer.TryComplete();
-            return _consoleBufferReadLoop;
-        }
-
         public void WriteHandler(string evt)
         {
             _writeEvent(evt);
@@ -162,6 +149,19 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             }
 
             GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Primarily for testing. Do not call in production.
+        /// </summary>
+        /// <remarks>
+        /// Not called 'FlushAsync' because this does stop processing messages.
+        /// </remarks>
+        /// <returns>A task that completes when all buffered messages are drained.</returns>
+        internal Task CompleteAsync()
+        {
+            _consoleBuffer.Writer.TryComplete();
+            return _consoleBufferReadLoop;
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/BufferedConsoleWriter.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/BufferedConsoleWriter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Channels;
@@ -50,6 +51,21 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             _exceptionhandler = exceptionHandler;
         }
 
+        public TextWriter Writer { get; init; } = Console.Out;
+
+        /// <summary>
+        /// Primarily for testing. Do not call in production.
+        /// </summary>
+        /// <remarks>
+        /// Not called 'FlushAsync' because this does stop processing messages.
+        /// </remarks>
+        /// <returns>A task that completes when all buffered messages are drained.</returns>
+        public Task CompleteAsync()
+        {
+            _consoleBuffer.Writer.TryComplete();
+            return _consoleBufferReadLoop;
+        }
+
         public void WriteHandler(string evt)
         {
             _writeEvent(evt);
@@ -65,7 +81,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 // If the wait failed, write to the console. Otherwise, try the writing again - if that fails, write to the console.
                 if (waitFailed || !_consoleBuffer.Writer.TryWrite(evt))
                 {
-                    Console.WriteLine(evt);
+                    Writer.WriteLine(evt);
                 }
             }
         }
@@ -108,12 +124,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                             }
 
                             _writeResetEvent.Set();
-                            Console.Write(builder.ToString());
+                            Writer.Write(builder.ToString());
                             builder.Clear();
                         }
                         else
                         {
-                            Console.WriteLine(line1);
+                            Writer.WriteLine(line1);
                         }
                     }
                 }
@@ -126,7 +142,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             finally
             {
                 // if this has failed for any reason, fall everything back to console
-                _writeEvent = Console.WriteLine;
+                _writeEvent = Writer.WriteLine;
                 _consoleBuffer.Writer.TryComplete();
             }
         }

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxContainerEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxContainerEventGenerator.cs
@@ -2,13 +2,14 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 {
-    internal class LinuxContainerEventGenerator : LinuxEventGenerator, IDisposable
+    internal sealed class LinuxContainerEventGenerator : LinuxEventGenerator, IDisposable
     {
         private const int MaxDetailsLength = 10000;
         private static readonly Lazy<LinuxContainerEventGenerator> _Lazy = new Lazy<LinuxContainerEventGenerator>(() => new LinuxContainerEventGenerator(SystemEnvironment.Instance, Console.WriteLine));
@@ -19,7 +20,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         private string _containerName;
         private string _stampName;
         private string _tenantId;
-        private bool _disposed;
 
         public LinuxContainerEventGenerator(IEnvironment environment, IOptions<ConsoleLoggingOptions> consoleLoggingOptions)
         {
@@ -29,11 +29,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             }
             else if (!consoleLoggingOptions.Value.BufferEnabled)
             {
-                _writeEvent = Console.WriteLine;
+                _writeEvent = consoleLoggingOptions.Value.Writer.WriteLine;
             }
             else
             {
-                _consoleWriter = new BufferedConsoleWriter(consoleLoggingOptions.Value.BufferSize, LogUnhandledException);
+                _consoleWriter = new BufferedConsoleWriter(consoleLoggingOptions.Value.BufferSize, LogUnhandledException)
+                {
+                    Writer = consoleLoggingOptions.Value.Writer
+                };
+
                 _writeEvent = _consoleWriter.WriteHandler;
             }
 
@@ -172,22 +176,21 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 eventTimestamp: DateTime.UtcNow);
         }
 
-        protected virtual void Dispose(bool disposing)
+        /// <summary>
+        /// Primarily for testing. Do not call in production.
+        /// </summary>
+        /// <remarks>
+        /// Not called 'FlushAsync' because this does stop processing messages.
+        /// </remarks>
+        /// <returns>A task that completes when all buffered messages are drained.</returns>
+        public Task CompleteAsync()
         {
-            if (!_disposed)
-            {
-                if (disposing)
-                {
-                    _consoleWriter?.Dispose();
-                }
-                _disposed = true;
-            }
+            return _consoleWriter is { } writer ? writer.CompleteAsync() : Task.CompletedTask;
         }
 
         public void Dispose()
         {
-            Dispose(disposing: true);
-            GC.SuppressFinalize(this);
+            _consoleWriter?.Dispose();
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/LinuxContainerEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/LinuxContainerEventGenerator.cs
@@ -176,6 +176,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 eventTimestamp: DateTime.UtcNow);
         }
 
+        public void Dispose()
+        {
+            _consoleWriter?.Dispose();
+        }
+
         /// <summary>
         /// Primarily for testing. Do not call in production.
         /// </summary>
@@ -183,14 +188,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         /// Not called 'FlushAsync' because this does stop processing messages.
         /// </remarks>
         /// <returns>A task that completes when all buffered messages are drained.</returns>
-        public Task CompleteAsync()
+        internal Task CompleteAsync()
         {
             return _consoleWriter is { } writer ? writer.CompleteAsync() : Task.CompletedTask;
-        }
-
-        public void Dispose()
-        {
-            _consoleWriter?.Dispose();
         }
     }
 }

--- a/src/WebJobs.Script/Config/ConsoleLoggingOptions.cs
+++ b/src/WebJobs.Script/Config/ConsoleLoggingOptions.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+using System.IO;
+
 namespace Microsoft.Azure.WebJobs.Script.Config
 {
     public class ConsoleLoggingOptions
@@ -10,18 +13,17 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         // So in the extreme case, this is about 1 second of buffer and should be less than 3MB
         public const int DefaultBufferSize = 8000;
 
-        public ConsoleLoggingOptions()
-        {
-            LoggingDisabled = false;
-            BufferEnabled = true;
-            BufferSize = DefaultBufferSize;
-        }
-
         public bool LoggingDisabled { get; set; }
 
         // Use BufferSize = 0 to disable the buffer
-        public bool BufferEnabled { get; internal set; }
+        public bool BufferEnabled { get; set; } = true;
 
-        public int BufferSize { get; set; }
+        public int BufferSize { get; set; } = DefaultBufferSize;
+
+        /// <summary>
+        /// Gets or sets the <see cref="TextWriter"/> to write logs to.
+        /// IMPORTANT: this is primarily for unit tests to redirect logs to a different writer.
+        /// </summary>
+        internal TextWriter Writer { get; set; } = Console.Out;
     }
 }

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxContainerEventGeneratorWithConsoleOutputTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxContainerEventGeneratorWithConsoleOutputTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Config;
@@ -15,26 +16,17 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 {
-    public class LinuxContainerEventGeneratorWithConsoleOutputTests : IDisposable
+    public sealed class LinuxContainerEventGeneratorWithConsoleOutputTests : IDisposable
     {
-        private readonly MemoryStream _consoleOut = new MemoryStream();
+        private readonly StringWriter _writer = new();
         private readonly string _containerName = "test-container";
         private readonly string _stampName = "test-stamp";
         private readonly string _tenantId = "test-tenant";
         private readonly string _testNodeAddress = "test-address";
 
-        public LinuxContainerEventGeneratorWithConsoleOutputTests()
-        {
-            var streamWriter = new StreamWriter(_consoleOut);
-            streamWriter.AutoFlush = true;
-            Console.SetOut(streamWriter);
-        }
-
         public void Dispose()
         {
-            var standardOutput = new StreamWriter(Console.OpenStandardOutput());
-            standardOutput.AutoFlush = true;
-            Console.SetOut(standardOutput);
+            _writer.Dispose();
         }
 
         private IEnvironment CreateEnvironment()
@@ -49,19 +41,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 
         private IOptions<ConsoleLoggingOptions> CreateLoggingOptions(bool? consoleDisabled = null, bool? bufferEnabled = null, int? bufferSize = null)
         {
-            var options = new ConsoleLoggingOptions();
-
-            if (consoleDisabled != null)
+            ConsoleLoggingOptions options = new() { Writer = _writer };
+            if (consoleDisabled.HasValue)
             {
                 options.LoggingDisabled = consoleDisabled.Value;
             }
 
-            if (bufferEnabled != null)
+            if (bufferEnabled.HasValue)
             {
                 options.BufferEnabled = bufferEnabled.Value;
             }
 
-            if (bufferSize != null)
+            if (bufferSize.HasValue)
             {
                 options.BufferSize = bufferSize.Value;
             }
@@ -78,11 +69,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 
             generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", DateTime.Now);
 
-            using var sr = new StreamReader(_consoleOut);
-            _consoleOut.Position = 0;
-            var output = sr.ReadToEnd().Trim();
-
-            Assert.Equal(string.Empty, output);
+            Assert.Equal(string.Empty, _writer.ToString().Trim());
         }
 
         [Fact]
@@ -95,10 +82,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             var timestamp = DateTime.Parse("2023-04-19T14:12:00.0000000Z");
             generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
 
-            using var sr = new StreamReader(_consoleOut);
-            _consoleOut.Position = 0;
-            var output = sr.ReadToEnd().Trim();
-
+            string output = _writer.ToString().Trim();
             Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName,{Environment.ProcessId}", output);
         }
 
@@ -111,12 +95,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 
             var timestamp = DateTime.Parse("2023-04-19T14:12:00.0000000Z");
             generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
-            await Task.Delay(TimeSpan.FromMilliseconds(10));
+            await generator.CompleteAsync();
 
-            using var sr = new StreamReader(_consoleOut);
-            _consoleOut.Position = 0;
-            var output = sr.ReadToEnd().Trim();
-
+            // TODO: fix delay
+            string output = _writer.ToString().Trim();
             Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName,{Environment.ProcessId}", output);
         }
 
@@ -131,12 +113,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction1", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
             generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction2", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
             generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction3", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
-            await Task.Delay(TimeSpan.FromMilliseconds(10));
 
-            using var sr = new StreamReader(_consoleOut);
-            _consoleOut.Position = 0;
-            var output = sr.ReadToEnd().Trim().SplitLines();
-
+            await generator.CompleteAsync();
+            string[] output = _writer.ToString().Trim().SplitLines();
             Assert.Equal(3, output.Length);
 
             Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction1,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName,{Environment.ProcessId}", output[0]);
@@ -149,7 +128,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         {
             // setup in a state where the buffer isn't being processed and can only hold two messages
             var env = CreateEnvironment();
-            var consoleWriter = new BufferedConsoleWriter(bufferSize: 2, LinuxContainerEventGenerator.LogUnhandledException, consoleBufferTimeout: TimeSpan.FromMilliseconds(10), autoStart: false);
+            var consoleWriter = new BufferedConsoleWriter(bufferSize: 2, LinuxContainerEventGenerator.LogUnhandledException, consoleBufferTimeout: TimeSpan.FromMilliseconds(10), autoStart: false)
+            {
+                Writer = _writer
+            };
+
             var generator = new LinuxContainerEventGenerator(env, consoleWriter);
 
             var timestamp = DateTime.Parse("2023-04-19T14:12:00.0000000Z");
@@ -159,9 +142,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             // This write will block until the above timeout expires, and then it should write directly to the console
             generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction3", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
 
-            using var sr = new StreamReader(_consoleOut);
-            _consoleOut.Position = 0;
-            var output = sr.ReadToEnd().Trim().SplitLines();
+            string[] output = _writer.ToString().Trim().SplitLines();
 
             // The first two messages are still stuck in the buffer. The third message will have been written to the console.
             Assert.Equal(1, output.Length);
@@ -173,7 +154,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         {
             var env = CreateEnvironment();
             // setup in a state where the buffer isn't being processed and can only hold two messages
-            var consoleWriter = new BufferedConsoleWriter(bufferSize: 2, LinuxContainerEventGenerator.LogUnhandledException, consoleBufferTimeout: TimeSpan.FromMilliseconds(500), autoStart: false);
+            var consoleWriter = new BufferedConsoleWriter(bufferSize: 2, LinuxContainerEventGenerator.LogUnhandledException, consoleBufferTimeout: TimeSpan.FromMilliseconds(500), autoStart: false)
+            {
+                Writer = _writer
+            };
+
             var generator = new LinuxContainerEventGenerator(env, consoleWriter);
 
             var timestamp = DateTime.Parse("2023-04-19T14:12:00.0000000Z");
@@ -187,10 +172,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             consoleWriter.StartProcessingBuffer();
             await Task.Delay(TimeSpan.FromMilliseconds(50));
 
-            using var sr = new StreamReader(_consoleOut);
-            _consoleOut.Position = 0;
-            var output = sr.ReadToEnd().Trim().SplitLines();
-
+            string[] output = _writer.ToString().Trim().SplitLines();
             Assert.Equal(3, output.Length);
 
             // the log from TestFunction3 will be first because it was written directly to the console
@@ -203,21 +185,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         public async Task FlushesBufferOnDispose()
         {
             var env = CreateEnvironment();
-            var consoleWriter = new BufferedConsoleWriter(bufferSize: 10, LinuxContainerEventGenerator.LogUnhandledException, consoleBufferTimeout: TimeSpan.FromMilliseconds(500), autoStart: true);
+            ControlledWriter control = new(_writer);
+            var consoleWriter = new BufferedConsoleWriter(bufferSize: 10, LinuxContainerEventGenerator.LogUnhandledException, consoleBufferTimeout: TimeSpan.FromMilliseconds(500), autoStart: true)
+            {
+                Writer = control,
+            };
+
             var generator = new LinuxContainerEventGenerator(env, consoleWriter);
 
             // Setup console output that will block until we release the semaphore.
-            var controlledWriter = new ControlledWriter(_consoleOut);
-            await controlledWriter.Semaphore.WaitAsync();
-            Console.SetOut(controlledWriter);
-
+            await control.Semaphore.WaitAsync();
             var timestamp = DateTime.Parse("2023-04-19T14:12:00.0000000Z");
             generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction1", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
             generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction2", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
             await Task.Delay(TimeSpan.FromMilliseconds(20));
 
             // We haven't released the semaphore yet, so nothing should have been written.
-            Assert.Equal(0, _consoleOut.Length);
+            Assert.Equal(0, control.WriteCount);
 
             var disposeTask = Task.Run(consoleWriter.Dispose);
             await Task.Delay(TimeSpan.FromMilliseconds(20));
@@ -225,16 +209,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             // Dispose should be blocked on flushing the buffer, which is blocked on the semaphore.
             Assert.False(disposeTask.IsCompleted);
 
-            controlledWriter.Semaphore.Release();
+            control.Semaphore.Release();
             await disposeTask;
 
             // after being disposed, console writer should fall back to direct console write, just so that we don't get errors on logging paths
             generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction3", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
 
-            using var sr = new StreamReader(_consoleOut);
-            _consoleOut.Position = 0;
-            var output = sr.ReadToEnd().Trim().SplitLines();
-
+            string[] output = _writer.ToString().Trim().SplitLines();
             Assert.Equal(3, output.Length);
 
             Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction1,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName,{Environment.ProcessId}", output[0]);
@@ -242,26 +223,27 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction3,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName,{Environment.ProcessId}", output[2]);
         }
 
-        private class ControlledWriter : StreamWriter
+        private class ControlledWriter(TextWriter inner) : TextWriter
         {
-            public ControlledWriter(Stream stream) : base(stream)
-            {
-                this.AutoFlush = true;
-            }
+            public int WriteCount { get; private set; }
 
             public SemaphoreSlim Semaphore { get; set; } = new SemaphoreSlim(1);
+
+            public override Encoding Encoding => inner.Encoding;
 
             public override void Write(string value)
             {
                 Semaphore.Wait();
-                base.Write(value);
+                WriteCount++;
+                inner.Write(value);
                 Semaphore.Release();
             }
 
             public override void WriteLine(string value)
             {
                 Semaphore.Wait();
-                base.WriteLine(value);
+                WriteCount++;
+                inner.WriteLine(value);
                 Semaphore.Release();
             }
         }

--- a/test/WebJobs.Script.Tests/Diagnostics/LinuxContainerEventGeneratorWithConsoleOutputTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/LinuxContainerEventGeneratorWithConsoleOutputTests.cs
@@ -97,7 +97,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
             generator.LogFunctionTraceEvent(LogLevel.Information, "C37E3412-86D1-4B93-BC5A-A2AE09D26C2D", "TestApp", "TestFunction", "TestEvent", "TestSource", "These are the details, lots of details", "This is the summary, a great summary", "TestExceptionType", "Test exception message, with details", "E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3", "3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829", "F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53", "TestRuntimeSiteName", "TestSlotName", timestamp);
             await generator.CompleteAsync();
 
-            // TODO: fix delay
             string output = _writer.ToString().Trim();
             Assert.Equal($"MS_FUNCTION_LOGS 4,C37E3412-86D1-4B93-BC5A-A2AE09D26C2D,TestApp,TestFunction,TestEvent,TestSource,\"These are the details, lots of details\",\"This is the summary, a great summary\",{ScriptHost.Version},{timestamp.ToString("O")},TestExceptionType,\"Test exception message, with details\",E2D5A6ED-4CE3-4CFD-8878-FD4814F0A1F3,3AD41658-1C4E-4C9D-B0B9-24F2BDAE2829,F0AAA9AD-C3A6-48B9-A75E-57BB280EBB53,TEST-CONTAINER,test-stamp,test-tenant,TestRuntimeSiteName,TestSlotName,{Environment.ProcessId}", output);
         }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR -- TODO
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Addresses unit test issues with `LinuxContainerEventGeneratorWithConsoleOutputTests`

1. These tests globally redirected `Console.Out` which could have adverse effects for other tests running in parallel.
    - FIX: added a way to supply a custom `TextWriter` that tests use. Defaults to `Console.Out`.
2. These tests relied on task delays to wait for a buffer to drain.
    - FIX: added a `CompleteAsync` method to classes being tested, giving a way to delay until buffers are fully drained.
