### PR TITLE
Incorporate MinorVersionPrefix with multi-TFM

### DIFF
--- a/eng/build/Engineering.props
+++ b/eng/build/Engineering.props
@@ -13,6 +13,7 @@
     <WarningsAsErrors Condition="'$(CI)' == 'true'">$(WarningsAsErrors)NU1904;</WarningsAsErrors>
     <NuGetAuditLevel>moderate</NuGetAuditLevel> <!-- warn on moderate severity only. -->
     <NuGetAuditMode>all</NuGetAuditMode> <!-- audit transitive dependencies. -->
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/build/Version.props
+++ b/eng/build/Version.props
@@ -1,5 +1,10 @@
 <Project>
 
+  <PropertyGroup Condition="'$(MinorVersionPrefix)' == ''">
+    <MinorVersionPrefix Condition="'$(TargetFramework)' == 'net6.0'">6</MinorVersionPrefix>
+    <MinorVersionPrefix Condition="'$(TargetFramework)' == 'net8.0'">8</MinorVersionPrefix>
+  </PropertyGroup>
+
   <!--
     Import the first 'Directory.Version.props' seen from project being built up.
     This allows each directory cone to set its own versioning at the time this file needs it set.
@@ -24,13 +29,9 @@
     <AssemblyVersion>$(VersionPrefix.Substring(0, $(VersionPrefix.LastIndexOf('.')))).0.0</AssemblyVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(CI)' != 'true'">
-    <!-- Constant file version for local dev. -->
-    <FileVersion>42.42.42.4242</FileVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(CI)' == 'true'">
-    <FileVersion>$(VersionPrefix).$(BuildNumber)</FileVersion>
+  <PropertyGroup>
+    <FileVersion Condition="'$(CI)' != 'true'">42.42.42.4242</FileVersion> <!-- Constant file version for local dev. -->
+    <FileVersion Condition="'$(CI)' == 'true'">$(VersionPrefix).$(BuildNumber)</FileVersion>
   </PropertyGroup>
 
 </Project>

--- a/eng/build/Version.targets
+++ b/eng/build/Version.targets
@@ -14,6 +14,12 @@
     <Version>$(VersionPrefix)-$(VersionSuffix)</Version>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(MinorVersionPrefix)' != ''">
+    <!-- Removing MinorVersionPrefix from the package version. -->
+    <!-- NOTE: this relies on minor version being 1 digit. -->
+    <PackageVersion>$(Version.Remove(2, $(MinorVersionPrefix.Length)))</PackageVersion>
+  </PropertyGroup>
+
   <!-- When building in Azure pipelines, update the build number. -->
   <!-- Specifically use '$(TF_BUILD)' and not '$(CI)' to ensure we are in Azure pipelines. -->
   <Target Name="UpdateAzDoBuildNumber" Condition="'$(TF_BUILD)' == 'true' AND '$(UpdateBuildNumber)' == 'true'" BeforeTargets="BeforeBuild">

--- a/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
+++ b/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <AssemblyName>Microsoft.Azure.WebJobs.Script.Grpc</AssemblyName>
-    <PackageId>$(AssemblyName).InProc</PackageId>
     <Ext Condition="'$(OS)' == 'Windows_NT'">bat</Ext>
     <Ext Condition="'$(OS)' != 'Windows_NT'">sh</Ext>
   </PropertyGroup>

--- a/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
+++ b/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
@@ -2,9 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
-    <PackageId>Microsoft.Azure.WebJobs.Script.Grpc</PackageId>
     <AssemblyName>Microsoft.Azure.WebJobs.Script.Grpc</AssemblyName>
-    <RootNamespace>Microsoft.Azure.WebJobs.Script.Grpc</RootNamespace>
+    <PackageId>$(AssemblyName).InProc</PackageId>
     <Ext Condition="'$(OS)' == 'Windows_NT'">bat</Ext>
     <Ext Condition="'$(OS)' != 'Windows_NT'">sh</Ext>
   </PropertyGroup>

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <AssemblyName>Microsoft.Azure.WebJobs.Script.WebHost</AssemblyName>
-    <RootNamespace>Microsoft.Azure.WebJobs.Script.WebHost</RootNamespace>
-    <PackageId>Microsoft.Azure.WebJobs.Script.WebHost.InProc</PackageId>
+    <PackageId>$(AssemblyName).InProc</PackageId>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <TieredCompilation>false</TieredCompilation>
     <NoWarn>NU5104</NoWarn>

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -1,9 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
-    <PackageId>Microsoft.Azure.WebJobs.Script</PackageId>
     <AssemblyName>Microsoft.Azure.WebJobs.Script</AssemblyName>
-    <RootNamespace>Microsoft.Azure.WebJobs.Script</RootNamespace>
+    <PackageId>$(AssemblyName).InProc</PackageId>
     <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AssemblyName>Microsoft.Azure.WebJobs.Script</AssemblyName>
-    <PackageId>$(AssemblyName).InProc</PackageId>
     <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This PR impacts **only** the nuget packages we produce and thus core tools. This is because we build with the `-p:MinorVersionPrefix={Version}` for the windows site extension and linux artifacts, so it has no impact to customer deployed code.

What it does:

**TODAY**
- Our in-proc nuget packages do not have the `MinorVersionPrefix` in them anywhere at all.
- We only changed the package ID for the _WebHost_ in-proc package.

**WITH THIS CHANGE**
- All in-proc packages will now have the `.InProc` package suffix.
  - This shouldn't impact CoreTools. It only directly references the WebHost package, which already has the `InProc` suffix. CoreTools will see transitive packages shift to the new ID when updating WebHost package to a new version with this change.
-  We will now incorporate `MinorVersionPrefix` based on TFM into the assembly version details.
- PackageVersion has the MinorVersionPrefix stripped from it, so that it is 1 version for 2 TFMs. IE: package `4.43.100` will contain net8.0 assembly with version `4.843.100` and net6.0 assembly with version `4.643.100`
- This **DOES NOT** current affect `Microsoft.Azure.WebJobs.Script.dll` because it is not multi-targeted. We will need to make that assembly multi-targeted for `ScriptHost.Version` to report the correct version.
