### PR TITLE
Adding support for collecting cross-platform perf traces and generating PGO JIT traces

### DIFF
--- a/eng/ci/host.coldstart.yml
+++ b/eng/ci/host.coldstart.yml
@@ -13,6 +13,35 @@ schedules:
     always: true
 
 parameters:
+
+# Function apps to include in the run.
+- name: includeHelloHttpNet9
+  displayName: Include HelloHttpNet9 (.NET9 Web Application)
+  type: boolean
+  default: true
+- name: includeHelloHttpNet9NoProxy
+  displayName: Include HelloHttpNet9NoProxy (.NET9 Worker Application)
+  type: boolean
+  default: true
+- name: includeHelloHttpNode
+  displayName: Include HelloHttpNode (Node Application)
+  type: boolean
+  default: false
+
+# Dotnet trace profile collection & jit trace generation.
+- name: collectNetTrace
+  displayName: Collect DotNet trace
+  type: boolean
+  default: false
+- name: netTraceCollectArguments
+  displayName: DotNet trace profile collection arguments (Valid only if "Collect DotNet trace" is true)). Example `-n Microsoft.Azure.WebJobs.Script.WebHost --profile cpu-sampling --duration 00:00:00:10`
+  type: string
+  default: '-n Microsoft.Azure.WebJobs.Script.WebHost --providers Microsoft-Diagnostics-DiagnosticSource:0xfffffffffffff7ff:5,Microsoft-Windows-DotNETRuntime:0x10:5,Microsoft-Windows-DotNETRuntime:0x4000080018:5,FunctionsSystemLogsEventSource:0xFFFFFFFFFFFFFFFF:5 --stopping-event-provider-name Microsoft-Diagnostics-DiagnosticSource --stopping-event-event-name Activity1/Stop'
+- name: createJitTrace
+  displayName: Create Jit trace (Ensure "Collect DotNet trace" is set to true)
+  type: boolean
+  default: false
+
 - name: collectPerfViewProfileOnWindows
   displayName: Collect PerfView Profile (on Windows)
   type: boolean
@@ -50,37 +79,66 @@ extends:
       displayName: Record latency(Windows)
       jobs:
       - ${{ each appId in split(variables.runInstances, ',') }}:
-        - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
-          parameters:
-            description: .NET9 Web Application
-            functionAppName: HelloHttpNet9
-            instanceId: ${{ appId }} 
-            collectPerfViewProfileOnWindows: ${{ parameters.collectPerfViewProfileOnWindows }}
-            perfViewCollectArguments: ${{ parameters.perfViewCollectArguments }}
-        - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
-          parameters:
-            description: .NET9 Worker Application
-            functionAppName: HelloHttpNet9NoProxy
-            instanceId: ${{ appId }}
-            collectPerfViewProfileOnWindows: ${{ parameters.collectPerfViewProfileOnWindows }}
-            perfViewCollectArguments: ${{ parameters.perfViewCollectArguments }}
+        - ${{ if eq(parameters.includeHelloHttpNet9, true) }}:
+          - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
+            parameters:
+              description: .NET9 Web Application
+              functionAppName: HelloHttpNet9
+              instanceId: ${{ appId }} 
+              collectPerfViewProfileOnWindows: ${{ parameters.collectPerfViewProfileOnWindows }}
+              perfViewCollectArguments: ${{ parameters.perfViewCollectArguments }}
+              netTraceCollectArguments: ${{ parameters.netTraceCollectArguments }}
+              collectNetTrace: ${{ parameters.collectNetTrace }}
+              createJitTrace: ${{ parameters.createJitTrace }}
+        - ${{ if eq(parameters.includeHelloHttpNet9NoProxy, true) }}:
+          - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
+            parameters:
+              description: .NET9 Worker Application
+              functionAppName: HelloHttpNet9NoProxy
+              instanceId: ${{ appId }}
+              collectPerfViewProfileOnWindows: ${{ parameters.collectPerfViewProfileOnWindows }}
+              perfViewCollectArguments: ${{ parameters.perfViewCollectArguments }}
+              netTraceCollectArguments: ${{ parameters.netTraceCollectArguments }}
+              collectNetTrace: ${{ parameters.collectNetTrace }}
+              createJitTrace: ${{ parameters.createJitTrace }}
+        - ${{ if eq(parameters.includeHelloHttpNode, true) }}:
+          - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
+            parameters:
+              description: Node Application
+              functionAppName: HelloHttpNode
+              instanceId: ${{ appId }}
+              collectPerfViewProfileOnWindows: ${{ parameters.collectPerfViewProfileOnWindows }}
+              perfViewCollectArguments: ${{ parameters.perfViewCollectArguments }}
+              netTraceCollectArguments: ${{ parameters.netTraceCollectArguments }}
+              collectNetTrace: ${{ parameters.collectNetTrace }}
+              createJitTrace: ${{ parameters.createJitTrace }}
 
     - stage: CalculateWindows
       displayName: Process results(Windows)
       dependsOn: RunWindows
