### PR TITLE
Reduce allocations in GrpcMessageExtensionUtilities.ConvertFromHttpMessageToExpando

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Replaced `dynamic` usage with static typing in `ConvertFromHttpMessageToExpando` for improved performance. (#11054)

--- a/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageExtensionUtilities.cs
+++ b/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageExtensionUtilities.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
-using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
@@ -13,30 +12,58 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 {
     internal static class GrpcMessageExtensionUtilities
     {
-        public static object ConvertFromHttpMessageToExpando(RpcHttp inputMessage)
+        private static readonly object BoxedTrue = true;
+        private static readonly object BoxedFalse = false;
+        private static readonly IReadOnlyDictionary<string, object> EmptyHeaders = new Dictionary<string, object>();
+
+        public static ExpandoObject ConvertFromHttpMessageToExpando(RpcHttp inputMessage)
         {
-            if (inputMessage == null)
+            if (inputMessage is null)
             {
                 return null;
             }
 
-            dynamic expando = new ExpandoObject();
-            expando.method = inputMessage.Method;
-            expando.query = inputMessage.Query as IDictionary<string, string>;
-            expando.statusCode = inputMessage.StatusCode;
-            expando.headers = inputMessage.Headers.ToDictionary(p => p.Key, p => (object)p.Value);
-            expando.enableContentNegotiation = inputMessage.EnableContentNegotiation;
+            var expando = new ExpandoObject();
+            IDictionary<string, object> dict = expando;
 
-            expando.cookies = new List<Tuple<string, string, CookieOptions>>();
-            foreach (RpcHttpCookie cookie in inputMessage.Cookies)
+            dict["method"] = inputMessage.Method;
+            dict["query"] = inputMessage.Query;
+            dict["statusCode"] = inputMessage.StatusCode;
+            dict["enableContentNegotiation"] = inputMessage.EnableContentNegotiation ? BoxedTrue : BoxedFalse;
+
+            if (inputMessage.Headers is { Count: > 0 })
             {
-                expando.cookies.Add(RpcHttpCookieConverter(cookie));
+                var headerDict = new Dictionary<string, object>(inputMessage.Headers.Count);
+                foreach (var kvp in inputMessage.Headers)
+                {
+                    headerDict[kvp.Key] = kvp.Value;
+                }
+                dict["headers"] = headerDict;
+            }
+            else
+            {
+                dict["headers"] = EmptyHeaders;
             }
 
-            if (inputMessage.Body != null)
+            if (inputMessage.Cookies is { Count: > 0 })
             {
-                expando.body = inputMessage.Body.ToObject();
+                var cookiesList = new List<Tuple<string, string, CookieOptions>>(inputMessage.Cookies.Count);
+                foreach (var cookie in inputMessage.Cookies)
+                {
+                    cookiesList.Add(RpcHttpCookieConverter(cookie));
+                }
+                dict["cookies"] = cookiesList;
             }
+            else
+            {
+                dict["cookies"] = Array.Empty<Tuple<string, string, CookieOptions>>();
+            }
+
+            if (inputMessage.Body is not null)
+            {
+                dict["body"] = inputMessage.Body.ToObject();
+            }
+
             return expando;
         }
 
@@ -80,27 +107,17 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
         internal static void UpdateWorkerMetadata(this WorkerMetadata workerMetadata, RpcWorkerConfig workerConfig)
         {
-            workerMetadata.RuntimeName = string.IsNullOrEmpty(workerMetadata.RuntimeName)
-                                            ? workerConfig.Description.Language : workerMetadata.RuntimeName;
-            workerMetadata.RuntimeVersion = string.IsNullOrEmpty(workerMetadata.RuntimeVersion)
-                                            ? workerConfig.Description.DefaultRuntimeVersion : workerMetadata.RuntimeVersion;
+            workerMetadata.RuntimeName ??= workerConfig.Description.Language;
+            workerMetadata.RuntimeVersion ??= workerConfig.Description.DefaultRuntimeVersion;
         }
 
-        private static SameSiteMode RpcSameSiteEnumConverter(RpcHttpCookie.Types.SameSite sameSite)
+        private static SameSiteMode RpcSameSiteEnumConverter(RpcHttpCookie.Types.SameSite sameSite) => sameSite switch
         {
-            switch (sameSite)
-            {
-                case RpcHttpCookie.Types.SameSite.Strict:
-                    return SameSiteMode.Strict;
-                case RpcHttpCookie.Types.SameSite.Lax:
-                    return SameSiteMode.Lax;
-                case RpcHttpCookie.Types.SameSite.None:
-                    return SameSiteMode.Unspecified;
-                case RpcHttpCookie.Types.SameSite.ExplicitNone:
-                    return SameSiteMode.None;
-                default:
-                    return SameSiteMode.Unspecified;
-            }
-        }
+            RpcHttpCookie.Types.SameSite.Strict => SameSiteMode.Strict,
+            RpcHttpCookie.Types.SameSite.Lax => SameSiteMode.Lax,
+            RpcHttpCookie.Types.SameSite.None => SameSiteMode.Unspecified,
+            RpcHttpCookie.Types.SameSite.ExplicitNone => SameSiteMode.None,
+            _ => SameSiteMode.Unspecified
+        };
     }
 }


