### PR TITLE
Specify rid for publish in the benchmarking app

### DIFF
--- a/eng/ci/templates/official/jobs/setup-benchmark-agents.yml
+++ b/eng/ci/templates/official/jobs/setup-benchmark-agents.yml
@@ -26,7 +26,10 @@ jobs:
     agentId: ${{ parameters.functionAppName }}${{ parameters.os }}
     functionApp: ${{ parameters.functionAppName }}
     functionAppOutputPath: $(Build.ArtifactStagingDirectory)/FunctionApps/$(functionApp)
-
+    ${{ if eq(parameters.os, 'Linux') }}:
+      publishRid: linux-x64
+    ${{ if eq(parameters.os, 'Windows') }}:
+      publishRid: win-x64
   steps:
 
   - template: /eng/ci/templates/install-dotnet.yml@self
@@ -58,7 +61,7 @@ jobs:
       zipAfterPublish: false
       modifyOutputPath: false
       projects: '$(Build.ArtifactStagingDirectory)/PerformanceTestApps/$(functionApp)/HelloHttp.csproj'
-      arguments: -c Release -o $(functionAppOutputPath) -f net9.0
+      arguments: -c Release -o $(functionAppOutputPath) -f net9.0 -r $(publishRid)
       workingDirectory: $(Build.ArtifactStagingDirectory)/PerformanceTestApps/$(functionApp)
 
   - ${{ if eq(parameters.os, 'Windows') }}:


### PR DESCRIPTION
Specifying runtime identifier when publishing the benchmark application.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

Additional PR information
