### PR TITLE
Adding coldstart data collection support from dev inner loop

### DIFF
--- a/eng/build/PlaceholderSimulation.props
+++ b/eng/build/PlaceholderSimulation.props
@@ -3,8 +3,7 @@
   <!-- PlaceholderSimulation.props
     This props file is to be imported only when test placeholder behavior. Importing this file will set up the WebHost to simulate placeholder behavior.
     There are integrity checks in this file to ensure correct use:
-      1. Must not be imported during CI.
-      2. PlaceholderSimulation must be set to 'true' on import and remain 'true' for the entire build.
+      1. PlaceholderSimulation must be set to 'true' on import and remain 'true' for the entire build.
   -->
 
   <PropertyGroup>
@@ -12,11 +11,6 @@
     <_PlaceholderSimulationOriginal>$(PlaceholderSimulation)</_PlaceholderSimulationOriginal>
     <DefineConstants>$(DefineConstants)PLACEHOLDER_SIMULATION;</DefineConstants>
   </PropertyGroup>
-
-  <!-- Verify this is not imported during CI build or without PlaceholderSimulation=true -->
-  <Target Name="_PlaceholderFailWrongImport" BeforeTargets="Build" Condition="'$(CI)' == 'true' OR '$(_PlaceholderSimulationOriginal)' != 'true'">
-    <Error Text="PlaceholderSimulation is enabled, but CI is true. PlaceholderSimulation is not allowed in CI." />
-  </Target>
 
   <!-- Verify PlaceholderSimulation remains 'true' for the entire build. -->
   <Target Name="_PlaceholderFailWrongValue" AfterTargets="Build" Condition="'$(PlaceholderSimulation)' != 'true'">

--- a/eng/ci/host.coldstart.yml
+++ b/eng/ci/host.coldstart.yml
@@ -1,0 +1,107 @@
+# No triggers for code push to any branch.
+trigger: none
+
+# No PR triggers for now
+pr: none
+
+schedules:
+  - cron: "0 1 * * *"
+    displayName: Nightly Build
+    branches:
+      include:
+      - dev
+    always: true
+
+resources:
+  repositories:
+  - repository: 1es
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+  - repository: eng
+    type: git
+    name: engineering
+    ref: refs/tags/release
+
+variables:
+  - template: /eng/ci/templates/variables/coldstart.yml@self
+  - template: /ci/variables/cfs.yml@eng
+
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
+  parameters:
+    pool:
+      name: 1es-pool-azfunc-benchmarking-large
+      image: 1es-windows-2022-benchmark-runner-vanilla
+      os: windows
+
+    stages:
+    - stage: RunWindows
+      displayName: Record latency(Windows)
+      jobs:
+      - ${{ each appId in split(variables.runInstances, ',') }}:
+        - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
+          parameters:
+            description: .NET9 Web Application
+            functionAppName: HelloHttpNet9
+            instanceId: ${{ appId }} 
+        - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
+          parameters:
+            description: .NET9 Worker Application
+            functionAppName: HelloHttpNet9NoProxy
+            instanceId: ${{ appId }}  
+
+    - stage: CalculateWindows
+      displayName: Process results(Windows)
+      dependsOn: RunWindows
+      jobs:
+      - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
+        parameters:
+          functionAppName: HelloHttpNet9
+          description: .NET9 Web Application
+          runInstances: 
+            items: ${{ split(variables.runInstances, ',') }}
+      - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
+        parameters:
+          functionAppName: HelloHttpNet9NoProxy
+          description: .NET9 Worker Application
+          runInstances: 
+            items: ${{ split(variables.runInstances, ',') }}
+
+# # LINUX
+    - stage: RunLinux
+      dependsOn: []
+      displayName:  Record latency(Linux)
+      jobs:
+      - ${{ each appId in split(variables.runInstances, ',') }}:
+        - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
+          parameters:
+            description: .NET9 Web Application
+            functionAppName: HelloHttpNet9
+            instanceId: ${{ appId }}
+            os: Linux
+        - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
+          parameters:
+            description: .NET9 Worker Application
+            functionAppName: HelloHttpNet9NoProxy
+            instanceId: ${{ appId }}
+            os: Linux
+  
+    - stage: CalculateLinux
+      displayName:  Process results(Linux)
+      dependsOn: RunLinux
+      jobs:
+      - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
+        parameters:
+          functionAppName: HelloHttpNet9
+          description: .NET9 Web Application
+          os: Linux
+          runInstances: 
+            items: ${{ split(variables.runInstances, ',') }}
+      - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
+        parameters:
+          functionAppName: HelloHttpNet9NoProxy
+          description: .NET9 Worker Application
+          os: Linux
+          runInstances: 
+            items: ${{ split(variables.runInstances, ',') }}

--- a/eng/ci/host.coldstart.yml
+++ b/eng/ci/host.coldstart.yml
@@ -5,7 +5,7 @@ trigger: none
 pr: none
 
 schedules:
-  - cron: "0 1 * * *"
+  - cron: "0 5 * * *"
     displayName: Nightly Build
     branches:
       include:
@@ -13,14 +13,14 @@ schedules:
     always: true
 
 parameters:
