### PR TITLE
Update gitattributes to use the union merge driver for release notes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -49,3 +49,7 @@
 *.fsproj text=auto
 *.dbproj text=auto
 *.sln text=auto eol=crlf
+
+# Use union on release notes to keep both local and remote changes
+# and avoid merge conflicts.
+release_notes.md merge=union


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

Similar to the change made by @liliankasem [here](https://github.com/Azure/azure-functions-core-tools/pull/4601) to use the union merge driver for release notes.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
