### PR TITLE
Fix warmup URL in placeholder simulation mode.

### DIFF
--- a/eng/ci/templates/official/jobs/run-coldstart.yml
+++ b/eng/ci/templates/official/jobs/run-coldstart.yml
@@ -124,7 +124,7 @@ jobs:
       displayName: Start host in placeholder mode
 
   - pwsh: |     
-      $url = "http://localhost:5000/api/warmup"
+      $url = "http://localhost:5000" # In placeholder simulation mode, calling homepage triggers warmup.
       Write-Host "Checking if host is ready at $url..."
       $maxAttempts = 10
 


### PR DESCRIPTION
Host was not executing the warmup middleware in the cold start pipeline runs. When running in placeholder simulation mode, warmup will be executed [on the call to homepage](https://github.com/Azure/azure-functions-host/blob/e23bd89f14f2b9c2d55025a179d33f3d6ec4684f/src/WebJobs.Script.WebHost/Middleware/HostWarmupMiddleware.cs#L171).  This fix will resolve that issue.

[Here](https://azfunc.visualstudio.com/internal/_build/results?buildId=205639&view=logs&j=0d5bc021-dcd4-5cd1-961a-7a722cb55a5f&t=d33b5da1-626c-524f-9111-4a165382ac98&l=382) is a successful run with this fix. Logs confirm warmup is being executed.


### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)