+      condition: always()
       jobs:
-      - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
-        parameters:
-          functionAppName: HelloHttpNet9
-          description: .NET9 Web Application
-          runInstances: 
-            items: ${{ split(variables.runInstances, ',') }}
-      - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
-        parameters:
-          functionAppName: HelloHttpNet9NoProxy
-          description: .NET9 Worker Application
-          runInstances: 
-            items: ${{ split(variables.runInstances, ',') }}
+      - ${{ if eq(parameters.includeHelloHttpNet9, true) }}:
+        - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
+          parameters:
+            functionAppName: HelloHttpNet9
+            description: .NET9 Web Application
+            runInstances: 
+              items: ${{ split(variables.runInstances, ',') }}
+      - ${{ if eq(parameters.includeHelloHttpNet9NoProxy, true) }}:
+        - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
+          parameters:
+            functionAppName: HelloHttpNet9NoProxy
+            description: .NET9 Worker Application
+            runInstances: 
+              items: ${{ split(variables.runInstances, ',') }}
+      - ${{ if eq(parameters.includeHelloHttpNode, true) }}:
+        - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
+          parameters:
+            functionAppName: HelloHttpNode
+            description: Node Application
+            runInstances: 
+              items: ${{ split(variables.runInstances, ',') }}
 
 # # LINUX
     - stage: RunLinux
@@ -88,34 +146,84 @@ extends:
       displayName:  Record latency(Linux)
       jobs:
       - ${{ each appId in split(variables.runInstances, ',') }}:
-        - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
-          parameters:
-            description: .NET9 Web Application
-            functionAppName: HelloHttpNet9
-            instanceId: ${{ appId }}
-            os: Linux
-        - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
-          parameters:
-            description: .NET9 Worker Application
-            functionAppName: HelloHttpNet9NoProxy
-            instanceId: ${{ appId }}
-            os: Linux
-  
+        - ${{ if eq(parameters.includeHelloHttpNet9, true) }}:
+          - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
+            parameters:
+              description: .NET9 Web Application
+              functionAppName: HelloHttpNet9
+              instanceId: ${{ appId }}
+              os: Linux
+              collectNetTrace: ${{ parameters.collectNetTrace }}
+              netTraceCollectArguments: ${{ parameters.netTraceCollectArguments }}
+              createJitTrace: ${{ parameters.createJitTrace }}
+        - ${{ if eq(parameters.includeHelloHttpNet9NoProxy, true) }}:
+          - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
+            parameters:
+              description: .NET9 Worker Application
+              functionAppName: HelloHttpNet9NoProxy
+              instanceId: ${{ appId }}
+              os: Linux
+              collectNetTrace: ${{ parameters.collectNetTrace }}
+              netTraceCollectArguments: ${{ parameters.netTraceCollectArguments }}
+              createJitTrace: ${{ parameters.createJitTrace }}
+        - ${{ if eq(parameters.includeHelloHttpNode, true) }}:
+          - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
+            parameters:
+              description: Node Application
+              functionAppName: HelloHttpNode
+              instanceId: ${{ appId }}
+              os: Linux
+              collectNetTrace: ${{ parameters.collectNetTrace }}
+              netTraceCollectArguments: ${{ parameters.netTraceCollectArguments }}
+              createJitTrace: ${{ parameters.createJitTrace }}  
+
     - stage: CalculateLinux
       displayName:  Process results(Linux)
       dependsOn: RunLinux
+      condition: always()
       jobs:
-      - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
+      - ${{ if eq(parameters.includeHelloHttpNet9, true) }}:
+        - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
+          parameters:
+            functionAppName: HelloHttpNet9
+            description: .NET9 Web Application
+            os: Linux
+            runInstances: 
+              items: ${{ split(variables.runInstances, ',') }}
+      - ${{ if eq(parameters.includeHelloHttpNet9NoProxy, true) }}:
+        - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
+          parameters:
+            functionAppName: HelloHttpNet9NoProxy
+            description: .NET9 Worker Application
+            os: Linux
+            runInstances: 
+              items: ${{ split(variables.runInstances, ',') }}
+      - ${{ if eq(parameters.includeHelloHttpNode, true) }}:
+        - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
+          parameters:
+            functionAppName: HelloHttpNode
+            description: Node Application
+            os: Linux
+            runInstances: 
+              items: ${{ split(variables.runInstances, ',') }}
+
+# Merge JIT traces from different function apps and dedupe.
+    - stage: MergeWindowsJitTraceFiles
+      displayName: Create jit trace(Windows)
+      condition: and(succeeded(), eq('${{ parameters.createJitTrace }}', true))
+      dependsOn:
+        - CalculateWindows
+      jobs:
+      - template: /eng/ci/templates/official/jobs/merge-jittrace.yml@self
         parameters:
