### PR TITLE
adding a read-only ContainerApps secret repository

### DIFF
--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/ContainerAppsSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/ContainerAppsSecretsRepository.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/ContainerAppsSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/ContainerAppsSecretsRepository.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost;
+
+public class ContainerAppsSecretsRepository : ISecretsRepository
+{
+    internal const string ContainerAppsSecretsDir = "/run/secrets/functions-keys";
+
+    // host.master = value
+    private const string MasterKey = "host.master";
+    // host.function.{keyName} = value
+    private const string HostFunctionKeyPrefix = "host.function.";
+    // host.systemKey.{keyName} = value
+    private const string SystemKeyPrefix = "host.systemKey.";
+    // functions.{functionName}.{keyName} = value
+    private const string FunctionKeyPrefix = "functions.";
+
+    private readonly ILogger<ContainerAppsSecretsRepository> _logger;
+
+    public ContainerAppsSecretsRepository(ILogger<ContainerAppsSecretsRepository> logger)
+    {
+        _logger = logger;
+    }
+
+    public event EventHandler<SecretsChangedEventArgs> SecretsChanged;
+
+    public bool IsEncryptionSupported => false;
+
+    public string Name => nameof(ContainerAppsSecretsRepository);
+
+    public async Task<ScriptSecrets> ReadAsync(ScriptSecretsType type, string functionName)
+    {
+        if (type == ScriptSecretsType.Function && string.IsNullOrEmpty(functionName))
+        {
+            throw new ArgumentNullException(nameof(functionName), $"{nameof(functionName)} cannot be null or empty with {nameof(type)} = {nameof(ScriptSecretsType.Function)}");
+        }
+
+        return type == ScriptSecretsType.Host ? await ReadHostSecretsAsync() : await ReadFunctionSecretsAsync(functionName?.ToLowerInvariant());
+    }
+
+    public Task WriteAsync(ScriptSecretsType type, string functionName, ScriptSecrets secrets)
+        => throw new NotImplementedException();
+
+    private async Task<ScriptSecrets> ReadHostSecretsAsync()
+    {
+        var secrets = await GetFromFilesAsync(ContainerAppsSecretsDir);
+
+        HostSecrets hostSecrets = new HostSecrets()
+        {
+            FunctionKeys = [],
+            SystemKeys = []
+        };
+
+        foreach (var pair in secrets)
+        {
+            if (pair.Key.StartsWith(MasterKey, StringComparison.OrdinalIgnoreCase))
+            {
+                hostSecrets.MasterKey = new Key("master", pair.Value);
+            }
+            else if (pair.Key.StartsWith(HostFunctionKeyPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                hostSecrets.FunctionKeys.Add(ParseKeyWithPrefix(HostFunctionKeyPrefix, pair.Key, pair.Value));
+            }
+            else if (pair.Key.StartsWith(SystemKeyPrefix))
+            {
+                hostSecrets.SystemKeys.Add(ParseKeyWithPrefix(SystemKeyPrefix, pair.Key, pair.Value));
+            }
+        }
+
+        // Always return a HostSecrets object, even if empty. This will prevent the SecretManager from thinking
+        // it needs to create and persist new secrets, which is not supported in Container Apps.
+        return hostSecrets;
+    }
+
+    private async Task<ScriptSecrets> ReadFunctionSecretsAsync(string functionName)
+    {
+        var secrets = await GetFromFilesAsync(ContainerAppsSecretsDir);
+
+        var prefix = $"{FunctionKeyPrefix}{functionName}.";
+
+        var functionSecrets = new FunctionSecrets()
+        {
+            Keys = secrets
+                .Where(p => p.Key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                .Select(p => ParseKeyWithPrefix(prefix, p.Key, p.Value))
+                .ToList()
+        };
+
+        // Always return a FunctionSecrets object, even if empty. This will prevent the SecretManager from thinking
+        // it needs to create and persist new secrets, which is not supported in Container Apps.
+        return functionSecrets;
+    }
+
+    private static async Task<IDictionary<string, string>> GetFromFilesAsync(string path)
+    {
+        string[] files = await FileUtility.GetFilesAsync(path, "*");
+        var secrets = new Dictionary<string, string>(files.Length);
+
+        foreach (var file in files)
+        {
+            secrets.Add(Path.GetFileName(file), await FileUtility.ReadAsync(file));
+        }
+
+        return secrets;
+    }
+
+    public Task WriteSnapshotAsync(ScriptSecretsType type, string functionName, ScriptSecrets secrets)
+        => throw new NotImplementedException();
+
+    public Task PurgeOldSecretsAsync(IList<string> currentFunctions, ILogger logger)
+        => throw new NotImplementedException();
+
+    public Task<string[]> GetSecretSnapshots(ScriptSecretsType type, string functionName)
+        => throw new NotImplementedException();
+
+    private static Key ParseKeyWithPrefix(string prefix, string key, string value)
+        => new(key.Substring(prefix.Length), value);
+}

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/ContainerAppsSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/ContainerAppsSecretsRepository.cs
@@ -49,7 +49,7 @@ public class ContainerAppsSecretsRepository : ISecretsRepository
             throw new ArgumentNullException(nameof(functionName), $"{nameof(functionName)} cannot be null or empty with {nameof(type)} = {nameof(ScriptSecretsType.Function)}");
         }
 
-        return type == ScriptSecretsType.Host ? await ReadHostSecretsAsync() : await ReadFunctionSecretsAsync(functionName?.ToLowerInvariant());
+        return type == ScriptSecretsType.Host ? await ReadHostSecretsAsync() : await ReadFunctionSecretsAsync(functionName.ToLowerInvariant());
     }
 
     public Task WriteAsync(ScriptSecretsType type, string functionName, ScriptSecrets secrets)
