### PR TITLE
[WIP] Flow cancellation token to PendingItem

### DIFF
--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -267,7 +267,13 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             next.SetResult(message);
         }
 
-        private void RegisterCallbackForNextGrpcMessage(MsgType messageType, TimeSpan timeout, int count, Action<InboundGrpcEvent> callback, Action<Exception> faultHandler)
+        private void RegisterCallbackForNextGrpcMessage(
+            MsgType messageType,
+            TimeSpan timeout,
+            int count,
+            Action<InboundGrpcEvent> callback,
+            Action<Exception> faultHandler,
+            CancellationToken cancellationToken = default)
         {
             Queue<PendingItem> queue;
             lock (_pendingActions)
@@ -289,8 +295,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                 for (int i = 0; i < count; i++)
                 {
                     var newItem = (i == count - 1) && (timeout != TimeSpan.Zero)
-                        ? new PendingItem(callback, faultHandler, timeout)
-                        : new PendingItem(callback, faultHandler);
+                        ? new PendingItem(callback, faultHandler, timeout, cancellationToken)
+                        : new PendingItem(callback, faultHandler, cancellationToken);
                     queue.Enqueue(newItem);
                 }
             }
@@ -371,8 +377,16 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
         public async Task StartWorkerProcessAsync(CancellationToken cancellationToken)
         {
-            RegisterCallbackForNextGrpcMessage(MsgType.StartStream, _workerConfig.CountOptions.ProcessStartupTimeout, 1, SendWorkerInitRequest, HandleWorkerStartStreamError);
-            // note: it is important that the ^^^ StartStream is in place *before* we start process the loop, otherwise we get a race condition
+            cancellationToken.ThrowIfCancellationRequested();
+
+            RegisterCallbackForNextGrpcMessage(
+                MsgType.StartStream,
+                _workerConfig.CountOptions.ProcessStartupTimeout,
+                1,
+                grpcEvent => SendWorkerInitRequest(grpcEvent, cancellationToken),
+                HandleWorkerStartStreamError,
+                cancellationToken);
+            // Note: it is important that the ^^^ StartStream is in place *before* we start process the loop, otherwise we get a race condition
             _ = ProcessInbound();
 
             _workerChannelLogger.LogDebug("Initiating Worker Process start up");
@@ -418,10 +432,12 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         }
 
         // send capabilities to worker, wait for WorkerInitResponse
