### PR TITLE
Enhancement to memory metrics reporting

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Improved memory metrics reporting using CGroup data for Linux consumption (#10968)

--- a/src/WebJobs.Script.WebHost/Metrics/CgroupMemoryUsageHelper.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/CgroupMemoryUsageHelper.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
+{
+    internal static class CgroupMemoryUsageHelper
+    {
+        private const string CgroupPathV1 = "/sys/fs/cgroup/memory/memory.usage_in_bytes";
+        private const string CgroupPathV2 = "/sys/fs/cgroup/memory.current";
+
+        /// <summary>
+        /// Retrieves the memory usage of the control group in bytes, supporting both cgroup v1 and v2.
+        /// </summary>
+        /// <param name="logger">An <see cref="ILogger{TCategoryName}"/> instance for logging.</param>
+        /// <returns>The memory usage in bytes if available; otherwise, 0.</returns>
+        internal static long GetMemoryUsageInBytes(ILogger logger)
+        {
+            try
+            {
+                if (TryReadMemoryUsage(CgroupPathV2, out var usageInBytes) || TryReadMemoryUsage(CgroupPathV1, out usageInBytes))
+                {
+                    return usageInBytes;
+                }
+
+                logger.LogWarning("Memory usage not available from either control group v1 or v2.");
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error reading control group resource usage.");
+                return 0;
+            }
+        }
+
+        private static bool TryReadMemoryUsage(string path, out long memoryUsageInBytes)
+        {
+            memoryUsageInBytes = 0;
+
+            if (!File.Exists(path))
+            {
+                return false;
+            }
+
+            return long.TryParse(File.ReadAllText(path), out memoryUsageInBytes);
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Metrics/LinuxContainerLegionMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/LinuxContainerLegionMetricsPublisher.cs
@@ -75,15 +75,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             _hostingConfigOptionsOnChangeListener = _hostingConfigOptions.OnChange(OnHostingConfigOptionsChanged);
         }
 
-        private void OnHostingConfigOptionsChanged(FunctionsHostingConfigOptions newOptions)
-        {
-            if (newOptions.IsCGroupMemoryMetricsEnabled != _isCGroupMemoryMetricsEnabled)
-            {
-                _logger.LogInformation("CGroup memory metrics enabled: {Enabled}", newOptions.IsCGroupMemoryMetricsEnabled);
-                _isCGroupMemoryMetricsEnabled = newOptions.IsCGroupMemoryMetricsEnabled;
-            }
-        }
-
         public IMetricsLogger MetricsLogger
         {
             get
@@ -97,6 +88,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
                 }
 
                 return _metricsLogger;
+            }
+        }
+
+        private void OnHostingConfigOptionsChanged(FunctionsHostingConfigOptions newOptions)
+        {
+            if (newOptions.IsCGroupMemoryMetricsEnabled != _isCGroupMemoryMetricsEnabled)
+            {
+                _logger.LogInformation("CGroup memory metrics enabled: {Enabled}", newOptions.IsCGroupMemoryMetricsEnabled);
+                _isCGroupMemoryMetricsEnabled = newOptions.IsCGroupMemoryMetricsEnabled;
             }
         }
 

--- a/src/WebJobs.Script.WebHost/Metrics/LinuxContainerLegionMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/LinuxContainerLegionMetricsPublisher.cs
@@ -7,6 +7,7 @@ using System.IO.Abstractions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
 using Microsoft.Extensions.Logging;
@@ -21,11 +22,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         private readonly TimeSpan _memorySnapshotInterval = TimeSpan.FromMilliseconds(1000);
         private readonly TimeSpan _timerStartDelay = TimeSpan.FromSeconds(2);
         private readonly IOptionsMonitor<StandbyOptions> _standbyOptions;
-        private readonly IDisposable _standbyOptionsOnChangeSubscription;
+        private readonly IDisposable _standbyOptionsOnChangeListener;
+        private readonly IDisposable _hostingConfigOptionsOnChangeListener;
         private readonly IEnvironment _environment;
         private readonly ILogger _logger;
         private readonly IScriptHostManager _scriptHostManager;
         private readonly string _containerName;
+        private readonly IOptionsMonitor<FunctionsHostingConfigOptions> _hostingConfigOptions;
 
         private IMetricsLogger _metricsLogger;
         private TimeSpan _metricPublishInterval;
@@ -33,10 +36,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         private Timer _processMonitorTimer;
         private Timer _metricsPublisherTimer;
         private bool _initialized = false;
+        private bool _isCGroupMemoryMetricsEnabled = false;
 
         public LinuxContainerLegionMetricsPublisher(IEnvironment environment, IOptionsMonitor<StandbyOptions> standbyOptions,
             IOptions<LinuxConsumptionLegionMetricsPublisherOptions> options, ILogger<LinuxContainerLegionMetricsPublisher> logger,
             IFileSystem fileSystem, ILinuxConsumptionMetricsTracker metricsTracker, IScriptHostManager scriptHostManager,
+            IOptionsMonitor<FunctionsHostingConfigOptions> functionsHostingConfigOptions,
             int? metricsPublishIntervalMS = null)
         {
             _standbyOptions = standbyOptions ?? throw new ArgumentNullException(nameof(standbyOptions));
@@ -44,6 +49,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _metricsTracker = metricsTracker ?? throw new ArgumentNullException(nameof(metricsTracker));
             _scriptHostManager = scriptHostManager ?? throw new ArgumentNullException(nameof(scriptHostManager));
+            _hostingConfigOptions = functionsHostingConfigOptions ?? throw new ArgumentNullException(nameof(functionsHostingConfigOptions));
             _containerName = options.Value.ContainerName;
 
             // Set this to 15 minutes worth of files
@@ -59,11 +65,22 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
 
             if (_standbyOptions.CurrentValue.InStandbyMode)
             {
-                _standbyOptionsOnChangeSubscription = _standbyOptions.OnChange(o => OnStandbyOptionsChange(o));
+                _standbyOptionsOnChangeListener = _standbyOptions.OnChange(o => OnStandbyOptionsChange(o));
             }
             else
             {
                 Start();
+            }
+
+            _hostingConfigOptionsOnChangeListener = _hostingConfigOptions.OnChange(OnHostingConfigOptionsChanged);
+        }
+
+        private void OnHostingConfigOptionsChanged(FunctionsHostingConfigOptions newOptions)
+        {
+            if (newOptions.IsCGroupMemoryMetricsEnabled != _isCGroupMemoryMetricsEnabled)
+            {
+                _logger.LogInformation("CGroup memory metrics enabled: {Enabled}", newOptions.IsCGroupMemoryMetricsEnabled);
+                _isCGroupMemoryMetricsEnabled = newOptions.IsCGroupMemoryMetricsEnabled;
             }
         }
 
@@ -185,11 +202,20 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         {
             try
             {
-                _process.Refresh();
-                var commitSizeBytes = _process.WorkingSet64;
-                if (commitSizeBytes != 0)
+                long memoryUsageInBytes;
+                if (_hostingConfigOptions.CurrentValue.IsCGroupMemoryMetricsEnabled)
                 {
-                    AddMemoryActivity(DateTime.UtcNow, commitSizeBytes);
+                    memoryUsageInBytes = CgroupMemoryUsageHelper.GetMemoryUsageInBytes(_logger);
+                }
+                else
+                {
+                    _process.Refresh();
+                    memoryUsageInBytes = _process.WorkingSet64;
+                }
+
+                if (memoryUsageInBytes != 0)
+                {
+                    AddMemoryActivity(DateTime.UtcNow, memoryUsageInBytes);
                 }
             }
             catch (Exception e)
@@ -244,6 +270,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             _metricsPublisherTimer = null;
 
             _metricsTracker.OnDiagnosticEvent -= OnMetricsDiagnosticEvent;
+            _standbyOptionsOnChangeListener?.Dispose();
+            _hostingConfigOptionsOnChangeListener?.Dispose();
         }
 
         internal class Metrics

--- a/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Formatting;
@@ -19,7 +20,7 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
 {
-    public class LinuxContainerMetricsPublisher : IMetricsPublisher
+    public sealed class LinuxContainerMetricsPublisher : IMetricsPublisher, IDisposable
     {
         public const string PublishMemoryActivityPath = "/memoryactivity";
         public const string PublishFunctionActivityPath = "/functionactivity";
@@ -36,10 +37,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         private readonly TimeSpan _metricPublishInterval = TimeSpan.FromMilliseconds(30 * 1000);
         private readonly TimeSpan _timerStartDelay = TimeSpan.FromSeconds(2);
         private readonly IOptionsMonitor<StandbyOptions> _standbyOptions;
-        private readonly IDisposable _standbyOptionsOnChangeSubscription;
+        private readonly IDisposable _standbyOptionsOnChangeListener;
+        private readonly IDisposable _hostingConfigOptionsOnChangeListener;
         private readonly string _requestUri;
         private readonly IEnvironment _environment;
-        private readonly IOptions<FunctionsHostingConfigOptions> _hostingConfigOptions;
+        private readonly IOptionsMonitor<FunctionsHostingConfigOptions> _hostingConfigOptions;
 
         // Buffer for all memory activities for this container.
         private BlockingCollection<MemoryActivity> _memoryActivities;
@@ -65,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         private string _stampName;
         private bool _initialized = false;
 
-        public LinuxContainerMetricsPublisher(IEnvironment environment, IOptionsMonitor<StandbyOptions> standbyOptions, ILogger<LinuxContainerMetricsPublisher> logger, HostNameProvider hostNameProvider, IOptions<FunctionsHostingConfigOptions> functionsHostingConfigOptions, HttpClient httpClient = null)
+        public LinuxContainerMetricsPublisher(IEnvironment environment, IOptionsMonitor<StandbyOptions> standbyOptions, ILogger<LinuxContainerMetricsPublisher> logger, HostNameProvider hostNameProvider, IOptionsMonitor<FunctionsHostingConfigOptions> functionsHostingConfigOptions, HttpClient httpClient = null)
         {
             _standbyOptions = standbyOptions ?? throw new ArgumentNullException(nameof(standbyOptions));
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
@@ -86,12 +88,19 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             _httpClient = (httpClient != null) ? httpClient : CreateMetricsPublisherHttpClient();
             if (_standbyOptions.CurrentValue.InStandbyMode)
             {
-                _standbyOptionsOnChangeSubscription = _standbyOptions.OnChange(o => OnStandbyOptionsChange());
+                _standbyOptionsOnChangeListener = _standbyOptions.OnChange(o => OnStandbyOptionsChange());
             }
             else
             {
                 Start();
             }
+
+            _hostingConfigOptionsOnChangeListener = _hostingConfigOptions.OnChange(OnHostingConfigOptionsChanged);
+        }
+
+        private void OnHostingConfigOptionsChanged(FunctionsHostingConfigOptions newOptions)
+        {
+            _logger.LogInformation("CGroup memory metrics enabled: {Enabled}", newOptions.IsCGroupMemoryMetricsEnabled);
         }
 
         private void OnStandbyOptionsChange()
@@ -234,7 +243,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             try
             {
                 var request = BuildRequest(HttpMethod.Post, publishPath, activitiesToPublish.ToArray());
-
                 HttpResponseMessage response = await _httpClient.SendAsync(request);
                 response.EnsureSuccessStatusCode();
             }
@@ -261,15 +269,60 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             _logger.LogInformation(string.Format("Starting metrics publisher for container : {0}. Publishing endpoint is {1}", _containerName, _requestUri));
         }
 
+        private long GetControlGroupMemoryUsage()
+        {
+            try
+            {
+                const string cgroupPathV1 = "/sys/fs/cgroup/memory/memory.usage_in_bytes";
+                const string cgroupPathV2 = "/sys/fs/cgroup/memory.current";
+
+                // Newer distros use cgroup v2
+                if (TryReadMemoryUsage(cgroupPathV2, out var memoryUsageInBytes) || TryReadMemoryUsage(cgroupPathV1, out memoryUsageInBytes))
+                {
+                    return memoryUsageInBytes;
+                }
+
+                _logger.LogDebug("Memory usage not available from either control group v1 or v2");
+                return 0;
+
+                bool TryReadMemoryUsage(string path, out long result)
+                {
+                    result = default;
+
+                    if (!File.Exists(path))
+                    {
+                        _logger.LogDebug("Control group path {ControlGroupPath} does not exist.", path);
+                        return false;
+                    }
+
+                    return long.TryParse(File.ReadAllText(path), out result);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error reading control group resource usage.");
+                return 0;
+            }
+        }
+
         private void OnProcessMonitorTimer(object state)
         {
             try
             {
-                _process.Refresh();
-                var commitSizeBytes = _process.WorkingSet64;
-                if (commitSizeBytes != 0)
+                long memoryUsageInBytes;
+                if (!PlatformHelper.IsWindows && _hostingConfigOptions.CurrentValue.IsCGroupMemoryMetricsEnabled)
                 {
-                    AddMemoryActivity(DateTime.UtcNow, commitSizeBytes);
+                    memoryUsageInBytes = GetControlGroupMemoryUsage();
+                }
+                else
+                {
+                    _process.Refresh();
+                    memoryUsageInBytes = _process.WorkingSet64;
+                }
+
+                if (memoryUsageInBytes != 0)
+                {
+                    AddMemoryActivity(DateTime.UtcNow, memoryUsageInBytes);
                 }
             }
             catch (Exception e)
@@ -292,7 +345,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             request.Headers.Add(HostNameHeader, _hostNameProvider.Value);
             request.Headers.Add(StampNameHeader, _stampName);
 
-            if (_hostingConfigOptions.Value.SwtIssuerEnabled)
+            if (_hostingConfigOptions.CurrentValue.SwtIssuerEnabled)
             {
                 string swtToken = SimpleWebTokenHelper.CreateToken(DateTime.UtcNow.AddMinutes(5));
                 request.Headers.Add(ScriptConstants.SiteRestrictedTokenHeaderName, swtToken);
@@ -312,6 +365,17 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         public void OnFunctionCompleted(string functionName, string invocationId)
         {
             // nothing to do
+        }
+
+        public void Dispose()
+        {
+            _standbyOptionsOnChangeListener?.Dispose();
+            _hostingConfigOptionsOnChangeListener?.Dispose();
+            _processMonitorTimer?.Dispose();
+            _metricsPublisherTimer?.Dispose();
+            _httpClient?.Dispose();
+            _memoryActivities?.Dispose();
+            _functionActivities?.Dispose();
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
@@ -274,45 +274,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             _logger.LogInformation(string.Format("Starting metrics publisher for container : {0}. Publishing endpoint is {1}", _containerName, _requestUri));
         }
 
-        /// <summary>
-        /// Retrieves the memory usage of the control group in bytes. Supports both cgroup v1 and v2 paths.
-        /// </summary>
-        /// <returns>The memory usage in bytes if available; otherwise, 0.</returns>
-        private long GetControlGroupMemoryUsage()
-        {
-            try
-            {
-                const string cgroupPathV1 = "/sys/fs/cgroup/memory/memory.usage_in_bytes";
-                const string cgroupPathV2 = "/sys/fs/cgroup/memory.current";
-
-                // Newer distros use cgroup v2
-                if (TryReadMemoryUsage(cgroupPathV2, out var memoryUsageInBytes) || TryReadMemoryUsage(cgroupPathV1, out memoryUsageInBytes))
-                {
-                    return memoryUsageInBytes;
-                }
-
-                _logger.LogWarning("Memory usage not available from either control group v1 or v2");
-                return 0;
-
-                static bool TryReadMemoryUsage(string path, out long result)
-                {
-                    result = default;
-
-                    if (!File.Exists(path))
-                    {
-                        return false;
-                    }
-
-                    return long.TryParse(File.ReadAllText(path), out result);
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error reading control group resource usage.");
-                return 0;
-            }
-        }
-
         private void OnProcessMonitorTimer(object state)
         {
             try
@@ -320,7 +281,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
                 long memoryUsageInBytes;
                 if (_hostingConfigOptions.CurrentValue.IsCGroupMemoryMetricsEnabled)
                 {
-                    memoryUsageInBytes = GetControlGroupMemoryUsage();
+                    memoryUsageInBytes = CgroupMemoryUsageHelper.GetMemoryUsageInBytes(_logger);
                 }
                 else
                 {

--- a/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
@@ -313,7 +313,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             try
             {
                 long memoryUsageInBytes;
-                if (!PlatformHelper.IsWindows && _hostingConfigOptions.CurrentValue.IsCGroupMemoryMetricsEnabled)
+                if (_hostingConfigOptions.CurrentValue.IsCGroupMemoryMetricsEnabled)
                 {
                     memoryUsageInBytes = GetControlGroupMemoryUsage();
                 }

--- a/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         private int _errorCount = 0;
         private string _stampName;
         private bool _initialized = false;
+        private bool _isCGroupMemoryMetricsEnabled = false;
 
         public LinuxContainerMetricsPublisher(IEnvironment environment, IOptionsMonitor<StandbyOptions> standbyOptions, ILogger<LinuxContainerMetricsPublisher> logger, HostNameProvider hostNameProvider, IOptionsMonitor<FunctionsHostingConfigOptions> functionsHostingConfigOptions, HttpClient httpClient = null)
         {
@@ -100,7 +101,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
 
         private void OnHostingConfigOptionsChanged(FunctionsHostingConfigOptions newOptions)
         {
-            _logger.LogInformation("CGroup memory metrics enabled: {Enabled}", newOptions.IsCGroupMemoryMetricsEnabled);
+            if (newOptions.IsCGroupMemoryMetricsEnabled != _isCGroupMemoryMetricsEnabled)
+            {
+                _logger.LogInformation("CGroup memory metrics enabled: {Enabled}", newOptions.IsCGroupMemoryMetricsEnabled);
+                _isCGroupMemoryMetricsEnabled = newOptions.IsCGroupMemoryMetricsEnabled;
+            }
         }
 
         private void OnStandbyOptionsChange()

--- a/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
@@ -269,6 +269,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             _logger.LogInformation(string.Format("Starting metrics publisher for container : {0}. Publishing endpoint is {1}", _containerName, _requestUri));
         }
 
+        /// <summary>
+        /// Retrieves the memory usage of the control group in bytes. Supports both cgroup v1 and v2 paths.
+        /// </summary>
+        /// <returns>The memory usage in bytes if available; otherwise, 0.</returns>
         private long GetControlGroupMemoryUsage()
         {
             try
@@ -282,16 +286,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
                     return memoryUsageInBytes;
                 }
 
-                _logger.LogDebug("Memory usage not available from either control group v1 or v2");
+                _logger.LogWarning("Memory usage not available from either control group v1 or v2");
                 return 0;
 
-                bool TryReadMemoryUsage(string path, out long result)
+                static bool TryReadMemoryUsage(string path, out long result)
                 {
                     result = default;
 
                     if (!File.Exists(path))
                     {
-                        _logger.LogDebug("Control group path {ControlGroupPath} does not exist.", path);
                         return false;
                     }
 

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -320,7 +320,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     var logger = s.GetService<ILogger<LinuxContainerMetricsPublisher>>();
                     var standbyOptions = s.GetService<IOptionsMonitor<StandbyOptions>>();
                     var hostNameProvider = s.GetService<HostNameProvider>();
-                    var hostingConfigOptions = s.GetService<IOptions<FunctionsHostingConfigOptions>>();
+                    var hostingConfigOptions = s.GetService<IOptionsMonitor<FunctionsHostingConfigOptions>>();
                     return new LinuxContainerMetricsPublisher(environment, standbyOptions, logger, hostNameProvider, hostingConfigOptions);
                 }
 

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -305,7 +305,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     var metricsTracker = s.GetService<ILinuxConsumptionMetricsTracker>();
                     var standbyOptions = s.GetService<IOptionsMonitor<StandbyOptions>>();
                     var scriptHostManager = s.GetService<IScriptHostManager>();
-                    return new LinuxContainerLegionMetricsPublisher(environment, standbyOptions, options, logger, new FileSystem(), metricsTracker, scriptHostManager);
+                    var hostingConfigOptions = s.GetService<IOptionsMonitor<FunctionsHostingConfigOptions>>();
+                    return new LinuxContainerLegionMetricsPublisher(environment, standbyOptions, options, logger, new FileSystem(), metricsTracker, scriptHostManager, hostingConfigOptions);
                 }
                 else if (environment.IsFlexConsumptionSku())
                 {

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -79,6 +79,22 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to use cgroup memory metrics for reporting memory usage.
+        /// </summary>
+        internal bool IsCGroupMemoryMetricsEnabled
+        {
+            get
+            {
+                return GetFeatureAsBooleanOrDefault(ScriptConstants.FeatureFlagEnableCGroupMemoryMetrics, false);
+            }
+
+            set
+            {
+                _features[ScriptConstants.FeatureFlagEnableCGroupMemoryMetrics] = value ? "1" : "0";
+            }
+        }
+
+        /// <summary>
         /// Gets or sets a string delimited by '|' that contains a list of admin APIs that are allowed to
         /// be invoked internally by platform components.
         /// </summary>

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -142,6 +142,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FeatureFlagDisableOrderedInvocationMessages = "DisableOrderedInvocationMessages";
         public const string FeatureFlagEnableAzureMonitorTimeIsoFormat = "EnableAzureMonitorTimeIsoFormat";
         public const string FeatureFlagEnableTestDataSuppression = "EnableTestDataSuppression";
+        public const string FeatureFlagEnableCGroupMemoryMetrics = "EnableCGroupMemoryMetrics";
         public const string HostingConfigDisableLinuxAppServiceDetailedExecutionEvents = "DisableLinuxExecutionDetails";
         public const string HostingConfigDisableLinuxAppServiceExecutionEventLogBackoff = "DisableLinuxLogBackoff";
         public const string FeatureFlagEnableLegacyDurableVersionCheck = "EnableLegacyDurableVersionCheck";

--- a/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
@@ -34,48 +34,49 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 //       It is recommended that new properties only look at "1/0" for their setting.
 #pragma warning disable SA1010 // Opening square brackets should be spaced correctly
 #pragma warning disable SA1011 // Closing square brackets should be spaced correctly
-                yield return [ nameof(FunctionsHostingConfigOptions.DisableLinuxAppServiceExecutionDetails), "DisableLinuxExecutionDetails=1", true ];
-                yield return [ nameof(FunctionsHostingConfigOptions.DisableLinuxAppServiceLogBackoff), "DisableLinuxLogBackoff=1", true ];
+                yield return [nameof(FunctionsHostingConfigOptions.DisableLinuxAppServiceExecutionDetails), "DisableLinuxExecutionDetails=1", true];
+                yield return [nameof(FunctionsHostingConfigOptions.DisableLinuxAppServiceLogBackoff), "DisableLinuxLogBackoff=1", true];
 
                 // Supports True/False/1/0
-                yield return [ nameof(FunctionsHostingConfigOptions.EnableOrderedInvocationMessages), "EnableOrderedInvocationMessages=True", true ];
-                yield return [ nameof(FunctionsHostingConfigOptions.EnableOrderedInvocationMessages), "EnableOrderedInvocationMessages=1", true ];
-                yield return [ nameof(FunctionsHostingConfigOptions.EnableOrderedInvocationMessages), "EnableOrderedInvocationMessages=unparseable", true ]; // default
-                yield return [ nameof(FunctionsHostingConfigOptions.EnableOrderedInvocationMessages), string.Empty, true ]; // default
+                yield return [nameof(FunctionsHostingConfigOptions.EnableOrderedInvocationMessages), "EnableOrderedInvocationMessages=True", true];
+                yield return [nameof(FunctionsHostingConfigOptions.EnableOrderedInvocationMessages), "EnableOrderedInvocationMessages=1", true];
+                yield return [nameof(FunctionsHostingConfigOptions.EnableOrderedInvocationMessages), "EnableOrderedInvocationMessages=unparseable", true]; // default
+                yield return [nameof(FunctionsHostingConfigOptions.EnableOrderedInvocationMessages), string.Empty, true]; // default
 
-                yield return [ nameof(FunctionsHostingConfigOptions.FunctionsWorkerDynamicConcurrencyEnabled), "FUNCTIONS_WORKER_DYNAMIC_CONCURRENCY_ENABLED=1", true ];
-                yield return [ nameof(FunctionsHostingConfigOptions.MaximumBundleV3Version), "FunctionRuntimeV4MaxBundleV3Version=teststring", "teststring" ];
-                yield return [ nameof(FunctionsHostingConfigOptions.MaximumBundleV4Version), "FunctionRuntimeV4MaxBundleV4Version=teststring", "teststring" ];
-                yield return [ nameof(FunctionsHostingConfigOptions.RevertWorkerShutdownBehavior), "REVERT_WORKER_SHUTDOWN_BEHAVIOR=1", true ];
-
-                // Supports True/False/1/0
-                yield return [ nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), "ShutdownWebhostWorkerChannelsOnHostShutdown=False", false ];
-                yield return [ nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), "ShutdownWebhostWorkerChannelsOnHostShutdown=True", true ];
-                yield return [ nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), "ShutdownWebhostWorkerChannelsOnHostShutdown=1", true ];
-                yield return [ nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), "ShutdownWebhostWorkerChannelsOnHostShutdown=unparseable", true ]; // default
-                yield return [ nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), string.Empty, true ]; // default
+                yield return [nameof(FunctionsHostingConfigOptions.FunctionsWorkerDynamicConcurrencyEnabled), "FUNCTIONS_WORKER_DYNAMIC_CONCURRENCY_ENABLED=1", true];
+                yield return [nameof(FunctionsHostingConfigOptions.MaximumBundleV3Version), "FunctionRuntimeV4MaxBundleV3Version=teststring", "teststring"];
+                yield return [nameof(FunctionsHostingConfigOptions.MaximumBundleV4Version), "FunctionRuntimeV4MaxBundleV4Version=teststring", "teststring"];
+                yield return [nameof(FunctionsHostingConfigOptions.RevertWorkerShutdownBehavior), "REVERT_WORKER_SHUTDOWN_BEHAVIOR=1", true];
 
                 // Supports True/False/1/0
-                yield return [ nameof(FunctionsHostingConfigOptions.SwtIssuerEnabled), "SwtIssuerEnabled=False", false ];
-                yield return [ nameof(FunctionsHostingConfigOptions.SwtIssuerEnabled), "SwtIssuerEnabled=True", true ];
-                yield return [ nameof(FunctionsHostingConfigOptions.SwtIssuerEnabled), "SwtIssuerEnabled=0", false ];
-                yield return [ nameof(FunctionsHostingConfigOptions.SwtIssuerEnabled), "SwtIssuerEnabled=unparseable", true ]; //default
-                yield return [ nameof(FunctionsHostingConfigOptions.SwtIssuerEnabled), string.Empty, true ]; // default
+                yield return [nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), "ShutdownWebhostWorkerChannelsOnHostShutdown=False", false];
+                yield return [nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), "ShutdownWebhostWorkerChannelsOnHostShutdown=True", true];
+                yield return [nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), "ShutdownWebhostWorkerChannelsOnHostShutdown=1", true];
+                yield return [nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), "ShutdownWebhostWorkerChannelsOnHostShutdown=unparseable", true]; // default
+                yield return [nameof(FunctionsHostingConfigOptions.ShutdownWebhostWorkerChannelsOnHostShutdown), string.Empty, true]; // default
 
