### PR TITLE
Switched memory usage reporting to use CGroup metrics by default for Linux consumption

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -17,3 +17,4 @@
 - Improvements to coldstart pipeline (#11102).
 - Update Python Worker Version to [4.38.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.38.0)
 - Only start the Diagnostic Events flush logs timer when events are present, preventing unnecessary flush attempts (#11100).
+- Switched memory usage reporting to use CGroup metrics by default for Linux consumption (#11114)

--- a/src/WebJobs.Script.WebHost/Metrics/LinuxContainerLegionMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/LinuxContainerLegionMetricsPublisher.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         private readonly TimeSpan _timerStartDelay = TimeSpan.FromSeconds(2);
         private readonly IOptionsMonitor<StandbyOptions> _standbyOptions;
         private readonly IDisposable _standbyOptionsOnChangeListener;
-        private readonly IDisposable _hostingConfigOptionsOnChangeListener;
         private readonly IEnvironment _environment;
         private readonly ILogger _logger;
         private readonly IServiceProvider _serviceProvider;
@@ -37,7 +36,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         private Timer _processMonitorTimer;
         private Timer _metricsPublisherTimer;
         private bool _initialized = false;
-        private bool _isCGroupMemoryMetricsEnabled = false;
 
         public LinuxContainerLegionMetricsPublisher(IEnvironment environment, IOptionsMonitor<StandbyOptions> standbyOptions,
             IOptions<LinuxConsumptionLegionMetricsPublisherOptions> options, ILogger<LinuxContainerLegionMetricsPublisher> logger,
@@ -72,20 +70,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             {
                 Start();
             }
-
-            _hostingConfigOptionsOnChangeListener = _hostingConfigOptions.OnChange(OnHostingConfigOptionsChanged);
         }
 
         private IMetricsLogger MetricsLogger => _metricsLogger ??= _serviceProvider.GetRequiredService<IMetricsLogger>();
-
-        private void OnHostingConfigOptionsChanged(FunctionsHostingConfigOptions newOptions)
-        {
-            if (newOptions.IsCGroupMemoryMetricsEnabled != _isCGroupMemoryMetricsEnabled)
-            {
-                _logger.LogInformation("CGroup memory metrics enabled: {Enabled}", newOptions.IsCGroupMemoryMetricsEnabled);
-                _isCGroupMemoryMetricsEnabled = newOptions.IsCGroupMemoryMetricsEnabled;
-            }
-        }
 
         public void Initialize()
         {
@@ -189,16 +176,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         {
             try
             {
-                long memoryUsageInBytes;
-                if (_hostingConfigOptions.CurrentValue.IsCGroupMemoryMetricsEnabled)
-                {
-                    memoryUsageInBytes = CgroupMemoryUsageHelper.GetMemoryUsageInBytes(_logger);
-                }
-                else
-                {
-                    _process.Refresh();
-                    memoryUsageInBytes = _process.WorkingSet64;
-                }
+                long memoryUsageInBytes = CgroupMemoryUsageHelper.GetMemoryUsageInBytes(_logger);
 
                 if (memoryUsageInBytes != 0)
                 {
@@ -258,7 +236,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
 
             _metricsTracker.OnDiagnosticEvent -= OnMetricsDiagnosticEvent;
             _standbyOptionsOnChangeListener?.Dispose();
-            _hostingConfigOptionsOnChangeListener?.Dispose();
         }
 
         internal class Metrics

--- a/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
@@ -38,7 +38,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         private readonly TimeSpan _timerStartDelay = TimeSpan.FromSeconds(2);
         private readonly IOptionsMonitor<StandbyOptions> _standbyOptions;
         private readonly IDisposable _standbyOptionsOnChangeListener;
-        private readonly IDisposable _hostingConfigOptionsOnChangeListener;
         private readonly string _requestUri;
         private readonly IEnvironment _environment;
         private readonly IOptionsMonitor<FunctionsHostingConfigOptions> _hostingConfigOptions;
@@ -66,7 +65,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         private int _errorCount = 0;
         private string _stampName;
         private bool _initialized = false;
-        private bool _isCGroupMemoryMetricsEnabled = false;
 
         public LinuxContainerMetricsPublisher(IEnvironment environment, IOptionsMonitor<StandbyOptions> standbyOptions, ILogger<LinuxContainerMetricsPublisher> logger, HostNameProvider hostNameProvider, IOptionsMonitor<FunctionsHostingConfigOptions> functionsHostingConfigOptions, HttpClient httpClient = null)
         {
@@ -94,17 +92,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             else
             {
                 Start();
-            }
-
-            _hostingConfigOptionsOnChangeListener = _hostingConfigOptions.OnChange(OnHostingConfigOptionsChanged);
-        }
-
-        private void OnHostingConfigOptionsChanged(FunctionsHostingConfigOptions newOptions)
-        {
-            if (newOptions.IsCGroupMemoryMetricsEnabled != _isCGroupMemoryMetricsEnabled)
-            {
-                _logger.LogInformation("CGroup memory metrics enabled: {Enabled}", newOptions.IsCGroupMemoryMetricsEnabled);
-                _isCGroupMemoryMetricsEnabled = newOptions.IsCGroupMemoryMetricsEnabled;
             }
         }
 
@@ -278,16 +265,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         {
             try
             {
-                long memoryUsageInBytes;
-                if (_hostingConfigOptions.CurrentValue.IsCGroupMemoryMetricsEnabled)
-                {
-                    memoryUsageInBytes = CgroupMemoryUsageHelper.GetMemoryUsageInBytes(_logger);
-                }
-                else
-                {
-                    _process.Refresh();
-                    memoryUsageInBytes = _process.WorkingSet64;
-                }
+                long memoryUsageInBytes = CgroupMemoryUsageHelper.GetMemoryUsageInBytes(_logger);
 
                 if (memoryUsageInBytes != 0)
                 {
@@ -339,7 +317,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
         public void Dispose()
         {
             _standbyOptionsOnChangeListener?.Dispose();
-            _hostingConfigOptionsOnChangeListener?.Dispose();
             _processMonitorTimer?.Dispose();
             _metricsPublisherTimer?.Dispose();
             _httpClient?.Dispose();

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -79,22 +79,6 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to use cgroup memory metrics for reporting memory usage.
-        /// </summary>
-        internal bool IsCGroupMemoryMetricsEnabled
-        {
-            get
-            {
-                return GetFeatureAsBooleanOrDefault(ScriptConstants.FeatureFlagEnableCGroupMemoryMetrics, false);
-            }
-
-            set
-            {
-                _features[ScriptConstants.FeatureFlagEnableCGroupMemoryMetrics] = value ? "1" : "0";
-            }
-        }
-
-        /// <summary>
         /// Gets or sets a string delimited by '|' that contains a list of admin APIs that are allowed to
         /// be invoked internally by platform components.
         /// </summary>

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -142,7 +142,6 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FeatureFlagDisableOrderedInvocationMessages = "DisableOrderedInvocationMessages";
         public const string FeatureFlagEnableAzureMonitorTimeIsoFormat = "EnableAzureMonitorTimeIsoFormat";
         public const string FeatureFlagEnableTestDataSuppression = "EnableTestDataSuppression";
-        public const string FeatureFlagEnableCGroupMemoryMetrics = "EnableCGroupMemoryMetrics";
         public const string HostingConfigDisableLinuxAppServiceDetailedExecutionEvents = "DisableLinuxExecutionDetails";
         public const string HostingConfigDisableLinuxAppServiceExecutionEventLogBackoff = "DisableLinuxLogBackoff";
         public const string FeatureFlagEnableLegacyDurableVersionCheck = "EnableLegacyDurableVersionCheck";

--- a/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
@@ -76,7 +76,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 yield return [nameof(FunctionsHostingConfigOptions.IsDotNetInProcDisabled), "DotNetInProcDisabled=0", false];
 
                 yield return [nameof(FunctionsHostingConfigOptions.IsTestDataSuppressionEnabled), "EnableTestDataSuppression=1", true];
-                yield return [nameof(FunctionsHostingConfigOptions.IsCGroupMemoryMetricsEnabled), "EnableCGroupMemoryMetrics=1", true];
 
 #pragma warning restore SA1011 // Closing square brackets should be spaced correctly
 #pragma warning restore SA1010 // Opening square brackets should be spaced correctly


### PR DESCRIPTION
Enable memory metric based on CGroup usage, for Linux consumption. This is a follow-up to PR #10984, where we introduced CGroup-based memory reporting behind a feature flag. This change removes the feature flag check and makes CGroup memory usage the default approach.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