@@ -122,14 +122,23 @@ public class ContainerAppsSecretsRepository : ISecretsRepository
         return secrets;
     }
 
+    /// <summary>
+    /// no-op - allow stale secrets to remain.
+    /// </summary>
+    public async Task PurgeOldSecretsAsync(IList<string> currentFunctions, ILogger logger)
+        => await Task.Yield();
+
+    /// <summary>
+    /// Runtime is not responsible for encryption so this code will never be executed.
+    /// </summary>
     public Task WriteSnapshotAsync(ScriptSecretsType type, string functionName, ScriptSecrets secrets)
-        => throw new NotImplementedException();
+        => throw new NotSupportedException();
 
-    public Task PurgeOldSecretsAsync(IList<string> currentFunctions, ILogger logger)
-        => throw new NotImplementedException();
-
+    /// <summary>
+    /// Runtime is not responsible for encryption so this code will never be executed.
+    /// </summary>
     public Task<string[]> GetSecretSnapshots(ScriptSecretsType type, string functionName)
-        => throw new NotImplementedException();
+        => throw new NotSupportedException();
 
     private static Key ParseKeyWithPrefix(string prefix, string key, string value)
         => new(key.Substring(prefix.Length), value);

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/ContainerAppsSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/ContainerAppsSecretsRepository.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -104,16 +105,20 @@ public class ContainerAppsSecretsRepository : ISecretsRepository
         return functionSecrets;
     }
 
-    private static async Task<IDictionary<string, string>> GetFromFilesAsync(string path)
+    private async Task<IDictionary<string, string>> GetFromFilesAsync(string path)
     {
         string[] files = await FileUtility.GetFilesAsync(path, "*");
         var secrets = new Dictionary<string, string>(files.Length);
 
+        StringBuilder sb = new StringBuilder("Loaded secrets from files:");
+
         foreach (var file in files)
         {
             secrets.Add(Path.GetFileName(file), await FileUtility.ReadAsync(file));
+            sb.AppendLine($"  {file}");
         }
 
+        _logger.LogDebug(sb.ToString());
         return secrets;
     }
 

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/ContainerAppsSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/ContainerAppsSecretsRepository.cs
@@ -30,7 +30,12 @@ public class ContainerAppsSecretsRepository : ISecretsRepository
         _logger = logger;
     }
 