-          functionAppName: HelloHttpNet9
-          description: .NET9 Web Application
-          os: Linux
-          runInstances: 
-            items: ${{ split(variables.runInstances, ',') }}
-      - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
+          os: Windows
+
+    - stage: MergeLinuxJitTraceFiles
+      displayName: Create jit trace(Linux)
+      condition: and(succeeded(), eq('${{ parameters.createJitTrace }}', true))
+      dependsOn:
+        - CalculateLinux
+      jobs:
+      - template: /eng/ci/templates/official/jobs/merge-jittrace.yml@self
         parameters:
-          functionAppName: HelloHttpNet9NoProxy
-          description: .NET9 Worker Application
           os: Linux
-          runInstances: 
-            items: ${{ split(variables.runInstances, ',') }}

--- a/eng/ci/host.coldstart.yml
+++ b/eng/ci/host.coldstart.yml
@@ -36,7 +36,7 @@ parameters:
 - name: netTraceCollectArguments
   displayName: DotNet trace profile collection arguments (Valid only if "Collect DotNet trace" is true)). Example `-n Microsoft.Azure.WebJobs.Script.WebHost --profile cpu-sampling --duration 00:00:00:10`
   type: string
-  default: '-n Microsoft.Azure.WebJobs.Script.WebHost --providers Microsoft-Diagnostics-DiagnosticSource:0xfffffffffffff7ff:5,Microsoft-Windows-DotNETRuntime:0x10:5,Microsoft-Windows-DotNETRuntime:0x4000080018:5,FunctionsSystemLogsEventSource:0xFFFFFFFFFFFFFFFF:5 --stopping-event-provider-name Microsoft-Diagnostics-DiagnosticSource --stopping-event-event-name Activity1/Stop'
+  default: '-n Microsoft.Azure.WebJobs.Script.WebHost --providers Microsoft-Diagnostics-DiagnosticSource:0xfffffffffffff7ff:5,Microsoft-Windows-DotNETRuntime:0xC0001801F9:5,FunctionsSystemLogsEventSource:0xFFFFFFFFFFFFFFFF:5 --stopping-event-provider-name Microsoft-Diagnostics-DiagnosticSource --stopping-event-event-name Activity1/Stop'
 - name: createJitTrace
   displayName: Create Jit trace (Ensure "Collect DotNet trace" is set to true)
   type: boolean

--- a/eng/ci/templates/official/jobs/merge-jittrace.yml
+++ b/eng/ci/templates/official/jobs/merge-jittrace.yml
@@ -1,0 +1,56 @@
+parameters:
+- name: os
+  type: string
+  default: Windows
+  values:
+    - Windows
+    - Linux
+- name: functionAppNames
+  type: object
+  default:
+    - HelloHttpNet9
+    - HelloHttpNet9NoProxy
+    - HelloHttpNode
+
+jobs:
+- job: ${{ parameters.os }}
+  pool:
+    name: 1es-pool-azfunc-benchmarking-large
+    image: 1es-windows-2022-benchmark-runner-vanilla
+    os: windows
+
+  variables:
+    mergedJitTraceOutputDirectory: $(Build.ArtifactStagingDirectory)/MergedJitTraces
+    mergedJitTraceFilePath: $(mergedJitTraceOutputDirectory)/$(Build.BuildNumber)_${{ parameters.os }}_coldstart.jittrace
+
+  templateContext:
+    outputParentDirectory: $(Build.ArtifactStagingDirectory)
+    outputs:
+    - output: pipelineArtifact
+      displayName: Publish benchmark results
+      path: $(mergedJitTraceFilePath)
+      artifact: Functions_JitTrace_${{ parameters.os }}
+
+  steps:
+    - pwsh: |
+        New-Item -ItemType Directory -Path $(mergedJitTraceOutputDirectory)
+      displayName: Create directories
+
+    - ${{ each functionApp in parameters.functionAppNames }}:
+      - task: DownloadPipelineArtifact@2
+        displayName: Download PerfTraceData artifacts for ${{ parameters.os }} ${{ functionApp }}
+        inputs:
+          artifact: AzFunc_${{ parameters.os }}_${{ functionApp }}
+          patterns: '**/*.jittrace'
+          path: '$(Pipeline.Workspace)/${{ parameters.os }}_jittrace/${{ functionApp }}'
+        continueOnError: true
+
+    - pwsh: |
+        $output = "$(mergedJitTraceFilePath)"
+        $files = Get-ChildItem -Path "$(Pipeline.Workspace)/${{ parameters.os }}_jittrace" -Recurse -Filter *.jittrace
+        Write-Host "Merging the following .jittrace files:"
+        $files | ForEach-Object { Write-Host $_.FullName }
+        $files | Get-Content | Sort-Object | Get-Unique | Set-Content $output
+        $lineCount = (Get-Content $output | Measure-Object -Line).Lines
+        Write-Host "Final merged file line count: $lineCount"
+      displayName: Merge all .jittrace files ${{ parameters.os }}