-        internal void SendWorkerInitRequest(GrpcEvent startEvent)
+        internal void SendWorkerInitRequest(GrpcEvent startEvent, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             _workerChannelLogger.LogDebug("Worker Process started. Received StartStream message");
-            RegisterCallbackForNextGrpcMessage(MsgType.WorkerInitResponse, _workerConfig.CountOptions.InitializationTimeout, 1, WorkerInitResponse, HandleWorkerInitError);
+            RegisterCallbackForNextGrpcMessage(MsgType.WorkerInitResponse, _workerConfig.CountOptions.InitializationTimeout, 1, WorkerInitResponse, HandleWorkerInitError, cancellationToken);
 
             WorkerInitRequest initRequest = GetWorkerInitRequest();
 
@@ -949,7 +965,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     if (!_functionMetadataRequestSent)
                     {
                         RegisterCallbackForNextGrpcMessage(MsgType.FunctionMetadataResponse, _functionLoadTimeout, 1,
-                    msg => ProcessFunctionMetadataResponses(msg.Message.FunctionMetadataResponse), HandleWorkerMetadataRequestError);
+                            msg => ProcessFunctionMetadataResponses(msg.Message.FunctionMetadataResponse), HandleWorkerMetadataRequestError);
 
                         _workerChannelLogger.LogDebug("Sending WorkerMetadataRequest to {language} worker with worker ID {workerID}", _runtime, _workerId);
 
@@ -1749,21 +1765,25 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         {
             private readonly Action<InboundGrpcEvent> _callback;
             private readonly Action<Exception> _faultHandler;
-            private CancellationTokenRegistration _ctr;
+            private CancellationTokenRegistration _timeoutRegistration;
+            private CancellationTokenRegistration _cancellationRegistration;
             private int _state;
 
-            public PendingItem(Action<InboundGrpcEvent> callback, Action<Exception> faultHandler)
+            public PendingItem(Action<InboundGrpcEvent> callback, Action<Exception> faultHandler, CancellationToken cancellationToken = default)
             {
                 _callback = callback;
                 _faultHandler = faultHandler;
+
+                // Register for host shutdown
+                _cancellationRegistration = cancellationToken.Register(static state => ((PendingItem)state).OnCanceled(), this);
             }
 
-            public PendingItem(Action<InboundGrpcEvent> callback, Action<Exception> faultHandler, TimeSpan timeout)
-                : this(callback, faultHandler)
+            public PendingItem(Action<InboundGrpcEvent> callback, Action<Exception> faultHandler, TimeSpan timeout, CancellationToken cancellationToken = default)
+                : this(callback, faultHandler, cancellationToken)
             {
                 var cts = new CancellationTokenSource();
                 cts.CancelAfter(timeout);
-                _ctr = cts.Token.Register(static state => ((PendingItem)state).OnTimeout(), this);
+                _timeoutRegistration = cts.Token.Register(static state => ((PendingItem)state).OnTimeout(), this);
             }
 
             public bool IsComplete => Volatile.Read(ref _state) != 0;
@@ -1772,8 +1792,11 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
             public void SetResult(InboundGrpcEvent message)
             {
-                _ctr.Dispose();
-                _ctr = default;
+                _timeoutRegistration.Dispose();
+                _cancellationRegistration.Dispose();
+                _timeoutRegistration = default;
+                _cancellationRegistration = default;
+
                 if (MakeComplete() && _callback != null)
                 {
                     try
@@ -1810,6 +1833,20 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                         catch
                         {
                         }
+                    }
+                }
+            }
+
+            private void OnCanceled()
+            {
+                if (MakeComplete() && _faultHandler != null)
+                {
+                    try
+                    {
+                        _faultHandler(new OperationCanceledException());
+                    }
+                    catch
+                    {
                     }
                 }
             }

--- a/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script/Host/WorkerFunctionMetadataProvider.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script
         private readonly IEnvironment _environment;
         private readonly IWebHostRpcWorkerChannelManager _channelManager;
         private readonly IScriptHostManager _scriptHostManager;
+        private readonly IHostApplicationLifetime _applicationLifetime;
         private string _workerRuntime;
         private ImmutableArray<FunctionMetadata> _functions;
         private IHost _currentJobHost = null;
@@ -38,7 +39,8 @@ namespace Microsoft.Azure.WebJobs.Script
             ILogger<WorkerFunctionMetadataProvider> logger,
             IEnvironment environment,
             IWebHostRpcWorkerChannelManager webHostRpcWorkerChannelManager,
-            IScriptHostManager scriptHostManager)
+            IScriptHostManager scriptHostManager,
+            IHostApplicationLifetime applicationLifetime)
         {
             _scriptOptions = scriptOptions;
             _logger = logger;
@@ -46,6 +48,7 @@ namespace Microsoft.Azure.WebJobs.Script
             _channelManager = webHostRpcWorkerChannelManager;
             _scriptHostManager = scriptHostManager;
             _workerRuntime = _environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime);
+            _applicationLifetime = applicationLifetime;
 
             _scriptHostManager.ActiveHostChanged += OnHostChanged;
         }