-- name: collectPerfviewProfileOnWindows
-  displayName: Collect Perfivew Profile (on Windows)
+- name: collectPerfViewProfileOnWindows
+  displayName: Collect PerfView Profile (on Windows)
   type: boolean
   default: false
-- name: perfviewCollectArguments
-  displayName: Perfview profile collection arguments (Valid only if "Collect Perfivew Profile" is true))
+- name: perfViewCollectArguments
+  displayName: PerfView profile collection arguments (Valid only if "Collect PerfView Profile" is true))
   type: string
-  default: '/NoGui /AcceptEula /NoV2Rundown /NoNGenRundown /BufferSizeMB=64 /CircularMB=64 /ThreadTime /Providers=a7044dd6-c8ef-4980-858c-942d972b6250'
+  default: '/NoGui /AcceptEula /NoV2Rundown /NoNGenRundown /NoClrRundown /BufferSizeMB=64 /CircularMB=64 /ThreadTime /Providers=a7044dd6-c8ef-4980-858c-942d972b6250'
 
 resources:
   repositories:
@@ -41,7 +41,7 @@ extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
   parameters:
     pool:
-      name: 1es-pool-azfunc-benchmarking-large
+      name: 1es-pool-azfunc-benchmarking
       image: 1es-windows-2022-benchmark-runner-vanilla
       os: windows
 
@@ -55,15 +55,15 @@ extends:
             description: .NET9 Web Application
             functionAppName: HelloHttpNet9
             instanceId: ${{ appId }} 
-            collectPerfviewProfileOnWindows: ${{ parameters.collectPerfviewProfileOnWindows }}
-            perfviewCollectArguments: ${{ parameters.perfviewCollectArguments }}
+            collectPerfViewProfileOnWindows: ${{ parameters.collectPerfViewProfileOnWindows }}
+            perfViewCollectArguments: ${{ parameters.perfViewCollectArguments }}
         - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
           parameters:
             description: .NET9 Worker Application
             functionAppName: HelloHttpNet9NoProxy
             instanceId: ${{ appId }}
-            collectPerfviewProfileOnWindows: ${{ parameters.collectPerfviewProfileOnWindows }}
-            perfviewCollectArguments: ${{ parameters.perfviewCollectArguments }}
+            collectPerfViewProfileOnWindows: ${{ parameters.collectPerfViewProfileOnWindows }}
+            perfViewCollectArguments: ${{ parameters.perfViewCollectArguments }}
 
     - stage: CalculateWindows
       displayName: Process results(Windows)

--- a/eng/ci/host.coldstart.yml
+++ b/eng/ci/host.coldstart.yml
@@ -12,6 +12,16 @@ schedules:
       - dev
     always: true
 
+parameters:
+- name: collectPerfviewProfileOnWindows
+  displayName: Collect Perfivew Profile (on Windows)
+  type: boolean
+  default: false
+- name: perfviewCollectArguments
+  displayName: Perfview profile collection arguments (Valid only if "Collect Perfivew Profile" is true))
+  type: string
+  default: '/NoGui /AcceptEula /NoV2Rundown /NoNGenRundown /BufferSizeMB=64 /CircularMB=64 /ThreadTime /Providers=a7044dd6-c8ef-4980-858c-942d972b6250'
+
 resources:
   repositories:
   - repository: 1es
@@ -45,11 +55,15 @@ extends:
             description: .NET9 Web Application
             functionAppName: HelloHttpNet9
             instanceId: ${{ appId }} 
+            collectPerfviewProfileOnWindows: ${{ parameters.collectPerfviewProfileOnWindows }}
+            perfviewCollectArguments: ${{ parameters.perfviewCollectArguments }}
         - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
           parameters:
             description: .NET9 Worker Application
             functionAppName: HelloHttpNet9NoProxy
-            instanceId: ${{ appId }}  
+            instanceId: ${{ appId }}
+            collectPerfviewProfileOnWindows: ${{ parameters.collectPerfviewProfileOnWindows }}
+            perfviewCollectArguments: ${{ parameters.perfviewCollectArguments }}
 
     - stage: CalculateWindows
       displayName: Process results(Windows)

--- a/eng/ci/templates/official/jobs/process-coldstart.yml
+++ b/eng/ci/templates/official/jobs/process-coldstart.yml
@@ -60,7 +60,7 @@ jobs:
             sourceVersion = $env:BUILD_SOURCEVERSION
             buildId = $env:BUILD_BUILDID
             buildNumber = $env:BUILD_BUILDNUMBER 
-            os = $env:AGENT_OS
+            os = $env:OS
             processorCount = $env:NUMBER_OF_PROCESSORS
         } | ConvertTo-Json -Depth 2
 

