### PR TITLE
Adding language EOL warning log

### DIFF
--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         /// Gets the minimum supported versions for this runtime.
         /// </summary>
         [JsonProperty(PropertyName = "minimumSupportedRuntimeVersion")]
-        public List<string> MinimumSupportedRuntimeVersion { get; }
+        public string MinimumSupportedRuntimeVersion { get; }
 
         /// <summary>
         /// Gets or sets the regex used for sanitizing the runtime version string.

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
@@ -54,6 +54,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public List<string> SupportedRuntimeVersions { get; set; }
 
         /// <summary>
+        /// Gets the minimum supported versions for this runtime.
+        /// </summary>
+        [JsonProperty(PropertyName = "minimumSupportedRuntimeVersion")]
+        public List<string> MinimumSupportedRuntimeVersion { get; }
+
+        /// <summary>
         /// Gets or sets the regex used for sanitizing the runtime version string.
         /// </summary>
         [JsonProperty(PropertyName = "sanitizeRuntimeVersionRegex")]
@@ -200,6 +206,22 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             if (!string.IsNullOrEmpty(workerRuntime) && workerRuntime.Equals(Language, StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(version))
             {
                 DefaultRuntimeVersion = GetSanitizedRuntimeVersion(version);
+            }
+
+            if (!string.IsNullOrEmpty(MinimumSupportedRuntimeVersion) && !string.IsNullOrEmpty(DefaultRuntimeVersion))
+            {
+                if (Version.TryParse(DefaultRuntimeVersion, out var currentVersion) &&
+                    Version.TryParse(MinimumSupportedRuntimeVersion, out var minVersion))
+                {
+                    if (currentVersion < minVersion)
+                    {
+                        logger.LogWarning($"The configured runtime version '{DefaultRuntimeVersion}' for language '{Language}' is lower than the minimum supported version '{MinimumSupportedRuntimeVersion}'. Please update to a supported version. Visit aka.ms/supported-language-versions for more information.");
+                    }
+                }
+                else
+                {
+                    logger.LogWarning($"Could not parse runtime version(s): '{DefaultRuntimeVersion}' or '{MinimumSupportedRuntimeVersion}' for language '{Language}'.");
+                }
             }
 
             ValidateDefaultWorkerPathFormatters(systemRuntimeInformation);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

In `worker.config`, a new property called `minimumSupportedRuntimeVersion` will be added. This will be the oldest supported version for each language. Any version older is EOL. Example: https://github.com/Azure/azure-functions-python-worker/pull/1740

This adds a new check when formatting the worker path to see if the language version used by the customer is older than the minimum supported version (aka, is EOL). If so, the host will log a warning message informing customers that their language version is old, and they should update.

This check will work for languages where the version is defined as major.minor (Python - 3.9) or major (Node - 20).

(aka.ms link to be created)

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
