### PR TITLE
Filter Azure monitor logs when customer does not subscribe for the categories

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/AzureMonitorDiagnosticLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/AzureMonitorDiagnosticLogger.cs
@@ -54,8 +54,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public bool IsEnabled(LogLevel logLevel)
         {
-            if ((_environment.IsFlexConsumptionSku() || _environment.IsLinuxConsumptionOnLegion())
-                && !_environment.IsAzureMonitorEnabledOnLegionSkus())
+            if (_environment.IsLegionBasedSku() && !_environment.IsAzureMonitorEnabled(useCache:true))
             {
                 return false;
             }

--- a/src/WebJobs.Script.WebHost/Diagnostics/AzureMonitorDiagnosticLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/AzureMonitorDiagnosticLogger.cs
@@ -5,15 +5,17 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
+using static Microsoft.Azure.WebJobs.Script.Utility;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 {
-    public class AzureMonitorDiagnosticLogger : ILogger
+    public class AzureMonitorDiagnosticLogger : ILogger, IDisposable
     {
         internal const string AzureMonitorCategoryName = "FunctionAppLogs";
         internal const string AzureMonitorOperationName = "Microsoft.Web/sites/functions/log";
@@ -29,7 +31,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         private readonly IEventGenerator _eventGenerator;
         private readonly IEnvironment _environment;
         private readonly IExternalScopeProvider _scopeProvider;
+        private readonly IDisposable _appServiceOptionsOnChangeListener;
         private AppServiceOptions _appServiceOptions;
+        private static bool isAzureMonitorLogsEnabled;
 
         public AzureMonitorDiagnosticLogger(string category, string hostInstanceId, IEventGenerator eventGenerator, IEnvironment environment, IExternalScopeProvider scopeProvider,
             HostNameProvider hostNameProvider, IOptionsMonitor<AppServiceOptions> appServiceOptionsMonitor)
@@ -42,8 +46,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             _hostNameProvider = hostNameProvider ?? throw new ArgumentNullException(nameof(hostNameProvider));
             _ = appServiceOptionsMonitor ?? throw new ArgumentNullException(nameof(appServiceOptionsMonitor));
 
-            appServiceOptionsMonitor.OnChange(newOptions => _appServiceOptions = newOptions);
-            _appServiceOptions = appServiceOptionsMonitor.CurrentValue;
+            _appServiceOptionsOnChangeListener = appServiceOptionsMonitor.OnChange(UpdateAppServiceOptions);
+            UpdateAppServiceOptions(appServiceOptionsMonitor.CurrentValue);
 
             _roleInstance = _environment.GetInstanceId();
 
@@ -54,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public bool IsEnabled(LogLevel logLevel)
         {
-            if (_environment.IsLegionBasedSku() && !_environment.IsAzureMonitorEnabled(useCache:true))
+            if (_environment.IsConsumptionOnLegion() && !isAzureMonitorLogsEnabled)
             {
                 return false;
             }
@@ -138,6 +142,17 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             }
 
             _eventGenerator.LogAzureMonitorDiagnosticLogEvent(logLevel, _hostNameProvider.Value, AzureMonitorOperationName, AzureMonitorCategoryName, _regionName, sw.ToString());
+        }
+
+        public void Dispose()
+        {
+            _appServiceOptionsOnChangeListener?.Dispose();
+        }
+
+        private void UpdateAppServiceOptions(AppServiceOptions newOptions)
+        {
+            _appServiceOptions = newOptions;
+            isAzureMonitorLogsEnabled = IsAzureMonitorLoggingEnabled(_appServiceOptions.AzureMonitorTraceCategory);
         }
 
         private static void WritePropertyIfNotNull<T>(JsonTextWriter writer, string propertyName, T propertyValue)

--- a/src/WebJobs.Script.WebHost/Diagnostics/AzureMonitorDiagnosticLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/AzureMonitorDiagnosticLogger.cs
@@ -5,17 +5,15 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
-using static Microsoft.Azure.WebJobs.Script.Utility;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 {
-    public class AzureMonitorDiagnosticLogger : ILogger, IDisposable
+    public class AzureMonitorDiagnosticLogger : ILogger
     {
         internal const string AzureMonitorCategoryName = "FunctionAppLogs";
         internal const string AzureMonitorOperationName = "Microsoft.Web/sites/functions/log";
@@ -31,9 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         private readonly IEventGenerator _eventGenerator;
         private readonly IEnvironment _environment;
         private readonly IExternalScopeProvider _scopeProvider;
-        private readonly IDisposable _appServiceOptionsOnChangeListener;
-        private AppServiceOptions _appServiceOptions;
-        private static bool isAzureMonitorLogsEnabled;
+        private IOptionsMonitor<AppServiceOptions> _appServiceOptionsMonitor;
 
         public AzureMonitorDiagnosticLogger(string category, string hostInstanceId, IEventGenerator eventGenerator, IEnvironment environment, IExternalScopeProvider scopeProvider,
             HostNameProvider hostNameProvider, IOptionsMonitor<AppServiceOptions> appServiceOptionsMonitor)
@@ -44,10 +40,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
             _scopeProvider = scopeProvider ?? throw new ArgumentNullException(nameof(scopeProvider));
             _hostNameProvider = hostNameProvider ?? throw new ArgumentNullException(nameof(hostNameProvider));
-            _ = appServiceOptionsMonitor ?? throw new ArgumentNullException(nameof(appServiceOptionsMonitor));
-
-            _appServiceOptionsOnChangeListener = appServiceOptionsMonitor.OnChange(UpdateAppServiceOptions);
-            UpdateAppServiceOptions(appServiceOptionsMonitor.CurrentValue);
+            _appServiceOptionsMonitor = appServiceOptionsMonitor ?? throw new ArgumentNullException(nameof(appServiceOptionsMonitor));
 
             _roleInstance = _environment.GetInstanceId();
 
@@ -58,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public bool IsEnabled(LogLevel logLevel)
         {
-            if (_environment.IsConsumptionOnLegion() && !isAzureMonitorLogsEnabled)
+            if (_environment.IsConsumptionOnLegion() && !_appServiceOptionsMonitor.CurrentValue.AzureMonitorLoggingEnabled)
             {
                 return false;
             }
@@ -115,7 +108,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             using (JsonTextWriter writer = new JsonTextWriter(sw) { Formatting = Formatting.None })
             {
                 writer.WriteStartObject();
-                WritePropertyIfNotNull(writer, "appName", _appServiceOptions.AppName);
+                WritePropertyIfNotNull(writer, "appName", _appServiceOptionsMonitor.CurrentValue.AppName);
                 WritePropertyIfNotNull(writer, "roleInstance", _roleInstance);
                 WritePropertyIfNotNull(writer, "message", formattedMessage);
                 WritePropertyIfNotNull(writer, "category", _category);
@@ -142,17 +135,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             }
 
             _eventGenerator.LogAzureMonitorDiagnosticLogEvent(logLevel, _hostNameProvider.Value, AzureMonitorOperationName, AzureMonitorCategoryName, _regionName, sw.ToString());
-        }
-
-        public void Dispose()
-        {
-            _appServiceOptionsOnChangeListener?.Dispose();
-        }
-
-        private void UpdateAppServiceOptions(AppServiceOptions newOptions)
-        {
-            _appServiceOptions = newOptions;
-            isAzureMonitorLogsEnabled = IsAzureMonitorLoggingEnabled(_appServiceOptions.AzureMonitorTraceCategory);
         }
 
         private static void WritePropertyIfNotNull<T>(JsonTextWriter writer, string propertyName, T propertyValue)

--- a/src/WebJobs.Script.WebHost/Diagnostics/AzureMonitorDiagnosticLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/AzureMonitorDiagnosticLogger.cs
@@ -54,6 +54,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public bool IsEnabled(LogLevel logLevel)
         {
+            if ((_environment.IsFlexConsumptionSku() || _environment.IsLinuxConsumptionOnLegion()) 
+                && !_environment.IsAzureMonitorEnabledOnLegionSkus()) {
+                return false;
+            }
             // We want to instantiate this Logger in placeholder mode to warm it up, but do not want to log anything.
             return !string.IsNullOrEmpty(_hostNameProvider.Value) && !_environment.IsPlaceholderModeEnabled();
         }

--- a/src/WebJobs.Script.WebHost/Diagnostics/AzureMonitorDiagnosticLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/AzureMonitorDiagnosticLogger.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public bool IsEnabled(LogLevel logLevel)
         {
-            if (_environment.IsConsumptionOnLegion() && !_appServiceOptionsMonitor.CurrentValue.AzureMonitorLoggingEnabled)
+            if (_environment.IsConsumptionOnLegion() && !_appServiceOptionsMonitor.CurrentValue.IsAzureMonitorLoggingEnabled)
             {
                 return false;
             }

--- a/src/WebJobs.Script.WebHost/Diagnostics/AzureMonitorDiagnosticLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/AzureMonitorDiagnosticLogger.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         private readonly IEventGenerator _eventGenerator;
         private readonly IEnvironment _environment;
         private readonly IExternalScopeProvider _scopeProvider;
+        private bool _isAzureMonitorLoggingEnabled;
         private IOptionsMonitor<AppServiceOptions> _appServiceOptionsMonitor;
 
         public AzureMonitorDiagnosticLogger(string category, string hostInstanceId, IEventGenerator eventGenerator, IEnvironment environment, IExternalScopeProvider scopeProvider,
@@ -41,6 +42,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             _scopeProvider = scopeProvider ?? throw new ArgumentNullException(nameof(scopeProvider));
             _hostNameProvider = hostNameProvider ?? throw new ArgumentNullException(nameof(hostNameProvider));
             _appServiceOptionsMonitor = appServiceOptionsMonitor ?? throw new ArgumentNullException(nameof(appServiceOptionsMonitor));
+            UpdateAppServiceOptions(_appServiceOptionsMonitor.CurrentValue);
+            _appServiceOptionsMonitor.OnChange(UpdateAppServiceOptions);
 
             _roleInstance = _environment.GetInstanceId();
 
@@ -51,12 +54,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public bool IsEnabled(LogLevel logLevel)
         {
-            if (_environment.IsConsumptionOnLegion() && !_appServiceOptionsMonitor.CurrentValue.IsAzureMonitorLoggingEnabled)
-            {
-                return false;
-            }
             // We want to instantiate this Logger in placeholder mode to warm it up, but do not want to log anything.
-            return !string.IsNullOrEmpty(_hostNameProvider.Value) && !_environment.IsPlaceholderModeEnabled();
+            return _isAzureMonitorLoggingEnabled && !string.IsNullOrEmpty(_hostNameProvider.Value) && !_environment.IsPlaceholderModeEnabled();
         }
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
@@ -135,6 +134,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             }
 
             _eventGenerator.LogAzureMonitorDiagnosticLogEvent(logLevel, _hostNameProvider.Value, AzureMonitorOperationName, AzureMonitorCategoryName, _regionName, sw.ToString());
+        }
+
+        private void UpdateAppServiceOptions(AppServiceOptions appServiceOptions)
+        {
+            _isAzureMonitorLoggingEnabled = !(_environment.IsConsumptionOnLegion() && !_appServiceOptionsMonitor.CurrentValue.IsAzureMonitorLoggingEnabled);
         }
 
         private static void WritePropertyIfNotNull<T>(JsonTextWriter writer, string propertyName, T propertyValue)

--- a/src/WebJobs.Script.WebHost/Diagnostics/AzureMonitorDiagnosticLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/AzureMonitorDiagnosticLogger.cs
@@ -54,8 +54,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public bool IsEnabled(LogLevel logLevel)
         {
-            if ((_environment.IsFlexConsumptionSku() || _environment.IsLinuxConsumptionOnLegion()) 
-                && !_environment.IsAzureMonitorEnabledOnLegionSkus()) {
+            if ((_environment.IsFlexConsumptionSku() || _environment.IsLinuxConsumptionOnLegion())
+                && !_environment.IsAzureMonitorEnabledOnLegionSkus())
+            {
                 return false;
             }
             // We want to instantiate this Logger in placeholder mode to warm it up, but do not want to log anything.

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -2,8 +2,11 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Net.Http;
 using System.Runtime.InteropServices;
+using Autofac.Core;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Executors;
@@ -25,6 +28,7 @@ using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
 using Microsoft.Azure.WebJobs.Script.WebHost.Middleware;
 using Microsoft.Azure.WebJobs.Script.WebHost.Storage;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -91,6 +95,21 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     loggingBuilder.AddWebJobsSystem<SystemLoggerProvider>();
                     if (environment.IsAzureMonitorEnabled())
                     {
+                        loggingBuilder.Services.AddOptions<LoggerFilterOptions>()
+                            .Configure<IConfiguration>((options, config) =>
+                            {
+                                string setting = config[EnvironmentSettingNames.AzureMonitorCategories];
+                                options.AddFilter<AzureMonitorDiagnosticLoggerProvider>((category, level) =>
+                                {
+                                    if (setting == null || string.Equals(ScriptConstants.DefaultAzureMonitorCategories, setting, StringComparison.Ordinal))
+                                    {
+                                        return true;
+                                    }
+                                    string[] categories = setting.Split(',');
+                                    return categories.Contains(ScriptConstants.AzureMonitorTraceCategory);
+                                });
+                            });
+
                         loggingBuilder.Services.AddSingleton<ILoggerProvider, AzureMonitorDiagnosticLoggerProvider>();
                     }
 

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -95,7 +95,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     loggingBuilder.AddWebJobsSystem<SystemLoggerProvider>();
                     if (environment.IsAzureMonitorEnabled())
                     {
-                        loggingBuilder.Services.AddOptions<LoggerFilterOptions>()
+                        if (environment.IsLegionBasedSku())
+                        {
+                            loggingBuilder.Services.AddOptions<LoggerFilterOptions>()
                             .Configure<IConfiguration>((options, config) =>
                             {
                                 string setting = config[EnvironmentSettingNames.AzureMonitorCategories];
@@ -109,8 +111,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                                     return categories.Contains(ScriptConstants.AzureMonitorTraceCategory);
                                 });
                             });
-
-                        loggingBuilder.Services.AddSingleton<ILoggerProvider, AzureMonitorDiagnosticLoggerProvider>();
+                        }
+                        else
+                        {
+                            loggingBuilder.Services.AddSingleton<ILoggerProvider, AzureMonitorDiagnosticLoggerProvider>();
+                        }
                     }
 
                     if (!FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableDiagnosticEventLogging))

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -98,10 +98,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                             loggingBuilder.Services.AddOptions<LoggerFilterOptions>()
                                 .Configure<IOptionsMonitor<AppServiceOptions>>((filters, options) =>
                                 {
-                                    bool isAzureMonitorLoggingEnabled = options.CurrentValue.AzureMonitorLoggingEnabled;
                                     filters.AddFilter<AzureMonitorDiagnosticLoggerProvider>((category, level) =>
                                     {
-                                        return isAzureMonitorLoggingEnabled;
+                                        return options.CurrentValue.AzureMonitorLoggingEnabled;
                                     });
                                 });
                         }

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
@@ -97,14 +96,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                         if (environment.IsConsumptionOnLegion())
                         {
                             loggingBuilder.Services.AddOptions<LoggerFilterOptions>()
-                            .Configure<IConfiguration>((options, config) =>
-                            {
-                                string value = config[EnvironmentSettingNames.AzureMonitorCategories];
-                                options.AddFilter<AzureMonitorDiagnosticLoggerProvider>((category, level) =>
+                                .Configure<IOptionsMonitor<AppServiceOptions>>((filters, options) =>
                                 {
-                                    return IsAzureMonitorLoggingEnabled(value);
+                                    bool isAzureMonitorLoggingEnabled = options.CurrentValue.AzureMonitorLoggingEnabled;
+                                    filters.AddFilter<AzureMonitorDiagnosticLoggerProvider>((category, level) =>
+                                    {
+                                        return isAzureMonitorLoggingEnabled;
+                                    });
                                 });
-                            });
                         }
                         loggingBuilder.Services.AddSingleton<ILoggerProvider, AzureMonitorDiagnosticLoggerProvider>();
                     }

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -5,8 +5,6 @@ using System;
 using System.Linq;
 using System.Net.Http;
 using System.Runtime.InteropServices;
-using Autofac.Core;
-using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Host.Executors;
@@ -34,6 +32,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using static Microsoft.Azure.WebJobs.Script.Utility;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
 {
@@ -95,27 +94,19 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     loggingBuilder.AddWebJobsSystem<SystemLoggerProvider>();
                     if (environment.IsAzureMonitorEnabled())
                     {
-                        if (environment.IsLegionBasedSku())
+                        if (environment.IsConsumptionOnLegion())
                         {
                             loggingBuilder.Services.AddOptions<LoggerFilterOptions>()
                             .Configure<IConfiguration>((options, config) =>
                             {
-                                string setting = config[EnvironmentSettingNames.AzureMonitorCategories];
+                                string value = config[EnvironmentSettingNames.AzureMonitorCategories];
                                 options.AddFilter<AzureMonitorDiagnosticLoggerProvider>((category, level) =>
                                 {
-                                    if (setting == null)
-                                    {
-                                        return true;
-                                    }
-                                    string[] categories = setting.Split(',');
-                                    return categories.Contains(ScriptConstants.AzureMonitorTraceCategory);
+                                    return IsAzureMonitorLoggingEnabled(value);
                                 });
                             });
                         }
-                        else
-                        {
-                            loggingBuilder.Services.AddSingleton<ILoggerProvider, AzureMonitorDiagnosticLoggerProvider>();
-                        }
+                        loggingBuilder.Services.AddSingleton<ILoggerProvider, AzureMonitorDiagnosticLoggerProvider>();
                     }
 
                     if (!FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableDiagnosticEventLogging))

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                                 {
                                     filters.AddFilter<AzureMonitorDiagnosticLoggerProvider>((category, level) =>
                                     {
-                                        return options.CurrentValue.AzureMonitorLoggingEnabled;
+                                        return options.CurrentValue.IsAzureMonitorLoggingEnabled;
                                     });
                                 });
                         }

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                                 string setting = config[EnvironmentSettingNames.AzureMonitorCategories];
                                 options.AddFilter<AzureMonitorDiagnosticLoggerProvider>((category, level) =>
                                 {
-                                    if (setting == null || string.Equals(ScriptConstants.DefaultAzureMonitorCategories, setting, StringComparison.Ordinal))
+                                    if (setting == null)
                                     {
                                         return true;
                                     }

--- a/src/WebJobs.Script/Config/AppServiceOptions.cs
+++ b/src/WebJobs.Script/Config/AppServiceOptions.cs
@@ -13,6 +13,6 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
 
         public string SlotName { get; set; }
 
-        public string AzureMonitorTraceCategory { get; set; }
+        public bool AzureMonitorLoggingEnabled { get; set; }
     }
 }

