### PR TITLE
update bundles upgrade help link

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,4 +6,4 @@
 - Adding activity sources for Durable and WebJobs (Kafka and RabbitMQ) (#11137)
 - Add JitTrace Files for v4.1041
 - Fix startup deadlock on transient exceptions (#11142)
-- Add warning log for end of support bundle version, any bundle version < 4 (#11075)
+- Add warning log for end of support bundle version, any bundle version < 4 (#11075), (#11160)

--- a/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
+++ b/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
@@ -209,12 +209,12 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
         private static readonly Action<ILogger, string, int, int, Exception> _outdatedExtensionBundleFuture =
            LoggerMessage.Define<string, int, int>(LogLevel.Warning,
            new EventId(342, nameof(OutdatedExtensionBundle)),
-           "Your current bundle version {currentVersion} will reach end of support on Aug 4, 2026. Upgrade to [{suggestedMinVersion}.*, {suggestedMaxVersion}.0.0). For more information, see https://aka.ms/functions-outdated-bundles");
+           "Your current bundle version {currentVersion} will reach end of support on Aug 4, 2026. Upgrade to [{suggestedMinVersion}.*, {suggestedMaxVersion}.0.0). For more information, see https://aka.ms/FunctionsBundlesUpgrade");
 
         private static readonly Action<ILogger, string, int, int, Exception> _outdatedExtensionBundlePast =
            LoggerMessage.Define<string, int, int>(LogLevel.Warning,
            new EventId(342, nameof(OutdatedExtensionBundle)),
-           "Your current bundle version {currentVersion} has reached end of support on Aug 4, 2026. Upgrade to [{suggestedMinVersion}.*, {suggestedMaxVersion}.0.0). For more information, see https://aka.ms/functions-outdated-bundles");
+           "Your current bundle version {currentVersion} has reached end of support on Aug 4, 2026. Upgrade to [{suggestedMinVersion}.*, {suggestedMaxVersion}.0.0). For more information, see https://aka.ms/FunctionsBundlesUpgrade");
 
         public static void PublishingMetrics(this ILogger logger, string metrics)
         {


### PR DESCRIPTION
Update bundles upgrade help link to aka.ms/FunctionsBundlesUpgrade

* [`src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs`](diffhunk://#diff-374e3d774adf38015c92a7b4077f75f152c0b2d19f4f0d3ecebfd2835ae57ce9L212-R217): Updated the outdated bundle warning messages (`_outdatedExtensionBundleFuture` and `_outdatedExtensionBundlePast`) to use the URL `https://aka.ms/FunctionsBundlesUpgrade` instead of `https://aka.ms/functions-outdated-bundles`.

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
