### PR TITLE
Reduce allocations in RpcWorkerConfigFactory.AddProviders 

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -14,3 +14,4 @@
 - Adding support for faas.invoke_duration metric and other spec related updates (#10929)
 - Increased the GC allocation budget value to improve cold start (#10953)
 - Fixed bug that could result in "Binding names must be unique" error (#10938)
+- Memory allocation optimizations in `RpcWorkerConfigFactory.AddProviders` (#10959)

--- a/src/WebJobs.Script/Workers/Profiles/Conditions/EnvironmentCondition.cs
+++ b/src/WebJobs.Script/Workers/Profiles/Conditions/EnvironmentCondition.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Profiles
             {
                 _name = conditionNameElement.GetString();
             }
+
             if (descriptor.Properties.TryGetValue(WorkerConstants.WorkerDescriptionProfileConditionExpression, out var conditionExpressionElement))
             {
                 _expression = conditionExpressionElement.GetString();

--- a/src/WebJobs.Script/Workers/Profiles/Conditions/EnvironmentCondition.cs
+++ b/src/WebJobs.Script/Workers/Profiles/Conditions/EnvironmentCondition.cs
@@ -30,8 +30,14 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Profiles
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
 
-            descriptor.Properties.TryGetValue(WorkerConstants.WorkerDescriptionProfileConditionName, out _name);
-            descriptor.Properties.TryGetValue(WorkerConstants.WorkerDescriptionProfileConditionExpression, out _expression);
+            if (descriptor.Properties.TryGetValue(WorkerConstants.WorkerDescriptionProfileConditionName, out var conditionNameElement))
+            {
+                _name = conditionNameElement.GetString();
+            }
+            if (descriptor.Properties.TryGetValue(WorkerConstants.WorkerDescriptionProfileConditionExpression, out var conditionExpressionElement))
+            {
+                _expression = conditionExpressionElement.GetString();
+            }
 
             Validate();
         }

--- a/src/WebJobs.Script/Workers/Profiles/Conditions/HostPropertyCondition.cs
+++ b/src/WebJobs.Script/Workers/Profiles/Conditions/HostPropertyCondition.cs
@@ -32,8 +32,14 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Profiles
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _systemRuntimeInformation = systemRuntimeInformation ?? throw new ArgumentNullException(nameof(systemRuntimeInformation));
 
-            descriptor.Properties.TryGetValue(WorkerConstants.WorkerDescriptionProfileConditionName, out _name);
-            descriptor.Properties.TryGetValue(WorkerConstants.WorkerDescriptionProfileConditionExpression, out _expression);
+            if (descriptor.Properties.TryGetValue(WorkerConstants.WorkerDescriptionProfileConditionName, out var conditionNameElement))
+            {
+                _name = conditionNameElement.GetString();
+            }
+            if (descriptor.Properties.TryGetValue(WorkerConstants.WorkerDescriptionProfileConditionExpression, out var conditionExpressionElement))
+            {
+                _expression = conditionExpressionElement.GetString();
+            }
 
             Validate();
         }

--- a/src/WebJobs.Script/Workers/Profiles/Conditions/HostPropertyCondition.cs
+++ b/src/WebJobs.Script/Workers/Profiles/Conditions/HostPropertyCondition.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Profiles
             {
                 _name = conditionNameElement.GetString();
             }
+
             if (descriptor.Properties.TryGetValue(WorkerConstants.WorkerDescriptionProfileConditionExpression, out var conditionExpressionElement))
             {
                 _expression = conditionExpressionElement.GetString();

--- a/src/WebJobs.Script/Workers/Profiles/WorkerProfileConditionDescriptor.cs
+++ b/src/WebJobs.Script/Workers/Profiles/WorkerProfileConditionDescriptor.cs
@@ -2,35 +2,18 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.Azure.WebJobs.Script.Workers.Profiles
 {
     public sealed class WorkerProfileConditionDescriptor
     {
-        [JsonExtensionData]
-#pragma warning disable CS0649 // The value is assigned by the serializer
-        private IDictionary<string, JToken> _extensionData;
-#pragma warning restore CS0649
-
-        private IDictionary<string, string> _properties;
-
-        [JsonProperty(Required = Required.Always, PropertyName = WorkerConstants.WorkerDescriptionProfileConditionType)]
+        [JsonRequired]
+        [JsonPropertyName(WorkerConstants.WorkerDescriptionProfileConditionType)]
         public string Type { get; set; }
 
-        public IDictionary<string, string> Properties
-        {
-            get
-            {
-                if (_properties == null)
-                {
-                    _properties = _extensionData?.ToDictionary(kv => kv.Key, kv => kv.Value.ToString()) ?? new Dictionary<string, string>();
-                }
-
-                return _properties;
-            }
-        }
+        [JsonExtensionData]
+        public Dictionary<string, JsonElement> Properties { get; set; } = new Dictionary<string, JsonElement>();
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -124,7 +124,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     if (!string.IsNullOrWhiteSpace(_workerRuntime) && !_environment.IsPlaceholderModeEnabled() && !_environment.IsMultiLanguageRuntimeEnvironment())
                     {
                         string workerRuntime = Path.GetFileName(workerDir);
-                        // We do not want to skip non-worker directories like function app payload directory.
+                        // Only skip worker directories that don't match the current runtime.
+                        // Do not skip non-worker directories like the function app payload directory
                         if (!workerRuntime.Equals(_workerRuntime, StringComparison.OrdinalIgnoreCase) && workerDir.StartsWith(WorkersDirPath))
                         {
                             return;
@@ -141,7 +142,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
                     _logger.LogDebug("Found worker config: {workerConfigPath}", workerConfigPath);
 
-                    JsonElement workerConfig = GetWorkerConfigJsonElement(workerConfigPath);
+                    var workerConfig = GetWorkerConfigJsonElement(workerConfigPath);
                     var workerDescriptionElement = workerConfig.GetProperty(WorkerConstants.WorkerDescription);
                     var workerDescription = workerDescriptionElement.Deserialize<RpcWorkerDescription>(_jsonSerializerOptions);
                     workerDescription.WorkerDirectory = workerDir;
@@ -212,9 +213,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         private static JsonElement GetWorkerConfigJsonElement(string workerConfigPath)
         {
-            ReadOnlySpan<byte> jsonSpan = File.ReadAllBytes(workerConfigPath).AsSpan();
+            ReadOnlySpan<byte> jsonSpan = File.ReadAllBytes(workerConfigPath);
 
-            if (jsonSpan.StartsWith(stackalloc byte[] { 0xEF, 0xBB, 0xBF }))
+            if (jsonSpan.StartsWith<byte>([0xEF, 0xBB, 0xBF]))
             {
                 jsonSpan = jsonSpan[3..]; // Skip UTF-8 Byte Order Mark (BOM) if present at the beginning of the file.
             }

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -5,12 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Workers.Profiles;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 {
@@ -24,6 +24,10 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         private readonly IMetricsLogger _metricsLogger;
         private readonly string _workerRuntime;
         private readonly IEnvironment _environment;
+        private readonly JsonSerializerOptions _jsonSerializerOptions = new()
+        {
+            PropertyNameCaseInsensitive = true
+        };
 
         private Dictionary<string, RpcWorkerConfig> _workerDescriptionDictionary = new Dictionary<string, RpcWorkerConfig>();
 
@@ -116,6 +120,16 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             {
                 try
                 {
+                    // After specialization, load worker config only for the specified runtime unless it's a multi-language app.
+                    if (!string.IsNullOrWhiteSpace(_workerRuntime) && !_environment.IsPlaceholderModeEnabled() && !_environment.IsMultiLanguageRuntimeEnvironment())
+                    {
+                        string workerRuntime = Path.GetFileName(workerDir);
+                        if (!workerRuntime.Equals(_workerRuntime, StringComparison.OrdinalIgnoreCase) && workerDir.Contains("workers", StringComparison.OrdinalIgnoreCase))
+                        {
+                            return;
+                        }
+                    }
+
                     string workerConfigPath = Path.Combine(workerDir, RpcWorkerConstants.WorkerConfigFileName);
 
                     if (!File.Exists(workerConfigPath))
@@ -126,15 +140,21 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
                     _logger.LogDebug("Found worker config: {workerConfigPath}", workerConfigPath);
 
-                    // Parse worker config file
-                    string json = File.ReadAllText(workerConfigPath);
-                    JObject workerConfig = JObject.Parse(json);
-                    RpcWorkerDescription workerDescription = workerConfig.Property(WorkerConstants.WorkerDescription).Value.ToObject<RpcWorkerDescription>();
+                    ReadOnlySpan<byte> jsonSpan = File.ReadAllBytes(workerConfigPath).AsSpan();
+                    if (jsonSpan.StartsWith(stackalloc byte[] { 0xEF, 0xBB, 0xBF }))
+                    {
+                        jsonSpan = jsonSpan[3..]; // Skip Byte Order Mark if present in the begining of the file.
+                    }
+                    var reader = new Utf8JsonReader(jsonSpan, isFinalBlock: true, state: default);
+                    using var doc = JsonDocument.ParseValue(ref reader);
+                    JsonElement workerConfig = doc.RootElement;
+
+                    var workerDescriptionElement = workerConfig.GetProperty(WorkerConstants.WorkerDescription);
+                    var workerDescription = workerDescriptionElement.Deserialize<RpcWorkerDescription>(_jsonSerializerOptions);
                     workerDescription.WorkerDirectory = workerDir;
 
-                    //Read the profiles from worker description and load the profile for which the conditions match
-                    JToken profiles = workerConfig.GetValue(WorkerConstants.WorkerDescriptionProfiles);
-                    if (profiles != null)
+                    // Read the profiles from worker description and load the profile for which the conditions match
+                    if (workerConfig.TryGetProperty(WorkerConstants.WorkerDescriptionProfiles, out var profiles))
                     {
                         List<WorkerDescriptionProfile> workerDescriptionProfiles = ReadWorkerDescriptionProfiles(profiles);
                         if (workerDescriptionProfiles.Count > 0)
@@ -146,12 +166,13 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
                     // Check if any app settings are provided for that language
                     var languageSection = _config.GetSection($"{RpcWorkerConstants.LanguageWorkersSectionName}:{workerDescription.Language}");
-                    workerDescription.Arguments = workerDescription.Arguments ?? new List<string>();
+                    workerDescription.Arguments ??= new List<string>();
                     GetWorkerDescriptionFromAppSettings(workerDescription, languageSection);
                     AddArgumentsFromAppSettings(workerDescription, languageSection);
 
                     // Validate workerDescription
-                    workerDescription.ApplyDefaultsAndValidate(Directory.GetCurrentDirectory(), _logger);
+                    var currentDirectory = Directory.GetCurrentDirectory();
+                    workerDescription.ApplyDefaultsAndValidate(currentDirectory, _logger);
 
                     if (workerDescription.IsDisabled == true)
                     {
@@ -197,9 +218,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             }
         }
 
-        private List<WorkerDescriptionProfile> ReadWorkerDescriptionProfiles(JToken profilesJToken)
+        private List<WorkerDescriptionProfile> ReadWorkerDescriptionProfiles(JsonElement profilesElement)
         {
-            var profiles = profilesJToken.ToObject<IList<WorkerProfileDescriptor>>();
+            var profiles = profilesElement.Deserialize<IList<WorkerProfileDescriptor>>(_jsonSerializerOptions);
 
             if (profiles == null || profiles.Count <= 0)
             {
@@ -237,11 +258,16 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             return descriptionProfiles;
         }
 
-        internal WorkerProcessCountOptions GetWorkerProcessCount(JObject workerConfig)
+        internal WorkerProcessCountOptions GetWorkerProcessCount(JsonElement workerConfig)
         {
-            WorkerProcessCountOptions workerProcessCount = workerConfig.Property(WorkerConstants.ProcessCount)?.Value.ToObject<WorkerProcessCountOptions>();
+            WorkerProcessCountOptions workerProcessCount = null;
 
-            workerProcessCount = workerProcessCount ?? new WorkerProcessCountOptions();
+            if (workerConfig.TryGetProperty(WorkerConstants.ProcessCount, out var processCountElement))
+            {
+                workerProcessCount = processCountElement.Deserialize<WorkerProcessCountOptions>();
+            }
+
+            workerProcessCount ??= new WorkerProcessCountOptions();
 
             if (workerProcessCount.SetProcessCountToNumberOfCpuCores)
             {

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -124,6 +124,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     if (!string.IsNullOrWhiteSpace(_workerRuntime) && !_environment.IsPlaceholderModeEnabled() && !_environment.IsMultiLanguageRuntimeEnvironment())
                     {
                         string workerRuntime = Path.GetFileName(workerDir);
+                        // We do not want to skip non-worker directories like function app payload directory.
                         if (!workerRuntime.Equals(_workerRuntime, StringComparison.OrdinalIgnoreCase) && workerDir.Contains("workers", StringComparison.OrdinalIgnoreCase))
                         {
                             return;
@@ -140,15 +141,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
                     _logger.LogDebug("Found worker config: {workerConfigPath}", workerConfigPath);
 
-                    ReadOnlySpan<byte> jsonSpan = File.ReadAllBytes(workerConfigPath).AsSpan();
-                    if (jsonSpan.StartsWith(stackalloc byte[] { 0xEF, 0xBB, 0xBF }))
-                    {
-                        jsonSpan = jsonSpan[3..]; // Skip Byte Order Mark if present in the begining of the file.
-                    }
-                    var reader = new Utf8JsonReader(jsonSpan, isFinalBlock: true, state: default);
-                    using var doc = JsonDocument.ParseValue(ref reader);
-                    JsonElement workerConfig = doc.RootElement;
-
+                    JsonElement workerConfig = GetWorkerConfigJsonElement(workerConfigPath);
                     var workerDescriptionElement = workerConfig.GetProperty(WorkerConstants.WorkerDescription);
                     var workerDescription = workerDescriptionElement.Deserialize<RpcWorkerDescription>(_jsonSerializerOptions);
                     workerDescription.WorkerDirectory = workerDir;
@@ -215,6 +208,19 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     _logger.LogError(ex, "Failed to initialize worker provider for: {workerDir}", workerDir);
                 }
             }
+        }
+
+        private static JsonElement GetWorkerConfigJsonElement(string workerConfigPath)
+        {
+            ReadOnlySpan<byte> jsonSpan = File.ReadAllBytes(workerConfigPath).AsSpan();
+            if (jsonSpan.StartsWith(stackalloc byte[] { 0xEF, 0xBB, 0xBF }))
+            {
+                jsonSpan = jsonSpan[3..]; // Skip UTF-8 Byte Order Mark (BOM) if present at the beginning of the file.
+            }
+            var reader = new Utf8JsonReader(jsonSpan, isFinalBlock: true, state: default);
+            using var doc = JsonDocument.ParseValue(ref reader);
+
+            return doc.RootElement.Clone();
         }
 
         private List<WorkerDescriptionProfile> ReadWorkerDescriptionProfiles(JsonElement profilesElement)

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -171,8 +171,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     AddArgumentsFromAppSettings(workerDescription, languageSection);
 
                     // Validate workerDescription
-                    var currentDirectory = Directory.GetCurrentDirectory();
-                    workerDescription.ApplyDefaultsAndValidate(currentDirectory, _logger);
+                    workerDescription.ApplyDefaultsAndValidate(Directory.GetCurrentDirectory(), _logger);
 
                     if (workerDescription.IsDisabled == true)
                     {

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     {
                         string workerRuntime = Path.GetFileName(workerDir);
                         // We do not want to skip non-worker directories like function app payload directory.
-                        if (!workerRuntime.Equals(_workerRuntime, StringComparison.OrdinalIgnoreCase) && workerDir.Contains("workers", StringComparison.OrdinalIgnoreCase))
+                        if (!workerRuntime.Equals(_workerRuntime, StringComparison.OrdinalIgnoreCase) && workerDir.StartsWith(WorkersDirPath))
                         {
                             return;
                         }
@@ -213,10 +213,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         private static JsonElement GetWorkerConfigJsonElement(string workerConfigPath)
         {
             ReadOnlySpan<byte> jsonSpan = File.ReadAllBytes(workerConfigPath).AsSpan();
+
             if (jsonSpan.StartsWith(stackalloc byte[] { 0xEF, 0xBB, 0xBF }))
             {
                 jsonSpan = jsonSpan[3..]; // Skip UTF-8 Byte Order Mark (BOM) if present at the beginning of the file.
             }
+
             var reader = new Utf8JsonReader(jsonSpan, isFinalBlock: true, state: default);
             using var doc = JsonDocument.ParseValue(ref reader);
 

--- a/test/WebJobs.Script.Tests/Workers/Profiles/EnvironmentConditionTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Profiles/EnvironmentConditionTests.cs
@@ -1,8 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Profiles;
 using Xunit;
@@ -28,8 +28,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles
             var descriptor = new WorkerProfileConditionDescriptor();
             descriptor.Type = WorkerConstants.WorkerDescriptionProfileEnvironmentCondition;
 
-            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = name;
-            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = expression;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = JsonSerializer.SerializeToElement(name);
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = JsonSerializer.SerializeToElement(expression);
 
             Assert.Throws<ValidationException>(() => new EnvironmentCondition(testLogger, _testEnvironment, descriptor));
         }
@@ -45,8 +45,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles
 
             var descriptor = new WorkerProfileConditionDescriptor();
             descriptor.Type = WorkerConstants.WorkerDescriptionProfileEnvironmentCondition;
-            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = name;
-            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = testExpression;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = JsonSerializer.SerializeToElement(name);
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = JsonSerializer.SerializeToElement(testExpression);
 
             var environmentCondition = new EnvironmentCondition(testLogger, _testEnvironment, descriptor);
 
@@ -64,8 +64,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles
 
             var descriptor = new WorkerProfileConditionDescriptor();
             descriptor.Type = WorkerConstants.WorkerDescriptionProfileEnvironmentCondition;
-            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = name;
-            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = testExpression;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = JsonSerializer.SerializeToElement(name); ; ;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = JsonSerializer.SerializeToElement(testExpression);
 
             var environmentCondition = new EnvironmentCondition(testLogger, _testEnvironment, descriptor);
 

--- a/test/WebJobs.Script.Tests/Workers/Profiles/EnvironmentConditionTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Profiles/EnvironmentConditionTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles
 
             var descriptor = new WorkerProfileConditionDescriptor();
             descriptor.Type = WorkerConstants.WorkerDescriptionProfileEnvironmentCondition;
-            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = JsonSerializer.SerializeToElement(name); ; ;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = JsonSerializer.SerializeToElement(name);
             descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = JsonSerializer.SerializeToElement(testExpression);
 
             var environmentCondition = new EnvironmentCondition(testLogger, _testEnvironment, descriptor);

--- a/test/WebJobs.Script.Tests/Workers/Profiles/HostPropertyConditionTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Profiles/HostPropertyConditionTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations;
+using System.Linq.Expressions;
+using System.Text.Json;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Profiles;
 using Xunit;
@@ -29,8 +31,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles
             var descriptor = new WorkerProfileConditionDescriptor();
             descriptor.Type = WorkerConstants.WorkerDescriptionProfileHostPropertyCondition;
 
-            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = name;
-            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = expression;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = JsonSerializer.SerializeToElement(name);
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = JsonSerializer.SerializeToElement(expression);
 
             Assert.Throws<ValidationException>(() => new HostPropertyCondition(testLogger, _testSystemRuntimeInfo, descriptor));
         }
@@ -45,8 +47,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles
 
             var descriptor = new WorkerProfileConditionDescriptor();
             descriptor.Type = WorkerConstants.WorkerDescriptionProfileHostPropertyCondition;
-            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = name;
-            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = testExpression;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = JsonSerializer.SerializeToElement(name);
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = JsonSerializer.SerializeToElement(testExpression);
 
             var hostPropertyCondition = new HostPropertyCondition(testLogger, _testSystemRuntimeInfo, descriptor);
 
@@ -63,8 +65,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles
 
             var descriptor = new WorkerProfileConditionDescriptor();
             descriptor.Type = WorkerConstants.WorkerDescriptionProfileHostPropertyCondition;
-            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = name;
-            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = testExpression;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = JsonSerializer.SerializeToElement(name);
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = JsonSerializer.SerializeToElement(testExpression);
 
             var hostPropertyCondition = new HostPropertyCondition(testLogger, _testSystemRuntimeInfo, descriptor);
 

--- a/test/WebJobs.Script.Tests/Workers/Profiles/ProfilesTestUtilities.cs
+++ b/test/WebJobs.Script.Tests/Workers/Profiles/ProfilesTestUtilities.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Text.Json;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Profiles;
 using Microsoft.Extensions.Logging;
@@ -29,8 +30,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles
         {
             var descriptor = new WorkerProfileConditionDescriptor();
             descriptor.Type = WorkerConstants.WorkerDescriptionProfileEnvironmentCondition;
-            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = name;
-            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = expression;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = JsonSerializer.SerializeToElement(name);
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = JsonSerializer.SerializeToElement(expression);
 
             return new EnvironmentCondition(logger, testEnvironment, descriptor);
         }
@@ -39,8 +40,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles
         {
             var descriptor = new WorkerProfileConditionDescriptor();
             descriptor.Type = WorkerConstants.WorkerDescriptionProfileHostPropertyCondition;
-            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = name;
-            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = expression;
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionName] = JsonSerializer.SerializeToElement(name);
+            descriptor.Properties[WorkerConstants.WorkerDescriptionProfileConditionExpression] = JsonSerializer.SerializeToElement(expression);
 
             return new HostPropertyCondition(logger, testSystemRuntimeInfo, descriptor);
         }

--- a/test/WebJobs.Script.Tests/Workers/Profiles/WorkerProfileConditionDescriptorTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Profiles/WorkerProfileConditionDescriptorTests.cs
@@ -1,10 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Profiles;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles
@@ -14,20 +14,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles
         [Fact]
         public void ConditionDescriptor_ConvertsJObject()
         {
-            var conditionJObject = new JObject();
-            conditionJObject[WorkerConstants.WorkerDescriptionProfileConditionName] = WorkerConstants.WorkerDescriptionProfileConditionName;
-            conditionJObject[WorkerConstants.WorkerDescriptionProfileConditionExpression] = WorkerConstants.WorkerDescriptionProfileConditionExpression;
+            var conditionJObject = new JsonObject
+            {
+                [WorkerConstants.WorkerDescriptionProfileConditionName] = WorkerConstants.WorkerDescriptionProfileConditionName,
+                [WorkerConstants.WorkerDescriptionProfileConditionExpression] = WorkerConstants.WorkerDescriptionProfileConditionExpression
+            };
 
-            Assert.Throws<JsonSerializationException>(() => conditionJObject.ToObject<WorkerProfileConditionDescriptor>());
+            Assert.Throws<JsonException>(() => conditionJObject.Deserialize<WorkerProfileConditionDescriptor>());
 
             conditionJObject[WorkerConstants.WorkerDescriptionProfileConditionType] = WorkerConstants.WorkerDescriptionProfileEnvironmentCondition;
 
-            var conditionDescriptor = conditionJObject.ToObject<WorkerProfileConditionDescriptor>();
-            conditionDescriptor.Properties.TryGetValue(WorkerConstants.WorkerDescriptionProfileConditionName, out string conditionDescriptorName);
-            conditionDescriptor.Properties.TryGetValue(WorkerConstants.WorkerDescriptionProfileConditionExpression, out string conditionDescriptorExpression);
+            var conditionDescriptor = conditionJObject.Deserialize<WorkerProfileConditionDescriptor>();
+            conditionDescriptor.Properties.TryGetValue(WorkerConstants.WorkerDescriptionProfileConditionName, out var conditionDescriptorName);
+            conditionDescriptor.Properties.TryGetValue(WorkerConstants.WorkerDescriptionProfileConditionExpression, out var conditionDescriptorExpression);
 
-            Assert.Equal(WorkerConstants.WorkerDescriptionProfileConditionName, conditionDescriptorName);
-            Assert.Equal(WorkerConstants.WorkerDescriptionProfileConditionExpression, conditionDescriptorExpression);
+            Assert.Equal(WorkerConstants.WorkerDescriptionProfileConditionName, conditionDescriptorName.GetString());
+            Assert.Equal(WorkerConstants.WorkerDescriptionProfileConditionExpression, conditionDescriptorExpression.GetString());
             Assert.Equal(WorkerConstants.WorkerDescriptionProfileEnvironmentCondition, conditionDescriptor.Type);
         }
     }

--- a/test/WebJobs.Script.Tests/Workers/Profiles/WorkerProfileManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Profiles/WorkerProfileManagerTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Profiles;
@@ -53,11 +55,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Profiles
         [Fact]
         public void TryCreateWorkerProfileCondition_ValidCondition_ReturnsTrue()
         {
-            var conditionJObject = new JObject();
-            conditionJObject[WorkerConstants.WorkerDescriptionProfileConditionType] = "environment";
-            conditionJObject[WorkerConstants.WorkerDescriptionProfileConditionName] = "PROFILE_TEST_ENVIRONMENT_VARIABLE";
-            conditionJObject[WorkerConstants.WorkerDescriptionProfileConditionExpression] = "true";
-            var conditionDescriptor = conditionJObject.ToObject<WorkerProfileConditionDescriptor>();
+            var conditionJObject = new JsonObject
+            {
+                [WorkerConstants.WorkerDescriptionProfileConditionType] = "environment",
+                [WorkerConstants.WorkerDescriptionProfileConditionName] = "PROFILE_TEST_ENVIRONMENT_VARIABLE",
+                [WorkerConstants.WorkerDescriptionProfileConditionExpression] = "true"
+            };
+
+            WorkerProfileConditionDescriptor conditionDescriptor = conditionJObject.Deserialize<WorkerProfileConditionDescriptor>();
 
             WorkerProfileManager profileManager = new(_testLogger, _testEnvironment);
             var result = profileManager.TryCreateWorkerProfileCondition(conditionDescriptor, out var condition);

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
@@ -5,12 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Profiles;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.Configuration;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, _testEnvironment, new TestMetricsLogger(), _testWorkerProfileManager);
 
             var workerConfigs = configFactory.GetConfigs();
-
+            var errors = testLogger.GetLogMessages().Where(m => m.Exception != null).ToList();
             Assert.False(testLogger.GetLogMessages().Any(m => m.Exception != null), "There should not be an exception logged while executing GetConfigs method.");
             Assert.Equal(1, workerConfigs.Count);
             Assert.EndsWith("worker1\\1.bat", workerConfigs[0].Description.DefaultWorkerPath);
@@ -217,17 +217,29 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         [InlineData(false, true, true, 4, 8, "00:00:05")]
         public void GetWorkerProcessCount_Tests(bool defaultWorkerConfig, bool setProcessCountToNumberOfCpuCores, bool setWorkerCountInEnv, int minProcessCount, int maxProcessCount, string processStartupInterval)
         {
-            JObject processCount = new JObject();
-            processCount["ProcessCount"] = minProcessCount;
-            processCount["MaxProcessCount"] = maxProcessCount;
-            processCount["ProcessStartupInterval"] = processStartupInterval;
-            processCount["SetProcessCountToNumberOfCpuCores"] = setProcessCountToNumberOfCpuCores;
-
-            JObject workerConfig = new JObject();
-            if (!defaultWorkerConfig)
+            using var stream = new MemoryStream();
+            using (var writer = new Utf8JsonWriter(stream))
             {
-                workerConfig[WorkerConstants.ProcessCount] = processCount;
+                writer.WriteStartObject();
+
+                if (!defaultWorkerConfig)
+                {
+                    writer.WritePropertyName(WorkerConstants.ProcessCount);
+                    writer.WriteStartObject();
+
+                    writer.WriteNumber("ProcessCount", minProcessCount);
+                    writer.WriteNumber("MaxProcessCount", maxProcessCount);
+                    writer.WriteString("ProcessStartupInterval", processStartupInterval);
+                    writer.WriteBoolean("SetProcessCountToNumberOfCpuCores", setProcessCountToNumberOfCpuCores);
+
+                    writer.WriteEndObject();
+                }
+
+                writer.WriteEndObject();
             }
+
+            using var jsonDocument = JsonDocument.Parse(stream.ToArray());
+            JsonElement workerConfig = jsonDocument.RootElement;
 
             if (setWorkerCountInEnv)
             {
@@ -273,14 +285,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         [Fact]
         public void GetWorkerProcessCount_ThrowsException_Tests()
         {
-            JObject processCount = new JObject();
-            processCount["ProcessCount"] = -4;
-            processCount["MaxProcessCount"] = 10;
-            processCount["ProcessStartupInterval"] = "00:10:00";
-            processCount["SetProcessCountToNumberOfCpuCores"] = false;
-
-            JObject workerConfig = new JObject();
-            workerConfig[WorkerConstants.ProcessCount] = processCount;
+            JsonElement workerConfig = CreateWorkerConfig(-4, 10, "00:10:00", false);
 
             var config = new ConfigurationBuilder().Build();
             var testLogger = new TestLogger("test");
@@ -288,14 +293,35 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var resultEx1 = Assert.Throws<ArgumentOutOfRangeException>(() => rpcWorkerConfigFactory.GetWorkerProcessCount(workerConfig));
             Assert.Contains("ProcessCount must be greater than 0", resultEx1.Message);
 
-            processCount["ProcessCount"] = 40;
+            workerConfig = CreateWorkerConfig(40, 10, "00:10:00", false);
             var resultEx2 = Assert.Throws<ArgumentException>(() => rpcWorkerConfigFactory.GetWorkerProcessCount(workerConfig));
             Assert.Contains("ProcessCount must not be greater than MaxProcessCount", resultEx2.Message);
 
-            processCount["ProcessStartupInterval"] = "-800";
-            processCount["ProcessCount"] = 10;
-            var resultEx3 = Assert.Throws<ArgumentOutOfRangeException>(() => rpcWorkerConfigFactory.GetWorkerProcessCount(workerConfig));
-            Assert.Contains("The TimeSpan must not be negative", resultEx3.Message);
+            workerConfig = CreateWorkerConfig(10, 10, "-800", false);
+            var resultEx3 = Assert.Throws<JsonException>(() => rpcWorkerConfigFactory.GetWorkerProcessCount(workerConfig));
+            Assert.Contains("value could not be converted to System.TimeSpan", resultEx3.Message);
+        }
+
+        private static JsonElement CreateWorkerConfig(int processCount, int maxProcessCount, string processStartupInterval, bool setProcessCountToCores)
+        {
+            using var stream = new MemoryStream();
+            using (var writer = new Utf8JsonWriter(stream))
+            {
+                writer.WriteStartObject();
+                writer.WritePropertyName(WorkerConstants.ProcessCount);
+
+                writer.WriteStartObject();
+                writer.WriteNumber("ProcessCount", processCount);
+                writer.WriteNumber("MaxProcessCount", maxProcessCount);
+                writer.WriteString("ProcessStartupInterval", processStartupInterval);
+                writer.WriteBoolean("SetProcessCountToNumberOfCpuCores", setProcessCountToCores);
+                writer.WriteEndObject();
+
+                writer.WriteEndObject();
+            }
+
+            using var doc = JsonDocument.Parse(stream.ToArray());
+            return doc.RootElement.Clone();
         }
     }
 }


### PR DESCRIPTION
resolves #10931

1. Replaced Newtonsoft.Json with System.Text.Json for deserializing worker profiles.
2. Previously, all worker configs were loaded and parsed into `RpcWorkerDescription` objects before filtering using `ShouldAddWorkerConfig`. Now, we skip loading configs for non-matching runtimes and only parse the config that matches FUNCTIONS_WORKER_RUNTIME, reducing unnecessary overhead after specialization.

This change reduced allocations in the `AddProviders` method, during specialization (and even during placeholder mode).

### Before

|Function Name|Total \(Allocations\)|Self \(Allocations\)|Total Size \(Bytes\)|Self Size \(Bytes\)|
|-|-|-|-|-|
|RpcWorkerConfigFactory.GetConfigs\(\)|5,618|6|536,320|192|
|RpcWorkerConfigFactory.AddProviders\(\)|5,039|2|481,990|64|
|RpcWorkerConfigFactory.AddProvider\(string\)|4,997|30|476,358|1,040|


### After

|Function Name|Total \(Allocations\)|Self \(Allocations\)|Total Size \(Bytes\)|Self Size \(Bytes\)|
|-|-|-|-|-|
|RpcWorkerConfigFactory.GetConfigs\(\)|3,961|6|271,511|192|
|RpcWorkerConfigFactory.AddProviders\(\)|3,521|2|243,522|64|
|RpcWorkerConfigFactory.AddProvider\(string\)|3,479|16|237,890|592|

### Delta

- `RpcWorkerConfigFactory.AddProviders()` - Total allocations dropped by 1,518 (30.13%).
- `RpcWorkerConfigFactory.AddProviders()` - Total allocated size reduced by ~238 KB (nearly 50%).

#### Before
<img width="889" alt="image" src="https://github.com/user-attachments/assets/73a0fb96-d4df-4aab-bf94-6c23ae858225" />

#### After
<img width="860" alt="image" src="https://github.com/user-attachments/assets/969cc4fb-4cd9-468f-ad53-ef95a0878a14" />

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
