### PR TITLE
[in-proc backport] Refactor Linux container management to avoid race condition that leads the host to initialize placeholder (warmup) function

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,9 +3,11 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+
 - Update Java Worker Version to [2.18.1](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.18.1)
 - Add support for new FeatureFlag `EnableAzureMonitorTimeIsoFormat` to enable iso time format for azmon logs for Linux Dedicated/EP Skus. (part of #7864)
 - Update PowerShell worker to 4.0.4175 (sets defaultRuntimeVersion to 7.4 in worker.config.json)
 - Fixing default DateTime bug with TimeZones in TimerTrigger (#10906)
 - Add support for the release channel setting `WEBSITE_PlatformReleaseChannel` and use this value in extension bundles resolution.
 - Bug fix for platform release channel bundles resolution casing issue and additional logging (#10921)
+- Fix race condition that leads the host to initialize placeholder (warmup) function in Linux environments (#10848)

--- a/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerInitializationHostedService.cs
+++ b/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerInitializationHostedService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
@@ -51,8 +52,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
                 var assignmentContext = _startupContextProvider.SetContext(encryptedAssignmentContext);
                 await SpecializeMSISideCar(assignmentContext);
 
-                bool success = _instanceManager.StartAssignment(assignmentContext);
-                _logger.LogDebug($"StartAssignment invoked (Success={success})");
+                try
+                {
+                    bool success = await _instanceManager.AssignInstanceAsync(assignmentContext);
+                    _logger.LogDebug("AssignInstanceAsync was invoked (Success={success})", success);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to assign instance.");
+                }
             }
             else
             {

--- a/src/WebJobs.Script.WebHost/Management/IInstanceManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/IInstanceManager.cs
@@ -13,6 +13,18 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
         Task<string> ValidateContext(HostAssignmentContext assignmentContext);
 
+        /// <summary>
+        /// Asynchronously assigns a host instance.
+        /// </summary>
+        /// <param name="assignmentContext">The <see cref="HostAssignmentContext"/> that will be applied to the instance being assigned to the application.</param>
+        /// <returns><see langword="true"/> if environment validation succeeds; otherwise <see langword="false"/>.</returns>
+        Task<bool> AssignInstanceAsync(HostAssignmentContext assignmentContext);
+
+        /// <summary>
+        /// Validates the assignment context and begins the assignment process in a "fire and forget" pattern.
+        /// </summary>
+        /// <param name="assignmentContext">The <see cref="HostAssignmentContext"/> that will be applied to the instance being assigned to the application.</param>
+        /// <returns><see langword="true"/> if environment validation succeeds; otherwise <see langword="false"/>.</returns>
         bool StartAssignment(HostAssignmentContext assignmentContext);
 
         Task<string> SpecializeMSISidecar(HostAssignmentContext assignmentContext);

--- a/test/WebJobs.Script.Tests.Integration/ContainerManagement/AtlasContainerInitializationHostedServiceTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ContainerManagement/AtlasContainerInitializationHostedServiceTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Castle.Components.DictionaryAdapter.Xml;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
@@ -68,36 +69,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ContainerManagement
         [Fact]
         public async Task Assigns_Context_From_CONTAINER_START_CONTEXT()
         {
-            var containerEncryptionKey = TestHelpers.GenerateKeyHexString();
-            var hostAssignmentContext = GetHostAssignmentContext();
-            var secrets = new FunctionAppSecrets();
-            secrets.Host = new FunctionAppSecrets.HostSecrets
-            {
-                Master = "test-key",
-                Function = new Dictionary<string, string>
-                {
-                    { "host-function-key-1", "test-key" }
-                },
-                System = new Dictionary<string, string>
-                {
-                    { "host-system-key-1", "test-key" }
-                }
-            };
-            hostAssignmentContext.Secrets = secrets;
-            hostAssignmentContext.MSIContext = new MSIContext();
-
-            var encryptedHostAssignmentContext = GetEncryptedHostAssignmentContext(hostAssignmentContext, containerEncryptionKey);
-            var serializedContext = JsonConvert.SerializeObject(new { encryptedContext = encryptedHostAssignmentContext });
-
-            _environment.SetEnvironmentVariable(ContainerStartContext, serializedContext);
-            _environment.SetEnvironmentVariable(ContainerEncryptionKey, containerEncryptionKey);
-            AddLinuxConsumptionSettings(_environment);
+            var (hostAssignmentContext, _) = SetupHostAssignmentContext();
 
             _instanceManagerMock.Setup(m =>
                 m.SpecializeMSISidecar(It.Is<HostAssignmentContext>(context =>
                     hostAssignmentContext.Equals(context) && !context.IsWarmupRequest))).Returns(Task.FromResult(string.Empty));
 
-            _instanceManagerMock.Setup(manager => manager.StartAssignment(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context) && !context.IsWarmupRequest))).Returns(true);
+            _instanceManagerMock.Setup(manager => manager.AssignInstanceAsync(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context) && !context.IsWarmupRequest))).Returns(Task.FromResult(true));
 
             var initializationHostService = new AtlasContainerInitializationHostedService(_environment, _instanceManagerMock.Object, NullLogger<AtlasContainerInitializationHostedService>.Instance, _startupContextProvider);
             await initializationHostService.StartAsync(CancellationToken.None);
@@ -106,7 +84,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ContainerManagement
                 m.SpecializeMSISidecar(It.Is<HostAssignmentContext>(context =>
                     hostAssignmentContext.Equals(context) && !context.IsWarmupRequest)), Times.Once);
 
