### PR TITLE
Update Python Worker to 4.36.1

### DIFF
--- a/eng/build/Workers.Python.props
+++ b/eng/build/Workers.Python.props
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <!-- Python worker does not ship with the host for windows. -->
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.35.0" Condition="!$(RuntimeIdentifier.StartsWith('win'))" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.36.1" Condition="!$(RuntimeIdentifier.StartsWith('win'))" />
   </ItemGroup>
 
 </Project>

--- a/release_notes.md
+++ b/release_notes.md
@@ -18,3 +18,4 @@
 - Fixed bug that could result in "Binding names must be unique" error (#10938)
 - Fix race condition that leads the host to initialize placeholder (warmup) function in Linux environments (#10848)
 - Updating Azure.Core and OTel related packages, recording exception and retaining "Microsoft.Azure.WebJobs" logs  (#10965)
+- Update Python Worker Version to [4.36.1](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.36.1)

--- a/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
+++ b/test/WebJobs.Script.Tests/WebJobs.Script.Tests.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.35.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" Version="4.36.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Python Worker Release note [4.36.1](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.36.1)

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * [X] Otherwise: Link to backporting PR https://github.com/Azure/azure-functions-host/pull/10971
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * [ ] Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