-    public event EventHandler<SecretsChangedEventArgs> SecretsChanged;
+    // explicitly implementing this to avoid "unused" warnings on build
+    event EventHandler<SecretsChangedEventArgs> ISecretsRepository.SecretsChanged
+    {
+        add { }
+        remove { }
+    }
 
     public bool IsEncryptionSupported => false;
 

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/ContainerAppsSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/ContainerAppsSecretsRepository.cs
@@ -44,22 +44,22 @@ public class ContainerAppsSecretsRepository : ISecretsRepository
 
     public async Task<ScriptSecrets> ReadAsync(ScriptSecretsType type, string functionName)
     {
-        if (type == ScriptSecretsType.Function && string.IsNullOrEmpty(functionName))
+        if (type == ScriptSecretsType.Function)
         {
-            throw new ArgumentNullException(nameof(functionName), $"{nameof(functionName)} cannot be null or empty with {nameof(type)} = {nameof(ScriptSecretsType.Function)}");
+            ArgumentException.ThrowIfNullOrEmpty(functionName);
         }
 
         return type == ScriptSecretsType.Host ? await ReadHostSecretsAsync() : await ReadFunctionSecretsAsync(functionName.ToLowerInvariant());
     }
 
     public Task WriteAsync(ScriptSecretsType type, string functionName, ScriptSecrets secrets)
-        => throw new NotImplementedException();
+        => throw new NotSupportedException($"The {nameof(ContainerAppsSecretsRepository)} is read-only.");
 
     private async Task<ScriptSecrets> ReadHostSecretsAsync()
     {
-        var secrets = await GetFromFilesAsync(ContainerAppsSecretsDir);
+        IDictionary<string, string> secrets = await GetFromFilesAsync(ContainerAppsSecretsDir);
 
-        HostSecrets hostSecrets = new HostSecrets()
+        HostSecrets hostSecrets = new()
         {
             FunctionKeys = [],
             SystemKeys = []
@@ -67,11 +67,11 @@ public class ContainerAppsSecretsRepository : ISecretsRepository
 
         foreach (var pair in secrets)
         {
-            if (pair.Key.StartsWith(MasterKey, StringComparison.OrdinalIgnoreCase))
+            if (string.Compare(pair.Key, MasterKey) == 0)
             {
                 hostSecrets.MasterKey = new Key("master", pair.Value);
             }
-            else if (pair.Key.StartsWith(HostFunctionKeyPrefix, StringComparison.OrdinalIgnoreCase))
+            else if (pair.Key.StartsWith(HostFunctionKeyPrefix))
             {
                 hostSecrets.FunctionKeys.Add(ParseKeyWithPrefix(HostFunctionKeyPrefix, pair.Key, pair.Value));
             }
@@ -110,7 +110,7 @@ public class ContainerAppsSecretsRepository : ISecretsRepository
         string[] files = await FileUtility.GetFilesAsync(path, "*");
         var secrets = new Dictionary<string, string>(files.Length);
 
-        StringBuilder sb = new StringBuilder("Loaded secrets from files:");
+        StringBuilder sb = new("Loaded secrets from files:");
 
         foreach (var file in files)
         {
@@ -118,27 +118,31 @@ public class ContainerAppsSecretsRepository : ISecretsRepository
             sb.AppendLine($"  {file}");
         }
 
-        _logger.LogDebug(sb.ToString());
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug(sb.ToString());
+        }
+
         return secrets;
     }
 
     /// <summary>
     /// no-op - allow stale secrets to remain.
     /// </summary>
-    public async Task PurgeOldSecretsAsync(IList<string> currentFunctions, ILogger logger)
-        => await Task.Yield();
+    public Task PurgeOldSecretsAsync(IList<string> currentFunctions, ILogger logger)
+        => Task.CompletedTask;
 
     /// <summary>
     /// Runtime is not responsible for encryption so this code will never be executed.
     /// </summary>
     public Task WriteSnapshotAsync(ScriptSecretsType type, string functionName, ScriptSecrets secrets)
-        => throw new NotSupportedException();
+        => throw new NotSupportedException($"The {nameof(ContainerAppsSecretsRepository)} is read-only.");
 
     /// <summary>
     /// Runtime is not responsible for encryption so this code will never be executed.
     /// </summary>
     public Task<string[]> GetSecretSnapshots(ScriptSecretsType type, string functionName)
-        => throw new NotSupportedException();
+        => throw new NotSupportedException($"The {nameof(ContainerAppsSecretsRepository)} is read-only.");
 
     private static Key ParseKeyWithPrefix(string prefix, string key, string value)
         => new(key.Substring(prefix.Length), value);

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/DefaultSecretManagerProvider.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/DefaultSecretManagerProvider.cs
@@ -123,6 +123,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                                                                     _environment,
                                                                     _azureBlobStorageProvider);
                 }
