### PR TITLE
Exclude test data from functions endpoint response

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -12,3 +12,4 @@
 - Fixing invalid DateTimes in status blobs when invoking via portal (#10916)
 - Bug fix for platform release channel bundles resolution casing issue and additional logging (#10921)
 - Adding support for faas.invoke_duration metric and other spec related updates (#10929)
+- Added the option to exclude test data from the `/functions` endpoint API response (#10943)

--- a/src/WebJobs.Script.WebHost/Extensions/FunctionMetadataExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Extensions/FunctionMetadataExtensions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Extensions
                 response.ConfigHref = VirtualFileSystem.FilePathToVfsUri(functionMetadataFilePath, baseUrl, hostOptions);
             }
 
-            if (!string.IsNullOrEmpty(hostOptions.TestDataPath) && !excludeTestData)
+            if (!excludeTestData && !string.IsNullOrEmpty(hostOptions.TestDataPath))
             {
                 var testDataFilePath = functionMetadata.GetTestDataFilePath(hostOptions);
                 response.TestDataHref = VirtualFileSystem.FilePathToVfsUri(testDataFilePath, baseUrl, hostOptions);

--- a/src/WebJobs.Script.WebHost/Extensions/FunctionMetadataExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Extensions/FunctionMetadataExtensions.cs
@@ -19,8 +19,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Extensions
         /// </summary>
         /// <param name="functionMetadata">FunctionMetadata to be mapped.</param>
         /// <param name="hostOptions">The host options.</param>
+        /// <param name="excludeTestData">If true, the returned <see cref="FunctionMetadataResponse"/> will not populate the <see cref="FunctionMetadataResponse.TestData"/> property.</param>
         /// <returns>Promise of a FunctionMetadataResponse.</returns>
-        public static async Task<FunctionMetadataResponse> ToFunctionMetadataResponse(this FunctionMetadata functionMetadata, ScriptJobHostOptions hostOptions, string routePrefix, string baseUrl)
+        public static async Task<FunctionMetadataResponse> ToFunctionMetadataResponse(this FunctionMetadata functionMetadata, ScriptJobHostOptions hostOptions, string routePrefix, string baseUrl, bool excludeTestData)
         {
             string functionPath = GetFunctionPathOrNull(hostOptions.RootScriptPath, functionMetadata.Name);
             string functionMetadataFilePath = GetMetadataPathOrNull(functionPath);
@@ -54,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Extensions
                 response.ConfigHref = VirtualFileSystem.FilePathToVfsUri(functionMetadataFilePath, baseUrl, hostOptions);
             }
 
-            if (!string.IsNullOrEmpty(hostOptions.TestDataPath))
+            if (!string.IsNullOrEmpty(hostOptions.TestDataPath) && !excludeTestData)
             {
                 var testDataFilePath = functionMetadata.GetTestDataFilePath(hostOptions);
                 response.TestDataHref = VirtualFileSystem.FilePathToVfsUri(testDataFilePath, baseUrl, hostOptions);
@@ -194,7 +195,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Extensions
 
         private static async Task<string> GetTestData(string testDataPath, ScriptJobHostOptions config)
         {
-            if (!File.Exists(testDataPath))
+            if (!FileUtility.FileExists(testDataPath))
             {
                 FileUtility.EnsureDirectoryExists(Path.GetDirectoryName(testDataPath));
                 await FileUtility.WriteAsync(testDataPath, string.Empty);

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -339,7 +339,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
             // Add all listable functions details to the payload
             var listableFunctions = _functionMetadataManager.GetFunctionMetadata().Where(m => !m.IsCodeless());
-            var functionDetails = await WebFunctionsManager.GetFunctionMetadataResponse(listableFunctions, hostOptions, _hostNameProvider, excludeTestData: _hostingConfigOptions.Value.EnableTestDataSuppression);
+            var functionDetails = await WebFunctionsManager.GetFunctionMetadataResponse(listableFunctions, hostOptions, _hostNameProvider, excludeTestData: _hostingConfigOptions.Value.IsTestDataSuppressionEnabled);
             result.Add("functions", new JArray(functionDetails.Select(p => JObject.FromObject(p))));
 
             // TEMP: refactor this code to properly add extensions in all scenario(#7394)

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -339,7 +339,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
             // Add all listable functions details to the payload
             var listableFunctions = _functionMetadataManager.GetFunctionMetadata().Where(m => !m.IsCodeless());
-            var functionDetails = await WebFunctionsManager.GetFunctionMetadataResponse(listableFunctions, hostOptions, _hostNameProvider, excludeTestData: _hostingConfigOptions.Value.EnableTestDataExclusionInApiResponse);
+            var functionDetails = await WebFunctionsManager.GetFunctionMetadataResponse(listableFunctions, hostOptions, _hostNameProvider, excludeTestData: _hostingConfigOptions.Value.EnableTestDataSuppression);
             result.Add("functions", new JArray(functionDetails.Select(p => JObject.FromObject(p))));
 
             // TEMP: refactor this code to properly add extensions in all scenario(#7394)

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -339,7 +339,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
             // Add all listable functions details to the payload
             var listableFunctions = _functionMetadataManager.GetFunctionMetadata().Where(m => !m.IsCodeless());
-            var functionDetails = await WebFunctionsManager.GetFunctionMetadataResponse(listableFunctions, hostOptions, _hostNameProvider);
+            var functionDetails = await WebFunctionsManager.GetFunctionMetadataResponse(listableFunctions, hostOptions, _hostNameProvider, excludeTestData: _hostingConfigOptions.Value.EnableTestDataExclusionInApiResponse);
             result.Add("functions", new JArray(functionDetails.Select(p => JObject.FromObject(p))));
 
             // TEMP: refactor this code to properly add extensions in all scenario(#7394)

--- a/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
@@ -7,14 +7,12 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Azure;
-using Azure.Core;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Management.Models;
 using Microsoft.Azure.WebJobs.Script.WebHost.Extensions;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
@@ -33,9 +31,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         private readonly IFunctionMetadataManager _functionMetadataManager;
         private readonly IHostFunctionMetadataProvider _hostFunctionMetadataProvider;
         private readonly IOptionsMonitor<LanguageWorkerOptions> _languageWorkerOptions;
+        private readonly IOptions<FunctionsHostingConfigOptions> _hostingConfigOptions;
 
         public WebFunctionsManager(IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, ILoggerFactory loggerFactory, IHttpClientFactory httpClientFactory, ISecretManagerProvider secretManagerProvider, IFunctionsSyncManager functionsSyncManager, HostNameProvider hostNameProvider, IFunctionMetadataManager functionMetadataManager, IHostFunctionMetadataProvider hostFunctionMetadataProvider,
-            IOptionsMonitor<LanguageWorkerOptions> languageWorkerOptions)
+            IOptionsMonitor<LanguageWorkerOptions> languageWorkerOptions, IOptions<FunctionsHostingConfigOptions> hostingConfigOptions)
         {
             _applicationHostOptions = applicationHostOptions;
             _logger = loggerFactory?.CreateLogger(ScriptConstants.LogCategoryHostGeneral);
@@ -46,6 +45,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             _functionMetadataManager = functionMetadataManager;
             _hostFunctionMetadataProvider = hostFunctionMetadataProvider;
             _languageWorkerOptions = languageWorkerOptions;
+            _hostingConfigOptions = hostingConfigOptions;
         }
 
         public async Task<IEnumerable<FunctionMetadataResponse>> GetFunctionsMetadata(bool includeProxies)
@@ -53,14 +53,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             var hostOptions = _applicationHostOptions.CurrentValue.ToHostOptions();
             var functionsMetadata = GetFunctionsMetadata(includeProxies, forceRefresh: false);
 
-            return await GetFunctionMetadataResponse(functionsMetadata, hostOptions, _hostNameProvider);
+            return await GetFunctionMetadataResponse(functionsMetadata, hostOptions, _hostNameProvider, excludeTestData: _hostingConfigOptions.Value.EnableTestDataExclusionInApiResponse);
         }
 
-        internal static async Task<IEnumerable<FunctionMetadataResponse>> GetFunctionMetadataResponse(IEnumerable<FunctionMetadata> functionsMetadata, ScriptJobHostOptions hostOptions, HostNameProvider hostNameProvider)
+        internal static async Task<IEnumerable<FunctionMetadataResponse>> GetFunctionMetadataResponse(IEnumerable<FunctionMetadata> functionsMetadata, ScriptJobHostOptions hostOptions, HostNameProvider hostNameProvider, bool excludeTestData)
         {
             string baseUrl = GetBaseUrl(hostNameProvider);
             string routePrefix = await GetRoutePrefix(hostOptions.RootScriptPath);
-            var tasks = functionsMetadata.Select(p => p.ToFunctionMetadataResponse(hostOptions, routePrefix, baseUrl));
+            var tasks = functionsMetadata.Select(p => p.ToFunctionMetadataResponse(hostOptions, routePrefix, baseUrl, excludeTestData));
 
             return await tasks.WhenAll();
         }
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             FunctionMetadataResponse functionMetadataResult = null;
             if (metadata != null)
             {
-                functionMetadataResult = await GetFunctionMetadataResponseAsync(metadata, hostOptions, request);
+                functionMetadataResult = await GetFunctionMetadataResponseAsync(metadata, hostOptions, request, _hostingConfigOptions.Value.EnableTestDataExclusionInApiResponse);
                 success = true;
             }
 
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
             if (functionMetadata != null)
             {
-                var functionMetadataResponse = await GetFunctionMetadataResponseAsync(functionMetadata, hostOptions, request);
+                var functionMetadataResponse = await GetFunctionMetadataResponseAsync(functionMetadata, hostOptions, request, _hostingConfigOptions.Value.EnableTestDataExclusionInApiResponse);
                 return (true, functionMetadataResponse);
             }
             else
@@ -245,11 +245,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             }
         }
 
-        private static async Task<FunctionMetadataResponse> GetFunctionMetadataResponseAsync(FunctionMetadata functionMetadata, ScriptJobHostOptions hostOptions, HttpRequest request)
+        private async Task<FunctionMetadataResponse> GetFunctionMetadataResponseAsync(FunctionMetadata functionMetadata, ScriptJobHostOptions hostOptions, HttpRequest request, bool excludeTestData)
         {
             string routePrefix = await GetRoutePrefix(hostOptions.RootScriptPath);
             var baseUrl = $"{request.Scheme}://{request.Host}";
-            return await functionMetadata.ToFunctionMetadataResponse(hostOptions, routePrefix, baseUrl);
+            return await functionMetadata.ToFunctionMetadataResponse(hostOptions, routePrefix, baseUrl, excludeTestData);
         }
 
         // TODO : Due to lifetime scoping issues (this service lifetime is longer than the lifetime

--- a/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             var hostOptions = _applicationHostOptions.CurrentValue.ToHostOptions();
             var functionsMetadata = GetFunctionsMetadata(includeProxies, forceRefresh: false);
 
-            return await GetFunctionMetadataResponse(functionsMetadata, hostOptions, _hostNameProvider, excludeTestData: _hostingConfigOptions.Value.EnableTestDataExclusionInApiResponse);
+            return await GetFunctionMetadataResponse(functionsMetadata, hostOptions, _hostNameProvider, excludeTestData: _hostingConfigOptions.Value.EnableTestDataSuppression);
         }
 
         internal static async Task<IEnumerable<FunctionMetadataResponse>> GetFunctionMetadataResponse(IEnumerable<FunctionMetadata> functionsMetadata, ScriptJobHostOptions hostOptions, HostNameProvider hostNameProvider, bool excludeTestData)
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 configChanged = true;
             }
 
-            if (functionMetadata.TestData != null)
+            if (functionMetadata.TestData != null && !_hostingConfigOptions.Value.EnableTestDataSuppression)
             {
                 await FileUtility.WriteAsync(dataFilePath, functionMetadata.TestData);
             }
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             FunctionMetadataResponse functionMetadataResult = null;
             if (metadata != null)
             {
-                functionMetadataResult = await GetFunctionMetadataResponseAsync(metadata, hostOptions, request, _hostingConfigOptions.Value.EnableTestDataExclusionInApiResponse);
+                functionMetadataResult = await GetFunctionMetadataResponseAsync(metadata, hostOptions, request, _hostingConfigOptions.Value.EnableTestDataSuppression);
                 success = true;
             }
 
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
             if (functionMetadata != null)
             {
-                var functionMetadataResponse = await GetFunctionMetadataResponseAsync(functionMetadata, hostOptions, request, _hostingConfigOptions.Value.EnableTestDataExclusionInApiResponse);
+                var functionMetadataResponse = await GetFunctionMetadataResponseAsync(functionMetadata, hostOptions, request, _hostingConfigOptions.Value.EnableTestDataSuppression);
                 return (true, functionMetadataResponse);
             }
             else

--- a/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/WebFunctionsManager.cs
@@ -31,10 +31,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         private readonly IFunctionMetadataManager _functionMetadataManager;
         private readonly IHostFunctionMetadataProvider _hostFunctionMetadataProvider;
         private readonly IOptionsMonitor<LanguageWorkerOptions> _languageWorkerOptions;
-        private readonly IOptions<FunctionsHostingConfigOptions> _hostingConfigOptions;
+        private readonly IOptionsMonitor<FunctionsHostingConfigOptions> _hostingConfigOptions;
 
         public WebFunctionsManager(IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, ILoggerFactory loggerFactory, IHttpClientFactory httpClientFactory, ISecretManagerProvider secretManagerProvider, IFunctionsSyncManager functionsSyncManager, HostNameProvider hostNameProvider, IFunctionMetadataManager functionMetadataManager, IHostFunctionMetadataProvider hostFunctionMetadataProvider,
-            IOptionsMonitor<LanguageWorkerOptions> languageWorkerOptions, IOptions<FunctionsHostingConfigOptions> hostingConfigOptions)
+            IOptionsMonitor<LanguageWorkerOptions> languageWorkerOptions, IOptionsMonitor<FunctionsHostingConfigOptions> hostingConfigOptions)
         {
             _applicationHostOptions = applicationHostOptions;
             _logger = loggerFactory?.CreateLogger(ScriptConstants.LogCategoryHostGeneral);
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             var hostOptions = _applicationHostOptions.CurrentValue.ToHostOptions();
             var functionsMetadata = GetFunctionsMetadata(includeProxies, forceRefresh: false);
 
-            return await GetFunctionMetadataResponse(functionsMetadata, hostOptions, _hostNameProvider, excludeTestData: _hostingConfigOptions.Value.EnableTestDataSuppression);
+            return await GetFunctionMetadataResponse(functionsMetadata, hostOptions, _hostNameProvider, excludeTestData: _hostingConfigOptions.CurrentValue.IsTestDataSuppressionEnabled);
         }
 
         internal static async Task<IEnumerable<FunctionMetadataResponse>> GetFunctionMetadataResponse(IEnumerable<FunctionMetadata> functionsMetadata, ScriptJobHostOptions hostOptions, HostNameProvider hostNameProvider, bool excludeTestData)
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 configChanged = true;
             }
 
