### PR TITLE
Handles loading extensions.json with empty extensions

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,3 +7,4 @@
 - Add JitTrace Files for v4.1041
 - Fix startup deadlock on transient exceptions (#11142)
 - Add warning log for end of support bundle version, any bundle version < 4 (#11075), (#11160)
+- Handles loading extensions.json with empty extensions(#11174)

--- a/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs
+++ b/src/WebJobs.Script/DependencyInjection/ScriptStartupTypeLocator.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.WebJobs.Script.DependencyInjection
                     await using var stream = File.OpenRead(metadataFilePath);
                     var extensionReferences = await JsonSerializer.DeserializeAsync(stream, ExtensionReferencesJsonContext.Default.ExtensionReferences);
 
-                    if (extensionReferences?.Extensions == null || extensionReferences.Extensions.Length == 0)
+                    if (extensionReferences?.Extensions == null)
                     {
                         _logger.ScriptStartUpUnableParseMetadataMissingProperty(metadataFilePath);
                         return [];

--- a/test/WebJobs.Script.Tests/ScriptStartupTypeDiscovererTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptStartupTypeDiscovererTests.cs
@@ -716,7 +716,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
         }
 
-
         [Theory]
         [InlineData(false)]
         [InlineData(true)]

--- a/test/WebJobs.Script.Tests/ScriptStartupTypeDiscovererTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptStartupTypeDiscovererTests.cs
@@ -182,6 +182,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     Assert.True(traces.Any(m => m.FormattedMessage.Contains($"Loading extension bundle")));
                 }
                 Assert.True(traces.Any(m => m.FormattedMessage.Contains($"Loading startup extension 'Storage")));
+                AssertNoErrors(traces);
             }
         }
 
@@ -310,6 +311,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 {
                     Assert.True(traces.Any(m => m.FormattedMessage.Contains($"Loading startup extension 'Storage")));
                 }
+                AssertNoErrors(traces);
             }
         }
 
@@ -423,6 +425,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Assert.Equal(typeof(AzureStorageWebJobsStartup).FullName, types.Single().FullName);
                 Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, $"The extension startup type '{references[0].TypeName}' belongs to a builtin extension")));
                 Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, $"The extension startup type '{references[1].TypeName}' belongs to a builtin extension")));
+                AssertNoErrors(traces);
             }
         }
 
@@ -516,6 +519,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Assert.Equal(typeof(AzureStorageWebJobsStartup).FullName, types.Single().FullName);
                 Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, $"The extension startup type '{references[0].TypeName}' belongs to a builtin extension")));
                 Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, $"The extension startup type '{references[1].TypeName}' belongs to a builtin extension")));
+                AssertNoErrors(traces);
             }
         }
 
@@ -592,11 +596,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
                 // Act
                 var types = await discoverer.GetExtensionsStartupTypesAsync();
+                var traces = testLoggerProvider.GetAllLogMessages();
 
                 // Assert
                 AreExpectedMetricsGenerated(testMetricsLogger);
                 Assert.Equal(types.Count(), 2);
                 Assert.Equal(typeof(AzureStorageWebJobsStartup).FullName, types.FirstOrDefault().FullName);
+                AssertNoErrors(traces);
             }
         }
 
@@ -644,11 +650,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
                 // Act
                 var types = await discoverer.GetExtensionsStartupTypesAsync();
+                var traces = testLoggerProvider.GetAllLogMessages();
 
                 // Assert
                 AreExpectedMetricsGenerated(testMetricsLogger);
                 Assert.Single(types);
                 Assert.Equal(typeof(AzureStorageWebJobsStartup).FullName, types.Single().FullName);
+                AssertNoErrors(traces);
             }
         }
 
@@ -698,13 +706,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
                 // Act
                 var types = await discoverer.GetExtensionsStartupTypesAsync();
+                var traces = testLoggerProvider.GetAllLogMessages();
 
                 //Assert
                 AreExpectedMetricsGenerated(testMetricsLogger);
                 Assert.Single(types);
                 Assert.Equal(typeof(AzureStorageWebJobsStartup).FullName, types.Single().FullName);
+                AssertNoErrors(traces);
             }
         }
+
 
         [Theory]
         [InlineData(false)]
@@ -1144,13 +1155,55 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
                 // Act
                 var types = await discoverer.GetExtensionsStartupTypesAsync();
+                var traces = testLoggerProvider.GetAllLogMessages();
                 Environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, null);
                 Environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, null);
 
                 //Assert that filtering did not take place because of worker indexing
                 Assert.True(types.Count() == 1);
                 Assert.Equal(typeof(AzureStorageWebJobsStartup).FullName, types.ElementAt(0).FullName);