+                else if (repositoryType == typeof(ContainerAppsSecretsRepository))
+                {
+                    repository = new ContainerAppsSecretsRepository(_loggerFactory.CreateLogger<ContainerAppsSecretsRepository>());
+                }
             }
 
             if (repository == null)
@@ -164,6 +168,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             else if (secretStorageType != null && secretStorageType.Equals("kubernetes", StringComparison.OrdinalIgnoreCase))
             {
                 repositoryType = typeof(KubernetesSecretsRepository);
+                return true;
+            }
+            else if (secretStorageType != null && secretStorageType.Equals("containerapps", StringComparison.OrdinalIgnoreCase))
+            {
+                repositoryType = typeof(ContainerAppsSecretsRepository);
                 return true;
             }
             else if (secretStorageSas != null)

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
@@ -17,7 +17,6 @@ using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Properties;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security;
 using Microsoft.Extensions.Logging;
-using static Microsoft.Azure.WebJobs.Script.WebHost.Models.FunctionAppSecrets;
 using DataProtectionConstants = Microsoft.Azure.Web.DataProtection.Constants;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
@@ -140,7 +139,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                         }
 
                         // before caching  any secrets, validate them
-                        string masterKeyValue = hostSecrets.MasterKey.Value;
+                        string masterKeyValue = hostSecrets.MasterKey?.Value;
                         var functionKeys = hostSecrets.FunctionKeys.ToDictionary(p => p.Name, p => p.Value);
                         var systemKeys = hostSecrets.SystemKeys.ToDictionary(p => p.Name, p => p.Value);
                         ValidateHostSecrets(masterKeyValue, functionKeys, systemKeys);
@@ -740,7 +739,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         {
             return new HostSecrets
             {
-                MasterKey = _keyValueConverterFactory.ReadKey(hostSecrets.MasterKey),
+                MasterKey = hostSecrets.MasterKey is null ? null : _keyValueConverterFactory.ReadKey(hostSecrets.MasterKey),
                 FunctionKeys = hostSecrets.FunctionKeys.Select(k => _keyValueConverterFactory.ReadKey(k)).ToList(),
                 SystemKeys = hostSecrets.SystemKeys?.Select(k => _keyValueConverterFactory.ReadKey(k)).ToList() ?? new List<Key>()
             };

--- a/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
@@ -522,7 +522,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
         }
 
-        public class Fixture : IDisposable
+        public class Fixture : IAsyncLifetime
         {
             private readonly DefaultAzureCredentialOptions _azureCredentialOptions;
 
@@ -614,14 +614,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 };
             }
 
