### PR TITLE
fixing startup deadlock

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,3 +5,4 @@
 -->
 - Adding activity sources for Durable and WebJobs (Kafka and RabbitMQ) (#11137)
 - Add JitTrace Files for v4.1041
+- Fix startup deadlock on transient exceptions (#11142)

--- a/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
@@ -83,9 +83,11 @@ namespace Microsoft.Azure.WebJobs.Script
                 // Start up GRPC channels if they are not already running.
                 if (channels?.Any() != true)
                 {
+                    // Note: Error can mean transient error, so we want to attempt a normal startup.
                     if (_scriptHostManager.State is ScriptHostState.Default
                         || _scriptHostManager.State is ScriptHostState.Starting
-                        || _scriptHostManager.State is ScriptHostState.Initialized)
+                        || _scriptHostManager.State is ScriptHostState.Initialized
+                        || _scriptHostManager.State is ScriptHostState.Error)
                     {
                         // We don't need to restart if the host hasn't even been created yet.
                         _logger.LogDebug("Host is starting up, initializing language worker channel");

--- a/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
@@ -11,6 +11,8 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
@@ -18,7 +20,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Script
 {
-    internal class WorkerFunctionMetadataProvider : IWorkerFunctionMetadataProvider
+    internal class WorkerFunctionMetadataProvider : IWorkerFunctionMetadataProvider, IDisposable
     {
         private const string _metadataProviderName = "Worker";
         private readonly Dictionary<string, ICollection<string>> _functionErrors = new Dictionary<string, ICollection<string>>();
@@ -30,6 +32,7 @@ namespace Microsoft.Azure.WebJobs.Script
         private readonly JsonSerializerSettings _dateTimeSerializerSettings;
         private string _workerRuntime;
         private ImmutableArray<FunctionMetadata> _functions;
+        private IHost _currentJobHost = null;
 
         public WorkerFunctionMetadataProvider(
             IOptionsMonitor<ScriptApplicationHostOptions> scriptOptions,
@@ -45,6 +48,8 @@ namespace Microsoft.Azure.WebJobs.Script
             _scriptHostManager = scriptHostManager;
             _workerRuntime = _environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime);
             _dateTimeSerializerSettings = new JsonSerializerSettings { DateParseHandling = DateParseHandling.None };
+
+            _scriptHostManager.ActiveHostChanged += OnHostChanged;
         }
 
         public ImmutableDictionary<string, ImmutableArray<string>> FunctionErrors
@@ -83,21 +88,14 @@ namespace Microsoft.Azure.WebJobs.Script
                 // Start up GRPC channels if they are not already running.
                 if (channels?.Any() != true)
                 {
-                    // Note: Error can mean transient error, so we want to attempt a normal startup.
-                    if (_scriptHostManager.State is ScriptHostState.Default
-                        || _scriptHostManager.State is ScriptHostState.Starting
-                        || _scriptHostManager.State is ScriptHostState.Initialized
-                        || _scriptHostManager.State is ScriptHostState.Error)
+                    if (IsJobHostStarting())
                     {
-                        // We don't need to restart if the host hasn't even been created yet.
-                        _logger.LogDebug("Host is starting up, initializing language worker channel");
+                        _logger.LogDebug("JobHost is starting with state '{State}'. Initializing worker channel.", _scriptHostManager.State);
                         await _channelManager.InitializeChannelAsync(workerConfigs, _workerRuntime);
                     }
                     else
                     {
-                        // During the restart flow, GetFunctionMetadataAsync gets invoked
-                        // again through a new script host initialization flow.
-                        _logger.LogDebug("Host is running without any initialized channels, restarting the JobHost.");
+                        _logger.LogDebug("JobHost has started and has state '{State}' without any worker channels. Restarting host to reinitialize.", _scriptHostManager.State);
                         await _scriptHostManager.RestartHostAsync();
                     }
 
@@ -149,6 +147,38 @@ namespace Microsoft.Azure.WebJobs.Script
             }
 
             return new FunctionMetadataResult(useDefaultMetadataIndexing: false, _functions);
+        }
+
+        private void OnHostChanged(object sender, ActiveHostChangedEventArgs args)
+        {
+            // Track the current host so we can get state later if needed.
+            _currentJobHost = args.NewHost;
+        }
+
+        private bool IsJobHostStarting()
+        {
+            if (_scriptHostManager.State is ScriptHostState.Default
+                || _scriptHostManager.State is ScriptHostState.Starting
+                || _scriptHostManager.State is ScriptHostState.Initialized)
+            {
+                return true;
+            }
+
+            // The Error state can occur when the host is in a "final" state after completely starting,
+            // or during a retry of a transient error. This check allows us to determine the difference. If
+            // the host has not completely started, it means that it is still in the process of starting.
+            if (_currentJobHost is not null && _scriptHostManager.State == ScriptHostState.Error)
+            {
+                var lifetime = _currentJobHost.Services?.GetService<IHostApplicationLifetime>();
+
+                if (lifetime is not null &&
+                    !lifetime.ApplicationStarted.IsCancellationRequested)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         internal void ValidateFunctionAppFormat(string scriptPath, ILogger logger, IEnvironment environment, IFileSystem fileSystem = null)
@@ -299,6 +329,11 @@ namespace Microsoft.Azure.WebJobs.Script
                 return true;
             }
             return false;
+        }
+
+        public void Dispose()
+        {
+            _scriptHostManager.ActiveHostChanged -= OnHostChanged;
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/Host/WebJobsScriptHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/WebJobsScriptHostServiceTests.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Azure.WebJobs.Script.Scale;
+using Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
 using Microsoft.Extensions.DependencyInjection;
@@ -352,23 +353,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Host
         public void Dispose()
         {
             _testHost?.Dispose();
-        }
-
-        private class InterceptingScriptHostBuilder : IScriptHostBuilder
-        {
-            private readonly DefaultScriptHostBuilder _builder;
-            private readonly Func<IScriptHostBuilder, bool, bool, IHost> _interceptCallback;
-
-            public InterceptingScriptHostBuilder(IOptionsMonitor<ScriptApplicationHostOptions> appHostOptions, IServiceProvider rootServiceProvider, IServiceCollection rootServices, Func<IScriptHostBuilder, bool, bool, IHost> interceptCallback)
-            {
-                _builder = new DefaultScriptHostBuilder(appHostOptions, rootServices, rootServiceProvider);
-                _interceptCallback = interceptCallback;
-            }
-
-            public IHost BuildHost(bool skipHostStartup, bool skipHostConfigurationParsing)
-            {
-                return _interceptCallback(_builder, skipHostStartup, skipHostConfigurationParsing);
-            }
         }
 
         [Extension("TestWebHook", "TestWebHook")]

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/InterceptingScriptHostBuilder.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/InterceptingScriptHostBuilder.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd;
+
+internal class InterceptingScriptHostBuilder : IScriptHostBuilder
+{
+    private readonly DefaultScriptHostBuilder _builder;
+    private readonly Func<IScriptHostBuilder, bool, bool, IHost> _interceptCallback;
+
+    public InterceptingScriptHostBuilder(IOptionsMonitor<ScriptApplicationHostOptions> appHostOptions, IServiceProvider rootServiceProvider, IServiceCollection rootServices, Func<IScriptHostBuilder, bool, bool, IHost> interceptCallback)
+    {
+        _builder = new DefaultScriptHostBuilder(appHostOptions, rootServices, rootServiceProvider);
+        _interceptCallback = interceptCallback;
+    }
+
+    public IHost BuildHost(bool skipHostStartup, bool skipHostConfigurationParsing)
+    {
+        return _interceptCallback(_builder, skipHostStartup, skipHostConfigurationParsing);
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebHostStartupEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebHostStartupEndToEndTests.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd;
+
+public class WebHostStartupEndToEndTests
+{
+    [Fact]
+    public async Task TransientError_DuringHostBuild_DoesNotDeadlock()
+    {
+        bool thrownOnce = false;
+        void ThrowOnFirstBuild()
+        {
+            if (!thrownOnce)
+            {
+                // Simulate a transient error during first host build
+                thrownOnce = true;
+                throw new InvalidOperationException("Simulated transient error during host build.");
+            }
+        }
+
+        var fixture = new WebHostStartupEndToEndTestFixture(ThrowOnFirstBuild);
+
+        await fixture.InitializeAsync();
+
+        // This should recover as the second call to BuildHost should succeed
+        await TestHelpers.Await(async () =>
+        {
+            var result = await fixture.Host.HttpClient.GetAsync("/api/HttpRequestDataFunction");
+            return result.IsSuccessStatusCode && await result.Content.ReadAsStringAsync() == "Welcome to Azure Functions!";
+
+        }, 10000, userMessageCallback: fixture.Host.GetLog);
+
+        await fixture.DisposeAsync();
+    }
+
+    private class WebHostStartupEndToEndTestFixture : EndToEndTestFixture
+    {
+        private readonly Action _scriptHostBuildInterceptor;
+
+        public WebHostStartupEndToEndTestFixture(Action scriptHostBuildInterceptor = null)
+            : base(@"..\..\DotNetIsolated60\debug", "WebHostStartupEndToEndTests", "dotnet-isolated")
+        {
+            _scriptHostBuildInterceptor = scriptHostBuildInterceptor;
+        }
+
+        protected override Task CreateTestStorageEntities() => Task.CompletedTask;
+
+        public override void ConfigureWebHost(IServiceCollection rootServices)
+        {
+            rootServices.AddSingleton<IScriptHostBuilder>(rootProvider =>
+            {
+                var appHostOptions = rootProvider.GetService<IOptionsMonitor<ScriptApplicationHostOptions>>();
+
+                IHost Intercept(IScriptHostBuilder builder, bool skipHostStartup, bool skipHostConfigurationParsing)
+                {
+                    _scriptHostBuildInterceptor?.Invoke();
+
+                    return builder.BuildHost(skipHostStartup, skipHostConfigurationParsing);
+                }
+
+                return new InterceptingScriptHostBuilder(appHostOptions, rootProvider, rootServices, Intercept);
+            });
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebHostStartupEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebHostStartupEndToEndTests.cs
@@ -42,8 +42,9 @@ public class WebHostStartupEndToEndTests
 
         var debugMsg = fixture.Host.GetWebHostLogMessages("Microsoft.Azure.WebJobs.Script.WorkerFunctionMetadataProvider")
             .Where(m => m.Level == Microsoft.Extensions.Logging.LogLevel.Debug)
-            .Where(m => m.FormattedMessage == "Host is starting up with state 'Error'. Initializing worker channel.");
+            .Where(m => m.FormattedMessage.StartsWith("JobHost is starting with state"));
         Assert.Single(debugMsg);
+        Assert.Contains("'Error'", debugMsg.Single().FormattedMessage);
 
         await fixture.DisposeAsync();
     }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebHostStartupEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebHostStartupEndToEndTests.cs
@@ -30,23 +30,28 @@ public class WebHostStartupEndToEndTests
 
         var fixture = new WebHostStartupEndToEndTestFixture(ThrowOnFirstBuild);
 
-        await fixture.InitializeAsync();
-
-        // This should recover as the second call to BuildHost should succeed
-        await TestHelpers.Await(async () =>
+        try
         {
-            var result = await fixture.Host.HttpClient.GetAsync("/api/HttpRequestDataFunction");
-            return result.IsSuccessStatusCode && await result.Content.ReadAsStringAsync() == "Welcome to Azure Functions!";
+            await fixture.InitializeAsync();
 
-        }, 10000, userMessageCallback: fixture.Host.GetLog);
+            // This should recover as the second call to BuildHost should succeed
+            await TestHelpers.Await(async () =>
+            {
+                var result = await fixture.Host.HttpClient.GetAsync("/api/HttpRequestDataFunction");
+                return result.IsSuccessStatusCode && await result.Content.ReadAsStringAsync() == "Welcome to Azure Functions!";
 
-        var debugMsg = fixture.Host.GetWebHostLogMessages("Microsoft.Azure.WebJobs.Script.WorkerFunctionMetadataProvider")
-            .Where(m => m.Level == Microsoft.Extensions.Logging.LogLevel.Debug)
-            .Where(m => m.FormattedMessage.StartsWith("JobHost is starting with state"));
-        Assert.Single(debugMsg);
-        Assert.Contains("'Error'", debugMsg.Single().FormattedMessage);
+            }, 10000, userMessageCallback: fixture.Host.GetLog);
 
-        await fixture.DisposeAsync();
+            var debugMsg = fixture.Host.GetWebHostLogMessages("Microsoft.Azure.WebJobs.Script.WorkerFunctionMetadataProvider")
+                .Where(m => m.Level == Microsoft.Extensions.Logging.LogLevel.Debug)
+                .Where(m => m.FormattedMessage.StartsWith("JobHost is starting with state"));
+            Assert.Single(debugMsg);
+            Assert.Contains("'Error'", debugMsg.Single().FormattedMessage);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
     }
 
     private class WebHostStartupEndToEndTestFixture : EndToEndTestFixture

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebHostStartupEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebHostStartupEndToEndTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Extensions.DependencyInjection;
@@ -38,6 +39,11 @@ public class WebHostStartupEndToEndTests
             return result.IsSuccessStatusCode && await result.Content.ReadAsStringAsync() == "Welcome to Azure Functions!";
 
         }, 10000, userMessageCallback: fixture.Host.GetLog);
+
+        var debugMsg = fixture.Host.GetWebHostLogMessages("Microsoft.Azure.WebJobs.Script.WorkerFunctionMetadataProvider")
+            .Where(m => m.Level == Microsoft.Extensions.Logging.LogLevel.Debug)
+            .Where(m => m.FormattedMessage == "Host is starting up with state 'Error'. Initializing worker channel.");
+        Assert.Single(debugMsg);
 
         await fixture.DisposeAsync();
     }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #10766

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

The problem here (outlined in the issue) is that:
1. Even in transient error situations, we were setting the `State` to `Error`.
2. If we tried to recover, the `WorkerFunctionMetadataProvider` would look at that state, think that the host was in a stable state without any channels, and issue a restart here: https://github.com/Azure/azure-functions-host/blob/71738799181ebd3c8f7104ba2c881c618cd1e631/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs#L99
3. That restart would deadlock waiting for the current startup to complete... but it was part of the current startup so it'd never complete.
4. Deadlock.


After looking through all the code, I've concluded that:
- ~~`Error` and `Offline` (and to some extent `Running`) are considered "terminal" events... that's the state things will remain in. We have code that immediately returns if it sees `Error`, etc.~~
- ~~However, during a transient error, this isn't the case. We are recovering and need to communicate that somehow.~~
- ~~In this specific case, it's untrue that the `ScriptHost` is in an `Error` state. We are retrying fresh, so the metadata manager needs to know that.~~
- ~~By resetting to `Default`, it communicates that we're still starting up.~~
- ~~Yes, this may go on forever as we'll back off but retry until the platform stops us. However, the places that are waiting on this also have timeouts applied, so they should be unaffected. And in fact, they should behave better under transient conditions.~~

My original attempt had added a `HandlingHostError` state that, while did communicate correctly, change the assumptions across other services. A handful of tests failed.

After seeing tests fail b/c they assumed `Error`, I've changed the approach to simply starting worker channels also while in the `Error` state. This seems fine the more I look at it -- we are performing a normal startup (or else these services wouldn't start), so we should behave as such. Every other service behaves normally here and we just happen to have this unique piece of code for an odd situation where we need to recover.

Other considerations:
- What we really should do is make sure that when `RestartAsync()` is called, the `CancellationToken` we call will flow all the way down, effectively cancelling itself. However, that would be a *large* refactoring of code that is already being completely rewritten. I consider this a strategic fix to stop the issues we're currently seeing and the next iteration of worker management will take care of this scenario in a cleaner way.