### PR TITLE
Logging improvements to DiagnosticEventTableStorageRepository 

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,3 +4,12 @@
 - My change description (#PR)
 -->
 - Improved memory metrics reporting using CGroup data for Linux consumption (#10968)
+- Memory allocation optimizations in `RpcWorkerConfigFactory.AddProviders` (#10959)
+- Fixing GrpcWorkerChannel concurrency bug (#10998)
+- Avoid circular dependency when resolving LinuxContainerLegionMetricsPublisher. (#10991)
+- Add 'unix' to the list of runtimes kept when importing PowerShell worker for Linux builds
+- Update PowerShell 7.4 worker to 4.0.4206
+- Update Python Worker Version to [4.37.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.37.0)
+- Add runtime and process metrics. (#11034)
+- Add `win-arm64` and `linux-arm64` to the list of PowerShell runtimes; added filter for `osx` RIDs (includes `osx-x64` and `osx-arm64`) (#11013)
+- Disable Diagnostic Events when Table Storage is not accessible (#10996)

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.Log.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.Log.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
+{
+    public partial class DiagnosticEventTableStorageRepository
+    {
+        private static class Logger
+        {
+            private static readonly Action<ILogger, Exception> _serviceDisabledFailedToCreateClient =
+                LoggerMessage.Define(LogLevel.Warning, new EventId(1, nameof(ServiceDisabledFailedToCreateClient)), "An error occurred initializing the Table Storage Client. We are unable to record diagnostic events, so the diagnostic logging service is being stopped.");
+
+            private static readonly Action<ILogger, Exception> _serviceDisabledUnauthorizedClient =
+                LoggerMessage.Define(LogLevel.Warning, new EventId(2, nameof(ServiceDisabledUnauthorizedClient)), "The Table Storage Client is not authorized to access the table storage account. We are unable to record diagnostic events, so the diagnostic logging service is being stopped.");
+
+            private static readonly Action<ILogger, string, Exception> _purgingDiagnosticEvents =
+                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(3, nameof(PurgingDiagnosticEvents)), "Purging diagnostic events with versions older than '{currentEventVersion}'.");
+
+            private static readonly Action<ILogger, string, Exception> _deletingTableWithoutEventVersion =
+                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(4, nameof(DeletingTableWithoutEventVersion)), "Deleting table '{tableName}' as it contains records without an EventVersion.");
+
+            private static readonly Action<ILogger, string, Exception> _deletingTableWithOutdatedEventVersion =
+                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(5, nameof(DeletingTableWithOutdatedEventVersion)), "Deleting table '{tableName}' as it contains records with an outdated EventVersion.");
+
+            private static readonly Action<ILogger, Exception> _errorPurgingDiagnosticEventVersions =
+                LoggerMessage.Define(LogLevel.Error, new EventId(6, nameof(ErrorPurgingDiagnosticEventVersions)), "Error occurred when attempting to purge previous diagnostic event versions.");
+
+            private static readonly Action<ILogger, Exception> _unableToGetTableReference =
+                LoggerMessage.Define(LogLevel.Error, new EventId(7, nameof(UnableToGetTableReference)), "Unable to get table reference. Aborting write operation.");
+
+            private static readonly Action<ILogger, Exception> _unableToGetTableReferenceOrCreateTable =
+                LoggerMessage.Define(LogLevel.Error, new EventId(8, nameof(UnableToGetTableReferenceOrCreateTable)), "Unable to get table reference or create table. Aborting write operation.");
+
+            private static readonly Action<ILogger, Exception> _unableToWriteDiagnosticEvents =
+                LoggerMessage.Define(LogLevel.Error, new EventId(9, nameof(UnableToWriteDiagnosticEvents)), "Unable to write diagnostic events to table storage.");
+
+            private static readonly Action<ILogger, Exception> _primaryHostStateProviderNotAvailable =
+                LoggerMessage.Define(LogLevel.Debug, new EventId(10, nameof(PrimaryHostStateProviderNotAvailable)), "PrimaryHostStateProvider is not available. Skipping the check for primary host.");
+
+            private static readonly Action<ILogger, Exception> _stoppingFlushLogsTimer =
+                LoggerMessage.Define(LogLevel.Information, new EventId(11, nameof(StoppingFlushLogsTimer)), "Stopping the flush logs timer.");
+
+            private static readonly Action<ILogger, Exception> _queueingBackgroundTablePurge =
+                LoggerMessage.Define(LogLevel.Debug, new EventId(12, nameof(QueueingBackgroundTablePurge)), "Queueing background table purge.");
+
+            public static void ServiceDisabledFailedToCreateClient(ILogger logger) => _serviceDisabledFailedToCreateClient(logger, null);
+
+            public static void ServiceDisabledUnauthorizedClient(ILogger logger, Exception exception) => _serviceDisabledUnauthorizedClient(logger, exception);
+
+            public static void PurgingDiagnosticEvents(ILogger logger, string currentEventVersion) => _purgingDiagnosticEvents(logger, currentEventVersion, null);
+
+            public static void DeletingTableWithoutEventVersion(ILogger logger, string tableName) => _deletingTableWithoutEventVersion(logger, tableName, null);
+
+            public static void DeletingTableWithOutdatedEventVersion(ILogger logger, string tableName) => _deletingTableWithOutdatedEventVersion(logger, tableName, null);
+
+            public static void ErrorPurgingDiagnosticEventVersions(ILogger<DiagnosticEventTableStorageRepository> logger, Exception exception) => _errorPurgingDiagnosticEventVersions(logger, exception);
+
+            public static void UnableToGetTableReference(ILogger logger) => _unableToGetTableReference(logger, null);
+
+            public static void UnableToGetTableReferenceOrCreateTable(ILogger logger, Exception exception) => _unableToGetTableReferenceOrCreateTable(logger, exception);
+
+            public static void UnableToWriteDiagnosticEvents(ILogger logger, Exception exception) => _unableToWriteDiagnosticEvents(logger, exception);
+
+            public static void PrimaryHostStateProviderNotAvailable(ILogger logger) => _primaryHostStateProviderNotAvailable(logger, null);
+
+            public static void StoppingFlushLogsTimer(ILogger logger) => _stoppingFlushLogsTimer(logger, null);
+
+            public static void QueueingBackgroundTablePurge(ILogger logger) => _queueingBackgroundTablePurge(logger, null);
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.Log.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.Log.cs
@@ -11,44 +11,58 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         private static class Logger
         {
             private static readonly Action<ILogger, Exception> _serviceDisabledFailedToCreateClient =
-                LoggerMessage.Define(LogLevel.Warning, new EventId(1, nameof(ServiceDisabledFailedToCreateClient)), "An error occurred initializing the Table Storage Client. We are unable to record diagnostic events, so the diagnostic logging service is being stopped.");
+                LoggerMessage.Define(
+                    LogLevel.Warning,
+                    new EventId(1, nameof(ServiceDisabledFailedToCreateClient)),
+                    "We couldn’t initialize the Table Storage Client using the 'AzureWebJobsStorage' connection string. We are unable to record diagnostic events, so the diagnostic logging service is being stopped. Please check the 'AzureWebJobsStorage' connection string in Application Settings.");
 
             private static readonly Action<ILogger, Exception> _serviceDisabledUnauthorizedClient =
-                LoggerMessage.Define(LogLevel.Warning, new EventId(2, nameof(ServiceDisabledUnauthorizedClient)), "The Table Storage Client is not authorized to access the table storage account. We are unable to record diagnostic events, so the diagnostic logging service is being stopped.");
+                LoggerMessage.Define(
+                    LogLevel.Warning,
+                    new EventId(2, nameof(ServiceDisabledUnauthorizedClient)),
+                    "We couldn’t access the Table service in the Azure Storage account defined by the 'AzureWebJobsStorage' setting. We are unable to record diagnostic events, so the diagnostic logging service is being stopped. Please ensure the connection string or managed identity has permissions to access the Table service and that any network rules allow connectivity.");
+
+            private static readonly Action<ILogger, Exception> _serviceDisabledUnableToConnectToStorage =
+                LoggerMessage.Define(
+                    LogLevel.Warning,
+                    new EventId(3, nameof(ServiceDisabledUnableToConnectToStorage)),
+                    "We couldn’t reach the Table service endpoint specified in the 'AzureWebJobsStorage' setting. We are unable to record diagnostic events, so the diagnostic logging service is being stopped. Please confirm network connectivity and endpoint accessibility.");
 
             private static readonly Action<ILogger, string, Exception> _purgingDiagnosticEvents =
-                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(3, nameof(PurgingDiagnosticEvents)), "Purging diagnostic events with versions older than '{currentEventVersion}'.");
+                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(4, nameof(PurgingDiagnosticEvents)), "Purging diagnostic events with versions older than '{currentEventVersion}'.");
 
             private static readonly Action<ILogger, string, Exception> _deletingTableWithoutEventVersion =
-                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(4, nameof(DeletingTableWithoutEventVersion)), "Deleting table '{tableName}' as it contains records without an EventVersion.");
+                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(5, nameof(DeletingTableWithoutEventVersion)), "Deleting table '{tableName}' as it contains records without an EventVersion.");
 
             private static readonly Action<ILogger, string, Exception> _deletingTableWithOutdatedEventVersion =
-                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(5, nameof(DeletingTableWithOutdatedEventVersion)), "Deleting table '{tableName}' as it contains records with an outdated EventVersion.");
+                LoggerMessage.Define<string>(LogLevel.Debug, new EventId(6, nameof(DeletingTableWithOutdatedEventVersion)), "Deleting table '{tableName}' as it contains records with an outdated EventVersion.");
 
             private static readonly Action<ILogger, Exception> _errorPurgingDiagnosticEventVersions =
-                LoggerMessage.Define(LogLevel.Error, new EventId(6, nameof(ErrorPurgingDiagnosticEventVersions)), "Error occurred when attempting to purge previous diagnostic event versions.");
+                LoggerMessage.Define(LogLevel.Error, new EventId(7, nameof(ErrorPurgingDiagnosticEventVersions)), "Error occurred when attempting to purge previous diagnostic event versions.");
 
             private static readonly Action<ILogger, Exception> _unableToGetTableReference =
-                LoggerMessage.Define(LogLevel.Error, new EventId(7, nameof(UnableToGetTableReference)), "Unable to get table reference. Aborting write operation.");
+                LoggerMessage.Define(LogLevel.Error, new EventId(8, nameof(UnableToGetTableReference)), "Unable to get table reference. Aborting write operation.");
 
             private static readonly Action<ILogger, Exception> _unableToGetTableReferenceOrCreateTable =
-                LoggerMessage.Define(LogLevel.Error, new EventId(8, nameof(UnableToGetTableReferenceOrCreateTable)), "Unable to get table reference or create table. Aborting write operation.");
+                LoggerMessage.Define(LogLevel.Error, new EventId(9, nameof(UnableToGetTableReferenceOrCreateTable)), "Unable to get table reference or create table. Aborting write operation.");
 
             private static readonly Action<ILogger, Exception> _unableToWriteDiagnosticEvents =
-                LoggerMessage.Define(LogLevel.Error, new EventId(9, nameof(UnableToWriteDiagnosticEvents)), "Unable to write diagnostic events to table storage.");
+                LoggerMessage.Define(LogLevel.Error, new EventId(10, nameof(UnableToWriteDiagnosticEvents)), "Unable to write diagnostic events to table storage.");
 
             private static readonly Action<ILogger, Exception> _primaryHostStateProviderNotAvailable =
-                LoggerMessage.Define(LogLevel.Debug, new EventId(10, nameof(PrimaryHostStateProviderNotAvailable)), "PrimaryHostStateProvider is not available. Skipping the check for primary host.");
+                LoggerMessage.Define(LogLevel.Debug, new EventId(11, nameof(PrimaryHostStateProviderNotAvailable)), "PrimaryHostStateProvider is not available. Skipping the check for primary host.");
 
             private static readonly Action<ILogger, Exception> _stoppingFlushLogsTimer =
-                LoggerMessage.Define(LogLevel.Information, new EventId(11, nameof(StoppingFlushLogsTimer)), "Stopping the flush logs timer.");
+                LoggerMessage.Define(LogLevel.Information, new EventId(12, nameof(StoppingFlushLogsTimer)), "Stopping the flush logs timer.");
 
             private static readonly Action<ILogger, Exception> _queueingBackgroundTablePurge =
-                LoggerMessage.Define(LogLevel.Debug, new EventId(12, nameof(QueueingBackgroundTablePurge)), "Queueing background table purge.");
+                LoggerMessage.Define(LogLevel.Debug, new EventId(13, nameof(QueueingBackgroundTablePurge)), "Queueing background table purge.");
 
             public static void ServiceDisabledFailedToCreateClient(ILogger logger) => _serviceDisabledFailedToCreateClient(logger, null);
 
             public static void ServiceDisabledUnauthorizedClient(ILogger logger, Exception exception) => _serviceDisabledUnauthorizedClient(logger, exception);
+
+            public static void ServiceDisabledUnableToConnectToStorage(ILogger logger, Exception exception) => _serviceDisabledUnableToConnectToStorage(logger, exception);
 
             public static void PurgingDiagnosticEvents(ILogger logger, string currentEventVersion) => _purgingDiagnosticEvents(logger, currentEventVersion, null);
 

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.Log.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.Log.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 LoggerMessage.Define(
                     LogLevel.Warning,
                     new EventId(2, nameof(ServiceDisabledUnauthorizedClient)),
-                    "We couldn’t access the Table service in the Azure Storage account defined by the 'AzureWebJobsStorage' setting. We are unable to record diagnostic events, so the diagnostic logging service is being stopped. Please ensure the connection string or managed identity has permissions to access the Table service and that any network rules allow connectivity.");
+                    "We couldn’t access the Table service in the Azure Storage account defined by the 'AzureWebJobsStorage' setting. We are unable to record diagnostic events, so the diagnostic logging service is being stopped. Please ensure the connection string or managed identity has permissions to access the Table service and that any network rules allow connectivity. If you're using an identity-based connection, make sure it has been assigned the 'Storage Table Data Contributor' role.");
 
             private static readonly Action<ILogger, Exception> _serviceDisabledUnableToConnectToStorage =
                 LoggerMessage.Define(

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
@@ -5,10 +5,12 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure;
 using Azure.Data.Tables;
+using Azure.Data.Tables.Models;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Hosting;
 using Microsoft.Azure.WebJobs.Logging;
@@ -77,15 +79,22 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                         _ = TableStorageHelpers.TableExist(testTable, _tableClient);
                         _ = testTable.CreateIfNotExists();
                     }
-                    catch (RequestFailedException ex) when (ex.Status == 403)
+                    catch (RequestFailedException rfe) when (rfe.Status == (int)HttpStatusCode.Conflict || rfe.ErrorCode == TableErrorCode.TableBeingDeleted)
+                    {
+                        // The table is being deleted or there could be a conflict for several instances initializing.
+                        // We can ignore this error as it is not a failure and we tested the permissions.
+                    }
+                    catch (RequestFailedException rfe) when (rfe.Status == (int)HttpStatusCode.Forbidden)
                     {
                         DisableService();
-                        Logger.ServiceDisabledUnauthorizedClient(_logger, ex);
+                        Logger.ServiceDisabledUnauthorizedClient(_logger, rfe);
                     }
-                    catch (Exception)
+                    catch (Exception ex)
                     {
-                        // Other exceptions might be due to conflict issues or other transient errors
-                        // which don't necessarily indicate a permissions problem
+                        // We failed to connect to the table storage account. This could be due to a transient error or a configuration issue, such network issues.
+                        // We will disable the service.
+                        DisableService();
+                        Logger.ServiceDisabledUnableToConnectToStorage(_logger, ex);
                     }
                 }
 
@@ -228,6 +237,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                     TableStorageHelpers.QueueBackgroundTablePurge(table, TableClient, TableNamePrefix, _logger);
                 }
             }