### PR DESCRIPTION
Optimizations in `GrpcMessageExtensionUtilities.ConvertFromHttpMessageToExpando` method, which is a hotpath method and gets executed on every invocation in HTTP non-proxy use case.

- Removed the use of the `dynamic` type to build the HTTP response object, eliminating late binding and runtime dispatch.
- Replaced certain LINQ allocations.
- Using cached boxed boolean values to avoid per request boxing.
- Using a cached empty dictionary.


#### Improvements captured from benchmarking pipeline (Requests/sec - max) - 4 core machines.

- [Windows](https://azfunc.visualstudio.com/internal/_build/results?buildId=216487&view=logs&j=eba86677-de9c-53f5-623d-d8a79eaed3b8&t=2414e5fa-9e39-5ae7-440d-7f4d8d45bc69&l=50)
- [Linux](https://azfunc.visualstudio.com/internal/_build/results?buildId=216487&view=logs&j=393a2ac6-8c47-5fa4-a7b9-b4809b594f49&t=b9c01787-1c02-5d41-48a7-0487b6838bcc&l=50)

##### Requests/sec (max) 
| Platform | Before | After | Delta     |
|----------|--------|-------|-----------|
| Linux    | 10,894 | 12,743 | +16.96%   |
| Windows  | 15,248 | 17,111 | +12.21%   |

With this change, app handles burst traffic better. Other core metrics, such as average RPS and memory usage, have remained stable or improved slightly.


I also collected perf profiles with a local load test run which sends stable traffic (1,000 requests)

#### Before

| Name | Total (Allocations) | Self (Allocations) | Total Size (Bytes) | Self Size (Bytes) |
|:-----|:--------------------|:-------------------|:--------------------|:------------------|
ConvertFromHttpMessageToExpando(RpcHttp) | 85,859 | 3,568 | 4,472,970 | 147,112 |

![image](https://github.com/user-attachments/assets/a7e22a0c-c4ae-4113-9e09-c8fb753a700f)




#### After

| Name | Total (Allocations) | Self (Allocations) | Total Size (Bytes) | Self Size (Bytes) |
|:-----|:--------------------|:-------------------|:--------------------|:------------------|
ConvertFromHttpMessageToExpando(RpcHttp) | 15,084 | 3,000 | 763,724 | 184,000 |


<img width="1091" alt="image" src="https://github.com/user-attachments/assets/bb705bd6-e5cd-438b-8385-ca6d969c7873" />


#### Delta
- `GrpcMessageExtensionUtilities.ConvertFromHttpMessageToExpando` – Total allocations dropped by **70,775 (82.45%)**
- `GrpcMessageExtensionUtilities.ConvertFromHttpMessageToExpando` – Total allocated size dropped by **3.54 MB (82.92%)**

https://github.com/Azure/azure-functions-host/pull/11040 added test coverage for this code path.


### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)
