### PR TITLE
[Backport] Update Java Worker Version to 2.19.0

### DIFF
--- a/eng/build/Workers.Java.props
+++ b/eng/build/Workers.Java.props
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.18.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.19.0" />
   </ItemGroup>
 
 </Project>

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,6 +3,7 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Update Java Worker Version to [2.19.0](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.0)
 
 - Update Java Worker Version to [2.18.1](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.18.1)
 - Add support for new FeatureFlag `EnableAzureMonitorTimeIsoFormat` to enable iso time format for azmon logs for Linux Dedicated/EP Skus. (part of #7864)

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,8 +4,6 @@
 - My change description (#PR)
 -->
 - Update Java Worker Version to [2.19.0](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.0)
-
-- Update Java Worker Version to [2.18.1](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.18.1)
 - Add support for new FeatureFlag `EnableAzureMonitorTimeIsoFormat` to enable iso time format for azmon logs for Linux Dedicated/EP Skus. (part of #7864)
 - Update PowerShell worker to 4.0.4175 (sets defaultRuntimeVersion to 7.4 in worker.config.json)
 - Fixing default DateTime bug with TimeZones in TimerTrigger (#10906)


### PR DESCRIPTION
### Issue describing the changes in this PR

Update Java Worker Version to 2.19.0

Java Worker Release note [2.19.0](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.0)

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the in-proc branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the in-proc branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to elease_notes.md
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
