### PR TITLE
Fixes to improve the reliability of the LinuxContainerActivityPublisher

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,11 +4,11 @@
 - My change description (#PR)
 -->
 - Improved memory metrics reporting using CGroup data for Linux consumption (#10968)
-- Memory allocation optimizations in `RpcWorkerConfigFactory.AddProviders` (#10959)
-- Fixing GrpcWorkerChannel concurrency bug (#10998)
+- Memory allocation optimizations in `RpcWorkerConfigFactory.AddProviders` (#10959)- Fixing GrpcWorkerChannel concurrency bug (#10998)
 - Avoid circular dependency when resolving LinuxContainerLegionMetricsPublisher. (#10991)
 - Add 'unix' to the list of runtimes kept when importing PowerShell worker for Linux builds
 - Update PowerShell 7.4 worker to 4.0.4206
 - Update Python Worker Version to [4.37.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.37.0)
 - Add runtime and process metrics. (#11034)
 - Add `win-arm64` and `linux-arm64` to the list of PowerShell runtimes; added filter for `osx` RIDs (includes `osx-x64` and `osx-arm64`) (#11013)
+- Fixes to improve the reliability of the LinuxContainerActivityPublisher

--- a/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerActivityPublisher.cs
+++ b/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerActivityPublisher.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
 {
-    public class LinuxContainerActivityPublisher : IHostedService, IDisposable, ILinuxContainerActivityPublisher
+    public sealed class LinuxContainerActivityPublisher : IHostedService, IAsyncDisposable, ILinuxContainerActivityPublisher
     {
         public const string SpecializationCompleteEvent = "SpecializationCompleted";
         private const int InitialFlushIntervalMs = 5 * 1000; // 5 seconds
@@ -30,9 +30,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
         private readonly HashSet<ContainerFunctionExecutionActivity> _uniqueActivities;
         private IDisposable _standbyOptionsOnChangeSubscription;
         private DateTime _lastHeartBeatTime = DateTime.MinValue;
-        private Timer _timer;
         private int _flushInProgress;
         private bool _initialPublish;
+        private CancellationTokenSource _publishingCts;
+        private Task _publishingTask;
 
         public LinuxContainerActivityPublisher(IOptionsMonitor<StandbyOptions> standbyOptions,
             IMeshServiceClient meshServiceClient, IEnvironment environment,
@@ -49,7 +50,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
             _logger = logger;
             _flushIntervalMs = flushIntervalMs;
             _initialFlushIntervalMs = initialFlushIntervalMs;
-            _timer = new Timer(OnTimer, null, Timeout.Infinite, Timeout.Infinite);
             _uniqueActivities = new HashSet<ContainerFunctionExecutionActivity>();
             _flushInProgress = 0;
             _initialPublish = true;
@@ -59,8 +59,47 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
         {
             _logger.LogInformation($"Starting {nameof(LinuxContainerActivityPublisher)}");
 
-            // start the timer by setting the due time
-            SetTimerInterval(_initialFlushIntervalMs);
+            _publishingTask = StartPublishingAsync();
+        }
+
+        private async Task StartPublishingAsync()
+        {
+            _publishingCts = new CancellationTokenSource();
+
+            try
+            {
+                while (!_publishingCts.IsCancellationRequested)
+                {
+                    try
+                    {
+                        var nextFlushDelay = _flushIntervalMs;
+
+                        if (_initialPublish)
+                        {
+                            _initialPublish = false;
+                            await PublishSpecializationCompleteEvent();
+
+                            nextFlushDelay -= _initialFlushIntervalMs;
+                        }
+                        else
+                        {
+                            await FlushFunctionExecutionActivities();
+                        }
+
+                        await Task.Delay(nextFlushDelay, _publishingCts.Token);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex,$"Error in {nameof(LinuxContainerActivityPublisher)} publishing loop.");
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected in normal termination flow
+            }
+
+            _logger.LogInformation($"{nameof(LinuxContainerActivityPublisher)} publishing loop completed.");
         }
 
         private void OnStandbyOptionsChange()
@@ -94,25 +133,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
         {
             _logger.LogInformation($"Stopping {nameof(LinuxContainerActivityPublisher)}");
 
-            // stop the timer if it has been started
-            _timer?.Change(Timeout.Infinite, Timeout.Infinite);
+            _publishingCts.Cancel();
 
             return Task.CompletedTask;
-        }
-
-        private async void OnTimer(object state)
-        {
-            if (_initialPublish)
-            {
-                _initialPublish = false;
-                await PublishSpecializationCompleteEvent();
-                SetTimerInterval(_flushIntervalMs - _initialFlushIntervalMs);
-            }
-            else
-            {
-                await FlushFunctionExecutionActivities();
-                SetTimerInterval(_flushIntervalMs);
-            }
         }
 
         private async Task PublishSpecializationCompleteEvent()
@@ -169,81 +192,72 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
             }
         }
 
-        private void SetTimerInterval(int dueTime)
-        {
-            var timer = _timer;
-            try
-            {
-                timer?.Change(dueTime, Timeout.Infinite);
-            }
-            catch (ObjectDisposedException)
-            {
-                // might race with dispose
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(e, nameof(SetTimerInterval));
-            }
-        }
-
-        public void Dispose()
-        {
-            if (_timer != null)
-            {
-                _timer?.Dispose();
-                _timer = null;
-            }
-        }
-
         private bool PublishActivity(ContainerFunctionExecutionActivity activity)
         {
-            if (_activitiesLock.TryEnterWriteLock(LockTimeOutMs))
+            if (!_activitiesLock.TryEnterWriteLock(LockTimeOutMs))
             {
-                try
-                {
-                    _uniqueActivities.Add(activity);
-                }
-                finally
-                {
-                    _activitiesLock.ExitWriteLock();
-                }
-                return true;
+                return false;
             }
 
-            return false;
+            try
+            {
+                _uniqueActivities.Add(activity);
+            }
+            finally
+            {
+                _activitiesLock.ExitWriteLock();
+            }
+
+            return true;
         }
 
         private bool TryGetCurrentActivities(IList<ContainerFunctionExecutionActivity> currentActivities)
         {
-            if (_activitiesLock.TryEnterWriteLock(LockTimeOutMs))
+            if (!_activitiesLock.TryEnterWriteLock(LockTimeOutMs))
             {
-                try
-                {
-                    foreach (var activity in _uniqueActivities)
-                    {
-                        currentActivities.Add(activity);
-                    }
-                    _uniqueActivities.Clear();
-                }
-                finally
-                {
-                    _activitiesLock.ExitWriteLock();
-                }
-                return true;
+                return false;
             }
 
-            return false;
+            try
+            {
+                foreach (var activity in _uniqueActivities)
+                {
+                    currentActivities.Add(activity);
+                }
+
+                _uniqueActivities.Clear();
+            }
+            finally
+            {
+                _activitiesLock.ExitWriteLock();
+            }
+            return true;
         }
 
         public void PublishFunctionExecutionActivity(ContainerFunctionExecutionActivity activity)
         {
-            if (!_standbyOptions.CurrentValue.InStandbyMode)
+            if (_standbyOptions.CurrentValue.InStandbyMode)
             {
-                if (!PublishActivity(activity))
-                {
-                    _logger.LogWarning($"Failed to add activity {activity}");
-                }
+                return;
             }
+
+            if (!PublishActivity(activity))
+            {
+                _logger.LogWarning($"Failed to add activity {activity}");
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            // Wait for the publishing task to complete
+            if (_publishingTask != null)
+            {
+                await _publishingTask;
+            }
+
+            _activitiesLock?.Dispose();
+            _standbyOptionsOnChangeSubscription?.Dispose();
+            _publishingCts?.Dispose();
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerActivityPublisher.cs
+++ b/src/WebJobs.Script.WebHost/ContainerManagement/LinuxContainerActivityPublisher.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogError(ex,$"Error in {nameof(LinuxContainerActivityPublisher)} publishing loop.");
+                        _logger.LogError(ex, $"Error in {nameof(LinuxContainerActivityPublisher)} publishing loop.");
                     }
                 }
             }
@@ -249,6 +249,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
 
         public async ValueTask DisposeAsync()
         {
+            if (_publishingCts is { IsCancellationRequested: false })
+            {
+                await _publishingCts.CancelAsync();
+            }
+
             // Wait for the publishing task to complete
             if (_publishingTask != null)
             {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Fixes to improve the reliability of the LinuxContainerActivityPublisher. The key issue being resolved is a change to move away from a timer callback that was using the `async void` pattern.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

