### PR TITLE
Host Metrics heartbeat published every 30 seconds

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,8 +4,9 @@
 - My change description (#PR)
 -->
 - Improved memory metrics reporting using CGroup data for Linux consumption (#10968)
-- Memory allocation optimizations in `RpcWorkerConfigFactory.AddProviders` (#10959)
+- Memory allocation optimizations in `RpcWorkerConfigFactory.AddProviders` (#10959)
 - Fixing GrpcWorkerChannel concurrency bug (#10998)
 - Avoid circular dependency when resolving LinuxContainerLegionMetricsPublisher. (#10991)
 - Add 'unix' to the list of runtimes kept when importing PowerShell worker for Linux builds
 - Update PowerShell 7.4 worker to 4.0.4206
+- Update flex metric publisher to publish every 30 seconds (regardless of actvity) (#11019)

--- a/src/WebJobs.Script.WebHost/Configuration/FlexConsumptionMetricsPublisherOptions.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/FlexConsumptionMetricsPublisherOptions.cs
@@ -14,12 +14,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
         internal const int DefaultMetricsPublishIntervalMS = 5000;
         internal const int DefaultMinimumActivityIntervalMS = 1000;
         internal const int DefaultMetricsGranularityMS = 100;
+        internal const int DefaultKeepAliveIntervalMS = 30000;
 
         public FlexConsumptionMetricsPublisherOptions()
         {
             MetricsPublishIntervalMS = DefaultMetricsPublishIntervalMS;
             MinimumActivityIntervalMS = DefaultMinimumActivityIntervalMS;
             MetricsGranularityMS = DefaultMetricsGranularityMS;
+            KeepAliveIntervalMS = DefaultKeepAliveIntervalMS;
             InitialPublishDelayMS = Utility.ColdStartDelayMS;
 
             // Default this to 15 minutes worth of files
@@ -66,5 +68,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
         /// When over this limit, the oldest files will be deleted to make room for new files.
         /// </remarks>
         public int MaxFileCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum interval at which metrics are published.
+        /// </summary>
+        /// <remarks>
+        /// This is required to ensure that we publish something even if there are no
+        /// new metrics or activity to report so that we have a heartbeat.
+        /// </remarks>
+        public int KeepAliveIntervalMS { get; set; }
     }
 }

--- a/src/WebJobs.Script.WebHost/Metrics/FlexConsumptionMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/FlexConsumptionMetricsPublisher.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         private IDisposable _standbyOptionsOnChangeSubscription;
         private TimeSpan _metricPublishInterval;
         private TimeSpan _initialPublishDelay;
+        private DateTime _lastPublishTime = DateTime.MinValue;
 
         public FlexConsumptionMetricsPublisher(IEnvironment environment, IOptionsMonitor<StandbyOptions> standbyOptions, IOptions<FlexConsumptionMetricsPublisherOptions> options,
             ILogger<FlexConsumptionMetricsPublisher> logger, IFileSystem fileSystem, IHostMetricsProvider metricsProvider)
@@ -105,9 +106,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
                     }
                 }
 
-                if (FunctionExecutionCount == 0 && FunctionExecutionTimeMS == 0 && !IsAlwaysReady && !_metricsProvider.HasMetrics())
+                bool hasActivity = FunctionExecutionCount > 0 || FunctionExecutionTimeMS > 0 || IsAlwaysReady || _metricsProvider.HasMetrics();
+                bool shouldForcePublish = (now - _lastPublishTime) >= TimeSpan.FromMilliseconds(_options.KeepAliveIntervalMS);
+
+                if (!hasActivity && !shouldForcePublish)
                 {
-                    // no activity to report
+                    // No activity and not time for keep-alive publish
                     return;
                 }
 
@@ -135,6 +139,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
                     }
 
                     FunctionExecutionTimeMS = FunctionExecutionCount = 0;
+                    _lastPublishTime = now;
                 }
 
                 await _metricsFileManager.PublishMetricsAsync(metrics);
@@ -321,6 +326,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             /// Gets or sets the total number of function invocations that have started.
             /// </summary>
             public long StartedInvocationCount { get; set; }
+
+            /// <summary>
+            /// Gets a value indicating whether the publisher is alive and sending metrics.
+            /// Will always be true. If not sent, the platform should assume the host is unable to publish metrics.
+            /// </summary>
+            public bool IsAlive { get; } = true;
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Metrics/FlexConsumptionMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/FlexConsumptionMetricsPublisher.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         private IDisposable _standbyOptionsOnChangeSubscription;
         private TimeSpan _metricPublishInterval;
         private TimeSpan _initialPublishDelay;
-        private DateTime _lastPublishTime = DateTime.MinValue;
+        private DateTime _lastPublishTime = DateTime.UtcNow;
 
         public FlexConsumptionMetricsPublisher(IEnvironment environment, IOptionsMonitor<StandbyOptions> standbyOptions, IOptions<FlexConsumptionMetricsPublisherOptions> options,
             ILogger<FlexConsumptionMetricsPublisher> logger, IFileSystem fileSystem, IHostMetricsProvider metricsProvider)
@@ -106,12 +106,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
                     }
                 }
 
