### PR TITLE
Using managed identity for persisting benchmark result data

### DIFF
--- a/eng/ci/templates/official/jobs/run-benchmarks.yml
+++ b/eng/ci/templates/official/jobs/run-benchmarks.yml
@@ -54,14 +54,6 @@ jobs:
 
   steps:
 
-  - task: AzureKeyVault@2
-    condition: and(succeeded(), eq(variables['storeBenchmarkResultsInDatabase'], true))
-    inputs:
-      azureSubscription: Azure-Functions-Host-CI-internal
-      KeyVaultName: functions-perf-crank-kv
-      SecretsFilter: BenchmarkResultsSqlConnectionString
-      RunAsPreJob: false
-
   - template: /eng/ci/templates/install-dotnet.yml@self
 
   - script: dotnet tool install -g Microsoft.Crank.Agent --version "0.2.0-*"
@@ -113,12 +105,16 @@ jobs:
           }
         } while (-not $Entity)
 
-  - pwsh: |
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: $(ServiceConnection)
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript: |
         $crankArgs = "--config $(configFilePath) --scenario hellohttp --profile win2022 --load.options.reuseBuild true --description `"$(runDescription)`" --command-line-property --no-measurements --json $(benchmarkResultsJsonPath) --property sourceVersion=$(Build.SourceVersion) --property buildNumber=$(Build.BuildNumber) --property buildId=$(Build.BuildId) --property sourceBranch=$(Build.SourceBranch) --variable FunctionsWorkerRuntime=$(functionsWorkerRuntime) --variable HostLocation=$(hostLocation) --variable FunctionAppPath=$(functionAppOutputPath)"
         $crankArgs += " --variable CrankAgentAppVm=$(appAgentHostName) --variable CrankAgentLoadVm=localhost --variable AspNetUrls=http://$(appAgentHostName):5000"
         $crankArgs += " $(AdditionalCrankArguments)"
         $command = "crank $crankArgs"
-
         if ('$(storeBenchmarkResultsInDatabase)' -eq 'true') {
             $command += " --table HttpBenchmarks --sql `"$(BenchmarkResultsSqlConnectionString)`""
         }


### PR DESCRIPTION
Using managed identity for persisting benchmark result data. 
Previously we were using SQL auth and the connection string (with sql uid & pass) was retrieved from key vault. With this change, the connection string will not have password. SQL authentication is also disabled on the sql server level.

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
