### PR TITLE
Adding support for faas.invoke_duration metric

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -11,3 +11,4 @@
 - Adjusting the logic to determine the warmup call in placeholder simulation mode to align with the production flow (#10918)
 - Fixing invalid DateTimes in status blobs when invoking via portal (#10916)
 - Bug fix for platform release channel bundles resolution casing issue and additional logging (#10921)
+- Adding support for faas.invoke_duration metric and other spec related updates (#10929)

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -1718,7 +1718,6 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             if (isOtelEnabled)
             {
                 Activity.Current?.AddTag(ResourceSemanticConventions.FaaSName, context.FunctionMetadata.Name);
-                Activity.Current?.AddTag(ResourceSemanticConventions.FaaSTrigger, OpenTelemetryConstants.ResolveTriggerType(context.FunctionMetadata?.Trigger?.Type));
             }
         }
 

--- a/src/WebJobs.Script.WebHost/Diagnostics/FunctionInstanceLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/FunctionInstanceLogger.cs
@@ -131,6 +131,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             }
 
             _metrics.EndEvent(invokeLatencyEvent);
+            _hostMetrics.TrackFunctionExecutionDuration(item.Duration.TotalSeconds, functionName);
         }
 
         public Task FlushAsync(CancellationToken cancellationToken = default(CancellationToken)) => Task.CompletedTask;

--- a/src/WebJobs.Script/Diagnostics/OpenTelemetry/FunctionsResourceDetector.cs
+++ b/src/WebJobs.Script/Diagnostics/OpenTelemetry/FunctionsResourceDetector.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Reflection;
 using OpenTelemetry.Resources;
 
 namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
@@ -22,7 +21,6 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
                 attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.ServiceVersion, version));
                 attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.AISDKPrefix, $@"{OpenTelemetryConstants.SDKPrefix}:{version}"));
                 attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.ProcessId, Process.GetCurrentProcess().Id));
-                attributeList.Add(new KeyValuePair<string, object>(ResourceSemanticConventions.FaaSVersion, version));
 
                 // Add these attributes only if running in Azure.
                 if (!string.IsNullOrEmpty(serviceName))

--- a/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
+++ b/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
@@ -51,95 +52,94 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
             }
 
             loggingBuilder
-                .AddOpenTelemetry(o =>
-                {
-                    o.SetResourceBuilder(ConfigureResource(ResourceBuilder.CreateDefault()));
-                    if (enableOtlp)
-                    {
-                        o.AddOtlpExporter();
-                    }
-                    if (enableAzureMonitor)
-                    {
-                        o.AddAzureMonitorLogExporter(options => ConfigureAzureMonitorOptions(options, azMonConnectionString, credential));
-                    }
-                    o.IncludeFormattedMessage = true;
-                    o.IncludeScopes = false;
-                })
-                .AddDefaultOpenTelemetryFilters();
+                .ConfigureLogging(enableOtlp, enableAzureMonitor, azMonConnectionString, credential).Services
+                .AddOpenTelemetry()
+                .ConfigureResource(r => ConfigureResource(r))
+                .ConfigureMetrics(enableOtlp, enableAzureMonitor, azMonConnectionString, credential)
+                .ConfigureTracing(enableOtlp, enableAzureMonitor, azMonConnectionString, credential)
+                .ConfigureEventLogLevel(context.Configuration);
 
             // Azure SDK instrumentation is experimental.
             AppContext.SetSwitch("Azure.Experimental.EnableActivitySource", true);
-
-            ConfigureTracing(loggingBuilder, enableOtlp, enableAzureMonitor, azMonConnectionString, credential);
-
-            ConfigureEventLogLevel(loggingBuilder, context.Configuration);
-
-            ConfigureMetrics(loggingBuilder, enableOtlp, enableAzureMonitor, azMonConnectionString, credential);
         }
 
