### PR TITLE
Enabling runtime and process metrics.

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -11,3 +11,4 @@
 - Add 'unix' to the list of runtimes kept when importing PowerShell worker for Linux builds
 - Update PowerShell 7.4 worker to 4.0.4206
 - Update Python Worker Version to [4.37.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.37.0)
+- Add runtime and process metrics. (#11034)

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -888,7 +888,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                 }
 
                 var invocationRequest = await context.ToRpcInvocationRequest(_workerChannelLogger, _workerCapabilities, _isSharedMemoryDataTransferEnabled, _sharedMemoryManager);
-                AddAdditionalTraceContext(invocationRequest.TraceContext.Attributes, context);
+                AddAdditionalTraceContext(invocationRequest, context);
                 _executingInvocations.TryAdd(invocationRequest.InvocationId, new(context, _messageDispatcherFactory.Create(invocationRequest.InvocationId)));
                 _metricsLogger.LogEvent(string.Format(MetricEventNames.WorkerInvoked, Id), functionName: Sanitizer.Sanitize(context.FunctionMetadata.Name));
 
@@ -1680,8 +1680,9 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             }
         }
 
-        private void AddAdditionalTraceContext(MapField<string, string> attributes, ScriptInvocationContext context)
+        private void AddAdditionalTraceContext(InvocationRequest invocationRequest, ScriptInvocationContext context)
         {
+            MapField<string, string> attributes = invocationRequest.TraceContext.Attributes;
             bool isOtelEnabled = _scriptHostOptions?.Value.TelemetryMode == TelemetryMode.OpenTelemetry;
             bool isAIEnabled = _environment.IsApplicationInsightsAgentEnabled();
 
@@ -1721,6 +1722,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             if (isOtelEnabled)
             {
                 Activity.Current?.AddTag(ResourceSemanticConventions.FaaSName, context.FunctionMetadata.Name);
+                Activity.Current?.AddTag(ResourceSemanticConventions.FaaSInvocationId, invocationRequest.InvocationId);
             }
         }
 

