### PR TITLE
Fix error log in custom handler streaming for $return scenarios

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -9,3 +9,4 @@
 - Refactor code to move the logic to search for WorkerConfigs to a default worker configuration resolver (#11219)
 - Update Node.js Worker Version to [3.11.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.11.0)
 - Adding restart reason to the logs (#11191)
+- Fix custom handler streaming bug where `$return` output binding scenarios result in error logs (#11262)

--- a/src/WebJobs.Script/Description/Workers/ScriptInvocationResult.cs
+++ b/src/WebJobs.Script/Description/Workers/ScriptInvocationResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Generic;

--- a/src/WebJobs.Script/Description/Workers/ScriptInvocationResult.cs
+++ b/src/WebJobs.Script/Description/Workers/ScriptInvocationResult.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Generic;

--- a/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs
+++ b/src/WebJobs.Script/Description/Workers/WorkerFunctionInvoker.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
@@ -211,6 +212,11 @@ namespace Microsoft.Azure.WebJobs.Script.Description
 
         private void HandleReturnParameter(ScriptInvocationResult result)
         {
+            if (result.Outputs is IImmutableDictionary<string, object> immutableOutputs)
+            {
+                return;
+            }
+
             result.Outputs[ScriptConstants.SystemReturnParameterBindingName] = result.Return;
         }
 

--- a/src/WebJobs.Script/Workers/Http/DefaultHttpWorkerService.cs
+++ b/src/WebJobs.Script/Workers/Http/DefaultHttpWorkerService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -101,6 +101,13 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
                 _httpProxyService.StartForwarding(scriptInvocationContext, _destinationPrefix);
 
                 await _httpProxyService.EnsureSuccessfulForwardingAsync(scriptInvocationContext); // this will throw if forwarding is unsuccessful
+
+                // this needs to be removed to avoid downstream errors since the HttpResponse is already returned by proxying
+                if (scriptInvocationContext.BindingData.Any(p => string.Equals(ScriptConstants.SystemReturnParameterBindingName, p.Key, StringComparison.OrdinalIgnoreCase)))
+                {
+                    scriptInvocationContext.BindingData[ScriptConstants.SystemReturnParameterBindingName] = null;
+                }
+
                 scriptInvocationContext.ResultSource.SetResult(ScriptInvocationResult.Success);
             }
             catch (Exception exc)

--- a/test/WebJobs.Script.Tests/Description/Worker/WorkerFunctionInvokerTests.cs
+++ b/test/WebJobs.Script.Tests/Description/Worker/WorkerFunctionInvokerTests.cs
@@ -1,15 +1,13 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.ObjectModel;
-using System.Diagnostics.Metrics;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Binding;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Metrics;
 using Microsoft.Azure.WebJobs.Script.Workers;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -50,7 +48,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var sc = host.GetScriptHost();
 
             FunctionMetadata metaData = new FunctionMetadata();
-            _testFunctionInvoker = new TestWorkerFunctionInvoker(sc, null, metaData, NullLoggerFactory.Instance, null, new Collection<FunctionBinding>(),
+            BindingMetadata bindingMetadata = new BindingMetadata();
+            bindingMetadata.Name = "TestName";
+            _testFunctionInvoker = new TestWorkerFunctionInvoker(sc, bindingMetadata, metaData, NullLoggerFactory.Instance, new Collection<FunctionBinding>(), new Collection<FunctionBinding>(),
                 _mockFunctionInvocationDispatcher.Object, _applicationLifetime.Object, TimeSpan.FromSeconds(5));
         }
 
@@ -103,6 +103,45 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
             }
             _applicationLifetime.Verify(a => a.StopApplication(), Times.Never);
+        }
+
+        [Fact]
+        public async Task InvokeCore_DoesNotAddReturn_WhenOutputsIsImmutableDictionary()
+        {
+            // Arrange
+            var mockBinder = new Mock<Binder>();
+            var immutableOutputs = System.Collections.Immutable.ImmutableDictionary<string, object>.Empty;
+            var invocationResult = new ScriptInvocationResult
+            {
+                Outputs = immutableOutputs,
+            };
+
+            // Setup the dispatcher to complete the invocation with our result
+            _mockFunctionInvocationDispatcher
+                .Setup(d => d.InvokeAsync(It.IsAny<ScriptInvocationContext>()))
+                .Callback<ScriptInvocationContext>(ctx =>
+                {
+                    ctx.ResultSource.SetResult(invocationResult);
+                })
+                .Returns(Task.CompletedTask);
+
+            _mockFunctionInvocationDispatcher.Setup(a => a.State).Returns(FunctionInvocationDispatcherState.Initialized);
+
+            // Act
+            var result = await _testFunctionInvoker.InvokeCore(
+                new object[] { null, null, null, null, default(System.Threading.CancellationToken) },
+                new FunctionInvocationContext
+                {
+                    Binder = mockBinder.Object,
+                    ExecutionContext = new ExecutionContext
+                    {
+                        InvocationId = Guid.NewGuid()
+                    }
+                });
+
+            // Assert
+            Assert.IsType<System.Collections.Immutable.ImmutableDictionary<string, object>>(invocationResult.Outputs);
+            Assert.False(invocationResult.Outputs.ContainsKey("$return"));
         }
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

In custom handler streaming scenarios where the output binding is represented by `$return`, the HTTP requests succeed while the function invocation logs an error due to an attempt to modify an immutable output bindings array. This fixes that bug.

#11035 introduced this bug by introducing `ScriptInvocationResult.Success` (see [here](https://github.com/Azure/azure-functions-host/blob/f8fcc65161b7706367e154305e826ebf8b5db3a4/src/WebJobs.Script/Description/Workers/ScriptInvocationResult.cs#L11)).  This resulted in an existing, downstream trying to modify the immutable dictionary and setting the `$return` binding value.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [x] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
