### PR TITLE
Fix the incorrect variable value check inside PowerShell block.

### DIFF
--- a/eng/ci/templates/official/jobs/run-benchmarks.yml
+++ b/eng/ci/templates/official/jobs/run-benchmarks.yml
@@ -119,7 +119,7 @@ jobs:
         $crankArgs += " $(AdditionalCrankArguments)"
         $command = "crank $crankArgs"
 
-        if ('${{ variables['storeBenchmarkResultsInDatabase'] }}' -eq 'true') {
+        if ('$(storeBenchmarkResultsInDatabase)' -eq 'true') {
             $command += " --table HttpBenchmarks --sql `"$(BenchmarkResultsSqlConnectionString)`""
         }
 


### PR DESCRIPTION
Fix the incorrect variable value check inside PowerShell block. The scheduled runs were not persisting data because of this.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