-            _instanceManagerMock.Verify(manager => manager.StartAssignment(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context) && !context.IsWarmupRequest)), Times.Once);
+            _instanceManagerMock.Verify(manager => manager.AssignInstanceAsync(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context) && !context.IsWarmupRequest)), Times.Once);
 
             var hostSecrets = _startupContextProvider.GetHostSecretsOrNull();
             Assert.Equal("test-key", hostSecrets.MasterKey);
@@ -119,26 +97,83 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ContainerManagement
             await initializationHostService.StartAsync(CancellationToken.None);
 
             _instanceManagerMock.Verify(m => m.SpecializeMSISidecar(It.IsAny<HostAssignmentContext>()), Times.Never);
-            _instanceManagerMock.Verify(manager => manager.StartAssignment(It.IsAny<HostAssignmentContext>()), Times.Never);
+            _instanceManagerMock.Verify(manager => manager.AssignInstanceAsync(It.IsAny<HostAssignmentContext>()), Times.Never);
         }
 
         [Fact]
         public async Task Assigns_Even_If_MSI_Specialization_Fails()
         {
-            var containerEncryptionKey = TestHelpers.GenerateKeyHexString();
+            var (hostAssignmentContext, _) = SetupHostAssignmentContext();
+
+            _instanceManagerMock.Setup(m =>
+                m.SpecializeMSISidecar(It.Is<HostAssignmentContext>(context =>
+                    hostAssignmentContext.Equals(context) && !context.IsWarmupRequest))).Returns(Task.FromResult("msi-specialization-error"));
+
+            _instanceManagerMock.Setup(manager => manager.AssignInstanceAsync(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context) && !context.IsWarmupRequest))).Returns(Task.FromResult(true));
+
+            var initializationHostService = new AtlasContainerInitializationHostedService(_environment, _instanceManagerMock.Object, NullLogger<AtlasContainerInitializationHostedService>.Instance, _startupContextProvider);
+            await initializationHostService.StartAsync(CancellationToken.None);
+
+            _instanceManagerMock.Verify(m =>
+                m.SpecializeMSISidecar(It.Is<HostAssignmentContext>(context =>
+                    hostAssignmentContext.Equals(context) && !context.IsWarmupRequest)), Times.Once);
+
+            _instanceManagerMock.Verify(manager => manager.AssignInstanceAsync(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context) && !context.IsWarmupRequest)), Times.Once);
+
+            var hostSecrets = _startupContextProvider.GetHostSecretsOrNull();
+            Assert.Equal("test-key", hostSecrets.MasterKey);
+        }
+
+        [Fact]
+        public async Task AssignInstance_Failure_Logged()
+        {
+            var (hostAssignmentContext, _) = SetupHostAssignmentContext();
+
+            _instanceManagerMock.Setup(m =>
+                m.SpecializeMSISidecar(It.Is<HostAssignmentContext>(context =>
+                    hostAssignmentContext.Equals(context) && !context.IsWarmupRequest)))
+                .Returns(Task.FromResult(string.Empty));
+
+            // Setup assignment to throw
+            _instanceManagerMock.Setup(manager =>
+                manager.AssignInstanceAsync(It.Is<HostAssignmentContext>(context =>
+                    hostAssignmentContext.Equals(context) && !context.IsWarmupRequest)))
+                .ThrowsAsync(new InvalidOperationException("Assignment failed"));
+
+            var logger = new TestLogger<AtlasContainerInitializationHostedService>();
+
+            var initializationHostService = new AtlasContainerInitializationHostedService(
+                _environment,
+                _instanceManagerMock.Object,
+                logger,
+                _startupContextProvider);
+
+            await initializationHostService.StartAsync(CancellationToken.None);
+
+            // Verify assignment was attempted
+            _instanceManagerMock.Verify(manager =>
+                manager.AssignInstanceAsync(It.Is<HostAssignmentContext>(context =>
+                    hostAssignmentContext.Equals(context) && !context.IsWarmupRequest)), Times.Once);
+
+            // Verify error was logged
+            Assert.Contains(logger.GetLogMessages(), m =>
+                m.Level == LogLevel.Error &&
+                m.Exception?.Message == "Assignment failed");
+
+        }
+
+        private (HostAssignmentContext context, string serializedContext) SetupHostAssignmentContext(string containerEncryptionKey = null)
+        {
+            containerEncryptionKey ??= TestHelpers.GenerateKeyHexString();
             var hostAssignmentContext = GetHostAssignmentContext();
-            var secrets = new FunctionAppSecrets();
-            secrets.Host = new FunctionAppSecrets.HostSecrets
+            var secrets = new FunctionAppSecrets
             {
-                Master = "test-key",
-                Function = new Dictionary<string, string>
-                {
-                    { "host-function-key-1", "test-key" }
-                },
-                System = new Dictionary<string, string>
-                {
-                    { "host-system-key-1", "test-key" }
-                }
+                Host = new FunctionAppSecrets.HostSecrets
+                    {
+                        Master = "test-key",
+                        Function = new Dictionary<string, string> {{ "host-function-key-1", "test-key" }},
+                        System = new Dictionary<string, string> {{ "host-system-key-1", "test-key" }}
+                    }
             };
             hostAssignmentContext.Secrets = secrets;
             hostAssignmentContext.MSIContext = new MSIContext();
@@ -150,23 +185,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ContainerManagement
             _environment.SetEnvironmentVariable(ContainerEncryptionKey, containerEncryptionKey);
             AddLinuxConsumptionSettings(_environment);
 
-            _instanceManagerMock.Setup(m =>
-                m.SpecializeMSISidecar(It.Is<HostAssignmentContext>(context =>
-                    hostAssignmentContext.Equals(context) && !context.IsWarmupRequest))).Returns(Task.FromResult("msi-specialization-error"));
-
-            _instanceManagerMock.Setup(manager => manager.StartAssignment(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context) && !context.IsWarmupRequest))).Returns(true);
-
-            var initializationHostService = new AtlasContainerInitializationHostedService(_environment, _instanceManagerMock.Object, NullLogger<AtlasContainerInitializationHostedService>.Instance, _startupContextProvider);
-            await initializationHostService.StartAsync(CancellationToken.None);
-
-            _instanceManagerMock.Verify(m =>
-                m.SpecializeMSISidecar(It.Is<HostAssignmentContext>(context =>
-                    hostAssignmentContext.Equals(context) && !context.IsWarmupRequest)), Times.Once);
-
-            _instanceManagerMock.Verify(manager => manager.StartAssignment(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context) && !context.IsWarmupRequest)), Times.Once);
-
-            var hostSecrets = _startupContextProvider.GetHostSecretsOrNull();
-            Assert.Equal("test-key", hostSecrets.MasterKey);
+            return (hostAssignmentContext, serializedContext);
         }
 
         private static string GetEncryptedHostAssignmentContext(HostAssignmentContext hostAssignmentContext, string containerEncryptionKey)

