### PR TITLE
Fixing /admin/host/resume ObjectDisposedException

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
@@ -90,9 +90,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 config.UseMiddleware<HostWarmupMiddleware>();
             });
 
-            // This middleware must be registered before any other middleware depending on
-            // JobHost/ScriptHost scoped services.
-            builder.UseMiddleware<ScriptHostRequestServiceProviderMiddleware>();
+            builder.UseWhen(context => !context.Request.IsAdminResumeRequest(), config =>
+            {
+                // This middleware must be registered before any other middleware depending on
+                // JobHost/ScriptHost scoped services.
+                config.UseMiddleware<ScriptHostRequestServiceProviderMiddleware>();
+            });
 
             if (environment.IsLinuxAzureManagedHosting())
             {

--- a/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs
+++ b/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
     {
         private static readonly PathString _adminRoot = new PathString("/admin");
         private static readonly PathString _adminDownloadRequestRoot = new PathString("/admin/functions/download");
+        private static readonly PathString _adminResumeRequestRoot = new PathString("/admin/host/resume");
 
         public static bool IsAdminRequest(this HttpRequest request)
         {
@@ -33,6 +34,11 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
         public static bool IsAdminDownloadRequest(this HttpRequest request)
         {
             return request.Path.StartsWithSegments(_adminDownloadRequestRoot);
+        }
+
+        public static bool IsAdminResumeRequest(this HttpRequest request)
+        {
+            return request.Path.StartsWithSegments(_adminResumeRequestRoot);
         }
 
         public static TValue GetRequestPropertyOrDefault<TValue>(this HttpRequest request, string key)

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/DrainModeResumeEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/DrainModeResumeEndToEndTests.cs
@@ -1,9 +1,14 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Microsoft.WebJobs.Script.Tests;
 using Newtonsoft.Json;
 using Xunit;
@@ -43,9 +48,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 
             // Validate host is "Running" after resume is called
             response = await SamplesTestHelpers.InvokeResume(this);
+            Assert.True(HttpStatusCode.OK == response.StatusCode,
+                string.Join(Environment.NewLine, Host.GetWebHostLogMessages().Where(m => m.Level == LogLevel.Error).Select(m => m.ToString())));
             responseString = await response.Content.ReadAsStringAsync();
             var resumeStatus = JsonConvert.DeserializeObject<ResumeStatus>(responseString);
-
             Assert.Equal(ScriptHostState.Running, resumeStatus.State);
 
             // Validate the drain state is changed to "Disabled"
@@ -88,18 +94,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 
     public class ResumeTestFixture : EndToEndTestFixture
     {
-        static ResumeTestFixture()
-        {
-        }
-
         public ResumeTestFixture()
             : base(Path.Combine(Environment.CurrentDirectory, "..", "..", "..", "..", "sample", "NodeResume"), "samples", RpcWorkerConstants.NodeLanguageWorkerName)
         {
         }
 
-        public override void ConfigureScriptHost(IWebJobsBuilder webJobsBuilder)
+        public override void ConfigureWebHost(IConfigurationBuilder configBuilder)
         {
-            base.ConfigureScriptHost(webJobsBuilder);
+            base.ConfigureWebHost(configBuilder);
+
+            configBuilder.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                // This forces the hosts to be stopped and disposed before a new one starts.
+                // There was a bug hiding here originally, so we'll run all these tests this way.
+                { ConfigurationSectionNames.SequentialJobHostRestart, "true" }
+            });
         }
     }
 }


### PR DESCRIPTION
Fixes #11263

The bug here is that during a request, we register a DI child scope container with the request... then we dispose it mid-request, so when anything in ASP.NET tries to get a service later, it throws. It's a race b/c it's possible that the request returns before the old container is disposed. Despite this, everything seems to be working b/c all the hard work has already been done by the time the exception is thrown. The JobHost is restarted and everything continues on happily even though we return a 500 to the caller.

I have a preliminary PR that I've just pushed up but it's not truly complete. It'll work for what we need but it's quite tricky to get right with how DI works.

Some background:
- For in-proc we use DryIoc and completely replace the DI engine to manage child scopes
- We added this code to prevent disposal of the DI container while a child scope was still active: https://github.com/Azure/azure-functions-host/blob/b0797762d1afb53b1c7093922c9d2bea2357d025/src/WebJobs.Script.WebHost/DependencyInjection/ScopedResolver.cs#L33-L37
- When we moved to out-of-proc, we removed DryIoc and use the default Microsoft.Extensions.DependencyInjection and did not add this "child scope tracking" behavior.
- There's not a great way to use the decorator pattern here. There's a bunch of ways to bypass the decorator (e.g. with constructor injection) and use the original IServiceProvider/IServiceScopeFactory because they're hard-coded and not able to be overwritten:
  - this issue links to other discussions: https://github.com/dotnet/runtime/issues/38240 
  - here's the hard-coding: https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs#L63-L66

~~What I've got *should* be good enough for the very specific scenario we need it for, but there still seems like there's gaps that may bite us later.~~

~~Want to discuss with @fabiocav later whether we should use this same approach? Or abandon it and just skip registering services for /admin calls? Or if there's other approaches.~~

~~Will leave it in Draft for now.~~

Edit:
This is now ready for review. Rather than use the non-optimal approach with the built-in DI, we're going to just skip replacing these services on calls that we know don't need them and can be problematic. We can add to this if we need to in the future.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)