-        private static void ConfigureMetrics(ILoggingBuilder loggingBuilder, bool enableOtlp, bool enableAzureMonitor, string azMonConnectionString, TokenCredential credential)
+        private static IOpenTelemetryBuilder ConfigureMetrics(this IOpenTelemetryBuilder builder, bool enableOtlp, bool enableAzureMonitor, string azMonConnectionString, TokenCredential credential)
         {
-            loggingBuilder.Services.AddOpenTelemetry()
-                .ConfigureResource(r => ConfigureResource(r))
-                .WithMetrics(builder =>
+            return builder.WithMetrics(builder =>
+            {
+                builder.AddAspNetCoreInstrumentation();
+                builder.AddMeter(HostMetrics.FaasMeterName);
+                builder.AddView(HostMetrics.FaasInvokeDuration, new ExplicitBucketHistogramConfiguration
                 {
-                    builder.AddAspNetCoreInstrumentation();
-                    builder.AddMeter(HostMetrics.MeterName);
-                    builder.AddView(HostMetrics.FaasInvokeDuration, new ExplicitBucketHistogramConfiguration
-                    {
-                        Boundaries = new double[] { 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 }
-                    });
-
-                    // Ignore all other metrics
-                    builder.AddView(instrument => instrument.Name == HostMetrics.FaasInvokeDuration ? new MetricStreamConfiguration() : MetricStreamConfiguration.Drop);
-
-                    if (enableOtlp)
-                    {
-                        builder.AddOtlpExporter();
-                    }
-                    if (enableAzureMonitor)
-                    {
-                        builder.AddAzureMonitorMetricExporter(opt => ConfigureAzureMonitorOptions(opt, azMonConnectionString, credential));
-                    }
+                    Boundaries = new double[] { 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 }
                 });
+
+                if (enableOtlp)
+                {
+                    builder.AddOtlpExporter();
+                }
+                if (enableAzureMonitor)
+                {
+                    builder.AddAzureMonitorMetricExporter(opt => ConfigureAzureMonitorOptions(opt, azMonConnectionString, credential));
+                }
+            });
         }
 
-        private static void ConfigureTracing(ILoggingBuilder loggingBuilder, bool enableOtlp, bool enableAzureMonitor, string azMonConnectionString, TokenCredential credential)
+        private static IOpenTelemetryBuilder ConfigureTracing(this IOpenTelemetryBuilder builder, bool enableOtlp, bool enableAzureMonitor, string azMonConnectionString, TokenCredential credential)
         {
-            loggingBuilder.Services.AddOpenTelemetry()
-                .ConfigureResource(r => ConfigureResource(r))
-                .WithTracing(builder =>
+            return builder.WithTracing(builder =>
+            {
+                builder.AddSource("Azure.*")
+                .AddAspNetCoreInstrumentation(o =>
                 {
-                    builder.AddSource("Azure.*")
-                    .AddAspNetCoreInstrumentation(o =>
+                    o.EnrichWithHttpResponse = (activity, httpResponse) =>
                     {
-                        o.EnrichWithHttpResponse = (activity, httpResponse) =>
+                        if (Activity.Current != null)
                         {
-                            if (Activity.Current != null)
-                            {
-                                var routingFeature = httpResponse.HttpContext.Features.Get<AspNetCore.Routing.IRoutingFeature>();
-                                var template = routingFeature.RouteData.Routers.FirstOrDefault(r => r is Route) as Route;
+                            var routingFeature = httpResponse.HttpContext.Features.Get<AspNetCore.Routing.IRoutingFeature>();
+                            var template = routingFeature.RouteData.Routers.FirstOrDefault(r => r is Route) as Route;
 
-                                Activity.Current.DisplayName = $"{Activity.Current.DisplayName} {template?.RouteTemplate}";
-                                Activity.Current.AddTag(ResourceSemanticConventions.HttpRoute, template?.RouteTemplate);
-                                Activity.Current.AddTag(ResourceSemanticConventions.FaaSTrigger, OpenTelemetryConstants.HttpTriggerType);
-                            }
-                        };
-                    });
-
-                    if (enableOtlp)
-                    {
-                        builder.AddOtlpExporter();
-                    }
-
-                    if (enableAzureMonitor)
-                    {
-                        builder.AddAzureMonitorTraceExporter(opt => ConfigureAzureMonitorOptions(opt, azMonConnectionString, credential));
-                        builder.AddLiveMetrics(opt => ConfigureAzureMonitorOptions(opt, azMonConnectionString, credential));
-                    }
-
-                    builder.AddProcessor(ActivitySanitizingProcessor.Instance);
+                            Activity.Current.DisplayName = $"{Activity.Current.DisplayName} {template?.RouteTemplate}";
+                            Activity.Current.AddTag(ResourceSemanticConventions.HttpRoute, template?.RouteTemplate);
+                            Activity.Current.AddTag(ResourceSemanticConventions.FaaSTrigger, OpenTelemetryConstants.HttpTriggerType);
+                        }
+                    };
                 });
+
+                if (enableOtlp)
+                {
+                    builder.AddOtlpExporter();
+                }
+
+                if (enableAzureMonitor)
+                {
+                    builder.AddAzureMonitorTraceExporter(opt => ConfigureAzureMonitorOptions(opt, azMonConnectionString, credential));
+                    builder.AddLiveMetrics(opt => ConfigureAzureMonitorOptions(opt, azMonConnectionString, credential));
+                }
+
+                builder.AddProcessor(ActivitySanitizingProcessor.Instance);
+            });
+        }
+
+        private static ILoggingBuilder ConfigureLogging(this ILoggingBuilder builder, bool enableOtlp, bool enableAzureMonitor, string azMonConnectionString, TokenCredential credential)
+        {
+            builder.AddOpenTelemetry(o =>
+            {
+                o.SetResourceBuilder(ConfigureResource(ResourceBuilder.CreateDefault()));
+                if (enableOtlp)
+                {
+                    o.AddOtlpExporter();
+                }
+                if (enableAzureMonitor)
+                {
+                    o.AddAzureMonitorLogExporter(options => ConfigureAzureMonitorOptions(options, azMonConnectionString, credential));
+                }
+                o.IncludeFormattedMessage = true;
+                o.IncludeScopes = false;
+            });
+            builder.AddDefaultOpenTelemetryFilters();
+
+            return builder;
         }
 
         private static ILoggingBuilder AddDefaultOpenTelemetryFilters(this ILoggingBuilder loggingBuilder)
