### PR TITLE
Ensuring JWT token validation parameters support Linux Consumption on…

### DIFF
--- a/src/WebJobs.Script.WebHost/Program.cs
+++ b/src/WebJobs.Script.WebHost/Program.cs
@@ -109,9 +109,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             {
                 AppDomain.CurrentDomain.UnhandledException += CurrentDomainOnUnhandledExceptionInLinuxConsumption;
             }
-            else if (SystemEnvironment.Instance.IsFlexConsumptionSku())
+            else if (SystemEnvironment.Instance.IsFlexConsumptionSku() ||
+                SystemEnvironment.Instance.IsLinuxConsumptionOnLegion())
             {
-                //todo: Replace with legion specific logger.
+                // TODO: Replace with legion specific logger?
                 AppDomain.CurrentDomain.UnhandledException += CurrentDomainOnUnhandledExceptionInLinuxConsumption;
             }
             else if (SystemEnvironment.Instance.IsLinuxAppService())

--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -105,7 +105,8 @@ namespace Microsoft.Extensions.DependencyInjection
                         ScriptSettingsManager.Instance.GetSetting(WebsitePodName)
                     };
                 }
-                else if (SystemEnvironment.Instance.IsLinuxConsumptionOnAtlas())
+                else if (SystemEnvironment.Instance.IsLinuxConsumptionOnAtlas() ||
+                    SystemEnvironment.Instance.IsLinuxConsumptionOnLegion())
                 {
                     return new string[]
                     {


### PR DESCRIPTION
PR https://github.com/Azure/azure-functions-host/pull/10932 adjusted the `IsFlexConsumptionSku` to be more specific, such that for Linux Consumption on Legion it'll now return false, where it returned true before. We need to adjust the token validation setup accordingly, to ensure we're handling Linux Consumption on Legion as well.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Already handled in a separate in-proc PR https://github.com/Azure/azure-functions-host/pull/10942
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