+                AssertNoErrors(traces);
             }
+        }
+
+        [Fact]
+        public async Task GetExtensionsStartupTypes_EmptyExtensionsArray()
+        {
+            TestMetricsLogger testMetricsLogger = new TestMetricsLogger();
+
+            using var directory = new TempDirectory();
+            var binPath = Path.Combine(directory.Path, "bin");
+            Directory.CreateDirectory(binPath);
+
+            // extensions.json file with an empty extensions array(simmulating extensions.json produced byin-proc app)
+            string extensionJson = """
+            {
+              "extensions": []
+            }
+            """;
+            File.WriteAllText(Path.Combine(binPath, "extensions.json"), extensionJson);
+
+            TestLoggerProvider testLoggerProvider = new TestLoggerProvider();
+            LoggerFactory factory = new LoggerFactory();
+            factory.AddProvider(testLoggerProvider);
+            var testLogger = factory.CreateLogger<ScriptStartupTypeLocator>();
+
+            var mockExtensionBundleManager = new Mock<IExtensionBundleManager>();
+            mockExtensionBundleManager.Setup(e => e.IsExtensionBundleConfigured()).Returns(true);
+            mockExtensionBundleManager.Setup(e => e.GetExtensionBundleDetails()).Returns(Task.FromResult(new ExtensionBundleDetails() { Id = "bundleID", Version = "1.0.0" }));
+            mockExtensionBundleManager.Setup(e => e.GetExtensionBundleBinPathAsync()).Returns(Task.FromResult(binPath));
+
+            var languageWorkerOptions = new TestOptionsMonitor<LanguageWorkerOptions>(new LanguageWorkerOptions());
+            var mockFunctionMetadataManager = GetTestFunctionMetadataManager(languageWorkerOptions);
+            OptionsWrapper<ExtensionRequirementOptions> optionsWrapper = new(new ExtensionRequirementOptions());
+            var discoverer = new ScriptStartupTypeLocator(directory.Path, testLogger, mockExtensionBundleManager.Object, mockFunctionMetadataManager, testMetricsLogger, optionsWrapper);
+
+            var types = await discoverer.GetExtensionsStartupTypesAsync();
+            var traces = testLoggerProvider.GetAllLogMessages();
+
+            AreExpectedMetricsGenerated(testMetricsLogger);
+            Assert.Empty(types); // Ensure no types are loaded because the extensions array is empty
+            AssertNoErrors(traces);
         }
 
         private IFunctionMetadataManager GetTestFunctionMetadataManager(IOptionsMonitor<LanguageWorkerOptions> options, ICollection<FunctionMetadata> metadataCollection = null, bool hasPrecompiledFunction = false, bool hasNodeFunctions = false, bool hasDotnetIsolatedFunctions = false)
@@ -1233,6 +1286,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             factory.AddProvider(testLoggerProvider);
             var testLogger = factory.CreateLogger<ScriptStartupTypeLocator>();
             return testLogger;
+        }
+
+        private static void AssertNoErrors(IList<LogMessage> traces)
+        {
+            Assert.False(traces.Any(m => m.Level == LogLevel.Error || m.Level == LogLevel.Critical));
         }
     }
 }

--- a/test/WebJobs.Script.Tests/ScriptStartupTypeDiscovererTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptStartupTypeDiscovererTests.cs
@@ -1174,7 +1174,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var binPath = Path.Combine(directory.Path, "bin");
             Directory.CreateDirectory(binPath);
 
-            // extensions.json file with an empty extensions array(simmulating extensions.json produced byin-proc app)
+            // extensions.json file with an empty extensions array(simulating extensions.json produced byin-proc app)
             string extensionJson = """
             {
               "extensions": []

--- a/test/WebJobs.Script.Tests/ScriptStartupTypeDiscovererTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptStartupTypeDiscovererTests.cs
@@ -1174,7 +1174,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var binPath = Path.Combine(directory.Path, "bin");
             Directory.CreateDirectory(binPath);
 
-            // extensions.json file with an empty extensions array(simulating extensions.json produced byin-proc app)
+            // extensions.json file with an empty extensions array (simulating extensions.json produced by in-proc app)
             string extensionJson = """
             {
               "extensions": []


### PR DESCRIPTION
Handles loading extensions.json with empty extensions, which is valid for in-proc apps.
Added a test to cover this case. Updated other tests to ensure no errors are logged in success usecases.


### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

