### PR TITLE
Reduce allocations in DependencyHelper.GetExtensionRequirements

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,4 +3,5 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Memory allocation optimizations in `DependencyHelper.GetExtensionRequirements` (#11022)
 - Memory allocation optimizations in `ScriptStartupTypeLocator.GetExtensionsStartupTypesAsync` (#11012)

--- a/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs
+++ b/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs
@@ -349,7 +349,11 @@ namespace Microsoft.Azure.WebJobs.Script.DependencyInjection
         private ExtensionRequirementsInfo GetExtensionRequirementsInfo()
         {
             ExtensionRequirementsInfo requirementsInfo = _extensionRequirementOptions.Value.Bundles != null || _extensionRequirementOptions.Value.Extensions != null
-                ? new ExtensionRequirementsInfo(_extensionRequirementOptions.Value.Bundles, _extensionRequirementOptions.Value.Extensions)
+                ? new ExtensionRequirementsInfo
+                {
+                    Bundles = _extensionRequirementOptions.Value.Bundles.ToList(),
+                    Types = _extensionRequirementOptions.Value.Extensions.ToList()
+                }
                 : DependencyHelper.GetExtensionRequirements();
             return requirementsInfo;
         }

--- a/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs
+++ b/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs
@@ -349,11 +349,7 @@ namespace Microsoft.Azure.WebJobs.Script.DependencyInjection
         private ExtensionRequirementsInfo GetExtensionRequirementsInfo()
         {
             ExtensionRequirementsInfo requirementsInfo = _extensionRequirementOptions.Value.Bundles != null || _extensionRequirementOptions.Value.Extensions != null
-                ? new ExtensionRequirementsInfo
-                {
-                    Bundles = _extensionRequirementOptions.Value.Bundles?.ToArray() ?? [],
-                    Types = _extensionRequirementOptions.Value.Extensions?.ToArray() ?? []
-                }
+                ? new ExtensionRequirementsInfo(_extensionRequirementOptions.Value.Bundles?.ToArray() ?? [], _extensionRequirementOptions.Value.Extensions?.ToArray() ?? [])
                 : DependencyHelper.GetExtensionRequirements();
             return requirementsInfo;
         }

--- a/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs
+++ b/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs
@@ -351,8 +351,8 @@ namespace Microsoft.Azure.WebJobs.Script.DependencyInjection
             ExtensionRequirementsInfo requirementsInfo = _extensionRequirementOptions.Value.Bundles != null || _extensionRequirementOptions.Value.Extensions != null
                 ? new ExtensionRequirementsInfo
                 {
-                    Bundles = _extensionRequirementOptions.Value.Bundles.ToList(),
-                    Types = _extensionRequirementOptions.Value.Extensions.ToList()
+                    Bundles = _extensionRequirementOptions.Value.Bundles?.ToArray() ?? [],
+                    Types = _extensionRequirementOptions.Value.Extensions?.ToArray() ?? []
                 }
                 : DependencyHelper.GetExtensionRequirements();
             return requirementsInfo;

--- a/src/WebJobs.Script/Description/DotNet/DependencyHelper.cs
+++ b/src/WebJobs.Script/Description/DotNet/DependencyHelper.cs
@@ -5,7 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using Microsoft.Azure.WebJobs.Script.ExtensionRequirements;
 using Microsoft.Extensions.DependencyModel;
 using Newtonsoft.Json.Linq;
@@ -15,7 +17,15 @@ namespace Microsoft.Azure.WebJobs.Script.Description
     public static class DependencyHelper
     {
         private const string AssemblyNamePrefix = "assembly:";
-        private static readonly Lazy<Dictionary<string, string[]>> _ridGraph = new Lazy<Dictionary<string, string[]>>(BuildRuntimesGraph);
+        private static readonly Assembly ThisAssembly = typeof(DependencyHelper).Assembly;
+        private static readonly string ThisAssemblyName = ThisAssembly.GetName().Name;
+        private static readonly Lazy<Dictionary<string, string[]>> RidGraph = new Lazy<Dictionary<string, string[]>>(BuildRuntimesGraph);
+        private static readonly JsonDocumentOptions JsonDocumentOptions = new()
+        {
+            CommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true
+        };
+
         private static string _runtimeIdentifier;
 
         private static Dictionary<string, string[]> BuildRuntimesGraph()
@@ -73,12 +83,20 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         private static string GetResourceFileContents(string fileName)
         {
-            var assembly = typeof(DependencyHelper).Assembly;
-            using (Stream resource = assembly.GetManifestResourceStream($"{assembly.GetName().Name}.{fileName}"))
+            var assembly = ThisAssembly;
+            using (Stream resource = assembly.GetManifestResourceStream($"{ThisAssemblyName}.{fileName}"))
             using (var reader = new StreamReader(resource))
             {
                 return reader.ReadToEnd();
             }
+        }
+
+        private static Stream GetResourceStream(string fileName)
+        {
+            var manifestResourceName = $"{ThisAssemblyName}.{fileName}";
+            var stream = ThisAssembly.GetManifestResourceStream(manifestResourceName);
+
+            return stream ?? throw new InvalidOperationException($"The embedded resource '{manifestResourceName}' could not be found.");
         }
 
         internal static Dictionary<string, ScriptRuntimeAssembly> GetRuntimeAssemblies(string assemblyManifestName)
@@ -93,14 +111,20 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         internal static ExtensionRequirementsInfo GetExtensionRequirements()
         {
-            string requirementsJson = GetResourceFileContents("extensionrequirements.json");
-            JObject requirements = JObject.Parse(requirementsJson);
+            const string fileName = "extensionrequirements.json";
 
-            var bundleRequirements = requirements["bundles"]
-                .ToObject<BundleRequirement[]>();
+            using var resourceStream = GetResourceStream(fileName);
+            using var doc = JsonDocument.Parse(resourceStream, JsonDocumentOptions);
 
-            var extensionRequirements = requirements["types"]
-                .ToObject<ExtensionStartupTypeRequirement[]>();
+            var jsonElementRoot = doc.RootElement;
+
+            var bundleRequirements = jsonElementRoot.TryGetProperty("bundles", out var bundles)
+                ? bundles.Deserialize(ExtensionRequirementsJsonContext.Default.BundleRequirementArray)
+                : [];
+
+            var extensionRequirements = jsonElementRoot.TryGetProperty("types", out var types)
+                ? types.Deserialize(ExtensionRequirementsJsonContext.Default.ExtensionStartupTypeRequirementArray)
+                : [];
 
             return new ExtensionRequirementsInfo(bundleRequirements, extensionRequirements);
         }
@@ -115,7 +139,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         /// <returns>The runtime fallbacks for the provided identifier.</returns>
         public static RuntimeFallbacks GetDefaultRuntimeFallbacks(string rid)
         {
-            var ridGraph = _ridGraph.Value;
+            var ridGraph = RidGraph.Value;
 
             var runtimeFallbacks = new RuntimeFallbacks(rid);
             var fallbacks = new List<string>();
@@ -184,7 +208,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         /// <returns> bool if string in was in proper assembly representation format. </returns>
         public static bool IsAssemblyReferenceFormat(string assemblyFormatString)
         {
-           return assemblyFormatString != null && assemblyFormatString.StartsWith(AssemblyNamePrefix);
+            return assemblyFormatString != null && assemblyFormatString.StartsWith(AssemblyNamePrefix);
         }
 
         /// <summary>

--- a/src/WebJobs.Script/Description/DotNet/DependencyHelper.cs
+++ b/src/WebJobs.Script/Description/DotNet/DependencyHelper.cs
@@ -8,9 +8,9 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.Json;
+using Microsoft.Azure.WebJobs.Script.Description.DotNet;
 using Microsoft.Azure.WebJobs.Script.ExtensionRequirements;
 using Microsoft.Extensions.DependencyModel;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Script.Description
 {
@@ -20,30 +20,27 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         private static readonly Assembly ThisAssembly = typeof(DependencyHelper).Assembly;
         private static readonly string ThisAssemblyName = ThisAssembly.GetName().Name;
         private static readonly Lazy<Dictionary<string, string[]>> RidGraph = new Lazy<Dictionary<string, string[]>>(BuildRuntimesGraph);
-        private static readonly JsonDocumentOptions JsonDocumentOptions = new()
-        {
-            CommentHandling = JsonCommentHandling.Skip,
-            AllowTrailingCommas = true
-        };
 
         private static string _runtimeIdentifier;
 
         private static Dictionary<string, string[]> BuildRuntimesGraph()
         {
-            var ridGraph = new Dictionary<string, string[]>();
-            string runtimesJson = GetRuntimesGraphJson();
-            var runtimes = (JObject)JObject.Parse(runtimesJson)["runtimes"];
+            using var stream = GetResourceStream("runtimes.json");
+            var parsed = JsonSerializer.Deserialize(stream, RuntimeGraphJsonContext.Default.RuntimeGraph);
 
-            foreach (var runtime in runtimes)
+            if (parsed is null)
             {
-                string[] imports = ((JObject)runtime.Value)["#import"]
-                    ?.Values<string>()
-                    .ToArray();
-
-                ridGraph.Add(runtime.Key, imports);
+                throw new InvalidOperationException("Failed to deserialize runtimes graph JSON.");
             }
 
-            return ridGraph;
+            var result = new Dictionary<string, string[]>(parsed.Runtimes.Count, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var (rid, info) in parsed.Runtimes)
+            {
+                result[rid] = info.Imports ?? [];
+            }
+
+            return result;
         }
 
         private static string GetDefaultPlatformRid()
@@ -76,57 +73,43 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             return rid;
         }
 
-        private static string GetRuntimesGraphJson()
-        {
-            return GetResourceFileContents("runtimes.json");
-        }
-
-        private static string GetResourceFileContents(string fileName)
-        {
-            var assembly = ThisAssembly;
-            using (Stream resource = assembly.GetManifestResourceStream($"{ThisAssemblyName}.{fileName}"))
-            using (var reader = new StreamReader(resource))
-            {
-                return reader.ReadToEnd();
-            }
-        }
-
         private static Stream GetResourceStream(string fileName)
         {
-            var manifestResourceName = $"{ThisAssemblyName}.{fileName}";
-            var stream = ThisAssembly.GetManifestResourceStream(manifestResourceName);
+            var stream = ThisAssembly.GetManifestResourceStream($"{ThisAssemblyName}.{fileName}");
 
-            return stream ?? throw new InvalidOperationException($"The embedded resource '{manifestResourceName}' could not be found.");
+            return stream ?? throw new InvalidOperationException($"The embedded resource '{ThisAssemblyName}.{fileName}' could not be found.");
         }
 
         internal static Dictionary<string, ScriptRuntimeAssembly> GetRuntimeAssemblies(string assemblyManifestName)
         {
-            string assembliesJson = GetResourceFileContents(assemblyManifestName);
-            JObject assemblies = JObject.Parse(assembliesJson);
+            using var stream = GetResourceStream(assemblyManifestName);
+            var runtimeAssemblies = JsonSerializer.Deserialize(stream, RuntimeAssembliesJsonContext.Default.RuntimeAssembliesConfig);
 
-            return assemblies["runtimeAssemblies"]
-                .ToObject<ScriptRuntimeAssembly[]>()
-                .ToDictionary(a => a.Name, StringComparer.OrdinalIgnoreCase);
+            var assemblies = runtimeAssemblies?.RuntimeAssemblies ?? throw new InvalidOperationException($"Failed to retrieve runtime assemblies from the embedded resource '{assemblyManifestName}'.");
+
+            var dictionary = new Dictionary<string, ScriptRuntimeAssembly>(assemblies.Count, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var assembly in assemblies)
+            {
+                dictionary[assembly.Name] = assembly;
+            }
+
+            return dictionary;
         }
 
         internal static ExtensionRequirementsInfo GetExtensionRequirements()
         {
             const string fileName = "extensionrequirements.json";
 
-            using var resourceStream = GetResourceStream(fileName);
-            using var doc = JsonDocument.Parse(resourceStream, JsonDocumentOptions);
+            using var stream = GetResourceStream(fileName);
+            var extensionRequirementsInfo = JsonSerializer.Deserialize(stream, ExtensionRequirementsJsonContext.Default.ExtensionRequirementsInfo);
 
-            var jsonElementRoot = doc.RootElement;
+            if (extensionRequirementsInfo is null)
+            {
+                throw new InvalidOperationException($"Failed to deserialize extension requirements from embedded resource '{fileName}'.");
+            }
 
-            var bundleRequirements = jsonElementRoot.TryGetProperty("bundles", out var bundles)
-                ? bundles.Deserialize(ExtensionRequirementsJsonContext.Default.BundleRequirementArray)
-                : [];
-
-            var extensionRequirements = jsonElementRoot.TryGetProperty("types", out var types)
-                ? types.Deserialize(ExtensionRequirementsJsonContext.Default.ExtensionStartupTypeRequirementArray)
-                : [];
-
-            return new ExtensionRequirementsInfo(bundleRequirements, extensionRequirements);
+            return extensionRequirementsInfo;
         }
 
         /// <summary>

--- a/src/WebJobs.Script/Description/DotNet/DependencyHelper.cs
+++ b/src/WebJobs.Script/Description/DotNet/DependencyHelper.cs
@@ -25,22 +25,23 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         private static Dictionary<string, string[]> BuildRuntimesGraph()
         {
-            using var stream = GetResourceStream("runtimes.json");
-            var parsed = JsonSerializer.Deserialize(stream, RuntimeGraphJsonContext.Default.RuntimeGraph);
+            using var stream = GetEmbeddedResourceStream("runtimes.json");
 
-            if (parsed is null)
+            var runtimeGraph = JsonSerializer.Deserialize(stream, RuntimeGraphJsonContext.Default.RuntimeGraph);
+
+            if (runtimeGraph is not { Runtimes.Count: > 0 })
             {
-                throw new InvalidOperationException("Failed to deserialize runtimes graph JSON.");
+                throw new InvalidOperationException("Failed to deserialize runtimes graph JSON or runtimes section is empty.");
             }
 
-            var result = new Dictionary<string, string[]>(parsed.Runtimes.Count, StringComparer.OrdinalIgnoreCase);
+            var ridGraph = new Dictionary<string, string[]>(runtimeGraph.Runtimes.Count, StringComparer.OrdinalIgnoreCase);
 
-            foreach (var (rid, info) in parsed.Runtimes)
+            foreach (var (rid, info) in runtimeGraph.Runtimes)
             {
-                result[rid] = info.Imports ?? [];
+                ridGraph[rid] = info.Imports ?? [];
             }
 
-            return result;
+            return ridGraph;
         }
 
         private static string GetDefaultPlatformRid()
@@ -73,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
             return rid;
         }
 
-        private static Stream GetResourceStream(string fileName)
+        private static Stream GetEmbeddedResourceStream(string fileName)
         {
             var stream = ThisAssembly.GetManifestResourceStream($"{ThisAssemblyName}.{fileName}");
 
@@ -82,7 +83,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         internal static Dictionary<string, ScriptRuntimeAssembly> GetRuntimeAssemblies(string assemblyManifestName)
         {
-            using var stream = GetResourceStream(assemblyManifestName);
+            using var stream = GetEmbeddedResourceStream(assemblyManifestName);
             var runtimeAssemblies = JsonSerializer.Deserialize(stream, RuntimeAssembliesJsonContext.Default.RuntimeAssembliesConfig);
 
             var assemblies = runtimeAssemblies?.RuntimeAssemblies ?? throw new InvalidOperationException($"Failed to retrieve runtime assemblies from the embedded resource '{assemblyManifestName}'.");
@@ -101,7 +102,7 @@ namespace Microsoft.Azure.WebJobs.Script.Description
         {
             const string fileName = "extensionrequirements.json";
 
-            using var stream = GetResourceStream(fileName);
+            using var stream = GetEmbeddedResourceStream(fileName);
             var extensionRequirementsInfo = JsonSerializer.Deserialize(stream, ExtensionRequirementsJsonContext.Default.ExtensionRequirementsInfo);
 
             if (extensionRequirementsInfo is null)

--- a/src/WebJobs.Script/Description/DotNet/RuntimeAssembliesConfig.cs
+++ b/src/WebJobs.Script/Description/DotNet/RuntimeAssembliesConfig.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Script.Description
+{
+    /// <summary>
+    /// Represents the configuration that lists runtime assemblies and their resolution policies.
+    /// </summary>
+    internal sealed class RuntimeAssembliesConfig
+    {
+        public List<ScriptRuntimeAssembly> RuntimeAssemblies { get; set; }
+    }
+}

--- a/src/WebJobs.Script/Description/DotNet/RuntimeAssembliesJsonContext.cs
+++ b/src/WebJobs.Script/Description/DotNet/RuntimeAssembliesJsonContext.cs
@@ -4,9 +4,9 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace Microsoft.Azure.WebJobs.Script.ExtensionRequirements
+namespace Microsoft.Azure.WebJobs.Script.Description.DotNet
 {
     [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, ReadCommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true)]
-    [JsonSerializable(typeof(ExtensionRequirementsInfo))]
-    internal partial class ExtensionRequirementsJsonContext : JsonSerializerContext;
+    [JsonSerializable(typeof(RuntimeAssembliesConfig))]
+    internal partial class RuntimeAssembliesJsonContext : JsonSerializerContext;
 }

--- a/src/WebJobs.Script/Description/DotNet/RuntimeGraph.cs
+++ b/src/WebJobs.Script/Description/DotNet/RuntimeGraph.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Script.Description.DotNet
+{
+    /// <summary>
+    /// Represents the runtime graph configuration defined in runtimes.json.
+    /// </summary>
+    internal sealed class RuntimeGraph
+    {
+        public Dictionary<string, RuntimeInfo> Runtimes { get; set; } = [];
+    }
+}

--- a/src/WebJobs.Script/Description/DotNet/RuntimeGraphJsonContext.cs
+++ b/src/WebJobs.Script/Description/DotNet/RuntimeGraphJsonContext.cs
@@ -4,9 +4,9 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace Microsoft.Azure.WebJobs.Script.ExtensionRequirements
+namespace Microsoft.Azure.WebJobs.Script.Description.DotNet
 {
     [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, ReadCommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true)]
-    [JsonSerializable(typeof(ExtensionRequirementsInfo))]
-    internal partial class ExtensionRequirementsJsonContext : JsonSerializerContext;
+    [JsonSerializable(typeof(RuntimeGraph))]
+    internal partial class RuntimeGraphJsonContext : JsonSerializerContext;
 }

--- a/src/WebJobs.Script/Description/DotNet/RuntimeInfo.cs
+++ b/src/WebJobs.Script/Description/DotNet/RuntimeInfo.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Azure.WebJobs.Script.Description.DotNet
+{
+    internal sealed class RuntimeInfo
+    {
+        [JsonPropertyName("#import")]
+        public string[] Imports { get; set; } = [];
+    }
+}

--- a/src/WebJobs.Script/ExtensionRequirements/ExtensionRequirementsInfo.cs
+++ b/src/WebJobs.Script/ExtensionRequirements/ExtensionRequirementsInfo.cs
@@ -7,37 +7,19 @@ using System.Linq;
 
 namespace Microsoft.Azure.WebJobs.Script.ExtensionRequirements
 {
-    internal sealed class ExtensionRequirementsInfo
+    internal sealed class ExtensionRequirementsInfo(BundleRequirement[] bundles, ExtensionStartupTypeRequirement[] types)
     {
         private Dictionary<string, BundleRequirement> _bundleRequirementsById;
         private Dictionary<string, ExtensionStartupTypeRequirement> _extensionRequirementsByStartupType;
-        private BundleRequirement[] _bundles = [];
-        private ExtensionStartupTypeRequirement[] _types = [];
 
-        public BundleRequirement[] Bundles
-        {
-            get => _bundles;
-            set
-            {
-                _bundles = value ?? [];
-                _bundleRequirementsById = null;
-            }
-        }
+        public BundleRequirement[] Bundles { get; } = bundles;
 
-        public ExtensionStartupTypeRequirement[] Types
-        {
-            get => _types;
-            set
-            {
-                _types = value ?? [];
-                _extensionRequirementsByStartupType = null;
-            }
-        }
+        public ExtensionStartupTypeRequirement[] Types { get; } = types;
 
-        public Dictionary<string, BundleRequirement> BundleRequirementsByBundleId =>
+        internal Dictionary<string, BundleRequirement> BundleRequirementsByBundleId =>
             _bundleRequirementsById ??= Bundles.ToDictionary(b => b.Id, StringComparer.OrdinalIgnoreCase);
 
-        public Dictionary<string, ExtensionStartupTypeRequirement> ExtensionRequirementsByStartupType =>
+        internal Dictionary<string, ExtensionStartupTypeRequirement> ExtensionRequirementsByStartupType =>
             _extensionRequirementsByStartupType ??= Types.ToDictionary(t => t.Name, StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/WebJobs.Script/ExtensionRequirements/ExtensionRequirementsInfo.cs
+++ b/src/WebJobs.Script/ExtensionRequirements/ExtensionRequirementsInfo.cs
@@ -11,10 +11,10 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionRequirements
     {
         private Dictionary<string, BundleRequirement> _bundleRequirementsById;
         private Dictionary<string, ExtensionStartupTypeRequirement> _extensionRequirementsByStartupType;
-        private List<BundleRequirement> _bundles = [];
-        private List<ExtensionStartupTypeRequirement> _types = [];
+        private BundleRequirement[] _bundles = [];
+        private ExtensionStartupTypeRequirement[] _types = [];
 
-        public List<BundleRequirement> Bundles
+        public BundleRequirement[] Bundles
         {
             get => _bundles;
             set
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionRequirements
             }
         }
 
-        public List<ExtensionStartupTypeRequirement> Types
+        public ExtensionStartupTypeRequirement[] Types
         {
             get => _types;
             set

--- a/src/WebJobs.Script/ExtensionRequirements/ExtensionRequirementsInfo.cs
+++ b/src/WebJobs.Script/ExtensionRequirements/ExtensionRequirementsInfo.cs
@@ -9,15 +9,35 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionRequirements
 {
     internal sealed class ExtensionRequirementsInfo
     {
-        public ExtensionRequirementsInfo(IEnumerable<BundleRequirement> bundleRequirements, IEnumerable<ExtensionStartupTypeRequirement> extensionRequirements)
-        {
-            BundleRequirementsByBundleId = bundleRequirements?.ToDictionary(a => a.Id, StringComparer.OrdinalIgnoreCase);
+        private Dictionary<string, BundleRequirement> _bundleRequirementsById;
+        private Dictionary<string, ExtensionStartupTypeRequirement> _extensionRequirementsByStartupType;
+        private List<BundleRequirement> _bundles = [];
+        private List<ExtensionStartupTypeRequirement> _types = [];
 
-            ExtensionRequirementsByStartupType = extensionRequirements?.ToDictionary(a => a.Name, StringComparer.OrdinalIgnoreCase);
+        public List<BundleRequirement> Bundles
+        {
+            get => _bundles;
+            set
+            {
+                _bundles = value ?? [];
+                _bundleRequirementsById = null;
+            }
         }
 
-        public Dictionary<string, BundleRequirement> BundleRequirementsByBundleId { get; private set; }
+        public List<ExtensionStartupTypeRequirement> Types
+        {
+            get => _types;
+            set
+            {
+                _types = value ?? [];
+                _extensionRequirementsByStartupType = null;
+            }
+        }
 
-        public Dictionary<string, ExtensionStartupTypeRequirement> ExtensionRequirementsByStartupType { get; private set; }
+        public Dictionary<string, BundleRequirement> BundleRequirementsByBundleId =>
+            _bundleRequirementsById ??= Bundles.ToDictionary(b => b.Id, StringComparer.OrdinalIgnoreCase);
+
+        public Dictionary<string, ExtensionStartupTypeRequirement> ExtensionRequirementsByStartupType =>
+            _extensionRequirementsByStartupType ??= Types.ToDictionary(t => t.Name, StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/WebJobs.Script/ExtensionRequirements/ExtensionRequirementsJsonContext.cs
+++ b/src/WebJobs.Script/ExtensionRequirements/ExtensionRequirementsJsonContext.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Azure.WebJobs.Script.ExtensionRequirements
+{
+    [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+    [JsonSerializable(typeof(BundleRequirement[]))]
+    [JsonSerializable(typeof(ExtensionStartupTypeRequirement[]))]
+    internal partial class ExtensionRequirementsJsonContext : JsonSerializerContext;
+}

--- a/test/WebJobs.Script.Tests/Description/DotNet/DependencyHelperTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/DependencyHelperTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Extensions.DependencyModel;
 using Xunit;
@@ -13,6 +12,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Description
 {
     public class DependencyHelperTests
     {
+        [Fact]
+        public void GetExtensionRequirementsReturnsEmbededManifestContent()
+        {
+            var extensionRequirements = DependencyHelper.GetExtensionRequirements();
+
+            Assert.NotNull(extensionRequirements);
+            Assert.NotNull(extensionRequirements.BundleRequirementsByBundleId);
+            Assert.NotNull(extensionRequirements.ExtensionRequirementsByStartupType);
+
+            // Ensure properties are populated for an item in the collection.
+            Assert.NotEmpty(extensionRequirements.ExtensionRequirementsByStartupType.First().Value.AssemblyName);
+            Assert.NotEmpty(extensionRequirements.ExtensionRequirementsByStartupType.First().Value.Name);
+            Assert.NotEmpty(extensionRequirements.ExtensionRequirementsByStartupType.First().Value.PackageName);
+            Assert.NotEmpty(extensionRequirements.ExtensionRequirementsByStartupType.First().Value.MinimumAssemblyVersion);
+            Assert.NotEmpty(extensionRequirements.ExtensionRequirementsByStartupType.First().Value.MinimumPackageVersion);
+        }
+
         [Fact]
         public void GetDefaultRuntimeFallbacks_MatchesCurrentRuntimeFallbacks()
         {


### PR DESCRIPTION
Optimized the following methods to reduce memory allocations and improve deserialization performance:

1. `DependencyHelper.GetExtensionRequirements()`
2. `RuntimeAssembliesInfo.GetRuntimeAssemblies()`
3. `RuntimeInformationProvider.BuildRuntimesGraph()`

These methods previously used JObject.Parse to deserialize embedded JSON resources. This PR replaces them with System.Text.Json and source generation.

#### Before

| Name | Total (Allocations) | Self (Allocations) | Total Size (Bytes) | Self Size (Bytes) |
|:-----|:--------------------|:-------------------|:--------------------|:------------------|
DependencyHelper.GetExtensionRequirements() | 4,700 | 1 | 358,800 | 32 |
RuntimeAssembliesInfo.GetRuntimeAssemblies() | 10,647 | 0 | 794,082 | 0 |

![image](https://github.com/user-attachments/assets/9e7d10cc-c9b2-4b4e-a008-7cf390019cc3)

![image](https://github.com/user-attachments/assets/f9e709d2-914e-487c-b038-6dda560b2768)

#### After

| Name | Total (Allocations) | Self (Allocations) | Total Size (Bytes) | Self Size (Bytes) |
|:-----|:--------------------|:-------------------|:--------------------|:------------------|
DependencyHelper.GetExtensionRequirements() | 420 | 12 | 31,548 | 384 |
RuntimeAssembliesInfo.GetRuntimeAssemblies() | 1,432 | 0 | 101,568 | 0 |

![image](https://github.com/user-attachments/assets/a48cdbb0-248f-45db-9258-6306614392f6)

![image](https://github.com/user-attachments/assets/829ffb52-39ef-4419-9c36-7341e54ce4ba)

#### Delta

- `DependencyHelper.GetExtensionRequirements` – Total allocations dropped by **4,280 (91.06%)**
- `DependencyHelper.GetExtensionRequirements` – Total allocated size dropped by **319.5 KB (91.23%)**
- `RuntimeAssembliesInfo.GetRuntimeAssemblies` – Total allocations dropped by **9,215 (86.56%)**
- `RuntimeAssembliesInfo.GetRuntimeAssemblies` – Total allocated size dropped by **676.1 KB (87.21%)**



### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x ] I have added all required tests (Unit tests, E2E tests) 

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