--- a/test/WebJobs.Script.Tests.Integration/ContainerManagement/LegionContainerInitializationHostedServiceTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ContainerManagement/LegionContainerInitializationHostedServiceTests.cs
@@ -15,7 +15,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.WebJobs.Script.Tests;
 using Moq;
-using Moq.Protected;
 using Newtonsoft.Json;
 using Xunit;
 using static Microsoft.Azure.WebJobs.Script.EnvironmentSettingNames;
@@ -102,15 +101,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ContainerManagement
             _instanceManagerMock.Setup(m =>
                 m.SpecializeMSISidecar(It.Is<HostAssignmentContext>(context =>
                     hostAssignmentContext.Equals(context) && !context.IsWarmupRequest))).Returns(Task.FromResult(string.Empty));
-
-            _instanceManagerMock.Setup(manager => manager.StartAssignment(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context) && !context.IsWarmupRequest))).Returns(true);
+            _instanceManagerMock.Setup(m => m.AssignInstanceAsync(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context) && !context.IsWarmupRequest))).Returns(Task.FromResult(true));
 
             var initializationHostService = new LegionContainerInitializationHostedService(_environment, _instanceManagerMock.Object, NullLogger<LegionContainerInitializationHostedService>.Instance, _startupContextProvider);
             await initializationHostService.StartAsync(CancellationToken.None);
 
             _instanceManagerMock.Verify(m => m.SpecializeMSISidecar(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context) && !context.IsWarmupRequest)), Times.Never);
             