-                yield return [ nameof(FunctionsHostingConfigOptions.ThrowOnMissingFunctionsWorkerRuntime), "THROW_ON_MISSING_FUNCTIONS_WORKER_RUNTIME=1", true ];
-                yield return [ nameof(FunctionsHostingConfigOptions.WorkerIndexingDisabledApps), "WORKER_INDEXING_DISABLED_APPS=teststring", "teststring" ];
-                yield return [ nameof(FunctionsHostingConfigOptions.WorkerIndexingEnabled), "WORKER_INDEXING_ENABLED=1", true ];
-                yield return [ nameof(FunctionsHostingConfigOptions.WorkerRuntimeStrictValidationEnabled), "WORKER_RUNTIME_STRICT_VALIDATION_ENABLED=1", true ];
+                // Supports True/False/1/0
+                yield return [nameof(FunctionsHostingConfigOptions.SwtIssuerEnabled), "SwtIssuerEnabled=False", false];
+                yield return [nameof(FunctionsHostingConfigOptions.SwtIssuerEnabled), "SwtIssuerEnabled=True", true];
+                yield return [nameof(FunctionsHostingConfigOptions.SwtIssuerEnabled), "SwtIssuerEnabled=0", false];
+                yield return [nameof(FunctionsHostingConfigOptions.SwtIssuerEnabled), "SwtIssuerEnabled=unparseable", true]; //default
+                yield return [nameof(FunctionsHostingConfigOptions.SwtIssuerEnabled), string.Empty, true]; // default
 
