### PR TITLE
Adding a null check for routingFeature.

### DIFF
--- a/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
+++ b/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
@@ -96,14 +96,17 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
                     {
                         if (Activity.Current is not null)
                         {
-                            var routingFeature = httpResponse.HttpContext.Features.Get<IRoutingFeature>();
-                            if (routingFeature is not null)
-                            {
-                                var template = routingFeature.RouteData.Routers.FirstOrDefault(r => r is Route) as Route;
-                                Activity.Current.DisplayName = $"{Activity.Current.DisplayName} {template?.RouteTemplate}";
-                                Activity.Current.AddTag(ResourceSemanticConventions.HttpRoute, template?.RouteTemplate);
-                            }
                             Activity.Current.AddTag(ResourceSemanticConventions.FaaSTrigger, OpenTelemetryConstants.HttpTriggerType);
+
+                            var routingFeature = httpResponse.HttpContext.Features.Get<IRoutingFeature>();
+                            if (routingFeature is null)
+                            {
+                                return;
+                            }
+
+                            var template = routingFeature.RouteData.Routers.FirstOrDefault(r => r is Route) as Route;
+                            Activity.Current.DisplayName = $"{Activity.Current.DisplayName} {template?.RouteTemplate}";
+                            Activity.Current.AddTag(ResourceSemanticConventions.HttpRoute, template?.RouteTemplate);
                         }
                     };
                 });

--- a/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
+++ b/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
@@ -94,13 +94,15 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
                 {
                     o.EnrichWithHttpResponse = (activity, httpResponse) =>
                     {
-                        if (Activity.Current != null)
+                        if (Activity.Current is not null)
                         {
-                            var routingFeature = httpResponse.HttpContext.Features.Get<AspNetCore.Routing.IRoutingFeature>();
-                            var template = routingFeature.RouteData.Routers.FirstOrDefault(r => r is Route) as Route;
-
-                            Activity.Current.DisplayName = $"{Activity.Current.DisplayName} {template?.RouteTemplate}";
-                            Activity.Current.AddTag(ResourceSemanticConventions.HttpRoute, template?.RouteTemplate);
+                            var routingFeature = httpResponse.HttpContext.Features.Get<IRoutingFeature>();
+                            if (routingFeature is not null)
+                            {
+                                var template = routingFeature.RouteData.Routers.FirstOrDefault(r => r is Route) as Route;
+                                Activity.Current.DisplayName = $"{Activity.Current.DisplayName} {template?.RouteTemplate}";
+                                Activity.Current.AddTag(ResourceSemanticConventions.HttpRoute, template?.RouteTemplate);
+                            }
                             Activity.Current.AddTag(ResourceSemanticConventions.FaaSTrigger, OpenTelemetryConstants.HttpTriggerType);
                         }
                     };


### PR DESCRIPTION
Adding a null check for `RoutingFeature`. This is null in placeholder mode.

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