-            if (functionMetadata.TestData != null && !_hostingConfigOptions.Value.EnableTestDataSuppression)
+            if (functionMetadata.TestData != null && !_hostingConfigOptions.CurrentValue.IsTestDataSuppressionEnabled)
             {
                 await FileUtility.WriteAsync(dataFilePath, functionMetadata.TestData);
             }
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             FunctionMetadataResponse functionMetadataResult = null;
             if (metadata != null)
             {
-                functionMetadataResult = await GetFunctionMetadataResponseAsync(metadata, hostOptions, request, _hostingConfigOptions.Value.EnableTestDataSuppression);
+                functionMetadataResult = await GetFunctionMetadataResponseAsync(metadata, hostOptions, request, _hostingConfigOptions.CurrentValue.IsTestDataSuppressionEnabled);
                 success = true;
             }
 
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
             if (functionMetadata != null)
             {
-                var functionMetadataResponse = await GetFunctionMetadataResponseAsync(functionMetadata, hostOptions, request, _hostingConfigOptions.Value.EnableTestDataSuppression);
+                var functionMetadataResponse = await GetFunctionMetadataResponseAsync(functionMetadata, hostOptions, request, _hostingConfigOptions.CurrentValue.IsTestDataSuppressionEnabled);
                 return (true, functionMetadataResponse);
             }
             else

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -148,18 +148,18 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to exclude the function test data property from API responses.
+        /// Gets or sets a value indicating whether to ignore the TestData property during read and write operations of functions metadata.
         /// </summary>