-                yield return [ nameof(FunctionsHostingConfigOptions.InternalAuthApisAllowList), "InternalAuthApisAllowList=|", "|" ];
-                yield return [ nameof(FunctionsHostingConfigOptions.InternalAuthApisAllowList), "InternalAuthApisAllowList=/admin/host/foo|/admin/host/bar", "/admin/host/foo|/admin/host/bar" ];
+                yield return [nameof(FunctionsHostingConfigOptions.ThrowOnMissingFunctionsWorkerRuntime), "THROW_ON_MISSING_FUNCTIONS_WORKER_RUNTIME=1", true];
+                yield return [nameof(FunctionsHostingConfigOptions.WorkerIndexingDisabledApps), "WORKER_INDEXING_DISABLED_APPS=teststring", "teststring"];
+                yield return [nameof(FunctionsHostingConfigOptions.WorkerIndexingEnabled), "WORKER_INDEXING_ENABLED=1", true];
+                yield return [nameof(FunctionsHostingConfigOptions.WorkerRuntimeStrictValidationEnabled), "WORKER_RUNTIME_STRICT_VALIDATION_ENABLED=1", true];
 
-                yield return [ nameof(FunctionsHostingConfigOptions.IsDotNetInProcDisabled), "DotNetInProcDisabled=False", false ];
-                yield return [ nameof(FunctionsHostingConfigOptions.IsDotNetInProcDisabled), "DotNetInProcDisabled=True", true ];
-                yield return [ nameof(FunctionsHostingConfigOptions.IsDotNetInProcDisabled), "DotNetInProcDisabled=1", true ];
-                yield return [ nameof(FunctionsHostingConfigOptions.IsDotNetInProcDisabled), "DotNetInProcDisabled=0", false ];
+                yield return [nameof(FunctionsHostingConfigOptions.InternalAuthApisAllowList), "InternalAuthApisAllowList=|", "|"];
+                yield return [nameof(FunctionsHostingConfigOptions.InternalAuthApisAllowList), "InternalAuthApisAllowList=/admin/host/foo|/admin/host/bar", "/admin/host/foo|/admin/host/bar"];
+
+                yield return [nameof(FunctionsHostingConfigOptions.IsDotNetInProcDisabled), "DotNetInProcDisabled=False", false];
+                yield return [nameof(FunctionsHostingConfigOptions.IsDotNetInProcDisabled), "DotNetInProcDisabled=True", true];
+                yield return [nameof(FunctionsHostingConfigOptions.IsDotNetInProcDisabled), "DotNetInProcDisabled=1", true];
+                yield return [nameof(FunctionsHostingConfigOptions.IsDotNetInProcDisabled), "DotNetInProcDisabled=0", false];
 
                 yield return [nameof(FunctionsHostingConfigOptions.IsTestDataSuppressionEnabled), "EnableTestDataSuppression=1", true];
