### PR TITLE
Change log level from error to debug in LinuxContainerMetricsPublisher

### DIFF
--- a/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/LinuxContainerMetricsPublisher.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, $"Failed to publish status to {publishPath}");
+                _logger.LogDebug(ex, $"Failed to publish status to {publishPath}");
             }
         }
 

--- a/test/WebJobs.Script.Tests/Metrics/LinuxContainerMetricsPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/LinuxContainerMetricsPublisherTests.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             _metricsPublisher.SendRequest(testQueue, "testPath").GetAwaiter().GetResult();
             Assert.Matches("Failed to publish status to testPath", _testLoggerProvider.GetAllLogMessages().Single().FormattedMessage);
             Assert.Matches("NullReferenceException", _testLoggerProvider.GetAllLogMessages().Single().Exception.ToString());
-            Assert.Equal(LogLevel.Error, _testLoggerProvider.GetAllLogMessages().Single().Level);
+            Assert.Equal(LogLevel.Debug, _testLoggerProvider.GetAllLogMessages().Single().Level);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

- Changes log level of a `LinuxContainerMetricsPublisher` error to debug to reduce customer facing noise.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