--- a/src/WebJobs.Script/Config/AppServiceOptions.cs
+++ b/src/WebJobs.Script/Config/AppServiceOptions.cs
@@ -13,6 +13,6 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
 
         public string SlotName { get; set; }
 
-        public bool AzureMonitorLoggingEnabled { get; set; }
+        public bool IsAzureMonitorLoggingEnabled { get; set; }
     }
 }

--- a/src/WebJobs.Script/Config/AppServiceOptions.cs
+++ b/src/WebJobs.Script/Config/AppServiceOptions.cs
@@ -12,5 +12,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
         public string RuntimeSiteName { get; set; }
 
         public string SlotName { get; set; }
+
+        public string AzureMonitorTraceCategory { get; set; }
     }
 }

--- a/src/WebJobs.Script/Config/AppServiceOptionsSetup.cs
+++ b/src/WebJobs.Script/Config/AppServiceOptionsSetup.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             options.SubscriptionId = _environment.GetSubscriptionId() ?? string.Empty;
             options.RuntimeSiteName = _environment.GetRuntimeSiteName() ?? string.Empty;
             options.SlotName = _environment.GetSlotName() ?? string.Empty;
-            options.AzureMonitorLoggingEnabled = _environment.IsAzureMonitorEnabled();
+            options.IsAzureMonitorLoggingEnabled = _environment.IsAzureMonitorEnabled();
         }
     }
 }