+            catch (RequestFailedException ex) when (ex.Status == 403)
+            {
+                // If we reach this point, we already checked for permissions on TableClient initialization. It is possible that the permissions changed after the initialization or any storage firewall/network configuration changed.
+                // We will log the error and disable the service.
+                Logger.UnableToGetTableReferenceOrCreateTable(_logger, ex);
+                DisableService();
+                Logger.ServiceDisabledUnauthorizedClient(_logger, ex);
+            }
             catch (Exception ex)
             {
                 Logger.UnableToGetTableReferenceOrCreateTable(_logger, ex);
@@ -264,6 +281,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             }
             catch (RequestFailedException ex) when (ex.Status == 403)
             {
+                // If we reach this point, we already checked for permissions on TableClient initialization. It is possible that the permissions changed after the initialization or any firewall/network rules were changed.
+                // We will log the error and disable the service.
+                Logger.UnableToWriteDiagnosticEvents(_logger, ex);
                 DisableService();
                 Logger.ServiceDisabledUnauthorizedClient(_logger, ex);
             }

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                         // When using RBAC, we need "Storage Table Data Contributor" as we require to list, create and delete tables and query/insert/delete entities.
                         // Testing permissions by listing tables, creating and deleting a test table.
                         var testTable = _tableClient.GetTableClient($"{TableNamePrefix}Check");
