### PR TITLE
test improvements

### DIFF
--- a/eng/ci/templates/official/jobs/run-integration-tests.yml
+++ b/eng/ci/templates/official/jobs/run-integration-tests.yml
@@ -41,6 +41,12 @@ jobs:
       command: ci
       workingDir: sample/CustomHandlerRetry
 
+  - task: DotNetCoreCLI@2
+    displayName: Build Integration.csproj
+    inputs:
+      command: build
+      projects: $(IntegrationProject)
+
   - task: AzurePowerShell@5
     displayName: Checkout secrets
     inputs:
@@ -72,12 +78,6 @@ jobs:
       CosmosDbSecretMap: $(CosmosDb)
       AzureWebJobsEventHubSenderSecretMap: $(EventHub)
       AzureWebJobsEventHubReceiverSecretMap: $(EventHub)
-
-  - task: DotNetCoreCLI@2
-    displayName: Build Integration.csproj
-    inputs:
-      command: build
-      projects: $(IntegrationProject)
 
   - task: DotNetCoreCLI@2
     displayName: C# end to end tests

--- a/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
+++ b/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
@@ -29,6 +29,12 @@ jobs:
       targetType: inline
       script: 'Install-Module -Name Az.Storage -RequiredVersion 1.11.0 -Scope CurrentUser -Force -AllowClobber'
 
+  - task: DotNetCoreCLI@2
+    displayName: Build Integration.csproj
+    inputs:
+      command: build
+      projects: $(IntegrationProject)
+
   - task: AzurePowerShell@5
     displayName: Checkout secrets
     inputs:
@@ -61,12 +67,6 @@ jobs:
   - bash: |
       az login --service-principal -u $(ARM_CLIENT_ID) --tenant $(ARM_TENANT_ID) --allow-no-subscriptions --federated-token $(ARM_ID_TOKEN)
     displayName: 'Login to Azure'
-
-  - task: DotNetCoreCLI@2
-    displayName: Build Integration.csproj
-    inputs:
-      command: build
-      projects: $(IntegrationProject)
 
   - task: DotNetCoreCLI@2
     displayName: Non-E2E integration tests

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CustomHandlerRetry.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CustomHandlerRetry.cs
@@ -5,12 +5,9 @@ using System;
 using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.WebJobs.Script.Tests;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
@@ -19,13 +16,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
     [Trait(TestTraits.Group, TestTraits.SamplesEndToEnd)]
     public class SamplesEndToEndTests_CustomHandlerRetry : IClassFixture<SamplesEndToEndTests_CustomHandlerRetry.TestFixture>
     {
-        private readonly ScriptSettingsManager _settingsManager;
         private TestFixture _fixture;
 
         public SamplesEndToEndTests_CustomHandlerRetry(TestFixture fixture)
         {
             _fixture = fixture;
-            _settingsManager = ScriptSettingsManager.Instance;
         }
 
         [Fact]
@@ -46,18 +41,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
 
         public class TestFixture : EndToEndTestFixture
         {
-            static TestFixture()
-            {
-            }
-
             public TestFixture()
                 : base(Path.Combine(Environment.CurrentDirectory, "..", "..", "..", "..", "sample", "CustomHandlerRetry"), "samples", RpcWorkerConstants.PowerShellLanguageWorkerName)
             {
             }
 
-            public override void ConfigureScriptHost(IWebJobsBuilder webJobsBuilder)
+            protected override Task CreateTestStorageEntities()
             {
-                base.ConfigureScriptHost(webJobsBuilder);
+                // no need
+                return Task.CompletedTask;
             }
         }
     }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcesses.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcesses.cs
