### PR TITLE
Update outdated bundle message as per policy

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,5 +5,5 @@
 -->
 - Add JitTrace Files for v4.1042
 - Updating OTel related nuget packages (#11216)
-- Moving to version 1.5.7 of Microsoft.Azure.AppService.Middleware.Functions (<https://github.com/Azure/azure-functions-host/pull/11231>)
+- Moving to version 1.5.7 of Microsoft.Azure.AppService.Middleware.Functions (#11231)
 - Update outdated bundle message - removed deprecation date (#11230)

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,3 +4,4 @@
 - My change description (#PR)
 -->
 - Add JitTrace Files for v4.1042
+- Update outdated bundle message - removed deprecation date #11230

--- a/release_notes.md
+++ b/release_notes.md
@@ -10,4 +10,4 @@
 - Update Node.js Worker Version to [3.11.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.11.0)
 - Adding restart reason to the logs (#11191)
 - Fix custom handler streaming bug where `$return` output binding scenarios result in error logs (#11262)
-- Update outdated bundle message - removed deprecation date (#11230)
+- Update outdated bundle message to align as per the policy (#11230)

--- a/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
+++ b/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
@@ -206,15 +206,10 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
         private static readonly Action<ILogger, string, Exception> _publishingMetrics =
             LoggerMessage.Define<string>(LogLevel.Debug, new EventId(338, nameof(PublishingMetrics)), "{metrics}");
 
-        private static readonly Action<ILogger, string, int, int, Exception> _outdatedExtensionBundleFuture =
+        private static readonly Action<ILogger, string, int, int, Exception> _outdatedExtensionBundle =
            LoggerMessage.Define<string, int, int>(LogLevel.Warning,
            new EventId(342, nameof(OutdatedExtensionBundle)),
-           "Your current bundle version {currentVersion} will reach end of support on Aug 4, 2026. Upgrade to [{suggestedMinVersion}.*, {suggestedMaxVersion}.0.0). For more information, see https://aka.ms/FunctionsBundlesUpgrade");
-
-        private static readonly Action<ILogger, string, int, int, Exception> _outdatedExtensionBundlePast =
-           LoggerMessage.Define<string, int, int>(LogLevel.Warning,
-           new EventId(342, nameof(OutdatedExtensionBundle)),
-           "Your current bundle version {currentVersion} has reached end of support on Aug 4, 2026. Upgrade to [{suggestedMinVersion}.*, {suggestedMaxVersion}.0.0). For more information, see https://aka.ms/FunctionsBundlesUpgrade");
+           "Your app is using an older version - {currentVersion} of extension bundle. Upgrade to [{suggestedMinVersion}.*, {suggestedMaxVersion}.0.0). For more information, see https://aka.ms/FunctionsBundlesUpgrade");
 
         public static void PublishingMetrics(this ILogger logger, string metrics)
         {
@@ -420,17 +415,7 @@ Lock file hash: {currentLockFileHash}";
 
         public static void OutdatedExtensionBundle(this ILogger logger, string currentVersion, int suggestedMinVersion, int suggestedMaxVersion)
         {
-            var currentTime = DateTime.UtcNow;
-            var deprecationDate = new DateTime(2026, 8, 5, 0, 0, 0, DateTimeKind.Utc);
-
-            if (currentTime >= deprecationDate)
-            {
-                _outdatedExtensionBundlePast(logger, currentVersion, suggestedMinVersion, suggestedMaxVersion, null);
-            }
-            else
-            {
-                _outdatedExtensionBundleFuture(logger, currentVersion, suggestedMinVersion, suggestedMaxVersion, null);
-            }
+            _outdatedExtensionBundle(logger, currentVersion, suggestedMinVersion, suggestedMaxVersion, null);
         }
     }
 }

--- a/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
+++ b/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
         private static readonly Action<ILogger, string, int, int, Exception> _outdatedExtensionBundle =
            LoggerMessage.Define<string, int, int>(LogLevel.Warning,
            new EventId(342, nameof(OutdatedExtensionBundle)),
-           "Your app is using an older version - {currentVersion} of extension bundles. Upgrade to [{suggestedMinVersion}.*, {suggestedMaxVersion}.0.0). For more information, see https://aka.ms/FunctionsBundlesUpgrade");
+           "Your app is using a deprecated version - {currentVersion} of extension bundles. Upgrade to a supported version: https://aka.ms/FunctionsBundlesUpgrade");
 
         private static readonly Action<ILogger, string, Exception> _defaultWorkersDirectoryPath =
            LoggerMessage.Define<string>(LogLevel.Debug,

--- a/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
+++ b/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
         private static readonly Action<ILogger, string, int, int, Exception> _outdatedExtensionBundle =
            LoggerMessage.Define<string, int, int>(LogLevel.Warning,
            new EventId(342, nameof(OutdatedExtensionBundle)),
-           "Your app is using an older version - {currentVersion} of extension bundle. Upgrade to [{suggestedMinVersion}.*, {suggestedMaxVersion}.0.0). For more information, see https://aka.ms/FunctionsBundlesUpgrade");
+           "Your app is using an older version - {currentVersion} of extension bundles. Upgrade to [{suggestedMinVersion}.*, {suggestedMaxVersion}.0.0). For more information, see https://aka.ms/FunctionsBundlesUpgrade");
 
         private static readonly Action<ILogger, string, Exception> _defaultWorkersDirectoryPath =
            LoggerMessage.Define<string>(LogLevel.Debug,

--- a/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
+++ b/src/WebJobs.Script/Diagnostics/Extensions/LoggerExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -206,8 +206,8 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
         private static readonly Action<ILogger, string, Exception> _publishingMetrics =
             LoggerMessage.Define<string>(LogLevel.Debug, new EventId(338, nameof(PublishingMetrics)), "{metrics}");
 
-        private static readonly Action<ILogger, string, int, int, Exception> _outdatedExtensionBundle =
-           LoggerMessage.Define<string, int, int>(LogLevel.Warning,
+        private static readonly Action<ILogger, string, Exception> _outdatedExtensionBundle =
+           LoggerMessage.Define<string>(LogLevel.Warning,
            new EventId(342, nameof(OutdatedExtensionBundle)),
            "Your app is using a deprecated version - {currentVersion} of extension bundles. Upgrade to a supported version: https://aka.ms/FunctionsBundlesUpgrade");
 
@@ -423,9 +423,9 @@ Lock file hash: {currentLockFileHash}";
             _defaultWorkersDirectoryPath(logger, workersDirPath, null);
         }
 
-        public static void OutdatedExtensionBundle(this ILogger logger, string currentVersion, int suggestedMinVersion, int suggestedMaxVersion)
+        public static void OutdatedExtensionBundle(this ILogger logger, string currentVersion)
         {
-            _outdatedExtensionBundle(logger, currentVersion, suggestedMinVersion, suggestedMaxVersion, null);
+            _outdatedExtensionBundle(logger, currentVersion, null);
         }
     }
 }

--- a/src/WebJobs.Script/Host/ExtensionBundleManagerValidator.cs
+++ b/src/WebJobs.Script/Host/ExtensionBundleManagerValidator.cs
@@ -26,8 +26,7 @@ namespace Microsoft.Azure.WebJobs.Script.Host
             string outdatedBundleVersion = _extensionBundleManager.GetOutdatedBundleVersion();
             if (!string.IsNullOrEmpty(outdatedBundleVersion))
             {
-                int latestMajorVersion = ScriptConstants.ExtensionBundleV4MajorVersion;
-                logger.OutdatedExtensionBundle(outdatedBundleVersion, latestMajorVersion, latestMajorVersion + 1);
+                logger.OutdatedExtensionBundle(outdatedBundleVersion);
             }
         }
     }

--- a/test/WebJobs.Script.Tests/Description/FunctionAppValidationServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Description/FunctionAppValidationServiceTests.cs
@@ -198,14 +198,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             // Assert
             var logMessages = _testLoggerProvider.GetAllLogMessages();
 
-            // Check for both possible resource strings (future and past deprecation)
-            bool hasFutureWarning = logMessages.Any(m => m.FormattedMessage.Contains(bundleVersion)
-                && m.FormattedMessage.Contains("will reach end of support on Aug 4, 2026.")
+            bool hasOutdatedBundleLog = logMessages.Any(m => m.FormattedMessage.Contains(bundleVersion)
+                && m.FormattedMessage.Contains("older version")
                 && m.Level == LogLevel.Warning);
-            bool hasPastWarning = logMessages.Any(m => m.FormattedMessage.Contains(bundleVersion)
-                && m.FormattedMessage.Contains("has reached end of support on Aug 4, 2026.")
-                && m.Level == LogLevel.Warning);
-            bool hasOutdatedBundleLog = hasFutureWarning || hasPastWarning;
 
             Assert.Equal(shouldLogEvent, hasOutdatedBundleLog);
         }

--- a/test/WebJobs.Script.Tests/Description/FunctionAppValidationServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Description/FunctionAppValidationServiceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -199,7 +199,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var logMessages = _testLoggerProvider.GetAllLogMessages();
 
             bool hasOutdatedBundleLog = logMessages.Any(m => m.FormattedMessage.Contains(bundleVersion)
-                && m.FormattedMessage.Contains("older version")
+                && m.FormattedMessage.Contains("deprecated version")
                 && m.Level == LogLevel.Warning);
 
             Assert.Equal(shouldLogEvent, hasOutdatedBundleLog);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
Updated the outdated bundle warning message to be generic as the deprecation date is getting postponed.

resolves #10941 

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