-                        _ = TableStorageHelpers.TableExist(testTable, _tableClient);
+                        _ = TableStorageHelpers.TableExists(testTable, _tableClient);
                         _ = testTable.CreateIfNotExists();
                         _ = testTable.Delete();
                     }

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         {
             get
             {
-                if (!_environment.IsPlaceholderModeEnabled() && _tableClient == null)
+                if (_tableClient is null && !_environment.IsPlaceholderModeEnabled())
                 {
                     if (!_azureTableStorageProvider.TryCreateHostingTableServiceClient(out _tableClient))
                     {
@@ -261,6 +261,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 }
                 await table.SubmitTransactionAsync(batch);
                 events.Clear();
+            }
+            catch (RequestFailedException ex) when (ex.Status == 403)
+            {
+                DisableService();
+                Logger.ServiceDisabledUnauthorizedClient(_logger, ex);
             }
             catch (Exception ex)
             {

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
@@ -74,10 +74,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                     try
                     {
                         // When using RBAC, we need "Storage Table Data Contributor" as we require to list, create and delete tables and query/insert/delete entities.
-                        // Testing permissions by listing tables and creating a test table.
+                        // Testing permissions by listing tables, creating and deleting a test table.
                         var testTable = _tableClient.GetTableClient($"{TableNamePrefix}Check");
                         _ = TableStorageHelpers.TableExist(testTable, _tableClient);
                         _ = testTable.CreateIfNotExists();
+                        _ = testTable.Delete();
                     }
                     catch (RequestFailedException rfe) when (rfe.Status == (int)HttpStatusCode.Conflict || rfe.ErrorCode == TableErrorCode.TableBeingDeleted)
                     {

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
 using Azure.Data.Tables;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Hosting;
@@ -17,7 +18,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 {
-    public class DiagnosticEventTableStorageRepository : IDiagnosticEventRepository, IDisposable
+    public partial class DiagnosticEventTableStorageRepository : IDiagnosticEventRepository, IDisposable
     {
         internal const string TableNamePrefix = "AzureFunctionsDiagnosticEvents";
         private const int LogFlushInterval = 1000 * 60 * 10; // 10 minutes
@@ -59,11 +60,33 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         {
             get
             {
-                if (!_environment.IsPlaceholderModeEnabled() && _tableClient == null && !_azureTableStorageProvider.TryCreateHostingTableServiceClient(out _tableClient))
+                if (!_environment.IsPlaceholderModeEnabled() && _tableClient == null)
                 {
-                    _logger.LogWarning("An error occurred initializing the Table Storage Client. We are unable to record diagnostic events, so the diagnostic logging service is being stopped.");
-                    _isEnabled = false;
-                    StopTimer();
+                    if (!_azureTableStorageProvider.TryCreateHostingTableServiceClient(out _tableClient))
+                    {
+                        DisableService();
+                        Logger.ServiceDisabledFailedToCreateClient(_logger);
+                        return _tableClient;
+                    }
+
+                    try
+                    {
+                        // When using RBAC, we need "Storage Table Data Contributor" as we require to list, create and delete tables and query/insert/delete entities.
+                        // Testing permissions by listing tables and creating a test table.
+                        var testTable = _tableClient.GetTableClient($"{TableNamePrefix}Check");
+                        _ = TableStorageHelpers.TableExist(testTable, _tableClient);
+                        _ = testTable.CreateIfNotExists();
+                    }
+                    catch (RequestFailedException ex) when (ex.Status == 403)
+                    {
+                        DisableService();
+                        Logger.ServiceDisabledUnauthorizedClient(_logger, ex);
+                    }
+                    catch (Exception)
+                    {
+                        // Other exceptions might be due to conflict issues or other transient errors
+                        // which don't necessarily indicate a permissions problem
+                    }
                 }
 
                 return _tableClient;
@@ -83,6 +106,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         }
 
         internal ConcurrentDictionary<string, DiagnosticEvent> Events => _events;
+
+        private void DisableService()
+        {
+            _isEnabled = false;
+            StopTimer();
+            _events.Clear();
+        }
 
         internal TableClient GetDiagnosticEventsTable(DateTime? now = null)
         {
@@ -114,7 +144,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         private async Task PurgePreviousEventVersions()
         {
-            _logger.LogDebug("Purging diagnostic events with versions older than '{currentEventVersion}'.", DiagnosticEvent.CurrentEventVersion);
+            Logger.PurgingDiagnosticEvents(_logger, DiagnosticEvent.CurrentEventVersion);
 
             bool tableDeleted = false;
 
@@ -133,7 +163,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                             // Delete table if it doesn't have records with EventVersion
                             if (string.IsNullOrEmpty(record.EventVersion) == true)
                             {
-                                _logger.LogDebug("Deleting table '{tableName}' as it contains records without an EventVersion.", table.Name);
+                                Logger.DeletingTableWithoutEventVersion(_logger, table.Name);
                                 await table.DeleteAsync();
                                 tableDeleted = true;
                                 break;
@@ -142,7 +172,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                             // If the table does have EventVersion, query if it is an outdated version
                             if (string.Compare(DiagnosticEvent.CurrentEventVersion, record.EventVersion, StringComparison.Ordinal) > 0)
                             {
-                                _logger.LogDebug("Deleting table '{tableName}' as it contains records with an outdated EventVersion.", table.Name);
+                                Logger.DeletingTableWithOutdatedEventVersion(_logger, table.Name);
                                 await table.DeleteAsync();
                                 tableDeleted = true;
                                 break;
@@ -154,7 +184,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error occurred when attempting to purge previous diagnostic event versions.");
+                    Logger.ErrorPurgingDiagnosticEventVersions(_logger, ex);
                 }
             }, maxRetries: 5, retryInterval: TimeSpan.FromSeconds(5));
 
@@ -170,7 +200,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             // TableClient is initialized lazily and it will stop the timer that schedules flush logs whenever it fails to initialize.
             // We need to check if the TableClient is null before proceeding. This helps when the first time the property is accessed is as part of the FlushLogs method.
             // We should not have any events stored pending to be written since WriteDiagnosticEvent will check for an initialized TableClient.
-            if (_environment.IsPlaceholderModeEnabled() || TableClient is null)
+            if (_environment.IsPlaceholderModeEnabled() || TableClient is null || !IsEnabled())
             {
                 return;
             }
@@ -186,21 +216,21 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
                 if (table == null)
                 {
-                    _logger.LogError("Unable to get table reference. Aborting write operation.");
-                    StopTimer();
+                    Logger.UnableToGetTableReference(_logger);
+                    DisableService();
                     return;
                 }
 
                 bool tableCreated = await TableStorageHelpers.CreateIfNotExistsAsync(table, TableClient, TableCreationMaxRetryCount);
                 if (tableCreated)
                 {
-                    _logger.LogDebug("Queueing background table purge.");
+                    Logger.QueueingBackgroundTablePurge(_logger);
                     TableStorageHelpers.QueueBackgroundTablePurge(table, TableClient, TableNamePrefix, _logger);
                 }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Unable to get table reference or create table. Aborting write operation.");
+                Logger.UnableToGetTableReferenceOrCreateTable(_logger, ex);
                 // Clearing the memory cache to avoid memory build up.
                 _events.Clear();
                 return;
@@ -234,7 +264,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Unable to write diagnostic events to table storage.");
+                Logger.UnableToWriteDiagnosticEvents(_logger, ex);
             }
         }
 
@@ -275,7 +305,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             var primaryHostStateProvider = _serviceProvider?.GetService<IPrimaryHostStateProvider>();
             if (primaryHostStateProvider is null)
             {
-                _logger.LogDebug("PrimaryHostStateProvider is not available. Skipping the check for primary host.");
+                Logger.PrimaryHostStateProviderNotAvailable(_logger);
                 return false;
             }
 
@@ -284,7 +314,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         private void StopTimer()
         {
-            _logger.LogInformation("Stopping the flush logs timer.");
+            Logger.StoppingFlushLogsTimer(_logger);
             _flushLogsTimer?.Change(Timeout.Infinite, Timeout.Infinite);
         }
 

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                     TableStorageHelpers.QueueBackgroundTablePurge(table, TableClient, TableNamePrefix, _logger);
                 }
             }
-            catch (RequestFailedException ex) when (ex.Status == 403)
+            catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.Forbidden)
             {
                 // If we reach this point, we already checked for permissions on TableClient initialization. It is possible that the permissions changed after the initialization or any storage firewall/network configuration changed.
                 // We will log the error and disable the service.
@@ -279,9 +279,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 await table.SubmitTransactionAsync(batch);
                 events.Clear();
             }
-            catch (RequestFailedException ex) when (ex.Status == 403)
+            catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.Forbidden)
             {
-                // If we reach this point, we already checked for permissions on TableClient initialization. It is possible that the permissions changed after the initialization or any firewall/network rules were changed.
+                // If we reach this point, we already checked for permissions on TableClient initialization.
+                // It is possible that the permissions changed after the initialization, any firewall/network rules were changed or it's a custom role where we don't have permissions to write entities.
                 // We will log the error and disable the service.
                 Logger.UnableToWriteDiagnosticEvents(_logger, ex);
                 DisableService();

--- a/src/WebJobs.Script.WebHost/Helpers/TableStorageHelpers.cs
+++ b/src/WebJobs.Script.WebHost/Helpers/TableStorageHelpers.cs
@@ -96,6 +96,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Helpers
 
         internal static async Task<IEnumerable<TableClient>> ListTablesAsync(TableServiceClient tableClient, string tableNamePrefix)
         {
+            ArgumentNullException.ThrowIfNull(tableClient, nameof(tableClient));
+
             // Azure.Data.Tables doesn't have a direct way to list tables with a prefix so we need to do it manually
             var givenValue = tableNamePrefix + "{";
             AsyncPageable<TableItem> tablesQuery = tableClient.QueryAsync(p => p.Name.CompareTo(tableNamePrefix) >= 0 && p.Name.CompareTo(givenValue) <= 0);
@@ -114,6 +116,18 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Helpers
             var query = tableClient.QueryAsync(p => p.Name == table.Name);
 
             await foreach (var item in query)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        internal static bool TableExist(TableClient table, TableServiceClient tableClient)
+        {
+            var query = tableClient.Query(p => p.Name == table.Name);
+
+            foreach (var item in query)
             {
                 return true;
             }

--- a/src/WebJobs.Script.WebHost/Helpers/TableStorageHelpers.cs
+++ b/src/WebJobs.Script.WebHost/Helpers/TableStorageHelpers.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Helpers
             return false;
         }
 
-        internal static bool TableExist(TableClient table, TableServiceClient tableClient)
+        internal static bool TableExists(TableClient table, TableServiceClient tableClient)
         {
             var query = tableClient.Query(p => p.Name == table.Name);
 

--- a/test/WebJobs.Script.Tests.Integration/Diagnostics/DiagnosticEventTableStorageRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Diagnostics/DiagnosticEventTableStorageRepositoryTests.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             var cloudTable = repository.GetDiagnosticEventsTable(dateTime);
             Assert.Null(cloudTable);
             var messages = _loggerProvider.GetAllLogMessages();
-            var errorIntializingPresent = messages.Any(m => m.FormattedMessage.Contains("An error occurred initializing the Table Storage Client. We are unable to record diagnostic events, so the diagnostic logging service is being stopped."));
+            var errorIntializingPresent = messages.Any(m => m.FormattedMessage.Contains("We couldn’t initialize the Table Storage Client using the 'AzureWebJobsStorage' connection string. We are unable to record diagnostic events, so the diagnostic logging service is being stopped. Please check the 'AzureWebJobsStorage' connection string in Application Settings."));
             Assert.True(errorIntializingPresent);
             Assert.False(repository.IsEnabled());
         }
@@ -294,7 +294,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             await repository.FlushLogs();
 
             // Assert
-            var createFailureMessagePresent = _loggerProvider.GetAllLogMessages().Any(m => m.FormattedMessage.Contains("An error occurred initializing the Table Storage Client. We are unable to record diagnostic events, so the diagnostic logging service is being stopped."));
+            var createFailureMessagePresent = _loggerProvider.GetAllLogMessages().Any(m => m.FormattedMessage.Contains("We couldn’t initialize the Table Storage Client using the 'AzureWebJobsStorage' connection string. We are unable to record diagnostic events, so the diagnostic logging service is being stopped. Please check the 'AzureWebJobsStorage' connection string in Application Settings."));
             Assert.True(createFailureMessagePresent);
 
             var purgeEventMessagePresent = _loggerProvider.GetAllLogMessages().Any(m => m.FormattedMessage.Contains("Purging diagnostic events with versions older than"));

--- a/test/WebJobs.Script.Tests.Integration/Diagnostics/DiagnosticEventTableStorageRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Diagnostics/DiagnosticEventTableStorageRepositoryTests.cs
@@ -19,21 +19,24 @@ using Azure.Data.Tables;
 using Moq;
 using Moq.Protected;
 using Xunit;
+using Microsoft.Azure.WebJobs.Script.Tests.Integration.Fixtures;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
 {
-    public class DiagnosticEventTableStorageRepositoryTests
+    public class DiagnosticEventTableStorageRepositoryTests : IClassFixture<AzuriteFixture>
     {
         private const string TestHostId = "testhostid";
         private readonly IHostIdProvider _hostIdProvider;
         private readonly TestLoggerProvider _loggerProvider;
         private readonly IAzureTableStorageProvider _azureTableStorageProvider;
+        private readonly AzuriteFixture _azurite;
 
         private ILogger<DiagnosticEventTableStorageRepository> _logger;
         private Mock<IScriptHostManager> _scriptHostMock;
 
-        public DiagnosticEventTableStorageRepositoryTests()
+        public DiagnosticEventTableStorageRepositoryTests(AzuriteFixture azurite)
         {
+            _azurite = azurite;
             _hostIdProvider = new FixedHostIdProvider(TestHostId);
 
             var mockPrimaryHostStateProvider = new Mock<IPrimaryHostStateProvider>(MockBehavior.Strict);
@@ -47,7 +50,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             loggerFactory.AddProvider(_loggerProvider);
             _logger = loggerFactory.CreateLogger<DiagnosticEventTableStorageRepository>();
 
-            var configuration = new ConfigurationBuilder().AddEnvironmentVariables().Build();
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "AzureWebJobsStorage", _azurite.GetConnectionString() },
+                })
+                .Build();
             _azureTableStorageProvider = TestHelpers.GetAzureTableStorageProvider(configuration);
         }
 
@@ -164,7 +172,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             var cloudTable = repository.GetDiagnosticEventsTable(dateTime);
             Assert.Null(cloudTable);
             var messages = _loggerProvider.GetAllLogMessages();
-            var errorIntializingPresent = messages.Any(m => m.FormattedMessage.Contains( "An error occurred initializing the Table Storage Client. We are unable to record diagnostic events, so the diagnostic logging service is being stopped."));
+            var errorIntializingPresent = messages.Any(m => m.FormattedMessage.Contains("An error occurred initializing the Table Storage Client. We are unable to record diagnostic events, so the diagnostic logging service is being stopped."));
             Assert.True(errorIntializingPresent);
             Assert.False(repository.IsEnabled());
         }
@@ -419,9 +427,33 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             events.TryAdd("EC123", diagnosticEvent);
             await repository.ExecuteBatchAsync(events, table);
 
-            ExecuteQuery(tableClient, table);
             string message = _loggerProvider.GetAllLogMessages()[0].FormattedMessage;
             Assert.True(message.StartsWith("Unable to write diagnostic events to table storage"));
+        }
+
+        [Fact]
+        public async Task FlushLogs_DisablesService_NoPermissions()
+        {
+            IEnvironment testEnvironment = new TestEnvironment();
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+
+            // Tamper the connection string to simulate a permissions issue, we need a valid base64 connection string to create the TableServiceClient.
+            var connectionString = _azurite.GetConnectionString();
+            var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "AzureWebJobsStorage", connectionString.Replace(AzuriteFixture.AccountKey, TamperKey(AzuriteFixture.AccountKey)) },
+            })
+            .Build();
+            var localStorageProvider = TestHelpers.GetAzureTableStorageProvider(configuration);
+
+            DiagnosticEventTableStorageRepository repository =
+                new DiagnosticEventTableStorageRepository(_hostIdProvider, testEnvironment, _scriptHostMock.Object, localStorageProvider, _logger);
+
+            // The repository should be initially enabled and then disabled after failing to initialize the TableServiceClient while flushing Logs.
+            Assert.True(repository.IsEnabled());
+            await repository.FlushLogs();
+            Assert.False(repository.IsEnabled());
         }
 
         private DiagnosticEvent CreateDiagnosticEvent(DateTime timestamp, string errorCode, LogLevel level, string message, string helpLink, Exception exception, string eventVersion)