--- a/eng/ci/templates/official/jobs/process-coldstart.yml
+++ b/eng/ci/templates/official/jobs/process-coldstart.yml
@@ -1,0 +1,93 @@
+parameters:
+- name: functionAppName
+  type: string
+- name: description
+  type: string
+- name: os
+  type: string
+  default: Windows
+  values:
+    - Windows
+    - Linux
+- name: runInstances
+  type: object
+
+jobs:
+- job: ${{ parameters.functionAppName }}${{ parameters.os }}
+  displayName: ${{ parameters.description }}(${{ parameters.os }})
+
+  pool:
+    name: 1es-pool-azfunc-benchmarking-large
+    image: 1es-windows-2022-benchmark-runner-vanilla
+    os: windows
+
+  variables:
+    resultsJsonPath: $(Build.ArtifactStagingDirectory)/ColdStartResults/coldstart_$(Build.BuildNumber)_${{ parameters.os }}_${{ parameters.functionAppName }}.json
+    artifactName: coldstart_${{ parameters.os }}_${{ parameters.functionAppName }}
+
+    ${{ each r in parameters.runInstances.items }}:
+      latencies${{ r }}: $[stageDependencies.Run${{ parameters.os }}.${{ parameters.functionAppName }}_${{ r }}.outputs['Record.coldStartLatency']]
+
+  templateContext:
+    outputParentDirectory: $(Build.ArtifactStagingDirectory)
+    outputs:
+    - output: pipelineArtifact
+      displayName: Publish coldstart results
+      path: $(resultsJsonPath)
+      artifact: $(artifactName)
+
+  steps:
+  - checkout: none
+  - pwsh: |
+        $sampleSize = $env:SAMPLE_SIZE
+        $values = @()
+        for ($i = 1; $i -le $sampleSize; $i++) {
+          $latencyValue = [System.Environment]::GetEnvironmentVariable("LATENCY$i")
+          $values += [double]$latencyValue
+        }
+
+        $values = $values | Sort-Object
+
+        $json = @{
+            values = $values
+            p50 = $values[[math]::Ceiling($values.Count * 0.5) - 1]
+            p75 = $values[[math]::Ceiling($values.Count * 0.75) - 1]
+            p99 = $values[[math]::Ceiling($values.Count * 0.99) - 1]
+            sourceVersion = $env:BUILD_SOURCEVERSION
+            buildId = $env:BUILD_BUILDID
+            buildNumber = $env:BUILD_BUILDNUMBER 
+            os = $env:AGENT_OS
+            processorCount = $env:NUMBER_OF_PROCESSORS
+        } | ConvertTo-Json -Depth 2
+
+        Write-Host "$json"
+        
+        $directory = Split-Path -Path $(resultsJsonPath) -Parent
+        New-Item -Path $directory -ItemType Directory | Out-Null
+
+        $json | Set-Content -Path $(resultsJsonPath)
+        
+    displayName: Process results
+    env:
+      ${{ each i in parameters.runInstances.items }}:
+        LATENCY${{ i }}: $(latencies${{ i }})
+      SAMPLE_SIZE: ${{ length(parameters.runInstances.items) }}
+
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: $(ServiceConnection)
+      scriptType: 'pscore'
+      scriptLocation: 'inlineScript'
+      inlineScript: |
+        $json = Get-Content -Path $(resultsJsonPath) -Raw
+        $dateTimeUtc = [datetimeoffset]::UtcNow
+
+        $query = @"
+        INSERT INTO ColdStart (DateTimeUtc, OS, Description, Document)
+        VALUES ('$dateTimeUtc', '${{ parameters.os }}', '${{ parameters.description }}', '$json')
+        "@
+
+        Invoke-Sqlcmd -ConnectionString "$(ColdStartResultsSqlConnectionString)" -Query $query
+
+    displayName: Persist results
+    condition: eq(variables['Build.Reason'], 'Schedule')

--- a/eng/ci/templates/official/jobs/process-coldstart.yml
+++ b/eng/ci/templates/official/jobs/process-coldstart.yml
@@ -17,7 +17,7 @@ jobs:
   displayName: ${{ parameters.description }}(${{ parameters.os }})
 
   pool:
-    name: 1es-pool-azfunc-benchmarking-large
+    name: 1es-pool-azfunc-benchmarking
     image: 1es-windows-2022-benchmark-runner-vanilla
     os: windows
 
@@ -32,7 +32,7 @@ jobs:
     outputParentDirectory: $(Build.ArtifactStagingDirectory)
     outputs:
     - output: pipelineArtifact
-      displayName: Publish coldstart results
+      displayName: Publish ColdStart results
       path: $(resultsJsonPath)
       artifact: $(artifactName)
 

--- a/eng/ci/templates/official/jobs/process-coldstart.yml
+++ b/eng/ci/templates/official/jobs/process-coldstart.yml
@@ -48,11 +48,15 @@ jobs:
 
         $values = $values | Sort-Object
 