-        internal bool EnableTestDataExclusionInApiResponse
+        internal bool EnableTestDataSuppression
         {
             get
             {
-                return GetFeatureAsBooleanOrDefault(ScriptConstants.FeatureFlagEnableTestDataExclusionInApiResponse, false);
+                return GetFeatureAsBooleanOrDefault(ScriptConstants.FeatureFlagEnableTestDataSuppression, false);
             }
 
             set
             {
-                _features[ScriptConstants.FeatureFlagEnableTestDataExclusionInApiResponse] = value ? "1" : "0";
+                _features[ScriptConstants.FeatureFlagEnableTestDataSuppression] = value ? "1" : "0";
             }
         }
 

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -148,6 +148,22 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to exclude the function test data property from API responses.
+        /// </summary>
+        internal bool EnableTestDataExclusionInApiResponse
+        {
+            get
+            {
+                return GetFeatureAsBooleanOrDefault(ScriptConstants.FeatureFlagEnableTestDataExclusionInApiResponse, false);
+            }
+
+            set
+            {
+                _features[ScriptConstants.FeatureFlagEnableTestDataExclusionInApiResponse] = value ? "1" : "0";
+            }
+        }
+
+        /// <summary>
         /// Gets the highest version of extension bundle v3 supported.
         /// </summary>
         internal string MaximumBundleV3Version

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         /// <summary>
         /// Gets or sets a value indicating whether to ignore the TestData property during read and write operations of functions metadata.
         /// </summary>