@@ -148,15 +148,17 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
                 // These are messages piped back to the host from the worker - we don't handle these anymore if the worker has OpenTelemetry enabled.
                 // Instead, we expect the user's own code to be logging these where they want them to go.
                 .AddFilter<OpenTelemetryLoggerProvider>("Function.*", _ => !ScriptHost.WorkerOpenTelemetryEnabled)
-                .AddFilter<OpenTelemetryLoggerProvider>("Azure.*", _ => !ScriptHost.WorkerOpenTelemetryEnabled)
+
+                // Always filter out these logs
+                .AddFilter<OpenTelemetryLoggerProvider>("Azure.*", _ => false)
                 // Host.Results and Host.Aggregator are used to emit metrics, ignoring these categories.
-                .AddFilter<OpenTelemetryLoggerProvider>("Host.Results", _ => !ScriptHost.WorkerOpenTelemetryEnabled)
-                .AddFilter<OpenTelemetryLoggerProvider>("Host.Aggregator", _ => !ScriptHost.WorkerOpenTelemetryEnabled)
+                .AddFilter<OpenTelemetryLoggerProvider>("Host.Results", _ => false)
+                .AddFilter<OpenTelemetryLoggerProvider>("Host.Aggregator", _ => false)
                 // Ignoring all Microsoft.Azure.WebJobs.* logs like /getScriptTag and /lock.