+                yield return [nameof(FunctionsHostingConfigOptions.IsCGroupMemoryMetricsEnabled), "EnableCGroupMemoryMetrics=1", true];
 
 #pragma warning restore SA1011 // Closing square brackets should be spaced correctly
 #pragma warning restore SA1010 // Opening square brackets should be spaced correctly

--- a/test/WebJobs.Script.Tests/Metrics/LinuxContainerLegionMetricsPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/LinuxContainerLegionMetricsPublisherTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
@@ -62,7 +63,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
                 MetricsFilePath = _metricsFilePath
             });
 
-            return new LinuxContainerLegionMetricsPublisher(_environment, _standbyOptionsMonitor, _options, _logger, new FileSystem(), _testMetricsTracker, _scriptHostManager, metricsPublishInterval);
+            var testHostingConfigOptionsMonitor = new TestOptionsMonitor<FunctionsHostingConfigOptions>(new FunctionsHostingConfigOptions());
+
+            return new LinuxContainerLegionMetricsPublisher(_environment, _standbyOptionsMonitor, _options, _logger, new FileSystem(), _testMetricsTracker, _scriptHostManager, testHostingConfigOptionsMonitor, metricsPublishInterval);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Metrics/LinuxContainerMetricsPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/LinuxContainerMetricsPublisherTests.cs
@@ -86,11 +86,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
 
             _hostingConfigOptions = new FunctionsHostingConfigOptions();
             var hostingConfigOptionsWrapper = new OptionsWrapper<FunctionsHostingConfigOptions>(_hostingConfigOptions);
