### PR TITLE
Pin Microsoft.Extensions.Azure to 1.11.0 in test app

### DIFF
--- a/test/Resources/TestProjects/DotNetIsolated60/DotNetIsolated60.csproj
+++ b/test/Resources/TestProjects/DotNetIsolated60/DotNetIsolated60.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage" Version="6.6.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.15.1" /> <!-- Do not update. Verifies worker behavior. -->
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Resources/TestProjects/DotNetIsolatedUnsupportedWorker/DotNetIsolatedUnsupportedWorker.csproj
+++ b/test/Resources/TestProjects/DotNetIsolatedUnsupportedWorker/DotNetIsolatedUnsupportedWorker.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="1.3.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage" Version="6.6.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.14.0" /> <!-- Do not update. Verifies worker behavior. -->
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.11.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Pin Microsoft.Extensions.Azure to 1.11.0 in test app.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

