### PR TITLE
Removing Task.Delay()

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/DeferredLoggerProvider.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DeferredLoggerProvider.cs
@@ -60,56 +60,57 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                         foreach (var forwardingProvider in forwardingProviders)
                         {
                             var logger = forwardingProvider.CreateLogger(log.Category);
-                            List<IDisposable> scopes = null;
-
                             if (log.ScopeStorage?.Count > 0)
                             {
-                                try
-                                {
-                                    // Create a scope for each object in ScopeObject
-                                    scopes ??= new List<IDisposable>();
-                                    foreach (var scope in log.ScopeStorage)
-                                    {
-                                        // Create and store each scope
-                                        scopes.Add(logger.BeginScope(scope));
-                                    }
-
-                                    // Log the message
-                                    logger.Log(log.LogLevel, log.EventId, log.Exception, log.Message);
-                                }
-                                finally
-                                {
-                                    if (scopes is not null)
-                                    {
-                                        // Dispose all scopes in reverse order to properly unwind them
-                                        for (int i = scopes.Count - 1; i >= 0; i--)
-                                        {
-                                            scopes[i].Dispose();
-                                        }
-                                    }
-                                }
+                                ProcessLogWithScope(logger, log);
                             }
                             else
                             {
-                                // No scopes, avoid try-finally block
+                                // No scopes
                                 logger.Log(log.LogLevel, log.EventId, log.Exception, log.Message);
                             }
                         }
                     }
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ex.IsFatal())
             {
-                if (ex.IsFatal())
-                {
-                    throw;
-                }
+                // Ignore exceptions
             }
         }
 
         public void SetScopeProvider(IExternalScopeProvider scopeProvider)
         {
             _scopeProvider = scopeProvider;
+        }
+
+        private static void ProcessLogWithScope(ILogger logger, DeferredLogEntry log)
+        {
+            List<IDisposable> scopes = null;
+            try
+            {
+                // Create a scope for each object in ScopeObject
+                scopes ??= new List<IDisposable>();
+                foreach (var scope in log.ScopeStorage)
+                {
+                    // Create and store each scope
+                    scopes.Add(logger.BeginScope(scope));
+                }
+
+                // Log the message
+                logger.Log(log.LogLevel, log.EventId, log.Exception, log.Message);
+            }
+            finally
+            {
+                if (scopes is not null)
+                {
+                    // Dispose all scopes in reverse order to properly unwind them
+                    for (int i = scopes.Count - 1; i >= 0; i--)
+                    {
+                        scopes[i].Dispose();
+                    }
+                }
+            }
         }
 
         public void Dispose()

--- a/src/WebJobs.Script.WebHost/Diagnostics/DeferredLoggerProvider.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DeferredLoggerProvider.cs
@@ -37,10 +37,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             return _isEnabled ? new DeferredLogger(_channel, categoryName, _scopeProvider, _environment) : NullLogger.Instance;
         }
 