@@ -459,6 +491,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
 
             return table.Query<TableEntity>();
         }
+
+        private string TamperKey(string key) =>
+            string.Create(key.Length, key, (destination, source) =>
+            {
+                source.AsSpan().CopyTo(destination);
+                // We simply replace the first character to maintain a well-formed base64 key
+                destination[0] = destination[0] == 'A' ? 'B' : 'A';
+            });
 
         private class FixedHostIdProvider : IHostIdProvider
         {

--- a/test/WebJobs.Script.Tests.Integration/Diagnostics/DiagnosticEventTableStorageRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Diagnostics/DiagnosticEventTableStorageRepositoryTests.cs
@@ -164,7 +164,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             var cloudTable = repository.GetDiagnosticEventsTable(dateTime);
             Assert.Null(cloudTable);
             var messages = _loggerProvider.GetAllLogMessages();
-            Assert.Equal(messages[0].FormattedMessage, "An error occurred initializing the Table Storage Client. We are unable to record diagnostic events, so the diagnostic logging service is being stopped.");
+            var errorIntializingPresent = messages.Any(m => m.FormattedMessage.Contains( "An error occurred initializing the Table Storage Client. We are unable to record diagnostic events, so the diagnostic logging service is being stopped."));
+            Assert.True(errorIntializingPresent);
             Assert.False(repository.IsEnabled());
         }
 


### PR DESCRIPTION
### Issue describing the changes in this PR

This PR introduces improvements to the logging and error handling mechanisms within the `DiagnosticEventTableStorageRepository` class. The main changes include the addition of a dedicated `Logger` class for structured logging and enhancements to error handling to disable the service when it's not able to connect to the table storage service.

Resolves #10757 #10995 

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: #11041
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