-                .AddFilter<OpenTelemetryLoggerProvider>("Microsoft.Azure.WebJobs.*", _ => !ScriptHost.WorkerOpenTelemetryEnabled);
+                .AddFilter<OpenTelemetryLoggerProvider>("Microsoft.Azure.WebJobs.*", _ => false);
         }
 
-        private static void ConfigureEventLogLevel(ILoggingBuilder loggingBuilder, IConfiguration configuration)
+        private static IOpenTelemetryBuilder ConfigureEventLogLevel(this IOpenTelemetryBuilder builder, IConfiguration configuration)
         {
             string eventLogLevel = GetConfigurationValue(EnvironmentSettingNames.OpenTelemetryEventListenerLogLevel, configuration);
             EventLevel level = !string.IsNullOrEmpty(eventLogLevel) &&
@@ -164,7 +166,9 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
                                ? parsedLevel
                                : EventLevel.Warning;
 
-            loggingBuilder.Services.AddHostedService(_ => new OpenTelemetryEventListenerService(level));
+            builder.Services.AddHostedService(_ => new OpenTelemetryEventListenerService(level));
+
+            return builder;
         }
 
         private static ResourceBuilder ConfigureResource(ResourceBuilder builder)

--- a/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
+++ b/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
@@ -2,11 +2,15 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Diagnostics.Tracing;
+using System.Linq;
 using Azure.Core;
 using Azure.Identity;
 using Azure.Monitor.OpenTelemetry.Exporter;
 using Azure.Monitor.OpenTelemetry.LiveMetrics;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Azure.WebJobs.Script.Metrics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -69,6 +73,35 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
             ConfigureTracing(loggingBuilder, enableOtlp, enableAzureMonitor, azMonConnectionString, credential);
 
             ConfigureEventLogLevel(loggingBuilder, context.Configuration);
+
+            ConfigureMetrics(loggingBuilder, enableOtlp, enableAzureMonitor, azMonConnectionString, credential);
+        }
+
+        private static void ConfigureMetrics(ILoggingBuilder loggingBuilder, bool enableOtlp, bool enableAzureMonitor, string azMonConnectionString, TokenCredential credential)
+        {
+            loggingBuilder.Services.AddOpenTelemetry()
+                .ConfigureResource(r => ConfigureResource(r))
+                .WithMetrics(builder =>
+                {
+                    builder.AddAspNetCoreInstrumentation();
+                    builder.AddMeter(HostMetrics.MeterName);
+                    builder.AddView(HostMetrics.FaasInvokeDuration, new ExplicitBucketHistogramConfiguration
+                    {
+                        Boundaries = new double[] { 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 }
+                    });
+
+                    // Ignore all other metrics
+                    builder.AddView(instrument => instrument.Name == HostMetrics.FaasInvokeDuration ? new MetricStreamConfiguration() : MetricStreamConfiguration.Drop);
+
+                    if (enableOtlp)
+                    {
+                        builder.AddOtlpExporter();
+                    }
+                    if (enableAzureMonitor)
+                    {
+                        builder.AddAzureMonitorMetricExporter(opt => ConfigureAzureMonitorOptions(opt, azMonConnectionString, credential));
+                    }
+                });
         }
 
         private static void ConfigureTracing(ILoggingBuilder loggingBuilder, bool enableOtlp, bool enableAzureMonitor, string azMonConnectionString, TokenCredential credential)
