### PR TITLE
Adds support to create TableServiceClient from JobHost configuration

### DIFF
--- a/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
+++ b/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
@@ -23,6 +23,10 @@ jobs:
       jdkArchitectureOption: x64
       jdkSourceOption: PreInstalled
 
+  - script: |
+      npm install -g azurite
+    displayName: Install Azurite
+
   - task: PowerShell@2
     displayName: Install Az.Storage Powershell module
     inputs:

--- a/src/WebJobs.Script/StorageProvider/HostAzureTableStorageProvider.cs
+++ b/src/WebJobs.Script/StorageProvider/HostAzureTableStorageProvider.cs
@@ -3,6 +3,8 @@
 
 using System;
 using Azure.Data.Tables;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -15,11 +17,32 @@ namespace Microsoft.Azure.WebJobs.Script
         private readonly TableServiceClientProvider _tableServiceClientProvider;
         private readonly IConfiguration _configuration;
 
-        public HostAzureTableStorageProvider(IConfiguration configuration, ILogger<HostAzureTableStorageProvider> logger, AzureComponentFactory componentFactory, AzureEventSourceLogForwarder logForwarder)
+        public HostAzureTableStorageProvider(IScriptHostManager scriptHostManager, IConfiguration configuration, ILogger<HostAzureTableStorageProvider> logger, AzureComponentFactory componentFactory, AzureEventSourceLogForwarder logForwarder)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _tableServiceClientProvider = new TableServiceClientProvider(componentFactory, logForwarder);
-            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
+            if (FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableMergedWebHostScriptHostConfiguration))
+            {
+                _configuration = configuration;
+            }
+            else
+            {
+                if (scriptHostManager == null)
+                {
+                    throw new ArgumentNullException(nameof(scriptHostManager));
+                }
+
+                _configuration = new ConfigurationBuilder()
+                    .Add(new ActiveHostConfigurationSource(scriptHostManager))
+                    .AddConfiguration(configuration)
+                    .Build();
+            }
         }
 
         public bool TryCreateTableServiceClient(string connection, out TableServiceClient client)

--- a/src/WebJobs.Script/StorageProvider/HostAzureTableStorageProvider.cs
+++ b/src/WebJobs.Script/StorageProvider/HostAzureTableStorageProvider.cs
@@ -22,10 +22,7 @@ namespace Microsoft.Azure.WebJobs.Script
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _tableServiceClientProvider = new TableServiceClientProvider(componentFactory, logForwarder);
 
-            if (configuration == null)
-            {
-                throw new ArgumentNullException(nameof(configuration));
-            }
+            ArgumentNullException.ThrowIfNull(configuration);
 
             if (FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableMergedWebHostScriptHostConfiguration))
             {
@@ -33,10 +30,7 @@ namespace Microsoft.Azure.WebJobs.Script
             }
             else
             {
-                if (scriptHostManager == null)
-                {
-                    throw new ArgumentNullException(nameof(scriptHostManager));
-                }
+                ArgumentNullException.ThrowIfNull(scriptHostManager);
 
                 _configuration = new ConfigurationBuilder()
                     .Add(new ActiveHostConfigurationSource(scriptHostManager))

--- a/test/WebJobs.Script.Tests.Integration/Scale/TableStorageScaleMetricsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Scale/TableStorageScaleMetricsRepositoryTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Scale
             _loggerProvider = new TestLoggerProvider();
             ILoggerFactory loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(_loggerProvider);
-            _azureTableStorageProvider = TestHelpers.GetAzureTableStorageProvider(configuration, new TestEnvironment());
+            _azureTableStorageProvider = TestHelpers.GetAzureTableStorageProvider(configuration, environment: new TestEnvironment());
             // Allow for up to 30 seconds of creation retries for tests due to slow table deletes
             _repository = new TableStorageScaleMetricsRepository(_hostIdProviderMock.Object, new OptionsWrapper<ScaleOptions>(_scaleOptions), loggerFactory, _azureTableStorageProvider, 60);
 

--- a/test/WebJobs.Script.Tests.Integration/Storage/AzureTableStorageProviderTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Storage/AzureTableStorageProviderTests.cs
@@ -159,7 +159,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Storage
             }
             public override void Load()
             {
-                Data = _data;
+                // _data might be already case-insensitive but we want to ensure it's case-sensitive
+                Data = new Dictionary<string, string>(_data, StringComparer.Ordinal);
             }
         }
     }