@@ -89,7 +92,7 @@ namespace Microsoft.Azure.WebJobs.Script
                     if (IsJobHostStarting())
                     {
                         _logger.LogDebug("JobHost is starting with state '{State}'. Initializing worker channel.", _scriptHostManager.State);
-                        await _channelManager.InitializeChannelAsync(workerConfigs, _workerRuntime);
+                        await _channelManager.InitializeChannelAsync(workerConfigs, _workerRuntime, _applicationLifetime.ApplicationStopping);
                     }
                     else
                     {
@@ -167,10 +170,8 @@ namespace Microsoft.Azure.WebJobs.Script
             // the host has not completely started, it means that it is still in the process of starting.
             if (_currentJobHost is not null && _scriptHostManager.State == ScriptHostState.Error)
             {
-                var lifetime = _currentJobHost.Services?.GetService<IHostApplicationLifetime>();
-
-                if (lifetime is not null &&
-                    !lifetime.ApplicationStarted.IsCancellationRequested)
+                if (_applicationLifetime is not null &&
+                    !_applicationLifetime.ApplicationStarted.IsCancellationRequested)
                 {
                     return true;
                 }

--- a/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script/Workers/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -158,13 +158,13 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         internal async Task InitializeJobhostLanguageWorkerChannelAsync(int attemptCount, string language) =>
             await InitializeJobhostLanguageWorkerChannelAsync(attemptCount, new[] { language });
 
-        internal async Task InitializeJobhostLanguageWorkerChannelAsync(int attemptCount, IEnumerable<string> languages)
+        internal async Task InitializeJobhostLanguageWorkerChannelAsync(int attemptCount, IEnumerable<string> languages, CancellationToken cancellationToken = default)
         {
             foreach (string language in languages)
             {
                 var rpcWorkerChannel = _rpcWorkerChannelFactory.Create(_scriptOptions.RootScriptPath, language, _metricsLogger, attemptCount, _workerConfigs);
                 _jobHostLanguageWorkerChannelManager.AddChannel(rpcWorkerChannel, language);
-                await rpcWorkerChannel.StartWorkerProcessAsync();
+                await rpcWorkerChannel.StartWorkerProcessAsync(cancellationToken);
                 _logger.LogDebug("Adding jobhost language worker channel for runtime: {language}. workerId:{id}", language, rpcWorkerChannel.Id);
 
                 // if the worker is indexing, we will not have function metadata yet. So, we cannot set up invocation buffers or send load requests

--- a/src/WebJobs.Script/Workers/Rpc/IWebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/IWebHostRpcWorkerChannelManager.cs
@@ -3,13 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 {
     public interface IWebHostRpcWorkerChannelManager
     {
-        Task<IRpcWorkerChannel> InitializeChannelAsync(IEnumerable<RpcWorkerConfig> workerConfigs, string language);
+        Task<IRpcWorkerChannel> InitializeChannelAsync(IEnumerable<RpcWorkerConfig> workerConfigs, string language, CancellationToken cancellationToken = default);
 
         IDictionary<string, TaskCompletionSource<IRpcWorkerChannel>> GetChannels(string language);
 

--- a/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.AppService.Proxy.Common.Infra;
 using Microsoft.Azure.WebJobs.Script.Config;
@@ -72,22 +73,24 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             _shutdownStandbyWorkerChannels = _shutdownStandbyWorkerChannels.Debounce(milliseconds: 5000);
         }
 
-        public Task<IRpcWorkerChannel> InitializeChannelAsync(IEnumerable<RpcWorkerConfig> workerConfigs, string runtime)
+        public Task<IRpcWorkerChannel> InitializeChannelAsync(IEnumerable<RpcWorkerConfig> workerConfigs, string runtime, CancellationToken cancellationToken = default)
         {
             _logger?.LogDebug("Initializing language worker channel for runtime:{runtime}", runtime);
-            return InitializeLanguageWorkerChannel(workerConfigs, runtime, _applicationHostOptions.CurrentValue.ScriptPath);
+            return InitializeLanguageWorkerChannel(workerConfigs, runtime, _applicationHostOptions.CurrentValue.ScriptPath, cancellationToken);
         }
 
-        internal async Task<IRpcWorkerChannel> InitializeLanguageWorkerChannel(IEnumerable<RpcWorkerConfig> workerConfigs, string runtime, string scriptRootPath)
+        internal async Task<IRpcWorkerChannel> InitializeLanguageWorkerChannel(IEnumerable<RpcWorkerConfig> workerConfigs, string runtime, string scriptRootPath, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             IRpcWorkerChannel rpcWorkerChannel = null;
             string workerId = Guid.NewGuid().ToString();
-            _logger.LogDebug("Creating language worker channel for runtime:{runtime}", runtime);
+            _logger.LogWarning("Creating language worker channel for runtime:{runtime}", runtime);
             try
             {
                 rpcWorkerChannel = _rpcWorkerChannelFactory.Create(scriptRootPath, runtime, _metricsLogger, 0, workerConfigs);
                 AddOrUpdateWorkerChannels(runtime, rpcWorkerChannel);
-                await rpcWorkerChannel.StartWorkerProcessAsync().ContinueWith(processStartTask =>
+                await rpcWorkerChannel.StartWorkerProcessAsync(cancellationToken).ContinueWith(processStartTask =>
                 {
                     if (processStartTask.Status == TaskStatus.RanToCompletion)
                     {

--- a/test/WebJobs.Script.Tests/WorkerFunctionMetadataProviderTests.cs
+++ b/test/WebJobs.Script.Tests/WorkerFunctionMetadataProviderTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -28,13 +29,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var mockEnvironment = new Mock<IEnvironment>();
             var mockChannelManager = new Mock<IWebHostRpcWorkerChannelManager>();
             var mockScriptHostManager = new Mock<IScriptHostManager>();
+            var mockLifetime = new Mock<IHostApplicationLifetime>();
 
             _workerFunctionMetadataProvider = new WorkerFunctionMetadataProvider(
                 mockScriptOptions.Object,
                 mockLogger.Object,
                 mockEnvironment.Object,
                 mockChannelManager.Object,
-                mockScriptHostManager.Object);
+                mockScriptHostManager.Object,
+                mockLifetime.Object);
         }
 
         [Fact]
@@ -188,6 +191,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var mockScriptHostManager = new Mock<IScriptHostManager>();
             mockScriptHostManager.Setup(m => m.State).Returns(ScriptHostState.Running);
 
+            var mockLifetime = new Mock<IHostApplicationLifetime>();
+
             var mockWebHostRpcWorkerChannelManager = new Mock<IWebHostRpcWorkerChannelManager>();
             mockWebHostRpcWorkerChannelManager.Setup(m => m.GetChannels(It.IsAny<string>())).Returns(() => new Dictionary<string, TaskCompletionSource<IRpcWorkerChannel>>
             {
@@ -197,7 +202,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, "node");
 
             var workerFunctionMetadataProvider = new WorkerFunctionMetadataProvider(optionsMonitor, logger, SystemEnvironment.Instance,
-                                                    mockWebHostRpcWorkerChannelManager.Object, mockScriptHostManager.Object);
+                                                    mockWebHostRpcWorkerChannelManager.Object, mockScriptHostManager.Object, mockLifetime.Object);
             await workerFunctionMetadataProvider.GetFunctionMetadataAsync(workerConfigs, false);
 
             var traces = logger.GetLogMessages();
@@ -230,6 +235,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var mockChannelManager = new Mock<IWebHostRpcWorkerChannelManager>(MockBehavior.Strict);
             var mockScriptHostManager = new Mock<IScriptHostManager>(MockBehavior.Strict);
             var mockOptionsMonitor = new Mock<IOptionsMonitor<ScriptApplicationHostOptions>>(MockBehavior.Strict);
+            var mockLifetime = new Mock<IHostApplicationLifetime>(MockBehavior.Strict);
             var scriptOptions = new ScriptApplicationHostOptions
             {
                 IsFileSystemReadOnly = true
@@ -265,7 +271,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 NullLogger<WorkerFunctionMetadataProvider>.Instance,
                 testEnvironment,
                 mockChannelManager.Object,
-                mockScriptHostManager.Object);
+                mockScriptHostManager.Object,
+                mockLifetime.Object);
 
             var workerConfigs = new List<RpcWorkerConfig>();
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcInitializationServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcInitializationServiceTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _workerOptionsMonitor = TestHelpers.CreateOptionsMonitor(TestHelpers.GetTestLanguageWorkerOptions());
 
             IRpcWorkerChannel testLanguageWorkerChannel = new TestRpcWorkerChannel(Guid.NewGuid().ToString(), RpcWorkerConstants.NodeLanguageWorkerName);
-            _mockLanguageWorkerChannelManager.Setup(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), It.IsAny<string>()))
+            _mockLanguageWorkerChannelManager.Setup(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
                                              .Returns(Task.FromResult<IRpcWorkerChannel>(testLanguageWorkerChannel));
         }
 
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 offlineFilePath = TestHelpers.CreateOfflineFile();
                 _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger, _workerOptionsMonitor);
                 await _rpcInitializationService.StartAsync(CancellationToken.None);
-                _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), RpcWorkerConstants.JavaLanguageWorkerName), Times.Never);
+                _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), RpcWorkerConstants.JavaLanguageWorkerName, It.IsAny<CancellationToken>()), Times.Never);
                 Assert.DoesNotContain("testserver", testRpcServer.Uri.ToString());
                 await testRpcServer.ShutdownAsync();
             }
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeSettingName)).Returns(RpcWorkerConstants.NodeLanguageWorkerName);
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger, _workerOptionsMonitor);
             await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), RpcWorkerConstants.NodeLanguageWorkerName), Times.Never);