-                bool hasActivity = FunctionExecutionCount > 0 || FunctionExecutionTimeMS > 0 || IsAlwaysReady || _metricsProvider.HasMetrics();
+                bool hasActivity = FunctionExecutionCount > 0 || FunctionExecutionTimeMS > 0 || _metricsProvider.HasMetrics();
                 bool shouldForcePublish = (now - _lastPublishTime) >= TimeSpan.FromMilliseconds(_options.KeepAliveIntervalMS);
 
-                if (!hasActivity && !shouldForcePublish)
+                if (!hasActivity && !shouldForcePublish && !IsAlwaysReady)
                 {
-                    // No activity and not time for keep-alive publish
+                    // No activity and not time for keep-alive publish & not always ready
                     return;
                 }
 

--- a/src/WebJobs.Script.WebHost/Metrics/FlexConsumptionMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/FlexConsumptionMetricsPublisher.cs
@@ -326,12 +326,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             /// Gets or sets the total number of function invocations that have started.
             /// </summary>
             public long StartedInvocationCount { get; set; }
-
-            /// <summary>
-            /// Gets a value indicating whether the publisher is alive and sending metrics.
-            /// Will always be true. If not sent, the platform should assume the host is unable to publish metrics.
-            /// </summary>
-            public bool IsAlive { get; } = true;
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Metrics/FlexConsumptionMetricsPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/FlexConsumptionMetricsPublisherTests.cs
@@ -532,6 +532,37 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
         }
 
         [Fact]
