### PR TITLE
Use -or operator in New-PrivateSiteExtension.ps1

### DIFF
--- a/src/WebJobs.Script.SiteExtension/New-PrivateSiteExtension.ps1
+++ b/src/WebJobs.Script.SiteExtension/New-PrivateSiteExtension.ps1
@@ -65,7 +65,7 @@ if (-not (Join-Path $InputPath "extension.xml" | Test-Path))
     exit 1
 }
 
-if ($AppendOutputName || !$OutputPath)
+if ($AppendOutputName -or !$OutputPath)
 {
     $runtime = $Bitness -eq '32bit' ? 'win-x86' : 'win-x64'
     $leaf = (Split-Path $InputPath -Leaf)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Our release pipeline for the Host started failing to create the PrivateSiteExtension. When we looked at the logs, we saw the following line:
```
Published private site extension to .zip
```
Normally, this would be something like:
```
Published private site extension to Functions.Private.4.1040.300.win-x86.zip
```
I could see that this log was coming from the last line of the script. This suggested that there was an issue with the `$OutputPath`.

When I ran the script locally, I could see that `$OutputPath` was never getting set. After some trial and error, I was able to pin it down to the line being modified in this PR. This condition was not resolving to true, even though both `$AppendOutputName` and `$OutputPath` are null at that point in the script and therefore `!$OutputPath` should be equal to true.

When I ran the script with the `-or` operator instead of `||`, the script worked as expected and the `$OutputPath` was set correctly.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
