### PR TITLE
Cherry-pick changes to release/in-proc/4.38 from patch/4.38.200: Update PS workers for patch (in-proc) (#10925), Platform release channel bundles resolution fix and additional logging (#10921), [in-proc backport] Support release channel settings in extension bundles resolution (#10915)

### DIFF
--- a/eng/build/Workers.Powershell.props
+++ b/eng/build/Workers.Powershell.props
@@ -7,7 +7,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" Version="4.0.4175" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" Version="4.0.4206" />
   </ItemGroup>
 
   <Target Name="RemovePowershellWorkerRuntimes" BeforeTargets="AssignTargetPaths" Condition="$(RuntimeIdentifier.StartsWith(win))">

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,5 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+
+- Add support for the release channel setting `WEBSITE_PlatformReleaseChannel` and use this value in extension bundles resolution.

--- a/release_notes.md
+++ b/release_notes.md
@@ -5,3 +5,4 @@
 -->
 
 - Add support for the release channel setting `WEBSITE_PlatformReleaseChannel` and use this value in extension bundles resolution.
+- Bug fix for platform release channel bundles resolution casing issue and additional logging (#10921)

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,12 +3,3 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-- Update Java Worker Version to [2.18.0](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.18.0)
-- Updated Microsoft.Extensions.DependencyModel to 6.0.2 and 8.0.2 for .NET 6 and .NET 8, respectively. (#10661)
-- Update the `DefaultHttpProxyService` to better handle client disconnect scenarios (#10688)
-  - Replaced `InvalidOperationException` with `HttpForwardingException` when there is a ForwarderError
-- [In-proc] Codeql : Fix to remove exception details from the response (#10751)
-- Update PowerShell 7.4 worker to [4.0.4134](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.4134)
-- Update Python Worker Version to [4.35.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.35.0)
-- Update domain for CDN URI
-- Update PowerShell worker to 4.0.4175 (sets defaultRuntimeVersion to 7.4 in worker.config.json)

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,3 +6,4 @@
 
 - Add support for the release channel setting `WEBSITE_PlatformReleaseChannel` and use this value in extension bundles resolution.
 - Bug fix for platform release channel bundles resolution casing issue and additional logging (#10921)
+- Update PowerShell worker to [4.0.4206](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.4206)

--- a/src/Directory.Version.props
+++ b/src/Directory.Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.$(MinorVersionPrefix)38.100</VersionPrefix>
+    <VersionPrefix>4.$(MinorVersionPrefix)38.200</VersionPrefix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 </Project>

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -141,6 +141,9 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AntaresPlatformVersionWindows = "WEBSITE_PLATFORM_VERSION";
         public const string AntaresPlatformVersionLinux = "PLATFORM_VERSION";
 
+        // Antares Release Channel / RU Feed Settings
+        public const string AntaresPlatformReleaseChannel = "WEBSITE_PlatformReleaseChannel";
+
         // Machine identifier
         public const string AntaresComputerName = "COMPUTERNAME";
 

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -5,10 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
-using System.IO.Pipes;
 using System.Linq;
 using System.Net.Http;
-using System.Resources;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Configuration;
@@ -27,15 +25,17 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
         private readonly FunctionsHostingConfigOptions _configOption;
         private readonly ILogger _logger;
         private readonly string _cdnUri;
+        private readonly string _platformReleaseChannel;
         private string _extensionBundleVersion;
 
         public ExtensionBundleManager(ExtensionBundleOptions options, IEnvironment environment, ILoggerFactory loggerFactory, FunctionsHostingConfigOptions configOption)
         {
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
             _logger = loggerFactory.CreateLogger<ExtensionBundleManager>() ?? throw new ArgumentNullException(nameof(loggerFactory));
-            _cdnUri = _environment.GetEnvironmentVariable(EnvironmentSettingNames.ExtensionBundleSourceUri) ?? ScriptConstants.ExtensionBundleDefaultSourceUri;
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _configOption = configOption ?? throw new ArgumentNullException(nameof(configOption));
+            _cdnUri = _environment.GetEnvironmentVariable(EnvironmentSettingNames.ExtensionBundleSourceUri) ?? ScriptConstants.ExtensionBundleDefaultSourceUri;
+            _platformReleaseChannel = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AntaresPlatformReleaseChannel) ?? ScriptConstants.LatestPlatformChannelNameUpper;
         }
 
         public async Task<ExtensionBundleDetails> GetExtensionBundleDetails()
@@ -250,7 +250,7 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
             return matchingBundleVersion;
         }
 
-        internal static string FindBestVersionMatch(VersionRange versionRange, IEnumerable<string> versions, string bundleId, FunctionsHostingConfigOptions configOption)
+        internal string FindBestVersionMatch(VersionRange versionRange, IEnumerable<string> versions, string bundleId, FunctionsHostingConfigOptions configOption)
         {
             var bundleVersions = versions.Select(p =>
             {
@@ -261,9 +261,9 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
                     version = versionRange.Satisfies(version) ? version : null;
                 }
                 return version;
-            }).Where(v => v != null);
+            }).Where(v => v != null).OrderByDescending(version => version.Version).ToList();
 
-            var matchingVersion = bundleVersions.OrderByDescending(version => version.Version).FirstOrDefault();
+            var matchingVersion = ResolvePlatformReleaseChannelVersion(bundleVersions);
 
             if (bundleId != ScriptConstants.DefaultExtensionBundleId)
             {
@@ -291,6 +291,42 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
             }
 
             return matchingVersion?.ToString();
+        }
+
+        private NuGetVersion ResolvePlatformReleaseChannelVersion(IList<NuGetVersion> orderedByDescBundles) => _platformReleaseChannel switch
+        {
+            ScriptConstants.StandardPlatformChannelNameUpper or ScriptConstants.ExtendedPlatformChannelNameUpper => GetStandardOrExtendedBundleVersion(orderedByDescBundles),
+            ScriptConstants.LatestPlatformChannelNameUpper or "" => GetLatestBundleVersion(orderedByDescBundles),
+            _ => HandleUnknownPlatformReleaseChannelName(orderedByDescBundles)
+        };
+
+        // Standard: Resolves to the version prior to the latest(n-1), if that version is available.
+        // Extended: Resolves to the version two releases prior to the latest(n-2), if that version is available.
+        // However, Functions and Rapid Update should treat Standard and Extended the same, resolving to n-1.
+        private NuGetVersion GetStandardOrExtendedBundleVersion(IList<NuGetVersion> orderedByDescBundlesList)
+        {
+            if (orderedByDescBundlesList.Count > 1)
+            {
+                // These channels should resolve to the version prior to latest. This list is in descending order, which makes latest [0], and prior-to-latest [1].
+                return orderedByDescBundlesList[1];
+            }
+
+            // keep the latest version, log a notice
+            var latest = orderedByDescBundlesList.FirstOrDefault();
+            _logger.LogInformation("Unable to apply platform release channel configuration {platformReleaseChannelName}. Only one matching bundle version is available. {latestBundleVersion} will be used", _platformReleaseChannel, latest);
+            return latest;
+        }
+
+        private static NuGetVersion GetLatestBundleVersion(IList<NuGetVersion> orderedByDescBundlesList)
+        {
+            return orderedByDescBundlesList.FirstOrDefault();
+        }
+
+        private NuGetVersion HandleUnknownPlatformReleaseChannelName(IList<NuGetVersion> orderedByDescBundlesList)
+        {
+            var latest = GetLatestBundleVersion(orderedByDescBundlesList);
+            _logger.LogInformation("Unknown platform release channel name {platformReleaseChannelName}. The latest bundle version, {latestBundleVersion}, will be used.", _platformReleaseChannel, latest);
+            return latest;
         }
 
         public async Task<string> GetExtensionBundleBinPathAsync()

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -293,7 +293,7 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
             return matchingVersion?.ToString();
         }
 
