### PR TITLE
Prepare in-proc branch for VNext: Clear notes, update version to 4.39.100

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,12 +3,3 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-- Update Java Worker Version to [2.18.0](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.18.0)
-
-- Updated Microsoft.Extensions.DependencyModel to 6.0.2 and 8.0.2 for .NET 6 and .NET 8, respectively. (#10661)
-- Update the `DefaultHttpProxyService` to better handle client disconnect scenarios (#10688)
-  - Replaced `InvalidOperationException` with `HttpForwardingException` when there is a ForwarderError
-- [In-proc] Codeql : Fix to remove exception details from the response (#10751)
-- Update PowerShell 7.4 worker to [4.0.4134](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.4134)
-- Update Python Worker Version to [4.35.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.35.0)
-- Update domain for CDN URI

--- a/src/Directory.Version.props
+++ b/src/Directory.Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.$(MinorVersionPrefix)38.100</VersionPrefix>
+    <VersionPrefix>4.$(MinorVersionPrefix)39.100</VersionPrefix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This PR contains the following changes:
- Update version to 4.39.100
- Clear release notes

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the in-proc branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the in-proc branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to release_notes.md
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