--- a/eng/ci/templates/official/jobs/merge-jittrace.yml
+++ b/eng/ci/templates/official/jobs/merge-jittrace.yml
@@ -50,7 +50,7 @@ jobs:
         $files = Get-ChildItem -Path "$(Pipeline.Workspace)/${{ parameters.os }}_jittrace" -Recurse -Filter *.jittrace
         Write-Host "Merging the following .jittrace files:"
         $files | ForEach-Object { Write-Host $_.FullName }
-        $files | Get-Content | Sort-Object | Get-Unique | Set-Content $output
+        $files | Get-Content | Sort-Object -Unique | Set-Content $output
         $lineCount = (Get-Content $output | Measure-Object -Line).Lines
         Write-Host "Final merged file line count: $lineCount"
       displayName: Merge all .jittrace files ${{ parameters.os }}

--- a/eng/ci/templates/official/jobs/run-coldstart.yml
+++ b/eng/ci/templates/official/jobs/run-coldstart.yml
@@ -17,6 +17,14 @@ parameters:
 - name: perfViewCollectArguments
   type: string
   default: ''
+- name: collectNetTrace
+  type: boolean
+  default: false
+- name: netTraceCollectArguments
+  type: string
+- name: createJitTrace
+  type: boolean
+  default: false
 
 jobs:
 - job: ${{ parameters.functionAppName }}_${{ parameters.instanceId }}
@@ -24,11 +32,17 @@ jobs:
   pool:
     name: 1es-pool-azfunc-benchmarking
     ${{ if eq(parameters.os, 'Linux') }}:
-      image: 1es-ubuntu-22.04-benchmark-runner-vanilla
-      os: linux 
+      os: linux
+      ${{ if and(eq(parameters.createJitTrace, true), eq(parameters.instanceId, '1')) }}:
+        image: 1es-ubuntu-22.04-mms-benchmark-coreclr-builder
+      ${{ else }}:
+        image: 1es-ubuntu-22.04-benchmark-runner-vanilla
     ${{ else }}:
-      image: 1es-windows-2022-benchmark-runner-vanilla
       os: windows
+      ${{ if and(eq(parameters.createJitTrace, true), eq(parameters.instanceId, '1')) }}:
+        image: 1es-windows-2022-mms-benchmark-coreclr-builder
+      ${{ else }}:
+        image: 1es-windows-2022-benchmark-runner-vanilla
 
   variables:
     functionAppOutputPath: $(Build.BinariesDirectory)/Published/${{ parameters.functionAppName }}
@@ -37,58 +51,111 @@ jobs:
     logsDirectory: $(Build.ArtifactStagingDirectory)/Logs
     stdOutLogsFilePath: $(logsDirectory)/std_out_logs.txt
     stdErrorLogsFilePath: $(logsDirectory)/std_error_logs.txt
-    FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
-    FUNCTIONS_WORKER_RUNTIME_VERSION: '9.0'
+    ${{ if or(eq(parameters.functionAppName, 'HelloHttpNet9'), eq(parameters.functionAppName, 'HelloHttpNet9NoProxy')) }}:
+      FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
+      FUNCTIONS_WORKER_RUNTIME_VERSION: '9.0'
+    ${{ if eq(parameters.functionAppName, 'HelloHttpNode') }}:
+      FUNCTIONS_WORKER_RUNTIME: 'node'
+      WEBSITE_RUN_FROM_PACKAGE: '1' # Node app needs this to use placeholder channel.
     AzureWebJobsScriptRoot: '$(functionAppOutputPath)'
     perfViewPath: C:\.tools\perfview\perfview.exe 
     traceDirectory: $(Build.ArtifactStagingDirectory)/out
+    netTraceDirectory: $(traceDirectory)/nettrace
     traceFileNameWithoutExtension: PerfViewData_$(Build.BuildNumber)_${{ parameters.functionAppName }}
     traceFileName: $(traceFileNameWithoutExtension).etl
     traceFileZipName: $(traceFileName).zip
     traceFilePath: $(traceDirectory)/$(traceFileName)
     traceZipFilePath: $(traceDirectory)/$(traceFileZipName)
-    traceAnalysisResultsDirectory: $(traceDirectory)/results
+    traceAnalysisResultsDirectory: $(netTraceDirectory)/results
     traceAnalysisResultMarkdownFilePath: $(traceAnalysisResultsDirectory)/$(traceFileNameWithoutExtension).md
     traceLogPath: $(logsDirectory)/logs.log
     ${{ if eq(parameters.os, 'Linux') }}:
       publishRid: linux-x64
     ${{ if eq(parameters.os, 'Windows') }}:
       publishRid: win-x64
