### PR TITLE
[In-proc] Fixing GrpcWorkerChannel concurrency bug

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,3 +5,4 @@
 -->
 
 - Added the option to exclude test data from the `/functions` endpoint API response (#10943)
+- Fixing GrpcWorkerChannel concurrency bug

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -65,8 +65,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         private bool _disposing;
         private WorkerInitResponse _initMessage;
         private RpcWorkerChannelState _state;
-        private IDictionary<string, Exception> _functionLoadErrors = new Dictionary<string, Exception>();
-        private IDictionary<string, Exception> _metadataRequestErrors = new Dictionary<string, Exception>();
+        private IDictionary<string, Exception> _functionLoadErrors = new ConcurrentDictionary<string, Exception>();
+        private IDictionary<string, Exception> _metadataRequestErrors = new ConcurrentDictionary<string, Exception>();
         private ConcurrentDictionary<string, ExecutingInvocation> _executingInvocations = new();
         private IDictionary<string, BufferBlock<ScriptInvocationContext>> _functionInputBuffers = new ConcurrentDictionary<string, BufferBlock<ScriptInvocationContext>>();
         private ConcurrentDictionary<string, TaskCompletionSource<bool>> _workerStatusRequests = new ConcurrentDictionary<string, TaskCompletionSource<bool>>();


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://github.com/Azure/azure-functions-host/issues/10682

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