-        private NuGetVersion ResolvePlatformReleaseChannelVersion(IList<NuGetVersion> orderedByDescBundles) => _platformReleaseChannel switch
+        private NuGetVersion ResolvePlatformReleaseChannelVersion(IList<NuGetVersion> orderedByDescBundles) => _platformReleaseChannel.ToUpper() switch
         {
             ScriptConstants.StandardPlatformChannelNameUpper or ScriptConstants.ExtendedPlatformChannelNameUpper => GetStandardOrExtendedBundleVersion(orderedByDescBundles),
             ScriptConstants.LatestPlatformChannelNameUpper or "" => GetLatestBundleVersion(orderedByDescBundles),
@@ -305,27 +305,36 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
         // However, Functions and Rapid Update should treat Standard and Extended the same, resolving to n-1.
         private NuGetVersion GetStandardOrExtendedBundleVersion(IList<NuGetVersion> orderedByDescBundlesList)
         {
+            var latest = orderedByDescBundlesList.FirstOrDefault();
+
             if (orderedByDescBundlesList.Count > 1)
             {
+                var previous = orderedByDescBundlesList[1];
+                _logger.LogInformation("Applying platform release channel configuration {platformReleaseChannelName}. Previous bundle version {previous} will be used instead of latest version {latest}.", _platformReleaseChannel, previous, latest);
+
                 // These channels should resolve to the version prior to latest. This list is in descending order, which makes latest [0], and prior-to-latest [1].
-                return orderedByDescBundlesList[1];
+                return previous;
             }
 
             // keep the latest version, log a notice
-            var latest = orderedByDescBundlesList.FirstOrDefault();
-            _logger.LogInformation("Unable to apply platform release channel configuration {platformReleaseChannelName}. Only one matching bundle version is available. {latestBundleVersion} will be used", _platformReleaseChannel, latest);
+            _logger.LogWarning("Unable to apply platform release channel configuration {platformReleaseChannelName}. Only one matching bundle version is available. {latestBundleVersion} will be used", _platformReleaseChannel, latest);
             return latest;
         }
 
-        private static NuGetVersion GetLatestBundleVersion(IList<NuGetVersion> orderedByDescBundlesList)
+        private NuGetVersion GetLatestBundleVersion(IList<NuGetVersion> orderedByDescBundlesList)
         {
-            return orderedByDescBundlesList.FirstOrDefault();
+            var latest = orderedByDescBundlesList.FirstOrDefault();
+            if (string.Equals(_platformReleaseChannel.ToUpper(), ScriptConstants.LatestPlatformChannelNameUpper))
+            {
+                _logger.LogInformation("Applying platform release channel configuration {platformReleaseChannelName}. Bundle version {latest} will be used", _platformReleaseChannel, latest);
+            }
+            return latest;
         }
 
         private NuGetVersion HandleUnknownPlatformReleaseChannelName(IList<NuGetVersion> orderedByDescBundlesList)
         {
             var latest = GetLatestBundleVersion(orderedByDescBundlesList);
-            _logger.LogInformation("Unknown platform release channel name {platformReleaseChannelName}. The latest bundle version, {latestBundleVersion}, will be used.", _platformReleaseChannel, latest);
+            _logger.LogWarning("Unknown platform release channel name {platformReleaseChannelName}. The latest bundle version, {latestBundleVersion}, will be used.", _platformReleaseChannel, latest);
             return latest;
         }
 

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -214,6 +214,11 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string LogicAppDefaultExtensionBundleVersion = "[1.*, 2.0.0)";
         public const string DefaultExtensionBundleVersion = "[4.*, 5.0.0)";
 
+        // Antares Platform Channel Names, used in extension bundle resolution
+        public const string LatestPlatformChannelNameUpper = "LATEST";
+        public const string StandardPlatformChannelNameUpper = "STANDARD";
+        public const string ExtendedPlatformChannelNameUpper = "EXTENDED";
+
         public const string AzureMonitorTraceCategory = "FunctionAppLogs";
 
         public const string KubernetesManagedAppName = "K8SE_APP_NAME";

--- a/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
@@ -418,8 +418,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
         [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.1.0", "4.1.0")]
         [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.1.0", "4.1.0")]
         [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.3.0")]
+        [InlineData("latest", "[4.*, 5.0.0)", null, "4.3.0")]
         [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.2.0")]
+        [InlineData("standard", "[4.*, 5.0.0)", null, "4.2.0")]
         [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.2.0")]
+        [InlineData("extended", "[4.*, 5.0.0)", null, "4.2.0")]
         public void WhenPlatformReleaseChannelSet_ExpectedVersionChosen(string platformReleaseChannelName, string versionRange, string hostConfigMaxVersion, string expectedVersion)
         {
             var range = VersionRange.Parse(versionRange);
@@ -462,7 +465,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
             var expected = "4.20.0";
 
             var loggedString = $"Unable to apply platform release channel configuration {platformReleaseChannelName}. Only one matching bundle version is available. {expected} will be used";
-            var mockLogger = GetVerifiableMockLogger(loggedString);
+            var mockLogger = GetVerifiableMockLogger(loggedString, LogLevel.Warning);
             var mockLoggerFactory = new Mock<ILoggerFactory>();
             mockLoggerFactory.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(() => mockLogger.Object);
 
@@ -485,7 +488,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
 
             var incorrectChannelName = "someIncorrectReleaseChannelName";
             var loggedString = $"Unknown platform release channel name {incorrectChannelName}. The latest bundle version, {expected}, will be used.";
-            var mockLogger = GetVerifiableMockLogger(loggedString);
+            var mockLogger = GetVerifiableMockLogger(loggedString, LogLevel.Warning);
             var mockLoggerFactory = new Mock<ILoggerFactory>();
             mockLoggerFactory.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(() => mockLogger.Object);
 
@@ -573,12 +576,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
             { "3.7.0", "3.10.0", "3.11.0", "3.15.0", "3.14.0", "2.16.0", "3.13.0", "3.12.0", "3.9.1", "2.12.1", "2.18.0", "3.16.0", "2.19.0", "3.17.0", "4.0.2", "2.20.0", "3.18.0", "4.1.0", "4.2.0", "2.21.0", "3.19.0", "3.19.2", "4.3.0", "3.20.0" };
         }
 
-        private Mock<ILogger> GetVerifiableMockLogger(string stringToVerify)
+        private Mock<ILogger> GetVerifiableMockLogger(string stringToVerify, LogLevel logLevel)
         {
             var mockLogger = new Mock<ILogger>();
             mockLogger
                 .Setup(x => x.Log(
-                    LogLevel.Information,
+                    logLevel,
                     It.IsAny<EventId>(),
                     It.Is<It.IsAnyType>((v, t) => v.ToString().Contains(stringToVerify)),
                     It.IsAny<Exception>(),


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This PR contains the following changes:
- Update version to `4.38.200`
- Cherry-pick the following changes to `release/in-proc/4.38`:
   - https://github.com/Azure/azure-functions-host/pull/10925
   - https://github.com/Azure/azure-functions-host/pull/10921
   - https://github.com/Azure/azure-functions-host/pull/10915

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
