### PR TITLE
Add AzuriteFixture

### DIFF
--- a/eng/ci/templates/official/jobs/run-integration-tests.yml
+++ b/eng/ci/templates/official/jobs/run-integration-tests.yml
@@ -4,7 +4,7 @@ jobs:
 
   pool:
     name: 1es-pool-azfunc
-    image: 1es-windows-2022 
+    image: 1es-windows-2022
     os: windows
 
   variables:
@@ -28,6 +28,10 @@ jobs:
       versionSpec: '11'
       jdkArchitectureOption: x64
       jdkSourceOption: PreInstalled
+
+  - script: |
+      npm install -g azurite
+    displayName: Install Azurite
 
   - task: PowerShell@2
     displayName: Install Az.Storage Powershell module

--- a/test/WebJobs.Script.Tests.Integration/Fixtures/AzuriteFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/Fixtures/AzuriteFixture.cs
@@ -88,13 +88,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Fixtures
             }
         }
 
-        public Task DisposeAsync()
+        public async Task DisposeAsync()
         {
-            _process?.CancelOutputRead();
-            _process?.CancelErrorRead();
-            _process?.Kill();
-            _process?.Dispose();
-            return _process.WaitForExitAsync();
+            if (Interlocked.Exchange(ref _process, null) is { } p)
+            {
+                if (!p.HasExited)
+                {
+                    p.Kill(entireProcessTree: true);
+                }
+
+                using CancellationTokenSource cts = new(TimeSpan.FromSeconds(5));
+                await p.WaitForExitAsync(cts.Token);
+
+                p.Dispose();
+            }
         }
 
         private static int GetFreeTcpPort()

