### PR TITLE
Moving to latest App Service Middleware version

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,3 +4,4 @@
 - My change description (#PR)
 -->
 - Add JitTrace Files for v4.1042
+- Moving to version 1.5.7 of Microsoft.Azure.AppService.Middleware.Functions (https://github.com/Azure/azure-functions-host/pull/11231)

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -61,7 +61,7 @@
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.8" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Azure.AppService.Middleware.Functions" Version="1.5.5" />
+    <PackageReference Include="Microsoft.Azure.AppService.Middleware.Functions" Version="1.5.7" />
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.3.20240307.67" />
     <PackageReference Include="Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption" Version="1.0.5" />
     <PackageReference Include="Microsoft.Azure.Storage.File" Version="11.1.7" />


### PR DESCRIPTION
The latest version of the middleware contains bug fixes we require. Specifically, the version contains a fix for https://msazure.visualstudio.com/Antares/_workitems/edit/33100719. E2E private environment testing was done to verify this fix.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * https://github.com/Azure/azure-functions-host/pull/11232
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
