### PR TITLE
making GetFunctionMetadataAsync idempotent

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -12,3 +12,4 @@
 - Fixing invalid DateTimes in status blobs when invoking via portal (#10916)
 - Bug fix for platform release channel bundles resolution casing issue and additional logging (#10921)
 - Adding support for faas.invoke_duration metric and other spec related updates (#10929)
+- Fixed bug that could result in "Binding names must be unique" error (#10938)

--- a/src/WebJobs.Script.Abstractions/WebJobs.Script.Abstractions.csproj
+++ b/src/WebJobs.Script.Abstractions/WebJobs.Script.Abstractions.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.21.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
+++ b/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Rpc.Core" Version="3.0.37" />
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="all" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     <PackageReference Include="Yarp.ReverseProxy" Version="2.0.1" />
   </ItemGroup>

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -72,7 +72,7 @@
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(IdentityDependencyVersion)" />
     <PackageReference Include="Microsoft.Security.Utilities" Version="1.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="all" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="$(IdentityDependencyVersion)" />
 
     <!--

--- a/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
@@ -251,6 +251,10 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             HashSet<string> bindingNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+            // This method takes the RawBindings and adds them to the FunctionMetadata object. It's possible
+            // to call this twice, and we don't want to duplicate the bindings in that case.
+            function.Bindings.Clear();
+
             foreach (string binding in rawBindings)
             {
                 var deserializedObj = JsonConvert.DeserializeObject<JObject>(binding, _dateTimeSerializerSettings);

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -56,7 +56,7 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="all" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
     <PackageReference Include="System.Formats.Asn1" Version="6.0.1" />

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.35.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/WebJobs.Script.Tests/WorkerFunctionMetadataProviderTests.cs
+++ b/test/WebJobs.Script.Tests/WorkerFunctionMetadataProviderTests.cs
@@ -269,15 +269,27 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var workerConfigs = new List<RpcWorkerConfig>();
 
+            // Calling this twice should return the same data
             var result1 = await provider.GetFunctionMetadataAsync(workerConfigs, true);
             var result2 = await provider.GetFunctionMetadataAsync(workerConfigs, true);
 
             var function1 = result1.Functions.Single();
             var function2 = result2.Functions.Single();
 
-            // Current bug is that calling GetFunctionMetadataAsync twice will add the same binding twice!
-            Assert.Single(function1.Bindings);
-            Assert.Single(function2.Bindings);
+            static void AssertFunction(FunctionMetadata function)
+            {
+                Assert.Equal("TestFunction", function.Name);
+                Assert.Equal("node", function.Language);
+                Assert.Collection(function.Bindings, binding =>
+                {
+                    Assert.Equal("httpTrigger", binding.Type);
+                    Assert.Equal("req", binding.Name);
+                    Assert.Equal(BindingDirection.In, binding.Direction);
+                });
+            }
+
+            AssertFunction(function1);
+            AssertFunction(function2);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/WorkerFunctionMetadataProviderTests.cs
+++ b/test/WebJobs.Script.Tests/WorkerFunctionMetadataProviderTests.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
-        public async Task GetFunctionMetadataAsync_AddsFunctionToMetadataList()
+        public async Task GetFunctionMetadataAsync_Idempotent()
         {
             var mockFunctionMetadataProvider = new Mock<IWorkerFunctionMetadataProvider>(MockBehavior.Strict);
             var mockChannelManager = new Mock<IWebHostRpcWorkerChannelManager>(MockBehavior.Strict);

--- a/test/WebJobs.Script.Tests/WorkerFunctionMetadataProviderTests.cs
+++ b/test/WebJobs.Script.Tests/WorkerFunctionMetadataProviderTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -29,11 +30,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var mockScriptHostManager = new Mock<IScriptHostManager>();
 
             _workerFunctionMetadataProvider = new WorkerFunctionMetadataProvider(
-             mockScriptOptions.Object,
-             mockLogger.Object,
-             mockEnvironment.Object,
-             mockChannelManager.Object,
-             mockScriptHostManager.Object);
+                mockScriptOptions.Object,
+                mockLogger.Object,
+                mockEnvironment.Object,
+                mockChannelManager.Object,
+                mockScriptHostManager.Object);
         }
 
         [Fact]
@@ -220,6 +221,63 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var function = _workerFunctionMetadataProvider.ValidateBindings(rawBindings, functionMetadata);
             Assert.Equal(isoString, function.Bindings.FirstOrDefault().Raw["startFromTime"].ToString());
+        }
+
+        [Fact]
+        public async Task GetFunctionMetadataAsync_AddsFunctionToMetadataList()
+        {
+            var mockFunctionMetadataProvider = new Mock<IWorkerFunctionMetadataProvider>(MockBehavior.Strict);
+            var mockChannelManager = new Mock<IWebHostRpcWorkerChannelManager>(MockBehavior.Strict);
+            var mockScriptHostManager = new Mock<IScriptHostManager>(MockBehavior.Strict);
+            var mockOptionsMonitor = new Mock<IOptionsMonitor<ScriptApplicationHostOptions>>(MockBehavior.Strict);
+            var scriptOptions = new ScriptApplicationHostOptions
+            {
+                IsFileSystemReadOnly = true
+            };
+            mockOptionsMonitor.Setup(m => m.CurrentValue).Returns(scriptOptions);
+
+            var testEnvironment = new TestEnvironment();
+            testEnvironment.SetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME", "node");
+
+            var mockRpcWorkerChannel = new Mock<IRpcWorkerChannel>(MockBehavior.Strict);
+            var rawFunctionMetadataList = new List<RawFunctionMetadata>
+            {
+                new RawFunctionMetadata
+                {
+                    Metadata = new FunctionMetadata { Name = "TestFunction" },
+                    Bindings = ["{\"type\": \"httpTrigger\", \"name\": \"req\", \"direction\": \"in\"}"],
+                    UseDefaultMetadataIndexing = false
+                }
+            };
+            mockRpcWorkerChannel.Setup(m => m.GetFunctionMetadata()).ReturnsAsync(rawFunctionMetadataList);
+
+            var tcs = new TaskCompletionSource<IRpcWorkerChannel>();
+            tcs.SetResult(mockRpcWorkerChannel.Object);
+            var channels = new Dictionary<string, TaskCompletionSource<IRpcWorkerChannel>>
+            {
+                { "testWorkerId", tcs }
+            };
+
+            mockChannelManager.Setup(m => m.GetChannels("node")).Returns(channels);
+
+            var provider = new WorkerFunctionMetadataProvider(
+                mockOptionsMonitor.Object,
+                NullLogger<WorkerFunctionMetadataProvider>.Instance,
+                testEnvironment,
+                mockChannelManager.Object,
+                mockScriptHostManager.Object);
+
+            var workerConfigs = new List<RpcWorkerConfig>();
+
+            var result1 = await provider.GetFunctionMetadataAsync(workerConfigs, true);
+            var result2 = await provider.GetFunctionMetadataAsync(workerConfigs, true);
+
+            var function1 = result1.Functions.Single();
+            var function2 = result2.Functions.Single();
+
+            // Current bug is that calling GetFunctionMetadataAsync twice will add the same binding twice!
+            Assert.Single(function1.Bindings);
+            Assert.Single(function2.Bindings);
         }
     }
 }


### PR DESCRIPTION
Bug found during CRI investigation that can lead to "Binding names must be unique" error.

Scenario was that customer had one instance out of many that, during startup, hit "Binding names must be unique" across all of their functions on that instance. This meant that we didn't enable any functions on this one instance and they ended up getting 404s any time the FE sent requests to it (all other instances were fine).

What I found on this one instance was that the platform specialized the app while it was in the middle of running the "infrastructure warmup" call. This caused specialization to occur when the process was not completely ready, which resulted in one extra restart request.

We seem to only ever expect a restart to happen once, but since it happened twice, we ran through the GetFunctionMetadataAsync() method twice with the same worker-indexed functions. This method has a bug where it modifies existing objects and creates bindings every time you call it. This resulted in duplicate bindings here.

This entire flow is being actively redesigned right now, so I did a very targeted fix for this one scenario so we don't hit it again while working on the new design.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)