--- a/test/WebJobs.Script.Tests.Integration/Storage/AzureTableStorageProviderTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Storage/AzureTableStorageProviderTests.cs
@@ -3,24 +3,30 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Threading.Tasks;
 using Azure.Data.Tables;
+using Microsoft.Azure.WebJobs.Script.Tests.Integration.Fixtures;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Storage
 {
-    public class AzureTableStorageProviderTests
+    public class AzureTableStorageProviderTests : IClassFixture<AzuriteFixture>
     {
-        private const string StorageConnection = "AzureWebJobsStorage";
+        private readonly AzuriteFixture _azurite;
+
+        public AzureTableStorageProviderTests(AzuriteFixture azurite)
+        {
+            _azurite = azurite;
+        }
 
         [Fact]
         public async Task TryCreateHostingTableServiceClient_ConnectionInWebHostConfiguration()
         {
-            var testConfiguration = TestHelpers.GetTestConfiguration();
             var testData = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
-                { "ConnectionStrings:AzureWebJobsStorage", testConfiguration.GetWebJobsConnectionString(StorageConnection) },
+                { "ConnectionStrings:AzureWebJobsStorage", _azurite.GetConnectionString() },
                 { "AzureWebJobsStorage", "" }
             };
 
@@ -34,15 +40,88 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Storage
         }
 
         [Fact]
+        public async Task TryCreateHostingTableServiceClient_ConnectionInJobHostConfiguration()
+        {
+            var testData = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                { "ConnectionStrings:AzureWebJobsStorage", _azurite.GetConnectionString() },
+                { "AzureWebJobsStorage", "" }
+            };
+
+            var webHostConfiguration = new ConfigurationBuilder().Build();
+            var jobHostConfiguration = new ConfigurationBuilder()
+                .AddInMemoryCollection(testData)
+                .Build();
+
+            var azureTableStorageProvider = TestHelpers.GetAzureTableStorageProvider(webHostConfiguration, jobHostConfiguration);
+            azureTableStorageProvider.TryCreateHostingTableServiceClient(out TableServiceClient client);
+            await VerifyTableServiceClientAvailable(client);
+        }
+
+        [Theory]
+        [InlineData("AzureWebJobsStorage:accountName", "storage")]
+        [InlineData("AzureWebJobsStorage:AccountName", "storage")]
+        [InlineData("AzureWebJobsStorage:tableServiceUri", "https://mytable.functions")]
+        [InlineData("AzureWebJobsStorage:TableServiceUri", "https://mytable.functions")]
+        public void TryCreateHostingTableServiceClient_IdentityBasedConnections(string key, string value)
+        {
+            var testData = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                { key, value }
+            };
+
+            // Using a case sensitive data source to match the ScriptEnvironmentVariablesConfigurationSource behavior on Linux (case-sensitive env vars)
+            var webHostConfiguration = new ConfigurationBuilder().Build();
+            var jobHostConfiguration = new ConfigurationBuilder()
+                .Add(new CaseSensitiveConfigurationSource(testData))
+                .Build();
+
+            var azureTableStorageProvider = TestHelpers.GetAzureTableStorageProvider(webHostConfiguration, jobHostConfiguration);
+            Assert.True(azureTableStorageProvider.TryCreateHostingTableServiceClient(out _));
+        }
+
+        [Fact]
         public void TryCreateHostingTableServiceClient_NoConnectionThrowsException()
         {
             var webHostConfiguration = new ConfigurationBuilder()
                 .Build();
+            var jobHostConfiguration = new ConfigurationBuilder()
+                .Build();
 
-            var azureTableStorageProvider = TestHelpers.GetAzureTableStorageProvider(webHostConfiguration);
+            var azureTableStorageProvider = TestHelpers.GetAzureTableStorageProvider(webHostConfiguration, jobHostConfiguration);
             Assert.False(azureTableStorageProvider.TryCreateHostingTableServiceClient(out _));
 
-            Assert.False(azureTableStorageProvider.TryCreateTableServiceClient(ConnectionStringNames.Storage, out TableServiceClient blobServiceClient));
+            Assert.False(azureTableStorageProvider.TryCreateTableServiceClient(ConnectionStringNames.Storage, out TableServiceClient tableServiceClient));
+        }
+
+        [Theory]
+        [InlineData("ConnectionStrings:AzureWebJobsStorage1")]
+        [InlineData("AzureWebJobsStorage1")]
+        [InlineData("Storage1")]
+        public void TestAzureBlobStorageProvider_JobHostConfigurationWinsConflict(string connectionName)
+        {
+            var bytes = Encoding.UTF8.GetBytes("someKey");
+            var encodedString = Convert.ToBase64String(bytes);
+
+            var webHostConfigData = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { connectionName, $"DefaultEndpointsProtocol=https;AccountName=webHostAccount;AccountKey={encodedString};EndpointSuffix=core.windows.net" },
+            };
+            var webHostConfiguration = new ConfigurationBuilder()
+                .AddInMemoryCollection(webHostConfigData)
+                .Build();
+
+            var jobHostConfigData = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { connectionName, $"DefaultEndpointsProtocol=https;AccountName=jobHostAccount;AccountKey={encodedString};EndpointSuffix=core.windows.net" },
+            };
+            var jobHostConfiguration = new ConfigurationBuilder()
+                .AddInMemoryCollection(jobHostConfigData)
+                .Build();
+
+            var azureTableStorageProvider = TestHelpers.GetAzureTableStorageProvider(webHostConfiguration, jobHostConfiguration);
+            Assert.True(azureTableStorageProvider.TryCreateTableServiceClient("Storage1", out TableServiceClient client));
+            Assert.Equal("webHostAccount", client.AccountName, ignoreCase: true);
         }
 
         private async Task VerifyTableServiceClientAvailable(TableServiceClient client)
