### PR TITLE
Replace timer with while loop

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,3 +7,4 @@
 - Fix invocation timeout when incoming request contains "x-ms-invocation-id" header (#10980)
 - Warn if .azurefunctions folder does not exist (#10967)
 - Memory allocation & CPU optimizations in `GrpcMessageExtensionUtilities.ConvertFromHttpMessageToExpando` (#11054)
+- Replace `Timer` with `while`-loop in `FlexConsumptionMetricsPublisher` (#11071)

--- a/src/WebJobs.Script.WebHost/Metrics/FlexConsumptionMetricsPublisher.Lifecycle.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/FlexConsumptionMetricsPublisher.Lifecycle.cs
@@ -1,0 +1,60 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.Extensions;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
+{
+    public partial class FlexConsumptionMetricsPublisher
+    {
+        private sealed class Lifecycle : IDisposable
+        {
+            private readonly FlexConsumptionMetricsPublisher _parent;
+            private readonly TimeSpan _initialDelay;
+            private readonly TimeSpan _intervalDelay;
+            private readonly CancellationTokenSource _cts = new();
+
+            public Lifecycle(FlexConsumptionMetricsPublisher parent, TimeSpan initialDelay, TimeSpan intervalDelay)
+            {
+                _parent = parent;
+                _initialDelay = initialDelay;
+                _intervalDelay = intervalDelay;
+                PublishLoopAsync(_cts.Token).Forget();
+            }
+
+            public void Dispose()
+            {
+                if (!_cts.IsCancellationRequested)
+                {
+                    // IsCancellationRequested serves as a dispose check.
+                    _cts.Cancel();
+                }
+
+                _cts.Dispose();
+            }
+
+            private async Task PublishLoopAsync(CancellationToken cancellation)
+            {
+                try
+                {
+                    ValueStopwatch stopwatch = ValueStopwatch.StartNew();
+                    await Task.Delay(_initialDelay, cancellation);
+                    while (!cancellation.IsCancellationRequested)
+                    {
+                        await _parent.OnPublishMetrics(DateTime.UtcNow, stopwatch);
+                        stopwatch = ValueStopwatch.StartNew();
+                        await Task.Delay(_intervalDelay, cancellation);
+                    }
+                }
+                catch (Exception ex) when (!ex.IsFatal())
+                {
+                    // swallow
+                }
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Metrics/FlexConsumptionMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/FlexConsumptionMetricsPublisher.cs
@@ -2,41 +2,33 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.IO;
 using System.IO.Abstractions;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
-using Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions;
 using Microsoft.Azure.WebJobs.Script.Metrics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
 {
-    public class FlexConsumptionMetricsPublisher : IMetricsPublisher, IDisposable
+    public sealed partial class FlexConsumptionMetricsPublisher : IMetricsPublisher, IDisposable
     {
         private readonly IOptionsMonitor<StandbyOptions> _standbyOptions;
         private readonly FlexConsumptionMetricsPublisherOptions _options;
         private readonly IEnvironment _environment;
         private readonly ILogger<FlexConsumptionMetricsPublisher> _logger;
         private readonly IHostMetricsProvider _metricsProvider;
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
         private readonly IFileSystem _fileSystem;
         private readonly LegionMetricsFileManager _metricsFileManager;
 
-        private Timer _metricsPublisherTimer;
-        private bool _started = false;
         private DateTime _currentActivityIntervalStart;
         private DateTime _activityIntervalHighWatermark = DateTime.MinValue;
-        private ValueStopwatch _intervalStopwatch;
         private IDisposable _standbyOptionsOnChangeSubscription;
-        private TimeSpan _metricPublishInterval;
-        private TimeSpan _initialPublishDelay;
         private DateTime _lastPublishTime = DateTime.UtcNow;
+        private Lifecycle _lifecycle;
 
         public FlexConsumptionMetricsPublisher(IEnvironment environment, IOptionsMonitor<StandbyOptions> standbyOptions, IOptions<FlexConsumptionMetricsPublisherOptions> options,
             ILogger<FlexConsumptionMetricsPublisher> logger, IFileSystem fileSystem, IHostMetricsProvider metricsProvider)
@@ -71,29 +63,43 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
 
         internal LegionMetricsFileManager MetricsFileManager => _metricsFileManager;
 
+        private bool IsStarted => _lifecycle is not null;
+
         public void Start()
         {
-            Initialize();
+            if (_lifecycle is not null)
+            {
+                return;
+            }
 
-            _logger.LogInformation($"Starting metrics publisher (AlwaysReady={IsAlwaysReady}, MetricsPath='{_metricsFileManager.MetricsFilePath}').");
+            lock (_lock)
+            {
+                if (_lifecycle is not null)
+                {
+                    return;
+                }
 
-            _metricsPublisherTimer = new Timer(OnFunctionMetricsPublishTimer, null, _initialPublishDelay, _metricPublishInterval);
-            _started = true;
+                IsAlwaysReady = _environment
+                    .GetEnvironmentVariable(EnvironmentSettingNames.FunctionsAlwaysReadyInstance) == "1";
+
+                _logger.LogInformation(
+                    $"Starting metrics publisher (AlwaysReady={IsAlwaysReady},"
+                    + $" MetricsPath='{_metricsFileManager.MetricsFilePath}').");
+
+                _lifecycle = new(
+                    this,
+                    TimeSpan.FromMilliseconds(_options.InitialPublishDelayMS),
+                    TimeSpan.FromMilliseconds(_options.MetricsPublishIntervalMS));
+            }
         }
 
-        /// <summary>
-        /// Initialize any environmentally derived state after specialization, prior to starting the publisher.
-        /// </summary>
-        internal void Initialize()
+        public void Dispose()
         {
-            _metricPublishInterval = TimeSpan.FromMilliseconds(_options.MetricsPublishIntervalMS);
-            _initialPublishDelay = TimeSpan.FromMilliseconds(_options.InitialPublishDelayMS);
-            _intervalStopwatch = ValueStopwatch.StartNew();
-
-            IsAlwaysReady = _environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsAlwaysReadyInstance) == "1";
+            Interlocked.Exchange(ref _lifecycle, null)?.Dispose();
+            Interlocked.Exchange(ref _standbyOptionsOnChangeSubscription, null)?.Dispose();
         }
 
-        internal async Task OnPublishMetrics(DateTime now)
+        internal async Task OnPublishMetrics(DateTime now, ValueStopwatch stopwatch)
         {
             try
             {
@@ -122,7 +128,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
                 {
                     metrics = new Metrics
                     {
-                        TotalTimeMS = (long)_intervalStopwatch.GetElapsedTime().TotalMilliseconds,
+                        TotalTimeMS = (long)stopwatch.GetElapsedTime().TotalMilliseconds,
                         ExecutionCount = FunctionExecutionCount,
                         ExecutionTimeMS = FunctionExecutionTimeMS,
                         IsAlwaysReady = IsAlwaysReady,
@@ -149,15 +155,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
                 // ensure no background exceptions escape
                 _logger.LogError(ex, $"Error publishing metrics.");
             }
-            finally
-            {
-                _intervalStopwatch = ValueStopwatch.StartNew();
-            }
-        }
-
-        private async void OnFunctionMetricsPublishTimer(object state)
-        {
-            await OnPublishMetrics(DateTime.UtcNow);
         }
 
         private void OnStandbyOptionsChange()
@@ -175,7 +172,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
 
         internal void OnFunctionStarted(string functionName, string invocationId, DateTime now)
         {
-            if (!_started)
+            if (!IsStarted)
             {
                 return;
             }
@@ -199,7 +196,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
 
         internal void OnFunctionCompleted(string functionName, string invocationId, DateTime now)
         {
-            if (!_started)
+            if (!IsStarted)
             {
                 return;
             }
@@ -265,15 +262,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         private static double RoundUp(double metric, int granularity)
         {
             return Math.Ceiling(metric / granularity) * granularity;
-        }
-
-        public void Dispose()
-        {
-            _metricsPublisherTimer?.Dispose();
-            _metricsPublisherTimer = null;
-
-            _standbyOptionsOnChangeSubscription?.Dispose();
-            _standbyOptionsOnChangeSubscription = null;
         }
 
         internal class Metrics

--- a/test/WebJobs.Script.Tests/Metrics/FlexConsumptionMetricsPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/FlexConsumptionMetricsPublisherTests.cs
@@ -8,6 +8,7 @@ using System.IO.Abstractions;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
 using Microsoft.Azure.WebJobs.Script.WebHost.Metrics;
@@ -47,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
                 _metricsFilePath = null;
             }
 
-            var publisher = CreatePublisher(inStandbyMode: true);
+            using var publisher = CreatePublisher(inStandbyMode: true);
 
             var logs = _logger.GetLogMessages();
             var log = logs.Single();
@@ -62,32 +63,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             Assert.NotNull(log);
         }
 
-        private FlexConsumptionMetricsPublisher CreatePublisher(TimeSpan? metricsPublishInterval = null, bool inStandbyMode = false)
-        {
-            _standbyOptions = new StandbyOptions { InStandbyMode = inStandbyMode };
-            _standbyOptionsMonitor = new TestOptionsMonitor<StandbyOptions>(_standbyOptions);
-            _options = new FlexConsumptionMetricsPublisherOptions
-            {
-                // for these unit tests we don't want the publish timer running -
-                // we want to publish manually
-                InitialPublishDelayMS = Timeout.Infinite,
-                MetricsFilePath = _metricsFilePath,
-                MaxFileCount = 5
-            };
-            if (metricsPublishInterval != null)
-            {
-                _options.MetricsPublishIntervalMS = (int)metricsPublishInterval.Value.TotalMilliseconds;
-            }
-            var optionsWrapper = new OptionsWrapper<FlexConsumptionMetricsPublisherOptions>(_options);
-            _logger = new TestLogger<FlexConsumptionMetricsPublisher>();
-            var serviceProvider = new Mock<IServiceProvider>();
-            var hostMetricsLogger = new TestLogger<HostMetricsProvider>();
-            _metricsProvider = new HostMetricsProvider(serviceProvider.Object, _standbyOptionsMonitor, hostMetricsLogger, _environment);
-            var publisher = new FlexConsumptionMetricsPublisher(_environment, _standbyOptionsMonitor, optionsWrapper, _logger, new FileSystem(), _metricsProvider);
-
-            return publisher;
-        }
-
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -100,12 +75,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
                 _environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionsAlwaysReadyInstance, "1");
             }
 
-            var publisher = CreatePublisher();
+            using var publisher = CreatePublisher();
 
             int delay = 100;
             await Task.Delay(delay);
 
-            await publisher.OnPublishMetrics(DateTime.UtcNow);
+            await publisher.OnPublishMetrics(DateTime.UtcNow, ValueStopwatch.StartNew());
 
             FileInfo[] files = GetMetricsFilesSafe(_metricsFilePath);
 
@@ -138,7 +113,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             delay = (int)executionDurationMS + 100;
             await Task.Delay(delay);
 
-            await publisher.OnPublishMetrics(DateTime.UtcNow);
+            await publisher.OnPublishMetrics(DateTime.UtcNow, ValueStopwatch.StartNew());
 
             files = GetMetricsFilesSafe(_metricsFilePath);
             Assert.Equal(1, files.Length);
@@ -172,7 +147,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
                 await Task.Delay(50);
             }
 
-            var publisher = CreatePublisher();
+            using var publisher = CreatePublisher();
 
             int executionDurationMS = 5678;
             publisher.FunctionExecutionCount = 123;
@@ -181,18 +156,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             int delay = (int)executionDurationMS + 100;
             await Task.Delay(delay);
 
-            await publisher.OnPublishMetrics(DateTime.UtcNow);
+            await publisher.OnPublishMetrics(DateTime.UtcNow, ValueStopwatch.StartNew());
 
             FileInfo[] files = GetMetricsFilesSafe(_metricsFilePath);
             Assert.Equal(5, files.Length);
 
             // we expect the oldest 4 of the initial files to be retained,
             // along with the last file written
-            var expectedfiles = metricsFiles.Skip(6).Take(4).ToArray();
+            var expectedFiles = metricsFiles.Skip(6).Take(4).ToArray();
 
             for (int i = 0; i < 4; i++)
             {
-                Assert.Equal(expectedfiles[i], files[i].Name);
+                Assert.Equal(expectedFiles[i], files[i].Name);
             }
 
             var logs = _logger.GetLogMessages().ToArray();
@@ -221,7 +196,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
         [Fact]
         public void FunctionsStartStop_CorrectCountsAreMaintained()
         {
-            var publisher = CreatePublisher(metricsPublishInterval: TimeSpan.FromHours(1), inStandbyMode: false);
+            using var publisher = CreatePublisher(metricsPublishInterval: TimeSpan.FromHours(1), inStandbyMode: false);
 
             Assert.Equal(0, publisher.ActiveFunctionCount);
             Assert.Equal(0, publisher.FunctionExecutionCount);
@@ -257,7 +232,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
         [Fact]
         public void FunctionsStartStop_MinimumActivityIntervals_Scenario1()
         {
-            var publisher = CreatePublisher(metricsPublishInterval: TimeSpan.FromHours(1), inStandbyMode: false);
+            using var publisher = CreatePublisher(metricsPublishInterval: TimeSpan.FromHours(1), inStandbyMode: false);
 
             Assert.Equal(1000, _options.MinimumActivityIntervalMS);
 
@@ -334,7 +309,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
         [Fact]
         public void FunctionsStartStop_MinimumActivityIntervals_Scenario2()
         {
-            var publisher = CreatePublisher(metricsPublishInterval: TimeSpan.FromHours(1), inStandbyMode: false);
+            using var publisher = CreatePublisher(metricsPublishInterval: TimeSpan.FromHours(1), inStandbyMode: false);
 
             Assert.Equal(1000, _options.MinimumActivityIntervalMS);
 
@@ -361,7 +336,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
         [Fact]
         public void FunctionsStartStop_MinimumActivityIntervals_Scenario3()
         {
-            var publisher = CreatePublisher(metricsPublishInterval: TimeSpan.FromHours(1), inStandbyMode: false);
+            using var publisher = CreatePublisher(metricsPublishInterval: TimeSpan.FromHours(1), inStandbyMode: false);
 
             Assert.Equal(1000, _options.MinimumActivityIntervalMS);
 
@@ -442,8 +417,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
         public async Task OnPublishMetrics_OutstandingActivityIsPublished()
         {
             CleanupMetricsFiles();
-
-            var publisher = CreatePublisher(metricsPublishInterval: TimeSpan.FromHours(1), inStandbyMode: false);
+            using var publisher = CreatePublisher(metricsPublishInterval: TimeSpan.FromHours(1), inStandbyMode: false);
 
             Assert.Equal(1000, _options.MinimumActivityIntervalMS);
 
@@ -459,7 +433,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             publisher.OnFunctionStarted("foo", "0", now);
 
             now += TimeSpan.FromMilliseconds(1800);
-            await publisher.OnPublishMetrics(now);
+            await publisher.OnPublishMetrics(now, ValueStopwatch.StartNew());
 
             FileInfo[] files = GetMetricsFilesSafe(_metricsFilePath);
             var metrics = await ReadMetricsAsync(files[0].FullName, deleteFile: true);
@@ -490,7 +464,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
 
             // wait another 300ms then simulate the end of the interval
             now += TimeSpan.FromMilliseconds(300);
-            await publisher.OnPublishMetrics(now);
+            await publisher.OnPublishMetrics(now, ValueStopwatch.StartNew());
 
             files = GetMetricsFilesSafe(_metricsFilePath);
             metrics = await ReadMetricsAsync(files[0].FullName, deleteFile: true);
@@ -516,13 +490,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
 
             // another function starts and continues running past the
             // end of the second interval
-            // at the end of thie interval, while the function has only
+            // at the end of the interval, while the function has only
             // ran for 700ms this gets rounded up to 1000ms
             now += TimeSpan.FromMilliseconds(400);
             publisher.OnFunctionStarted("foo", "4", now);
             now += TimeSpan.FromMilliseconds(700);
 
-            await publisher.OnPublishMetrics(now);
+            await publisher.OnPublishMetrics(now, ValueStopwatch.StartNew());
 
             files = GetMetricsFilesSafe(_metricsFilePath);
             metrics = await ReadMetricsAsync(files[0].FullName, deleteFile: true);
@@ -537,20 +511,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
         {
             CleanupMetricsFiles();
 
-            var publisher = CreatePublisher();
+            using var publisher = CreatePublisher();
 
             DateTime now = DateTime.UtcNow;
 
-            // Should not publish because there is no activity and keepalive internal has not passed
-            await publisher.OnPublishMetrics(now);
+            // Should not publish because there is no activity and keep-alive internal has not passed
+            await publisher.OnPublishMetrics(now, ValueStopwatch.StartNew());
             var files = GetMetricsFilesSafe(_metricsFilePath);
             Assert.Equal(0, files.Length);
 
             // Simulate 31 seconds passing with no function activity
             now = now.AddSeconds(31);
 
-            // Should publish as keepalive interval has passed
-            await publisher.OnPublishMetrics(now);
+            // Should publish as keep-alive interval has passed
+            await publisher.OnPublishMetrics(now, ValueStopwatch.StartNew());
             files = GetMetricsFilesSafe(_metricsFilePath);
             Assert.Equal(1, files.Length);
 
@@ -564,7 +538,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
         [Fact]
         public void OnFunctionCompleted_NoOutstandingInvocations_IgnoresEvent()
         {
-            var publisher = CreatePublisher(metricsPublishInterval: TimeSpan.FromHours(1), inStandbyMode: false);
+            using var publisher = CreatePublisher(metricsPublishInterval: TimeSpan.FromHours(1), inStandbyMode: false);
 
             Assert.Equal(1000, _options.MinimumActivityIntervalMS);
             Assert.Equal(0, publisher.ActiveFunctionCount);
@@ -597,6 +571,32 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             }
         }
 
+        private FlexConsumptionMetricsPublisher CreatePublisher(TimeSpan? metricsPublishInterval = null, bool inStandbyMode = false)
+        {
+            _standbyOptions = new StandbyOptions { InStandbyMode = inStandbyMode };
+            _standbyOptionsMonitor = new TestOptionsMonitor<StandbyOptions>(_standbyOptions);
+            _options = new FlexConsumptionMetricsPublisherOptions
+            {
+                // for these unit tests we don't want the publish timer running -
+                // we want to publish manually
+                InitialPublishDelayMS = Timeout.Infinite,
+                MetricsFilePath = _metricsFilePath,
+                MaxFileCount = 5
+            };
+            if (metricsPublishInterval != null)
+            {
+                _options.MetricsPublishIntervalMS = (int)metricsPublishInterval.Value.TotalMilliseconds;
+            }
+            var optionsWrapper = new OptionsWrapper<FlexConsumptionMetricsPublisherOptions>(_options);
+            _logger = new TestLogger<FlexConsumptionMetricsPublisher>();
+            var serviceProvider = new Mock<IServiceProvider>();
+            var hostMetricsLogger = new TestLogger<HostMetricsProvider>();
+            _metricsProvider = new HostMetricsProvider(serviceProvider.Object, _standbyOptionsMonitor, hostMetricsLogger, _environment);
+            var publisher = new FlexConsumptionMetricsPublisher(_environment, _standbyOptionsMonitor, optionsWrapper, _logger, new FileSystem(), _metricsProvider);
+
+            return publisher;
+        }
+
         private static async Task<FlexConsumptionMetricsPublisher.Metrics> ReadMetricsAsync(string metricsFilePath, bool deleteFile = false)
         {
             string content = await File.ReadAllTextAsync(metricsFilePath);
@@ -617,10 +617,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
                 return directory.GetFiles().OrderBy(p => p.CreationTime).ToArray();
             }
 
-            return new FileInfo[0];
+            return [];
         }
 
-        private void ValidateTotalTime(long value, long delay)
+        private static void ValidateTotalTime(long value, long delay)
         {
             // Ensure the measured total time for the timer interval is within
             // the expected range (plus a small margin of error)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Replaces the timer usage in `FlexConsumptionMetricsPublisher` with a `while` loop and `Task.Delay` usage. Adds lifecycle management to the publisher as well to guard against multiple start calls. We noticed on a dump multiple threads in the `OnPublishMetrics` call, leading us to believe executions are overlapping with the timer approach.
