### PR TITLE
Patch - 4.38.400 - add 'unix' to PowerShell worker runtimes on Linux

### DIFF
--- a/eng/build/Workers.Powershell.props
+++ b/eng/build/Workers.Powershell.props
@@ -9,7 +9,7 @@
   <Target Name="RemovePowershellWorkerRuntimes" BeforeTargets="AssignTargetPaths" Condition="'$(RuntimeIdentifier)' != ''">
     <ItemGroup>
       <_KeepPowerShellRuntime Include="win;win-x86;win10-x86;win-x64;win10-x64" Condition="$(RuntimeIdentifier.StartsWith(win))" />
-      <_KeepPowerShellRuntime Include="linux;linux-x64" Condition="$(RuntimeIdentifier.StartsWith(linux))" />
+      <_KeepPowerShellRuntime Include="linux;linux-x64;unix" Condition="$(RuntimeIdentifier.StartsWith(linux))" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,6 +3,3 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-- Update Java Worker Version to [2.18.1](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.18.1)
-- Bug fix for platform release channel bundles resolution casing issue and additional logging (#10921)
-- Update PowerShell worker to [4.0.4206](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.4206)

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Add 'unix' to the list of runtimes kept when importing PowerShell worker for Linux builds

--- a/src/Directory.Version.props
+++ b/src/Directory.Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.1038.300</VersionPrefix>
+    <VersionPrefix>4.1038.400</VersionPrefix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Resolves an issue with the PowerShell worker on Linux missing assemblies

These changes should be made available on both dev and in-proc once 4.38 release is complete

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