-        internal bool EnableTestDataSuppression
+        internal bool IsTestDataSuppressionEnabled
         {
             get
             {

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -141,6 +141,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FeatureFlagEnableResponseCompression = "EnableResponseCompression";
         public const string FeatureFlagDisableOrderedInvocationMessages = "DisableOrderedInvocationMessages";
         public const string FeatureFlagEnableAzureMonitorTimeIsoFormat = "EnableAzureMonitorTimeIsoFormat";
+        public const string FeatureFlagEnableTestDataExclusionInApiResponse = "EnableTestDataExclusionInApiResponse";
         public const string HostingConfigDisableLinuxAppServiceDetailedExecutionEvents = "DisableLinuxExecutionDetails";
         public const string HostingConfigDisableLinuxAppServiceExecutionEventLogBackoff = "DisableLinuxLogBackoff";
         public const string FeatureFlagEnableLegacyDurableVersionCheck = "EnableLegacyDurableVersionCheck";

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FeatureFlagEnableResponseCompression = "EnableResponseCompression";
         public const string FeatureFlagDisableOrderedInvocationMessages = "DisableOrderedInvocationMessages";
         public const string FeatureFlagEnableAzureMonitorTimeIsoFormat = "EnableAzureMonitorTimeIsoFormat";
-        public const string FeatureFlagEnableTestDataExclusionInApiResponse = "EnableTestDataExclusionInApiResponse";
+        public const string FeatureFlagEnableTestDataSuppression = "EnableTestDataSuppression";
         public const string HostingConfigDisableLinuxAppServiceDetailedExecutionEvents = "DisableLinuxExecutionDetails";
         public const string HostingConfigDisableLinuxAppServiceExecutionEventLogBackoff = "DisableLinuxLogBackoff";
         public const string FeatureFlagEnableLegacyDurableVersionCheck = "EnableLegacyDurableVersionCheck";

--- a/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 yield return [ nameof(FunctionsHostingConfigOptions.IsDotNetInProcDisabled), "DotNetInProcDisabled=1", true ];
                 yield return [ nameof(FunctionsHostingConfigOptions.IsDotNetInProcDisabled), "DotNetInProcDisabled=0", false ];
 
-                yield return [nameof(FunctionsHostingConfigOptions.EnableTestDataSuppression), "EnableTestDataSuppression=1", true];
+                yield return [nameof(FunctionsHostingConfigOptions.IsTestDataSuppressionEnabled), "EnableTestDataSuppression=1", true];
 
 #pragma warning restore SA1011 // Closing square brackets should be spaced correctly
 #pragma warning restore SA1010 // Opening square brackets should be spaced correctly

--- a/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
@@ -74,6 +74,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 yield return [ nameof(FunctionsHostingConfigOptions.IsDotNetInProcDisabled), "DotNetInProcDisabled=True", true ];
                 yield return [ nameof(FunctionsHostingConfigOptions.IsDotNetInProcDisabled), "DotNetInProcDisabled=1", true ];
                 yield return [ nameof(FunctionsHostingConfigOptions.IsDotNetInProcDisabled), "DotNetInProcDisabled=0", false ];
+
+                yield return [nameof(FunctionsHostingConfigOptions.EnableTestDataSuppression), "EnableTestDataSuppression=1", true];
+
 #pragma warning restore SA1011 // Closing square brackets should be spaced correctly
 #pragma warning restore SA1010 // Opening square brackets should be spaced correctly
             }

--- a/test/WebJobs.Script.Tests/Extensions/FunctionMetadataExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/FunctionMetadataExtensionsTests.cs
@@ -199,37 +199,45 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
                 TestDataPath = testDataFilePath
             };
 