--- a/src/WebJobs.Script/Config/AppServiceOptionsSetup.cs
+++ b/src/WebJobs.Script/Config/AppServiceOptionsSetup.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Microsoft.Extensions.Options;
+using static Microsoft.Azure.WebJobs.Script.EnvironmentSettingNames;
 
 namespace Microsoft.Azure.WebJobs.Script.Configuration
 {
@@ -20,6 +21,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             options.SubscriptionId = _environment.GetSubscriptionId() ?? string.Empty;
             options.RuntimeSiteName = _environment.GetRuntimeSiteName() ?? string.Empty;
             options.SlotName = _environment.GetSlotName() ?? string.Empty;
+            options.AzureMonitorTraceCategory = _environment.GetEnvironmentVariable(AzureMonitorCategories) ?? string.Empty;
         }
     }
 }

--- a/src/WebJobs.Script/Config/AppServiceOptionsSetup.cs
+++ b/src/WebJobs.Script/Config/AppServiceOptionsSetup.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Extensions.Options;
 using static Microsoft.Azure.WebJobs.Script.EnvironmentSettingNames;
+using static Microsoft.Azure.WebJobs.Script.Utility;
 
 namespace Microsoft.Azure.WebJobs.Script.Configuration
 {
@@ -21,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             options.SubscriptionId = _environment.GetSubscriptionId() ?? string.Empty;
             options.RuntimeSiteName = _environment.GetRuntimeSiteName() ?? string.Empty;
             options.SlotName = _environment.GetSlotName() ?? string.Empty;
-            options.AzureMonitorTraceCategory = _environment.GetEnvironmentVariable(AzureMonitorCategories) ?? string.Empty;
+            options.AzureMonitorLoggingEnabled = _environment.IsAzureMonitorEnabled();
         }
     }
 }

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using static Microsoft.Azure.WebJobs.Script.EnvironmentSettingNames;
+using static Microsoft.Azure.WebJobs.Script.Utility;
 
 namespace Microsoft.Azure.WebJobs.Script
 {
@@ -19,8 +20,6 @@ namespace Microsoft.Azure.WebJobs.Script
         private static bool? isApplicationInsightsAgentEnabled;
 
         private static bool? isMultiLanguageEnabled;
-
-        private static bool? isAzureMonitorLogsSubscribed;
 
         internal static string BaseDirectory { get; set; }
 
@@ -69,26 +68,9 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <summary>
         /// Returns true if any Functions AzureMonitor log categories are enabled.
         /// </summary>
-        public static bool IsAzureMonitorEnabled(this IEnvironment environment, bool useCache=false)
+        public static bool IsAzureMonitorEnabled(this IEnvironment environment)
         {
-            string value = environment.GetEnvironmentVariable(AzureMonitorCategories);
-            if (value == null)
-            {
-                return true;
-            }
-            if (string.Equals(ScriptConstants.DefaultAzureMonitorCategories, value, StringComparison.Ordinal))
-            {
-                // Default value for the env variable is None.
-                // This is set when customer does not subscribe any category.
-                return false;
-            }
-            if (useCache && isAzureMonitorLogsSubscribed != null)
-            {
-                return isAzureMonitorLogsSubscribed.Value;
-            }
-            string[] categories = value.Split(',');
-            isAzureMonitorLogsSubscribed = categories.Contains(ScriptConstants.AzureMonitorTraceCategory);
-            return isAzureMonitorLogsSubscribed.Value;
+            return IsAzureMonitorLoggingEnabled(environment.GetEnvironmentVariable(AzureMonitorCategories));
         }
 
         /// <summary>
@@ -265,16 +247,6 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
-        /// Gets a value indicating whether the application is running in Legion.
-        /// </summary>
-        /// <param name="environment">The environment to verify.</param>
-        /// <returns><see cref="true"/> if running on legion, false otherwise.</returns>
-        public static bool IsLegionBasedSku(this IEnvironment environment)
-        {
-            return environment.IsFlexConsumptionSku() || environment.IsLinuxConsumptionOnLegion();
-        }
-
-        /// <summary>
         /// Returns true if the app is running on Virtual Machine Scale Sets (VMSS).
         /// </summary>
         public static bool IsVMSS(this IEnvironment environment)
@@ -360,7 +332,7 @@ namespace Microsoft.Azure.WebJobs.Script
                    string.IsNullOrEmpty(environment.GetEnvironmentVariable(LegionServiceHost));
         }
 