--- a/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
+++ b/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
@@ -67,9 +67,11 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
         {
             return builder.WithMetrics(builder =>
             {
-                builder.AddAspNetCoreInstrumentation();
-                builder.AddMeter(HostMetrics.FaasMeterName);
-                builder.AddView(HostMetrics.FaasInvokeDuration, new ExplicitBucketHistogramConfiguration
+                builder.AddAspNetCoreInstrumentation()
+                .AddRuntimeInstrumentation()
+                .AddProcessInstrumentation()
+                .AddMeter(HostMetrics.FaasMeterName)
+                .AddView(HostMetrics.FaasInvokeDuration, new ExplicitBucketHistogramConfiguration
                 {
                     Boundaries = new double[] { 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 }
                 });

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -56,6 +56,8 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.7" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="all" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.0" />

--- a/src/WebJobs.Script/runtimeassemblies.json
+++ b/src/WebJobs.Script/runtimeassemblies.json
@@ -948,6 +948,14 @@
       "resolutionPolicy": "private"
     },
     {
+      "name": "OpenTelemetry.Instrumentation.Process",
+      "resolutionPolicy": "private"
+    },
+    {
+      "name": "OpenTelemetry.Instrumentation.Runtime",
+      "resolutionPolicy": "private"
+    },
+    {
       "name": "OpenTelemetry.PersistentStorage.Abstractions",
       "resolutionPolicy": "private"
     },

--- a/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
+++ b/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
@@ -6,7 +6,7 @@
   "compilationOptions": {},
   "targets": {
     ".NETCoreApp,Version=v8.0": {
-      "Microsoft.Azure.WebJobs.Script.WebHost/4.1039.100-dev": {
+      "Microsoft.Azure.WebJobs.Script.WebHost/4.1040.100-pr.25225.14": {
         "dependencies": {
           "Azure.Data.Tables": "12.8.3",
           "Azure.Identity": "1.11.4",
@@ -22,18 +22,18 @@
           "Microsoft.Azure.AppService.Middleware.Functions": "1.5.5",
           "Microsoft.Azure.AppService.Proxy.Client": "2.3.20240307.67",
           "Microsoft.Azure.Functions.DotNetIsolatedNativeHost": "1.0.12",
-          "Microsoft.Azure.Functions.JavaWorker": "2.18.1",
+          "Microsoft.Azure.Functions.JavaWorker": "2.19.0",
           "Microsoft.Azure.Functions.NodeJsWorker": "3.10.1",
           "Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption": "1.0.5",
           "Microsoft.Azure.Functions.PowerShellWorker.PS7.0": "4.0.3148",
           "Microsoft.Azure.Functions.PowerShellWorker.PS7.2": "4.0.4025",
-          "Microsoft.Azure.Functions.PowerShellWorker.PS7.4": "4.0.4134",
-          "Microsoft.Azure.Functions.PythonWorker": "4.35.0",
+          "Microsoft.Azure.Functions.PowerShellWorker.PS7.4": "4.0.4206",
+          "Microsoft.Azure.Functions.PythonWorker": "4.37.0",
           "Microsoft.Azure.Storage.File": "11.1.7",
           "Microsoft.Azure.WebJobs": "3.0.41",
           "Microsoft.Azure.WebJobs.Host.Storage": "5.0.1",
-          "Microsoft.Azure.WebJobs.Script": "4.1039.100-dev",
-          "Microsoft.Azure.WebJobs.Script.Grpc": "4.1039.100-dev",
+          "Microsoft.Azure.WebJobs.Script": "4.1040.100-pr.25225.14",
+          "Microsoft.Azure.WebJobs.Script.Grpc": "4.1040.100-pr.25225.14",
           "Microsoft.Azure.WebSites.DataProtection": "2.1.91-alpha",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.35.0",
           "Microsoft.IdentityModel.Tokens": "6.35.0",
@@ -44,8 +44,8 @@
           "System.IdentityModel.Tokens.Jwt": "6.35.0",
           "System.Memory.Data": "8.0.1",
           "System.Net.NameResolution": "4.3.0",
-          "Microsoft.Azure.WebJobs.Script.Reference": "4.1039.0.0",
-          "Microsoft.Azure.WebJobs.Script.Grpc.Reference": "4.1039.0.0"
+          "Microsoft.Azure.WebJobs.Script.Reference": "4.1040.0.0",
+          "Microsoft.Azure.WebJobs.Script.Grpc.Reference": "4.1040.0.0"
         },
         "runtime": {
           "Microsoft.Azure.WebJobs.Script.WebHost.dll": {}
@@ -851,7 +851,7 @@
         }
       },
       "Microsoft.Azure.Functions.DotNetIsolatedNativeHost/1.0.12": {},
-      "Microsoft.Azure.Functions.JavaWorker/2.18.1": {},
+      "Microsoft.Azure.Functions.JavaWorker/2.19.0": {},
       "Microsoft.Azure.Functions.NodeJsWorker/3.10.1": {},
       "Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption/1.0.5": {
         "dependencies": {
@@ -867,8 +867,8 @@
       },
       "Microsoft.Azure.Functions.PowerShellWorker.PS7.0/4.0.3148": {},
       "Microsoft.Azure.Functions.PowerShellWorker.PS7.2/4.0.4025": {},
-      "Microsoft.Azure.Functions.PowerShellWorker.PS7.4/4.0.4134": {},
-      "Microsoft.Azure.Functions.PythonWorker/4.35.0": {},
+      "Microsoft.Azure.Functions.PowerShellWorker.PS7.4/4.0.4206": {},
+      "Microsoft.Azure.Functions.PythonWorker/4.37.0": {},
       "Microsoft.Azure.KeyVault.Core/2.0.4": {
         "dependencies": {
           "System.Runtime": "4.3.1",
@@ -1044,7 +1044,7 @@
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Script.Abstractions.dll": {
             "assemblyVersion": "1.0.0.0",
-            "fileVersion": "1.0.19706.0"
+            "fileVersion": "1.0.21962.0"
           }
         }
       },
@@ -2017,6 +2017,28 @@
           }
         }
       },
+      "OpenTelemetry.Instrumentation.Process/0.5.0-beta.7": {
+        "dependencies": {
+          "OpenTelemetry.Api": "1.9.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/OpenTelemetry.Instrumentation.Process.dll": {
+            "assemblyVersion": "0.5.0.176",
+            "fileVersion": "0.5.0.176"
+          }
+        }
+      },
+      "OpenTelemetry.Instrumentation.Runtime/1.9.0": {
+        "dependencies": {
+          "OpenTelemetry.Api": "1.9.0"
+        },
+        "runtime": {
+          "lib/net6.0/OpenTelemetry.Instrumentation.Runtime.dll": {
+            "assemblyVersion": "1.9.0.57",
+            "fileVersion": "1.9.0.57"
+          }
+        }
+      },
       "OpenTelemetry.PersistentStorage.Abstractions/1.0.0": {
         "runtime": {
           "lib/netstandard2.0/OpenTelemetry.PersistentStorage.Abstractions.dll": {
@@ -2889,7 +2911,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Script/4.1039.100-dev": {
+      "Microsoft.Azure.WebJobs.Script/4.1040.100-pr.25225.14": {
         "dependencies": {
           "Azure.Core": "1.45.0",
           "Azure.Data.Tables": "12.8.3",
@@ -2921,6 +2943,8 @@
           "OpenTelemetry.Extensions.Hosting": "1.9.0",
           "OpenTelemetry.Instrumentation.AspNetCore": "1.9.0",
           "OpenTelemetry.Instrumentation.Http": "1.9.0",
+          "OpenTelemetry.Instrumentation.Process": "0.5.0-beta.7",
+          "OpenTelemetry.Instrumentation.Runtime": "1.9.0",
           "System.Diagnostics.DiagnosticSource": "8.0.0",
           "System.Drawing.Common": "8.0.0",
           "System.Formats.Asn1": "6.0.1",
@@ -2937,13 +2961,10 @@
           "System.Threading.Channels": "8.0.0"
         },
         "runtime": {
-          "Microsoft.Azure.WebJobs.Script.dll": {
-            "assemblyVersion": "4.1039.100-dev",
-            "fileVersion": ""
-          }
+          "Microsoft.Azure.WebJobs.Script.dll": {}
         }
       },
-      "Microsoft.Azure.WebJobs.Script.Grpc/4.1039.100-dev": {
+      "Microsoft.Azure.WebJobs.Script.Grpc/4.1040.100-pr.25225.14": {
         "dependencies": {
           "Grpc.AspNetCore": "2.55.0",
           "Microsoft.ApplicationInsights": "2.22.0",
@@ -2952,38 +2973,35 @@
           "Microsoft.ApplicationInsights.WindowsServer": "2.22.0",
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.22.0",
           "Microsoft.Azure.WebJobs.Rpc.Core": "3.0.37",
-          "Microsoft.Azure.WebJobs.Script": "4.1039.100-dev",
+          "Microsoft.Azure.WebJobs.Script": "4.1040.100-pr.25225.14",
           "System.IO.FileSystem.Primitives": "4.3.0",
           "System.Threading.Channels": "8.0.0",
           "Yarp.ReverseProxy": "2.0.1"
         },
         "runtime": {
-          "Microsoft.Azure.WebJobs.Script.Grpc.dll": {
-            "assemblyVersion": "4.1039.100-dev",
-            "fileVersion": ""
-          }
+          "Microsoft.Azure.WebJobs.Script.Grpc.dll": {}
         }
       },
-      "Microsoft.Azure.WebJobs.Script.Reference/4.1039.0.0": {
+      "Microsoft.Azure.WebJobs.Script.Reference/4.1040.0.0": {
         "runtime": {
           "Microsoft.Azure.WebJobs.Script.dll": {
-            "assemblyVersion": "4.1039.0.0",
-            "fileVersion": "42.42.42.4242"
+            "assemblyVersion": "4.1040.0.0",
+            "fileVersion": "4.1040.100.25225"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Script.Grpc.Reference/4.1039.0.0": {
+      "Microsoft.Azure.WebJobs.Script.Grpc.Reference/4.1040.0.0": {
         "runtime": {
           "Microsoft.Azure.WebJobs.Script.Grpc.dll": {
-            "assemblyVersion": "4.1039.0.0",
-            "fileVersion": "42.42.42.4242"
+            "assemblyVersion": "4.1040.0.0",
+            "fileVersion": "4.1040.100.25225"
           }
         }
       }
     }
   },
   "libraries": {
-    "Microsoft.Azure.WebJobs.Script.WebHost/4.1039.100-dev": {
+    "Microsoft.Azure.WebJobs.Script.WebHost/4.1040.100-pr.25225.14": {
       "type": "project",
       "serviceable": false,
       "sha512": ""
@@ -3555,12 +3573,12 @@
       "path": "microsoft.azure.functions.dotnetisolatednativehost/1.0.12",
       "hashPath": "microsoft.azure.functions.dotnetisolatednativehost.1.0.12.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.JavaWorker/2.18.1": {
+    "Microsoft.Azure.Functions.JavaWorker/2.19.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-XxzCZa9meGb6UTxyc7c/3ls8tG6IkMSCxkt2cdKgGeWX0Ytk1nVpQi2rFsHgVeoS0ZViDPCFMa1jznHyn+Z3Uw==",
-      "path": "microsoft.azure.functions.javaworker/2.18.1",
-      "hashPath": "microsoft.azure.functions.javaworker.2.18.1.nupkg.sha512"
+      "sha512": "sha512-sZbpZQQ+4CSmoKCwZTryI1oJ8rvU2TwvA5u4+Mn/VOt5C1wTZLSiRX2w7fCY34LF5PUhJsi++YzQg8+RGt0LdA==",
+      "path": "microsoft.azure.functions.javaworker/2.19.0",
+      "hashPath": "microsoft.azure.functions.javaworker.2.19.0.nupkg.sha512"
     },
     "Microsoft.Azure.Functions.NodeJsWorker/3.10.1": {
       "type": "package",
@@ -3590,19 +3608,19 @@
       "path": "microsoft.azure.functions.powershellworker.ps7.2/4.0.4025",
       "hashPath": "microsoft.azure.functions.powershellworker.ps7.2.4.0.4025.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.PowerShellWorker.PS7.4/4.0.4134": {
+    "Microsoft.Azure.Functions.PowerShellWorker.PS7.4/4.0.4206": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-fw1PMts2zstpaLMsFORy5U/7yZ515bzaYjSCQayTZ5VA15p/5+mbbhKTzEWDoxvVaJJRToFxeod+n79V0LWU5g==",
-      "path": "microsoft.azure.functions.powershellworker.ps7.4/4.0.4134",
-      "hashPath": "microsoft.azure.functions.powershellworker.ps7.4.4.0.4134.nupkg.sha512"
+      "sha512": "sha512-wW1OUKmlb1bN3VeenBjLKzorWwcmQuwM4mEzGgRQqObniZW5b6pQbRoHmwyX6exbRNWoH8OcwQusFqsxPpbvJA==",
+      "path": "microsoft.azure.functions.powershellworker.ps7.4/4.0.4206",
+      "hashPath": "microsoft.azure.functions.powershellworker.ps7.4.4.0.4206.nupkg.sha512"
     },
-    "Microsoft.Azure.Functions.PythonWorker/4.35.0": {
+    "Microsoft.Azure.Functions.PythonWorker/4.37.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-zkQWdqBEx47jzUjQZd/+v3tJ/3VW1hWAiDjVgG6Z6OVrAoCoS8J5r9kzYXapg63M/9VULHy7jTo3xY8zwmso6Q==",
-      "path": "microsoft.azure.functions.pythonworker/4.35.0",
-      "hashPath": "microsoft.azure.functions.pythonworker.4.35.0.nupkg.sha512"
+      "sha512": "sha512-QWKmhG7xBdDEDBwkXLT7idrKWAtj5w8dDnhB1g3GdFtVXgfJo7EVg14crNf3eBxAn7S7wdDeQj0sKU2HkkarhQ==",
+      "path": "microsoft.azure.functions.pythonworker/4.37.0",
+      "hashPath": "microsoft.azure.functions.pythonworker.4.37.0.nupkg.sha512"
     },
     "Microsoft.Azure.KeyVault.Core/2.0.4": {
       "type": "package",
@@ -3649,7 +3667,7 @@
     "Microsoft.Azure.WebJobs.Extensions.Http/3.2.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-i4LAWVe6zRdDUwLFyKI1xrh8FeajSiA9h8kWsdGDqEQ1t9rWvvz3PKuRJeH5nAMDSuLT9vsUxXZwI5a7lOqlZQ==",
+      "sha512": "sha512-IXLuo5fOliOYKUZjWO5kQ/j3XblM9TNnk1agjzNYkubpDXq6M436GihaVzwTeQlX279P3G1KquS6I+b7pXaFuQ==",
       "path": "microsoft.azure.webjobs.extensions.http/3.2.0",
       "hashPath": "microsoft.azure.webjobs.extensions.http.3.2.0.nupkg.sha512"
     },
@@ -3663,7 +3681,7 @@
     "Microsoft.Azure.WebJobs.Host.Storage/5.0.1": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-5fF88jDYdxUs4EdYZw3MqK7ghG4mZ5MsCt8MhKk38CiTK90VmoWtXbBYURohil+WJ8vB/i0UwQGg64y6TdvliA==",
+      "sha512": "sha512-eO/sX41oaGkDiXHpT7y/F1F5Wvzm7e1QqFmd4GGMJOMdLOHGvwOvZR82AfR7rjvpqQZWyKjRHqxAVcntq+ZYwQ==",
       "path": "microsoft.azure.webjobs.host.storage/5.0.1",
       "hashPath": "microsoft.azure.webjobs.host.storage.5.0.1.nupkg.sha512"
     },
@@ -3684,7 +3702,7 @@
     "Microsoft.Azure.WebJobs.Script.Abstractions/1.0.4-preview": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-mvgXnFKwh4/Gw8BXc99ZJd2iQ8DQJTCotvY9PZ9Y2UHa4KiOsYaEW4kuZ5RFBD9KqGO2vXG56w3wMFVyxmaA2g==",
+      "sha512": "sha512-6yQIbQWV+Js168FJFPu0aIdwaVl6IkaIqZOuq9RT/8QgNFjIiHYE6w/bJjTDWzf4FccVgbYAz9nXWXd5u45OEg==",
       "path": "microsoft.azure.webjobs.script.abstractions/1.0.4-preview",
       "hashPath": "microsoft.azure.webjobs.script.abstractions.1.0.4-preview.nupkg.sha512"
     },
@@ -4240,6 +4258,20 @@
       "sha512": "sha512-+ZXppf8Qxz3OdC803T8fB6i8iSscc8PsxMnM/JizSOYmkz+8vGiScEiaBBBFNZtMh2KpA0q+qxwnSwQUkbvzog==",
       "path": "opentelemetry.instrumentation.http/1.9.0",
       "hashPath": "opentelemetry.instrumentation.http.1.9.0.nupkg.sha512"
+    },
+    "OpenTelemetry.Instrumentation.Process/0.5.0-beta.7": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-v+g5CPU/sJhyc1FTOgTaQTwvrQXquSxdndF+E3fS8SXYPLVAa2INHa8jqCFKvYp1rO+yaVizRw1gCOaDJJzauA==",
+      "path": "opentelemetry.instrumentation.process/0.5.0-beta.7",
+      "hashPath": "opentelemetry.instrumentation.process.0.5.0-beta.7.nupkg.sha512"
+    },
+    "OpenTelemetry.Instrumentation.Runtime/1.9.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-6raJb9Pvi1CaBB59SX86Mr9NQiQbiv9ialO+cQKFRGCq3Bl2WC8cTTcbfGtaRX0quqWnZC/dK7xrXuOuYcwANA==",
+      "path": "opentelemetry.instrumentation.runtime/1.9.0",
+      "hashPath": "opentelemetry.instrumentation.runtime.1.9.0.nupkg.sha512"
     },
     "OpenTelemetry.PersistentStorage.Abstractions/1.0.0": {
       "type": "package",
@@ -4990,22 +5022,22 @@
       "path": "yarp.reverseproxy/2.0.1",
       "hashPath": "yarp.reverseproxy.2.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Script/4.1039.100-dev": {
+    "Microsoft.Azure.WebJobs.Script/4.1040.100-pr.25225.14": {
       "type": "project",
       "serviceable": false,
       "sha512": ""
     },
-    "Microsoft.Azure.WebJobs.Script.Grpc/4.1039.100-dev": {
+    "Microsoft.Azure.WebJobs.Script.Grpc/4.1040.100-pr.25225.14": {
       "type": "project",
       "serviceable": false,
       "sha512": ""
     },
-    "Microsoft.Azure.WebJobs.Script.Reference/4.1039.0.0": {
+    "Microsoft.Azure.WebJobs.Script.Reference/4.1040.0.0": {
       "type": "reference",
       "serviceable": false,
       "sha512": ""
     },
-    "Microsoft.Azure.WebJobs.Script.Grpc.Reference/4.1039.0.0": {
+    "Microsoft.Azure.WebJobs.Script.Grpc.Reference/4.1040.0.0": {
       "type": "reference",
       "serviceable": false,
       "sha512": ""


### PR DESCRIPTION
- Adding process and runtime metrics.
- Adding invocationId to the span.


**DependencyTests.Verify_DepsJsonChanges**

Added:
- OpenTelemetry.Instrumentation.Process.dll: 0.5.0.176/0.5.0.176
- OpenTelemetry.Instrumentation.Runtime.dll: 1.9.0.57/1.9.0.57

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