+        public async Task OnPublishMetrics_KeepAliveMetricsPublished_WhenNoActivity()
+        {
+            CleanupMetricsFiles();
+
+            var publisher = CreatePublisher(metricsPublishInterval: TimeSpan.FromHours(1), inStandbyMode: false);
+
+            DateTime now = DateTime.UtcNow;
+
+            // No function activity at all
+            await publisher.OnPublishMetrics(now);
+
+            // Should not publish anything because it's the first call and not yet 60 seconds
+            var files = GetMetricsFilesSafe(_metricsFilePath);
+            Assert.Empty(files);
+
+            // Simulate 31 seconds passing with no function activity
+            now = now.AddSeconds(31);
+            await publisher.OnPublishMetrics(now);
+
+            files = GetMetricsFilesSafe(_metricsFilePath);
+            Assert.Single(files);
+
+            var metrics = await ReadMetricsAsync(files[0].FullName, deleteFile: true);
+
+            // We expect all activity values to be zero
+            Assert.Equal(0, metrics.ExecutionCount);
+            Assert.Equal(0, metrics.ExecutionTimeMS);
+            Assert.True(metrics.IsAlive); // The keep-alive flag should be true
+        }
+
+        [Fact]
         public void OnFunctionCompleted_NoOutstandingInvocations_IgnoresEvent()
         {
             var publisher = CreatePublisher(metricsPublishInterval: TimeSpan.FromHours(1), inStandbyMode: false);

--- a/test/WebJobs.Script.Tests/Metrics/FlexConsumptionMetricsPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/FlexConsumptionMetricsPublisherTests.cs
@@ -111,12 +111,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
 
             FlexConsumptionMetricsPublisher.Metrics metrics = null;
             FileInfo metricsFile = null;
-            if (!isAlwaysReadyInstance)
-            {
-                // don't expect a file to be written when no activity
-                Assert.Equal(0, files.Length);
-            }
-            else
+
+            if (isAlwaysReadyInstance)
             {
                 Assert.Equal(1, files.Length);
 
@@ -536,7 +532,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
         {
             CleanupMetricsFiles();
 
-            var publisher = CreatePublisher(metricsPublishInterval: TimeSpan.FromHours(1), inStandbyMode: false);
+            var publisher = CreatePublisher();
 
             DateTime now = DateTime.UtcNow;
 
@@ -545,14 +541,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
 
             // Should not publish anything because it's the first call and not yet 60 seconds
             var files = GetMetricsFilesSafe(_metricsFilePath);
-            Assert.Empty(files);
+            Assert.Equal(0, files.Length);
 
             // Simulate 31 seconds passing with no function activity
             now = now.AddSeconds(31);
             await publisher.OnPublishMetrics(now);
 
             files = GetMetricsFilesSafe(_metricsFilePath);
-            Assert.Single(files);
+            Assert.Equal(1, files.Length);
 
             var metrics = await ReadMetricsAsync(files[0].FullName, deleteFile: true);
 

--- a/test/WebJobs.Script.Tests/Metrics/FlexConsumptionMetricsPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/FlexConsumptionMetricsPublisherTests.cs
@@ -559,7 +559,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             // We expect all activity values to be zero
             Assert.Equal(0, metrics.ExecutionCount);
             Assert.Equal(0, metrics.ExecutionTimeMS);
-            Assert.True(metrics.IsAlive); // The keep-alive flag should be true
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Metrics/FlexConsumptionMetricsPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/FlexConsumptionMetricsPublisherTests.cs
@@ -112,7 +112,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             FlexConsumptionMetricsPublisher.Metrics metrics = null;
             FileInfo metricsFile = null;
 
-            if (isAlwaysReadyInstance)
+            if (!isAlwaysReadyInstance)
+            {
+                // don't expect a file to be written when no activity
+                Assert.Equal(0, files.Length);
+            }
+            else
             {
                 Assert.Equal(1, files.Length);
 
@@ -536,23 +541,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
 
             DateTime now = DateTime.UtcNow;
 
-            // No function activity at all
+            // Should not publish because there is no activity and keepalive internal has not passed
             await publisher.OnPublishMetrics(now);
-
-            // Should not publish anything because it's the first call and not yet 60 seconds
             var files = GetMetricsFilesSafe(_metricsFilePath);
             Assert.Equal(0, files.Length);
 
             // Simulate 31 seconds passing with no function activity
             now = now.AddSeconds(31);
-            await publisher.OnPublishMetrics(now);
 
+            // Should publish as keepalive interval has passed
+            await publisher.OnPublishMetrics(now);
             files = GetMetricsFilesSafe(_metricsFilePath);
             Assert.Equal(1, files.Length);
 
             var metrics = await ReadMetricsAsync(files[0].FullName, deleteFile: true);
 
-            // We expect all activity values to be zero
+            // We expect all activity values to be zero as there has been no activity
             Assert.Equal(0, metrics.ExecutionCount);
             Assert.Equal(0, metrics.ExecutionTimeMS);
         }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

The metric publisher currently triggers every 5 seconds, if there is activity, it will publish metrics. If there is no activity is will skip. With this change, the same thing occurs, however now every 30 seconds we publish regardless of if there is any activity or not. This acts as a sort of heartbeat signal so that the platform can know if we are still able to publish metrics or not.