+        $p50 = $values[[math]::Ceiling($values.Count * 0.5) - 1]
+        $p75 = $values[[math]::Ceiling($values.Count * 0.75) - 1]
+        $p99 = $values[[math]::Ceiling($values.Count * 0.99) - 1]
+
         $json = @{
             values = $values
-            p50 = $values[[math]::Ceiling($values.Count * 0.5) - 1]
-            p75 = $values[[math]::Ceiling($values.Count * 0.75) - 1]
-            p99 = $values[[math]::Ceiling($values.Count * 0.99) - 1]
+            p50 = $p50
+            p75 = $p75
+            p99 = $p99
             sourceVersion = $env:BUILD_SOURCEVERSION
             buildId = $env:BUILD_BUILDID
             buildNumber = $env:BUILD_BUILDNUMBER 
@@ -66,12 +70,27 @@ jobs:
         New-Item -Path $directory -ItemType Directory | Out-Null
 
         $json | Set-Content -Path $(resultsJsonPath)
-        
+
+        # Generate and upload a summary file to add a new tab in the pipeline run summary UI.
+        $summaryContent = @"
+          | Metric  | Value     |
+          | :------ | :-------- |
+          | P50     | $p50 ms   |
+          | P75     | $p75 ms   |
+          | P99     | $p99 ms   |
+        "@
+        $summaryFilePath = "$(Build.ArtifactStagingDirectory)/summary.md"
+        $summaryContent | Out-File -FilePath $summaryFilePath
+        $summaryName = "ColdStart latency - $($env:OS) $($env:FUNCTION_APP_NAME)"
+        Write-Host "##vso[task.addattachment type=Distributedtask.Core.Summary;name=$summaryName;]$summaryFilePath"
+
     displayName: Process results
     env:
       ${{ each i in parameters.runInstances.items }}:
         LATENCY${{ i }}: $(latencies${{ i }})
       SAMPLE_SIZE: ${{ length(parameters.runInstances.items) }}
+      FUNCTION_APP_NAME: ${{ parameters.functionAppName }}
+      OS: ${{ parameters.os }}
 
   - task: AzureCLI@2
     inputs:

--- a/eng/ci/templates/official/jobs/run-coldstart.yml
+++ b/eng/ci/templates/official/jobs/run-coldstart.yml
@@ -25,8 +25,8 @@ jobs:
       os: windows
 
   variables:
-    functionAppOutputPath: $(Build.ArtifactStagingDirectory)/Published/${{ parameters.functionAppName }}
-    hostOutputPath: $(Build.ArtifactStagingDirectory)/Published/HostRuntime
+    functionAppOutputPath: $(Build.BinariesDirectory)/Published/${{ parameters.functionAppName }}
+    hostOutputPath: $(Build.BinariesDirectory)/Published/HostRuntime
     hostAssemblyPath: $(hostOutputPath)/Microsoft.Azure.WebJobs.Script.WebHost.dll
     logsDirectory: $(Build.ArtifactStagingDirectory)/Logs
     stdOutLogsFilePath: $(logsDirectory)/std_out_logs.txt
@@ -34,6 +34,21 @@ jobs:
     FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
     FUNCTIONS_WORKER_RUNTIME_VERSION: '9.0'
     AzureWebJobsScriptRoot: '$(functionAppOutputPath)'
+    perfviewPath: C:\.tools\perfview\perfview.exe 
+    traceDirectory: $(Build.ArtifactStagingDirectory)/out
+    traceFileName: PerfViewData_$(Build.BuildNumber)_${{ parameters.functionAppName }}.etl
+    traceFilePath: $(traceDirectory)/$(traceFileName)
+    traceLogPath: $(logsDirectory)/logs.log
+
+  ${{ if and(eq(parameters.os, 'Windows'), eq(parameters.instanceId, '1')) }}:
+    templateContext:
+      outputParentDirectory: $(System.DefaultWorkingDirectory)/out
+      outputs:
+        - output: pipelineArtifact
+          displayName: Publish perfview profile
+          path: $(traceFilePath).zip
+          artifact: PerfViewData_${{ parameters.functionAppName }}
+          condition: eq(variables['CollectPerfviewProfile'], 'true')
 
   steps:
   - template: /eng/ci/templates/install-dotnet.yml@self
@@ -76,7 +91,9 @@ jobs:
   - ${{ if eq(parameters.os, 'Windows') }}:
     - pwsh: |
         $errorLogFilePath = "$(Build.ArtifactStagingDirectory)/Logs/std_err_logs.txt"
-        Start-Process -FilePath "powershell.exe" -ArgumentList "-Command", "dotnet $(hostAssemblyPath)" -RedirectStandardOutput $(stdOutLogsFilePath) -RedirectStandardError $(stdErrorLogsFilePath) -PassThru
+        $process = Start-Process -FilePath "$(hostOutputPath)/Microsoft.Azure.WebJobs.Script.WebHost.exe" -RedirectStandardOutput $(stdOutLogsFilePath) -RedirectStandardError $(stdErrorLogsFilePath) -PassThru
+        Write-Host "Started process ID: $($process.Id)"
+        echo $process.Id > $(Build.ArtifactStagingDirectory)/hostProcessId.txt
       displayName: Start host in placeholder mode
   - ${{ else }}:
     - script: |
@@ -85,6 +102,7 @@ jobs:
         # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#environment-variables
         export AzureWebJobsScriptRoot="$(functionAppOutputPath)"
         nohup dotnet $(hostAssemblyPath) > $(stdOutLogsFilePath) 2> $(stdErrorLogsFilePath) &
+        echo $! > $(Build.ArtifactStagingDirectory)/hostProcessId.txt
       displayName: Start host in placeholder mode
 
   - pwsh: |     
@@ -105,6 +123,20 @@ jobs:
 
     displayName: Wait until host is warmed up
 
+  - ${{ if and(eq(parameters.os, 'Windows'), eq(parameters.instanceId, '1')) }}: # collect profile only on the first instance
+    - pwsh: |
+        New-Item -ItemType Directory -Path $(traceDirectory)
+        if (Test-Path $(perfviewPath)) {
+            $collectArguments = ${env:PerfviewCollectArguments}
+            Write-Host "perfview.exe found. Executing with arguments '$collectArguments'"
+            Start-Process -FilePath $(perfviewPath) -ArgumentList "collect $collectArguments /LogFile:$(traceLogPath) /DataFile:$(traceFilePath)" -NoNewWindow
+        } else {
+            Write-Host "perfview.exe not found in $(perfviewPath)"
+            exit 1
+        }
+      displayName: Start Perfview
+      condition: eq(variables['CollectPerfviewProfile'], 'true')
+
   - pwsh: |
       $helloUrl = "http://localhost:5000/api/hello?forcespecialization=1"
       Write-Host "Calling $helloUrl"
@@ -118,6 +150,64 @@ jobs:
       Write-Host "##vso[task.setvariable variable=coldStartLatency;isOutput=true]$($duration.TotalMilliseconds)"
     displayName: Record cold start latency
     name: Record
+
+  - ${{ if and(eq(parameters.os, 'Windows'), eq(parameters.instanceId, '1')) }}:
+    - pwsh: |
+        Write-Host "Stopping Perfview..."
+        & $(perfviewPath) stop
+
+        # Wait for the zip file to be created
+        $maxAttempts = 10
+        $attempt = 0
+
+        while ($attempt -lt $maxAttempts) {
+            $files = Get-ChildItem -Path $(traceDirectory)
+            $fileCount = $files.Count
+            if ($fileCount -eq 1 -and $files[0].Name -eq '$(traceFileName).zip') {
+                break
+            } else {
+                Write-Host "Expected zip file not found. Rechecking again in 15 seconds..."
+                Start-Sleep -Seconds 15
+                $attempt++
+            }
+        }
+
+        $perfviewProcess = Get-Process -Name "perfview" -ErrorAction SilentlyContinue
+        if ($perfviewProcess) {
+            Write-Host "Killing Perfview process..."
+            $perfviewProcess | Stop-Process -Force
+        }
+
+        Write-Host "PerfView logs:"
+        Get-Content $(traceLogPath)
+      displayName: Stop PerfView
+      condition: eq(variables['CollectPerfviewProfile'], 'true')
+
+  - ${{ if eq(parameters.os, 'Windows') }}:
+    - pwsh: |
+        $processIdFile = "$(Build.ArtifactStagingDirectory)/hostProcessId.txt"
+        if (Test-Path $processIdFile) {
+            $processId = Get-Content $processIdFile
+            Write-Host "Sending SIGTERM to process ID: $processId"
+            Stop-Process -Id $processId -Force
+        } else {
+            Write-Host "Process ID file not found."
+        }
+      displayName: Stop host process
+      condition: always()
+
+  - ${{ if eq(parameters.os, 'Linux') }}:
+    - script: |
+        processIdFile="$(Build.ArtifactStagingDirectory)/hostProcessId.txt"
+        if [ -f "$processIdFile" ]; then
+            processId=$(cat $processIdFile)
+            echo "Sending SIGTERM to process ID: $processId"
+            kill -SIGTERM $processId
+        else
+            echo "Process ID file not found."
+        fi
+      displayName: Stop host process
+      condition: always()
 
   - pwsh: |
       Write-Host "Logs:"

--- a/eng/ci/templates/official/jobs/run-coldstart.yml
+++ b/eng/ci/templates/official/jobs/run-coldstart.yml
@@ -1,0 +1,129 @@
+parameters:
+- name: description
+  type: string
+- name: functionAppName
+  type: string
+- name: instanceId
+  type: string
+- name: os
+  type: string
+  default: Windows
+  values:
+    - Windows
+    - Linux
+
+jobs:
+- job: ${{ parameters.functionAppName }}_${{ parameters.instanceId }}
+  displayName: ${{ parameters.description }} ${{ parameters.instanceId }}
+  pool:
+    name: 1es-pool-azfunc-benchmarking-large
+    ${{ if eq(parameters.os, 'Linux') }}:
+      image: 1es-ubuntu-22.04-benchmark-runner-vanilla-sd4
+      os: linux 
+    ${{ else }}:
+      image: 1es-windows-2022-benchmark-runner-vanilla-sd4
+      os: windows
+
+  variables:
+    functionAppOutputPath: $(Build.ArtifactStagingDirectory)/Published/${{ parameters.functionAppName }}
+    hostOutputPath: $(Build.ArtifactStagingDirectory)/Published/HostRuntime
+    hostAssemblyPath: $(hostOutputPath)/Microsoft.Azure.WebJobs.Script.WebHost.dll
+    logsDirectory: $(Build.ArtifactStagingDirectory)/Logs
+    stdOutLogsFilePath: $(logsDirectory)/std_out_logs.txt
+    stdErrorLogsFilePath: $(logsDirectory)/std_error_logs.txt    
+    FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
+    FUNCTIONS_WORKER_RUNTIME_VERSION: '9.0'
+    AzureWebJobsScriptRoot: '$(functionAppOutputPath)'
+
+  steps:
+  - template: /eng/ci/templates/install-dotnet.yml@self
+
+  - task: CopyFiles@2
+    displayName: Copy benchmark apps to temp location
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)/test/Performance/Apps'
+      Contents: '**/*'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)/PerformanceTestApps'
+      CleanTargetFolder: true
+
+  - task: DotNetCoreCLI@2
+    displayName: Publish benchmark app
+    inputs:
+      command: publish
+      publishWebProjects: false
+      zipAfterPublish: false
+      modifyOutputPath: false
+      projects: '$(Build.ArtifactStagingDirectory)/PerformanceTestApps/${{ parameters.functionAppName }}/HelloHttp.csproj'
+      arguments: -c Release -o $(functionAppOutputPath) -f net9.0 
+      workingDirectory: $(Build.ArtifactStagingDirectory)/PerformanceTestApps/${{ parameters.functionAppName }}
+
+  - task: DotNetCoreCLI@2
+    displayName: Publish host
+    inputs:
+      command: publish
+      publishWebProjects: false
+      zipAfterPublish: false
+      modifyOutputPath: false
+      projects: '$(Build.SourcesDirectory)/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj'
+      arguments: -c Release -o $(hostOutputPath) -f net8.0 -p:PlaceholderSimulation=true 
+      workingDirectory: $(Build.SourcesDirectory)/src/WebJobs.Script.WebHost
+
+  - pwsh: |
+      Write-Host "Creating log directory: $(logsDirectory)"
+      New-Item -ItemType Directory -Path $(logsDirectory)
+    displayName: Create log directory
+
+  - ${{ if eq(parameters.os, 'Windows') }}:
+    - pwsh: |
+        $errorLogFilePath = "$(Build.ArtifactStagingDirectory)/Logs/std_err_logs.txt"
+        Start-Process -FilePath "powershell.exe" -ArgumentList "-Command", "dotnet $(hostAssemblyPath)" -RedirectStandardOutput $(stdOutLogsFilePath) -RedirectStandardError $(stdErrorLogsFilePath) -PassThru
+      displayName: Start host in placeholder mode
+  - ${{ else }}:
+    - script: |
+        # In Azure DevOps, when variables convert into environment variables, variable names become uppercase, and periods turn into underscores.
+        # This works for windows when getting the env variable value, but fails on linux. So we need to pass the variable value using correct case.
+        # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#environment-variables
+        export AzureWebJobsScriptRoot="$(functionAppOutputPath)"
+        nohup dotnet $(hostAssemblyPath) > $(stdOutLogsFilePath) 2> $(stdErrorLogsFilePath) &
+      displayName: Start host in placeholder mode
+
+  - pwsh: |     
+      $url = "http://localhost:5000/api/warmup"
+      Write-Host "Checking if host is ready at $url..."
+      $maxAttempts = 10
+
+      for ($attempt = 0; $attempt -lt $maxAttempts; $attempt++) {
+          try {
+              $response = Invoke-RestMethod -Uri $url -Method Get -TimeoutSec 5 -ErrorAction Stop
+              Write-Host "Response: $response"
+              break
+          } catch {
+              Write-Host "Attempt $($attempt+1) failed: $_.Exception.Message. Retrying in 10 seconds..."
+              Start-Sleep -Seconds 10
+          }
+      }
+
+    displayName: Wait until host is warmed up
+
+  - pwsh: |
+      $helloUrl = "http://localhost:5000/api/hello?forcespecialization=1"
+      Write-Host "Calling $helloUrl"
+
+      $duration = Measure-Command {
+          $response = Invoke-WebRequest -Uri $helloUrl -Method Get -ErrorAction Stop
+      }
+
+      Write-Host "Response: $($response)"
+      Write-Host "Cold start latency: $($duration.TotalMilliseconds) ms"
+      Write-Host "##vso[task.setvariable variable=coldStartLatency;isOutput=true]$($duration.TotalMilliseconds)"
+    displayName: Record cold start latency
+    name: Record
+
+  - pwsh: |
+      Write-Host "Logs:"
+      Get-Content $(stdOutLogsFilePath)
+      Write-Host "----"
+      Write-Host "Error logs:"
+      Get-Content $(stdErrorLogsFilePath)
+    displayName: Print logs
+    condition: always()

