### PR TITLE
Setting min and max cap for dotnet 6 inproc host (4.2.0, 4.22.0) 

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+Cap v4.x extension bundle versions on .NET 6 to the range (>4.2.0, <4.22.0) by default (#11289)

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -164,28 +164,6 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         }
 
         /// <summary>
-        /// Gets the highest version of extension bundle v3 supported.
-        /// </summary>
-        internal string MaximumBundleV3Version
-        {
-            get
-            {
-                return GetFeature(ScriptConstants.MaximumBundleV3Version);
-            }
-        }
-
-        /// <summary>
-        /// Gets the highest version of extension bundle v4 supported.
-        /// </summary>
-        internal string MaximumBundleV4Version
-        {
-            get
-            {
-                return GetFeature(ScriptConstants.MaximumBundleV4Version);
-            }
-        }
-
-        /// <summary>
         /// Gets a value indicating whether the host should revert the worker shutdown behavior in the WebHostWorkerChannelManager.
         /// </summary>
         internal bool RevertWorkerShutdownBehavior

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -252,45 +252,67 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
 
         internal string FindBestVersionMatch(VersionRange versionRange, IEnumerable<string> versions, string bundleId, FunctionsHostingConfigOptions configOption)
         {
+            int dotnetVersion = typeof(string).Assembly.GetName().Version.Major;
+
+            // Limit the version range for v4.x bundles on .NET 6 to be between 4.2.0 and 4.22.0
+            // Return original version range if not .NET 6 or not v4.x bundle
+            var effectiveVersionRange = GetAdjustedVersion(dotnetVersion, versionRange, bundleId);
+
+            // Check if there is a max version configured in hosting config for the current dotnet version and bundle major version
+            if (TryGetMaxBundleVersionFromHostingConfig(bundleId, versionRange.MinVersion.Major, dotnetVersion, configOption, out NuGetVersion maxBundleVersion))
+            {
+                effectiveVersionRange = new VersionRange(effectiveVersionRange.MinVersion, effectiveVersionRange.IsMinInclusive, maxBundleVersion, true);
+            }
+
             var bundleVersions = versions.Select(p =>
             {
                 var dirName = Path.GetFileName(p);
                 NuGetVersion.TryParse(dirName, out NuGetVersion version);
                 if (version != null)
                 {
-                    version = versionRange.Satisfies(version) ? version : null;
+                    version = effectiveVersionRange.Satisfies(version) ? version : null;
                 }
                 return version;
             }).Where(v => v != null).OrderByDescending(version => version.Version).ToList();
 
             var matchingVersion = ResolvePlatformReleaseChannelVersion(bundleVersions);
 
-            if (bundleId != ScriptConstants.DefaultExtensionBundleId)
-            {
-                return matchingVersion?.ToString();
-            }
-
-            // Check to see if there is a max bundle version set via hosting configuration, if yes then use that instead of the one
-            // available on VM or local machine. Only use MaximumBundleV3Version or MaximumBundleV4Version if the version configured
-            // by the customer resolved to version higher than the version set via hosting config.
-            if (!string.IsNullOrEmpty(configOption.MaximumBundleV3Version)
-                && matchingVersion?.Major == ScriptConstants.ExtensionBundleV3MajorVersion)
-            {
-                var maximumBundleV3Version = NuGetVersion.Parse(configOption.MaximumBundleV3Version);
-                matchingVersion = matchingVersion > maximumBundleV3Version ? maximumBundleV3Version : matchingVersion;
-                return matchingVersion?.ToString();
-            }
-
-            if (!string.IsNullOrEmpty(configOption.MaximumBundleV4Version)
-                && matchingVersion?.Major == ScriptConstants.ExtensionBundleV4MajorVersion)
-            {
-                var maximumBundleV4Version = NuGetVersion.Parse(configOption.MaximumBundleV4Version);
-                matchingVersion = matchingVersion > maximumBundleV4Version
-                                ? maximumBundleV4Version
-                                : matchingVersion;
-            }
-
             return matchingVersion?.ToString();
+        }
+
+        // Applies bundle version limits for .NET 6, using the default bundle if referencing a v4 major bundle version.
+        private VersionRange GetAdjustedVersion(int dotnetVersion, VersionRange versionRange, string bundleId)
+        {
+            if (dotnetVersion != 6
+                || !string.Equals(bundleId, ScriptConstants.DefaultExtensionBundleId, StringComparison.OrdinalIgnoreCase)
+                || versionRange.MinVersion.Major != ScriptConstants.ExtensionBundleV4MajorVersion)
+            {
+                return versionRange;
+            }
+
+            var effectiveMinVersion = new NuGetVersion(ScriptConstants.Net6MinimunV4BundleVersion);
+            var effectiveMaxVersion = new NuGetVersion(ScriptConstants.Net6MaximumV4BundleVersion);
+
+            var minVersion = versionRange.MinVersion < effectiveMinVersion ? effectiveMinVersion : versionRange.MinVersion;
+            var maxVersion = versionRange.MaxVersion > effectiveMaxVersion ? effectiveMaxVersion : versionRange.MaxVersion;
+
+            // Use the original inclusion values if it is within the min or max range.
+            bool isMinInclusive = versionRange.MinVersion > effectiveMinVersion && versionRange.IsMinInclusive;
+            bool isMaxInclusive = versionRange.MaxVersion < effectiveMaxVersion && versionRange.IsMaxInclusive;
+
+            versionRange = new VersionRange(minVersion, isMinInclusive, maxVersion, isMaxInclusive);
+            return versionRange;
+        }
+
+        private bool TryGetMaxBundleVersionFromHostingConfig(string bundleId, int bundleVersion, int dotnetVersion, FunctionsHostingConfigOptions configOption, out NuGetVersion maxVersion)
+        {
+            maxVersion = null;
+            string hostingConfig = $"Net{dotnetVersion}MaximumBundleV{bundleVersion}Version";
+            string hostingConfigValue = configOption.GetFeature(hostingConfig);
+
+            return string.Equals(bundleId, ScriptConstants.DefaultExtensionBundleId, StringComparison.OrdinalIgnoreCase)
+                && !string.IsNullOrEmpty(hostingConfigValue)
+                && NuGetVersion.TryParse(hostingConfigValue, out maxVersion);
         }
 
         private NuGetVersion ResolvePlatformReleaseChannelVersion(IList<NuGetVersion> orderedByDescBundles) => _platformReleaseChannel.ToUpper() switch

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -249,8 +249,8 @@ namespace Microsoft.Azure.WebJobs.Script
         public static readonly string LiveLogsSessionAIKey = "#AzFuncLiveLogsSessionId";
 
         public static readonly string FunctionsHostingConfigSectionName = "FunctionsHostingConfig";
