### PR TITLE
Fix Instance Manager for Linux Consumption Running on Legion

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Fix Instance Manager for CV1 Migration (#11072)

--- a/release_notes.md
+++ b/release_notes.md
@@ -2,4 +2,4 @@
 
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
-- Disable Diagnostic Events when Table Storage is not accessible (#10996)
+-->

--- a/src/Directory.Version.props
+++ b/src/Directory.Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.1039.500</VersionPrefix>
+    <VersionPrefix>4.1039.600</VersionPrefix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 </Project>

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddTransient<VirtualFileSystem>();
             services.AddTransient<VirtualFileSystemMiddleware>();
 
-            if (SystemEnvironment.Instance.IsFlexConsumptionSku())
+            if (SystemEnvironment.Instance.IsLinuxConsumptionOnLegion() || SystemEnvironment.Instance.IsFlexConsumptionSku())
             {
                 services.AddSingleton<IInstanceManager, LegionInstanceManager>();
             }

--- a/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
+++ b/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Microsoft.WebJobs.Script.Tests;
 using Xunit;
 using static Microsoft.Azure.WebJobs.Script.EnvironmentSettingNames;
@@ -242,6 +243,24 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(isLinuxConsumptionOnAtlas || isLinuxConsumptionOnLegion, testEnvironment.IsConsumptionSku());
             Assert.Equal(isLinuxConsumptionOnAtlas || isLinuxConsumptionOnLegion, testEnvironment.IsDynamicSku());
             Assert.False(isLinuxConsumptionOnAtlas ? isLinuxConsumptionOnLegion : isLinuxConsumptionOnAtlas);
+        }
+
+        [Theory]
+        [InlineData(ScriptConstants.DynamicSku, "containerName", "", "", false)]
+        [InlineData(ScriptConstants.DynamicSku, "containerName", "podName", "", false)]
+        [InlineData(ScriptConstants.DynamicSku, "containerName", "podName", "legionServiceHost", true)]
+        [InlineData(ScriptConstants.DynamicSku, "containerName", "", "legionServiceHost", true)]
+        public void Returns_AtlasOrLegionConsumption(string sku, string containerName, string podName, string legionServiceHost, bool legion)
+        {
+            var testEnvironment = new TestEnvironment();
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, string.Empty);
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, sku);
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, containerName);
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.PodName, podName);
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.LegionServiceHost, legionServiceHost);
+
+            Assert.Equal(legion, testEnvironment.IsLinuxConsumptionOnLegion());
+            Assert.Equal(!legion, testEnvironment.IsLinuxConsumptionOnAtlas());
         }
 
         [Theory]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Cherry-picked https://github.com/Azure/azure-functions-host/pull/11072 into `release/4.39`.

CV1 Migration pods are starting with the incorrect instance manager. Fixing the AddWebJobsScriptHost() to choose the correct instance manager based on the environment

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * in-proc already checks for IsLinuxConsumptionOnLegion() for LegionInstanceManager [Code](https://github.com/Azure/azure-functions-host/blob/891505ec91c7b45e9f7aa303adce403ea0a1db4a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs#L135C13-L138C14)
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information

