### PR TITLE
Only start flush logs timer when there's an event to write

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -15,3 +15,4 @@
 - Update Java Worker Version to [2.19.1](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.1)
 - Memory allocation optimizations in `FeatureFlags.IsEnabled` by adopting zero-allocation `ContainsToken` for efficient delimited token search (#11075)
 - Improvements to coldstart pipeline (#11102).
+- Only start the Diagnostic Events flush logs timer when events are present, preventing unnecessary flush attempts (#11100).

--- a/release_notes.md
+++ b/release_notes.md
@@ -15,4 +15,5 @@
 - Update Java Worker Version to [2.19.1](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.1)
 - Memory allocation optimizations in `FeatureFlags.IsEnabled` by adopting zero-allocation `ContainsToken` for efficient delimited token search (#11075)
 - Improvements to coldstart pipeline (#11102).
+- Update Python Worker Version to [4.38.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.38.0)
 - Only start the Diagnostic Events flush logs timer when events are present, preventing unnecessary flush attempts (#11100).

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.Log.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.Log.cs
@@ -38,16 +38,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 LoggerMessage.Define<string>(LogLevel.Debug, new EventId(6, nameof(DeletingTableWithOutdatedEventVersion)), "Deleting table '{tableName}' as it contains records with an outdated EventVersion.");
 
             private static readonly Action<ILogger, Exception> _errorPurgingDiagnosticEventVersions =
-                LoggerMessage.Define(LogLevel.Error, new EventId(7, nameof(ErrorPurgingDiagnosticEventVersions)), "Error occurred when attempting to purge previous diagnostic event versions.");
+                LoggerMessage.Define(LogLevel.Warning, new EventId(7, nameof(ErrorPurgingDiagnosticEventVersions)), "Error occurred when attempting to purge previous diagnostic event versions.");
 
             private static readonly Action<ILogger, Exception> _unableToGetTableReference =
-                LoggerMessage.Define(LogLevel.Error, new EventId(8, nameof(UnableToGetTableReference)), "Unable to get table reference. Aborting write operation.");
+                LoggerMessage.Define(LogLevel.Warning, new EventId(8, nameof(UnableToGetTableReference)), "Unable to get table reference. Aborting write operation.");
 
             private static readonly Action<ILogger, Exception> _unableToGetTableReferenceOrCreateTable =
-                LoggerMessage.Define(LogLevel.Error, new EventId(9, nameof(UnableToGetTableReferenceOrCreateTable)), "Unable to get table reference or create table. Aborting write operation.");
+                LoggerMessage.Define(LogLevel.Warning, new EventId(9, nameof(UnableToGetTableReferenceOrCreateTable)), "Unable to get table reference or create table. Aborting write operation.");
 
             private static readonly Action<ILogger, Exception> _unableToWriteDiagnosticEvents =
-                LoggerMessage.Define(LogLevel.Error, new EventId(10, nameof(UnableToWriteDiagnosticEvents)), "Unable to write diagnostic events to table storage.");
+                LoggerMessage.Define(LogLevel.Warning, new EventId(10, nameof(UnableToWriteDiagnosticEvents)), "Unable to write diagnostic events to table storage.");
 
             private static readonly Action<ILogger, Exception> _primaryHostStateProviderNotAvailable =
                 LoggerMessage.Define(LogLevel.Debug, new EventId(11, nameof(PrimaryHostStateProviderNotAvailable)), "PrimaryHostStateProvider is not available. Skipping the check for primary host.");

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
@@ -203,7 +203,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 }
                 catch (Exception ex)
                 {
+                    // We failed to connect to the table storage account. This could be due to a transient error or a configuration issue (e.g., network problems).
+                    // To avoid repeatedly retrying in a potentially unhealthy state, we will disable the service.
+                    // The operation may succeed in a future instance if the underlying issue is resolved.
                     Logger.ErrorPurgingDiagnosticEventVersions(_logger, ex);
+                    DisableService();
+                    Logger.ServiceDisabledUnableToConnectToStorage(_logger, ex);
                 }
             }, maxRetries: 5, retryInterval: TimeSpan.FromSeconds(5));
 
@@ -254,12 +259,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 Logger.UnableToGetTableReferenceOrCreateTable(_logger, ex);
                 DisableService();
                 Logger.ServiceDisabledUnauthorizedClient(_logger, ex);
+                return;
             }
             catch (Exception ex)
             {
+                // We failed to connect to the table storage account. This could be due to a transient error or a configuration issue (e.g., network problems).
+                // To avoid repeatedly retrying in a potentially unhealthy state, we will disable the service.
+                // The operation may succeed in a future instance if the underlying issue is resolved.
                 Logger.UnableToGetTableReferenceOrCreateTable(_logger, ex);
-                // Clearing the memory cache to avoid memory build up.
-                _events.Clear();
+                DisableService();
+                Logger.ServiceDisabledUnableToConnectToStorage(_logger, ex);
                 return;
             }
 
@@ -301,6 +310,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             catch (Exception ex)
             {
                 Logger.UnableToWriteDiagnosticEvents(_logger, ex);
+                DisableService();
+                Logger.ServiceDisabledUnableToConnectToStorage(_logger, ex);
             }
         }
 

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         {
             get
             {
-                if (!_environment.IsPlaceholderModeEnabled() && string.IsNullOrEmpty(_hostId))
+                if (string.IsNullOrEmpty(_hostId) && !_environment.IsPlaceholderModeEnabled())
                 {
                     _hostId = _hostIdProvider?.GetHostIdAsync(CancellationToken.None).GetAwaiter().GetResult();
                 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         private const int LogFlushInterval = 1000 * 60 * 10; // 10 minutes
         private const int TableCreationMaxRetryCount = 5;
 
-        private readonly Timer _flushLogsTimer;
+        private readonly Lazy<Timer> _flushLogsTimer;
         private readonly IHostIdProvider _hostIdProvider;
         private readonly IEnvironment _environment;
         private readonly IAzureTableStorageProvider _azureTableStorageProvider;
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             _environment = environment;
             _serviceProvider = scriptHostManager as IServiceProvider;
             _logger = logger;
-            _flushLogsTimer = new Timer(OnFlushLogs, null, logFlushInterval, logFlushInterval);
+            _flushLogsTimer = new Lazy<Timer>(() => new Timer(OnFlushLogs, null, logFlushInterval, logFlushInterval));
             _azureTableStorageProvider = azureTableStorageProvider;
         }
 
@@ -192,6 +192,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
                     _purged = true;
                 }
+                catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.Forbidden)
+                {
+                    // If we reach this point, we already checked for permissions on TableClient initialization.
+                    // It is possible that the permissions changed after the initialization, any firewall/network rules were changed or it's a custom role where we don't have permissions to query entities.
+                    // We will log the error and disable the service.
+                    Logger.ErrorPurgingDiagnosticEventVersions(_logger, ex);
+                    DisableService();
+                    Logger.ServiceDisabledUnauthorizedClient(_logger, ex);
+                }
                 catch (Exception ex)
                 {
                     Logger.ErrorPurgingDiagnosticEventVersions(_logger, ex);
@@ -297,7 +306,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public void WriteDiagnosticEvent(DateTime timestamp, string errorCode, LogLevel level, string message, string helpLink, Exception exception)
         {
-            if (TableClient is null || string.IsNullOrEmpty(HostId))
+            if (TableClient is null || string.IsNullOrEmpty(HostId) || !IsEnabled())
             {
                 return;
             }
@@ -320,6 +329,18 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                     _events[errorCode].HitCount++;
                 }
             }
+
+            EnsureFlushLogsTimerInitialized();
+        }
+
+        internal void EnsureFlushLogsTimerInitialized()
+        {
+            if (_disposed || !IsEnabled())
+            {
+                return;
+            }
+
+            _ = _flushLogsTimer.Value;
         }
 
         public bool IsEnabled()
