### PR TITLE
Increase max attempts/wait time for trace file generation

### DIFF
--- a/eng/ci/templates/official/jobs/run-coldstart.yml
+++ b/eng/ci/templates/official/jobs/run-coldstart.yml
@@ -176,7 +176,7 @@ jobs:
         & $(perfViewPath) stop
 
         # Wait for the zip file to be created
-        $maxAttempts = 10
+        $maxAttempts = 20
         $attempt = 0
 
         while ($attempt -lt $maxAttempts) {


### PR DESCRIPTION
The PerfView stop step occasionally fails when the creation of the trace file takes longer (which I noticed a couple of times). So, increasing the time we wait for it.

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