-        private static bool IsConsumptionOnLegion(this IEnvironment environment)
+        public static bool IsConsumptionOnLegion(this IEnvironment environment)
         {
             return !environment.IsAppService() &&
                    (!string.IsNullOrEmpty(environment.GetEnvironmentVariable(ContainerName)) ||

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -69,21 +69,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <summary>
         /// Returns true if any Functions AzureMonitor log categories are enabled.
         /// </summary>
-        public static bool IsAzureMonitorEnabled(this IEnvironment environment)
-        {
-            string value = environment.GetEnvironmentVariable(AzureMonitorCategories);
-            if (value == null)
-            {
-                return true;
-            }
-            string[] categories = value.Split(',');
-            return categories.Contains(ScriptConstants.AzureMonitorTraceCategory);
-        }
-
-        /// <summary>
-        /// Returns true if any Functions AzureMonitor log categories are enabled on legion based SKUs.
-        /// </summary>
-        public static bool IsAzureMonitorEnabledOnLegionSkus(this IEnvironment environment)
+        public static bool IsAzureMonitorEnabled(this IEnvironment environment, bool useCache=false)
         {
             string value = environment.GetEnvironmentVariable(AzureMonitorCategories);
             if (value == null)
@@ -96,13 +82,12 @@ namespace Microsoft.Azure.WebJobs.Script
                 // This is set when customer does not subscribe any category.
                 return false;
             }
-            // If control came here, it means customer has subscribed to someazure monitor log categories.
-            // So, cache whether FunctionsLogs category is subscribed.
-            if (isAzureMonitorLogsSubscribed == null)
+            if (useCache && isAzureMonitorLogsSubscribed != null)
             {
-                string[] categories = value.Split(',');
-                isAzureMonitorLogsSubscribed = categories.Contains(ScriptConstants.AzureMonitorTraceCategory);
+                return isAzureMonitorLogsSubscribed.Value;
             }
+            string[] categories = value.Split(',');
+            isAzureMonitorLogsSubscribed = categories.Contains(ScriptConstants.AzureMonitorTraceCategory);
             return isAzureMonitorLogsSubscribed.Value;
         }
 
@@ -277,6 +262,16 @@ namespace Microsoft.Azure.WebJobs.Script
             // If we're running on Legion and the app isn't CV1 on Legion,
             // then it's Flex
             return !environment.WebsiteSkuIsDynamic();
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the application is running in Legion.
+        /// </summary>
+        /// <param name="environment">The environment to verify.</param>
+        /// <returns><see cref="true"/> if running on legion, false otherwise.</returns>
+        public static bool IsLegionBasedSku(this IEnvironment environment)
+        {
+            return environment.IsFlexConsumptionSku() || environment.IsLinuxConsumptionOnLegion();
         }
 
         /// <summary>

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
         private static bool? isMultiLanguageEnabled;
 
+        private static bool? isAzureMonitorLogsSubscribed;
+
         internal static string BaseDirectory { get; set; }
 
         public static string GetEnvironmentVariableOrDefault(this IEnvironment environment, string name, string defaultValue)
@@ -76,6 +78,32 @@ namespace Microsoft.Azure.WebJobs.Script
             }
             string[] categories = value.Split(',');
             return categories.Contains(ScriptConstants.AzureMonitorTraceCategory);
