### PR TITLE
Disable parallelization for env var manipulating tests

### DIFF
--- a/test/WebJobs.Script.Tests/Configuration/ActiveHostConfigurationSourceTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ActiveHostConfigurationSourceTests.cs
@@ -4,13 +4,13 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Azure.WebJobs.Script.Configuration;
-using Microsoft.Azure.WebJobs.Script.Extensions;
 using Microsoft.Extensions.Configuration;
 using Moq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 {
+    [Collection(DisableParallelizationCollection.Name)]
     public class ActiveHostConfigurationSourceTests
     {
         private Mock<IScriptHostManager> _mockScriptHostManager;

--- a/test/WebJobs.Script.Tests/Configuration/ApplicationInsightsConfigurationTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ApplicationInsightsConfigurationTests.cs
@@ -14,6 +14,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 {
+    [Collection(DisableParallelizationCollection.Name)]
     public class ApplicationInsightsConfigurationTests
     {
         [Fact]

--- a/test/WebJobs.Script.Tests/Configuration/ExtensionRequirementOptionsTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ExtensionRequirementOptionsTest.cs
@@ -4,25 +4,19 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Abstractions;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
-using Microsoft.Azure.AppService.Proxy.Runtime.Configuration.Policies;
 using Microsoft.Azure.WebJobs.Script.Config;
-using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
-
-using WebJobs.Script.Tests;
 using Xunit;
-using static Microsoft.Azure.AppService.Proxy.Runtime.Trace;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 {
+    [Collection(DisableParallelizationCollection.Name)]
     public class ExtensionRequirementOptionsTest
     {
         [Fact]

--- a/test/WebJobs.Script.Tests/Description/DotNet/DotNetFunctionInvokerTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/DotNetFunctionInvokerTests.cs
@@ -32,6 +32,7 @@ using IApplicationLifetime = Microsoft.AspNetCore.Hosting.IApplicationLifetime;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
+    [Collection(DisableParallelizationCollection.Name)]
     public class DotNetFunctionInvokerTests : IDisposable
     {
         private IHost _host;

--- a/test/WebJobs.Script.Tests/Description/DotNet/DynamicFunctionAssemblyLoadContextTests.cs
+++ b/test/WebJobs.Script.Tests/Description/DotNet/DynamicFunctionAssemblyLoadContextTests.cs
@@ -2,12 +2,9 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
-using System.Text;
-using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -17,6 +14,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Description.DotNet
 {
+    [Collection(DisableParallelizationCollection.Name)]
     public class DynamicFunctionAssemblyLoadContextTests
     {
         [Fact]

--- a/test/WebJobs.Script.Tests/Diagnostics/DiagnosticListenerServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/DiagnosticListenerServiceTests.cs
@@ -16,6 +16,7 @@ using static Microsoft.Azure.WebJobs.Script.ScriptConstants;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 {
+    [Collection(DisableParallelizationCollection.Name)]
     public class DiagnosticListenerServiceTests
     {
         /// <summary>

--- a/test/WebJobs.Script.Tests/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensionsTests.cs
@@ -25,6 +25,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.OpenTelemetry
 {
+    [Collection(DisableParallelizationCollection.Name)]
     public class OpenTelemetryConfigurationExtensionsTests
     {
         private readonly string _loggingPath = ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, "Logging");

--- a/test/WebJobs.Script.Tests/Extensions/HttpRequestExtensionsTest.cs
+++ b/test/WebJobs.Script.Tests/Extensions/HttpRequestExtensionsTest.cs
@@ -20,6 +20,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
 {
+    [Collection(DisableParallelizationCollection.Name)]
     public class HttpRequestExtensionsTest
     {
         [Fact]

--- a/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Managment/WebFunctionsManagerTests.cs
@@ -26,8 +26,9 @@ using Moq;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
-namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
+namespace Microsoft.Azure.WebJobs.Script.Tests.Management
 {
+    [Collection(DisableParallelizationCollection.Name)]
     public class WebFunctionsManagerTests : IDisposable
     {
         private const string Function1MetadataJson = @"
@@ -174,7 +175,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         {
             _hostingConfigOptions.IsTestDataSuppressionEnabled = shouldSuppressTestData;
 
-            var functionMetadataResponse = new Management.Models.FunctionMetadataResponse
+            var functionMetadataResponse = new Microsoft.Azure.WebJobs.Script.Management.Models.FunctionMetadataResponse
             {
                 TestData = "foo",
                 Config = JObject.Parse(Function1MetadataJson)

--- a/test/WebJobs.Script.Tests/ScriptSettingsManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptSettingsManagerTests.cs
@@ -2,16 +2,12 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Config;
-using Microsoft.Extensions.Configuration;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
+    [Collection(DisableParallelizationCollection.Name)]
     public class ScriptSettingsManagerTests
     {
         [Fact]

--- a/test/WebJobs.Script.Tests/ScriptStartupTypeDiscovererTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptStartupTypeDiscovererTests.cs
@@ -28,6 +28,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
+    [Collection(DisableParallelizationCollection.Name)]
     public class ScriptStartupTypeDiscovererTests
     {
         [Fact]

--- a/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
@@ -29,6 +29,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Security
 {
+    [Collection(DisableParallelizationCollection.Name)]
     public class SecretManagerTests
     {
         private const int TestSentinelWatcherInitializationDelayMS = 50;

--- a/test/WebJobs.Script.Tests/TestCollections/DisableParallelizationCollection.cs
+++ b/test/WebJobs.Script.Tests/TestCollections/DisableParallelizationCollection.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    /// <summary>
+    /// XUnit collection definition to disable parallelization. This is used for tests which
+    /// set global state and cannot run with other tests. A primary example is any test using
+    /// <see cref="TestScopedEnvironmentVariable" />.
+    /// </summary>
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public class DisableParallelizationCollection
+    {
+        public const string Name = "DisableParallelization";
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR -- TODO
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Attempt to mitigate test flakiness by disabling parallelization for unit tests which set environment variables, as this will interfere with other tests. Long term we need to refactor the systems under test to remove this dependency.