--- a/eng/ci/templates/official/jobs/run-coldstart.yml
+++ b/eng/ci/templates/official/jobs/run-coldstart.yml
@@ -18,10 +18,10 @@ jobs:
   pool:
     name: 1es-pool-azfunc-benchmarking-large
     ${{ if eq(parameters.os, 'Linux') }}:
-      image: 1es-ubuntu-22.04-benchmark-runner-vanilla-sd4
+      image: 1es-ubuntu-22.04-benchmark-runner-vanilla-sd2
       os: linux 
     ${{ else }}:
-      image: 1es-windows-2022-benchmark-runner-vanilla-sd4
+      image: 1es-windows-2022-benchmark-runner-vanilla-sd2
       os: windows
 
   variables:

--- a/eng/ci/templates/official/jobs/run-coldstart.yml
+++ b/eng/ci/templates/official/jobs/run-coldstart.yml
@@ -11,10 +11,10 @@ parameters:
   values:
     - Windows
     - Linux
-- name: collectPerfviewProfileOnWindows
+- name: collectPerfViewProfileOnWindows
   type: boolean
   default: false
-- name: perfviewCollectArguments
+- name: perfViewCollectArguments
   type: string
   default: ''
 
@@ -22,12 +22,12 @@ jobs:
 - job: ${{ parameters.functionAppName }}_${{ parameters.instanceId }}
   displayName: ${{ parameters.description }} ${{ parameters.instanceId }}
   pool:
