### PR TITLE
Fixes circular dependency when resolving LinuxContainerLegionMetricsPublisher

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,3 +4,4 @@
 - My change description (#PR)
 -->
 - Improved memory metrics reporting using CGroup data for Linux consumption (#10968)
+- Avoid circular dependency when resolving LinuxContainerLegionMetricsPublisher. (#10991)

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,4 +6,3 @@
 - Improved memory metrics reporting using CGroup data for Linux consumption (#10968)
 - Fixing GrpcWorkerChannel concurrency bug (#10998)
 - Avoid circular dependency when resolving LinuxContainerLegionMetricsPublisher. (#10991)
-- Fixing GrpcWorkerChannel concurrency bug (#10998)

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,4 +4,5 @@
 - My change description (#PR)
 -->
 - Improved memory metrics reporting using CGroup data for Linux consumption (#10968)
+- Fixing GrpcWorkerChannel concurrency bug (#10998)
 - Avoid circular dependency when resolving LinuxContainerLegionMetricsPublisher. (#10991)

--- a/src/WebJobs.Script.WebHost/Metrics/LinuxContainerLegionMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/LinuxContainerLegionMetricsPublisher.cs
@@ -10,6 +10,7 @@ using Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -26,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         private readonly IDisposable _hostingConfigOptionsOnChangeListener;
         private readonly IEnvironment _environment;
         private readonly ILogger _logger;
-        private readonly IScriptHostManager _scriptHostManager;
+        private readonly IServiceProvider _serviceProvider;
         private readonly string _containerName;
         private readonly IOptionsMonitor<FunctionsHostingConfigOptions> _hostingConfigOptions;
 
@@ -40,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
 
         public LinuxContainerLegionMetricsPublisher(IEnvironment environment, IOptionsMonitor<StandbyOptions> standbyOptions,
             IOptions<LinuxConsumptionLegionMetricsPublisherOptions> options, ILogger<LinuxContainerLegionMetricsPublisher> logger,
-            IFileSystem fileSystem, ILinuxConsumptionMetricsTracker metricsTracker, IScriptHostManager scriptHostManager,
+            IFileSystem fileSystem, ILinuxConsumptionMetricsTracker metricsTracker, IServiceProvider serviceProvider,
             IOptionsMonitor<FunctionsHostingConfigOptions> functionsHostingConfigOptions,
             int? metricsPublishIntervalMS = null)
         {
@@ -48,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _metricsTracker = metricsTracker ?? throw new ArgumentNullException(nameof(metricsTracker));
-            _scriptHostManager = scriptHostManager ?? throw new ArgumentNullException(nameof(scriptHostManager));
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
             _hostingConfigOptions = functionsHostingConfigOptions ?? throw new ArgumentNullException(nameof(functionsHostingConfigOptions));
             _containerName = options.Value.ContainerName;
 
@@ -75,21 +76,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             _hostingConfigOptionsOnChangeListener = _hostingConfigOptions.OnChange(OnHostingConfigOptionsChanged);
         }
 
-        public IMetricsLogger MetricsLogger
-        {
-            get
-            {
-                if (_metricsLogger == null)
-                {
-                    if (!Utility.TryGetHostService<IMetricsLogger>(_scriptHostManager, out _metricsLogger))
-                    {
-                        throw new InvalidOperationException($"Unable to resolve {nameof(IMetricsLogger)} service.");
-                    }
-                }
-
-                return _metricsLogger;
-            }
-        }
+        private IMetricsLogger MetricsLogger => _metricsLogger ??= _serviceProvider.GetRequiredService<IMetricsLogger>();
 
         private void OnHostingConfigOptionsChanged(FunctionsHostingConfigOptions newOptions)
         {

--- a/src/WebJobs.Script.WebHost/Properties/launchSettings.json
+++ b/src/WebJobs.Script.WebHost/Properties/launchSettings.json
@@ -4,15 +4,7 @@
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
-        "AzureWebJobsScriptRoot": "D:\\apps\\HelloHttpNet9NoProxy",
-        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-        "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-        "AZURE_FUNCTIONS_ENVIRONMENT": "Development",
-        "FUNCTIONS_WORKER_RUNTIME_VERSION": "9.0",
-        "WEBSITE_SKU": "dynamic",
-        "WEBSITE_POD_NAME": "podname",
-        "CONTAINER_NAME": "foo",
-        "LEGION_SERVICE_HOST": "1"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "applicationUrl": "https://localhost:62513;http://localhost:62514"
     }

--- a/src/WebJobs.Script.WebHost/Properties/launchSettings.json
+++ b/src/WebJobs.Script.WebHost/Properties/launchSettings.json
@@ -4,7 +4,15 @@
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "AzureWebJobsScriptRoot": "D:\\apps\\HelloHttpNet9NoProxy",
+        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+        "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+        "AZURE_FUNCTIONS_ENVIRONMENT": "Development",
+        "FUNCTIONS_WORKER_RUNTIME_VERSION": "9.0",
+        "WEBSITE_SKU": "dynamic",
+        "WEBSITE_POD_NAME": "podname",
+        "CONTAINER_NAME": "foo",
+        "LEGION_SERVICE_HOST": "1"
       },
       "applicationUrl": "https://localhost:62513;http://localhost:62514"
     }

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.IO.Abstractions;
 using System.Net.Http;
 using System.Runtime.InteropServices;
@@ -304,9 +305,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     var logger = s.GetService<ILogger<LinuxContainerLegionMetricsPublisher>>();
                     var metricsTracker = s.GetService<ILinuxConsumptionMetricsTracker>();
                     var standbyOptions = s.GetService<IOptionsMonitor<StandbyOptions>>();
-                    var scriptHostManager = s.GetService<IScriptHostManager>();
+                    var serviceProvider = s.GetService<IServiceProvider>();
                     var hostingConfigOptions = s.GetService<IOptionsMonitor<FunctionsHostingConfigOptions>>();
-                    return new LinuxContainerLegionMetricsPublisher(environment, standbyOptions, options, logger, new FileSystem(), metricsTracker, scriptHostManager, hostingConfigOptions);
+                    return new LinuxContainerLegionMetricsPublisher(environment, standbyOptions, options, logger, new FileSystem(), metricsTracker, serviceProvider, hostingConfigOptions);
                 }
                 else if (environment.IsFlexConsumptionSku())
                 {

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETestBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETestBase.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using System.Web.Http;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
@@ -73,6 +74,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName, websiteSiteName);
             }
 
+            var testMetricsTracker = new TestMetricsTracker();
             var webHostBuilder = Program.CreateWebHostBuilder()
                 .ConfigureAppConfiguration(c =>
                 {
@@ -102,6 +104,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
                     c.AddSingleton<IEnvironment>(_ => environment);
                     c.AddSingleton<IMetricsLogger>(_ => _metricsLogger);
+                    c.AddSingleton<ILinuxConsumptionMetricsTracker>(_ => testMetricsTracker);
                 })
                 .ConfigureScriptHostLogging(b =>
                 {

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETestBase.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETestBase.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             return webHostBuilder;
         }
 
-        protected async Task InitializeTestHostAsync(string testDirName, IEnvironment environment, string websiteSiteName = TestSiteName)
+        protected async Task<IWebHost> InitializeTestHostAsync(string testDirName, IEnvironment environment, string websiteSiteName = TestSiteName)
         {
             var webHostBuilder = await CreateWebHostBuilderAsync(testDirName, environment, websiteSiteName);
             _httpServer = new TestServer(webHostBuilder);
@@ -138,6 +138,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.NotNull(traces.Single(p => p.FormattedMessage.StartsWith("Host is in standby mode")));
 
             _expectedHostId = await _httpServer.Host.Services.GetService<IHostIdProvider>().GetHostIdAsync(CancellationToken.None);
+
+            return _httpServer.Host;
         }
 
 

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Linux.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Linux.cs
@@ -32,6 +32,41 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
     public class StandbyManagerE2ETests_Linux : StandbyManagerE2ETestBase
     {
         [Fact]
+        public async Task StandbyModeE2E_LinuxConsumptionOnLegion()
+        {
+            var vars = new Dictionary<string, string>
+            {
+                { EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1" },
+                { EnvironmentSettingNames.ContainerName, "testContainer" },
+                { EnvironmentSettingNames.AzureWebsiteHostName, "testapp.azurewebsites.net" },
+                { EnvironmentSettingNames.AzureWebsiteName, "TestApp" },
+                { EnvironmentSettingNames.ContainerEncryptionKey, Convert.ToBase64String(TestHelpers.GenerateKeyBytes()) },
+                { EnvironmentSettingNames.AzureWebsiteContainerReady, null },
+                { EnvironmentSettingNames.AzureWebsiteSku, "Dynamic" },
+                { EnvironmentSettingNames.AzureWebsiteZipDeployment, null },
+                { EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagEnableProxies },
+                { "AzureWebEncryptionKey", "0F75CA46E7EBDD39E4CA6B074D1F9A5972B849A55F91A248" },
+                { EnvironmentSettingNames.FunctionsTimeZone, "Europe/Berlin" },
+                { EnvironmentSettingNames.FunctionWorkerRuntime, "dotnet-isolated" },
+                { EnvironmentSettingNames.LegionServiceHost, "1"}
+            };
+
+            var environment = new TestEnvironment(vars);
+
+            Assert.True(environment.IsLinuxConsumptionOnLegion());
+            Assert.False(environment.IsFlexConsumptionSku());
+            Assert.True(environment.IsAnyLinuxConsumption());
+
+            await InitializeTestHostAsync("Linux", environment);
+
+            // verify the expected startup logs
+            var logEntries = _loggerProvider.GetAllLogMessages().Where(p => p.FormattedMessage != null);
+            Assert.True(logEntries.Any(m => m.Category == "Host.Startup" && m.FormattedMessage.Contains("Host is in standby mode")));
+            Assert.True(logEntries.Any(cat => cat.Category == "Microsoft.Azure.WebJobs.Script.WebHost.StandbyManager"));
+            Assert.True(logEntries.Any(cat => cat.Category == "Host.Triggers.Warmup"));
+        }
+
+        [Fact]
         public async Task StandbyModeE2E_LinuxContainer()
         {
             byte[] bytes = TestHelpers.GenerateKeyBytes();

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Linux.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Linux.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
+using Microsoft.Azure.WebJobs.Script.WebHost.Metrics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security;
 using Microsoft.Azure.WebJobs.Script.Workers;
@@ -57,13 +58,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.False(environment.IsFlexConsumptionSku());
             Assert.True(environment.IsAnyLinuxConsumption());
 
-            await InitializeTestHostAsync("Linux", environment);
+            var webHost = await InitializeTestHostAsync("Linux", environment);
 
             // verify the expected startup logs
-            var logEntries = _loggerProvider.GetAllLogMessages().Where(p => p.FormattedMessage != null);
+            var logEntries = _loggerProvider.GetAllLogMessages().Where(p => p.FormattedMessage != null).ToList();
             Assert.True(logEntries.Any(m => m.Category == "Host.Startup" && m.FormattedMessage.Contains("Host is in standby mode")));
             Assert.True(logEntries.Any(cat => cat.Category == "Microsoft.Azure.WebJobs.Script.WebHost.StandbyManager"));
             Assert.True(logEntries.Any(cat => cat.Category == "Host.Triggers.Warmup"));
+
+            // verify that the expected (legion specific) implementations are resolved
+            Assert.Equal(nameof(LinuxContainerLegionMetricsPublisher), webHost.Services.GetRequiredService<IMetricsPublisher>().GetType().Name);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Linux.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/StandbyManager/StandbyManagerE2ETests_Linux.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.True(logEntries.Any(cat => cat.Category == "Host.Triggers.Warmup"));
 
             // verify that the expected (legion specific) implementations are resolved
-            Assert.Equal(nameof(LinuxContainerLegionMetricsPublisher), webHost.Services.GetRequiredService<IMetricsPublisher>().GetType().Name);
+            Assert.Equal(typeof(LinuxContainerLegionMetricsPublisher), webHost.Services.GetRequiredService<IMetricsPublisher>().GetType());
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -103,8 +103,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     }
                     throw new ApplicationException(error);
                 }
-        }
             }
+        }
 
         public static async Task RetryFailedTest(Func<Task> test, int retries, ITestOutputHelper output = null)
         {

--- a/test/WebJobs.Script.Tests.Shared/TestMetricsTracker.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestMetricsTracker.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public class TestMetricsTracker : ILinuxConsumptionMetricsTracker
+    {
+        public event EventHandler<DiagnosticEventArgs> OnDiagnosticEvent;
+
+        public List<FunctionActivity> FunctionActivities { get; } = new List<FunctionActivity>();
+
+        public List<MemoryActivity> MemoryActivities { get; } = new List<MemoryActivity>();
+
+        public Queue<LinuxConsumptionMetrics> MetricsQueue { get; } = new Queue<LinuxConsumptionMetrics>();
+
+        public void AddFunctionActivity(FunctionActivity activity)
+        {
+            FunctionActivities.Add(activity);
+        }
+
+        public void AddMemoryActivity(MemoryActivity activity)
+        {
+            MemoryActivities.Add(activity);
+        }
+
+        public bool TryGetMetrics(out LinuxConsumptionMetrics metrics)
+        {
+            return MetricsQueue.TryDequeue(out metrics);
+        }
+
+        public void LogEvent(string eventName)
+        {
+            OnDiagnosticEvent?.Invoke(this, new DiagnosticEventArgs(eventName));
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Shared/WebJobs.Script.Tests.Shared.projitems
+++ b/test/WebJobs.Script.Tests.Shared/WebJobs.Script.Tests.Shared.projitems
@@ -24,6 +24,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)TestFunctionMetadataManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestHostBuilderExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestHostExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestMetricsTracker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestOutputHelperLogger.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestOutputHelperLoggerProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestMetricsLogger.cs" />

--- a/test/WebJobs.Script.Tests/Metrics/LinuxContainerLegionMetricsPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/LinuxContainerLegionMetricsPublisherTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
         private readonly Random _random = new Random();
         private readonly TestLogger<LinuxContainerLegionMetricsPublisher> _logger;
         private readonly TestMetricsLogger _testMetricsLogger;
-        private readonly IScriptHostManager _scriptHostManager;
+        private readonly IServiceProvider _serviceProvider;
 
         private IOptions<LinuxConsumptionLegionMetricsPublisherOptions> _options;
         private StandbyOptions _standbyOptions;
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             _environment = new TestEnvironment();
             _logger = new TestLogger<LinuxContainerLegionMetricsPublisher>();
             _testMetricsLogger = new TestMetricsLogger();
-            _scriptHostManager = new TestScriptHostManager(_testMetricsLogger);
+            _serviceProvider = new TestScriptHostManager(_testMetricsLogger);
 
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionsMetricsPublishPath, _metricsFilePath);
 
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
 
             var testHostingConfigOptionsMonitor = new TestOptionsMonitor<FunctionsHostingConfigOptions>(new FunctionsHostingConfigOptions());
 
-            return new LinuxContainerLegionMetricsPublisher(_environment, _standbyOptionsMonitor, _options, _logger, new FileSystem(), _testMetricsTracker, _scriptHostManager, testHostingConfigOptionsMonitor, metricsPublishInterval);
+            return new LinuxContainerLegionMetricsPublisher(_environment, _standbyOptionsMonitor, _options, _logger, new FileSystem(), _testMetricsTracker, _serviceProvider, testHostingConfigOptionsMonitor, metricsPublishInterval);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Metrics/LinuxContainerLegionMetricsPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/LinuxContainerLegionMetricsPublisherTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
@@ -18,7 +17,6 @@ using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
 using Newtonsoft.Json;
 using Xunit;
-using static Microsoft.Azure.WebJobs.Script.Tests.TestHelpers;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
 {
@@ -240,37 +238,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             return new FileInfo[0];
         }
 
-        private class TestMetricsTracker : ILinuxConsumptionMetricsTracker
-        {
-            public event EventHandler<DiagnosticEventArgs> OnDiagnosticEvent;
-
-            public List<FunctionActivity> FunctionActivities { get; } = new List<FunctionActivity>();
-
-            public List<MemoryActivity> MemoryActivities { get; } = new List<MemoryActivity>();
-
-            public Queue<LinuxConsumptionMetrics> MetricsQueue { get; } = new Queue<LinuxConsumptionMetrics>();
-
-            public void AddFunctionActivity(FunctionActivity activity)
-            {
-                FunctionActivities.Add(activity);
-            }
-
-            public void AddMemoryActivity(MemoryActivity activity)
-            {
-                MemoryActivities.Add(activity);
-            }
-
-            public bool TryGetMetrics(out LinuxConsumptionMetrics metrics)
-            {
-                return MetricsQueue.TryDequeue(out metrics);
-            }
-
-            public void LogEvent(string eventName)
-            {
-                OnDiagnosticEvent?.Invoke(this, new DiagnosticEventArgs(eventName));
-            }
-        }
-
         private class TestScriptHostManager : IServiceProvider, IScriptHostManager
         {
             private readonly IMetricsLogger _metricsLogger;
@@ -280,11 +247,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
                 _metricsLogger = metricsLogger;
             }
 
-            #pragma warning disable CS0067
+#pragma warning disable CS0067
             public event EventHandler HostInitializing;
 
             public event EventHandler<ActiveHostChangedEventArgs> ActiveHostChanged;
-            #pragma warning restore CS0067
+#pragma warning restore CS0067
 
             public ScriptHostState State => throw new NotImplementedException();
 


### PR DESCRIPTION
Fixes circular dependency when resolving LinuxContainerLegionMetricsPublisher (linux consumption on legion)

In our[ previous version](https://github.com/Azure/azure-functions-host/blob/701f376f9afbf7177f59791414590a0272934b4f/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs#L303-L308) we had the below:


1. When trying to resolve the `IMetricsPublisher` implementation for legion, we try to resolve `IScriptHostManager`.
2. `WebJobsScriptHostService` which is an implementation of `IScriptHostManager`, depends on `IMetricsLogger`.
3. `WebHostMetricsLogger` which is an implementation of `IMetricsLogger`, depends on `IMetricsPublisher`.

This creates a circular dependency where resolving `IMetricsPublisher` eventually leads back to itself. So, host startup is hung.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR - will follow
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)


