### PR TITLE
Add profile analysis support in cold start pipeline

### DIFF
--- a/eng/ci/host.coldstart.yml
+++ b/eng/ci/host.coldstart.yml
@@ -20,7 +20,7 @@ parameters:
 - name: perfViewCollectArguments
   displayName: PerfView profile collection arguments (Valid only if "Collect PerfView Profile" is true))
   type: string
-  default: '/NoGui /AcceptEula /NoV2Rundown /NoNGenRundown /NoClrRundown /BufferSizeMB=64 /CircularMB=64 /ThreadTime /Providers=a7044dd6-c8ef-4980-858c-942d972b6250'
+  default: '/NoGui /AcceptEula /NoV2Rundown /NoNGenRundown /NoClrRundown /BufferSizeMB=64 /CircularMB=64 /Providers=a7044dd6-c8ef-4980-858c-942d972b6250'
 
 resources:
   repositories:

--- a/eng/ci/templates/official/jobs/run-coldstart.yml
+++ b/eng/ci/templates/official/jobs/run-coldstart.yml
@@ -57,7 +57,7 @@ jobs:
 
   ${{ if and(eq(parameters.collectPerfViewProfileOnWindows, true), eq(parameters.instanceId, '1')) }}: # profile collection is only on the first instance
     templateContext:
-      outputParentDirectory: $(System.DefaultWorkingDirectory)/out
+      outputParentDirectory: $(traceDirectory)
       outputs:
         - output: pipelineArtifact
           displayName: Publish PerfView profile
@@ -208,9 +208,6 @@ jobs:
 
         # Upload analysis result
         Write-Host "##vso[task.addattachment type=Distributedtask.Core.Summary;name=$env:OS $env:FUNCTION_APP_NAME;]$(traceAnalysisResultMarkdownFilePath)"
-
-        # Cleanup unneeded files
-        Get-ChildItem $(traceDirectory) | Where-Object { $_.Name -notin @('$(traceFileZipName)', 'results') } | Remove-Item -Force -Recurse
       displayName: Analyze profile
       env:
         FUNCTION_APP_NAME: ${{ parameters.functionAppName }}

--- a/eng/ci/templates/official/jobs/run-coldstart.yml
+++ b/eng/ci/templates/official/jobs/run-coldstart.yml
@@ -42,9 +42,18 @@ jobs:
     AzureWebJobsScriptRoot: '$(functionAppOutputPath)'
     perfViewPath: C:\.tools\perfview\perfview.exe 
     traceDirectory: $(Build.ArtifactStagingDirectory)/out
-    traceFileName: PerfViewData_$(Build.BuildNumber)_${{ parameters.functionAppName }}.etl
+    traceFileNameWithoutExtension: PerfViewData_$(Build.BuildNumber)_${{ parameters.functionAppName }}
+    traceFileName: $(traceFileNameWithoutExtension).etl
+    traceFileZipName: $(traceFileName).zip
     traceFilePath: $(traceDirectory)/$(traceFileName)
+    traceZipFilePath: $(traceDirectory)/$(traceFileZipName)
+    traceAnalysisResultsDirectory: $(traceDirectory)/results
+    traceAnalysisResultMarkdownFilePath: $(traceAnalysisResultsDirectory)/$(traceFileNameWithoutExtension).md
     traceLogPath: $(logsDirectory)/logs.log
+    ${{ if eq(parameters.os, 'Linux') }}:
+      publishRid: linux-x64
+    ${{ if eq(parameters.os, 'Windows') }}:
+      publishRid: win-x64
 
   ${{ if and(eq(parameters.collectPerfViewProfileOnWindows, true), eq(parameters.instanceId, '1')) }}: # profile collection is only on the first instance
     templateContext:
@@ -52,8 +61,12 @@ jobs:
       outputs:
         - output: pipelineArtifact
           displayName: Publish PerfView profile
