### PR TITLE
[in-proc backport] Platform release channel bundles resolution fix and additional logging

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -8,3 +8,4 @@
 - Update PowerShell worker to 4.0.4175 (sets defaultRuntimeVersion to 7.4 in worker.config.json)
 - Fixing default DateTime bug with TimeZones in TimerTrigger (#10906)
 - Add support for the release channel setting `WEBSITE_PlatformReleaseChannel` and use this value in extension bundles resolution.
+- Bug fix for platform release channel bundles resolution casing issue and additional logging (#10921)

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -293,7 +293,7 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
             return matchingVersion?.ToString();
         }
 
-        private NuGetVersion ResolvePlatformReleaseChannelVersion(IList<NuGetVersion> orderedByDescBundles) => _platformReleaseChannel switch
+        private NuGetVersion ResolvePlatformReleaseChannelVersion(IList<NuGetVersion> orderedByDescBundles) => _platformReleaseChannel.ToUpper() switch
         {
             ScriptConstants.StandardPlatformChannelNameUpper or ScriptConstants.ExtendedPlatformChannelNameUpper => GetStandardOrExtendedBundleVersion(orderedByDescBundles),
             ScriptConstants.LatestPlatformChannelNameUpper or "" => GetLatestBundleVersion(orderedByDescBundles),
@@ -305,27 +305,36 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
         // However, Functions and Rapid Update should treat Standard and Extended the same, resolving to n-1.
         private NuGetVersion GetStandardOrExtendedBundleVersion(IList<NuGetVersion> orderedByDescBundlesList)
         {
+            var latest = orderedByDescBundlesList.FirstOrDefault();
+
             if (orderedByDescBundlesList.Count > 1)
             {
+                var previous = orderedByDescBundlesList[1];
+                _logger.LogInformation("Applying platform release channel configuration {platformReleaseChannelName}. Previous bundle version {previous} will be used instead of latest version {latest}.", _platformReleaseChannel, previous, latest);
+
                 // These channels should resolve to the version prior to latest. This list is in descending order, which makes latest [0], and prior-to-latest [1].
-                return orderedByDescBundlesList[1];
+                return previous;
             }
 
             // keep the latest version, log a notice
-            var latest = orderedByDescBundlesList.FirstOrDefault();
-            _logger.LogInformation("Unable to apply platform release channel configuration {platformReleaseChannelName}. Only one matching bundle version is available. {latestBundleVersion} will be used", _platformReleaseChannel, latest);
+            _logger.LogWarning("Unable to apply platform release channel configuration {platformReleaseChannelName}. Only one matching bundle version is available. {latestBundleVersion} will be used", _platformReleaseChannel, latest);
             return latest;
         }
 
-        private static NuGetVersion GetLatestBundleVersion(IList<NuGetVersion> orderedByDescBundlesList)
+        private NuGetVersion GetLatestBundleVersion(IList<NuGetVersion> orderedByDescBundlesList)
         {
-            return orderedByDescBundlesList.FirstOrDefault();
+            var latest = orderedByDescBundlesList.FirstOrDefault();
+            if (string.Equals(_platformReleaseChannel.ToUpper(), ScriptConstants.LatestPlatformChannelNameUpper))
+            {
+                _logger.LogInformation("Applying platform release channel configuration {platformReleaseChannelName}. Bundle version {latest} will be used", _platformReleaseChannel, latest);
+            }
+            return latest;
         }
 
         private NuGetVersion HandleUnknownPlatformReleaseChannelName(IList<NuGetVersion> orderedByDescBundlesList)
         {
             var latest = GetLatestBundleVersion(orderedByDescBundlesList);
-            _logger.LogInformation("Unknown platform release channel name {platformReleaseChannelName}. The latest bundle version, {latestBundleVersion}, will be used.", _platformReleaseChannel, latest);
+            _logger.LogWarning("Unknown platform release channel name {platformReleaseChannelName}. The latest bundle version, {latestBundleVersion}, will be used.", _platformReleaseChannel, latest);
             return latest;
         }
 

--- a/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
@@ -418,8 +418,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
         [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.1.0", "4.1.0")]
         [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.1.0", "4.1.0")]
         [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.3.0")]
+        [InlineData("latest", "[4.*, 5.0.0)", null, "4.3.0")]
         [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.2.0")]
+        [InlineData("standard", "[4.*, 5.0.0)", null, "4.2.0")]
         [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.2.0")]
+        [InlineData("extended", "[4.*, 5.0.0)", null, "4.2.0")]
         public void WhenPlatformReleaseChannelSet_ExpectedVersionChosen(string platformReleaseChannelName, string versionRange, string hostConfigMaxVersion, string expectedVersion)
         {
             var range = VersionRange.Parse(versionRange);
@@ -462,7 +465,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
             var expected = "4.20.0";
 
             var loggedString = $"Unable to apply platform release channel configuration {platformReleaseChannelName}. Only one matching bundle version is available. {expected} will be used";
-            var mockLogger = GetVerifiableMockLogger(loggedString);
+            var mockLogger = GetVerifiableMockLogger(loggedString, LogLevel.Warning);
             var mockLoggerFactory = new Mock<ILoggerFactory>();
             mockLoggerFactory.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(() => mockLogger.Object);
 
@@ -485,7 +488,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
 
             var incorrectChannelName = "someIncorrectReleaseChannelName";
             var loggedString = $"Unknown platform release channel name {incorrectChannelName}. The latest bundle version, {expected}, will be used.";
-            var mockLogger = GetVerifiableMockLogger(loggedString);
+            var mockLogger = GetVerifiableMockLogger(loggedString, LogLevel.Warning);
             var mockLoggerFactory = new Mock<ILoggerFactory>();
             mockLoggerFactory.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(() => mockLogger.Object);
 
@@ -573,12 +576,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
             { "3.7.0", "3.10.0", "3.11.0", "3.15.0", "3.14.0", "2.16.0", "3.13.0", "3.12.0", "3.9.1", "2.12.1", "2.18.0", "3.16.0", "2.19.0", "3.17.0", "4.0.2", "2.20.0", "3.18.0", "4.1.0", "4.2.0", "2.21.0", "3.19.0", "3.19.2", "4.3.0", "3.20.0" };
         }
 
-        private Mock<ILogger> GetVerifiableMockLogger(string stringToVerify)
+        private Mock<ILogger> GetVerifiableMockLogger(string stringToVerify, LogLevel logLevel)
         {
             var mockLogger = new Mock<ILogger>();
             mockLogger
                 .Setup(x => x.Log(
-                    LogLevel.Information,
+                    logLevel,
                     It.IsAny<EventId>(),
                     It.Is<It.IsAnyType>((v, t) => v.ToString().Contains(stringToVerify)),
                     It.IsAny<Exception>(),


### PR DESCRIPTION
### Issue describing the changes in this PR

Backport of https://github.com/Azure/azure-functions-host/pull/10921

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
