### PR TITLE
Optimizing ReadLanguageWorkerFile to avoid LOH allocations by reading files in chunks

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,3 +7,4 @@
 - Fix invocation timeout when incoming request contains "x-ms-invocation-id" header (#10980)
 - Warn if .azurefunctions folder does not exist (#10967)
 - Memory allocation & CPU optimizations in `GrpcMessageExtensionUtilities.ConvertFromHttpMessageToExpando` (#11054)
+- Memory allocation optimizations in `ReadLanguageWorkerFile` by reading files in buffered chunks, preventing LOH allocations (#11069)

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Workers.Profiles;
 using Microsoft.Extensions.Configuration;
@@ -357,13 +359,43 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         private void ReadLanguageWorkerFile(string workerPath)
         {
-            if (_environment.IsPlaceholderModeEnabled()
-                && !string.IsNullOrEmpty(_workerRuntime)
-                && File.Exists(workerPath))
+            if (!_environment.IsPlaceholderModeEnabled()
+                || string.IsNullOrWhiteSpace(_workerRuntime)
+                || !File.Exists(workerPath))
             {
-                // Read language worker file to avoid disk reads during specialization. This is only to page-in bytes.
-                File.ReadAllBytes(workerPath);
+                return;
             }
+
+            // Reads the file to warm up the operating system's file cache. Can run in the background.
+            _ = Task.Run(() =>
+            {
+                const int bufferSize = 4096;
+                var buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+
+                try
+                {
+                    using var fs = new FileStream(
+                        workerPath,
+                        FileMode.Open,
+                        FileAccess.Read,
+                        FileShare.Read,
+                        bufferSize,
+                        FileOptions.SequentialScan);
+
+                    while (fs.Read(buffer, 0, bufferSize) > 0)
+                    {
+                        // Do nothing. The goal is to read the file into the OS cache.
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Unexpected error warming up worker file: {filePath}", workerPath);
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(buffer);
+                }
+            });
         }
     }
 }


### PR DESCRIPTION

Optimized `RpcWorkerConfigFactory.ReadLanguageWorkerFile` to avoid LOH allocations by reading worker executable files in buffered chunks instead of using File.ReadAllBytes. The previous implementation loaded entire files into memory, resulting in LOH allocations and increased GC pressure. Since the method's main purpose is to preload files into the OS disk cache, reading in chunks achieves this efficiently, reducing memory usage and minimizing the likelihood of blocking GEN2 garbage collections.

### Visual Studio
#### Before

![image](https://github.com/user-attachments/assets/61bc76a0-ef3d-4fc9-a086-760785ccaa67)


#### After

![image](https://github.com/user-attachments/assets/4c4a47f0-3444-41ac-901b-aa3a344865c7)

### DotMemory

#### Before

<img width="753" alt="image" src="https://github.com/user-attachments/assets/3db091e3-af36-45ef-bbb1-2a916f2335c5" />

<img width="1180" alt="image" src="https://github.com/user-attachments/assets/e36b6f77-8537-4981-a78f-b31e498bb371" />


#### After

<img width="844" alt="image" src="https://github.com/user-attachments/assets/8ae3ec0b-edee-405e-ba68-acc7614b2c94" />
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/df9b5988-23a0-46ff-aeef-9160a7085ebf" />

With the previous approach, the 120MB+ LOH allocation would persist until the next Gen2 GC (blocking). Change in this PR reduces the likelihood of triggering a Gen2 GC by avoiding large object heap allocations.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