+            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), RpcWorkerConstants.NodeLanguageWorkerName, It.IsAny<CancellationToken>()), Times.Never);
             Assert.Contains("testserver", testRpcServer.Uri.ToString());
             await testRpcServer.ShutdownAsync();
         }
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger, _workerOptionsMonitor);
 
             await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), RpcWorkerConstants.NodeLanguageWorkerName), Times.Once);
+            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), RpcWorkerConstants.NodeLanguageWorkerName, It.IsAny<CancellationToken>()), Times.Once);
             Assert.Contains("testserver", testRpcServer.Uri.ToString());
             await testRpcServer.ShutdownAsync();
         }
@@ -112,9 +112,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger, _workerOptionsMonitor);
             await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), RpcWorkerConstants.NodeLanguageWorkerName), Times.Once);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), RpcWorkerConstants.JavaLanguageWorkerName), Times.Once);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), RpcWorkerConstants.PythonLanguageWorkerName), Times.Once);
+            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), RpcWorkerConstants.NodeLanguageWorkerName, It.IsAny<CancellationToken>()), Times.Once);
+            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), RpcWorkerConstants.JavaLanguageWorkerName, It.IsAny<CancellationToken>()), Times.Once);
+            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), RpcWorkerConstants.PythonLanguageWorkerName, It.IsAny<CancellationToken>()), Times.Once);
             Assert.Contains("testserver", testRpcServer.Uri.ToString());
             await testRpcServer.ShutdownAsync();
         }