@@ -55,6 +134,32 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Storage
             catch (Exception e)
             {
                 Assert.False(true, $"Could not establish connection to TableService. {e}");
+            }
+        }
+
+        private class CaseSensitiveConfigurationSource : IConfigurationSource
+        {
+            private readonly Dictionary<string, string> _data;
+            public CaseSensitiveConfigurationSource(Dictionary<string, string> data)
+            {
+                _data = data;
+            }
+            public IConfigurationProvider Build(IConfigurationBuilder builder)
+            {
+                return new CaseSensitiveConfigurationProvider(_data);
+            }
+        }
+
+        private class CaseSensitiveConfigurationProvider : ConfigurationProvider
+        {
+            private readonly Dictionary<string, string> _data;
+            public CaseSensitiveConfigurationProvider(Dictionary<string, string> data)
+            {
+                _data = data;
+            }
+            public override void Load()
+            {
+                Data = _data;
             }
         }
     }

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -533,18 +533,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             return services;
         }
 
-        public static IAzureTableStorageProvider GetAzureTableStorageProvider(IConfiguration configuration, IEnvironment environment = default)
+        public static IAzureTableStorageProvider GetAzureTableStorageProvider(IConfiguration webHostConfiguration, IConfiguration jobHostConfiguration = null, IEnvironment environment = default)
         {
             environment ??= new TestEnvironment();
 
             IHost tempHost = new HostBuilder()
                 .ConfigureServices(services =>
                 {
-                    AddTestAzureTableStorageProvider(services, configuration, environment);
+                    AddTestAzureTableStorageProvider(services, jobHostConfiguration ?? webHostConfiguration, environment);
                 })
                 .ConfigureAppConfiguration(c =>
                 {
-                    c.AddConfiguration(configuration);
+                    c.AddConfiguration(webHostConfiguration);
                 })
                 .Build();
 
@@ -552,10 +552,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             return azureTableStorageProvider;
         }
 
-        public static IServiceCollection AddTestAzureTableStorageProvider(IServiceCollection services, IConfiguration configuration, IEnvironment environment)
+        public static IServiceCollection AddTestAzureTableStorageProvider(IServiceCollection services, IConfiguration configuration, IEnvironment environment, IScriptHostManager scriptHostManager = null)
         {
             // Adds necessary Azure services to create clients
             services.AddAzureClientsCore();
+
+            if (scriptHostManager == null)
+            {
+                scriptHostManager = new TestScriptHostService(configuration);
+            }
+
+            services.AddSingleton<IScriptHostManager>(scriptHostManager);
+
             services.AddSingleton<IAzureTableStorageProvider, HostAzureTableStorageProvider>();
 
             return services;


### PR DESCRIPTION
### Issue describing the changes in this PR

This PR includes support to create `TableServiceClient `resolving the connection information from the `JobHost IConfiguration` and resolves #10865 since the `ActiveHostConfigurationSource` creates a case insensitive dictionary.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: #10891 
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

