### PR TITLE
Prepare in-proc branch for VNext: Clear notes, update version to 4.41.100

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,11 +3,3 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-
-- Added the option to exclude test data from the `/functions` endpoint API response (#10943)
-- Avoid circular dependency when resolving LinuxContainerLegionMetricsPublisher. (#10991)
-- Fixing GrpcWorkerChannel concurrency bug
-- Update PowerShell 7.4 worker to 4.0.4206
-- Re-add `Microsoft.DotNet.PlatformAbstractions` (#11031)
-- Update Python Worker Version to [4.37.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.37.0)
-- Disable Diagnostic Events when Table Storage is not accessible (#10996)

--- a/src/Directory.Version.props
+++ b/src/Directory.Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.$(MinorVersionPrefix)40.100</VersionPrefix>
+    <VersionPrefix>4.$(MinorVersionPrefix)41.100</VersionPrefix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This PR contains the following changes:
- Update version to 4.41.100
- Clear release notes

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the in-proc branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the in-proc branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to release_notes.md
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