@@ -129,9 +129,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             _rpcInitializationService = new RpcInitializationService(_optionsMonitor, mockEnvironment.Object, testRpcServer, _mockLanguageWorkerChannelManager.Object, _logger, _workerOptionsMonitor);
             await _rpcInitializationService.StartAsync(CancellationToken.None);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), RpcWorkerConstants.NodeLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), RpcWorkerConstants.JavaLanguageWorkerName), Times.Never);
-            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), RpcWorkerConstants.PythonLanguageWorkerName), Times.Never);
+            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), RpcWorkerConstants.NodeLanguageWorkerName, It.IsAny<CancellationToken>()), Times.Never);
+            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), RpcWorkerConstants.JavaLanguageWorkerName, It.IsAny<CancellationToken>()), Times.Never);
+            _mockLanguageWorkerChannelManager.Verify(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), RpcWorkerConstants.PythonLanguageWorkerName, It.IsAny<CancellationToken>()), Times.Never);
             Assert.Contains("testserver", testRpcServer.Uri.ToString());
             await testRpcServer.ShutdownAsync();
         }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannelManager.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/TestRpcWorkerChannelManager.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
@@ -44,7 +45,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             return null;
         }
 
-        public async Task<IRpcWorkerChannel> InitializeChannelAsync(IEnumerable<RpcWorkerConfig> workerConfigs, string language)
+        public async Task<IRpcWorkerChannel> InitializeChannelAsync(IEnumerable<RpcWorkerConfig> workerConfigs, string language, CancellationToken cancellationToken = default)
         {
             var metricsLogger = new Mock<IMetricsLogger>();
             IRpcWorkerChannel workerChannel = _testLanguageWorkerChannelFactory.Create(_scriptRootPath, language, metricsLogger.Object, 0, TestHelpers.GetTestWorkerConfigs());
@@ -58,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 _workerChannels[language].Add(workerChannel.Id, new TaskCompletionSource<IRpcWorkerChannel>());
             }
 
-            await workerChannel.StartWorkerProcessAsync().ContinueWith(processStartTask =>
+            await workerChannel.StartWorkerProcessAsync(cancellationToken).ContinueWith(processStartTask =>
             {
                 if (processStartTask.Status == TaskStatus.RanToCompletion)
                 {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Whilst investigating the core tools `ctrl+c` [issue](https://github.com/Azure/azure-functions-core-tools/issues/4355) I was able to narrow down the problem to this area of the code.

Cancellation tokens are not passed through and so when we hit `Ctrl+C` and trigger the application stopping lifetime event, nothing happens because we are either waiting for a response from the worker (which never happens in this state since we kill the channel), or until timeout. The timeout is set to 1 minute and that's why it often takes a minute for the host to shut down (if the host is stopped during startup).
