### PR TITLE
[release/4.38 port] Trigger code-mirror on all release branches

### DIFF
--- a/eng/ci/code-mirror.yml
+++ b/eng/ci/code-mirror.yml
@@ -3,8 +3,7 @@ trigger:
     include:
     - dev
     - in-proc
-    - release/4.*
-    - release/in-proc
+    - release/*
 
 resources:
   repositories:


### PR DESCRIPTION
Normalize code-mirror to trigger off all release branches.