-        public static readonly string MaximumBundleV3Version = "FunctionRuntimeV4MaxBundleV3Version";
-        public static readonly string MaximumBundleV4Version = "FunctionRuntimeV4MaxBundleV4Version";
+        public static readonly string Net6MinimunV4BundleVersion = "4.2.0";
+        public static readonly string Net6MaximumV4BundleVersion = "4.22.0";
 
         // HTTP Proxying constants
         public static readonly string HttpProxyingEnabled = "HttpProxyingEnabled";

--- a/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
@@ -111,8 +111,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 (nameof(FunctionsHostingConfigOptions.EnableOrderedInvocationMessages), string.Empty, true), // default
 
                 (nameof(FunctionsHostingConfigOptions.FunctionsWorkerDynamicConcurrencyEnabled), "FUNCTIONS_WORKER_DYNAMIC_CONCURRENCY_ENABLED=1", true),
-                (nameof(FunctionsHostingConfigOptions.MaximumBundleV3Version), "FunctionRuntimeV4MaxBundleV3Version=teststring", "teststring"),
-                (nameof(FunctionsHostingConfigOptions.MaximumBundleV4Version), "FunctionRuntimeV4MaxBundleV4Version=teststring", "teststring"),
                 (nameof(FunctionsHostingConfigOptions.RevertWorkerShutdownBehavior), "REVERT_WORKER_SHUTDOWN_BEHAVIOR=1", true),
 
                 // Supports True/False/1/0

