### PR TITLE
Fix invocation timeout when incoming request contains "x-ms-invocation-id" header

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,5 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+
+- Fix invocation timeout when incoming request contains "x-ms-invocation-id" header (#10980)

--- a/release_notes.md
+++ b/release_notes.md
@@ -5,7 +5,6 @@
 -->
 - Improved memory metrics reporting using CGroup data for Linux consumption (#10968)
 - Memory allocation optimizations in `RpcWorkerConfigFactory.AddProviders` (#10959)
-
 - Fixing GrpcWorkerChannel concurrency bug (#10998)
 - Avoid circular dependency when resolving LinuxContainerLegionMetricsPublisher. (#10991)
 - Add 'unix' to the list of runtimes kept when importing PowerShell worker for Linux builds

--- a/src/WebJobs.Script.Grpc/Properties/AssemblyInfo.cs
+++ b/src/WebJobs.Script.Grpc/Properties/AssemblyInfo.cs
@@ -6,3 +6,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.Script.Benchmarks")]
 [assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.Script.Tests")]
 [assembly: InternalsVisibleTo("Microsoft.Azure.WebJobs.Script.Tests.Integration")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
+++ b/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             // add invocation id as correlation id
             if (!httpRequest.Headers.TryAdd(ScriptConstants.HttpProxyCorrelationHeader, invocationId))
             {
-                httpRequest.Headers[ScriptConstants.HttpProxyingEnabled] = invocationId;
+                httpRequest.Headers[ScriptConstants.HttpProxyCorrelationHeader] = invocationId;
             }
 
             var forwardingTask = _httpForwarder.SendAsync(httpContext, httpUri.ToString(), _messageInvoker, _forwarderRequestConfig).AsTask();

--- a/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
+++ b/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Script.Description;
@@ -13,7 +11,6 @@ using Microsoft.Azure.WebJobs.Script.Grpc.Exceptions;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Extensions.Logging;
 using Yarp.ReverseProxy.Forwarder;
-using static Microsoft.Azure.AppService.Proxy.Common.Debug.DebugLogHelper;
 
 namespace Microsoft.Azure.WebJobs.Script.Grpc
 {

--- a/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
+++ b/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Script.Description;
@@ -12,6 +13,7 @@ using Microsoft.Azure.WebJobs.Script.Grpc.Exceptions;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Extensions.Logging;
 using Yarp.ReverseProxy.Forwarder;
+using static Microsoft.Azure.AppService.Proxy.Common.Debug.DebugLogHelper;
 
 namespace Microsoft.Azure.WebJobs.Script.Grpc
 {
@@ -99,7 +101,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             string invocationId = context.ExecutionContext.InvocationId.ToString();
 
             // add invocation id as correlation id, override existing header if present
-            httpRequest.Headers[ScriptConstants.HttpProxyCorrelationHeader] = invocationId;
+            httpRequest.Headers[ScriptConstants.HttpProxyCorrelationHeader] = context.ExecutionContext.InvocationId.ToString();
 
             var forwardingTask = _httpForwarder.SendAsync(httpContext, httpUri.ToString(), _messageInvoker, _forwarderRequestConfig).AsTask();
             context.Properties[ScriptConstants.HttpProxyTask] = forwardingTask;

--- a/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
+++ b/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
@@ -98,11 +98,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
             string invocationId = context.ExecutionContext.InvocationId.ToString();
 
-            // add invocation id as correlation id
-            if (!httpRequest.Headers.TryAdd(ScriptConstants.HttpProxyCorrelationHeader, invocationId))
-            {
-                httpRequest.Headers[ScriptConstants.HttpProxyCorrelationHeader] = invocationId;
-            }
+            // add invocation id as correlation id, override existing header if present
+            httpRequest.Headers[ScriptConstants.HttpProxyCorrelationHeader] = invocationId;
 
             var forwardingTask = _httpForwarder.SendAsync(httpContext, httpUri.ToString(), _messageInvoker, _forwarderRequestConfig).AsTask();
             context.Properties[ScriptConstants.HttpProxyTask] = forwardingTask;

--- a/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
+++ b/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
@@ -97,7 +97,12 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             httpContext.Items[ScriptConstants.HttpProxyingEnabled] = bool.TrueString;
 
             // add invocation id as correlation id
-            httpRequest.Headers.TryAdd(ScriptConstants.HttpProxyCorrelationHeader, context.ExecutionContext.InvocationId.ToString());
+            if (!httpRequest.Headers.TryAdd(ScriptConstants.HttpProxyCorrelationHeader, context.ExecutionContext.InvocationId.ToString()))
+            {
+                // try to remove the header if it already exists
+                httpRequest.Headers.Remove(ScriptConstants.HttpProxyCorrelationHeader);
+                httpRequest.Headers.TryAdd(ScriptConstants.HttpProxyCorrelationHeader, context.ExecutionContext.InvocationId.ToString());
+            }
 
             var forwardingTask = _httpForwarder.SendAsync(httpContext, httpUri.ToString(), _messageInvoker, _forwarderRequestConfig).AsTask();
             context.Properties[ScriptConstants.HttpProxyTask] = forwardingTask;

--- a/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
+++ b/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
@@ -98,8 +98,6 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             HttpContext httpContext = httpRequest.HttpContext;
             httpContext.Items[ScriptConstants.HttpProxyingEnabled] = bool.TrueString;
 
-            string invocationId = context.ExecutionContext.InvocationId.ToString();
-
             // add invocation id as correlation id, override existing header if present
             httpRequest.Headers[ScriptConstants.HttpProxyCorrelationHeader] = context.ExecutionContext.InvocationId.ToString();
 

--- a/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
+++ b/src/WebJobs.Script.Grpc/Server/DefaultHttpProxyService.cs
@@ -96,12 +96,12 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             HttpContext httpContext = httpRequest.HttpContext;
             httpContext.Items[ScriptConstants.HttpProxyingEnabled] = bool.TrueString;
 
+            string invocationId = context.ExecutionContext.InvocationId.ToString();
+
             // add invocation id as correlation id
-            if (!httpRequest.Headers.TryAdd(ScriptConstants.HttpProxyCorrelationHeader, context.ExecutionContext.InvocationId.ToString()))
+            if (!httpRequest.Headers.TryAdd(ScriptConstants.HttpProxyCorrelationHeader, invocationId))
             {
-                // try to remove the header if it already exists
-                httpRequest.Headers.Remove(ScriptConstants.HttpProxyCorrelationHeader);
-                httpRequest.Headers.TryAdd(ScriptConstants.HttpProxyCorrelationHeader, context.ExecutionContext.InvocationId.ToString());
+                httpRequest.Headers[ScriptConstants.HttpProxyingEnabled] = invocationId;
             }
 
             var forwardingTask = _httpForwarder.SendAsync(httpContext, httpUri.ToString(), _messageInvoker, _forwarderRequestConfig).AsTask();

--- a/test/WebJobs.Script.Tests/HttpProxyService/DefaultHttpProxyServiceTests.cs
+++ b/test/WebJobs.Script.Tests/HttpProxyService/DefaultHttpProxyServiceTests.cs
@@ -32,11 +32,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             var httpContext = new DefaultHttpContext();
             httpContext.Items.Add(ScriptConstants.AzureFunctionsHttpTriggerContext, new());
-
+            var invocationId = Guid.NewGuid();
             var context = new ScriptInvocationContext
             {
                 FunctionMetadata = new FunctionMetadata { Name = "TestFunction" },
-                ExecutionContext = new ExecutionContext { InvocationId = Guid.NewGuid() },
+                ExecutionContext = new ExecutionContext { InvocationId = invocationId },
                 Inputs = new List<(string Name, DataType Type, object Val)>
                 {
                     ("req", DataType.String, httpContext.Request)
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var httpRequest = (HttpRequest)context.Inputs.First().Val;
             Assert.True(httpRequest.Headers.ContainsKey(ScriptConstants.HttpProxyCorrelationHeader));
-            Assert.Equal(context.ExecutionContext.InvocationId.ToString(), httpRequest.Headers[ScriptConstants.HttpProxyCorrelationHeader]);
+            Assert.Equal(invocationId.ToString(), httpRequest.Headers[ScriptConstants.HttpProxyCorrelationHeader]);
         }
 
         [Fact]
@@ -58,11 +58,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             var httpContext = new DefaultHttpContext();
             httpContext.Items.Add(ScriptConstants.AzureFunctionsHttpTriggerContext, new());
-
+            var invocationId = Guid.NewGuid();
             var context = new ScriptInvocationContext
             {
                 FunctionMetadata = new FunctionMetadata { Name = "TestFunction" },
-                ExecutionContext = new ExecutionContext { InvocationId = Guid.NewGuid() },
+                ExecutionContext = new ExecutionContext { InvocationId = invocationId },
                 Inputs = new List<(string Name, DataType Type, object Val)>
                 {
                     ("req", DataType.String, httpContext.Request)
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             httpRequest.Headers[ScriptConstants.HttpProxyCorrelationHeader] = existingCorrelationId;
 
             _proxyService.StartForwarding(context, httpUri);
-            Assert.NotEqual<string>(existingCorrelationId, httpRequest.Headers[ScriptConstants.HttpProxyCorrelationHeader]);
+            Assert.Equal(invocationId.ToString(), httpRequest.Headers[ScriptConstants.HttpProxyCorrelationHeader]);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/HttpProxyService/DefaultHttpProxyServiceTests.cs
+++ b/test/WebJobs.Script.Tests/HttpProxyService/DefaultHttpProxyServiceTests.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Grpc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using Yarp.ReverseProxy.Forwarder;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public class DefaultHttpProxyServiceTests
+    {
+        private readonly Mock<IHttpForwarder> _httpForwarderMock;
+        private readonly Mock<ILogger<DefaultHttpProxyService>> _loggerMock;
+        private readonly DefaultHttpProxyService _proxyService;
+
+        public DefaultHttpProxyServiceTests()
+        {
+            _httpForwarderMock = new Mock<IHttpForwarder>();
+            _loggerMock = new Mock<ILogger<DefaultHttpProxyService>>();
+            _proxyService = new DefaultHttpProxyService(_httpForwarderMock.Object, _loggerMock.Object);
+        }
+
+        [Fact]
+        public void StartForwarding_SetsCorrelationHeader()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items.Add(ScriptConstants.AzureFunctionsHttpTriggerContext, new());
+
+            var context = new ScriptInvocationContext
+            {
+                FunctionMetadata = new FunctionMetadata { Name = "TestFunction" },
+                ExecutionContext = new ExecutionContext { InvocationId = Guid.NewGuid() },
+                Inputs = new List<(string Name, DataType Type, object Val)>
+                {
+                    ("req", DataType.String, httpContext.Request)
+                },
+                Properties = new Dictionary<string, object>()
+            };
+
+            var httpUri = new Uri("http://localhost");
+
+            _proxyService.StartForwarding(context, httpUri);
+
+            var httpRequest = (HttpRequest)context.Inputs.First().Val;
+            Assert.True(httpRequest.Headers.ContainsKey(ScriptConstants.HttpProxyCorrelationHeader));
+            Assert.Equal(context.ExecutionContext.InvocationId.ToString(), httpRequest.Headers[ScriptConstants.HttpProxyCorrelationHeader]);
+        }
+
+        [Fact]
+        public void StartForwarding_OverridesExistingCorrelationHeader()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Items.Add(ScriptConstants.AzureFunctionsHttpTriggerContext, new());
+
+            var context = new ScriptInvocationContext
+            {
+                FunctionMetadata = new FunctionMetadata { Name = "TestFunction" },
+                ExecutionContext = new ExecutionContext { InvocationId = Guid.NewGuid() },
+                Inputs = new List<(string Name, DataType Type, object Val)>
+                {
+                    ("req", DataType.String, httpContext.Request)
+                },
+                Properties = new Dictionary<string, object>()
+            };
+
+            var httpUri = new Uri("http://localhost");
+            var existingCorrelationId = Guid.NewGuid().ToString();
+            var httpRequest = (HttpRequest)context.Inputs.First().Val;
+            httpRequest.Headers[ScriptConstants.HttpProxyCorrelationHeader] = existingCorrelationId;
+
+            _proxyService.StartForwarding(context, httpUri);
+            Assert.NotEqual<string>(existingCorrelationId, httpRequest.Headers[ScriptConstants.HttpProxyCorrelationHeader]);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #10934

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)
