### PR TITLE
Support logicapps pwsh version setting

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,3 +4,4 @@
 - My change description (#PR)
 -->
 - Update Java Worker Version to [2.19.1](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.1)
+- Support `LOGIC_APPS_POWERSHELL_VERSION` when resolving powershell's `worker.config.json` for logic-app apps only. (#11105)

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
                     // Check if any app settings are provided for that language
                     var languageSection = _config.GetSection($"{RpcWorkerConstants.LanguageWorkersSectionName}:{workerDescription.Language}");
-                    workerDescription.Arguments = workerDescription.Arguments ?? new List<string>();
+                    workerDescription.Arguments ??= new List<string>();
                     GetWorkerDescriptionFromAppSettings(workerDescription, languageSection);
                     AddArgumentsFromAppSettings(workerDescription, languageSection);
 

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerConstants.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public const string FunctionWorkerRuntimeVersionSettingName = "FUNCTIONS_WORKER_RUNTIME_VERSION";
         public const string FunctionsWorkerProcessCountSettingName = "FUNCTIONS_WORKER_PROCESS_COUNT";
         public const string FunctionsWorkerSharedMemoryDataTransferEnabledSettingName = "FUNCTIONS_WORKER_SHARED_MEMORY_DATA_TRANSFER_ENABLED";
+        public const string LogicAppsPowerShellVersionSettingName = "LOGIC_APPS_POWERSHELL_VERSION";
 
         // Comma-separated list of directories where shared memory maps can be created for data transfer between host and worker.
         // This will override the default directories.

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         {
             if (!SupportedOperatingSystems.Any(s => s.Equals(os.ToString(), StringComparison.OrdinalIgnoreCase)))
             {
-                throw new PlatformNotSupportedException($"OS {os.ToString()} is not supported for language {Language}");
+                throw new PlatformNotSupportedException($"OS {os} is not supported for language {Language}");
             }
         }
 
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         {
             if (!SupportedArchitectures.Any(s => s.Equals(architecture.ToString(), StringComparison.OrdinalIgnoreCase)))
             {
-                throw new PlatformNotSupportedException($"Architecture {architecture.ToString()} is not supported for language {Language}");
+                throw new PlatformNotSupportedException($"Architecture {architecture} is not supported for language {Language}");
             }
         }
 
@@ -192,9 +192,20 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
             OSPlatform os = systemRuntimeInformation.GetOSPlatform();
             Architecture architecture = systemRuntimeInformation.GetOSArchitecture();
+
             string workerRuntime = environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName);
-            string version = environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName);
-            logger.LogDebug($"EnvironmentVariable {RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName}: {version}");
+
+            string workerRuntimeVersionSettingName = RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName;
+
+            // For LogicApps and the powershell worker config, we special case a separate environment variable.
+            if (environment.IsLogicApp() && string.Equals(
+                Language, RpcWorkerConstants.PowerShellLanguageWorkerName, StringComparison.Ordinal))
+            {
+                workerRuntimeVersionSettingName = RpcWorkerConstants.LogicAppsPowerShellVersionSettingName;
+            }
+
+            string version = environment.GetEnvironmentVariable(workerRuntimeVersionSettingName);
+            logger.LogDebug($"EnvironmentVariable {workerRuntimeVersionSettingName}: {version}");
 
             // Only over-write DefaultRuntimeVersion if workerRuntime matches language for the worker config
             if (!string.IsNullOrEmpty(workerRuntime) && workerRuntime.Equals(Language, StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(version))

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerConfigFactoryTests.cs
@@ -185,6 +185,25 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.Equal("7.4", powershellWorkerConfig.Description.DefaultRuntimeVersion);
         }
 
+        [Fact]
+        public void LogicApps_Overrides_PowershellVersionSetting()
+        {
+            var testEnvironment = new TestEnvironment();
+            testEnvironment.SetEnvironmentVariable("APP_KIND", "workflowapp");
+            testEnvironment.SetEnvironmentVariable("FUNCTIONS_WORKER_RUNTIME_VERSION", "7.2");
+            testEnvironment.SetEnvironmentVariable("LOGIC_APPS_POWERSHELL_VERSION", "7.4");
+            var configBuilder = ScriptSettingsManager.CreateDefaultConfigurationBuilder();
+            var config = configBuilder.Build();
+            var scriptSettingsManager = new ScriptSettingsManager(config);
+            var testLogger = new TestLogger("test");
+            var configFactory = new RpcWorkerConfigFactory(config, testLogger, _testSysRuntimeInfo, testEnvironment, new TestMetricsLogger(), _testWorkerProfileManager);
+            var workerConfigs = configFactory.GetConfigs();
+            var powershellWorkerConfig = workerConfigs.FirstOrDefault(w => w.Description.Language.Equals("powershell", StringComparison.OrdinalIgnoreCase));
+            Assert.Equal(4, workerConfigs.Count);
+            Assert.NotNull(powershellWorkerConfig);
+            Assert.Equal("7.4", powershellWorkerConfig.Description.DefaultRuntimeVersion);
+        }
+
         [Theory]
         [InlineData("python", "Python", false, true)]
         [InlineData("python", "NOde", false, false)]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #11067

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Special cases the env var `LOGIC_APPS_POWERSHELL_VERSION` when resolving `worker.config.json` for powershell. Allows this setting to take precedence over `FUNCTIONS_WORKER_RUNTIME_VERSION`. Logic Apps is a multi-language environment, and so it needs an env var specific to powershell and cannot rely on the generic `FUNCTIONS_WORKER_RUNTIME_VERSION`
