### PR TITLE
Setting min and max cap for dotnet 6 inproc host (4.2.0, 4.22.0)

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+Cap v4.x extension bundle versions on .NET 6 to the range (>4.2.0, <4.22.0) by default (#11289)

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -164,28 +164,6 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         }
 
         /// <summary>
-        /// Gets the highest version of extension bundle v3 supported.
-        /// </summary>
-        internal string MaximumBundleV3Version
-        {
-            get
-            {
-                return GetFeature(ScriptConstants.MaximumBundleV3Version);
-            }
-        }
-
-        /// <summary>
-        /// Gets the highest version of extension bundle v4 supported.
-        /// </summary>
-        internal string MaximumBundleV4Version
-        {
-            get
-            {
-                return GetFeature(ScriptConstants.MaximumBundleV4Version);
-            }
-        }
-
-        /// <summary>
         /// Gets a value indicating whether the host should revert the worker shutdown behavior in the WebHostWorkerChannelManager.
         /// </summary>
         internal bool RevertWorkerShutdownBehavior

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -255,17 +255,14 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
         {
             int dotnetVersion = typeof(string).Assembly.GetName().Version.Major;
 
-            // Cap the version range for v4.x bundles on .NET 6 to be between 4.2.0 and 4.22.0
+            // Limit the version range for v4.x bundles on .NET 6 to be between 4.2.0 and 4.22.0
             // Return original version range if not .NET 6 or not v4.x bundle
-            var cappedVersionRange = GetCappedVersion(dotnetVersion, versionRange, bundleId);
+            var effectiveVersionRange = GetAdjustedVersion(dotnetVersion, versionRange, bundleId);
 
             // Check if there is a max version configured in hosting config for the current dotnet version and bundle major version
-            var maxBundleVersion = GetMaxCappedBundleVersionFromHostingConfig(bundleId, versionRange.MinVersion.Major, dotnetVersion, configOption);
-
-            if (maxBundleVersion != null)
+            if (TryGetMaxBundleVersionFromHostingConfig(bundleId, versionRange.MinVersion.Major, dotnetVersion, configOption, out NuGetVersion maxBundleVersion))
             {
-                // If there is a max version configured in hosting config, use that to cap the version range
-                cappedVersionRange = new VersionRange(cappedVersionRange.MinVersion, cappedVersionRange.IsMinInclusive, maxBundleVersion, true);
+                effectiveVersionRange = new VersionRange(effectiveVersionRange.MinVersion, effectiveVersionRange.IsMinInclusive, maxBundleVersion, true);
             }
 
             var bundleVersions = versions.Select(p =>
@@ -274,54 +271,49 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
                 NuGetVersion.TryParse(dirName, out NuGetVersion version);
                 if (version != null)
                 {
-                    version = cappedVersionRange.Satisfies(version) ? version : null;
+                    version = effectiveVersionRange.Satisfies(version) ? version : null;
                 }
                 return version;
             }).Where(v => v != null).OrderByDescending(version => version.Version).ToList();
 
             var matchingVersion = ResolvePlatformReleaseChannelVersion(bundleVersions);
 
-            if (bundleId != ScriptConstants.DefaultExtensionBundleId)
-            {
-                return matchingVersion?.ToString();
-            }
-
             return matchingVersion?.ToString();
         }
 
-        // Limit the bundle version range so that it is higher than 4.2.0 and lower than 4.22.0
-        private VersionRange GetCappedVersion(int dotnetVersion, VersionRange versionRange, string bundleId)
+        // Applies bundle version limits for .NET 6, using the default bundle if referencing a v4 major bundle version.
+        private VersionRange GetAdjustedVersion(int dotnetVersion, VersionRange versionRange, string bundleId)
         {
-            if (dotnetVersion == ScriptConstants.DotNetVersionSix
-                    && bundleId == ScriptConstants.DefaultExtensionBundleId
-                    && versionRange.MinVersion.Major == ScriptConstants.ExtensionBundleV4MajorVersion)
+            if (!string.Equals(dotnetVersion, 6)
+                    || bundleId != ScriptConstants.DefaultExtensionBundleId
+                    || versionRange.MinVersion.Major != ScriptConstants.ExtensionBundleV4MajorVersion)
             {
-                NuGetVersion cappedMinversion = new(ScriptConstants.CappedMinimumBundleV4VersionExclusive);
-                NuGetVersion cappedMaxVersion = new(ScriptConstants.CappedMaximumBundleV4VersionExclusive);
-
-                var minversion = versionRange.MinVersion < cappedMinversion ? cappedMinversion : versionRange.MinVersion;
-                var maxversion = versionRange.MaxVersion > cappedMaxVersion ? cappedMaxVersion : versionRange.MaxVersion;
-
-                // Use the original inclusion values if it is within the min or max cap range.
-                bool isMinInclusive = versionRange.MinVersion > cappedMinversion && versionRange.IsMinInclusive;
-                bool isMaxInclusive = versionRange.MaxVersion < cappedMaxVersion && versionRange.IsMaxInclusive;
-
-                versionRange = new VersionRange(minversion, isMinInclusive, maxversion, isMaxInclusive);
+                return versionRange;
             }
+
+            var effectiveMinVersion = new NuGetVersion(ScriptConstants.Net6MinimunV4BundleVersion);
+            var effectiveMaxVersion = new NuGetVersion(ScriptConstants.Net6MaximumV4BundleVersion);
+
+            var minVersion = versionRange.MinVersion < effectiveMinVersion ? effectiveMinVersion : versionRange.MinVersion;
+            var maxVersion = versionRange.MaxVersion > effectiveMaxVersion ? effectiveMaxVersion : versionRange.MaxVersion;
+
+            // Use the original inclusion values if it is within the min or max range.
+            bool isMinInclusive = versionRange.MinVersion > effectiveMinVersion && versionRange.IsMinInclusive;
+            bool isMaxInclusive = versionRange.MaxVersion < effectiveMaxVersion && versionRange.IsMaxInclusive;
+
+            versionRange = new VersionRange(minVersion, isMinInclusive, maxVersion, isMaxInclusive);
             return versionRange;
         }
 