-            var testDataContent = @"
+            IFileSystem fileSystem = FileUtility.Instance;
+
+            try
+            {
+                var testDataContent = @"
                                     {
                                         ""method"": ""POST"",
                                         ""headers"": [],
                                         ""body"": ""foo""
                                     }";
 
-            var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(testDataContent))
+                var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(testDataContent))
+                {
+                    Position = 0
+                };
+                // Mock the file system
+                var mockFileSystem = new Mock<IFileSystem>();
+                var mockFile = new Mock<FileBase>();
+                mockFileSystem.Setup(f => f.Directory.Exists(It.IsAny<string>())).Returns(true);
+                mockFile.Setup(f => f.Exists(It.Is<string>(path => path.EndsWith(Path.Combine(functionName, "function.json"))))).Returns(true);
+                mockFile.Setup(f => f.Exists(It.Is<string>(path => path.EndsWith(testDataFileName)))).Returns(true);
+                mockFile.Setup(f => f.Open(It.Is<string>(path => path.EndsWith(testDataFileName)), It.IsAny<FileMode>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>()))
+                        .Returns(memoryStream);
+                mockFileSystem.Setup(fs => fs.File).Returns(mockFile.Object);
+                FileUtility.Instance = mockFileSystem.Object;
+
+                AddSampleBindings(functionMetadata);
+                var result = await functionMetadata.ToFunctionMetadataResponse(options, string.Empty, null, excludeTestData: shouldExcludeTestDataFromApiResponse);
+
+                Assert.Equal(functionName, result.Name);
+                Assert.Equal(shouldExcludeTestDataFromApiResponse, result.TestData == null);
+                if (!shouldExcludeTestDataFromApiResponse)
+                {
+                    Assert.True(result.TestData.Trim().Length > 0);
+                }
+            }
+            finally
             {
-                Position = 0
-            };
-
-            // Mock the file system
-            var mockFileSystem = new Mock<IFileSystem>();
-            var mockFile = new Mock<FileBase>();
-            mockFileSystem.Setup(f => f.Directory.Exists(It.IsAny<string>())).Returns(true);
-            mockFile.Setup(f => f.Exists(It.Is<string>(path => path.EndsWith(Path.Combine(functionName, "function.json"))))).Returns(true);
-            mockFile.Setup(f => f.Exists(It.Is<string>(path => path.EndsWith(testDataFileName)))).Returns(true);
-            mockFile.Setup(f => f.Open(It.Is<string>(path => path.EndsWith(testDataFileName)), It.IsAny<FileMode>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>()))
-                    .Returns(memoryStream);
-            mockFileSystem.Setup(fs => fs.File).Returns(mockFile.Object);
-            FileUtility.Instance = mockFileSystem.Object;
-
-            AddSampleBindings(functionMetadata);
-            var result = await functionMetadata.ToFunctionMetadataResponse(options, string.Empty, null, excludeTestData: shouldExcludeTestDataFromApiResponse);
-
-            Assert.Equal(functionName, result.Name);
-            Assert.Equal(shouldExcludeTestDataFromApiResponse, result.TestData == null);
-            if (!shouldExcludeTestDataFromApiResponse)
-            {
-                Assert.True(result.TestData.Trim().Length > 0);
+                FileUtility.Instance = fileSystem;
             }
         }
 

