### PR TITLE
Avoiding exporter set-up in the placeholder mode.

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -11,3 +11,4 @@
 - Added support for collecting cross-platform perf traces and generating PGO JIT traces (#11062)
 - Memory allocation optimizations in `DependencyHelper.GetExtensionRequirements` (#11022)
 - Fix Instance Manager for CV1 Migration (#11072)
+- Avoid setting up OTel and AzMon exporter in the placeholder mode. (#11090)

--- a/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
+++ b/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
@@ -28,9 +28,8 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
     {
         internal static void ConfigureOpenTelemetry(this ILoggingBuilder loggingBuilder, HostBuilderContext context, TelemetryMode telemetryMode)
         {
-            var (otlpEndpoint, azMonConnectionString) = (
-                GetConfigurationValue(EnvironmentSettingNames.OtlpEndpoint, context.Configuration),
-                GetConfigurationValue(EnvironmentSettingNames.AppInsightsConnectionString, context.Configuration));
+            var otlpEndpoint = GetConfigurationValue(EnvironmentSettingNames.OtlpEndpoint, context.Configuration);
+            var azMonConnectionString = GetConfigurationValue(EnvironmentSettingNames.AppInsightsConnectionString, context.Configuration);
 
             bool enableOtlp = !string.IsNullOrWhiteSpace(otlpEndpoint);
             bool enableAzureMonitor = !string.IsNullOrWhiteSpace(azMonConnectionString);
@@ -43,8 +42,9 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
                 return;
             }
 
-            loggingBuilder
-                .ConfigureLogging(enableOtlp, enableAzureMonitor, azMonConnectionString, credential, telemetryMode).Services
+            loggingBuilder.ConfigureLogging(enableOtlp, enableAzureMonitor, azMonConnectionString, credential, telemetryMode);
+
+            loggingBuilder.Services
                 .AddOpenTelemetry()
                 .ConfigureResource(r => ConfigureResource(r))
                 .ConfigureMetrics(enableOtlp, enableAzureMonitor, azMonConnectionString, credential, telemetryMode)

--- a/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
+++ b/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
@@ -28,42 +28,34 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
     {
         internal static void ConfigureOpenTelemetry(this ILoggingBuilder loggingBuilder, HostBuilderContext context, TelemetryMode telemetryMode)
         {
-            var connectionString = GetConfigurationValue(EnvironmentSettingNames.AppInsightsConnectionString, context.Configuration);
-            var (azMonConnectionString, credential, enableOtlp, enableAzureMonitor) = telemetryMode switch
-            {
-                // Initializing OTel services during placeholder mode as well to avoid the cost of JITting these objects during specialization.
-                // Azure Monitor Exporter requires a connection string to be initialized. Use placeholder connection string if in placeholder mode.
-                TelemetryMode.Placeholder => (
-                    "InstrumentationKey=00000000-0000-0000-0000-000000000000;",
-                    null,
-                    true,
-                    true),
-                _ => (
-                    connectionString,
-                    GetTokenCredential(context.Configuration),
-                    !string.IsNullOrEmpty(GetConfigurationValue(EnvironmentSettingNames.OtlpEndpoint, context.Configuration)),
-                    !string.IsNullOrEmpty(connectionString))
-            };
+            var (otlpEndpoint, azMonConnectionString) = (
+                GetConfigurationValue(EnvironmentSettingNames.OtlpEndpoint, context.Configuration),
+                GetConfigurationValue(EnvironmentSettingNames.AppInsightsConnectionString, context.Configuration));
 
-            // If neither OTLP nor Azure Monitor is enabled, don't configure OpenTelemetry.
-            if (!enableOtlp && !enableAzureMonitor)
+            bool enableOtlp = !string.IsNullOrWhiteSpace(otlpEndpoint);
+            bool enableAzureMonitor = !string.IsNullOrWhiteSpace(azMonConnectionString);
+
+            TokenCredential credential = enableAzureMonitor ? GetTokenCredential(context.Configuration) : null;
+
+            // If placeholder mode is disabled and both OTLP and Azure Monitor are not enabled, avoid configuring OpenTelemetry.
+            if (!enableOtlp && !enableAzureMonitor && telemetryMode != TelemetryMode.Placeholder)
             {
                 return;
             }
 
             loggingBuilder
-                .ConfigureLogging(enableOtlp, enableAzureMonitor, azMonConnectionString, credential).Services
+                .ConfigureLogging(enableOtlp, enableAzureMonitor, azMonConnectionString, credential, telemetryMode).Services
                 .AddOpenTelemetry()
                 .ConfigureResource(r => ConfigureResource(r))
-                .ConfigureMetrics(enableOtlp, enableAzureMonitor, azMonConnectionString, credential)
-                .ConfigureTracing(enableOtlp, enableAzureMonitor, azMonConnectionString, credential)
+                .ConfigureMetrics(enableOtlp, enableAzureMonitor, azMonConnectionString, credential, telemetryMode)
+                .ConfigureTracing(enableOtlp, enableAzureMonitor, azMonConnectionString, credential, telemetryMode)
                 .ConfigureEventLogLevel(context.Configuration);
 
             // Azure SDK instrumentation is experimental.
             AppContext.SetSwitch("Azure.Experimental.EnableActivitySource", true);
         }
 
-        private static IOpenTelemetryBuilder ConfigureMetrics(this IOpenTelemetryBuilder builder, bool enableOtlp, bool enableAzureMonitor, string azMonConnectionString, TokenCredential credential)
+        private static IOpenTelemetryBuilder ConfigureMetrics(this IOpenTelemetryBuilder builder, bool enableOtlp, bool enableAzureMonitor, string azMonConnectionString, TokenCredential credential, TelemetryMode telemetryMode)
         {
             return builder.WithMetrics(builder =>
             {
@@ -76,18 +68,22 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
                     Boundaries = new double[] { 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10 }
                 });
 
-                if (enableOtlp)
+                // Avoid configuring the exporter in placeholder mode, as it will default to sending telemetry to the predefined endpoint. These transmissions will be unsuccessful and create unnecessary noise.
+                if (telemetryMode != TelemetryMode.Placeholder)
                 {
-                    builder.AddOtlpExporter();
-                }
-                if (enableAzureMonitor)
-                {
-                    builder.AddAzureMonitorMetricExporter(opt => ConfigureAzureMonitorOptions(opt, azMonConnectionString, credential));
+                    if (enableOtlp)
+                    {
+                        builder.AddOtlpExporter();
+                    }
+                    if (enableAzureMonitor)
+                    {
+                        builder.AddAzureMonitorMetricExporter(opt => ConfigureAzureMonitorOptions(opt, azMonConnectionString, credential));
+                    }
                 }
             });
         }
 
-        private static IOpenTelemetryBuilder ConfigureTracing(this IOpenTelemetryBuilder builder, bool enableOtlp, bool enableAzureMonitor, string azMonConnectionString, TokenCredential credential)
+        private static IOpenTelemetryBuilder ConfigureTracing(this IOpenTelemetryBuilder builder, bool enableOtlp, bool enableAzureMonitor, string azMonConnectionString, TokenCredential credential, TelemetryMode telemetryMode)
         {
             return builder.WithTracing(builder =>
             {
@@ -113,34 +109,44 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
                     };
                 });
 
-                if (enableOtlp)
+                // Avoid configuring the exporter in placeholder mode, as it will default to sending telemetry to the predefined endpoint. These transmissions will be unsuccessful and create unnecessary noise.
+                if (telemetryMode != TelemetryMode.Placeholder)
                 {
-                    builder.AddOtlpExporter();
-                }
+                    if (enableOtlp)
+                    {
+                        builder.AddOtlpExporter();
+                    }
 
-                if (enableAzureMonitor)
-                {
-                    builder.AddAzureMonitorTraceExporter(opt => ConfigureAzureMonitorOptions(opt, azMonConnectionString, credential));
-                    builder.AddLiveMetrics(opt => ConfigureAzureMonitorOptions(opt, azMonConnectionString, credential));
+                    if (enableAzureMonitor)
+                    {
+                        builder.AddAzureMonitorTraceExporter(opt => ConfigureAzureMonitorOptions(opt, azMonConnectionString, credential));
+                        builder.AddLiveMetrics(opt => ConfigureAzureMonitorOptions(opt, azMonConnectionString, credential));
+                    }
                 }
 
                 builder.AddProcessor(ActivitySanitizingProcessor.Instance);
             });
         }
 
-        private static ILoggingBuilder ConfigureLogging(this ILoggingBuilder builder, bool enableOtlp, bool enableAzureMonitor, string azMonConnectionString, TokenCredential credential)
+        private static ILoggingBuilder ConfigureLogging(this ILoggingBuilder builder, bool enableOtlp, bool enableAzureMonitor, string azMonConnectionString, TokenCredential credential, TelemetryMode telemetryMode)
         {
             builder.AddOpenTelemetry(o =>
             {
                 o.SetResourceBuilder(ConfigureResource(ResourceBuilder.CreateDefault()));
-                if (enableOtlp)
+
+                // Avoid configuring the exporter in placeholder mode, as it will default to sending telemetry to the predefined endpoint. These transmissions will be unsuccessful and create unnecessary noise.
+                if (telemetryMode != TelemetryMode.Placeholder)
                 {
-                    o.AddOtlpExporter();
+                    if (enableOtlp)
+                    {
+                        o.AddOtlpExporter();
+                    }
+                    if (enableAzureMonitor)
+                    {
+                        o.AddAzureMonitorLogExporter(options => ConfigureAzureMonitorOptions(options, azMonConnectionString, credential));
+                    }
                 }
-                if (enableAzureMonitor)
-                {
-                    o.AddAzureMonitorLogExporter(options => ConfigureAzureMonitorOptions(options, azMonConnectionString, credential));
-                }
+
                 o.IncludeFormattedMessage = true;
                 o.IncludeScopes = false;
             });


### PR DESCRIPTION
OpenTelemetry and AzureMonitor exporters are enabled in the Placeholder mode to optimize for cold start. If OpenTelemetry exporter isn't configured with an endpoint, it defaults to localhost:4317, leading to errors since no valid endpoint is available. Similarly, AzureMonitor fails due to an invalid IKey, generating status code 400 errors.

`StatusCode="Unavailable", Detail="Error connecting to subchannel."`
`Status Code: 400. Code: InvalidInput. Message: . Exception: iKey is garbage or not in a valid GUID format.`

These exceptions are frequently logged while apps run in Placeholder mode but stop after specialization. The sandbox issues numerous warnings, and customers may later hit connection limits, even though no signs indicate reaching the threshold. When this happens, throttling occurs with 429 responses.

The [sandbox ](https://github.com/projectkudu/kudu/wiki/Azure-Web-App-sandbox#local-address-requests)blocks connection attempts to local addresses (e.g., localhost, 127.0.0.1) and the machine's own IP, logging a warning when this occurs.

resolves #11073

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