-            _instanceManagerMock.Verify(manager => manager.StartAssignment(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context) && !context.IsWarmupRequest)), Times.Once);
+            _instanceManagerMock.Verify(manager => manager.AssignInstanceAsync(It.Is<HostAssignmentContext>(context => hostAssignmentContext.Equals(context) && !context.IsWarmupRequest)), Times.Once);
 
             var hostSecrets = _startupContextProvider.GetHostSecretsOrNull();
             Assert.Equal("test-key", hostSecrets.MasterKey);
@@ -124,7 +122,45 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ContainerManagement
             var initializationHostService = new LegionContainerInitializationHostedService(_environment, _instanceManagerMock.Object, NullLogger<LegionContainerInitializationHostedService>.Instance, _startupContextProvider);
             await initializationHostService.StartAsync(CancellationToken.None);
 
-            _instanceManagerMock.Verify(manager => manager.StartAssignment(It.IsAny<HostAssignmentContext>()), Times.Never);
+            _instanceManagerMock.Verify(manager => manager.AssignInstanceAsync(It.IsAny<HostAssignmentContext>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task AssignInstance_Failure_Logged()
+        {
+            var containerEncryptionKey = TestHelpers.GenerateKeyHexString();
+            var hostAssignmentContext = GetHostAssignmentContext();
+
+            var encryptedHostAssignmentContext = GetEncryptedHostAssignmentContext(hostAssignmentContext, containerEncryptionKey);
+            var serializedContext = JsonConvert.SerializeObject(new { encryptedContext = encryptedHostAssignmentContext });
+
+            // Set up the context file
+            CreateTemporaryStartContextFile(serializedContext);
+
+            _environment.SetEnvironmentVariable(ContainerSpecializationContextVolumePath, ContainerSpecializationContextPath);
+            _environment.SetEnvironmentVariable(ContainerEncryptionKey, containerEncryptionKey);
+            AddLinuxConsumptionSettings(_environment);
+
+            // Mock the instance manager to simulate a failure
+            _instanceManagerMock.Setup(m => m.AssignInstanceAsync(It.IsAny<HostAssignmentContext>()))
+                .ThrowsAsync(new InvalidOperationException("Assignment failed"));
+
+            var logger = new TestLogger<LegionContainerInitializationHostedService>();
+
+            var initializationHostService = new LegionContainerInitializationHostedService(
+                _environment,
+                _instanceManagerMock.Object,
+                logger,
+                _startupContextProvider);
+
+            await initializationHostService.StartAsync(CancellationToken.None);
+
+            // Verify error was logged
+            Assert.Contains(logger.GetLogMessages(), m =>
+                m.Level == LogLevel.Error &&
+                m.Exception?.Message == "Assignment failed");
+
+            DeleteTemporaryStartContextFile();
         }
 
 

--- a/test/WebJobs.Script.Tests.Integration/Management/LegionInstanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/LegionInstanceManagerTests.cs
@@ -98,10 +98,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             };
             bool result = _instanceManager.StartAssignment(context);
             Assert.True(result);
-            Assert.True(_scriptWebEnvironment.InStandbyMode);
 
-            // specialization is done in the background
-            await Task.Delay(500);
+            await TestHelpers.Await(() => !_scriptWebEnvironment.InStandbyMode, timeout: 5000);
+
+            Assert.True(!_scriptWebEnvironment.InStandbyMode);
 
             var value = _environment.GetEnvironmentVariable(envValue.Name);
             Assert.Equal(value, envValue.Value);
@@ -149,7 +149,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             bool result = _instanceManager.StartAssignment(context);
             Assert.True(result);
-            Assert.True(_scriptWebEnvironment.InStandbyMode);
 
             await TestHelpers.Await(() => !_scriptWebEnvironment.InStandbyMode, timeout: 5000);
 
@@ -172,9 +171,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             };
             bool result = _instanceManager.StartAssignment(context);
             Assert.True(result);
