### PR TITLE
Setting the assembly visibility of Microsoft.Azure.Functions.PlatformMetrics.LinuxConsumption to private

### DIFF
--- a/src/WebJobs.Script/runtimeassemblies-relaxed.json
+++ b/src/WebJobs.Script/runtimeassemblies-relaxed.json
@@ -353,7 +353,7 @@
     },
     {
       "name": "Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption",
-      "resolutionPolicy": "minorMatchOrLower"
+      "resolutionPolicy": "private"
     },
     {
       "name": "Microsoft.Azure.WebJobs",


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Updating the resolution policy of `Microsoft.Azure.Functions.PlatformMetrics.LinuxConsumption` to `private`.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