--- a/test/WebJobs.Script.Tests.Integration/Fixtures/AzuriteFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/Fixtures/AzuriteFixture.cs
@@ -1,0 +1,208 @@
+﻿using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Sockets;
+using System.Net;
+using System.Runtime.ExceptionServices;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using System.Threading;
+using Xunit.Sdk;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Payloads;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Fixtures
+{
+    public class AzuriteFixture(IMessageSink sink) : IAsyncLifetime
+    {
+        public const string HostName = "127.0.0.1";
+
+        public const string AccountName = "devstoreaccount1";
+
+        [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification = "Well known account key for emulator. Used for testing.")]
+        public const string AccountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+
+        private int _blobPort;
+        private int _queuePort;
+        private int _tablePort;
+
+        private Process _process;
+        private ExceptionDispatchInfo _exceptionDispatchInfo;
+
+        public string GetConnectionString()
+        {
+            VerifyInitialized();
+            IEnumerable<(string Key, string Value)> properties =
+                [
+                    ("DefaultEndpointsProtocol", Uri.UriSchemeHttps),
+                    ("AccountName", AccountName),
+                    ("AccountKey", AccountKey),
+                    ("BlobEndpoint", GetBlobEndpoint()),
+                    ("QueueEndpoint", GetQueueEndpoint()),
+                    ("TableEndpoint", GetTableEndpoint()),
+                ];
+
+            return string.Join(";", properties.Select(p => $"{p.Key}={p.Value}"));
+        }
+
+        /// <summary>
+        /// Gets the blob endpoint
+        /// </summary>
+        /// <returns>The Azurite blob endpoint</returns>
+        public string GetBlobEndpoint()
+        {
+            VerifyInitialized();
+            return new UriBuilder(Uri.UriSchemeHttp, HostName, _blobPort, AccountName).ToString();
+        }
+
+        /// <summary>
+        /// Gets the queue endpoint
+        /// </summary>
+        /// <returns>The Azurite queue endpoint</returns>
+        public string GetQueueEndpoint()
+        {
+            VerifyInitialized();
+            return new UriBuilder(Uri.UriSchemeHttp, HostName, _queuePort, AccountName).ToString();
+        }
+
+        /// <summary>
+        /// Gets the table endpoint
+        /// </summary>
+        /// <returns>The Azurite table endpoint</returns>
+        public string GetTableEndpoint()
+        {
+            VerifyInitialized();
+            return new UriBuilder(Uri.UriSchemeHttp, HostName, _tablePort, AccountName).ToString();
+        }
+
+        public async Task InitializeAsync()
+        {
+            try
+            {
+                await StartAzuriteAsync();
+            }
+            catch (Exception ex)
+            {
+                _exceptionDispatchInfo = ExceptionDispatchInfo.Capture(ex);
+            }
+        }
+
+        public Task DisposeAsync()
+        {
+            Process p = Interlocked.Exchange(ref _process, null);
+            if (p is not null)
+            {
+                try
+                {
+                    p.Kill();
+                    p.Dispose();
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private static int GetFreeTcpPort()
+        {
+            using TcpListener listener = new(IPAddress.Loopback, 0);
+            listener.Start();
+
+            try
+            {
+                return ((IPEndPoint)listener.LocalEndpoint).Port;
+            }
+            finally
+            {
+                listener.Stop();
+            }
+        }
+
+        private Task StartAzuriteAsync()
+        {
+            _blobPort = GetFreeTcpPort();
+            _queuePort = GetFreeTcpPort();
+            _tablePort = GetFreeTcpPort();
+            GetAzuriteCommand(out string process, out string arguments);
+            ProcessStartInfo startInfo = new()
+            {
+                FileName = process,
+                Arguments = arguments,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+                ErrorDialog = false,
+            };
+
+            // We consider this startup complete when the first message is written.
+            // stdout: successfully started.
+            // stderr: failed to start.
+            TaskCompletionSource tcs = new();
+            _process = new() { StartInfo = startInfo };
+            _process.ErrorDataReceived += (_, e) => OnError(e, tcs);
+            _process.OutputDataReceived += (_, e) => OnMessage(e, tcs);
+            _process.Start();
+            _process.BeginErrorReadLine();
+            _process.BeginOutputReadLine();
+            return tcs.Task;
+        }
+
+        private void GetAzuriteCommand(out string process, out string arguments)
+        {
+            string azurite = $"azurite --silent --inMemoryPersistence --blobPort {_blobPort} --queuePort {_queuePort} --tablePort {_tablePort}";
+            if (OperatingSystem.IsWindows())
+            {
+                process = "cmd";
+                arguments = $"/C {azurite}";
+            }
+            else
+            {
+                process = "bash";
+                arguments = $"-c '{azurite}'";
+            }
+        }
+
+        private void OnMessage(DataReceivedEventArgs e, TaskCompletionSource tcs)
+        {
+            if (e.Data is not null)
+            {
+                tcs.TrySetResult();
+                sink.OnMessage(new DiagnosticMessage($"[azurite] {e.Data}"));
+            }
+        }
+
+        private void OnError(DataReceivedEventArgs e, TaskCompletionSource tcs)
+        {
+            if (e.Data is null)
+            {
+                return;
+            }
+
+            sink.OnMessage(new DiagnosticMessage($"[error][azurite] {e.Data}"));
+            try
+            {
+                throw new InvalidOperationException(e.Data);
+            }
+            catch (Exception ex)
+            {
+                tcs.TrySetException(ex);
+            }
+        }
+
+        private void VerifyInitialized()
+        {
+            if (_process is null)
+            {
+                throw new InvalidOperationException("AzuriteFixture is not initialized. Call InitializeAsync() before using this fixture.");
+            }
+
+            _exceptionDispatchInfo?.Throw();
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/Fixtures/AzuriteFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/Fixtures/AzuriteFixture.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Fixtures
             else
             {
                 process = "bash";
-                arguments = $"-c {azurite}";
+                arguments = $"-c \"{azurite}\"";
             }
         }
 

--- a/test/WebJobs.Script.Tests.Integration/Fixtures/AzuriteFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/Fixtures/AzuriteFixture.cs
@@ -11,7 +11,6 @@ using System.Threading;
 using Xunit.Sdk;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Client.Payloads;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Fixtures
 {
@@ -91,20 +90,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Fixtures
 
         public Task DisposeAsync()
         {
-            Process p = Interlocked.Exchange(ref _process, null);
-            if (p is not null)
-            {
-                try
-                {
-                    p.Kill();
-                    p.Dispose();
-                }
-                catch
-                {
-                    // ignore
-                }
-            }
-
+            _process?.Dispose();
             return Task.CompletedTask;
         }
 
@@ -133,7 +119,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Fixtures
             {
                 FileName = process,
                 Arguments = arguments,
-                UseShellExecute = false,
+                UseShellExecute = false, // we need stdio, cannot set to true.
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 CreateNoWindow = true,
@@ -155,6 +141,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Fixtures
 
         private void GetAzuriteCommand(out string process, out string arguments)
         {
+            // Azurite is not an executable itself, but a node module. However, it installs helper scripts on the path.
+            // We will use cmd or bash to run the helper script.
             string azurite = $"azurite --silent --inMemoryPersistence --blobPort {_blobPort} --queuePort {_queuePort} --tablePort {_tablePort}";
             if (OperatingSystem.IsWindows())
             {

--- a/test/WebJobs.Script.Tests.Integration/Fixtures/AzuriteFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/Fixtures/AzuriteFixture.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Fixtures
             _process?.CancelErrorRead();
             _process?.Kill();
             _process?.Dispose();
-            return Task.CompletedTask;
+            return _process.WaitForExitAsync();
         }
 
         private static int GetFreeTcpPort()

--- a/test/WebJobs.Script.Tests.Integration/Fixtures/AzuriteFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/Fixtures/AzuriteFixture.cs
@@ -90,6 +90,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Fixtures
 
         public Task DisposeAsync()
         {
+            _process?.CancelOutputRead();
+            _process?.CancelErrorRead();
+            _process?.Kill();
             _process?.Dispose();
             return Task.CompletedTask;
         }
@@ -152,7 +155,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Fixtures
             else
             {
                 process = "bash";
-                arguments = $"-c '{azurite}'";
+                arguments = $"-c {azurite}";
             }
         }
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             return null;
         }
 
-        public async Task InitializeAsync()
+        public virtual async Task InitializeAsync()
         {
             string nowString = DateTime.UtcNow.ToString("yyMMdd-HHmmss");
             string GetDestPath(int counter)

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestsBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestsBase.cs
@@ -25,7 +25,7 @@ using Xunit;
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public abstract class EndToEndTestsBase<TTestFixture> :
-        IClassFixture<TTestFixture> where TTestFixture : EndToEndTestFixture, new()
+        IClassFixture<TTestFixture> where TTestFixture : EndToEndTestFixture
     {
         private INameResolver _nameResolver;
         private IConfiguration _configuration;


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #10836 
resolves #10839 

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR -- TODO
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This PR adds an `AzuriteFixture`, which allows for declarative inclusion of Azurite as an Xunit fixture. `NodeEndToEndTests` has been updated to use this new fixture. Will update more tests later.

More on this fixture:
- Uses in memory persistence
- Will use random free ports on each run (so multiple fixtures can be active at once and not conflict)
- Requires Azurite to be installed beforehand and on the path.
- Uses `cmd` for windows, `bash` for all else.
    - Azurite v3 does not have an exe to invoke directly but rather is ran via node.
    - Leverages cmd/bash to discover and invoke the bash helpers installed by the npm module.
    - Intentionally does not use `UseShellExecute=true`, as that does not support redirecting stdout and stderr (which is needed).
