### PR TITLE
[in-proc backport] Support release channel settings in extension bundles resolution

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,3 +7,4 @@
 - Add support for new FeatureFlag `EnableAzureMonitorTimeIsoFormat` to enable iso time format for azmon logs for Linux Dedicated/EP Skus. (part of #7864)
 - Update PowerShell worker to 4.0.4175 (sets defaultRuntimeVersion to 7.4 in worker.config.json)
 - Fixing default DateTime bug with TimeZones in TimerTrigger (#10906)
+- Add support for the release channel setting `WEBSITE_PlatformReleaseChannel` and use this value in extension bundles resolution.

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -141,6 +141,9 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AntaresPlatformVersionWindows = "WEBSITE_PLATFORM_VERSION";
         public const string AntaresPlatformVersionLinux = "PLATFORM_VERSION";
 
+        // Antares Release Channel / RU Feed Settings
+        public const string AntaresPlatformReleaseChannel = "WEBSITE_PlatformReleaseChannel";
+
         // Machine identifier
         public const string AntaresComputerName = "COMPUTERNAME";
 

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -8,7 +8,6 @@ using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Grpc.Net.Client.Balancer;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions;

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -215,6 +215,11 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string LogicAppDefaultExtensionBundleVersion = "[1.*, 2.0.0)";
         public const string DefaultExtensionBundleVersion = "[4.*, 5.0.0)";
 
+        // Antares Platform Channel Names, used in extension bundle resolution
+        public const string LatestPlatformChannelNameUpper = "LATEST";
+        public const string StandardPlatformChannelNameUpper = "STANDARD";
+        public const string ExtendedPlatformChannelNameUpper = "EXTENDED";
+
         public const string AzureMonitorTraceCategory = "FunctionAppLogs";
 
         public const string KubernetesManagedAppName = "K8SE_APP_NAME";


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-host/issues/10778 - this was merged into dev a while back but was mistakenly not back-ported.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

