### PR TITLE
removing static ActiveOperations

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
@@ -150,7 +150,17 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
                 new EventId(522, nameof(CancelingStartupOperationForRestart)),
                 "Canceling startup operation '{operationId}' to unblock restart.");
 
-        // EventId 523 and 524 are defined in ScriptHostStartupOperation.
+        private static readonly Action<ILogger, Guid, Guid?, Exception> _startupOperationCreated =
+            LoggerMessage.Define<Guid, Guid?>(
+                LogLevel.Debug,
+                new EventId(524, nameof(StartupOperationCreated)),
+                "Startup operation '{operationId}' with parent id '{parentOperationId}' created.");
+
+        private static readonly Action<ILogger, Guid, Exception> _startupOperationCompleted =
+            LoggerMessage.Define<Guid>(
+                LogLevel.Debug,
+                new EventId(523, nameof(StartupOperationCompleted)),
+                "Startup operation '{operationId}' completed.");
 
         private static readonly Action<ILogger, Guid, string, Exception> _startupOperationStartingHost =
             LoggerMessage.Define<Guid, string>(
@@ -329,6 +339,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
         public static void CancelingStartupOperationForRestart(this ILogger logger, Guid operationId)
         {
             _cancelingStartupOperationForRestart(logger, operationId, null);
+        }
+
+        public static void StartupOperationCreated(this ILogger logger, Guid operationId, Guid? parentOperationId)
+        {
+            _startupOperationCreated(logger, operationId, parentOperationId, null);
+        }
+
+        public static void StartupOperationCompleted(this ILogger logger, Guid operationId)
+        {
+            _startupOperationCompleted(logger, operationId, null);
         }
 
         public static void StartupOperationStartingHost(this ILogger logger, Guid operationId, string hostInstanceId)

--- a/src/WebJobs.Script.WebHost/ScriptHostStartupOperation.cs
+++ b/src/WebJobs.Script.WebHost/ScriptHostStartupOperation.cs
@@ -4,49 +4,50 @@
 using System;
 using System.Threading;
 
-namespace Microsoft.Azure.WebJobs.Script.WebHost;
-
-/// <summary>
-/// Used to track all outstanding startup operations.
-/// </summary>
-internal class ScriptHostStartupOperation : IDisposable
+namespace Microsoft.Azure.WebJobs.Script.WebHost
 {
-    private bool _disposed = false;
-
     /// <summary>
-    /// Initializes a new instance of the <see cref="ScriptHostStartupOperation"/> class.
+    /// Used to track all startup operations.
     /// </summary>
-    /// <param name="cancellationToken">A CancellationToken that will be linked and exposed via the <see cref="CancellationTokenSource"/> property.</param>
-    /// <param name="parentId">The parent operation Id, if applicable.</param>
-    public ScriptHostStartupOperation(CancellationToken cancellationToken, Guid? parentId = null)
+    internal class ScriptHostStartupOperation : IDisposable
     {
-        Id = Guid.NewGuid();
-        CancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        ParentId = parentId;
-    }
+        private bool _disposed = false;
 
-    /// <summary>
-    /// Gets the Id of the operation, used for tracking through logs.
-    /// </summary>
-    public Guid Id { get; }
-
-    /// <summary>
-    /// Gets the parent operation that started this one. Used when restarting during exceptions.
-    /// </summary>
-    public Guid? ParentId { get; }
-
-    /// <summary>
-    /// Gets the CancellationTokenSource used to cancel this operation. This is CancellationTokenSource is linked to the
-    /// CancellationToken passed via the <see cref="Create(CancellationToken, ILogger, Guid?)"/> method.
-    /// </summary>
-    public CancellationTokenSource CancellationTokenSource { get; }
-
-    public void Dispose()
-    {
-        if (!_disposed)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScriptHostStartupOperation"/> class.
+        /// </summary>
+        /// <param name="cancellationToken">A CancellationToken that will be linked and exposed via the <see cref="CancellationTokenSource"/> property.</param>
+        /// <param name="parentId">The parent operation Id, if applicable.</param>
+        public ScriptHostStartupOperation(CancellationToken cancellationToken, Guid? parentId = null)
         {
-            CancellationTokenSource?.Dispose();
-            _disposed = true;
+            Id = Guid.NewGuid();
+            CancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            ParentId = parentId;
+        }
+
+        /// <summary>
+        /// Gets the Id of the operation, used for tracking through logs.
+        /// </summary>
+        public Guid Id { get; }
+
+        /// <summary>
+        /// Gets the parent operation that started this one. Used when restarting during exceptions.
+        /// </summary>
+        public Guid? ParentId { get; }
+
+        /// <summary>
+        /// Gets the CancellationTokenSource used to cancel this operation. This is CancellationTokenSource is linked to the
+        /// CancellationToken passed via the <see cref="ScriptHostStartupOperation"/> constructor.
+        /// </summary>
+        public CancellationTokenSource CancellationTokenSource { get; }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                CancellationTokenSource?.Dispose();
+                _disposed = true;
+            }
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/ScriptHostStartupOperation.cs
+++ b/src/WebJobs.Script.WebHost/ScriptHostStartupOperation.cs
@@ -2,108 +2,51 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Threading;
-using Microsoft.Extensions.Logging;
 
-namespace Microsoft.Azure.WebJobs.Script.WebHost
+namespace Microsoft.Azure.WebJobs.Script.WebHost;
+
+/// <summary>
+/// Used to track all outstanding startup operations.
+/// </summary>
+internal class ScriptHostStartupOperation : IDisposable
 {
+    private bool _disposed = false;
+
     /// <summary>
-    /// Used to track all outstanding startup operations.
+    /// Initializes a new instance of the <see cref="ScriptHostStartupOperation"/> class.
     /// </summary>
-    internal class ScriptHostStartupOperation : IDisposable
+    /// <param name="cancellationToken">A CancellationToken that will be linked and exposed via the <see cref="CancellationTokenSource"/> property.</param>
+    /// <param name="parentId">The parent operation Id, if applicable.</param>
+    public ScriptHostStartupOperation(CancellationToken cancellationToken, Guid? parentId = null)
     {
-        // Use a dictionary here as we need the concurrency support, but also need to be able to remove
-        // specific items from the collection.
-        private static readonly ConcurrentDictionary<ScriptHostStartupOperation, object> _startupOperations = new ConcurrentDictionary<ScriptHostStartupOperation, object>();
-        private readonly ILogger _logger;
+        Id = Guid.NewGuid();
+        CancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        ParentId = parentId;
+    }
 
-        private bool _disposed = false;
+    /// <summary>
+    /// Gets the Id of the operation, used for tracking through logs.
+    /// </summary>
+    public Guid Id { get; }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ScriptHostStartupOperation"/> class.
-        /// </summary>
-        /// <param name="cancellationToken">A CancellationToken that will be linked and exposed via the <see cref="CancellationTokenSource"/> property.</param>
-        /// <param name="parentId">The parent operation Id, if applicable.</param>
-        private ScriptHostStartupOperation(CancellationToken cancellationToken, ILogger logger, Guid? parentId = null)
+    /// <summary>
+    /// Gets the parent operation that started this one. Used when restarting during exceptions.
+    /// </summary>
+    public Guid? ParentId { get; }
+
+    /// <summary>
+    /// Gets the CancellationTokenSource used to cancel this operation. This is CancellationTokenSource is linked to the
+    /// CancellationToken passed via the <see cref="Create(CancellationToken, ILogger, Guid?)"/> method.
+    /// </summary>
+    public CancellationTokenSource CancellationTokenSource { get; }
+
+    public void Dispose()
+    {
+        if (!_disposed)
         {
-            Id = Guid.NewGuid();
-            CancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            ParentId = parentId;
-            _logger = logger;
-        }
-
-        /// <summary>
-        /// Gets the list of currently active operations.
-        /// </summary>
-        public static ICollection<ScriptHostStartupOperation> ActiveOperations => _startupOperations.Keys;
-
-        /// <summary>
-        /// Gets the Id of the operation, used for tracking through logs.
-        /// </summary>
-        public Guid Id { get; }
-
-        /// <summary>
-        /// Gets the parent operation that started this one. Used when restarting during exceptions.
-        /// </summary>
-        public Guid? ParentId { get; }
-
-        /// <summary>
-        /// Gets the CancellationTokenSource used to cancel this operation. This is CancellationTokenSource is linked to the
-        /// CancellationToken passed via the <see cref="Create(CancellationToken, ILogger, Guid?)"/> method.
-        /// </summary>
-        public CancellationTokenSource CancellationTokenSource { get; }
-
-        /// <summary>
-        /// Creates a new <see cref="ScriptHostStartupOperation"/> and adds it to the <see cref="ActiveOperations"/> collection.
-        /// </summary>
-        /// <param name="cancellationToken">A CancellationToken to be linked to <see cref="CancellationTokenSource"/>.</param>
-        /// <param name="logger">A logger.</param>
-        /// <param name="parentId">Ther parent operation id, if needed.</param>
-        /// <returns>A new instance.</returns>
-        public static ScriptHostStartupOperation Create(CancellationToken cancellationToken, ILogger logger, Guid? parentId = null)
-        {
-            var operation = new ScriptHostStartupOperation(cancellationToken, logger, parentId);
-            _startupOperations.AddOrUpdate(operation, addValue: null, (k, v) => null);
-            Log.StartupOperationCreated(logger, operation.Id, operation.ParentId);
-            return operation;
-        }
-
-        public void Dispose()
-        {
-            if (!_disposed)
-            {
-                _startupOperations.TryRemove(this, out object _);
-                CancellationTokenSource?.Dispose();
-                Log.StartupOperationCompleted(_logger, Id);
-                _disposed = true;
-            }
-        }
-
-        private static class Log
-        {
-            private static readonly Action<ILogger, Guid, Guid?, Exception> _startupOperationCreated =
-                LoggerMessage.Define<Guid, Guid?>(
-                    LogLevel.Debug,
-                    new EventId(524, nameof(StartupOperationCreated)),
-                    "Startup operation '{operationId}' with parent id '{parentOperationId}' created.");
-
-            private static readonly Action<ILogger, Guid, Exception> _startupOperationCompleted =
-                LoggerMessage.Define<Guid>(
-                    LogLevel.Debug,
-                    new EventId(523, nameof(StartupOperationCompleted)),
-                    "Startup operation '{operationId}' completed.");
-
-            public static void StartupOperationCreated(ILogger logger, Guid operationId, Guid? parentOperationId)
-            {
-                _startupOperationCreated(logger, operationId, parentOperationId, null);
-            }
-
-            public static void StartupOperationCompleted(ILogger logger, Guid operationId)
-            {
-                _startupOperationCompleted(logger, operationId, null);
-            }
+            CancellationTokenSource?.Dispose();
+            _disposed = true;
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -585,10 +585,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     {
                         // This can be disposed at any time.
                     }
-                    finally
-                    {
-                        EndStartupOperation(startupOperation);
-                    }
                 }
 
                 try
@@ -1022,6 +1018,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
         }
 
+        /// <summary>
+        /// Creates a new startup operation and adds it to the list of active operations. This operation should be completed by
+        /// calling <see cref="EndStartupOperation(ScriptHostStartupOperation)"/>."/>.
+        /// </summary>
+        /// <param name="parentToken">A CancellationToken to link to this operation. It can be canceled via the <see cref="ScriptHostStartupOperation.CancellationTokenSource"/> property.</param>
+        /// <param name="parentId">The Id of the parent operation if this one is being created due to a startup exception.</param>
+        /// <returns>The operation.</returns>
         private ScriptHostStartupOperation BeginStartupOperation(CancellationToken parentToken, Guid? parentId = null)
         {
             var operation = new ScriptHostStartupOperation(parentToken, parentId);
@@ -1030,6 +1033,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             return operation;
         }
 
+        /// <summary>
+        /// Removes the startup operation from the list of active operations and disposes of it.
+        /// </summary>
+        /// <param name="operation">The operation to complete.</param>
         private void EndStartupOperation(ScriptHostStartupOperation operation)
         {
             if (_activeStartupOperations.TryRemove(operation, out _))

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
@@ -62,8 +63,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         private readonly string _originalFunctionsWorkerRuntime;
         private readonly string _originalFunctionsWorkerRuntimeVersion;
         private readonly IOptionsChangeTokenSource<LanguageWorkerOptions> _languageWorkerOptionsChangeTokenSource;
-        private IScriptEventManager _eventManager;
 
+        // we're only using this dictionary's keys so it acts as a "ConcurrentHashSet"
+        private readonly ConcurrentDictionary<ScriptHostStartupOperation, byte> _activeStartupOperations = new();
+
+        private IScriptEventManager _eventManager;
         private IHost _host;
         private ScriptHostState _state;
         private CancellationTokenSource _startupLoopTokenSource;
@@ -285,7 +289,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             JobHostStartupMode startupMode = JobHostStartupMode.Normal, Guid? parentOperationId = null)
         {
             // Add this to the list of trackable startup operations. Restarts can use this to cancel any ongoing or pending operations.
-            var activeOperation = ScriptHostStartupOperation.Create(cancellationToken, _logger, parentOperationId);
+            var activeOperation = BeginStartupOperation(cancellationToken, parentOperationId);
 
             using (_metricsLogger.LatencyEvent(MetricEventNames.ScriptHostManagerStartService))
             {
@@ -570,7 +574,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                 // If anything is mid-startup, cancel it.
                 _startupLoopTokenSource?.Cancel();
-                foreach (var startupOperation in ScriptHostStartupOperation.ActiveOperations)
+                foreach (var startupOperation in _activeStartupOperations.Keys)
                 {
                     _logger.CancelingStartupOperationForRestart(startupOperation.Id);
                     try
@@ -580,6 +584,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     catch (ObjectDisposedException)
                     {
                         // This can be disposed at any time.
+                    }
+                    finally
+                    {
+                        EndStartupOperation(startupOperation);
                     }
                 }
 
@@ -599,7 +607,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     var previousHost = ActiveHost;
                     ActiveHost = null;
 
-                    using (var activeOperation = ScriptHostStartupOperation.Create(cancellationToken, _logger))
+                    var activeOperation = BeginStartupOperation(cancellationToken);
+
+                    try
                     {
                         Task startTask, stopTask;
 
@@ -620,6 +630,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                         }
 
                         await startTask;
+                    }
+                    finally
+                    {
+                        EndStartupOperation(activeOperation);
                     }
 
                     _logger.Restarted();
@@ -1006,6 +1020,24 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 logger.LogDebug(@"Disposing {providerName} ...", logProvider);
                 logProvider.Dispose();
             }
+        }
+
+        private ScriptHostStartupOperation BeginStartupOperation(CancellationToken parentToken, Guid? parentId = null)
+        {
+            var operation = new ScriptHostStartupOperation(parentToken, parentId);
+            _activeStartupOperations.TryAdd(operation, byte.MinValue);
+            _logger.StartupOperationCreated(operation.Id, operation.ParentId);
+            return operation;
+        }
+
+        private void EndStartupOperation(ScriptHostStartupOperation operation)
+        {
+            if (_activeStartupOperations.TryRemove(operation, out _))
+            {
+                operation.Dispose();
+            }
+
+            _logger.StartupOperationCompleted(operation.Id);
         }
 
         protected virtual void Dispose(bool disposing)


### PR DESCRIPTION
fixes #10831

previous PR #10850 helped, but the ultimate issue was that ActiveOperations was static, which allowed unrelated tests to interact with each other

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)