### PR TITLE
[in-proc backport] Set the kestrel MaxRequestBodySize=null for gRPC

### DIFF
--- a/src/WebJobs.Script.Grpc/Server/AspNetCoreGrpcHostBuilder.cs
+++ b/src/WebJobs.Script.Grpc/Server/AspNetCoreGrpcHostBuilder.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             {
                 webBuilder.UseKestrel(options =>
                 {
+                    // No limit. This server is exclusively between host and worker. All clients are trusted.
+                    options.Limits.MaxRequestBodySize = null;
                     options.Listen(IPAddress.Parse(WorkerConstants.HostName), port, listenOptions =>
                     {
                         listenOptions.Protocols = HttpProtocols.Http2;


### PR DESCRIPTION
Backport of #11295