### PR TITLE
Reduce allocations in ScriptStartupTypeLocator.GetExtensionsStartupTypesAsync

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,3 +6,4 @@
 - Improved memory metrics reporting using CGroup data for Linux consumption (#10968)
 - Fixing GrpcWorkerChannel concurrency bug (#10998)
 - Avoid circular dependency when resolving LinuxContainerLegionMetricsPublisher. (#10991)
+- Reduce allocations in `ScriptStartupTypeLocator.GetExtensionsStartupTypesAsync` (#11003)

--- a/src/WebJobs.Script/DependencyInjection/JsonSerializerOptionsProvider.cs
+++ b/src/WebJobs.Script/DependencyInjection/JsonSerializerOptionsProvider.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Text.Json;
+
+namespace Microsoft.Azure.WebJobs.Script.DependencyInjection
+{
+    /// <summary>
+    /// Provides shared <see cref="JsonSerializerOptions"/> instances for consistent JSON serialization behavior.
+    /// </summary>
+    public static class JsonSerializerOptionsProvider
+    {
+        /// <summary>
+        /// A preconfigured <see cref="JsonSerializerOptions"/> instance with case-insensitive property name matching.
+        /// </summary>
+        public static readonly JsonSerializerOptions CaseInsensitiveOptions = new()
+        {
+            PropertyNameCaseInsensitive = true
+        };
+    }
+}

--- a/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs
+++ b/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Hosting;
 using Microsoft.Azure.WebJobs.Script.Config;
@@ -19,8 +20,6 @@ using Microsoft.Azure.WebJobs.Script.Models;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Script.DependencyInjection
 {
@@ -28,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Script.DependencyInjection
     /// An implementation of an <see cref="IWebJobsStartupTypeLocator"/> that locates startup types
     /// from extension registrations.
     /// </summary>
-    public class ScriptStartupTypeLocator : IWebJobsStartupTypeLocator
+    public sealed class ScriptStartupTypeLocator : IWebJobsStartupTypeLocator
     {
         private const string ApplicationInsightsStartupType = "Microsoft.Azure.WebJobs.Extensions.ApplicationInsights.ApplicationInsightsWebJobsStartup, Microsoft.Azure.WebJobs.Extensions.ApplicationInsights, Version=1.0.0.0, Culture=neutral, PublicKeyToken=9475d07f10cb09df";
 
@@ -146,7 +145,7 @@ namespace Microsoft.Azure.WebJobs.Script.DependencyInjection
             string metadataFilePath = Path.Combine(extensionsMetadataPath, ScriptConstants.ExtensionsMetadataFileName);
 
             // parse the extensions file to get declared startup extensions
-            ExtensionReference[] extensionItems = ParseExtensions(metadataFilePath);
+            ExtensionReference[] extensionItems = await ParseExtensionsAsync(metadataFilePath);
 
             var startupTypes = new List<Type>();
 
@@ -222,33 +221,32 @@ namespace Microsoft.Azure.WebJobs.Script.DependencyInjection
             return startupTypes;
         }
 
-        private ExtensionReference[] ParseExtensions(string metadataFilePath)
+        private async Task<ExtensionReference[]> ParseExtensionsAsync(string metadataFilePath)
         {
             using (_metricsLogger.LatencyEvent(MetricEventNames.ParseExtensions))
             {
                 if (!File.Exists(metadataFilePath))
                 {
-                    return Array.Empty<ExtensionReference>();
+                    return [];
                 }
 
                 try
                 {
-                    var extensionMetadata = JObject.Parse(File.ReadAllText(metadataFilePath));
+                    await using var stream = File.OpenRead(metadataFilePath);
+                    var jsonData = await JsonSerializer.DeserializeAsync<Dictionary<string, ExtensionReference[]>>(stream, JsonSerializerOptionsProvider.CaseInsensitiveOptions);
 
-                    var extensionItems = extensionMetadata["extensions"]?.ToObject<List<ExtensionReference>>();
-                    if (extensionItems == null)
+                    if (jsonData == null || !jsonData.TryGetValue("extensions", out var extensions) || extensions == null)
                     {
                         _logger.ScriptStartUpUnableParseMetadataMissingProperty(metadataFilePath);
-                        return Array.Empty<ExtensionReference>();
+                        return [];
                     }
 
-                    return extensionItems.ToArray();
+                    return extensions;
                 }
-                catch (JsonReaderException exc)
+                catch (JsonException exc)
                 {
                     _logger.ScriptStartUpUnableParseMetadata(exc, metadataFilePath);
-
-                    return Array.Empty<ExtensionReference>();
+                    return [];
                 }
             }
         }
@@ -275,12 +273,13 @@ namespace Microsoft.Azure.WebJobs.Script.DependencyInjection
             {
                 return;
             }
-            var errors = new List<string>();
+            List<string> errors = null;
 
             void CollectError(Type extensionType, Version minimumVersion, ExtensionStartupTypeRequirement requirement)
             {
                 _logger.MinimumExtensionVersionNotSatisfied(extensionType.Name, extensionType.Assembly.FullName, minimumVersion, requirement.PackageName, requirement.MinimumPackageVersion);
                 string requirementNotMetError = $"ExtensionStartupType {extensionType.Name} from assembly '{extensionType.Assembly.FullName}' does not meet the required minimum version of {minimumVersion}. Update your NuGet package reference for {requirement.PackageName} to {requirement.MinimumPackageVersion} or later.";
+                errors ??= [];
                 errors.Add(requirementNotMetError);
             }
 
@@ -327,7 +326,7 @@ namespace Microsoft.Azure.WebJobs.Script.DependencyInjection
                 }
             }
 
-            if (errors.Count > 0)
+            if (errors != null && errors.Count > 0)
             {
                 var builder = new System.Text.StringBuilder();
                 builder.AppendLine("One or more loaded extensions do not meet the minimum requirements. For more information see https://aka.ms/func-min-extension-versions.");

--- a/src/WebJobs.Script/Models/ExtensionReference.cs
+++ b/src/WebJobs.Script/Models/ExtensionReference.cs
@@ -1,38 +1,34 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Text;
 
 namespace Microsoft.Azure.WebJobs.Script.Models
 {
     /// <summary>
     /// Represents a binding extension reference.
     /// </summary>
-    public class ExtensionReference
+    public sealed class ExtensionReference
     {
         /// <summary>
-        /// Gets or sets the extension name.
+        /// Gets the extension name.
         /// </summary>
-        public string Name { get; set; }
+        public string Name { get; init; }
 
         /// <summary>
-        /// Gets or sets the assembly-qualified name of the type.
+        /// Gets the assembly-qualified name of the type.
         /// </summary>
-        public string TypeName { get; set; }
+        public string TypeName { get; init; }
 
         /// <summary>
-        /// Gets or sets a hit path that may be used when loading the assembly containing the extension
+        /// Gets a hit path that may be used when loading the assembly containing the extension.
         /// implementation.
         /// </summary>
-        public string HintPath { get; set; }
+        public string HintPath { get;  init; }
 
         /// <summary>
-        /// Gets the binding exposed by the extension
+        /// Gets the binding exposed by the extension.
         /// </summary>
-        public ICollection<string> Bindings { get; } = new Collection<string>();
+        public ICollection<string> Bindings { get; init; } = [];
     }
 }


### PR DESCRIPTION
Optimization in `GetExtensionsStartupTypesAsync` method which gets executed during cold start. 

- Updated `ParseExtensions` sync method to use S.T.J for Json deserialization and made it async.

#### Before

|Name|Total \(Allocations\)|Self \(Allocations\)|Total Size \(Bytes\)|Self Size \(Bytes\)|
|-|-|-|-|-|
|\|\| - GetExtensionsStartupTypesAsync\(\)|11,611|8|1,650,762|352|

#### After

|Name|Total \(Allocations\)|Self \(Allocations\)|Total Size \(Bytes\)|Self Size \(Bytes\)|
|-|-|-|-|-|
|\|\| - GetExtensionsStartupTypesAsync\(\)|11,041|7|916,494|280|

#### Delta

- Total allocations dropped by 570 (4.91%)
- Total allocated size dropped by ~734 KB (44.5%) 

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