@@ -78,7 +111,21 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
                 .WithTracing(builder =>
                 {
                     builder.AddSource("Azure.*")
-                           .AddAspNetCoreInstrumentation();
+                    .AddAspNetCoreInstrumentation(o =>
+                    {
+                        o.EnrichWithHttpResponse = (activity, httpResponse) =>
+                        {
+                            if (Activity.Current != null)
+                            {
+                                var routingFeature = httpResponse.HttpContext.Features.Get<AspNetCore.Routing.IRoutingFeature>();
+                                var template = routingFeature.RouteData.Routers.FirstOrDefault(r => r is Route) as Route;
+
+                                Activity.Current.DisplayName = $"{Activity.Current.DisplayName} {template?.RouteTemplate}";
+                                Activity.Current.AddTag(ResourceSemanticConventions.HttpRoute, template?.RouteTemplate);
+                                Activity.Current.AddTag(ResourceSemanticConventions.FaaSTrigger, OpenTelemetryConstants.HttpTriggerType);
+                            }
+                        };
+                    });
 
                     if (enableOtlp)
                     {

--- a/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConstants.cs
+++ b/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConstants.cs
@@ -13,16 +13,6 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
         internal const string ResourceGroupEnvVar = "WEBSITE_RESOURCE_GROUP";
         internal const string OwnerNameEnvVar = "WEBSITE_OWNER_NAME";
         internal const string AzureFunctionsGroup = "azure.functions.group";
-
-        internal static string ResolveTriggerType(string trigger)
-        {
-            switch (trigger)
-            {
-                case "httpTrigger":
-                    return "http";
-                default:
-                    return trigger;
-            }
-        }
+        internal const string HttpTriggerType = "http";
     }
 }

--- a/src/WebJobs.Script/Diagnostics/OpenTelemetry/ResourceSemanticConventions.cs
+++ b/src/WebJobs.Script/Diagnostics/OpenTelemetry/ResourceSemanticConventions.cs
@@ -14,14 +14,13 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
         internal const string CloudProvider = "cloud.provider";
         internal const string CloudPlatform = "cloud.platform";
         internal const string CloudRegion = "cloud.region";
-        internal const string CloudResourceId = "cloud.resource.id";
+        internal const string CloudResourceId = "cloud.resource_id";
 
         //FaaS
         internal const string FaaSTrigger = "faas.trigger";
         internal const string FaaSInvocationId = "faas.invocation_id";
         internal const string FaaSColdStart = "faas.coldstart";
         internal const string FaaSName = "faas.name";
-        internal const string FaaSVersion = "faas.version";
         internal const string FaaSInstance = "faas.instance";
 
         // Process
@@ -30,6 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
         // Http
         internal const string QueryUrl = "url.query";
         internal const string FullUrl = "url.full";
+        internal const string HttpRoute = "http.route";
 
         // AI
         internal const string AISDKPrefix = "ai.sdk.prefix";

--- a/src/WebJobs.Script/Metrics/HostMetrics.cs
+++ b/src/WebJobs.Script/Metrics/HostMetrics.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.WebJobs.Script.Metrics
         private readonly ILogger _logger;
 
         public const string MeterName = "Microsoft.Azure.WebJobs.Script.Host.Internal";
+        public const string FaasMeterName = "Microsoft.Azure.Functions.Host";
         public const string CloudPlatformName = "azure_functions";
         public const string AppFailureCount = "azure.functions.app_failures";
         public const string ActiveInvocationCount = "azure.functions.active_invocations";
@@ -64,7 +65,8 @@ namespace Microsoft.Azure.WebJobs.Script.Metrics
             _appFailureCount = meter.CreateCounter<long>(AppFailureCount, "numeric", "Number of times the host has failed to start.");
             _startedInvocationCount = meter.CreateCounter<long>(StartedInvocationCount, "numeric", "Number of function invocations that have started.");
 
-            _faasInvokeDuration = meter.CreateHistogram<double>(
+            var faasMeter = meterFactory.Create(new MeterOptions(FaasMeterName));
+            _faasInvokeDuration = faasMeter.CreateHistogram<double>(
                 name: FaasInvokeDuration,
                 unit: "s",
                 description: "Measures the duration of the function's logic execution.");

--- a/src/WebJobs.Script/Metrics/HostMetrics.cs
+++ b/src/WebJobs.Script/Metrics/HostMetrics.cs
@@ -21,8 +21,12 @@ namespace Microsoft.Azure.WebJobs.Script.Metrics
         public const string ActiveInvocationCount = "azure.functions.active_invocations";
         public const string StartedInvocationCount = "azure.functions.started_invocations";
 
+        // FaaS Metrics
+        public const string FaasInvokeDuration = "faas.invoke_duration";
+
         private Counter<long> _appFailureCount;
         private Counter<long> _startedInvocationCount;
+        private Histogram<double> _faasInvokeDuration;
 
         private KeyValuePair<string, object>? _cachedFunctionGroupTag = null;
 
@@ -59,6 +63,11 @@ namespace Microsoft.Azure.WebJobs.Script.Metrics
 
             _appFailureCount = meter.CreateCounter<long>(AppFailureCount, "numeric", "Number of times the host has failed to start.");
             _startedInvocationCount = meter.CreateCounter<long>(StartedInvocationCount, "numeric", "Number of function invocations that have started.");
+
+            _faasInvokeDuration = meter.CreateHistogram<double>(
+                name: FaasInvokeDuration,
+                unit: "s",
+                description: "Measures the duration of the function’s logic execution.");
         }
 
         private KeyValuePair<string, object> FunctionGroupTag
@@ -95,5 +104,14 @@ namespace Microsoft.Azure.WebJobs.Script.Metrics
         public void AppFailure() => _appFailureCount.Add(1, FunctionGroupTag);
 
         public void IncrementStartedInvocationCount() => _startedInvocationCount.Add(1, FunctionGroupTag);
+
+        public void TrackFunctionExecutionDuration(double duration, string functionName)
+        {
+            var tags = new TagList()
+            {
+                { ResourceSemanticConventions.FaaSName, functionName }
+            };
+            _faasInvokeDuration.Record(duration, tags);
+        }
     }
 }