--- a/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
     {
         private const string BundleId = "Microsoft.Azure.Functions.ExtensionBundle";
         private string _downloadPath;
+        private static readonly IList<string> V3Versions = new List<string> { "3.19.0", "3.19.2", "3.20.0" };
 
         public ExtensionBundleManagerTests()
         {
@@ -381,24 +382,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
 
         [Theory]
         [InlineData("[3.*, 4.0.0)", "3.19.0", "3.19.0")]
-        [InlineData("[4.*, 5.0.0)", "4.2.0", "4.2.0")]
+        [InlineData("[4.*, 5.0.0)", "4.3.0", "4.3.0")]
+#if NET6_0
         [InlineData("[4.*, 5.0.0)", null, "4.3.0")]
-        [InlineData("[3.*, 4.0.0)", null, "3.20.0")]
+#elif NET8_0
+        [InlineData("[4.*, 5.0.0)", null, "4.23.0")]
+#endif
         public void LimitMaxVersion(string versionRange, string hostConfigVersion, string expectedVersion)
         {
             var range = VersionRange.Parse(versionRange);
             var hostingConfiguration = new FunctionsHostingConfigOptions();
             if (!string.IsNullOrEmpty(hostConfigVersion))
             {
-                if (range.MinVersion.Major == 3)
-                {
-                    hostingConfiguration.Features.Add(ScriptConstants.MaximumBundleV3Version, hostConfigVersion);
-                }
-
-                if (range.MinVersion.Major == 4)
-                {
-                    hostingConfiguration.Features.Add(ScriptConstants.MaximumBundleV4Version, hostConfigVersion);
-                }
+                int dotnetVersion = typeof(string).Assembly.GetName().Version.Major;
+                int bundleVersion = range.MinVersion.Major;
+                string hostingConfigVersionKey = $"Net{dotnetVersion}MaximumBundleV{bundleVersion}Version";
+                hostingConfiguration.Features.Add(hostingConfigVersionKey, hostConfigVersion);
             }
 
             var options = GetTestExtensionBundleOptions(BundleId, versionRange);
@@ -410,19 +409,74 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
         }
 
         [Theory]
+#if NET8_0
+        // No host-config max (full list available, no caps applied on .NET 8)
+        [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.23.0")]
+        [InlineData("latest", "[4.*, 5.0.0)", null, "4.23.0")]
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.22.1")]
+        [InlineData("standard", "[4.*, 5.0.0)", null, "4.22.1")]
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.22.1")]
+        [InlineData("extended", "[4.*, 5.0.0)", null, "4.22.1")]
+
+        // Host-config max at 4.22.0 (caps selection to <= 4.22.0)
+        // Ordered (desc) after cap: 4.22.0, 4.3.0, 4.2.1, 4.2.0, 4.1.0, 4.0.2
+        [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.22.0", "4.22.0")]
+        [InlineData("latest", "[4.*, 5.0.0)", "4.22.0", "4.22.0")]
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.22.0", "4.3.0")]
+        [InlineData("standard", "[4.*, 5.0.0)", "4.22.0", "4.3.0")]
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.22.0", "4.3.0")]
+        [InlineData("extended", "[4.*, 5.0.0)", "4.22.0", "4.3.0")]
+
+        // Host-config max at 4.2.1
+        // Ordered after cap: 4.2.1, 4.2.0, 4.1.0, 4.0.2
+        [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.1", "4.2.1")]
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.1", "4.2.0")]
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.1", "4.2.0")]
+
+        // Host-config max at 4.2.0
+        // Ordered after cap: 4.2.0, 4.1.0, 4.0.2
         [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.0", "4.2.0")]
-        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.0", "4.2.0")]
-        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.0", "4.2.0")]
-        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.3.0", "4.2.0")]
-        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.3.0", "4.2.0")]
-        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.1.0", "4.1.0")]
-        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.1.0", "4.1.0")]
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.0", "4.1.0")]
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.0", "4.1.0")]
+#elif NET6_0
+         // Existing scenarios (no host-config cap or cap at 4.3.0 -> top stays 4.3.0, standard/extended take 4.2.1)
+        [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.3.0", "4.3.0")]
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.3.0", "4.2.1")]
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.3.0", "4.2.1")]
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.2.1")]
         [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.3.0")]
         [InlineData("latest", "[4.*, 5.0.0)", null, "4.3.0")]
-        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.2.0")]
-        [InlineData("standard", "[4.*, 5.0.0)", null, "4.2.0")]
-        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.2.0")]
-        [InlineData("extended", "[4.*, 5.0.0)", null, "4.2.0")]
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.2.1")]
+        [InlineData("standard", "[4.*, 5.0.0)", null, "4.2.1")]
+        [InlineData("extended", "[4.*, 5.0.0)", null, "4.2.1")]
+
+        // Additional scenarios for .NET 6 caps + various host-config maximums:
+
+        // Host-config max = 4.21.0 (after natural cap: allowed >4.2.0 && <4.22.0, then <=4.21.0)
+        // Ordered candidates: 4.21.0, 4.3.0(excluded), 4.2.1
+        [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.21.0", "4.3.0")]
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.21.0", "4.2.1")]
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.21.0", "4.2.1")]
+        [InlineData("latest", "[4.*, 5.0.0)", "4.21.0", "4.3.0")]
+        [InlineData("standard", "[4.*, 5.0.0)", "4.21.0", "4.2.1")]
+        [InlineData("extended", "[4.*, 5.0.0)", "4.21.0", "4.2.1")]
+
+        // Host-config max = 4.2.1 (only one valid version after caps)
+        // Candidates: 4.2.1 (since >4.2.0 && <=4.2.1). Standard/Extended fall back to same (only one).
+        [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.1", "4.2.1")]
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.1", "4.2.1")]
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.1", "4.2.1")]
+        [InlineData("standard", "[4.*, 5.0.0)", "4.2.1", "4.2.1")]
+        [InlineData("extended", "[4.*, 5.0.0)", "4.2.1", "4.2.1")]
+
+        // Host-config max = 4.2.0 (excluded by >4.2.0 natural min cap) -> no valid versions -> null result
+        [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.0", null)]
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.0", null)]
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", "4.2.0", null)]
+        [InlineData("latest", "[4.*, 5.0.0)", "4.2.0", null)]
+        [InlineData("standard", "[4.*, 5.0.0)", "4.2.0", null)]
+        [InlineData("extended", "[4.*, 5.0.0)", "4.2.0", null)]
+#endif
         public void WhenPlatformReleaseChannelSet_ExpectedVersionChosen(string platformReleaseChannelName, string versionRange, string hostConfigMaxVersion, string expectedVersion)
         {
             var range = VersionRange.Parse(versionRange);
@@ -430,15 +484,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
 
             if (!string.IsNullOrEmpty(hostConfigMaxVersion))
             {
-                if (range.MinVersion.Major == 3)
-                {
-                    hostingConfiguration.Features.Add(ScriptConstants.MaximumBundleV3Version, hostConfigMaxVersion);
-                }
-
-                if (range.MinVersion.Major == 4)
-                {
-                    hostingConfiguration.Features.Add(ScriptConstants.MaximumBundleV4Version, hostConfigMaxVersion);
-                }
+                int dotnetVersion = typeof(string).Assembly.GetName().Version.Major;
+                int bundleVersion = range.MinVersion.Major;
+                string hostingConfigVersionKey = $"Net{dotnetVersion}MaximumBundleV{bundleVersion}Version";
+                hostingConfiguration.Features.Add(hostingConfigVersionKey, hostConfigMaxVersion);
             }
 
             var options = GetTestExtensionBundleOptions(BundleId, versionRange);
@@ -450,6 +499,114 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
             var resolvedVersion = manager.FindBestVersionMatch(range, versions, ScriptConstants.DefaultExtensionBundleId, hostingConfiguration);
 
             Assert.Equal(expectedVersion, resolvedVersion);
+        }
+
+        [Fact]
+        public void FindBestVersionMatch_V3_LatestChannel_NoHostConfig_ChoosesHighest()
+        {
+            var versionRange = VersionRange.Parse("[3.*, 4.0.0)");
+            var options = GetTestExtensionBundleOptions(BundleId, versionRange.OriginalString);
+            var env = GetTestAppServiceEnvironment(ScriptConstants.LatestPlatformChannelNameUpper);
+            var manager = GetExtensionBundleManager(options, env);
+
+            var resolved = manager.FindBestVersionMatch(versionRange, V3Versions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            Assert.Equal("3.20.0", resolved);
+        }
+
+        [Theory]
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "3.19.2")]
+        [InlineData("standard", "3.19.2")]
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "3.19.2")]
+        [InlineData("extended", "3.19.2")]
+        public void FindBestVersionMatch_V3_StandardOrExtended_NoHostConfig_ChoosesPrevious(string channel, string expected)
+        {
+            var versionRange = VersionRange.Parse("[3.*, 4.0.0)");
+            var options = GetTestExtensionBundleOptions(BundleId, versionRange.OriginalString);
+            var env = GetTestAppServiceEnvironment(channel);
+            var manager = GetExtensionBundleManager(options, env);
+
+            var resolved = manager.FindBestVersionMatch(versionRange, V3Versions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            Assert.Equal(expected, resolved);
+        }
+
+        [Fact]
+        public void FindBestVersionMatch_V3_HostConfigMax_CapsLatestAndStandardDiffers()
+        {
+            // Host-config max = 3.19.2, so candidates after cap: 3.19.2, 3.19.0
+            var versionRange = VersionRange.Parse("[3.*, 4.0.0)");
+            var hostConfig = new FunctionsHostingConfigOptions();
+            int dotnetVersion = typeof(string).Assembly.GetName().Version.Major;
+            hostConfig.Features.Add($"Net{dotnetVersion}MaximumBundleV3Version", "3.19.2");
+
+            var options = GetTestExtensionBundleOptions(BundleId, versionRange.OriginalString);
+
+            // Latest channel
+            var latestEnv = GetTestAppServiceEnvironment(ScriptConstants.LatestPlatformChannelNameUpper);
+            var manager = GetExtensionBundleManager(options, latestEnv);
+            var resolvedLatest = manager.FindBestVersionMatch(versionRange, V3Versions, ScriptConstants.DefaultExtensionBundleId, hostConfig);
+            Assert.Equal("3.19.2", resolvedLatest);
+
+            // Standard channel picks previous (3.19.0)
+            var stdEnv = GetTestAppServiceEnvironment(ScriptConstants.StandardPlatformChannelNameUpper);
+            manager = GetExtensionBundleManager(options, stdEnv);
+            var resolvedStd = manager.FindBestVersionMatch(versionRange, V3Versions, ScriptConstants.DefaultExtensionBundleId, hostConfig);
+            Assert.Equal("3.19.0", resolvedStd);
+        }
+
+        [Fact]
+        public void FindBestVersionMatch_V3_HostConfigMax_RemovesAllButOne_StandardFallsBackToSame()
+        {
+            // Host-config max = 3.19.0 leaves only one candidate.
+            var versionRange = VersionRange.Parse("[3.*, 4.0.0)");
+            var hostConfig = new FunctionsHostingConfigOptions();
+            int dotnetVersion = typeof(string).Assembly.GetName().Version.Major;
+            hostConfig.Features.Add($"Net{dotnetVersion}MaximumBundleV3Version", "3.19.0");
+
+            var options = GetTestExtensionBundleOptions(BundleId, versionRange.OriginalString);
+
+            var stdEnv = GetTestAppServiceEnvironment(ScriptConstants.StandardPlatformChannelNameUpper);
+            var extEnv = GetTestAppServiceEnvironment(ScriptConstants.ExtendedPlatformChannelNameUpper);
+            var latestEnv = GetTestAppServiceEnvironment(ScriptConstants.LatestPlatformChannelNameUpper);
+
+            var manager = GetExtensionBundleManager(options, latestEnv);
+            Assert.Equal("3.19.0", manager.FindBestVersionMatch(versionRange, V3Versions, ScriptConstants.DefaultExtensionBundleId, hostConfig));
+
+            manager = GetExtensionBundleManager(options, stdEnv);
+            Assert.Equal("3.19.0", manager.FindBestVersionMatch(versionRange, V3Versions, ScriptConstants.DefaultExtensionBundleId, hostConfig));
+
+            manager = GetExtensionBundleManager(options, extEnv);
+            Assert.Equal("3.19.0", manager.FindBestVersionMatch(versionRange, V3Versions, ScriptConstants.DefaultExtensionBundleId, hostConfig));
+        }
+
+        [Fact]
+        public void FindBestVersionMatch_V3_UnknownChannel_DefaultsToLatest()
+        {
+            var versionRange = VersionRange.Parse("[3.*, 4.0.0)");
+            var options = GetTestExtensionBundleOptions(BundleId, versionRange.OriginalString);
+            var env = GetTestAppServiceEnvironment("unrecognized-channel");
+            var manager = GetExtensionBundleManager(options, env);
+
+            var resolved = manager.FindBestVersionMatch(versionRange, V3Versions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            Assert.Equal("3.20.0", resolved);
+        }
+
+        [Fact]
+        public void FindBestVersionMatch_V3_IgnoresV4VersionsOutsideRange()
+        {
+            // Include some v4 versions; they must be ignored due to the version range upper bound.
+            var mixedVersions = new List<string>(V3Versions.Concat(new[] { "4.0.2", "4.1.0", "4.3.0" }));
+            var versionRange = VersionRange.Parse("[3.*, 4.0.0)");
+            var options = GetTestExtensionBundleOptions(BundleId, versionRange.OriginalString);
+            var env = GetTestAppServiceEnvironment(ScriptConstants.LatestPlatformChannelNameUpper);
+            var manager = GetExtensionBundleManager(options, env);
+
+            var resolved = manager.FindBestVersionMatch(versionRange, mixedVersions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            // Highest 3.x version remains selected; 4.x are out of range.
+            Assert.Equal("3.20.0", resolved);
         }
 
         [Theory]
@@ -477,6 +634,132 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
 
             Assert.Equal(expected, resolvedVersion);
             mockLogger.Verify();
+        }
+
+#if NET8_0
+        [Fact]
+        public void FindBestVersionMatch_V4Range_NoMinCap_Allows_4_2_0()
+        {
+            // On .NET 8 the min/max cap logic for v4 bundles is NOT applied (only applies to .NET 6).
+            // Therefore 4.2.0 should be a valid selectable version.
+            var range = VersionRange.Parse("[4.0.0, 5.0.0)");
+            var versions = new List<string> { "4.1.0", "4.2.0" };  // 4.2.0 should be chosen (highest)
+            var options = GetTestExtensionBundleOptions(BundleId, "[4.*,5.0.0)");
+            var manager = GetExtensionBundleManager(options, GetTestAppServiceEnvironment());
+
+            var resolved = manager.FindBestVersionMatch(range, versions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            Assert.Equal("4.2.0", resolved);
+        }
+
+        [Fact]
+        public void FindBestVersionMatch_V4Range_NoMaxCap_Allows_4_22_0()
+        {
+            // On .NET 8 the artificial exclusive max cap (< 4.22.0) is not enforced.
+            // If 4.22.0 is present and within the caller's range it must be selected as latest.
+            var range = VersionRange.Parse("[4.0.0, 5.0.0)");
+            var versions = new List<string> { "4.20.0", "4.21.5", "4.22.0" }; // 4.22.0 should be chosen
+            var options = GetTestExtensionBundleOptions(BundleId, "[4.*,5.0.0)");
+            var manager = GetExtensionBundleManager(options, GetTestAppServiceEnvironment());
+
+            var resolved = manager.FindBestVersionMatch(range, versions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            Assert.Equal("4.22.0", resolved);
+        }
+
+        [Fact]
+        public void FindBestVersionMatch_V4Range_NoCaps_MixedSet_PicksHighest()
+        {
+            // Ensure normal highest-version selection still works with a broader mixed set including values
+            // that would have been excluded on .NET 6 (4.2.0) and a high version (4.22.0).
+            var range = VersionRange.Parse("[4.0.0, 5.0.0)");
+            var versions = new List<string> { "4.2.0", "4.3.0", "4.10.0", "4.22.0", "4.21.9" };
+            var options = GetTestExtensionBundleOptions(BundleId, "[4.*,5.0.0)");
+            var manager = GetExtensionBundleManager(options, GetTestAppServiceEnvironment());
+
+            var resolved = manager.FindBestVersionMatch(range, versions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            Assert.Equal("4.22.0", resolved);
+        }
+#endif
+
+#if NET6_0
+        [Fact]
+        public void FindBestVersionMatch_V4Range_MinCapApplied_ExcludesCappedMin()
+        {
+            var range = VersionRange.Parse("[4.0.0, 5.0.0)");
+            var versions = new List<string> { "4.1.0", "4.2.0", "4.3.0" };
+            var options = GetTestExtensionBundleOptions(BundleId, "[4.*,5.0.0)");
+            var manager = GetExtensionBundleManager(options, GetTestAppServiceEnvironment());
+
+            var resolved = manager.FindBestVersionMatch(range, versions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            // 4.2.0 must be excluded (exclusive cap), so 4.3.0 chosen.
+            Assert.Equal("4.3.0", resolved);
+        }
+
+        [Fact]
+        public void FindBestVersionMatch_V4Range_MaxCapApplied_ExcludesCappedMax()
+        {
+            var range = VersionRange.Parse("[4.0.0, 5.0.0)");
+            var versions = new List<string> { "4.22.0", "4.21.5", "4.21.4" };
+            var options = GetTestExtensionBundleOptions(BundleId, "[4.*,5.0.0)");
+            var manager = GetExtensionBundleManager(options, GetTestAppServiceEnvironment());
+
+            var resolved = manager.FindBestVersionMatch(range, versions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            // 4.22.0 excluded (exclusive max cap), expect 4.21.5
+            Assert.Equal("4.21.5", resolved);
+        }
+
+        [Fact]
+        public void FindBestVersionMatch_V4Range_HostConfigMaxOverrides()
+        {
+            var range = VersionRange.Parse("[4.0.0, 5.0.0)");
+            var versions = new List<string> { "4.21.1", "4.21.0", "4.20.9" };
+
+            var hostingConfig = new FunctionsHostingConfigOptions();
+            int dotnetVersion = typeof(string).Assembly.GetName().Version.Major;
+            string key = $"Net{dotnetVersion}MaximumBundleV4Version";
+            hostingConfig.Features.Add(key, "4.21.0");
+
+            var options = GetTestExtensionBundleOptions(BundleId, "[4.*,5.0.0)");
+            var manager = GetExtensionBundleManager(options, GetTestAppServiceEnvironment());
+
+            var resolved = manager.FindBestVersionMatch(range, versions, ScriptConstants.DefaultExtensionBundleId, hostingConfig);
+
+            // Host config caps at 4.21.0 inclusive, so 4.21.0 selected (not 4.21.1)
+            Assert.Equal("4.21.0", resolved);
+        }
+
+        [Fact]
+        public void FindBestVersionMatch_V4Range_AllFiltered_ReturnsNull()
+        {
+            var range = VersionRange.Parse("[4.0.0, 5.0.0)");
+            var versions = new List<string> { "4.2.0" }; // Min cap makes 4.2.0 exclusive, so nothing remains.
+            var options = GetTestExtensionBundleOptions(BundleId, "[4.*,5.0.0)");
+            var manager = GetExtensionBundleManager(options, GetTestAppServiceEnvironment());
+
+            var resolved = manager.FindBestVersionMatch(range, versions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            Assert.Null(resolved);
+        }
+#endif
+
+        [Fact]
+        public void FindBestVersionMatch_NonDefaultBundle_NoCappingApplied()
+        {
+            var customBundleId = "Custom.Bundle";
+            var range = VersionRange.Parse("[4.0.0, 5.0.0)");
+            var versions = new List<string> { "4.1.0", "4.2.0", "4.3.0" };
+
+            var options = GetTestExtensionBundleOptions(customBundleId, "[4.*,5.0.0)");
+            var manager = GetExtensionBundleManager(options, GetTestAppServiceEnvironment());
+
+            var resolved = manager.FindBestVersionMatch(range, versions, customBundleId, new FunctionsHostingConfigOptions());
+
+            // No capping for non-default bundle; latest (4.3.0) returned.
+            Assert.Equal("4.3.0", resolved);
         }
 
         [Fact]
@@ -573,7 +856,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
         private IList<string> GetLargeVersionsList()
         {
             return new List<string>()
-            { "3.7.0", "3.10.0", "3.11.0", "3.15.0", "3.14.0", "2.16.0", "3.13.0", "3.12.0", "3.9.1", "2.12.1", "2.18.0", "3.16.0", "2.19.0", "3.17.0", "4.0.2", "2.20.0", "3.18.0", "4.1.0", "4.2.0", "2.21.0", "3.19.0", "3.19.2", "4.3.0", "3.20.0" };
+            { "3.7.0", "3.10.0", "3.11.0", "3.15.0", "3.14.0", "2.16.0", "3.13.0", "3.12.0", "3.9.1", "2.12.1", "2.18.0", "3.16.0", "2.19.0", "3.17.0", "4.0.2", "2.20.0", "3.18.0", "4.1.0", "4.2.0", "4.2.1", "2.21.0", "3.19.0", "3.19.2", "4.3.0", "3.20.0",  "4.22.0", "4.22.1", "4.23.0" };
         }
 
         private Mock<ILogger> GetVerifiableMockLogger(string stringToVerify, LogLevel logLevel)


### PR DESCRIPTION
Backporting PR https://github.com/Azure/azure-functions-host/pull/11289

<!-- Please provide all the information below.  -->

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