-        public void ProcessBufferedLogs(IReadOnlyCollection<ILoggerProvider> forwardingProviders, bool runImmediately = false)
+        public Task ProcessBufferedLogsAsync(IReadOnlyCollection<ILoggerProvider> forwardingProviders, bool runImmediately = false)
         {
             // Forward all buffered logs to the new provider
-            Task.Run(async () =>
+            return Task.Run(async () =>
             {
                 if (!runImmediately)
                 {

--- a/src/WebJobs.Script.WebHost/Diagnostics/DeferredLoggerProvider.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DeferredLoggerProvider.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             SingleWriter = false
         });
 
-        private readonly TimeSpan _deferredLogDelay = TimeSpan.FromSeconds(10);
         private readonly IEnvironment _environment;
         private IExternalScopeProvider _scopeProvider;
         private bool _isEnabled = true;
@@ -37,84 +36,75 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             return _isEnabled ? new DeferredLogger(_channel, categoryName, _scopeProvider, _environment) : NullLogger.Instance;
         }
 
-        public Task ProcessBufferedLogsAsync(IReadOnlyCollection<ILoggerProvider> forwardingProviders, bool runImmediately = false)
+        public async Task ProcessBufferedLogsAsync(IReadOnlyCollection<ILoggerProvider> forwardingProviders)
         {
             // Forward all buffered logs to the new provider
-            return Task.Run(async () =>
+            try
             {
-                if (!runImmediately)
+                if (forwardingProviders is null || forwardingProviders.Count == 0)
                 {
-                    // Wait for 10 seconds, this will increase the probability of these logs appearing in live metrics.
-                    await Task.Delay(_deferredLogDelay);
+                    // No providers, just drain the messages without logging and disable the channel.
+                    _isEnabled = false;
+                    _channel.Writer.TryComplete();
+                    while (_channel.Reader.TryRead(out _))
+                    {
+                        // Drain the channel
+                    }
+                    return;
                 }
 
-                try
+                while (await _channel.Reader.WaitToReadAsync())
                 {
-                    if (forwardingProviders is null || forwardingProviders.Count == 0)
+                    while (_channel.Reader.TryRead(out var log))
                     {
-                        // No providers, just drain the messages without logging and disable the channel.
-                        _isEnabled = false;
-                        _channel.Writer.TryComplete();
-                        while (_channel.Reader.TryRead(out _))
+                        foreach (var forwardingProvider in forwardingProviders)
                         {
-                            // Drain the channel
-                        }
-                        return;
-                    }
+                            var logger = forwardingProvider.CreateLogger(log.Category);
+                            List<IDisposable> scopes = null;
 
-                    while (await _channel.Reader.WaitToReadAsync())
-                    {
-                        while (_channel.Reader.TryRead(out var log))
-                        {
-                            foreach (var forwardingProvider in forwardingProviders)
+                            if (log.ScopeStorage?.Count > 0)
                             {
-                                var logger = forwardingProvider.CreateLogger(log.Category);
-                                List<IDisposable> scopes = null;
-
-                                if (log.ScopeStorage?.Count > 0)
+                                try
                                 {
-                                    try
+                                    // Create a scope for each object in ScopeObject
+                                    scopes ??= new List<IDisposable>();
+                                    foreach (var scope in log.ScopeStorage)
                                     {
-                                        // Create a scope for each object in ScopeObject
-                                        scopes ??= new List<IDisposable>();
-                                        foreach (var scope in log.ScopeStorage)
-                                        {
-                                            // Create and store each scope
-                                            scopes.Add(logger.BeginScope(scope));
-                                        }
+                                        // Create and store each scope
+                                        scopes.Add(logger.BeginScope(scope));
+                                    }
 
-                                        // Log the message
-                                        logger.Log(log.LogLevel, log.EventId, log.Exception, log.Message);
-                                    }
-                                    finally
-                                    {
-                                        if (scopes is not null)
-                                        {
-                                            // Dispose all scopes in reverse order to properly unwind them
-                                            for (int i = scopes.Count - 1; i >= 0; i--)
-                                            {
-                                                scopes[i].Dispose();
-                                            }
-                                        }
-                                    }
-                                }
-                                else
-                                {
-                                    // No scopes, avoid try-finally block
+                                    // Log the message
                                     logger.Log(log.LogLevel, log.EventId, log.Exception, log.Message);
                                 }
+                                finally
+                                {
+                                    if (scopes is not null)
+                                    {
+                                        // Dispose all scopes in reverse order to properly unwind them
+                                        for (int i = scopes.Count - 1; i >= 0; i--)
+                                        {
+                                            scopes[i].Dispose();
+                                        }
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                // No scopes, avoid try-finally block
+                                logger.Log(log.LogLevel, log.EventId, log.Exception, log.Message);
                             }
                         }
                     }
                 }
-                catch (Exception ex)
+            }
+            catch (Exception ex)
+            {
+                if (ex.IsFatal())
                 {
-                    if (ex.IsFatal())
-                    {
-                        throw;
-                    }
+                    throw;
                 }
-            });
+            }
         }
 
         public void SetScopeProvider(IExternalScopeProvider scopeProvider)

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -367,7 +367,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     if (deferredLogProvider is not null)
                     {
                         var selectedProviders = loggerProviders.Where(provider => provider is ApplicationInsightsLoggerProvider or OpenTelemetryLoggerProvider).ToArray();
-                        deferredLogProvider.ProcessBufferedLogs(selectedProviders);
+                        _ = deferredLogProvider.ProcessBufferedLogsAsync(selectedProviders);
                     }
                 }
 

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -367,7 +367,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     if (deferredLogProvider is not null)
                     {
                         var selectedProviders = loggerProviders.Where(provider => provider is ApplicationInsightsLoggerProvider or OpenTelemetryLoggerProvider).ToArray();
-                        _ = deferredLogProvider.ProcessBufferedLogsAsync(selectedProviders);
+                        _ = Task.Run(() => deferredLogProvider.ProcessBufferedLogsAsync(selectedProviders));
                     }
                 }
 

--- a/test/WebJobs.Script.Tests/Eventing/DeferredLoggerProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Eventing/DeferredLoggerProviderTests.cs
@@ -33,16 +33,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
         }
 
         [Fact]
-        public void CreateLogger_ReturnsNullLogger_WhenDisabled()
+        public async Task CreateLogger_ReturnsNullLogger_WhenDisabled()
         {
             var testEnvironment = new TestEnvironment();
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
 
             // Arrange
             var provider = new DeferredLoggerProvider(testEnvironment);
-            _ = provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>(), true);
-
-            provider.Dispose();
+            await provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>());
 
             // Act
             var logger = provider.CreateLogger("TestCategory");