-          path: $(traceFilePath).zip
+          path: $(traceZipFilePath)
           artifact: PerfViewData_${{ parameters.functionAppName }}
+        - output: pipelineArtifact
+          displayName: Publish ColdStart Analysis Result
+          path: $(traceAnalysisResultsDirectory)
+          artifact: ColdStartProfileAnalysisResult_${{ parameters.functionAppName }}
 
   steps:
   - template: /eng/ci/templates/install-dotnet.yml@self
@@ -74,7 +87,7 @@ jobs:
       zipAfterPublish: false
       modifyOutputPath: false
       projects: '$(Build.ArtifactStagingDirectory)/PerformanceTestApps/${{ parameters.functionAppName }}/HelloHttp.csproj'
-      arguments: -c Release -o $(functionAppOutputPath) -f net9.0 
+      arguments: -c Release -o $(functionAppOutputPath) -f net9.0 -r $(publishRid)
       workingDirectory: $(Build.ArtifactStagingDirectory)/PerformanceTestApps/${{ parameters.functionAppName }}
 
   - task: DotNetCoreCLI@2
@@ -85,7 +98,7 @@ jobs:
       zipAfterPublish: false
       modifyOutputPath: false
       projects: '$(Build.SourcesDirectory)/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj'
-      arguments: -c Release -o $(hostOutputPath) -f net8.0 -p:PlaceholderSimulation=true 
+      arguments: -c Release -o $(hostOutputPath) -r $(publishRid) -f net8.0 -p:PlaceholderSimulation=true 
       workingDirectory: $(Build.SourcesDirectory)/src/WebJobs.Script.WebHost
 
   - pwsh: |
@@ -169,7 +182,7 @@ jobs:
         while ($attempt -lt $maxAttempts) {
             $files = Get-ChildItem -Path $(traceDirectory)
             $fileCount = $files.Count
-            if ($fileCount -eq 1 -and $files[0].Name -eq '$(traceFileName).zip') {
+            if ($fileCount -eq 1 -and $files[0].Name -eq '$(traceFileZipName)') {
                 break
             } else {
                 Write-Host "Expected zip file not found. Rechecking again in 15 seconds..."
@@ -187,6 +200,21 @@ jobs:
         Write-Host "PerfView logs:"
         Get-Content $(traceLogPath)
       displayName: Stop PerfView
+
+    - pwsh: |
+        # Install the profile analyzer tool and run it on the trace file.
+        dotnet tool install -g Microsoft.Azure.Functions.ColdStartProfileAnalyzer --prerelease
+        func-cold-start-analyzer --file $(traceZipFilePath) --format markdown text
+
+        # Upload analysis result
+        Write-Host "##vso[task.addattachment type=Distributedtask.Core.Summary;name=$env:OS $env:FUNCTION_APP_NAME;]$(traceAnalysisResultMarkdownFilePath)"
+
+        # Cleanup unneeded files
+        Get-ChildItem $(traceDirectory) | Where-Object { $_.Name -notin @('$(traceFileZipName)', 'results') } | Remove-Item -Force -Recurse
+      displayName: Analyze profile
+      env:
+        FUNCTION_APP_NAME: ${{ parameters.functionAppName }}
+        OS: ${{ parameters.os }}
 
   - ${{ if eq(parameters.os, 'Windows') }}:
     - pwsh: |


### PR DESCRIPTION
resolves #10877

This PR implements the necessary changes to integrate the FunctionsColdStartProfileAnalyzer into the cold start pipeline. The FunctionsColdStartAnalyzer is published as a .NET tool to our internal feed. When profile collection is enabled, we execute the tool by passing the trace file, and it generates results in both markdown (summary) and text (detailed) formats. The markdown version is uploaded to the pipeline summary, while both files are uploaded as artifacts of the pipeline.

Sample run with the analysis summary uploaded to the UI: https://azfunc.visualstudio.com/internal/_build/results?buildId=205177&view=ms.vss-build-web.run-extensions-tab

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