--- a/test/WebJobs.Script.Tests/Extensions/FunctionMetadataExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/FunctionMetadataExtensionsTests.cs
@@ -2,9 +2,12 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.IO;
+using System.IO.Abstractions;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.WebHost.Extensions;
+using Moq;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -168,7 +171,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
             };
 
             AddSampleBindings(functionMetadata);
-            var result = await functionMetadata.ToFunctionMetadataResponse(options, string.Empty, null);
+            var result = await functionMetadata.ToFunctionMetadataResponse(options, string.Empty, null, excludeTestData: false);
 
             Assert.Null(result.ScriptRootPathHref);
             Assert.Null(result.ConfigHref);
@@ -176,6 +179,58 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
 
             var binding = result.Config["bindings"] as JArray;
             Assert.Equal("httpTrigger", binding[0]["type"].Value<string>());
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ToFunctionMetadataResponse_TestData_Exclusion(bool shouldExcludeTestDataFromApiResponse)
+        {
+            var functionName = "TestFunction1";
+            var functionMetadata = new FunctionMetadata
+            {
+                Name = functionName
+            };
+            var testDataFileName = $"{functionName}.dat";
+            var testDataFilePath = Path.Combine(_testRootScriptPath, testDataFileName);
+            var options = new ScriptJobHostOptions
+            {
+                RootScriptPath = _testRootScriptPath,
+                TestDataPath = testDataFilePath
+            };
+
+            var testDataContent = @"
+                                    {
+                                        ""method"": ""POST"",
+                                        ""headers"": [],
+                                        ""body"": ""foo""
+                                    }";
+
+            var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(testDataContent))
+            {
+                Position = 0
+            };
+
+            // Mock the file system
+            var mockFileSystem = new Mock<IFileSystem>();
+            var mockFile = new Mock<FileBase>();
+            mockFileSystem.Setup(f => f.Directory.Exists(It.IsAny<string>())).Returns(true);
+            mockFile.Setup(f => f.Exists(It.Is<string>(path => path.EndsWith(Path.Combine(functionName, "function.json"))))).Returns(true);
+            mockFile.Setup(f => f.Exists(It.Is<string>(path => path.EndsWith(testDataFileName)))).Returns(true);
+            mockFile.Setup(f => f.Open(It.Is<string>(path => path.EndsWith(testDataFileName)), It.IsAny<FileMode>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>()))
+                    .Returns(memoryStream);
+            mockFileSystem.Setup(fs => fs.File).Returns(mockFile.Object);
+            FileUtility.Instance = mockFileSystem.Object;
+
+            AddSampleBindings(functionMetadata);
+            var result = await functionMetadata.ToFunctionMetadataResponse(options, string.Empty, null, excludeTestData: shouldExcludeTestDataFromApiResponse);
+
+            Assert.Equal(functionName, result.Name);
+            Assert.Equal(shouldExcludeTestDataFromApiResponse, result.TestData == null);
+            if (!shouldExcludeTestDataFromApiResponse)
+            {
+                Assert.True(result.TestData.Trim().Length > 0);
+            }
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             var emptyOptions = new JobHostInternalStorageOptions();
             var azureBlobStorageProvider = TestHelpers.GetAzureBlobStorageProvider(configurationMock.Object, storageOptions: emptyOptions);
             var functionsSyncManager = new FunctionsSyncManager(hostIdProviderMock.Object, optionsMonitor, loggerFactory.CreateLogger<FunctionsSyncManager>(), httpClientFactory, secretManagerProviderMock.Object, mockWebHostEnvironment.Object, _mockEnvironment.Object, hostNameProvider, functionMetadataManager, azureBlobStorageProvider, hostingConfigOptionsWrapper, mockScriptHostManager.Object);
-            _webFunctionsManager = new WebFunctionsManager(optionsMonitor, loggerFactory, httpClientFactory, secretManagerProviderMock.Object, functionsSyncManager, hostNameProvider, functionMetadataManager, metadataProvider, new TestOptionsMonitor<LanguageWorkerOptions>(TestHelpers.GetTestLanguageWorkerOptions()));
+            _webFunctionsManager = new WebFunctionsManager(optionsMonitor, loggerFactory, httpClientFactory, secretManagerProviderMock.Object, functionsSyncManager, hostNameProvider, functionMetadataManager, metadataProvider, new TestOptionsMonitor<LanguageWorkerOptions>(TestHelpers.GetTestLanguageWorkerOptions()), hostingConfigOptionsWrapper);
         }
 
         [Theory]

--- a/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
@@ -56,15 +56,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         private readonly ScriptApplicationHostOptions _hostOptions;
         private readonly WebFunctionsManager _webFunctionsManager;
         private readonly Mock<IEnvironment> _mockEnvironment;