@@ -63,11 +61,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
             var logger = provider.CreateLogger("TestCategory");
             logger.LogInformation("Test Log Message");
 
-            // Close the channel so that ProcessBufferedLogsAsync can complete
-            provider.Dispose();
-
             // Act
-            await provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>(), true); // Process immediately
+            await provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>());
 
             // Assert
             Assert.Equal(0, provider.Count); // Ensure channel is drained
@@ -84,11 +79,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
             var logger = provider.CreateLogger("TestCategory");
             logger.LogInformation("Log before disposal");
 
-            // Close the channel so that ProcessBufferedLogsAsync can complete
-            provider.Dispose();
-
             // Act
-            await provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>(), true); // Process immediately
+            await provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>());
 
             // Assert
             Assert.False(provider.CreateLogger("TestCategory") is DeferredLogger);
@@ -139,11 +131,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
             var provider = new DeferredLoggerProvider(testEnvironment);
             var mockLoggerProvider = new Mock<ILoggerProvider>();
 
+            var task = provider.ProcessBufferedLogsAsync(new[] { mockLoggerProvider.Object });
+
             // Close the channel so that ProcessBufferedLogsAsync can complete
             provider.Dispose();
 
             // Act & Assert (no exceptions should be thrown)
-            var exception = await Record.ExceptionAsync(() => provider.ProcessBufferedLogsAsync(new[] { mockLoggerProvider.Object }, true));
+            var exception = await Record.ExceptionAsync(() => task);
             Assert.Null(exception);
         }
 
@@ -166,12 +160,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
             TestLoggerProvider testLoggerProvider = new TestLoggerProvider();
             testLoggerProvider.SetScopeProvider(new LoggerExternalScopeProvider());
 
+            // Act
+            var task = provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>() { testLoggerProvider });
+
             // Close the channel so that ProcessBufferedLogsAsync can complete
             provider.Dispose();
-
-            // Act
-            await provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>() { testLoggerProvider }, true); // Process immediately
-
+            await task;
             Assert.Equal(0, provider.Count); // Ensure channel is drained
 
             // Assert that the log was forwarded to the testLoggerProvider
@@ -199,7 +193,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
             testLoggerProvider.SetScopeProvider(new LoggerExternalScopeProvider());
 
             // Act
-            _ = provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>() { testLoggerProvider }, true); // Process immediately
+            _ = provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>() { testLoggerProvider });
 
             // Ensure that the LoggerProvider is not disabled and still returns DeferredLogger
             Assert.True(provider.CreateLogger("TestCategory") is DeferredLogger);

--- a/test/WebJobs.Script.Tests/Eventing/DeferredLoggerProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Eventing/DeferredLoggerProviderTests.cs
@@ -40,9 +40,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
 
             // Arrange
             var provider = new DeferredLoggerProvider(testEnvironment);
-            provider.ProcessBufferedLogs(new List<ILoggerProvider>(), true); // Disable the provider
+            await provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>(), true); // Disable the provider
 
-            await Task.Delay(1000);
             // Act
             var logger = provider.CreateLogger("TestCategory");
 
@@ -63,10 +62,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
             logger.LogInformation("Test Log Message");
 
             // Act
-            provider.ProcessBufferedLogs(new List<ILoggerProvider>(), true); // Process immediately
-
-            // Wait for forwarding task to complete
-            await Task.Delay(100); // Small delay to ensure the logs are processed
+            await provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>(), true); // Process immediately
 
             // Assert
             Assert.Equal(0, provider.Count); // Ensure channel is drained
@@ -84,11 +80,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
             logger.LogInformation("Log before disposal");
 
             // Act
-            provider.ProcessBufferedLogs(new List<ILoggerProvider>(), true); // Process immediately
+            await provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>(), true); // Process immediately
             provider.Dispose();
-
-            // Wait a short period to ensure the channel is completed
-            await Task.Delay(100);
 
             // Assert
             Assert.False(provider.CreateLogger("TestCategory") is DeferredLogger);
@@ -130,7 +123,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
         }
 
         [Fact]
-        public void ProcessBufferedLogs_ThrowsNoExceptionsWhenChannelIsEmpty()
+        public async Task ProcessBufferedLogs_ThrowsNoExceptionsWhenChannelIsEmpty()
         {
             var testEnvironment = new TestEnvironment();
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
@@ -140,7 +133,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
             var mockLoggerProvider = new Mock<ILoggerProvider>();
 
             // Act & Assert (no exceptions should be thrown)
-            provider.ProcessBufferedLogs(new[] { mockLoggerProvider.Object }, true);
+            var exception = await Record.ExceptionAsync(() => provider.ProcessBufferedLogsAsync(new[] { mockLoggerProvider.Object }, true));
+            Assert.Null(exception);
         }
 
         [Fact]