-            Assert.True(_scriptWebEnvironment.InStandbyMode);
 
             await TestHelpers.Await(() => !_scriptWebEnvironment.InStandbyMode, timeout: 5000);
+
+            Assert.False(_scriptWebEnvironment.InStandbyMode);
 
             var logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
             Assert.Collection(logs,
@@ -184,7 +184,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         }
 
         [Fact]
-        public async void StartAssignment_Does_Not_Assign_Settings_For_Warmup_Request()
+        public async Task StartAssignment_Does_Not_Assign_Settings_For_Warmup_Request()
         {
 
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");

--- a/test/WebJobs.Script.Tests/ContainerManagment/LinuxContainerInitializationHostedServiceTests.cs
+++ b/test/WebJobs.Script.Tests/ContainerManagment/LinuxContainerInitializationHostedServiceTests.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement;
+using Microsoft.Azure.WebJobs.Script.WebHost.Management;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.ContainerManagment
+{
+    public class LinuxContainerInitializationHostedServiceTests
+    {
+        private readonly Mock<IInstanceManager> _mockInstanceManager;
+        private readonly Mock<ILogger<LinuxContainerInitializationHostedService>> _mockLogger;
+        private readonly Mock<ILogger<StartupContextProvider>> _mockStartupContextProviderLogger;
+        private readonly Mock<StartupContextProvider> _mockStartupContextProvider;
+
+        public LinuxContainerInitializationHostedServiceTests()
+        {
+            _mockInstanceManager = new Mock<IInstanceManager>();
+            _mockLogger = new Mock<ILogger<LinuxContainerInitializationHostedService>>();
+            _mockStartupContextProviderLogger = new Mock<ILogger<StartupContextProvider>>();
+            _mockStartupContextProvider = new Mock<StartupContextProvider>(GetTestEnvironment(), _mockStartupContextProviderLogger.Object);
+        }
+
+        [Fact]
+        public async Task AssignInstanceAsyncIsAwaitedTest()
+        {
+            TaskCompletionSource<bool> tcs = new();
+            _mockInstanceManager.Setup(m => m.AssignInstanceAsync(It.IsAny<HostAssignmentContext>())).Returns(tcs.Task);
+
+            var assignmentContext = new HostAssignmentContext();
+            _mockStartupContextProvider.Setup(p => p.SetContext(It.IsAny<EncryptedHostAssignmentContext>())).Returns(assignmentContext);
+
+            var service = new TestLinuxContainerInitializationHostedService(GetTestEnvironment(), _mockInstanceManager.Object,
+                _mockLogger.Object, _mockStartupContextProvider.Object);
+
+            Task task = service.StartAsync(default); // start the call
+
+            Assert.False(task.IsCompleted); // verify this is not complete.
+            tcs.SetResult(true);
+            await task.WaitAsync(TimeSpan.FromMilliseconds(10));
+        }
+
+        private static TestEnvironment GetTestEnvironment()
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "TestContainerName");
+
+            return environment;
+        }
+
+        public class TestLinuxContainerInitializationHostedService : LinuxContainerInitializationHostedService
+        {
+            public TestLinuxContainerInitializationHostedService(IEnvironment environment, IInstanceManager instanceManager, ILogger logger, StartupContextProvider startupContextProvider) : base(environment, instanceManager, logger, startupContextProvider)
+            {
+            }
+
+            protected override Task<(bool HasStartContext, string StartContext)> TryGetStartContextOrNullAsync(CancellationToken cancellationToken)
+            {
+                var encryptedAssignmentContext = new EncryptedHostAssignmentContext { EncryptedContext = "test" };
+
+                return Task.FromResult((true, JsonConvert.SerializeObject(encryptedAssignmentContext)));
+            }
+
+            protected override Task SpecializeMSISideCar(HostAssignmentContext assignmentContext)
+            {
+                return Task.CompletedTask;
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

backport of https://github.com/Azure/azure-functions-host/pull/10848

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