-        private readonly Mock<HttpRequest> mockHttpRequest;
+        private readonly Mock<HttpRequest> _mockHttpRequest;
         private readonly IFileSystem _fileSystem;
         private readonly FunctionsHostingConfigOptions _hostingConfigOptions;
 
         public WebFunctionsManagerTests()
         {
-            mockHttpRequest = new Mock<HttpRequest>();
-            mockHttpRequest.Setup(r => r.Scheme).Returns("https");
-            mockHttpRequest.Setup(r => r.Host).Returns(new HostString(TestHostName));
+            _mockHttpRequest = new Mock<HttpRequest>();
+            _mockHttpRequest.Setup(r => r.Scheme).Returns("https");
+            _mockHttpRequest.Setup(r => r.Host).Returns(new HostString(TestHostName));
 
             _testRootScriptPath = Path.GetTempPath();
             _testHostConfigFilePath = Path.Combine(_testRootScriptPath, ScriptConstants.HostMetadataFileName);
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             var emptyOptions = new JobHostInternalStorageOptions();
             var azureBlobStorageProvider = TestHelpers.GetAzureBlobStorageProvider(configurationMock.Object, storageOptions: emptyOptions);
             var functionsSyncManager = new FunctionsSyncManager(hostIdProviderMock.Object, optionsMonitor, loggerFactory.CreateLogger<FunctionsSyncManager>(), httpClientFactory, secretManagerProviderMock.Object, mockWebHostEnvironment.Object, _mockEnvironment.Object, hostNameProvider, functionMetadataManager, azureBlobStorageProvider, hostingConfigOptionsWrapper, mockScriptHostManager.Object);
-            _webFunctionsManager = new WebFunctionsManager(optionsMonitor, loggerFactory, httpClientFactory, secretManagerProviderMock.Object, functionsSyncManager, hostNameProvider, functionMetadataManager, metadataProvider, new TestOptionsMonitor<LanguageWorkerOptions>(TestHelpers.GetTestLanguageWorkerOptions()), hostingConfigOptionsWrapper);
+            _webFunctionsManager = new WebFunctionsManager(optionsMonitor, loggerFactory, httpClientFactory, secretManagerProviderMock.Object, functionsSyncManager, hostNameProvider, functionMetadataManager, metadataProvider, new TestOptionsMonitor<LanguageWorkerOptions>(TestHelpers.GetTestLanguageWorkerOptions()), new TestOptionsMonitor<FunctionsHostingConfigOptions>(_hostingConfigOptions));
         }
 
         [Theory]
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         [InlineData(false)]
         public async Task TestDataShouldBeIgnoredIfSuppressionFeatureIsEnabled(bool shouldSuppressTestData)
         {
-            _hostingConfigOptions.EnableTestDataSuppression = shouldSuppressTestData;
+            _hostingConfigOptions.IsTestDataSuppressionEnabled = shouldSuppressTestData;
 
             var functionMetadataResponse = new Management.Models.FunctionMetadataResponse
             {
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             string testDataFilePath = Path.Combine(_hostOptions.TestDataPath, "function1.dat");
             var fileBaseMock = Mock.Get(_fileSystem.File);
 
-            var result = await _webFunctionsManager.CreateOrUpdate("function1", functionMetadataResponse, mockHttpRequest.Object);
+            var result = await _webFunctionsManager.CreateOrUpdate("function1", functionMetadataResponse, _mockHttpRequest.Object);
 
             Assert.True(result.Success);
 

--- a/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
@@ -10,6 +10,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.WebHost;
@@ -22,12 +23,32 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Moq;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 {
     public class WebFunctionsManagerTests : IDisposable
     {
+        private const string Function1MetadataJson = @"
+        {
+          ""scriptFile"": ""main.py"",
+          ""disabled"": false,
+          ""bindings"": [
+            {
+              ""authLevel"": ""anonymous"",
+              ""type"": ""httpTrigger"",
+              ""direction"": ""in"",
+              ""name"": ""req""
+            },
+            {
+              ""type"": ""http"",
+              ""direction"": ""out"",
+              ""name"": ""$return""
+            }
+          ]
+        }";
+
         private const string TestHostName = "test.azurewebsites.net";
 
         private readonly string _testRootScriptPath;
@@ -35,11 +56,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         private readonly ScriptApplicationHostOptions _hostOptions;
         private readonly WebFunctionsManager _webFunctionsManager;
         private readonly Mock<IEnvironment> _mockEnvironment;
+        private readonly Mock<HttpRequest> mockHttpRequest;
         private readonly IFileSystem _fileSystem;
         private readonly FunctionsHostingConfigOptions _hostingConfigOptions;
 
         public WebFunctionsManagerTests()
         {
+            mockHttpRequest = new Mock<HttpRequest>();
+            mockHttpRequest.Setup(r => r.Scheme).Returns("https");
+            mockHttpRequest.Setup(r => r.Host).Returns(new HostString(TestHostName));
+
             _testRootScriptPath = Path.GetTempPath();
             _testHostConfigFilePath = Path.Combine(_testRootScriptPath, ScriptConstants.HostMetadataFileName);
             FileUtility.DeleteFileSafe(_testHostConfigFilePath);
@@ -81,6 +107,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady)).Returns("1");
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.CoreToolsEnvironment)).Returns((string)null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName)).Returns(TestHostName);
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey)).Returns((string)null);
             var hostNameProvider = new HostNameProvider(_mockEnvironment.Object);
 
             _hostingConfigOptions = new FunctionsHostingConfigOptions();