+    ${{ if and(eq(parameters.collectNetTrace, true), eq(parameters.instanceId, '1')) }}:
+      netTraceFileNameWithoutExtension: azfunc_${{ parameters.functionAppName }}_${{ parameters.os }}_${{ parameters.instanceId }}
+      netTraceFileName: $(netTraceFileNameWithoutExtension).nettrace
+      netTraceFilePath: $(netTraceDirectory)/$(netTraceFileName)
+      netTraceAnalysisResultsMarkdownFilePath: $(netTraceDirectory)/results/$(netTraceFileNameWithoutExtension).md
+      # For JIT trace generation, ensure the trace is collected from an app with authentication enabled (as done by the SLA site).
+    ${{ if and(eq(parameters.createJitTrace, true), eq(parameters.instanceId, '1')) }}:
+      warmupApiUrl: http://localhost:5000  # For JIT trace generation case, we call the home page instead of the api/warmup endpoint to ensure the host is up and running.
+      WEBSITE_SITE_NAME: PGO_${{ parameters.functionAppName }}_${{ parameters.os }}
+      benchmarkAppBuildConstants: "-p:DefineConstants=AUTH_FUNCTION" # To publish the function app with authentication enabled.
+      functionInvocationUrl: http://localhost:5000/api/HelloAuth?forcespecialization=1&code=test
+    ${{ else }}:
+      warmupApiUrl: http://localhost:5000/api/warmup?restart=1
+      functionInvocationUrl: http://localhost:5000/api/Hello?forcespecialization=1
+      benchmarkAppBuildConstants: ""
 
-  ${{ if and(eq(parameters.collectPerfViewProfileOnWindows, true), eq(parameters.instanceId, '1')) }}: # profile collection is only on the first instance
+  ${{ if and(or(eq(parameters.collectPerfViewProfileOnWindows, true), eq(parameters.collectNetTrace, true)), eq(parameters.instanceId, '1')) }}:
     templateContext:
       outputParentDirectory: $(traceDirectory)
       outputs:
         - output: pipelineArtifact
-          displayName: Publish PerfView profile
-          path: $(traceZipFilePath)
-          artifact: PerfViewData_${{ parameters.functionAppName }}
-        - output: pipelineArtifact
-          displayName: Publish ColdStart Analysis Result
-          path: $(traceAnalysisResultsDirectory)
-          artifact: ColdStartProfileAnalysisResult_${{ parameters.functionAppName }}
+          displayName: Publish Trace artifacts
+          path: $(traceDirectory)
+          artifact: AzFunc_${{ parameters.os }}_${{ parameters.functionAppName }}
+          condition:: always()
 
   steps:
+
+  # # For JIT trace generation, ensure the app is configured with a storage account so the authentication flow can be executed end-to-end.
+  - ${{ if and(eq(parameters.createJitTrace, true), eq(parameters.instanceId, '1')) }}:
+    - task: AzureKeyVault@2
+      inputs:
+        azureSubscription: Azure-Functions-Host-CI-internal
+        KeyVaultName: azure-functions-perf
+        SecretsFilter: PGO-APP-AZURE-WEBJOBS-STORAGE
+        RunAsPreJob: false
+
   - template: /eng/ci/templates/install-dotnet.yml@self
 
-  - task: CopyFiles@2
-    displayName: Copy benchmark apps to temp location
+  - task: UseDotNet@2 
+    displayName: Install .NET 10
     inputs:
-      SourceFolder: '$(Build.SourcesDirectory)/test/Performance/Apps'
-      Contents: '**/*'
-      TargetFolder: '$(Build.ArtifactStagingDirectory)/PerformanceTestApps'
-      CleanTargetFolder: true
+      packageType: sdk
+      version: 10.x
+      includePreviewVersions: true
 
-  - task: DotNetCoreCLI@2
-    displayName: Publish benchmark app
-    inputs:
-      command: publish
-      publishWebProjects: false
-      zipAfterPublish: false
-      modifyOutputPath: false
-      projects: '$(Build.ArtifactStagingDirectory)/PerformanceTestApps/${{ parameters.functionAppName }}/HelloHttp.csproj'
-      arguments: -c Release -o $(functionAppOutputPath) -f net9.0 -r $(publishRid)
-      workingDirectory: $(Build.ArtifactStagingDirectory)/PerformanceTestApps/${{ parameters.functionAppName }}
+  - ${{ if eq(parameters.functionAppName, 'HelloHttpNode') }}:
+    - task: CopyFiles@2
+      displayName: Copy node js app content to script root dir
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)/test/Performance/Apps/HelloHttpNode'
+        Contents: '**/*'
+        TargetFolder: '$(functionAppOutputPath)'
+        CleanTargetFolder: true
+
+    - task: UseNode@1
+      displayName: Install Node.js
+      inputs:
+        version: '18.x'
+
+    - script: npm install
+      displayName: Run npm install for HelloHttpNode
+      workingDirectory: '$(functionAppOutputPath)'
+
+  - ${{ if or(eq(parameters.functionAppName, 'HelloHttpNet9'), eq(parameters.functionAppName, 'HelloHttpNet9NoProxy')) }}:
+    - task: CopyFiles@2
+      displayName: Copy benchmark apps to temp location
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)/test/Performance/Apps'
+        Contents: '**/*'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)/PerformanceTestApps'
+        CleanTargetFolder: true
+
+    - task: DotNetCoreCLI@2
+      displayName: Publish benchmark app
+      inputs:
+        command: publish
+        publishWebProjects: false
+        zipAfterPublish: false
+        modifyOutputPath: false
+        projects: '$(Build.ArtifactStagingDirectory)/PerformanceTestApps/${{ parameters.functionAppName }}/HelloHttp.csproj'
+        arguments: -c Release -o $(functionAppOutputPath) -f net9.0 -r $(publishRid) $(benchmarkAppBuildConstants)
+        workingDirectory: $(Build.ArtifactStagingDirectory)/PerformanceTestApps/${{ parameters.functionAppName }}
 
   - task: DotNetCoreCLI@2
     displayName: Publish host