@@ -163,10 +157,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
             testLoggerProvider.SetScopeProvider(new LoggerExternalScopeProvider());
 
             // Act
-            provider.ProcessBufferedLogs(new List<ILoggerProvider>() { testLoggerProvider }, true); // Process immediately
+            await provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>() { testLoggerProvider }, true); // Process immediately
 
-            // Wait a short period to ensure the channel is completed
-            await Task.Delay(100);
             Assert.Equal(0, provider.Count); // Ensure channel is drained
 
             // Assert that the log was forwarded to the testLoggerProvider

--- a/test/WebJobs.Script.Tests/Eventing/DeferredLoggerProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Eventing/DeferredLoggerProviderTests.cs
@@ -33,14 +33,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
         }
 
         [Fact]
-        public async Task CreateLogger_ReturnsNullLogger_WhenDisabled()
+        public void CreateLogger_ReturnsNullLogger_WhenDisabled()
         {
             var testEnvironment = new TestEnvironment();
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
 
             // Arrange
             var provider = new DeferredLoggerProvider(testEnvironment);
-            await provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>(), true); // Disable the provider
+            _ = provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>(), true);
+
+            provider.Dispose();
 
             // Act
             var logger = provider.CreateLogger("TestCategory");
@@ -61,6 +63,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
             var logger = provider.CreateLogger("TestCategory");
             logger.LogInformation("Test Log Message");
 
+            // Close the channel so that ProcessBufferedLogsAsync can complete
+            provider.Dispose();
+
             // Act
             await provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>(), true); // Process immediately
 
@@ -79,9 +84,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
             var logger = provider.CreateLogger("TestCategory");
             logger.LogInformation("Log before disposal");
 
+            // Close the channel so that ProcessBufferedLogsAsync can complete
+            provider.Dispose();
+
             // Act
             await provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>(), true); // Process immediately
-            provider.Dispose();
 
             // Assert
             Assert.False(provider.CreateLogger("TestCategory") is DeferredLogger);
@@ -132,6 +139,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
             var provider = new DeferredLoggerProvider(testEnvironment);
             var mockLoggerProvider = new Mock<ILoggerProvider>();
 
+            // Close the channel so that ProcessBufferedLogsAsync can complete
+            provider.Dispose();
+
             // Act & Assert (no exceptions should be thrown)
             var exception = await Record.ExceptionAsync(() => provider.ProcessBufferedLogsAsync(new[] { mockLoggerProvider.Object }, true));
             Assert.Null(exception);
@@ -156,6 +166,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
             TestLoggerProvider testLoggerProvider = new TestLoggerProvider();
             testLoggerProvider.SetScopeProvider(new LoggerExternalScopeProvider());
 
+            // Close the channel so that ProcessBufferedLogsAsync can complete
+            provider.Dispose();
+
             // Act
             await provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>() { testLoggerProvider }, true); // Process immediately
 
@@ -164,6 +177,29 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
             // Assert that the log was forwarded to the testLoggerProvider
             Assert.Equal(1, testLoggerProvider.GetAllLogMessages().Count);
             Assert.Equal(Assert.Single(testLoggerProvider.GetAllLogMessages()).FormattedMessage, "Error Log");
+        }
+
+        [Fact]
+        public void Dispose_DoNotDisablesProvider()
+        {
+            var testEnvironment = new TestEnvironment();
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+
+            // Arrange
+            var provider = new DeferredLoggerProvider(testEnvironment);
+            var logger = provider.CreateLogger("TestCategory");
+            logger.LogError("Error Log");
+
+            // Create an instance of IOptionsMonitor<OpenTelemetryLoggerOptions>
+            var optionsMonitor = Mock.Of<IOptionsMonitor<OpenTelemetryLoggerOptions>>();
+
+            // Pass the optionsMonitor to the OpenTelemetryLoggerProvider constructor
+            //OpenTelemetryLoggerProvider openTelemetryLoggerProvider = new(optionsMonitor);
+            TestLoggerProvider testLoggerProvider = new TestLoggerProvider();
+            testLoggerProvider.SetScopeProvider(new LoggerExternalScopeProvider());
+
+            // Act
+            _ = provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>() { testLoggerProvider }, true); // Process immediately
 
             // Ensure that the LoggerProvider is not disabled and still returns DeferredLogger
             Assert.True(provider.CreateLogger("TestCategory") is DeferredLogger);


### PR DESCRIPTION
Removing Task.Delay() from the tests in `DeferredLoggerProviderTests` to improve test stability.

resolves #10874 

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