-        private NuGetVersion GetMaxCappedBundleVersionFromHostingConfig(string bundleId, int bundleVersion, int dotnetVersion, FunctionsHostingConfigOptions configOption)
+        private bool TryGetMaxBundleVersionFromHostingConfig(string bundleId, int bundleVersion, int dotnetVersion, FunctionsHostingConfigOptions configOption, out NuGetVersion maxVersion)
         {
+            maxVersion = null;
             string hostingConfig = $"Net{dotnetVersion}MaximumBundleV{bundleVersion}Version";
             string hostingConfigValue = configOption.GetFeature(hostingConfig);
-            if (bundleId == ScriptConstants.DefaultExtensionBundleId
+
+            return bundleId == ScriptConstants.DefaultExtensionBundleId
                 && !string.IsNullOrEmpty(hostingConfigValue)
-                && NuGetVersion.TryParse(hostingConfigValue, out NuGetVersion maxVersion))
-            {
-                return maxVersion;
-            }
-            return null;
+                && NuGetVersion.TryParse(hostingConfigValue, out maxVersion);
         }
 
         private NuGetVersion ResolvePlatformReleaseChannelVersion(IList<NuGetVersion> orderedByDescBundles) => _platformReleaseChannel.ToUpper() switch

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Configuration;
@@ -284,9 +283,9 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
         // Applies bundle version limits for .NET 6, using the default bundle if referencing a v4 major bundle version.
         private VersionRange GetAdjustedVersion(int dotnetVersion, VersionRange versionRange, string bundleId)
         {
-            if (!string.Equals(dotnetVersion, 6)
-                    || bundleId != ScriptConstants.DefaultExtensionBundleId
-                    || versionRange.MinVersion.Major != ScriptConstants.ExtensionBundleV4MajorVersion)
+            if (dotnetVersion != 6
+                || !string.Equals(bundleId, ScriptConstants.DefaultExtensionBundleId, StringComparison.OrdinalIgnoreCase)
+                || versionRange.MinVersion.Major != ScriptConstants.ExtensionBundleV4MajorVersion)
             {
                 return versionRange;
             }
@@ -311,7 +310,7 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
             string hostingConfig = $"Net{dotnetVersion}MaximumBundleV{bundleVersion}Version";
             string hostingConfigValue = configOption.GetFeature(hostingConfig);
 
-            return bundleId == ScriptConstants.DefaultExtensionBundleId
+            return string.Equals(bundleId, ScriptConstants.DefaultExtensionBundleId, StringComparison.OrdinalIgnoreCase)
                 && !string.IsNullOrEmpty(hostingConfigValue)
                 && NuGetVersion.TryParse(hostingConfigValue, out maxVersion);
         }

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Configuration;
@@ -252,13 +253,28 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
 
         internal string FindBestVersionMatch(VersionRange versionRange, IEnumerable<string> versions, string bundleId, FunctionsHostingConfigOptions configOption)
         {
+            int dotnetVersion = typeof(string).Assembly.GetName().Version.Major;
+
+            // Cap the version range for v4.x bundles on .NET 6 to be between 4.2.0 and 4.22.0
+            // Return original version range if not .NET 6 or not v4.x bundle
+            var cappedVersionRange = GetCappedVersion(dotnetVersion, versionRange, bundleId);
+
+            // Check if there is a max version configured in hosting config for the current dotnet version and bundle major version
+            var maxBundleVersion = GetMaxCappedBundleVersionFromHostingConfig(bundleId, versionRange.MinVersion.Major, dotnetVersion, configOption);
+
+            if (maxBundleVersion != null)
+            {
+                // If there is a max version configured in hosting config, use that to cap the version range
+                cappedVersionRange = new VersionRange(cappedVersionRange.MinVersion, cappedVersionRange.IsMinInclusive, maxBundleVersion, true);
+            }
+
             var bundleVersions = versions.Select(p =>
             {
                 var dirName = Path.GetFileName(p);
                 NuGetVersion.TryParse(dirName, out NuGetVersion version);
                 if (version != null)
                 {
-                    version = versionRange.Satisfies(version) ? version : null;
+                    version = cappedVersionRange.Satisfies(version) ? version : null;
                 }
                 return version;
             }).Where(v => v != null).OrderByDescending(version => version.Version).ToList();
@@ -270,27 +286,42 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
                 return matchingVersion?.ToString();
             }
 