-    name: 1es-pool-azfunc-benchmarking-large
+    name: 1es-pool-azfunc-benchmarking
     ${{ if eq(parameters.os, 'Linux') }}:
-      image: 1es-ubuntu-22.04-benchmark-runner-vanilla-sd2
+      image: 1es-ubuntu-22.04-benchmark-runner-vanilla
       os: linux 
     ${{ else }}:
-      image: 1es-windows-2022-benchmark-runner-vanilla-sd2
+      image: 1es-windows-2022-benchmark-runner-vanilla
       os: windows
 
   variables:
@@ -36,25 +36,24 @@ jobs:
     hostAssemblyPath: $(hostOutputPath)/Microsoft.Azure.WebJobs.Script.WebHost.dll
     logsDirectory: $(Build.ArtifactStagingDirectory)/Logs
     stdOutLogsFilePath: $(logsDirectory)/std_out_logs.txt
-    stdErrorLogsFilePath: $(logsDirectory)/std_error_logs.txt    
+    stdErrorLogsFilePath: $(logsDirectory)/std_error_logs.txt
     FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
     FUNCTIONS_WORKER_RUNTIME_VERSION: '9.0'
     AzureWebJobsScriptRoot: '$(functionAppOutputPath)'
-    perfviewPath: C:\.tools\perfview\perfview.exe 
+    perfViewPath: C:\.tools\perfview\perfview.exe 
     traceDirectory: $(Build.ArtifactStagingDirectory)/out
     traceFileName: PerfViewData_$(Build.BuildNumber)_${{ parameters.functionAppName }}.etl
     traceFilePath: $(traceDirectory)/$(traceFileName)
     traceLogPath: $(logsDirectory)/logs.log
 
