### PR TITLE
Update Workers.Powershell.props runtime filters to include arm64

### DIFF
--- a/eng/build/Workers.Powershell.props
+++ b/eng/build/Workers.Powershell.props
@@ -8,8 +8,13 @@
 
   <Target Name="RemovePowershellWorkerRuntimes" BeforeTargets="AssignTargetPaths" Condition="'$(RuntimeIdentifier)' != ''">
     <ItemGroup>
-      <_KeepPowerShellRuntime Include="win;win-x86;win10-x86;win-x64;win10-x64" Condition="$(RuntimeIdentifier.StartsWith(win))" />
-      <_KeepPowerShellRuntime Include="linux;linux-x64;unix" Condition="$(RuntimeIdentifier.StartsWith(linux))" />
+      <_KeepPowerShellRuntime Include="win;win-x86;win10-x86;win-x64;win10-x64" Condition="$(RuntimeIdentifier.StartsWith('win')) and !$(RuntimeIdentifier.Contains('arm'))" />
+      <_KeepPowerShellRuntime Include="linux;linux-x64;unix" Condition="$(RuntimeIdentifier.StartsWith('linux')) and !$(RuntimeIdentifier.Contains('arm'))" />
+      <_KeepPowerShellRuntime Include="osx-x64" Condition="$(RuntimeIdentifier.StartsWith('osx')) and !$(RuntimeIdentifier.Contains('arm'))" />
+
+      <_KeepPowerShellRuntime Include="win-arm64" Condition="$(RuntimeIdentifier.StartsWith('win')) and $(RuntimeIdentifier.Contains('arm'))" />
+      <_KeepPowerShellRuntime Include="linux-arm64" Condition="$(RuntimeIdentifier.StartsWith('linux')) and $(RuntimeIdentifier.Contains('arm'))" />
+      <_KeepPowerShellRuntime Include="osx-arm64" Condition="$(RuntimeIdentifier.StartsWith('osx')) and $(RuntimeIdentifier.Contains('arm'))" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/eng/build/Workers.Powershell.props
+++ b/eng/build/Workers.Powershell.props
@@ -9,12 +9,13 @@
   <Target Name="RemovePowershellWorkerRuntimes" BeforeTargets="AssignTargetPaths" Condition="'$(RuntimeIdentifier)' != ''">
     <ItemGroup>
       <_KeepPowerShellRuntime Include="win;win-x86;win10-x86;win-x64;win10-x64" Condition="$(RuntimeIdentifier.StartsWith('win')) and !$(RuntimeIdentifier.Contains('arm'))" />
-      <_KeepPowerShellRuntime Include="linux;linux-x64;unix" Condition="$(RuntimeIdentifier.StartsWith('linux')) and !$(RuntimeIdentifier.Contains('arm'))" />
-      <_KeepPowerShellRuntime Include="osx-x64" Condition="$(RuntimeIdentifier.StartsWith('osx')) and !$(RuntimeIdentifier.Contains('arm'))" />
+      <_KeepPowerShellRuntime Include="win;win-arm;win-arm64" Condition="'$(RuntimeIdentifier)' == 'win-arm64'" />
 
-      <_KeepPowerShellRuntime Include="win-arm64" Condition="$(RuntimeIdentifier.StartsWith('win')) and $(RuntimeIdentifier.Contains('arm'))" />
-      <_KeepPowerShellRuntime Include="linux-arm64" Condition="$(RuntimeIdentifier.StartsWith('linux')) and $(RuntimeIdentifier.Contains('arm'))" />
-      <_KeepPowerShellRuntime Include="osx-arm64" Condition="$(RuntimeIdentifier.StartsWith('osx')) and $(RuntimeIdentifier.Contains('arm'))" />
+      <_KeepPowerShellRuntime Include="linux;unix;linux-x64" Condition="'$(RuntimeIdentifier)' == 'linux-x64'" />
+      <_KeepPowerShellRuntime Include="linux;unix;linux-arm;linux-arm64" Condition="'$(RuntimeIdentifier)' == 'linux-arm64'" />
+
+      <_KeepPowerShellRuntime Include="osx;unix;osx-x64" Condition="'$(RuntimeIdentifier)' == 'osx-x64'" />
+      <_KeepPowerShellRuntime Include="osx;unix;osx-arm64" Condition="'$(RuntimeIdentifier)' == 'osx-arm64'" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,8 +4,9 @@
 - My change description (#PR)
 -->
 - Improved memory metrics reporting using CGroup data for Linux consumption (#10968)
-- Memory allocation optimizations in `RpcWorkerConfigFactory.AddProviders` (#10959)
+- Memory allocation optimizations in `RpcWorkerConfigFactory.AddProviders` (#10959)
 - Fixing GrpcWorkerChannel concurrency bug (#10998)
 - Avoid circular dependency when resolving LinuxContainerLegionMetricsPublisher. (#10991)
-- Add 'unix' to the list of runtimes kept when importing PowerShell worker for Linux builds
-- Update PowerShell 7.4 worker to 4.0.4206
+- Add 'unix' to the list of runtimes kept when importing PowerShell worker for Linux builds (#11006)
+- Update PowerShell 7.4 worker to 4.0.4206 (#11006)
+- Add `win-arm64` and `linux-arm64` to the list of PowerShell runtimes; added filter for `osx` RIDs (includes `osx-x64` and `osx-arm64`) (#11013)

--- a/release_notes.md
+++ b/release_notes.md
@@ -5,7 +5,6 @@
 -->
 - Improved memory metrics reporting using CGroup data for Linux consumption (#10968)
 - Memory allocation optimizations in `RpcWorkerConfigFactory.AddProviders` (#10959)
-
 - Fixing GrpcWorkerChannel concurrency bug (#10998)
 - Avoid circular dependency when resolving LinuxContainerLegionMetricsPublisher. (#10991)
 - Add 'unix' to the list of runtimes kept when importing PowerShell worker for Linux builds


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

part of: [#4279](https://github.com/Azure/azure-functions-core-tools/issues/4279)

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

- Adding arm64 builds for windows and linux
- Adding a filter for osx builds