### PR TITLE
Adjusting the logic to determine the warmup call in placeholder simulation mode to align with the prod

### DIFF
--- a/eng/ci/templates/official/jobs/run-coldstart.yml
+++ b/eng/ci/templates/official/jobs/run-coldstart.yml
@@ -124,7 +124,7 @@ jobs:
       displayName: Start host in placeholder mode
 
   - pwsh: |     
-      $url = "http://localhost:5000" # In placeholder simulation mode, calling homepage triggers warmup.
+      $url = "http://localhost:5000/api/warmup?restart=1"
       Write-Host "Checking if host is ready at $url..."
       $maxAttempts = 10
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -8,3 +8,4 @@
 - Add support for new FeatureFlag `EnableAzureMonitorTimeIsoFormat` to enable iso time format for azmon logs for Linux Dedicated/EP Skus. (#10684)
 - Allow sync trigger to happen in managed environment when `AzureWebJobsStorage` is not set (#10767)
 - Fixing default DateTime bug with TimeZones in TimerTrigger (#10906)
+- Adjusting the logic to determine the warmup call in placeholder simulation mode to align with the production flow (#10918)

--- a/src/WebJobs.Script.WebHost/Middleware/HostWarmupMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/HostWarmupMiddleware.cs
@@ -167,9 +167,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
 
         public static bool IsWarmUpRequest(HttpRequest request, bool inStandbyMode, IEnvironment environment)
         {
-            // In placeholder simulation mode, we want the homepage request to also trigger warmup code.
-            var isWarmupViaHomePageRequest = Utility.IsInPlaceholderSimulationMode && inStandbyMode && request.Path.Value == "/";
-            if (isWarmupViaHomePageRequest)
+            // Check if the request is a warmup request in placeholder simulation mode
+            if (Utility.IsInPlaceholderSimulationMode && inStandbyMode &&
+                (request.Path.StartsWithSegments(_warmupRoutePath, StringComparison.OrdinalIgnoreCase) || request.Path.StartsWithSegments(_warmupRouteAlternatePath, StringComparison.OrdinalIgnoreCase)))
             {
                 return true;
             }


### PR DESCRIPTION
Adjusting the logic to determine the warmup call in placeholder simulation mode to align with the production flow.

Originally, when we created placeholder simulation support, we designed it so that the call to the home page would handle the prejitting. This approach was chosen to avoid an extra call to the warmup endpoint for those who were using it to measure and collect data. However, this method does not execute the InvocationMiddleware code path. With this change, we are aligning it with our production process by calling /api/warmup?restart=1

Sample run with the change: https://azfunc.visualstudio.com/internal/_build/results?buildId=205721&view=logs&j=70153b1d-c991-57e2-d310-e1fbc2487c94&t=8dce87a3-77ba-5d7c-53d7-9468b041ba80&l=12

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)


