### PR TITLE
Add ability to publish private site ext in host.public build

### DIFF
--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -1,5 +1,11 @@
 # This build is used for public PR and CI builds.
 
+parameters:
+- name: privateSiteExt
+  displayName: Build private site extension
+  type: boolean
+  default: false
+
 trigger:
   batch: true
   branches:
@@ -64,3 +70,9 @@ extends:
     - stage: Test
       jobs:
       - template: /eng/ci/templates/jobs/run-unit-tests.yml@self
+
+    - ${{ if eq(parameters.privateSiteExt, true) }}:
+      - stage: Build
+        dependsOn: []
+        jobs:
+        - template: /eng/ci/templates/jobs/build-private-site-ext.yml@self

--- a/eng/ci/templates/jobs/build-private-site-ext.yml
+++ b/eng/ci/templates/jobs/build-private-site-ext.yml
@@ -1,0 +1,29 @@
+jobs:
+- job: PrivateSiteExt
+  displayName: Build Private Site Extension
+
+  variables:
+    drop_path: $(Build.ArtifactStagingDirectory)
+    site_ext_path: $(drop_path)/site_ext
+    windows_drop_path: $(drop_path)/windows
+
+  templateContext:
+    outputParentDirectory: $(drop_path)
+    outputs:
+    - output: pipelineArtifact
+      displayName: Publish windows artifacts
+      path: $(windows_drop_path)
+      artifact: drop_windows
+
+  steps:
+  - template: /eng/ci/templates/install-dotnet.yml@self
+  - template: /eng/ci/templates/steps/build-site-ext.yml@self
+    parameters:
+      publishDir: $(site_ext_path)
+
+  - pwsh: |
+      cd $(site_ext_path) | Out-Null
+      New-Item -Path $(windows_drop_path) -ItemType Directory -Force | Out-Null
+      ./New-PrivateSiteExtension.ps1 -OutputPath '$(windows_drop_path)' -AppendOutputName
+      Write-Host "##vso[build.addbuildtag]private-site-ext"
+    displayName: Compress private site extension

--- a/src/WebJobs.Script.SiteExtension/New-PrivateSiteExtension.ps1
+++ b/src/WebJobs.Script.SiteExtension/New-PrivateSiteExtension.ps1
@@ -17,6 +17,9 @@
     .PARAMETER NoZip
     [Switch] Include to produce site extension as a folder and not a zip.
 
+    .PARAMETER AppendOutputName
+    [Switch] Used when supplying OutputPath to append the name of the private site extension to the OutputPath.
+
     .PARAMETER Force
     [Switch] Include to overwrite existing files.
 
@@ -32,6 +35,7 @@ param (
     [string] $OutputPath = $null,
     [ValidateSet('x64', '64bit', 'x86', '32bit')][string] $Bitness = '64bit',
     [switch] $NoZip,
+    [switch] $AppendOutputName,
     [switch] $Force
 )
 
@@ -61,12 +65,13 @@ if (-not (Join-Path $InputPath "extension.xml" | Test-Path))
     exit 1
 }
 
-if (-not $OutputPath)
+if ($AppendOutputName || !$OutputPath)
 {
     $runtime = $Bitness -eq '32bit' ? 'win-x86' : 'win-x64'
     $leaf = (Split-Path $InputPath -Leaf)
     $split = $leaf.IndexOf('.')
-    $OutputPath = "$($leaf.Substring(0, $split)).Private.$($leaf.Substring($split + 1)).$runtime"
+    $OutputPath = [System.IO.Path]::Combine(
+        $OutputPath, "$($leaf.Substring(0, $split)).Private.$($leaf.Substring($split + 1)).$runtime")
 }
 
 function New-TemporaryDirectory {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Adds the option to build the private site extension in the public build. This is only built during a manual build and the `[ ] Build private site extension` is checked off (default false)

Example run with private site ext: https://dev.azure.com/azfunc/public/_build/results?buildId=219220&view=results
