### PR TITLE
[LinuxConsumption] Mark Container Unhealthy During Failed Specialization

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,4 +6,4 @@
 - Add JitTrace Files for v4.1042
 - Updating OTel related nuget packages (#11216)
 - Moving to version 1.5.7 of Microsoft.Azure.AppService.Middleware.Functions (https://github.com/Azure/azure-functions-host/pull/11231)
-
+- Mark Failed Container Specialization as Fatal (https://github.com/Azure/azure-functions-host/pull/11250)

--- a/src/WebJobs.Script.WebHost/Management/AtlasInstanceManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/AtlasInstanceManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -301,13 +301,22 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             }
             else
             {
+                bool succeeded = true;
                 if (pkgContext.IsRunFromPackage(options, _logger))
                 {
-                    await _runFromPackageHandler.ApplyRunFromPackageContext(pkgContext, options.ScriptPath, false);
+                    succeeded = await _runFromPackageHandler.ApplyRunFromPackageContext(pkgContext, options.ScriptPath, false);
                 }
                 else if (assignmentContext.IsAzureFilesContentShareConfigured(_logger))
                 {
-                    await _runFromPackageHandler.MountAzureFileShare(assignmentContext);
+                    succeeded = await _runFromPackageHandler.MountAzureFileShare(assignmentContext);
+                }
+
+                if (!succeeded)
+                {
+                    await _meshServiceClient.NotifyHealthEvent(ContainerHealthEventType.Fatal, this.GetType(),
+                        "Failed to apply Run-From-Package context or mount Azure File Share");
+
+                    throw new Exception("Failed to apply Run-From-Package context or mount Azure File Share");
                 }
             }
 

--- a/src/WebJobs.Script.WebHost/Management/AtlasInstanceManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/AtlasInstanceManager.cs
@@ -276,6 +276,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                         _logger.LogWarning($"Failed to {nameof(_runFromPackageHandler.ApplyRunFromPackageContext)}. Attempting to use local disk instead");
                         await _runFromPackageHandler.ApplyRunFromPackageContext(pkgContext, options.ScriptPath, false);
                     }
+                    else if (!blobContextApplied && !azureFilesMounted)
+                    {
+                        await _meshServiceClient.NotifyHealthEvent(ContainerHealthEventType.Fatal, this.GetType(),
+                            $"Failed to mount Azure File Share and failed to {nameof(_runFromPackageHandler.ApplyRunFromPackageContext)}");
+                    }
                 }
                 else if (pkgContext.IsRunFromLocalPackage())
                 {
@@ -301,22 +306,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             }
             else
             {
-                bool succeeded = true;
                 if (pkgContext.IsRunFromPackage(options, _logger))
                 {
-                    succeeded = await _runFromPackageHandler.ApplyRunFromPackageContext(pkgContext, options.ScriptPath, false);
+                    await _runFromPackageHandler.ApplyRunFromPackageContext(pkgContext, options.ScriptPath, false);
                 }
                 else if (assignmentContext.IsAzureFilesContentShareConfigured(_logger))
                 {
-                    succeeded = await _runFromPackageHandler.MountAzureFileShare(assignmentContext);
-                }
-
-                if (!succeeded)
-                {
-                    await _meshServiceClient.NotifyHealthEvent(ContainerHealthEventType.Fatal, this.GetType(),
-                        "Failed to apply Run-From-Package context or mount Azure File Share");
-
-                    throw new Exception("Failed to apply Run-From-Package context or mount Azure File Share");
+                    await _runFromPackageHandler.MountAzureFileShare(assignmentContext);
                 }
             }
 

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -1189,6 +1189,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             runFromPackageHandler
                 .Setup(r => r.ApplyRunFromPackageContext(It.IsAny<RunFromPackageContext>(), It.IsAny<string>(), false,
                     false)).ReturnsAsync(false); // return false to trigger failure
+
+            // setup notifyhealth method
+            _meshServiceClientMock.Setup(m => m.NotifyHealthEvent(ContainerHealthEventType.Fatal,
+                It.IsAny<Type>(), It.IsAny<string>())).Returns(Task.CompletedTask);
 
             // There will be no 2nd attempt since azure files mounting failed.
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
WI: https://msazure.visualstudio.com/Antares/_workitems/edit/32785404/

resolves #9663

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)
