### PR TITLE
Updating default file encoding configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,7 @@
-﻿[*.cs]
+[*]
+indent_style = space
+charset = utf-8
 
+[*.cs]
 # SA1008: Opening parenthesis should not be preceded by a space.
 dotnet_diagnostic.SA1008.severity = silent


### PR DESCRIPTION
This pull request makes a minor update to the .editorconfig file to standardize file encoding settings across the project. The main change is the addition of a charset = utf-8 (no BOM) setting for all files, replacing the previous utf-8-bom setting for code files.

I am not changing all files with this PR to avoid the churn and history mess. This will ensure the configuration is enforced as we continue to work on the repo. We can evaluate changes to other files if needed.

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

Backport PR