--- a/src/WebJobs.Script/Metrics/HostMetrics.cs
+++ b/src/WebJobs.Script/Metrics/HostMetrics.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Script.Metrics
             _faasInvokeDuration = meter.CreateHistogram<double>(
                 name: FaasInvokeDuration,
                 unit: "s",
-                description: "Measures the duration of the function’s logic execution.");
+                description: "Measures the duration of the function's logic execution.");
         }
 
         private KeyValuePair<string, object> FunctionGroupTag

--- a/src/WebJobs.Script/Metrics/IHostMetrics.cs
+++ b/src/WebJobs.Script/Metrics/IHostMetrics.cs
@@ -19,5 +19,12 @@ namespace Microsoft.Azure.WebJobs.Script.Metrics
         /// that have started on a given instance.
         /// </summary>
         public void IncrementStartedInvocationCount();
+
+        /// <summary>
+        /// Measures the duration of the function’s logic execution.
+        /// </summary>
+        /// <param name="duration">Invoke duration.</param>
+        /// <param name="functionName">Function name.</param>
+        void TrackFunctionExecutionDuration(double duration, string functionName);
     }
 }

--- a/test/WebJobs.Script.Tests/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensionsTests.cs
@@ -166,6 +166,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.OpenTelemetry
             HasOtelServices(sc).Should().BeTrue();
             sc.Should().Contain(sd => sd.ServiceType.FullName == "OpenTelemetry.Trace.IConfigureTracerProviderBuilder");
             sc.Should().Contain(sd => sd.ServiceType.FullName == "OpenTelemetry.Logs.IConfigureLoggerProviderBuilder");
+            sc.Should().Contain(sd => sd.ServiceType.FullName == "OpenTelemetry.Metrics.IConfigureMeterProviderBuilder");
 
             host.Services.GetService<TelemetryClient>().Should().BeNull();
 
@@ -258,8 +259,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.OpenTelemetry
             using var host = hostBuilder.Build();
 
             // Act
