### PR TITLE
Allow UpdateBuildNumber to be set to false

### DIFF
--- a/src/Directory.Version.props
+++ b/src/Directory.Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>4.1040.100</VersionPrefix>
-    <UpdateBuildNumber>true</UpdateBuildNumber>
+    <UpdateBuildNumber Condition="'$(UpdateBuildNumber)' == ''">true</UpdateBuildNumber>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Some Azure DevOps organizations have `build.updatebuildnumber` disabled per policy. This causes a build warning. We self-host Azure Functions Host so it would like to eliminate these build warnings if possible.

If we can set `UpdateBuildNumber` to `false` then we can avoid the build warning.

This is used here:
https://github.com/Azure/azure-functions-host/blob/7e3e7b78fa90ec18eaefd995a9e7797d326d2d00/eng/build/Version.targets#L19-L21

### Pull request checklist

* [ ] Backporting to the `in-proc` branch is not required
  - I am not sure if this should be done. I THINK so based on the template description, but please let me know.
* [x] My changes **do not** require documentation changes
* [x] My changes **should not** be added to the release notes for the next release
* [x] My changes **do not** need to be backported to a previous version
* [x] My changes **do not** require diagnostic events changes
* [x] I have added all required tests (Unit tests, E2E tests)
  - N/A