@@ -102,9 +169,10 @@ jobs:
       workingDirectory: $(Build.SourcesDirectory)/src/WebJobs.Script.WebHost
 
   - pwsh: |
-      Write-Host "Creating log directory: $(logsDirectory)"
       New-Item -ItemType Directory -Path $(logsDirectory)
-    displayName: Create log directory
+      New-Item -ItemType Directory -Path $(traceDirectory)
+      New-Item -ItemType Directory -Path $(netTraceDirectory)
+    displayName: Create directories
 
   - ${{ if eq(parameters.os, 'Windows') }}:
     - pwsh: |
@@ -113,18 +181,23 @@ jobs:
         Write-Host "Started process ID: $($process.Id)"
         echo $process.Id > $(Build.ArtifactStagingDirectory)/hostProcessId.txt
       displayName: Start host in placeholder mode
+      ${{ if and(eq(parameters.createJitTrace, true), eq(parameters.instanceId, '1')) }}:
+        env:
+          AzureWebJobsStorage: $(PGO-APP-AZURE-WEBJOBS-STORAGE)
   - ${{ else }}:
     - script: |
         # In Azure DevOps, when variables convert into environment variables, variable names become uppercase, and periods turn into underscores.
         # This works for windows when getting the env variable value, but fails on linux. So we need to pass the variable value using correct case.
         # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#environment-variables
         export AzureWebJobsScriptRoot="$(functionAppOutputPath)"
-        nohup dotnet $(hostAssemblyPath) > $(stdOutLogsFilePath) 2> $(stdErrorLogsFilePath) &
+        nohup $(hostOutputPath)/Microsoft.Azure.WebJobs.Script.WebHost > $(stdOutLogsFilePath) 2> $(stdErrorLogsFilePath) &
         echo $! > $(Build.ArtifactStagingDirectory)/hostProcessId.txt
       displayName: Start host in placeholder mode
-
-  - pwsh: |     
-      $url = "http://localhost:5000/api/warmup?restart=1"
+      ${{ if and(eq(parameters.createJitTrace, true), eq(parameters.instanceId, '1')) }}:
+        env:
+          AzureWebJobsStorage: $(PGO-APP-AZURE-WEBJOBS-STORAGE)
+  - pwsh: |
+      $url = "$(warmupApiUrl)"
       Write-Host "Checking if host is ready at $url..."
       $maxAttempts = 10
 
@@ -156,8 +229,35 @@ jobs:
       env:
         COLLECT_ARGUMENTS: ${{ parameters.perfViewCollectArguments }}
 
+  - ${{ if and(eq(parameters.collectNetTrace, true), eq(parameters.instanceId, '1'), eq(parameters.os, 'Windows')) }}:
+    - pwsh: |
+        dotnet tool install --global dotnet-trace
+        $dotnetToolPath = [System.IO.Path]::Combine($env:USERPROFILE, ".dotnet", "tools")
+        $dotnetTraceExecutable = Join-Path $dotnetToolPath "dotnet-trace.exe"
+        $collectArguments = ${env:COLLECT_ARGUMENTS}
+        $arguments = "collect $collectArguments -o $(netTraceFilePath)"
+        Write-Host "Starting dotnet trace with command '$arguments'..."
+        Start-Process -FilePath $dotnetTraceExecutable -ArgumentList $arguments -NoNewWindow
+      displayName: "Start dotnet trace"
+      env:
+        COLLECT_ARGUMENTS: ${{ parameters.netTraceCollectArguments }}
+
+  - ${{ if and(eq(parameters.collectNetTrace, true), eq(parameters.instanceId, '1'), eq(parameters.os, 'Linux')) }}:
+    - pwsh: |
+        dotnet tool install --global dotnet-trace
+        $dotnetToolPath = Join-Path -Path $env:HOME -ChildPath ".dotnet/tools"
+        $dotnetTraceExecutable = Join-Path -Path $dotnetToolPath -ChildPath "dotnet-trace"
+        $collectArguments = ${env:COLLECT_ARGUMENTS}
+        # $arguments = "collect -n Microsoft.Azure.WebJobs.Script.WebHost --providers Microsoft-Diagnostics-DiagnosticSource:0xfffffffffffff7ff:5,Microsoft-Windows-DotNETRuntime:0x10:5,Microsoft-Windows-DotNETRuntime:0x4000080018:5 --stopping-event-provider-name Microsoft-Diagnostics-DiagnosticSource --stopping-event-event-name Activity1/Stop -o $(netTraceFilePath)"
+        $arguments = "collect $collectArguments -o $(netTraceFilePath)"
+        echo "Starting dotnet trace with command '$arguments'..."
+        bash -c "nohup $dotnetTraceExecutable $arguments > /dev/null 2>&1 &"
+      displayName: "Start dotnet trace"
+      env:
+        COLLECT_ARGUMENTS: ${{ parameters.netTraceCollectArguments }}
+
   - pwsh: |