-            var tracerProviderDescriptors = GetTracerProviderDescriptors(serviceCollection);
-            var resolvedClient = ExtractClientFromDescriptors(tracerProviderDescriptors);
+            var tracerProviderDescriptors = GetProviderDescriptors(serviceCollection, "IConfigureTracerProviderBuilder", "ConfigureTracerProviderBuilderCallbackWrapper");
+            var resolvedClient = ExtractTraceManagedIdentityCredential(tracerProviderDescriptors);
 
             // Extract the clientId from the client object
             var clientIdValue = resolvedClient?.GetType().GetProperty("ClientId", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(resolvedClient)?.ToString();
@@ -293,17 +294,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.OpenTelemetry
             using var host = hostBuilder.Build();
 
             // Act
-            var tracerProviderDescriptors = GetTracerProviderDescriptors(serviceCollection);
-            var resolvedClient = ExtractClientFromDescriptors(tracerProviderDescriptors);
+            var tracerProviderDescriptors = GetProviderDescriptors(serviceCollection, "IConfigureTracerProviderBuilder", "ConfigureTracerProviderBuilderCallbackWrapper");
+            var tracerResolvedClient = ExtractTraceManagedIdentityCredential(tracerProviderDescriptors);
+
+            var meterProviderDescriptors = GetProviderDescriptors(serviceCollection, "IConfigureMeterProviderBuilder", "ConfigureMeterProviderBuilderCallbackWrapper");
+            var meterResolvedClient = ExtractMeterManagedIdentityCredential(meterProviderDescriptors);
 
             // Extract the clientId from the client object
-            var clientIdValue = resolvedClient?.GetType().GetProperty("ClientId", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(resolvedClient)?.ToString();
+            var tracerClientIdValue = tracerResolvedClient?.GetType().GetProperty("ClientId", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(tracerResolvedClient)?.ToString();
+            var meterClientIdValue = meterResolvedClient?.GetType().GetProperty("ClientId", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(tracerResolvedClient)?.ToString();
 
             // Assert
             serviceCollection.Should().NotBeNullOrEmpty();
             // No clientId should be present as it was not provided
-            clientIdValue.Should().BeNull();
-            resolvedClient.GetType().Name.Should().Be("ManagedIdentityClient");
+            tracerClientIdValue.Should().BeNull();
+            meterClientIdValue.Should().BeNull();
+            tracerResolvedClient.GetType().Name.Should().Be("ManagedIdentityClient");
+            meterResolvedClient.GetType().Name.Should().Be("ManagedIdentityClient");
         }
 
         [Fact]
@@ -378,17 +385,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.OpenTelemetry
             });
         }
 
-        private static List<ServiceDescriptor> GetTracerProviderDescriptors(IServiceCollection services)
+        private static List<ServiceDescriptor> GetProviderDescriptors(IServiceCollection services, string serviceType, string instance)
         {
             return services
                 .Where(descriptor =>
                     descriptor.Lifetime == ServiceLifetime.Singleton &&
-                    descriptor.ServiceType.Name == "IConfigureTracerProviderBuilder" &&
-                    descriptor.ImplementationInstance?.GetType().Name == "ConfigureTracerProviderBuilderCallbackWrapper")
+                    descriptor.ServiceType.Name == serviceType &&
+                    descriptor.ImplementationInstance?.GetType().Name == instance)
                 .ToList();
         }
 
