### PR TITLE
Remove the installation of libssl1.1 from the pipeline YAML since it is now included in the image

### DIFF
--- a/eng/ci/templates/official/jobs/setup-benchmark-agents.yml
+++ b/eng/ci/templates/official/jobs/setup-benchmark-agents.yml
@@ -31,13 +31,6 @@ jobs:
 
   - template: /eng/ci/templates/install-dotnet.yml@self
 
-  - ${{ if eq(parameters.os, 'Linux') }}:
-    # Adds the Ubuntu 20.04 security repository to Ubuntu 22.04 and installs libssl1.1, which is unavailable by default.
-    - script: |
-        echo "deb http://security.ubuntu.com/ubuntu focal-security main" | sudo tee /etc/apt/sources.list.d/focal-security.list
-        sudo apt update && sudo apt install -y libssl1.1
-      displayName: "Install libssl1.1 on Ubuntu 22.04"
-
   - script: dotnet tool install -g Microsoft.Crank.Agent --version "0.2.0-*"
     displayName: Install Microsoft.Crank.Agent tool
 


### PR DESCRIPTION
The installation of the `libssl1.1` package is now baked into the Linux image, so it has been removed from the pipeline step. This step previously took over a minute, and its removal has reduced the Linux build time.

[Here is the PR](https://devdiv.visualstudio.com/XlabImageFactory/_git/XlabImageFactory/pullrequest/608527) where this became an image factory artifact. 

Sample pipeline run with this change: https://azfunc.visualstudio.com/internal/_build/results?buildId=202600&view=logs&j=ca6baa9e-9efc-5f7e-211f-565f0d3d6d9f

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)


