### PR TITLE
test logging improvements

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -95,7 +95,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var builder = new WebHostBuilder()
                 .ConfigureLogging(b =>
                 {
-                    b.Services.AddSingleton<ILoggerProvider, TestLoggerProvider>(_ =>
+                    _webHostLoggerProvider = new(_webHostInstanceId);
+                    b.Services.AddProvider(_webHostLoggerProvider);
                     {
                         _webHostLoggerProvider = new TestLoggerProvider(_webHostInstanceId);
                         return _webHostLoggerProvider;

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 .ConfigureLogging(b =>
                 {
                     _webHostLoggerProvider = new(_webHostInstanceId);
-                    b.Services.AddProvider(_webHostLoggerProvider);
+                    b.AddProvider(_webHostLoggerProvider);
 
                     b.AddFilter<TestLoggerProvider>(null, LogLevel.Trace)
                      .AddFilter<TestLoggerProvider>("Microsoft.AspNet", LogLevel.Warning)

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -97,10 +97,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 {
                     _webHostLoggerProvider = new(_webHostInstanceId);
                     b.Services.AddProvider(_webHostLoggerProvider);
-                    {
-                        _webHostLoggerProvider = new TestLoggerProvider(_webHostInstanceId);
-                        return _webHostLoggerProvider;
-                    });
+
                     b.AddFilter<TestLoggerProvider>(null, LogLevel.Trace)
                      .AddFilter<TestLoggerProvider>("Microsoft.AspNet", LogLevel.Warning)
                      .AddFilter<TestLoggerProvider>("Azure.Core", LogLevel.Warning);

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -21,7 +21,6 @@ using Microsoft.Azure.WebJobs.Script.ExtensionBundle;
 using Microsoft.Azure.WebJobs.Script.Models;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
-using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
 using Microsoft.Azure.WebJobs.Script.WebHost.Middleware;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security;
@@ -46,14 +45,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         private readonly ScriptApplicationHostOptions _hostOptions;
         private readonly TestServer _testServer;
         private readonly string _appRoot;
-        private readonly TestLoggerProvider _webHostLoggerProvider = new TestLoggerProvider();
-        private readonly TestLoggerProvider _scriptHostLoggerProvider = new TestLoggerProvider();
+        private readonly string _webHostInstanceId = Guid.NewGuid().ToString()[..8];
+        // we need to capture every provider created by host restarts
+        private readonly List<TestLoggerProvider> _scriptHostLoggerProviders = new();
         private readonly WebJobsScriptHostService _hostService;
 
         private readonly Timer _stillRunningTimer;
         private readonly DateTimeOffset _created = DateTimeOffset.UtcNow;
         private readonly string _createdStack;
         private readonly string _id = Guid.NewGuid().ToString();
+
+        private TestLoggerProvider _webHostLoggerProvider;
         private bool _timerFired = false;
         private bool _isDisposed = false;
 
@@ -93,9 +95,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var builder = new WebHostBuilder()
                 .ConfigureLogging(b =>
                 {
-                    b.AddProvider(_webHostLoggerProvider);
-                    b.AddFilter<TestLoggerProvider>("Host", LogLevel.Trace);
-                    b.AddFilter<TestLoggerProvider>("Microsoft.Azure.WebJobs", LogLevel.Trace);
+                    b.Services.AddSingleton<ILoggerProvider, TestLoggerProvider>(_ =>
+                    {
+                        _webHostLoggerProvider = new TestLoggerProvider(_webHostInstanceId);
+                        return _webHostLoggerProvider;
+                    });
+                    b.AddFilter<TestLoggerProvider>(null, LogLevel.Trace)
+                     .AddFilter<TestLoggerProvider>("Microsoft.AspNet", LogLevel.Warning)
+                     .AddFilter<TestLoggerProvider>("Azure.Core", LogLevel.Warning);
                 })
                 .ConfigureServices(services =>
                   {
@@ -143,8 +150,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 })
                 .ConfigureScriptHostLogging(scriptHostLoggingBuilder =>
                 {
-                    scriptHostLoggingBuilder.AddProvider(_scriptHostLoggerProvider);
-                    scriptHostLoggingBuilder.AddFilter<TestLoggerProvider>(_ => true);
+                    scriptHostLoggingBuilder.Services.AddSingleton<ILoggerProvider, TestLoggerProvider>(s =>
+                    {
+                        var options = s.GetService<IOptions<ScriptJobHostOptions>>();
+                        var shortInstanceId = options.Value.InstanceId[..8];
+                        var loggerProvider = new TestLoggerProvider($"{_webHostInstanceId}->{shortInstanceId}");
+                        _scriptHostLoggerProviders.Add(loggerProvider);
+                        return loggerProvider;
+                    });
+                    scriptHostLoggingBuilder.AddFilter<TestLoggerProvider>(null, LogLevel.Trace);
+                    scriptHostLoggingBuilder.AddFilter<TestLoggerProvider>("Microsoft.AspNet", LogLevel.Warning);
+                    scriptHostLoggingBuilder.AddFilter<TestLoggerProvider>("Azure.Core", LogLevel.Warning);
                     configureScriptHostLogging?.Invoke(scriptHostLoggingBuilder);
                 })
                 .ConfigureScriptHostServices(scriptHostServices =>
@@ -275,6 +291,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             sb.AppendLine($"A host created at '{_created:yyyy-MM-dd HH:mm:ss}' ({ago}s ago) is still running. Details:");
             sb.AppendLine($"  Host id:      {hostId}");
             sb.AppendLine($"  Test host id: {_id}");
+            sb.AppendLine($"  WebHost instance id: {_webHostInstanceId}");
             sb.AppendLine($"  ScriptRoot:   {jobOptions.Value.RootScriptPath}");
             sb.AppendLine($"  Allow list:   {allowList}");
             sb.AppendLine($"  The captured stack from this test host's constructor:");
@@ -309,6 +326,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             else
             {
                 exit = true;
+                Console.WriteLine("---- FLUSHING LOG TO CONSOLE BEFORE FAILURE ----");
                 Console.WriteLine(GetLog());
                 throw new Exception("Functions Host timed out trying to start.");
             }
@@ -345,7 +363,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         /// These providers use different LoggerProviders, so it's important to know which one is receiving the logs.
         /// </summary>
         /// <returns>The messages from the ScriptHost LoggerProvider</returns>
-        public IList<LogMessage> GetScriptHostLogMessages() => _scriptHostLoggerProvider.GetAllLogMessages();
+        public IList<LogMessage> GetScriptHostLogMessages() => _scriptHostLoggerProviders.SelectMany(p => p.GetAllLogMessages()).OrderBy(p => p.Timestamp).ToList();
         public IEnumerable<LogMessage> GetScriptHostLogMessages(string category) => GetScriptHostLogMessages().Where(p => p.Category == category);
 
         /// <summary>
@@ -361,7 +379,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public void ClearLogMessages()
         {
             _webHostLoggerProvider.ClearAllLogMessages();
-            _scriptHostLoggerProvider.ClearAllLogMessages();
+            foreach (var provider in _scriptHostLoggerProviders)
+            {
+                provider.ClearAllLogMessages();
+            }
         }
 
         public async Task BeginFunctionAsync(string functionName, JToken payload)

--- a/test/WebJobs.Script.Tests.Shared/TestLoggerProvider.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestLoggerProvider.cs
@@ -13,14 +13,21 @@ namespace Microsoft.WebJobs.Script.Tests
     public class TestLoggerProvider : ILoggerProvider, ISupportExternalScope
     {
         private IExternalScopeProvider _scopeProvider;
+        private ConcurrentDictionary<string, TestLogger> _loggerCache = new ConcurrentDictionary<string, TestLogger>();
 
-        private ConcurrentDictionary<string, TestLogger> LoggerCache { get; } = new ConcurrentDictionary<string, TestLogger>();
+        public TestLoggerProvider(string hostInstanceId = null)
+        {
+            HostInstanceId = hostInstanceId;
+        }
 
-        public IEnumerable<TestLogger> CreatedLoggers => LoggerCache.Values;
+        public IEnumerable<TestLogger> CreatedLoggers => _loggerCache.Values;
+
+        // settable by tests
+        public string HostInstanceId { get; set; }
 
         public ILogger CreateLogger(string categoryName)
         {
-            return LoggerCache.GetOrAdd(categoryName, (key) => new TestLogger(key, _scopeProvider));
+            return _loggerCache.GetOrAdd(categoryName, (key) => new TestLogger(key, HostInstanceId, _scopeProvider));
         }
 
         public IList<LogMessage> GetAllLogMessages()

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         {
             _eventManager.AddGrpcChannels(_workerId);
             _testOutput = testOutput;
-            _logger = new TestLogger("FunctionDispatcherTests", testOutput);
+            _logger = new TestLogger("FunctionDispatcherTests", testOutput: testOutput);
             _testFunctionRpcService = new TestFunctionRpcService(_eventManager, _workerId, _logger, _expectedLogMsg);
             _testWorkerConfig = TestHelpers.GetTestWorkerConfigs().FirstOrDefault();
             _testWorkerConfig.CountOptions.ProcessStartupTimeout = TimeSpan.FromSeconds(5);


### PR DESCRIPTION
Checking in some `TestLogger` improvements that ultimately let me track down the fix to #10854. 

This change adds more output details in the `TestFunctionHost` so that you can tell which WebHost *and* which ScriptHost a log message came from. Every log line will contain something like this now:

```
// If it's a WebHost log, it will contain the WebHost's id
[{Timestamp}] [{WebHostId}] ....

// If it's a ScriptHost log, it will have both the WebHost and ScriptHost ids
[{Timestamp}] [{WebHostId}->{ScriptHostId}] ....
```

For example, here are some log snippets that I captured after enabling this while debugging the linked issue above:

```
[17:21:40.827] [29ee582c] [Debug] [Host.General] Startup operation '2955b8e8-d3d4-43a8-9caa-1304d58a04ac' with parent id '(null)' created. 
[17:21:40.827] [29ee582c] [Debug] [Host.General] Startup operation '2955b8e8-d3d4-43a8-9caa-1304d58a04ac' starting. 
...
[17:21:40.290] [59b28b29->46577bfa] [Information] [Host.Startup] Directory change of type 'Deleted' detected for 'C:\Users\cloudtest\AppData\Local\Temp\FunctionsE2E\250214-171843_0\TimerTrigger' 
[17:21:40.290] [59b28b29->46577bfa] [Information] [Host.Startup] Host configuration has changed. Signaling restart 
...
[17:21:40.865] [29ee582c->7cb8baf6] [Debug] [Worker.HttpWorkerChannel.cc008782-b513-4bef-b557-87a7688563ac] Initiating Worker Process start up 
[17:21:40.865] [29ee582c->7cb8baf6] [Debug] [Worker.HttpWorkerProcess.cc008782-b513-4bef-b557-87a7688563ac] Starting worker process with FileName:node WorkingDirectory:C:\Users\cloudtest\AppData\Local\Temp\FunctionsE2E\250214-172140_0 Arguments: server.js 
[17:21:41.103] [59b28b29] [Debug] [Host.General] Restart requested. 
[17:21:41.104] [59b28b29] [Debug] [Host.General] Canceling startup operation '2955b8e8-d3d4-43a8-9caa-1304d58a04ac' to unblock restart.
```

This ultimately let me see that:
- The currently-running test was using WebHost `29ee582c` but there was another host (`59b28b29->46577bfa`) running in the background that detected a file delete event. When a test completes, we delete old folders in the temp directory to prevent filling up the disk.
- While the current host was starting up, it was suddenly told to restart by the *other* host. The new logs clearly show that the startup operation `2955b8e8-...` was started by host `29ee582c`, yet was canceled by host `59b28b29`. That should never happen. This led me to see that this list was `static`.

This led to the two previous PRs: one that correctly disposes the running test (#10850), and one that cleans up the static collection (#10854).

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