-        private static object ExtractClientFromDescriptors(List<ServiceDescriptor> descriptors)
+        private static object ExtractTraceManagedIdentityCredential(List<ServiceDescriptor> descriptors)
         {
             foreach (var descriptor in descriptors)
             {
@@ -413,6 +420,62 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.OpenTelemetry
                             var clientProperty = managedIdentityCredential.GetType().GetProperty("Client", BindingFlags.Instance | BindingFlags.NonPublic);
                             return clientProperty?.GetValue(managedIdentityCredential);
                         }
+                    }
+                }
+            }
+            return null;
+        }
+
+        private static object ExtractMeterManagedIdentityCredential(List<ServiceDescriptor> descriptors)
+        {
+            foreach (var descriptor in descriptors)
+            {
+                if (descriptor.ImplementationInstance is not { } implementation)
+                {
+                    continue;
+                }
+
+                var configureField = implementation.GetType().GetField("configure", BindingFlags.Instance | BindingFlags.NonPublic);
+                if (configureField?.GetValue(implementation) is not Action<IServiceProvider, MeterProviderBuilder> configureAction)
+                {
+                    continue;
+                }
+
+                var firstTarget = configureAction.Target;
+                if (firstTarget is null)
+                {
+                    continue;
+                }
+
+                foreach (var field in firstTarget.GetType().GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+                {
+                    if (field.GetValue(firstTarget) is not Delegate secondDelegate)
+                    {
+                        continue;
+                    }
+
+                    var secondTarget = secondDelegate.Target;
+                    if (secondTarget is null)
+                    {
+                        continue;
+                    }
+
+                    var configureField2 = secondTarget.GetType().GetField("configure", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                    if (configureField2?.GetValue(secondTarget) is not Delegate configureAction2)
+                    {
+                        continue;
+                    }
+
+                    var thirdTarget = configureAction2.Target;
+                    if (thirdTarget is null)
+                    {
+                        continue;
+                    }
+
+                    var credentialField = thirdTarget.GetType().GetField("credential", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                    if (credentialField?.GetValue(thirdTarget) is ManagedIdentityCredential managedIdentityCredential)
+                    {
+                        return managedIdentityCredential;
                     }
                 }
             }

--- a/test/WebJobs.Script.Tests/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensionsTests.cs
@@ -222,7 +222,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.OpenTelemetry
             Resource resource = detector.Detect();
 
             Assert.Equal($"/subscriptions/AAAAA-AAAAA-AAAAA-AAA/resourceGroups/rg/providers/Microsoft.Web/sites/appName",
-                resource.Attributes.FirstOrDefault(a => a.Key == "cloud.resource.id").Value);
+                resource.Attributes.FirstOrDefault(a => a.Key == "cloud.resource_id").Value);
             Assert.Equal($"EastUS", resource.Attributes.FirstOrDefault(a => a.Key == "cloud.region").Value);
         }
 
@@ -232,7 +232,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.OpenTelemetry
             FunctionsResourceDetector detector = new FunctionsResourceDetector();
             Resource resource = detector.Detect();
 
-            Assert.Equal(4, resource.Attributes.Count());
+            Assert.Equal(3, resource.Attributes.Count());
         }
 
         [Fact]
@@ -302,7 +302,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.OpenTelemetry
 
             // Extract the clientId from the client object
             var tracerClientIdValue = tracerResolvedClient?.GetType().GetProperty("ClientId", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(tracerResolvedClient)?.ToString();
-            var meterClientIdValue = meterResolvedClient?.GetType().GetProperty("ClientId", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(tracerResolvedClient)?.ToString();
+            var meterClientIdValue = meterResolvedClient?.GetType().GetProperty("ClientId", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(meterResolvedClient)?.ToString();
 
             // Assert
             serviceCollection.Should().NotBeNullOrEmpty();
@@ -310,7 +310,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.OpenTelemetry
             tracerClientIdValue.Should().BeNull();
             meterClientIdValue.Should().BeNull();
             tracerResolvedClient.GetType().Name.Should().Be("ManagedIdentityClient");
-            meterResolvedClient.GetType().Name.Should().Be("ManagedIdentityClient");
+            meterResolvedClient.GetType().Name.Should().Be("ManagedIdentityCredential");
         }
 
         [Fact]


### PR DESCRIPTION
- Adding support for faas.invoke_duration metric. 
- Updating attributes as per updated spec.
- Removed faas.version as it's no longer applicable.
- Setting http.route and display name.


<img width="551" alt="image" src="https://github.com/user-attachments/assets/463714fd-ab96-448a-8a83-321eae395d29" />


resolves #10454 
### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