@@ -21,13 +21,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
     [Trait(TestTraits.Group, TestTraits.SamplesEndToEnd)]
     public class SamplesEndToEndTests_Node_MultipleProcesses : IAsyncLifetime
     {
-        private readonly MultipleProcessesTestFixture _fixture;
-
-        public SamplesEndToEndTests_Node_MultipleProcesses()
-        {
-            // We want a new fixture for each test
-            _fixture = new MultipleProcessesTestFixture();
-        }
+        private readonly MultipleProcessesTestFixture _fixture = new();
 
         [Fact]
         public async Task NodeProcess_Different_AfterHostRestart()

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcesses.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcesses.cs
@@ -19,20 +19,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 {
     [Trait(TestTraits.Category, TestTraits.EndToEnd)]
     [Trait(TestTraits.Group, TestTraits.SamplesEndToEnd)]
-    public class SamplesEndToEndTests_Node_MultipleProcesses : IAsyncDisposable
+    public class SamplesEndToEndTests_Node_MultipleProcesses : IAsyncLifetime
     {
-        private readonly MultiplepleProcessesTestFixture _fixture;
+        private readonly MultipleProcessesTestFixture _fixture;
 
         public SamplesEndToEndTests_Node_MultipleProcesses()
         {
             // We want a new fixture for each test
-            _fixture = new MultiplepleProcessesTestFixture();
+            _fixture = new MultipleProcessesTestFixture();
         }
 
         [Fact]
         public async Task NodeProcess_Different_AfterHostRestart()
         {
-            await _fixture.InitializeAsync();
             await WaitForWebHostChannelCountAsync(3);
 
             await SamplesTestHelpers.InvokeAndValidateHttpTrigger(_fixture, "HttpTrigger");
@@ -56,8 +55,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         [Fact]
         public async Task NodeProcessCount_RemainsSame_AfterMultipleTimeouts()
         {
-            await _fixture.InitializeAsync();
-
             // Wait for all the 3 process to start
             List<Task<HttpResponseMessage>> timeoutTasks = new List<Task<HttpResponseMessage>>();
             await WaitForWebHostChannelCountAsync(3);
@@ -129,16 +126,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             return webHostPids.Concat(jobHostPids);
         }
 
-        public async ValueTask DisposeAsync()
-        {
-            await _fixture.DisposeAsync();
-        }
+        public Task InitializeAsync() => _fixture.InitializeAsync();
 
-        public class MultiplepleProcessesTestFixture : EndToEndTestFixture
+        Task IAsyncLifetime.DisposeAsync() => _fixture?.DisposeAsync();
+
+        private class MultipleProcessesTestFixture : EndToEndTestFixture
         {
-            public MultiplepleProcessesTestFixture()
+            public MultipleProcessesTestFixture()
                 : base(Path.Combine(Environment.CurrentDirectory, @"..", "..", "..", "..", "sample", "node"), "samples", RpcWorkerConstants.NodeLanguageWorkerName, 3)
             {
+            }
+
+            protected override Task CreateTestStorageEntities()
+            {
+                // not needed
+                return Task.CompletedTask;
             }
 
             public override void ConfigureScriptHost(IWebJobsBuilder webJobsBuilder)
@@ -156,8 +158,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                 webJobsBuilder.Services.AddOptions<LanguageWorkerOptions>()
                     .PostConfigure(o =>
                     {
-                        var nodeConfig = o.WorkerConfigs.Single(c => c.Description.Language == "node");
-                        nodeConfig.CountOptions.ProcessStartupInterval = TimeSpan.FromSeconds(3);
+                        var nodeConfig = o.WorkerConfigs.SingleOrDefault(c => c.Description.Language == "node");
+                        if (nodeConfig is not null)
+                        {
+                            nodeConfig.CountOptions.ProcessStartupInterval = TimeSpan.FromSeconds(3);
+                        }
                     });
             }
         }


### PR DESCRIPTION
Fixing and improving some test:
- xunit v2 doesn't support `IAsyncDisposable`, but it does support `IAsyncLifetime` for test classes. One test wasn't properly disposing b/c `DisposeAsync()` was never being called.
- Moving the build step for tests outside of the secrets lock we use for resources. This saves 4-5 minutes of lock time per run.
- Overriding the step that creates storage entities for some tests that don't need them. Should speed things up a little bit.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: https://github.com/Azure/azure-functions-host/pull/10851
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)