@@ -138,6 +165,38 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                     Assert.Equal(ScriptConstants.MaxTestDataInlineStringLength + 1, metadata[2].TestData.Length);
                 }
             }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task TestDataShouldBeIgnoredIfSuppressionFeatureIsEnabled(bool shouldSuppressTestData)
+        {
+            _hostingConfigOptions.EnableTestDataSuppression = shouldSuppressTestData;
+
+            var functionMetadataResponse = new Management.Models.FunctionMetadataResponse
+            {
+                TestData = "foo",
+                Config = JObject.Parse(Function1MetadataJson)
+            };
+
+            string testDataFilePath = Path.Combine(_hostOptions.TestDataPath, "function1.dat");
+            var fileBaseMock = Mock.Get(_fileSystem.File);
+
+            var result = await _webFunctionsManager.CreateOrUpdate("function1", functionMetadataResponse, mockHttpRequest.Object);
+
+            Assert.True(result.Success);
+
+            if (shouldSuppressTestData)
+            {
+                Assert.Null(result.Response.TestData);
+            }
+            else
+            {
+                Assert.NotNull(result.Response.TestData);
+            }
+            // File.Open is called twice when test data suppression is disabled: once for write, once for read.
+            fileBaseMock.Verify(f => f.Open(testDataFilePath, It.IsAny<FileMode>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>()), shouldSuppressTestData ? Times.Never() : Times.AtLeast(2));
         }
 
         [Fact]
@@ -263,23 +322,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                     Path.Combine(rootPath, "function3")
                 });
 
-            var function1 = @"{
-  ""scriptFile"": ""main.py"",
-  ""disabled"": false,
-  ""bindings"": [
-    {
-      ""authLevel"": ""anonymous"",
-      ""type"": ""httpTrigger"",
-      ""direction"": ""in"",
-      ""name"": ""req""
-    },
-    {
-      ""type"": ""http"",
-      ""direction"": ""out"",
-      ""name"": ""$return""
-    }
-  ]
-}";
             var function2 = @"{
   ""disabled"": false,
   ""scriptFile"": ""main.js"",
@@ -312,16 +354,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             string testData2 = "Test Data 2";
             string testData3 = TestHelpers.NewRandomString(ScriptConstants.MaxTestDataInlineStringLength + 1);
 
+            dirBase.Setup(d => d.Exists(Path.Combine(rootPath, @"function1"))).Returns(true);
             fileBase.Setup(f => f.Exists(Path.Combine(rootPath, @"function1", "function.json"))).Returns(true);
             fileBase.Setup(f => f.Exists(Path.Combine(rootPath, @"function1", "main.py"))).Returns(true);
-            fileBase.Setup(f => f.ReadAllText(Path.Combine(rootPath, @"function1", "function.json"))).Returns(function1);
+            fileBase.Setup(f => f.ReadAllText(Path.Combine(rootPath, @"function1", "function.json"))).Returns(Function1MetadataJson);
             fileBase.Setup(f => f.Open(Path.Combine(rootPath, @"function1", "function.json"), It.IsAny<FileMode>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>())).Returns(() =>
             {
-                return new MemoryStream(Encoding.UTF8.GetBytes(function1));
+                return new MemoryStream(Encoding.UTF8.GetBytes(Function1MetadataJson));
             });
             fileBase.Setup(f => f.Open(Path.Combine(testDataPath, "function1.dat"), It.IsAny<FileMode>(), It.IsAny<FileAccess>(), It.IsAny<FileShare>())).Returns(() =>
             {
-                return new MemoryStream(Encoding.UTF8.GetBytes(testData1));
+                // expandable(if there are write operation to this) stream.
+                var bytes = Encoding.UTF8.GetBytes(testData1);
+                var stream = new MemoryStream();
+                stream.Write(bytes, 0, bytes.Length);
+                stream.Position = 0;
+                return stream;
             });
 
             fileBase.Setup(f => f.Exists(Path.Combine(rootPath, @"function2", "function.json"))).Returns(true);


### PR DESCRIPTION
This PR modifies both read and write operations related to test data for functions.

1. When the `/admin/functions/{name}` PUT operation is called, the "TestData" property will no longer be saved. The response object for this call will not include "TestData" property populated.
2. When the `admin/functions/{name}` GET operation is called, the "TestData" property will no longer be included in the API response.

These changes are gated behind a feature flag, which is disabled (set to false) by default. We will begin by enabling this feature on a few stamps and, upon confirming its effectiveness, will roll it out more broadly. In a future release, we plan to remove the feature flag and enable this change by default.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR  - https://github.com/Azure/azure-functions-host/pull/10981
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
