### PR TITLE
Adding "isDefaultHostConfig" to host json WellKnownHostJsonProperties

### DIFF
--- a/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
                 "version", "functionTimeout", "retry", "functions", "http", "watchDirectories", "watchFiles", "queues", "serviceBus",
                 "eventHub", "singleton", "logging", "aggregator", "healthMonitor", "extensionBundle", "managedDependencies",
                 "customHandler", "httpWorker", "extensions", "concurrency", "telemetryMode", ConfigurationSectionNames.SendCanceledInvocationsToWorker,
-                ConfigurationSectionNames.MetadataProviderTimeout
+                ConfigurationSectionNames.MetadataProviderTimeout, "isDefaultHostConfig"
             };
 
             private readonly HostJsonFileConfigurationSource _configurationSource;

--- a/test/WebJobs.Script.Tests/Configuration/HostJsonFileConfigurationSourceTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/HostJsonFileConfigurationSourceTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         }
 
         [Fact]
-        public void MissingHostJson_CreatesHostJson_withDefaultExtensionBundleId()
+        public void MissingHostJson_GeneratesExpectedDefaultConfigFile()
         {
             Assert.False(File.Exists(_hostJsonFile));
             TestMetricsLogger testMetricsLogger = new TestMetricsLogger();
@@ -58,14 +58,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 
             AreExpectedMetricsGenerated(testMetricsLogger);
 
+            // verify actual file content
             Assert.Equal(_hostJsonWithBundles, File.ReadAllText(_hostJsonFile));
 
-            var log = _loggerProvider.GetAllLogMessages().Single(l => l.FormattedMessage == "No host configuration file found. Creating a default host.json file.");
-            Assert.Equal(LogLevel.Information, log.Level);
+            // verify log messages
+            var logs = _loggerProvider.GetAllLogMessages();
+            Assert.Single(logs.Where(l => l.Level == LogLevel.Information && l.FormattedMessage == "No host configuration file found. Creating a default host.json file."));
+            VerifySanitizedHostConfigLog(logs, ScriptConstants.DefaultExtensionBundleId, ScriptConstants.DefaultExtensionBundleVersion);
         }
 
         [Fact]
-        public void MissingHostJson_CreatesHostJson_withWorkFlowExtensionBundleId()
+        public void MissingHostJson_WorkflowApp_GeneratesExpectedDefaultConfigFile()
         {
             var environment = new TestEnvironment(new Dictionary<string, string>
             {
@@ -79,10 +82,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 
             AreExpectedMetricsGenerated(testMetricsLogger);
 
+            // verify actual file content
             Assert.Equal(_hostJsonWithWorkFlowBundle, File.ReadAllText(_hostJsonFile));
 
-            var log = _loggerProvider.GetAllLogMessages().Single(l => l.FormattedMessage == "No host configuration file found. Creating a default host.json file.");
-            Assert.Equal(LogLevel.Information, log.Level);
+            // verify log messages
+            var logs = _loggerProvider.GetAllLogMessages();
+            Assert.Single(logs.Where(l => l.Level == LogLevel.Information && l.FormattedMessage == "No host configuration file found. Creating a default host.json file."));
+            VerifySanitizedHostConfigLog(logs, ScriptConstants.WorkFlowExtensionBundleId, ScriptConstants.LogicAppDefaultExtensionBundleVersion);
         }
 
         [Theory]
@@ -278,6 +284,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             return metricsLogger.EventsBegan.Contains(MetricEventNames.LoadHostConfigurationSource) && metricsLogger.EventsEnded.Contains(MetricEventNames.LoadHostConfigurationSource)
                     && metricsLogger.EventsBegan.Contains(MetricEventNames.LoadHostConfiguration) && metricsLogger.EventsEnded.Contains(MetricEventNames.LoadHostConfiguration)
                     && metricsLogger.EventsBegan.Contains(MetricEventNames.InitializeHostConfiguration) && metricsLogger.EventsEnded.Contains(MetricEventNames.InitializeHostConfiguration);
+        }
+
+        private static void VerifySanitizedHostConfigLog(IList<LogMessage> logs, string expectedBundleId, string expectedBundleVersionSpec)
+        {
+            var hostJsonLog = logs.Single(p => p.EventId.Name == "HostConfigRead");
+            Assert.Equal(LogLevel.Information, hostJsonLog.Level);
+            string sanitizedJson = (string)hostJsonLog.State.ToDictionary()["sanitizedJson"];
+            var jo = JObject.Parse(sanitizedJson);
+
+            Assert.Equal(3, jo.Count);
+            Assert.Equal("2.0", jo["version"]);
+            Assert.Equal(true, jo["isDefaultHostConfig"]);
+
+            var bundleConfig = jo["extensionBundle"];
+            Assert.Equal(expectedBundleId, bundleConfig["id"]);
+            Assert.Equal(expectedBundleVersionSpec, bundleConfig["version"]);
         }
     }
 }


### PR DESCRIPTION
Currently in the sanitized host.json log we write, we don't include the "isDefaultHostConfig" property we write to the file when generating a default file. This came up in a recent CRI investigation - would have helped to have this had this included in our logs.

E.g. below is the default config we write, but in the log we don't include the "isDefaultHostConfig" property.

```javascript
{
  "version": "2.0",
  "isDefaultHostConfig": true,
  "extensionBundle": {
    "id": "Microsoft.Azure.Functions.ExtensionBundle",
    "version": "[4.*, 5.0.0)"
  }
}
```

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