-            // Check to see if there is a max bundle version set via hosting configuration, if yes then use that instead of the one
-            // available on VM or local machine. Only use MaximumBundleV3Version or MaximumBundleV4Version if the version configured
-            // by the customer resolved to version higher than the version set via hosting config.
-            if (!string.IsNullOrEmpty(configOption.MaximumBundleV3Version)
-                && matchingVersion?.Major == ScriptConstants.ExtensionBundleV3MajorVersion)
-            {
-                var maximumBundleV3Version = NuGetVersion.Parse(configOption.MaximumBundleV3Version);
-                matchingVersion = matchingVersion > maximumBundleV3Version ? maximumBundleV3Version : matchingVersion;
-                return matchingVersion?.ToString();
-            }
-
-            if (!string.IsNullOrEmpty(configOption.MaximumBundleV4Version)
-                && matchingVersion?.Major == ScriptConstants.ExtensionBundleV4MajorVersion)
-            {
-                var maximumBundleV4Version = NuGetVersion.Parse(configOption.MaximumBundleV4Version);
-                matchingVersion = matchingVersion > maximumBundleV4Version
-                                ? maximumBundleV4Version
-                                : matchingVersion;
-            }
-
             return matchingVersion?.ToString();
+        }
+
+        // Limit the bundle version range so that it is higher than 4.2.0 and lower than 4.22.0
+        private VersionRange GetCappedVersion(int dotnetVersion, VersionRange versionRange, string bundleId)
+        {
+            if (dotnetVersion == ScriptConstants.DotNetVersionSix
+                    && bundleId == ScriptConstants.DefaultExtensionBundleId
+                    && versionRange.MinVersion.Major == ScriptConstants.ExtensionBundleV4MajorVersion)
+            {
+                NuGetVersion cappedMinversion = new(ScriptConstants.CappedMinimumBundleV4VersionExclusive);
+                NuGetVersion cappedMaxVersion = new(ScriptConstants.CappedMaximumBundleV4VersionExclusive);
+
+                var minversion = versionRange.MinVersion < cappedMinversion ? cappedMinversion : versionRange.MinVersion;
+                var maxversion = versionRange.MaxVersion > cappedMaxVersion ? cappedMaxVersion : versionRange.MaxVersion;
+
+                // Use the original inclusion values if it is within the min or max cap range.
+                bool isMinInclusive = versionRange.MinVersion > cappedMinversion && versionRange.IsMinInclusive;
+                bool isMaxInclusive = versionRange.MaxVersion < cappedMaxVersion && versionRange.IsMaxInclusive;
+
+                versionRange = new VersionRange(minversion, isMinInclusive, maxversion, isMaxInclusive);
+            }
+            return versionRange;
+        }
+
+        private NuGetVersion GetMaxCappedBundleVersionFromHostingConfig(string bundleId, int bundleVersion, int dotnetVersion, FunctionsHostingConfigOptions configOption)
+        {
+            string hostingConfig = $"Net{dotnetVersion}MaximumBundleV{bundleVersion}Version";
+            string hostingConfigValue = configOption.GetFeature(hostingConfig);
+            if (bundleId == ScriptConstants.DefaultExtensionBundleId
+                && !string.IsNullOrEmpty(hostingConfigValue)
+                && NuGetVersion.TryParse(hostingConfigValue, out NuGetVersion maxVersion))
+            {
+                return maxVersion;
+            }
+            return null;
         }
 
         private NuGetVersion ResolvePlatformReleaseChannelVersion(IList<NuGetVersion> orderedByDescBundles) => _platformReleaseChannel.ToUpper() switch

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -249,11 +249,8 @@ namespace Microsoft.Azure.WebJobs.Script
         public static readonly string LiveLogsSessionAIKey = "#AzFuncLiveLogsSessionId";
 
         public static readonly string FunctionsHostingConfigSectionName = "FunctionsHostingConfig";
-        public static readonly string CappedMinimumBundleV4VersionExclusive = "4.2.0";
-        public static readonly string CappedMaximumBundleV4VersionExclusive = "4.22.0";
-        public static readonly int DotNetVersionSix = 6;
-        public static readonly int DotNetVersionEight = 8;
-
+        public static readonly string Net6MinimunV4BundleVersion = "4.2.0";
+        public static readonly string Net6MaximumV4BundleVersion = "4.22.0";
 
         // HTTP Proxying constants
         public static readonly string HttpProxyingEnabled = "HttpProxyingEnabled";

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -249,8 +249,11 @@ namespace Microsoft.Azure.WebJobs.Script
         public static readonly string LiveLogsSessionAIKey = "#AzFuncLiveLogsSessionId";
 
         public static readonly string FunctionsHostingConfigSectionName = "FunctionsHostingConfig";
-        public static readonly string MaximumBundleV3Version = "FunctionRuntimeV4MaxBundleV3Version";
-        public static readonly string MaximumBundleV4Version = "FunctionRuntimeV4MaxBundleV4Version";
+        public static readonly string CappedMinimumBundleV4VersionExclusive = "4.2.0";
+        public static readonly string CappedMaximumBundleV4VersionExclusive = "4.22.0";
+        public static readonly int DotNetVersionSix = 6;
+        public static readonly int DotNetVersionEight = 8;
+
 
         // HTTP Proxying constants
         public static readonly string HttpProxyingEnabled = "HttpProxyingEnabled";

--- a/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
@@ -111,8 +111,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 (nameof(FunctionsHostingConfigOptions.EnableOrderedInvocationMessages), string.Empty, true), // default
 
                 (nameof(FunctionsHostingConfigOptions.FunctionsWorkerDynamicConcurrencyEnabled), "FUNCTIONS_WORKER_DYNAMIC_CONCURRENCY_ENABLED=1", true),