-      $helloUrl = "http://localhost:5000/api/hello?forcespecialization=1"
+      $helloUrl = "$(functionInvocationUrl)"
       Write-Host "Calling $helloUrl"
 
       $duration = Measure-Command {
@@ -215,6 +315,7 @@ jobs:
 
   - ${{ if eq(parameters.os, 'Windows') }}:
     - pwsh: |
+        Start-Sleep -Seconds 30 # Waiting 30 seconds before stopping the host is a test-and-tried good value based on testing so far; this helps ensure dotnet trace has time to finish and the trace file is complete.
         $processIdFile = "$(Build.ArtifactStagingDirectory)/hostProcessId.txt"
         if (Test-Path $processIdFile) {
             $processId = Get-Content $processIdFile
@@ -228,6 +329,7 @@ jobs:
 
   - ${{ if eq(parameters.os, 'Linux') }}:
     - script: |
+        sleep 30 # Waiting 30 seconds before stopping the host is a test-and-tried good value based on testing so far; this helps ensure dotnet trace has time to finish and the trace file is complete.
         processIdFile="$(Build.ArtifactStagingDirectory)/hostProcessId.txt"
         if [ -f "$processIdFile" ]; then
             processId=$(cat $processIdFile)
@@ -247,3 +349,50 @@ jobs:
       Get-Content $(stdErrorLogsFilePath)
     displayName: Print logs
     condition: always()
+
+  - ${{ if and(eq(parameters.collectNetTrace, true), eq(parameters.instanceId, '1')) }}:
+    - pwsh: |
+        Write-Host "Checking '$(netTraceFileName)' file is generated inside '$(netTraceDirectory)'"
+        $maxAttempts = 10
+        $attempt = 0
+
+        while ($attempt -lt $maxAttempts) {
+            Start-Sleep -Seconds 15
+            $files = Get-ChildItem -Path $(netTraceDirectory)
+            $fileCount = $files.Count
+            Write-Host "Found $fileCount files in $(netTraceDirectory)"
+            if ($fileCount -eq 1 -and $files[0].Name -eq '$(netTraceFileName)') {
+                Write-Host "Found expected .nettrace file: $($files[0].Name)"
+                break
+            } else {
+                Write-Host "Expected .nettrace file not found. Rechecking again in 30 seconds..."
+                $attempt++
+            }
+        }  
+      displayName: Wait until trace file is created
+
+    - pwsh: |
+        dotnet tool install -g Microsoft.Azure.Functions.ColdStartProfileAnalyzer --prerelease
+        $analyzerArgs = ${env:ANALYZER_ARGS}
+        Write-Host "Invoking with arguments --file $(netTraceFilePath) --format markdown text $analyzerArgs"
+        func-cold-start-analyzer --file $(netTraceFilePath) --format markdown text $analyzerArgs
+      displayName: Generate JIT trace
+      ${{ if and(eq(parameters.createJitTrace, true), eq(parameters.instanceId, '1')) }}:
+        env:
+          ANALYZER_ARGS: --generate-jittrace
+
+    - pwsh: |
+        Get-ChildItem -Path "$(netTraceDirectory)"
+      displayName: List contents of netTraceDirectory
+
+    - pwsh: |
+        if (Test-Path $(netTraceAnalysisResultsMarkdownFilePath)) {
+            Write-Host "Analysis result file is present at $(netTraceAnalysisResultsMarkdownFilePath)"
+            Write-Host "##vso[task.addattachment type=Distributedtask.Core.Summary;name=$env:OS $env:FUNCTION_APP_NAME;]$(netTraceAnalysisResultsMarkdownFilePath)"
+        } else {
+            Write-Host "Analysis result file is not present at $(netTraceAnalysisResultsMarkdownFilePath)"
+        }
+      displayName: Upload analysis result
+      env:
+        FUNCTION_APP_NAME: ${{ parameters.functionAppName }}
+        OS: ${{ parameters.os }}

--- a/release_notes.md
+++ b/release_notes.md
@@ -5,3 +5,4 @@
 -->
 - Memory allocation optimizations in `ScriptStartupTypeLocator.GetExtensionsStartupTypesAsync` (#11012)
 - Fix invocation timeout when incoming request contains "x-ms-invocation-id" header (#10980)
+- Added support for collecting cross-platform perf traces and generating PGO JIT traces (#11062)

--- a/test/Performance/Apps/HelloHttpNet9/Hello.cs
+++ b/test/Performance/Apps/HelloHttpNet9/Hello.cs
@@ -7,8 +7,13 @@ namespace HelloHttpNet9
 {
     public sealed class Hello(ILogger<Hello> logger)
     {
+#if AUTH_FUNCTION
+        [Function("HelloAuth")]
+        public IActionResult Run([HttpTrigger(AuthorizationLevel.Function, "get", "post")] HttpRequest req)
+#else
         [Function("Hello")]
         public IActionResult Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequest req)
+#endif
         {
             logger.LogInformation("C# HTTP trigger function processed a request.");
             return new OkObjectResult("Welcome to Azure Functions!");

--- a/test/Performance/Apps/HelloHttpNet9NoProxy/Hello.cs
+++ b/test/Performance/Apps/HelloHttpNet9NoProxy/Hello.cs
@@ -7,8 +7,13 @@ namespace HelloHttpNet9
 {
     public sealed class Hello(ILogger<Hello> logger)
     {
+#if AUTH_FUNCTION
+        [Function("HelloAuth")]
+        public HttpResponseData Run([HttpTrigger(AuthorizationLevel.Function, "get", "post")] HttpRequestData req)
+#else
         [Function("Hello")]
         public HttpResponseData Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req)
+#endif        
         {
             logger.LogInformation("C# HTTP trigger function processed a request.");
 

--- a/test/Performance/Apps/HelloHttpNode/host.json
+++ b/test/Performance/Apps/HelloHttpNode/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/test/Performance/Apps/HelloHttpNode/package-lock.json
+++ b/test/Performance/Apps/HelloHttpNode/package-lock.json
@@ -1,0 +1,66 @@
+{
+  "name": "nodeapp",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nodeapp",
+      "version": "1.0.0",
+      "dependencies": {
+        "@azure/functions": "^4.0.0"
+      },
+      "devDependencies": {}
+    },
+    "node_modules/@azure/functions": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.7.0.tgz",
+      "integrity": "sha512-y1caGX6LYrA7msAckQVb/quFOhWHSPiGzWfIML17t0ee2ydpinJTBF+Sti+URfLAH63dtmXJR4meraZkhhK9tw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.7.0",
+        "long": "^4.0.0",
+        "undici": "^5.13.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    }
+  }
+}

--- a/test/Performance/Apps/HelloHttpNode/package.json
+++ b/test/Performance/Apps/HelloHttpNode/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "nodeapp",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "start": "func start",
+    "test": "echo \"No tests yet...\""
+  },
+  "dependencies": {
+    "@azure/functions": "^4.0.0"
+  },
+  "devDependencies": {},
+  "main": "src/{index.js,functions/*.js}"
+}

--- a/test/Performance/Apps/HelloHttpNode/src/functions/Hello.js
+++ b/test/Performance/Apps/HelloHttpNode/src/functions/Hello.js
@@ -1,0 +1,13 @@
+const { app } = require('@azure/functions');
+
+app.http('Hello', {
+    methods: ['GET', 'POST'],
+    authLevel: 'anonymous',
+    handler: async (request, context) => {
+        context.log(`Http function processed request for url "${request.url}"`);
+
+        const name = request.query.get('name') || await request.text() || 'world';
+
+        return { body: `Hello, ${name}!` };
+    }
+});

--- a/test/Performance/Apps/HelloHttpNode/src/functions/HelloAuth.js
+++ b/test/Performance/Apps/HelloHttpNode/src/functions/HelloAuth.js
@@ -1,0 +1,13 @@
+const { app } = require('@azure/functions');
+
+app.http('HelloAuth', {
+    methods: ['GET', 'POST'],
+    authLevel: 'function',
+    handler: async (request, context) => {
+        context.log(`Http function processed request for url "${request.url}"`);
+
+        const name = request.query.get('name') || await request.text() || 'world';
+
+        return { body: `Hello, ${name}!` };
+    }
+});

--- a/test/Performance/Apps/HelloHttpNode/src/index.js
+++ b/test/Performance/Apps/HelloHttpNode/src/index.js
@@ -1,0 +1,5 @@
+const { app } = require('@azure/functions');
+
+app.setup({
+    enableHttpStream: true,
+});


### PR DESCRIPTION
Enable cross-platform performance trace collection and PGO JIT trace generation.

1. Introduced a Node.js HTTP application to the test matrix for performance trace collection. This app is disabled by default, but can be enabled when running the pipeline.
2. Added a pipeline stage to merge and deduplicate JIT traces generated from multiple applications (currently supporting three apps).

UI experience

<img width="385" alt="image" src="https://github.com/user-attachments/assets/5c7df58d-f98e-40d2-9f9c-1979bd39e237" />

Sample run from this PR: https://azfunc.visualstudio.com/internal/_build/results?buildId=219404&view=results

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)