-  ${{ if and(eq(parameters.collectPerfviewProfileOnWindows, true), eq(parameters.instanceId, '1')) }}: # profile collection is only on the first instance
+  ${{ if and(eq(parameters.collectPerfViewProfileOnWindows, true), eq(parameters.instanceId, '1')) }}: # profile collection is only on the first instance
     templateContext:
       outputParentDirectory: $(System.DefaultWorkingDirectory)/out
       outputs:
         - output: pipelineArtifact
-          displayName: Publish perfview profile
+          displayName: Publish PerfView profile
           path: $(traceFilePath).zip
           artifact: PerfViewData_${{ parameters.functionAppName }}
-          condition: eq(variables['CollectPerfviewProfile'], 'true')
 
   steps:
   - template: /eng/ci/templates/install-dotnet.yml@self
@@ -129,19 +128,20 @@ jobs:
 
     displayName: Wait until host is warmed up
 
-  - ${{ if and(eq(parameters.collectPerfviewProfileOnWindows, true), eq(parameters.instanceId, '1')) }}: # collect profile only on the first instance
+  - ${{ if and(eq(parameters.collectPerfViewProfileOnWindows, true), eq(parameters.instanceId, '1')) }}: # collect profile only on the first instance
     - pwsh: |
         New-Item -ItemType Directory -Path $(traceDirectory)
-        if (Test-Path $(perfviewPath)) {
-            $collectArguments = ${env:PerfviewCollectArguments}
-            Write-Host "perfview.exe found. Executing with arguments '$collectArguments'"
-            Start-Process -FilePath $(perfviewPath) -ArgumentList "collect $collectArguments /LogFile:$(traceLogPath) /DataFile:$(traceFilePath)" -NoNewWindow
+        if (Test-Path $(perfViewPath)) {
+            $collectArguments = ${env:COLLECT_ARGUMENTS}
+            Write-Host "PerfView.exe found. Executing with arguments '$collectArguments'"
+            Start-Process -FilePath $(perfViewPath) -ArgumentList "collect $collectArguments /LogFile:$(traceLogPath) /DataFile:$(traceFilePath)" -NoNewWindow
         } else {
-            Write-Host "perfview.exe not found in $(perfviewPath)"
+            Write-Host "PerfView.exe not found in $(perfViewPath)"
             exit 1
         }
-      displayName: Start Perfview
-      condition: eq(variables['CollectPerfviewProfile'], 'true')
+      displayName: Start PerfView
+      env:
+        COLLECT_ARGUMENTS: ${{ parameters.perfViewCollectArguments }}
 
   - pwsh: |
       $helloUrl = "http://localhost:5000/api/hello?forcespecialization=1"
@@ -157,10 +157,10 @@ jobs:
     displayName: Record cold start latency
     name: Record
 
-  - ${{ if and(eq(parameters.collectPerfviewProfileOnWindows, true), eq(parameters.instanceId, '1')) }}:
+  - ${{ if and(eq(parameters.collectPerfViewProfileOnWindows, true), eq(parameters.instanceId, '1')) }}:
     - pwsh: |
-        Write-Host "Stopping Perfview..."
-        & $(perfviewPath) stop
+        Write-Host "Stopping PerfView..."
+        & $(perfViewPath) stop
 
         # Wait for the zip file to be created
         $maxAttempts = 10
@@ -178,16 +178,15 @@ jobs:
             }
         }
 