+        }
+
+        /// <summary>
+        /// Returns true if any Functions AzureMonitor log categories are enabled on legion based SKUs.
+        /// </summary>
+        public static bool IsAzureMonitorEnabledOnLegionSkus(this IEnvironment environment)
+        {
+            string value = environment.GetEnvironmentVariable(AzureMonitorCategories);
+            if (value == null)
+            {
+                return true;
+            }
+            if (string.Equals(ScriptConstants.DefaultAzureMonitorCategories, value, StringComparison.Ordinal))
+            {
+                // Default value for the env variable is None.
+                // This is set when customer does not subscribe any category.
+                return false;
+            }
+            // If control came here, it means customer has subscribed to someazure monitor log categories.
+            // So, cache whether FunctionsLogs category is subscribed.
+            if (isAzureMonitorLogsSubscribed == null)
+            {
+                string[] categories = value.Split(',');
+                isAzureMonitorLogsSubscribed = categories.Contains(ScriptConstants.AzureMonitorTraceCategory);
+            }
+            return isAzureMonitorLogsSubscribed.Value;
         }
 
         /// <summary>

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -227,6 +227,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string ExtendedPlatformChannelNameUpper = "EXTENDED";
 
         public const string AzureMonitorTraceCategory = "FunctionAppLogs";