-                (nameof(FunctionsHostingConfigOptions.MaximumBundleV3Version), "FunctionRuntimeV4MaxBundleV3Version=teststring", "teststring"),
-                (nameof(FunctionsHostingConfigOptions.MaximumBundleV4Version), "FunctionRuntimeV4MaxBundleV4Version=teststring", "teststring"),
                 (nameof(FunctionsHostingConfigOptions.RevertWorkerShutdownBehavior), "REVERT_WORKER_SHUTDOWN_BEHAVIOR=1", true),
 
                 // Supports True/False/1/0

--- a/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
     {
         private const string BundleId = "Microsoft.Azure.Functions.ExtensionBundle";
         private string _downloadPath;
+        private static readonly IList<string> V3Versions = new List<string> { "3.19.0", "3.19.2", "3.20.0" };
 
         public ExtensionBundleManagerTests()
         {
@@ -500,13 +501,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
             Assert.Equal(expectedVersion, resolvedVersion);
         }
 
-        private static readonly IList<string> V3Versions = new List<string>
-        {
-            "3.19.0",
-            "3.19.2",
-            "3.20.0"
-        };
-
         [Fact]
         public void FindBestVersionMatch_V3_LatestChannel_NoHostConfig_ChoosesHighest()
         {
@@ -521,10 +515,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
         }
 
         [Theory]
-        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "3.19.2")]  // STANDARD uppercase
-        [InlineData("standard", "3.19.2")]                                        // lowercase
-        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "3.19.2")]  // EXTENDED uppercase
-        [InlineData("extended", "3.19.2")]                                        // lowercase
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "3.19.2")]
+        [InlineData("standard", "3.19.2")]
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "3.19.2")]
+        [InlineData("extended", "3.19.2")]
         public void FindBestVersionMatch_V3_StandardOrExtended_NoHostConfig_ChoosesPrevious(string channel, string expected)
         {
             var versionRange = VersionRange.Parse("[3.*, 4.0.0)");

--- a/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
@@ -381,24 +381,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
 
         [Theory]
         [InlineData("[3.*, 4.0.0)", "3.19.0", "3.19.0")]
-        [InlineData("[4.*, 5.0.0)", "4.2.0", "4.2.0")]
+        [InlineData("[4.*, 5.0.0)", "4.3.0", "4.3.0")]
+#if NET6_0
         [InlineData("[4.*, 5.0.0)", null, "4.3.0")]
-        [InlineData("[3.*, 4.0.0)", null, "3.20.0")]
+#elif NET8_0
+        [InlineData("[4.*, 5.0.0)", null, "4.23.0")]
+#endif
         public void LimitMaxVersion(string versionRange, string hostConfigVersion, string expectedVersion)
         {
             var range = VersionRange.Parse(versionRange);
             var hostingConfiguration = new FunctionsHostingConfigOptions();
             if (!string.IsNullOrEmpty(hostConfigVersion))
             {
-                if (range.MinVersion.Major == 3)
-                {
-                    hostingConfiguration.Features.Add(ScriptConstants.MaximumBundleV3Version, hostConfigVersion);
-                }
-
-                if (range.MinVersion.Major == 4)
-                {
-                    hostingConfiguration.Features.Add(ScriptConstants.MaximumBundleV4Version, hostConfigVersion);
-                }
+                int dotnetVersion = typeof(string).Assembly.GetName().Version.Major;
+                int bundleVersion = range.MinVersion.Major;
+                string hostingConfigVersionKey = $"Net{dotnetVersion}MaximumBundleV{bundleVersion}Version";
+                hostingConfiguration.Features.Add(hostingConfigVersionKey, hostConfigVersion);
             }
 
             var options = GetTestExtensionBundleOptions(BundleId, versionRange);
@@ -410,19 +408,74 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
         }
 
         [Theory]
+#if NET8_0
+        // No host-config max (full list available, no caps applied on .NET 8)
+        [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.23.0")]
+        [InlineData("latest", "[4.*, 5.0.0)", null, "4.23.0")]
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.22.1")]
+        [InlineData("standard", "[4.*, 5.0.0)", null, "4.22.1")]
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.22.1")]
+        [InlineData("extended", "[4.*, 5.0.0)", null, "4.22.1")]
+
+        // Host-config max at 4.22.0 (caps selection to <= 4.22.0)
+        // Ordered (desc) after cap: 4.22.0, 4.3.0, 4.2.1, 4.2.0, 4.1.0, 4.0.2
+        [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.22.0", "4.22.0")]
+        [InlineData("latest", "[4.*, 5.0.0)", "4.22.0", "4.22.0")]
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.22.0", "4.3.0")]
+        [InlineData("standard", "[4.*, 5.0.0)", "4.22.0", "4.3.0")]
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.22.0", "4.3.0")]
+        [InlineData("extended", "[4.*, 5.0.0)", "4.22.0", "4.3.0")]
+
+        // Host-config max at 4.2.1
+        // Ordered after cap: 4.2.1, 4.2.0, 4.1.0, 4.0.2
+        [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.1", "4.2.1")]
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.1", "4.2.0")]
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.1", "4.2.0")]
+
+        // Host-config max at 4.2.0
+        // Ordered after cap: 4.2.0, 4.1.0, 4.0.2
         [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.0", "4.2.0")]
-        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.0", "4.2.0")]
-        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.0", "4.2.0")]
-        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.3.0", "4.2.0")]
-        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.3.0", "4.2.0")]
-        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.1.0", "4.1.0")]
-        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.1.0", "4.1.0")]
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.0", "4.1.0")]
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.0", "4.1.0")]
+#elif NET6_0
+         // Existing scenarios (no host-config cap or cap at 4.3.0 -> top stays 4.3.0, standard/extended take 4.2.1)
+        [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.3.0", "4.3.0")]
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.3.0", "4.2.1")]
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.3.0", "4.2.1")]
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.2.1")]
         [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.3.0")]
         [InlineData("latest", "[4.*, 5.0.0)", null, "4.3.0")]
-        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.2.0")]
-        [InlineData("standard", "[4.*, 5.0.0)", null, "4.2.0")]
-        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.2.0")]
-        [InlineData("extended", "[4.*, 5.0.0)", null, "4.2.0")]
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.2.1")]
+        [InlineData("standard", "[4.*, 5.0.0)", null, "4.2.1")]
+        [InlineData("extended", "[4.*, 5.0.0)", null, "4.2.1")]
+
+        // Additional scenarios for .NET 6 caps + various host-config maximums:
+
+        // Host-config max = 4.21.0 (after natural cap: allowed >4.2.0 && <4.22.0, then <=4.21.0)
+        // Ordered candidates: 4.21.0, 4.3.0(excluded), 4.2.1
+        [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.21.0", "4.3.0")]
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.21.0", "4.2.1")]
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.21.0", "4.2.1")]
+        [InlineData("latest", "[4.*, 5.0.0)", "4.21.0", "4.3.0")]
+        [InlineData("standard", "[4.*, 5.0.0)", "4.21.0", "4.2.1")]
+        [InlineData("extended", "[4.*, 5.0.0)", "4.21.0", "4.2.1")]
+
+        // Host-config max = 4.2.1 (only one valid version after caps)
+        // Candidates: 4.2.1 (since >4.2.0 && <=4.2.1). Standard/Extended fall back to same (only one).
+        [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.1", "4.2.1")]
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.1", "4.2.1")]
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.1", "4.2.1")]
+        [InlineData("standard", "[4.*, 5.0.0)", "4.2.1", "4.2.1")]
+        [InlineData("extended", "[4.*, 5.0.0)", "4.2.1", "4.2.1")]
+
+        // Host-config max = 4.2.0 (excluded by >4.2.0 natural min cap) -> no valid versions -> null result
+        [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.0", null)]
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.0", null)]
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.0", null)]
+        [InlineData("latest", "[4.*, 5.0.0)", "4.2.0", null)]
+        [InlineData("standard", "[4.*, 5.0.0)", "4.2.0", null)]
+        [InlineData("extended", "[4.*, 5.0.0)", "4.2.0", null)]
+#endif
         public void WhenPlatformReleaseChannelSet_ExpectedVersionChosen(string platformReleaseChannelName, string versionRange, string hostConfigMaxVersion, string expectedVersion)
         {
             var range = VersionRange.Parse(versionRange);
@@ -430,15 +483,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
 
             if (!string.IsNullOrEmpty(hostConfigMaxVersion))
             {
-                if (range.MinVersion.Major == 3)
-                {
-                    hostingConfiguration.Features.Add(ScriptConstants.MaximumBundleV3Version, hostConfigMaxVersion);
-                }
-
-                if (range.MinVersion.Major == 4)
-                {
-                    hostingConfiguration.Features.Add(ScriptConstants.MaximumBundleV4Version, hostConfigMaxVersion);
-                }
+                int dotnetVersion = typeof(string).Assembly.GetName().Version.Major;
+                int bundleVersion = range.MinVersion.Major;
+                string hostingConfigVersionKey = $"Net{dotnetVersion}MaximumBundleV{bundleVersion}Version";
+                hostingConfiguration.Features.Add(hostingConfigVersionKey, hostConfigMaxVersion);
             }
 
             var options = GetTestExtensionBundleOptions(BundleId, versionRange);
@@ -450,6 +498,121 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
             var resolvedVersion = manager.FindBestVersionMatch(range, versions, ScriptConstants.DefaultExtensionBundleId, hostingConfiguration);
 
             Assert.Equal(expectedVersion, resolvedVersion);
+        }
+
+        private static readonly IList<string> V3Versions = new List<string>
+        {
+            "3.19.0",
+            "3.19.2",
+            "3.20.0"
+        };
+
+        [Fact]
+        public void FindBestVersionMatch_V3_LatestChannel_NoHostConfig_ChoosesHighest()
+        {
+            var versionRange = VersionRange.Parse("[3.*, 4.0.0)");
+            var options = GetTestExtensionBundleOptions(BundleId, versionRange.OriginalString);
+            var env = GetTestAppServiceEnvironment(ScriptConstants.LatestPlatformChannelNameUpper);
+            var manager = GetExtensionBundleManager(options, env);
+
+            var resolved = manager.FindBestVersionMatch(versionRange, V3Versions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            Assert.Equal("3.20.0", resolved);
+        }
+
+        [Theory]
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "3.19.2")]  // STANDARD uppercase
+        [InlineData("standard", "3.19.2")]                                        // lowercase
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "3.19.2")]  // EXTENDED uppercase
+        [InlineData("extended", "3.19.2")]                                        // lowercase
+        public void FindBestVersionMatch_V3_StandardOrExtended_NoHostConfig_ChoosesPrevious(string channel, string expected)
+        {
+            var versionRange = VersionRange.Parse("[3.*, 4.0.0)");
+            var options = GetTestExtensionBundleOptions(BundleId, versionRange.OriginalString);
+            var env = GetTestAppServiceEnvironment(channel);
+            var manager = GetExtensionBundleManager(options, env);
+
+            var resolved = manager.FindBestVersionMatch(versionRange, V3Versions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            Assert.Equal(expected, resolved);
+        }
+
+        [Fact]
+        public void FindBestVersionMatch_V3_HostConfigMax_CapsLatestAndStandardDiffers()
+        {
+            // Host-config max = 3.19.2, so candidates after cap: 3.19.2, 3.19.0
+            var versionRange = VersionRange.Parse("[3.*, 4.0.0)");
+            var hostConfig = new FunctionsHostingConfigOptions();
+            int dotnetVersion = typeof(string).Assembly.GetName().Version.Major;
+            hostConfig.Features.Add($"Net{dotnetVersion}MaximumBundleV3Version", "3.19.2");
+
+            var options = GetTestExtensionBundleOptions(BundleId, versionRange.OriginalString);
+
+            // Latest channel
+            var latestEnv = GetTestAppServiceEnvironment(ScriptConstants.LatestPlatformChannelNameUpper);
+            var manager = GetExtensionBundleManager(options, latestEnv);
+            var resolvedLatest = manager.FindBestVersionMatch(versionRange, V3Versions, ScriptConstants.DefaultExtensionBundleId, hostConfig);
+            Assert.Equal("3.19.2", resolvedLatest);
+
+            // Standard channel picks previous (3.19.0)
+            var stdEnv = GetTestAppServiceEnvironment(ScriptConstants.StandardPlatformChannelNameUpper);
+            manager = GetExtensionBundleManager(options, stdEnv);
+            var resolvedStd = manager.FindBestVersionMatch(versionRange, V3Versions, ScriptConstants.DefaultExtensionBundleId, hostConfig);
+            Assert.Equal("3.19.0", resolvedStd);
+        }
+
+        [Fact]
+        public void FindBestVersionMatch_V3_HostConfigMax_RemovesAllButOne_StandardFallsBackToSame()
+        {
+            // Host-config max = 3.19.0 leaves only one candidate.
+            var versionRange = VersionRange.Parse("[3.*, 4.0.0)");
+            var hostConfig = new FunctionsHostingConfigOptions();
+            int dotnetVersion = typeof(string).Assembly.GetName().Version.Major;
+            hostConfig.Features.Add($"Net{dotnetVersion}MaximumBundleV3Version", "3.19.0");
+
+            var options = GetTestExtensionBundleOptions(BundleId, versionRange.OriginalString);
+
+            var stdEnv = GetTestAppServiceEnvironment(ScriptConstants.StandardPlatformChannelNameUpper);
+            var extEnv = GetTestAppServiceEnvironment(ScriptConstants.ExtendedPlatformChannelNameUpper);
+            var latestEnv = GetTestAppServiceEnvironment(ScriptConstants.LatestPlatformChannelNameUpper);
+
+            var manager = GetExtensionBundleManager(options, latestEnv);
+            Assert.Equal("3.19.0", manager.FindBestVersionMatch(versionRange, V3Versions, ScriptConstants.DefaultExtensionBundleId, hostConfig));
+
+            manager = GetExtensionBundleManager(options, stdEnv);
+            Assert.Equal("3.19.0", manager.FindBestVersionMatch(versionRange, V3Versions, ScriptConstants.DefaultExtensionBundleId, hostConfig));
+
+            manager = GetExtensionBundleManager(options, extEnv);
+            Assert.Equal("3.19.0", manager.FindBestVersionMatch(versionRange, V3Versions, ScriptConstants.DefaultExtensionBundleId, hostConfig));
+        }
+
+        [Fact]
+        public void FindBestVersionMatch_V3_UnknownChannel_DefaultsToLatest()
+        {
+            var versionRange = VersionRange.Parse("[3.*, 4.0.0)");
+            var options = GetTestExtensionBundleOptions(BundleId, versionRange.OriginalString);
+            var env = GetTestAppServiceEnvironment("unrecognized-channel");
+            var manager = GetExtensionBundleManager(options, env);
+
+            var resolved = manager.FindBestVersionMatch(versionRange, V3Versions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            Assert.Equal("3.20.0", resolved);
+        }
+
+        [Fact]
+        public void FindBestVersionMatch_V3_IgnoresV4VersionsOutsideRange()
+        {
+            // Include some v4 versions; they must be ignored due to the version range upper bound.
+            var mixedVersions = new List<string>(V3Versions.Concat(new[] { "4.0.2", "4.1.0", "4.3.0" }));
+            var versionRange = VersionRange.Parse("[3.*, 4.0.0)");
+            var options = GetTestExtensionBundleOptions(BundleId, versionRange.OriginalString);
+            var env = GetTestAppServiceEnvironment(ScriptConstants.LatestPlatformChannelNameUpper);
+            var manager = GetExtensionBundleManager(options, env);
+
+            var resolved = manager.FindBestVersionMatch(versionRange, mixedVersions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            // Highest 3.x version remains selected; 4.x are out of range.
+            Assert.Equal("3.20.0", resolved);
         }
 
         [Theory]
@@ -477,6 +640,132 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
 
             Assert.Equal(expected, resolvedVersion);
             mockLogger.Verify();
+        }
+
+#if NET8_0
+        [Fact]
+        public void FindBestVersionMatch_V4Range_NoMinCap_Allows_4_2_0()
+        {
+            // On .NET 8 the min/max cap logic for v4 bundles is NOT applied (only applies to .NET 6).
+            // Therefore 4.2.0 should be a valid selectable version.
+            var range = VersionRange.Parse("[4.0.0, 5.0.0)");
+            var versions = new List<string> { "4.1.0", "4.2.0" };  // 4.2.0 should be chosen (highest)
+            var options = GetTestExtensionBundleOptions(BundleId, "[4.*,5.0.0)");
+            var manager = GetExtensionBundleManager(options, GetTestAppServiceEnvironment());
+
+            var resolved = manager.FindBestVersionMatch(range, versions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            Assert.Equal("4.2.0", resolved);
+        }
+
+        [Fact]
+        public void FindBestVersionMatch_V4Range_NoMaxCap_Allows_4_22_0()
+        {
+            // On .NET 8 the artificial exclusive max cap (< 4.22.0) is not enforced.
+            // If 4.22.0 is present and within the caller's range it must be selected as latest.
+            var range = VersionRange.Parse("[4.0.0, 5.0.0)");
+            var versions = new List<string> { "4.20.0", "4.21.5", "4.22.0" }; // 4.22.0 should be chosen
+            var options = GetTestExtensionBundleOptions(BundleId, "[4.*,5.0.0)");
+            var manager = GetExtensionBundleManager(options, GetTestAppServiceEnvironment());
+
+            var resolved = manager.FindBestVersionMatch(range, versions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            Assert.Equal("4.22.0", resolved);
+        }
+
+        [Fact]
+        public void FindBestVersionMatch_V4Range_NoCaps_MixedSet_PicksHighest()
+        {
+            // Ensure normal highest-version selection still works with a broader mixed set including values
+            // that would have been excluded on .NET 6 (4.2.0) and a high version (4.22.0).
+            var range = VersionRange.Parse("[4.0.0, 5.0.0)");
+            var versions = new List<string> { "4.2.0", "4.3.0", "4.10.0", "4.22.0", "4.21.9" };
+            var options = GetTestExtensionBundleOptions(BundleId, "[4.*,5.0.0)");
+            var manager = GetExtensionBundleManager(options, GetTestAppServiceEnvironment());
+
+            var resolved = manager.FindBestVersionMatch(range, versions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            Assert.Equal("4.22.0", resolved);
+        }
+#endif
+
+#if NET6_0
+        [Fact]
+        public void FindBestVersionMatch_V4Range_MinCapApplied_ExcludesCappedMin()
+        {
+            var range = VersionRange.Parse("[4.0.0, 5.0.0)");
+            var versions = new List<string> { "4.1.0", "4.2.0", "4.3.0" };
+            var options = GetTestExtensionBundleOptions(BundleId, "[4.*,5.0.0)");
+            var manager = GetExtensionBundleManager(options, GetTestAppServiceEnvironment());
+
+            var resolved = manager.FindBestVersionMatch(range, versions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            // 4.2.0 must be excluded (exclusive cap), so 4.3.0 chosen.
+            Assert.Equal("4.3.0", resolved);
+        }
+
+        [Fact]
+        public void FindBestVersionMatch_V4Range_MaxCapApplied_ExcludesCappedMax()
+        {
+            var range = VersionRange.Parse("[4.0.0, 5.0.0)");
+            var versions = new List<string> { "4.22.0", "4.21.5", "4.21.4" };
+            var options = GetTestExtensionBundleOptions(BundleId, "[4.*,5.0.0)");
+            var manager = GetExtensionBundleManager(options, GetTestAppServiceEnvironment());
+
+            var resolved = manager.FindBestVersionMatch(range, versions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            // 4.22.0 excluded (exclusive max cap), expect 4.21.5
+            Assert.Equal("4.21.5", resolved);
+        }
+
+        [Fact]
+        public void FindBestVersionMatch_V4Range_HostConfigMaxOverrides()
+        {
+            var range = VersionRange.Parse("[4.0.0, 5.0.0)");
+            var versions = new List<string> { "4.21.1", "4.21.0", "4.20.9" };
+
+            var hostingConfig = new FunctionsHostingConfigOptions();
+            int dotnetVersion = typeof(string).Assembly.GetName().Version.Major;
+            string key = $"Net{dotnetVersion}MaximumBundleV4Version";
+            hostingConfig.Features.Add(key, "4.21.0");
+
+            var options = GetTestExtensionBundleOptions(BundleId, "[4.*,5.0.0)");
+            var manager = GetExtensionBundleManager(options, GetTestAppServiceEnvironment());
+
+            var resolved = manager.FindBestVersionMatch(range, versions, ScriptConstants.DefaultExtensionBundleId, hostingConfig);
+
+            // Host config caps at 4.21.0 inclusive, so 4.21.0 selected (not 4.21.1)
+            Assert.Equal("4.21.0", resolved);
+        }
+
+        [Fact]
+        public void FindBestVersionMatch_V4Range_AllFiltered_ReturnsNull()
+        {
+            var range = VersionRange.Parse("[4.0.0, 5.0.0)");
+            var versions = new List<string> { "4.2.0" }; // Min cap makes 4.2.0 exclusive, so nothing remains.
+            var options = GetTestExtensionBundleOptions(BundleId, "[4.*,5.0.0)");
+            var manager = GetExtensionBundleManager(options, GetTestAppServiceEnvironment());
+
+            var resolved = manager.FindBestVersionMatch(range, versions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            Assert.Null(resolved);
+        }
+#endif
+
+        [Fact]
+        public void FindBestVersionMatch_NonDefaultBundle_NoCappingApplied()
+        {
+            var customBundleId = "Custom.Bundle";
+            var range = VersionRange.Parse("[4.0.0, 5.0.0)");
+            var versions = new List<string> { "4.1.0", "4.2.0", "4.3.0" };
+
+            var options = GetTestExtensionBundleOptions(customBundleId, "[4.*,5.0.0)");
+            var manager = GetExtensionBundleManager(options, GetTestAppServiceEnvironment());
+
+            var resolved = manager.FindBestVersionMatch(range, versions, customBundleId, new FunctionsHostingConfigOptions());
+
+            // No capping for non-default bundle; latest (4.3.0) returned.
+            Assert.Equal("4.3.0", resolved);
         }
 
         [Fact]
@@ -573,7 +862,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
         private IList<string> GetLargeVersionsList()
         {
             return new List<string>()
-            { "3.7.0", "3.10.0", "3.11.0", "3.15.0", "3.14.0", "2.16.0", "3.13.0", "3.12.0", "3.9.1", "2.12.1", "2.18.0", "3.16.0", "2.19.0", "3.17.0", "4.0.2", "2.20.0", "3.18.0", "4.1.0", "4.2.0", "2.21.0", "3.19.0", "3.19.2", "4.3.0", "3.20.0" };
+            { "3.7.0", "3.10.0", "3.11.0", "3.15.0", "3.14.0", "2.16.0", "3.13.0", "3.12.0", "3.9.1", "2.12.1", "2.18.0", "3.16.0", "2.19.0", "3.17.0", "4.0.2", "2.20.0", "3.18.0", "4.1.0", "4.2.0", "4.2.1", "2.21.0", "3.19.0", "3.19.2", "4.3.0", "3.20.0",  "4.22.0", "4.22.1", "4.23.0" };
         }
 
         private Mock<ILogger> GetVerifiableMockLogger(string stringToVerify, LogLevel logLevel)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
This pull request updates the extension bundle version selection logic in Azure Functions to provide more granular and flexible control over the maximum extension bundle versions allowed, especially across different .NET runtimes. The previous approach of using static configuration keys for maximum bundle versions has been replaced with dynamic, runtime-specific keys and improved capping logic. The tests have also been expanded and updated to cover these changes.

**Extension bundle version selection improvements:**

- Replaced the static `MaximumBundleV3Version` and `MaximumBundleV4Version` properties in `FunctionsHostingConfigOptions` with a dynamic lookup that uses keys of the form `Net{dotnetVersion}MaximumBundleV{bundleVersion}Version`, allowing max bundle version configuration to be specific to both .NET runtime and bundle major version. [[1]](diffhunk://#diff-528c891736c9b1e7fb1cd78f3e349110b1c292142e812bd79023a4f9e7d024c9L166-L187) [[2]](diffhunk://#diff-85b762965162c1552dcb464ef2ab520b03ddbb1fabad4cc85bef3180b5a5c0dbR256-R277) [[3]](diffhunk://#diff-85b762965162c1552dcb464ef2ab520b03ddbb1fabad4cc85bef3180b5a5c0dbL273-R324) [[4]](diffhunk://#diff-5167ae476da8ce4b226962989d7659a0ce26e640b3aa9a92321e4e0f158cc6b3L252-R256)
- Introduced logic to cap v4.x extension bundle versions on .NET 6 to the range (>4.2.0, <4.22.0) by default, unless overridden by hosting config, to prevent unsupported bundle versions from being selected. [[1]](diffhunk://#diff-85b762965162c1552dcb464ef2ab520b03ddbb1fabad4cc85bef3180b5a5c0dbR256-R277) [[2]](diffhunk://#diff-85b762965162c1552dcb464ef2ab520b03ddbb1fabad4cc85bef3180b5a5c0dbL273-R324) [[3]](diffhunk://#diff-5167ae476da8ce4b226962989d7659a0ce26e640b3aa9a92321e4e0f158cc6b3L252-R256)
- Added helper methods `GetCappedVersion` and `GetMaxCappedBundleVersionFromHostingConfig` to centralize the capping logic and configuration lookup.

**Test updates and coverage:**

- Updated existing tests to use the new dynamic configuration keys for max bundle version, ensuring correct version selection for both v3 and v4 bundles across .NET 6 and .NET 8. [[1]](diffhunk://#diff-285fc4e1d06ff31162616d14d0e4723d86e424c37503d9a32fde927bbca69785L384-R399) [[2]](diffhunk://#diff-285fc4e1d06ff31162616d14d0e4723d86e424c37503d9a32fde927bbca69785R411-R489)
- Expanded test cases to cover a wide range of scenarios, including different platform channels, host-config maximums, and .NET runtimes, for both v3 and v4 bundles. [[1]](diffhunk://#diff-285fc4e1d06ff31162616d14d0e4723d86e424c37503d9a32fde927bbca69785R411-R489) [[2]](diffhunk://#diff-285fc4e1d06ff31162616d14d0e4723d86e424c37503d9a32fde927bbca69785R503-R617)
- Added new tests specifically for v3 bundle version selection logic, including handling of unknown channels and mixed version lists.

**Code cleanup:**

- Removed unused usings and the now-obsolete static configuration properties. [[1]](diffhunk://#diff-85b762965162c1552dcb464ef2ab520b03ddbb1fabad4cc85bef3180b5a5c0dbR10) [[2]](diffhunk://#diff-528c891736c9b1e7fb1cd78f3e349110b1c292142e812bd79023a4f9e7d024c9L166-L187) [[3]](diffhunk://#diff-61d01dc8b76ac70d3f06ac62f8b4f6d35b44bf710e66704dc0a42c345ae51b3eL114-L115)

These changes make extension bundle versioning safer, more predictable, and easier to configure for different runtime environments.

resolves #11279

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
