### PR TITLE
Ensuring ScriptTypeLocator does not return an uninitialized types collection.

### DIFF
--- a/src/WebJobs.Script/Config/ScriptTypeLocator.cs
+++ b/src/WebJobs.Script/Config/ScriptTypeLocator.cs
@@ -3,32 +3,58 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Threading;
 
 namespace Microsoft.Azure.WebJobs.Script.Config
 {
-    public class ScriptTypeLocator : ITypeLocator
+    public class ScriptTypeLocator : ITypeLocator, IDisposable
     {
+        private readonly ManualResetEventSlim _typesSetEvent;
+        private readonly TimeSpan _setWaitTimeout;
         private Type[] _types;
+        private bool _disposed;
 
         public ScriptTypeLocator()
+            : this(TimeSpan.FromMinutes(2))
+        { }
+
+        internal ScriptTypeLocator(TimeSpan setWaitTimeout)
         {
-            _types = Array.Empty<Type>();
+            _typesSetEvent = new ManualResetEventSlim(false);
+            _setWaitTimeout = setWaitTimeout;
         }
 
         public IReadOnlyList<Type> GetTypes()
         {
+            if (!_typesSetEvent.Wait(_setWaitTimeout))
+            {
+                throw new TimeoutException($"Timeout waiting for types to be set in {nameof(ScriptTypeLocator)}.");
+            }
+
             return _types;
         }
 
         internal void SetTypes(IEnumerable<Type> types)
         {
-            if (types == null)
-            {
-                throw new ArgumentNullException(nameof(types));
-            }
+            ArgumentNullException.ThrowIfNull(types);
 
-            _types = types.ToArray();
+            _types = [.. types];
+            _typesSetEvent.Set();
+        }
+
+        public void Dispose() => Dispose(true);
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _typesSetEvent.Dispose();
+                }
+
+                _disposed = true;
+            }
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Config/ScriptTypeLocatorTests.cs
+++ b/test/WebJobs.Script.Tests/Config/ScriptTypeLocatorTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Config.Tests
+{
+    public class ScriptTypeLocatorTests
+    {
+        [Fact]
+        public void GetTypes_ThrowsTimeoutException_WhenSetTypesNotCalled()
+        {
+            var locator = new ScriptTypeLocator(TimeSpan.FromSeconds(3));
+
+            Assert.Throws<TimeoutException>(() => locator.GetTypes());
+        }
+
+        [Fact]
+        public void GetTypes_ReturnsTypes_WhenSetTypesCalled()
+        {
+            var locator = new ScriptTypeLocator();
+            var expectedTypes = new[] { typeof(string), typeof(int) };
+
+            Task.Run(() => locator.SetTypes(expectedTypes));
+            var types = locator.GetTypes();
+
+            Assert.Equal(expectedTypes, types);
+        }
+
+        [Fact]
+        public void Dispose_DisposesManualResetEventSlim()
+        {
+            var locator = new ScriptTypeLocator();
+
+            locator.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => locator.GetTypes());
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

resolves #11015 

### Pull request checklist

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This pull request introduces enhancements to the `ScriptTypeLocator` class in `src/WebJobs.Script/Config/ScriptTypeLocator.cs` and adds corresponding unit tests in `test/WebJobs.Script.Tests/Config/ScriptTypeLocatorTests.cs`. The changes improve thread safety, add timeout handling, and implement proper disposal of resources. Additionally, new tests ensure the reliability of these features.

### Enhancements to `ScriptTypeLocator`:

* **Timeout Handling for Type Retrieval**: Added a `ManualResetEventSlim` and a timeout mechanism to ensure `GetTypes` waits for types to be set, throwing a `TimeoutException` if the operation exceeds the specified duration. 