+        public const string DefaultAzureMonitorCategories = "None";
 
         public const string KubernetesManagedAppName = "K8SE_APP_NAME";
         public const string KubernetesManagedAppNamespace = "K8SE_APP_NAMESPACE";

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -1145,6 +1145,22 @@ namespace Microsoft.Azure.WebJobs.Script
             return result = false;
         }
 
+        public static bool IsAzureMonitorLoggingEnabled(string azureMonitorcategoriesSubscribed)
+        {
+            if (azureMonitorcategoriesSubscribed == null)
+            {
+                return true;
+            }
+            if (string.Equals(ScriptConstants.DefaultAzureMonitorCategories, azureMonitorcategoriesSubscribed, StringComparison.Ordinal))
+            {
+                // Default value for the env variable is None.
+                // This is set when customer does not subscribe any category.
+                return false;
+            }
+            string[] categories = azureMonitorcategoriesSubscribed.Split(',');
+            return categories.Contains(ScriptConstants.AzureMonitorTraceCategory);
+        }
+
         private class FilteredExpandoObjectConverter : ExpandoObjectConverter
         {
             public override bool CanWrite => true;

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -1147,7 +1147,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public static bool IsAzureMonitorLoggingEnabled(string azureMonitorcategoriesSubscribed)
         {
-            if (azureMonitorcategoriesSubscribed == null)
+            if (string.IsNullOrEmpty(azureMonitorcategoriesSubscribed))
             {
                 return true;
             }

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -1147,7 +1147,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public static bool IsAzureMonitorLoggingEnabled(string azureMonitorcategoriesSubscribed)
         {
-            if (string.IsNullOrEmpty(azureMonitorcategoriesSubscribed))
+            if (azureMonitorcategoriesSubscribed == null)
             {
                 return true;
             }

--- a/test/WebJobs.Script.Tests/Eventing/DiagnosticLoggerTests.cs
+++ b/test/WebJobs.Script.Tests/Eventing/DiagnosticLoggerTests.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
                 _environment.SetEnvironmentVariable(EnvironmentSettingNames.LegionServiceHost, "legionhost");
             }
 
-            _appServiceOptionsWrapper.CurrentValue.AzureMonitorLoggingEnabled = isAzureMonitorEnabled;
+            _appServiceOptionsWrapper.CurrentValue.IsAzureMonitorLoggingEnabled = isAzureMonitorEnabled;
 
             Assert.Equal(isDisabled, _logger.IsEnabled(LogLevel.Information));
             _mockEventGenerator.Verify(m => m.LogAzureMonitorDiagnosticLogEvent(It.IsAny<LogLevel>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);

--- a/test/WebJobs.Script.Tests/Eventing/DiagnosticLoggerTests.cs
+++ b/test/WebJobs.Script.Tests/Eventing/DiagnosticLoggerTests.cs
@@ -216,7 +216,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
         [InlineData(EnvironmentSettingNames.AzureWebsiteHostName, "host", true, true, true)]
         public void Log_IsEnabled(string envVariableName, string envVariableVale, bool isConsumptionOnLegion, bool isAzureMonitorEnabled,  bool isDisabled)
         {
-            string message = "TestMessage";
             string functionInvocationId = Guid.NewGuid().ToString();
             string activityId = Guid.NewGuid().ToString();
 

--- a/test/WebJobs.Script.Tests/Eventing/DiagnosticLoggerTests.cs
+++ b/test/WebJobs.Script.Tests/Eventing/DiagnosticLoggerTests.cs
@@ -228,6 +228,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
             }
 
             _appServiceOptionsWrapper.CurrentValue.IsAzureMonitorLoggingEnabled = isAzureMonitorEnabled;
+            _appServiceOptionsWrapper.InvokeChanged();
 
             Assert.Equal(isDisabled, _logger.IsEnabled(LogLevel.Information));
             _mockEventGenerator.Verify(m => m.LogAzureMonitorDiagnosticLogEvent(It.IsAny<LogLevel>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);

--- a/test/WebJobs.Script.Tests/Eventing/DiagnosticLoggerTests.cs
+++ b/test/WebJobs.Script.Tests/Eventing/DiagnosticLoggerTests.cs
@@ -206,35 +206,31 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
             Assert.True(JToken.DeepEquals(actual, expected), $"Actual: {actual.ToString()}{Environment.NewLine}Expected: {expected.ToString()}");
         }
 
-        [Fact]
-        public void Log_DisabledIfPlaceholder()
+        [Theory]
+        [InlineData(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1", false, false, false)] // Placeholder
+        [InlineData(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1", true, false, false)] // Placeholder
+        [InlineData(EnvironmentSettingNames.AzureWebsiteHostName, null, false, false, false)] // NoSiteName
+        [InlineData(EnvironmentSettingNames.AzureWebsiteHostName, null, true, false, false)] // NoSiteName
+        [InlineData(EnvironmentSettingNames.AzureWebsiteHostName, "host", false, false, true)]
+        [InlineData(EnvironmentSettingNames.AzureWebsiteHostName, "host", true, false, false)]
+        [InlineData(EnvironmentSettingNames.AzureWebsiteHostName, "host", true, true, true)]
+        public void Log_IsEnabled(string envVariableName, string envVariableVale, bool isConsumptionOnLegion, bool isAzureMonitorEnabled,  bool isDisabled)
         {
             string message = "TestMessage";
             string functionInvocationId = Guid.NewGuid().ToString();
             string activityId = Guid.NewGuid().ToString();
 
-            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
+            _environment.SetEnvironmentVariable(envVariableName, envVariableVale);
+            if (isConsumptionOnLegion)
+            {
+                _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, string.Empty);
+                _environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "containername");
+                _environment.SetEnvironmentVariable(EnvironmentSettingNames.LegionServiceHost, "legionhost");
+            }
 
-            _logger.LogInformation(message);
+            _appServiceOptionsWrapper.CurrentValue.AzureMonitorLoggingEnabled = isAzureMonitorEnabled;
 
-            Assert.False(_logger.IsEnabled(LogLevel.Information));
-            _mockEventGenerator.Verify(m => m.LogAzureMonitorDiagnosticLogEvent(It.IsAny<LogLevel>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-        }
-
-        [Fact]
-        public void Log_DisabledIfNoSiteName()
-        {
-            string message = "TestMessage";
-            string functionInvocationId = Guid.NewGuid().ToString();
-            string activityId = Guid.NewGuid().ToString();
-            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName, null);
-
-            // Recreate the logger was we cache the site name in the constructor
-            ILogger logger = new AzureMonitorDiagnosticLogger(_category, _hostInstanceId, _mockEventGenerator.Object, _environment, new LoggerExternalScopeProvider(), _hostNameProvider, _appServiceOptionsWrapper);
-
-            logger.LogInformation(message);
-
-            Assert.False(logger.IsEnabled(LogLevel.Information));
+            Assert.Equal(isDisabled, _logger.IsEnabled(LogLevel.Information));
             _mockEventGenerator.Verify(m => m.LogAzureMonitorDiagnosticLogEvent(It.IsAny<LogLevel>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         }
 

--- a/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/EnvironmentExtensionsTests.cs
@@ -62,6 +62,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
         [InlineData(null, true)]
         [InlineData("", false)]
         [InlineData("Foo,FunctionAppLogs,Bar", true)]
+        [InlineData("FunctionAppLogs", true)]
+        [InlineData("None", false)]
         [InlineData("Foo,Bar", false)]
         public void IsAzureMonitorEnabled_ReturnsExpectedResult(string value, bool expected)
         {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
For a few SKUs in functions, we want to filter azure monitor logs based on the categories subscribed by the user. This PR checks for the env variable for the categories and skips logging.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [X] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [X] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [X] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