-
+            var testHostingConfigOptionsMonitor = new TestOptionsMonitor<FunctionsHostingConfigOptions>(_hostingConfigOptions);
             ILogger<LinuxContainerMetricsPublisher> logger = loggerFactory.CreateLogger<LinuxContainerMetricsPublisher>();
             var hostNameProvider = new HostNameProvider(mockEnvironment.Object);
             var standbyOptions = new TestOptionsMonitor<StandbyOptions>(new StandbyOptions { InStandbyMode = true });
-            _metricsPublisher = new LinuxContainerMetricsPublisher(mockEnvironment.Object, standbyOptions, logger, hostNameProvider, hostingConfigOptionsWrapper, _httpClient);
+            _metricsPublisher = new LinuxContainerMetricsPublisher(mockEnvironment.Object, standbyOptions, logger, hostNameProvider, testHostingConfigOptionsMonitor, _httpClient);
             _testLoggerProvider.ClearAllLogMessages();
         }
 


### PR DESCRIPTION
This PR includes changes to the `LinuxContainerMetricsPublisher` ,  `LinuxContainerLegionMetricsPublisher ` and related files to improve memory metrics reporting. A new method was added to read memory usage from CGroup. I was able to compare the value returned by this with `docker stats` command result and they match.

This change is behind a feature flag called "EnableCGroupMemoryMetrics" which has default value of `false`.

I also made a few other cleanups & optimizations such as disposing some resources.


### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)