-            public void Dispose()
+            public Task InitializeAsync()
+            {
+                return Task.CompletedTask;
+            }
+
+            public async Task DisposeAsync()
             {
                 try
                 {
                     // delete blob files
-                    ClearAllBlobSecrets().ContinueWith(t => { });
+                    await ClearAllBlobSecrets();
                     ClearAllFileSecrets();
-                    ClearAllKeyVaultSecrets().ContinueWith(t => { });
+                    await ClearAllKeyVaultSecrets();
                 }
                 catch
                 {

--- a/test/WebJobs.Script.Tests/Security/ContainerAppsSecretsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests/Security/ContainerAppsSecretsRepositoryTests.cs
@@ -1,0 +1,174 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests;
+
+public class ContainerAppsSecretsRepositoryTests : IDisposable
+{
+    private Dictionary<string, Func<MemoryStream>> _fileContentMap;
+    private ContainerAppsSecretsRepository _repo;
+
+    public ContainerAppsSecretsRepositoryTests()
+    {
+        // Mock the file system to return predefined secrets
+        var mockFileSystem = new Mock<IFileSystem>(MockBehavior.Strict);
+        var mockFile = new Mock<FileBase>(MockBehavior.Strict);
+        var mockDirectory = new Mock<DirectoryBase>(MockBehavior.Strict);
+
+        // Setup directory and file existence
+        mockDirectory.Setup(d => d.Exists(It.IsAny<string>())).Returns(true);
+        mockFileSystem.SetupGet(fs => fs.Directory).Returns(mockDirectory.Object);
+        mockFileSystem.SetupGet(fs => fs.File).Returns(mockFile.Object);
+
+        // Return all files when asked
+        mockDirectory
+            .Setup(d => d.GetFiles(ContainerAppsSecretsRepository.ContainerAppsSecretsDir, "*"))
+            .Returns(() => _fileContentMap.Keys.ToArray());
+
+        // Setup file existence checks
+        mockFile
+            .Setup(f => f.Exists(It.IsAny<string>()))
+            .Returns((string f) => _fileContentMap.ContainsKey(f));
+
+        // Return content when asked
+        mockFile
+            .Setup(f => f.Open(It.IsAny<string>(), FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete))
+            .Returns((string f, FileMode _, FileAccess _, FileShare _) => _fileContentMap[f]());
+
+        FileUtility.Instance = mockFileSystem.Object;
+
+        _repo = new ContainerAppsSecretsRepository(NullLogger<ContainerAppsSecretsRepository>.Instance);
+    }
+
+    [Fact]
+    public async Task Read_Host_Secrets()
+    {
+        _fileContentMap = new()
+        {
+            { "/run/secrets/functions-keys/host.master", () => GetStream("mk") },
+            { "/run/secrets/functions-keys/host.function.default", () => GetStream("hfd") },
+            { "/run/secrets/functions-keys/host.function.key1", () => GetStream("hfk1") },
+            { "/run/secrets/functions-keys/host.systemKey.key1", () => GetStream("hsk1") },
+        };
+
+        var result = await _repo.ReadAsync(ScriptSecretsType.Host, null);
+
+        var hostSecrets = result as HostSecrets;
+        Assert.NotNull(hostSecrets);
+        Assert.Equal("mk", hostSecrets.MasterKey.Value);
+        Assert.Equal("hfd", hostSecrets.GetFunctionKey("default", HostKeyScopes.FunctionKeys).Value);
+        Assert.Equal("hfk1", hostSecrets.GetFunctionKey("Key1", HostKeyScopes.FunctionKeys).Value);
+        Assert.Equal("hsk1", hostSecrets.GetFunctionKey("Key1", HostKeyScopes.SystemKeys).Value);
+    }
+
+    [Fact]
+    public async Task Read_Function_Secrets()
+    {
+        _fileContentMap = new()
+        {
+            { "/run/secrets/functions-keys/functions.function1.key1", () => GetStream("f1k1") },
+            { "/run/secrets/functions-keys/functions.function1.key2", () => GetStream("f1k2") },
+            { "/run/secrets/functions-keys/functions.function2.key1", () => GetStream("f2k1") },
+            { "/run/secrets/functions-keys/functions.function2.key2", () => GetStream("f2k2") }
+        };
+
+        var result = await _repo.ReadAsync(ScriptSecretsType.Function, "function1");
+
+        var functionSecrets = result as FunctionSecrets;
+        Assert.NotNull(functionSecrets);
+        Assert.Equal("f1k1", functionSecrets.GetFunctionKey("Key1", "function1").Value);
+        Assert.Equal("f1k2", functionSecrets.GetFunctionKey("key2", "Function1").Value);
+
+        result = await _repo.ReadAsync(ScriptSecretsType.Function, "function2");
+        functionSecrets = result as FunctionSecrets;
+        Assert.NotNull(functionSecrets);
+        Assert.Equal("f2k1", functionSecrets.GetFunctionKey("Key1", "funcTion2").Value);
+        Assert.Equal("f2k2", functionSecrets.GetFunctionKey("key2", "function2").Value);
+    }
+
+    [Fact]
+    public async Task No_HostKeys_Returns_Empty_HostSecrets()
+    {
+        _fileContentMap = [];
+
+        var result = await _repo.ReadAsync(ScriptSecretsType.Host, null);
+
+        var hostSecrets = result as HostSecrets;
+        Assert.NotNull(hostSecrets);
+        Assert.Null(hostSecrets.MasterKey);
+        Assert.Empty(hostSecrets.FunctionKeys);
+        Assert.Empty(hostSecrets.SystemKeys);
+    }
+
+    [Fact]
+    public async Task No_FunctionKeys_Returns_Empty_FunctionSecrets()
+    {
+        _fileContentMap = [];
+
+        var result = await _repo.ReadAsync(ScriptSecretsType.Function, "function1");
+
+        var hostSecrets = result as FunctionSecrets;
+        Assert.NotNull(hostSecrets);
+        Assert.Empty(hostSecrets.Keys);
+    }
+
+    [Fact]
+    public async Task SecretManager_DoesNotCreate_HostSecrets()
+    {
+        // no keys; we don't want the SecretManager to try to create new ones
+        _fileContentMap = [];
+
+        var testEnvironment = new TestEnvironment();
+        var mockHostNameProvider = new Mock<HostNameProvider>(MockBehavior.Strict, testEnvironment);
+        var startupContextProvider = new StartupContextProvider(testEnvironment, NullLogger<StartupContextProvider>.Instance);
+
+        var secretManager = new SecretManager(_repo, NullLogger.Instance, new TestMetricsLogger(), mockHostNameProvider.Object, startupContextProvider);
+
+        var hostSecrets = await secretManager.GetHostSecretsAsync();
+
+        Assert.NotNull(hostSecrets);
+        Assert.Null(hostSecrets.MasterKey);
+        Assert.Empty(hostSecrets.FunctionKeys);
+        Assert.Empty(hostSecrets.SystemKeys);
+    }
+
+    [Fact]
+    public async Task SecretManager_DoesNotCreate_FunctionSecrets()
+    {
+        // no keys; we don't want the SecretManager to try to create new ones
+        _fileContentMap = [];
+
+        var testEnvironment = new TestEnvironment();
+        var mockHostNameProvider = new Mock<HostNameProvider>(MockBehavior.Strict, testEnvironment);
+        var startupContextProvider = new StartupContextProvider(testEnvironment, NullLogger<StartupContextProvider>.Instance);
+
+        var secretManager = new SecretManager(_repo, NullLogger.Instance, new TestMetricsLogger(), mockHostNameProvider.Object, startupContextProvider);
+
+        var functionSecrets = await secretManager.GetFunctionSecretsAsync("function1");
+
+        Assert.NotNull(functionSecrets);
+        Assert.Empty(functionSecrets);
+    }
+
+    private static MemoryStream GetStream(string content)
+    {
+        return new MemoryStream(Encoding.UTF8.GetBytes(content));
+    }
+
+    public void Dispose()
+    {
+        FileUtility.Instance = null;
+    }
+}

--- a/test/WebJobs.Script.Tests/Security/ContainerAppsSecretsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests/Security/ContainerAppsSecretsRepositoryTests.cs
@@ -52,7 +52,7 @@ public class ContainerAppsSecretsRepositoryTests : IDisposable
         _repo = new ContainerAppsSecretsRepository(NullLogger<ContainerAppsSecretsRepository>.Instance);
     }
 
-    [Fact]
+    //[Fact]
     public async Task Read_Host_Secrets()
     {
         _fileContentMap = new()
@@ -73,7 +73,7 @@ public class ContainerAppsSecretsRepositoryTests : IDisposable
         Assert.Equal("hsk1", hostSecrets.GetFunctionKey("Key1", HostKeyScopes.SystemKeys).Value);
     }
 
-    [Fact]
+    //[Fact]
     public async Task Read_Function_Secrets()
     {
         _fileContentMap = new()
@@ -98,7 +98,7 @@ public class ContainerAppsSecretsRepositoryTests : IDisposable
         Assert.Equal("f2k2", functionSecrets.GetFunctionKey("key2", "function2").Value);
     }
 
-    [Fact]
+    //[Fact]
     public async Task No_HostKeys_Returns_Empty_HostSecrets()
     {
         _fileContentMap = [];
@@ -112,7 +112,7 @@ public class ContainerAppsSecretsRepositoryTests : IDisposable
         Assert.Empty(hostSecrets.SystemKeys);
     }
 
-    [Fact]
+    //[Fact]
     public async Task No_FunctionKeys_Returns_Empty_FunctionSecrets()
     {
         _fileContentMap = [];
@@ -124,7 +124,7 @@ public class ContainerAppsSecretsRepositoryTests : IDisposable
         Assert.Empty(hostSecrets.Keys);
     }
 
-    [Fact]
+    //[Fact]
     public async Task SecretManager_DoesNotCreate_HostSecrets()
     {
         // no keys; we don't want the SecretManager to try to create new ones
@@ -144,7 +144,7 @@ public class ContainerAppsSecretsRepositoryTests : IDisposable
         Assert.Empty(hostSecrets.SystemKeys);
     }
 
-    [Fact]
+    //[Fact]
     public async Task SecretManager_DoesNotCreate_FunctionSecrets()
     {
         // no keys; we don't want the SecretManager to try to create new ones

--- a/test/WebJobs.Script.Tests/Security/ContainerAppsSecretsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests/Security/ContainerAppsSecretsRepositoryTests.cs
@@ -52,7 +52,7 @@ public class ContainerAppsSecretsRepositoryTests : IDisposable
         _repo = new ContainerAppsSecretsRepository(NullLogger<ContainerAppsSecretsRepository>.Instance);
     }
 
-    //[Fact]
+    [Fact]
     public async Task Read_Host_Secrets()
     {
         _fileContentMap = new()
@@ -73,7 +73,7 @@ public class ContainerAppsSecretsRepositoryTests : IDisposable
         Assert.Equal("hsk1", hostSecrets.GetFunctionKey("Key1", HostKeyScopes.SystemKeys).Value);
     }
 
-    //[Fact]
+    [Fact]
     public async Task Read_Function_Secrets()
     {
         _fileContentMap = new()
@@ -98,7 +98,7 @@ public class ContainerAppsSecretsRepositoryTests : IDisposable
         Assert.Equal("f2k2", functionSecrets.GetFunctionKey("key2", "function2").Value);
     }
 
-    //[Fact]
+    [Fact]
     public async Task No_HostKeys_Returns_Empty_HostSecrets()
     {
         _fileContentMap = [];
@@ -112,7 +112,7 @@ public class ContainerAppsSecretsRepositoryTests : IDisposable
         Assert.Empty(hostSecrets.SystemKeys);
     }
 
-    //[Fact]
+    [Fact]
     public async Task No_FunctionKeys_Returns_Empty_FunctionSecrets()
     {
         _fileContentMap = [];
@@ -124,7 +124,7 @@ public class ContainerAppsSecretsRepositoryTests : IDisposable
         Assert.Empty(hostSecrets.Keys);
     }
 
-    //[Fact]
+    [Fact]
     public async Task SecretManager_DoesNotCreate_HostSecrets()
     {
         // no keys; we don't want the SecretManager to try to create new ones
@@ -144,7 +144,7 @@ public class ContainerAppsSecretsRepositoryTests : IDisposable
         Assert.Empty(hostSecrets.SystemKeys);
     }
 
-    //[Fact]
+    [Fact]
     public async Task SecretManager_DoesNotCreate_FunctionSecrets()
     {
         // no keys; we don't want the SecretManager to try to create new ones


### PR DESCRIPTION
fixes #11166 

Container Apps currently uses blob storage for it's secrets, which are not manageable easily.  We're transitioning secrets to be managed via [Container Apps itself](https://learn.microsoft.com/en-us/azure/container-apps/manage-secrets?tabs=azure-portal). In this case, the secrets will be in a drive in the container the same way as our K8S secrets are.

The main difference here is that these are read-only. We have no mechanism for auto-generating these in Container Apps, so they need to be created separately. 

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)