@@ -341,8 +362,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         private void StopTimer()
         {
+            if (!_flushLogsTimer.IsValueCreated)
+            {
+                return;
+            }
+
             Logger.StoppingFlushLogsTimer(_logger);
-            _flushLogsTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+            _flushLogsTimer?.Value?.Change(Timeout.Infinite, Timeout.Infinite);
         }
 
         protected virtual void Dispose(bool disposing)
@@ -351,9 +377,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             {
                 if (disposing)
                 {
-                    if (_flushLogsTimer != null)
+                    if (_flushLogsTimer?.Value != null)
                     {
-                        _flushLogsTimer.Dispose();
+                        _flushLogsTimer?.Value?.Dispose();
                     }
 
                     FlushLogs().GetAwaiter().GetResult();

--- a/test/WebJobs.Script.Tests.Integration/Diagnostics/DiagnosticEventTableStorageRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Diagnostics/DiagnosticEventTableStorageRepositoryTests.cs
@@ -69,6 +69,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
 
             DiagnosticEventTableStorageRepository repository = mockDiagnosticEventTableStorageRepository.Object;
 
+            // Write a diagnostic event to trigger the timer
+            mockDiagnosticEventTableStorageRepository.Object.WriteDiagnosticEvent(DateTime.UtcNow, "eh1", LogLevel.Information, "This is the message", "https://fwlink/", new Exception("exception message"));
+
             int numFlushes = 0;
             mockDiagnosticEventTableStorageRepository.Protected().Setup("OnFlushLogs", ItExpr.IsAny<object>())
                 .Callback<object>((state) =>
@@ -79,6 +82,27 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             await TestHelpers.Await(() => numFlushes >= 5, timeout: 2000, pollingInterval: 100, userMessageCallback: () => $"Expected numFlushes >= 5; Actual: {numFlushes}");
 
             mockDiagnosticEventTableStorageRepository.VerifyAll();
+        }
+
+        [Fact]
+        public void TimerFlush_NotStartedWithRepositoryDisabled()
+        {
+            IEnvironment testEnvironment = new TestEnvironment();
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+
+            var configuration = new ConfigurationBuilder().Build();
+            var localStorageProvider = TestHelpers.GetAzureTableStorageProvider(configuration);
+            DiagnosticEventTableStorageRepository repository =
+                new DiagnosticEventTableStorageRepository(_hostIdProvider, testEnvironment, _scriptHostMock.Object, localStorageProvider, _logger);
+
+            repository.WriteDiagnosticEvent(DateTime.UtcNow, "eh1", LogLevel.Information, "This is the message", "https://fwlink/", new Exception("exception message"));
+
+            var flushLogsTimerField = typeof(DiagnosticEventTableStorageRepository)
+            .GetField("_flushLogsTimer", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var lazyTimer = flushLogsTimerField.GetValue(repository) as Lazy<Timer>;
+
+            Assert.False(repository.IsEnabled());
+            Assert.False(lazyTimer.IsValueCreated, "Timer should not be created when repository is disabled");
         }
 
         [Fact]


### PR DESCRIPTION
The timer used to periodically flush logs for `DiagnosticEvents` is currently initialized as soon as the singleton Repository is created, regardless of whether any events are ever written. With the change in Service Provider implementation in the OOP host, this behavior changed: singletons are now initialized eagerly at startup by `JobHostScopedServiceProviderFactory`. https://github.com/Azure/azure-functions-host/blob/575890a52505f98009a3e57b21ed5c0f46cf1ed5/src/WebJobs.Script.WebHost/DependencyInjection/JobHostScopedServiceProviderFactory.cs#L68

resolves #11098 

### Changes:

* Transitions the `_flushLogsTimer` to a lazy initialization pattern, ensuring the timer is only started when there's an event to write.
* Changed logging levels from `Error` to `Warning` to better reflect the severity of the issues.
* Disabled the service when there's any failure (even if transient) as part of flush logs, purge events or execute batch. 

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