-        $perfviewProcess = Get-Process -Name "perfview" -ErrorAction SilentlyContinue
-        if ($perfviewProcess) {
-            Write-Host "Killing Perfview process..."
-            $perfviewProcess | Stop-Process -Force
+        $perfViewProcess = Get-Process -Name "PerfView" -ErrorAction SilentlyContinue
+        if ($perfViewProcess) {
+            Write-Host "Killing PerfView process..."
+            $perfViewProcess | Stop-Process -Force
         }
 
         Write-Host "PerfView logs:"
         Get-Content $(traceLogPath)
       displayName: Stop PerfView
-      condition: eq(variables['CollectPerfviewProfile'], 'true')
 
   - ${{ if eq(parameters.os, 'Windows') }}:
     - pwsh: |

--- a/eng/ci/templates/official/jobs/run-coldstart.yml
+++ b/eng/ci/templates/official/jobs/run-coldstart.yml
@@ -11,6 +11,12 @@ parameters:
   values:
     - Windows
     - Linux
+- name: collectPerfviewProfileOnWindows
+  type: boolean
+  default: false
+- name: perfviewCollectArguments
+  type: string
+  default: ''
 
 jobs:
 - job: ${{ parameters.functionAppName }}_${{ parameters.instanceId }}
@@ -40,7 +46,7 @@ jobs:
     traceFilePath: $(traceDirectory)/$(traceFileName)
     traceLogPath: $(logsDirectory)/logs.log
 
-  ${{ if and(eq(parameters.os, 'Windows'), eq(parameters.instanceId, '1')) }}:
+  ${{ if and(eq(parameters.collectPerfviewProfileOnWindows, true), eq(parameters.instanceId, '1')) }}: # profile collection is only on the first instance
     templateContext:
       outputParentDirectory: $(System.DefaultWorkingDirectory)/out
       outputs:
@@ -123,7 +129,7 @@ jobs:
 
     displayName: Wait until host is warmed up
 
-  - ${{ if and(eq(parameters.os, 'Windows'), eq(parameters.instanceId, '1')) }}: # collect profile only on the first instance
+  - ${{ if and(eq(parameters.collectPerfviewProfileOnWindows, true), eq(parameters.instanceId, '1')) }}: # collect profile only on the first instance
     - pwsh: |
         New-Item -ItemType Directory -Path $(traceDirectory)
         if (Test-Path $(perfviewPath)) {
@@ -151,7 +157,7 @@ jobs:
     displayName: Record cold start latency
     name: Record
 
-  - ${{ if and(eq(parameters.os, 'Windows'), eq(parameters.instanceId, '1')) }}:
+  - ${{ if and(eq(parameters.collectPerfviewProfileOnWindows, true), eq(parameters.instanceId, '1')) }}:
     - pwsh: |
         Write-Host "Stopping Perfview..."
         & $(perfviewPath) stop
@@ -188,7 +194,7 @@ jobs:
         $processIdFile = "$(Build.ArtifactStagingDirectory)/hostProcessId.txt"
         if (Test-Path $processIdFile) {
             $processId = Get-Content $processIdFile
-            Write-Host "Sending SIGTERM to process ID: $processId"
+            Write-Host "Stop functions host process with process ID: $processId"
             Stop-Process -Id $processId -Force
         } else {
             Write-Host "Process ID file not found."
@@ -201,7 +207,7 @@ jobs:
         processIdFile="$(Build.ArtifactStagingDirectory)/hostProcessId.txt"
         if [ -f "$processIdFile" ]; then
             processId=$(cat $processIdFile)
-            echo "Sending SIGTERM to process ID: $processId"
+            echo "Sending SIGTERM to functions host process process ID: $processId"
             kill -SIGTERM $processId
         else
             echo "Process ID file not found."

--- a/eng/ci/templates/variables/coldstart.yml
+++ b/eng/ci/templates/variables/coldstart.yml
@@ -1,0 +1,4 @@
+variables:
+# This controls how many cold start samples are collected for each app+OS combination.
+- name: runInstances
+  value: "1,2,3,4,5,6,7,8,9,10"


### PR DESCRIPTION
resolves #10859

Sample run: https://azfunc.visualstudio.com/internal/_build/results?buildId=203300&view=results

Each run will capture data for both ASP.NET Core and non-ASP.NET Core applications on Windows and Linux. A JSON file containing relevant details about the data collection process will be published as an artifact. For scheduled nightly runs, the collected data will be stored in a SQL table, enabling reporting and alerting.  

Perfview profile collection from windows agent is also enabled.  To capture the profile, set the  pipeline variable `CollectPerfviewProfile` to `true`

Sample run with perfview profile collection: https://azfunc.visualstudio.com/internal/_build/results?buildId=203913&view=results

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

