### PR TITLE
Adding Activity wrapper to create a function-level request telemetry when none exists

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -8,3 +8,4 @@
 - Update Python Worker Version to [4.39.2](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.39.2)
 - Add JitTrace Files for v4.1043 (#11281)
 - Update `Microsoft.Azure.WebJobs` reference to `3.0.42` (#11309)
+- Adding Activity wrapper to create a function-level request telemetry when none exists (#11311)

--- a/src/WebJobs.Script/Diagnostics/OpenTelemetry/ActivitySourceWrapper.cs
+++ b/src/WebJobs.Script/Diagnostics/OpenTelemetry/ActivitySourceWrapper.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
     {
         private readonly ActivitySource _activitySource;
 
-        public ActivitySourceWrapper(string sourceName)
+        public ActivitySourceWrapper(string sourceName, string version)
         {
-            _activitySource = new ActivitySource(sourceName);
+            _activitySource = new ActivitySource(sourceName, version);
         }
 
         public IDisposable? StartActivity(IFunctionInstanceEx functionInstance)

--- a/src/WebJobs.Script/Diagnostics/OpenTelemetry/ActivitySourceWrapper.cs
+++ b/src/WebJobs.Script/Diagnostics/OpenTelemetry/ActivitySourceWrapper.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Diagnostics;
+using Microsoft.Azure.WebJobs.Host.Abstractions;
+using Microsoft.Azure.WebJobs.Host.Executors;
+
+namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
+{
+    internal sealed class ActivitySourceWrapper : IActivitySourceAbstraction
+    {
+        private readonly ActivitySource _activitySource;
+
+        public ActivitySourceWrapper(string sourceName)
+        {
+            _activitySource = new ActivitySource(sourceName);
+        }
+
+        public IDisposable? StartActivity(IFunctionInstanceEx functionInstance)
+        {
+            if (Activity.Current != null)
+            {
+                return null;
+            }
+
+            // If no current activity exists, create one for the entire function run.
+            // HTTP, Service Bus, Event Hub, and other instrumented triggers will have their own activities.
+            // BeginFunctionScope creates a function activity when AppInsights SDK is enabled.
+            // In OTel mode, Activity.Current will be null unless the trigger is instrumented.
+            return _activitySource.StartActivity(functionInstance.FunctionDescriptor.LogName, ActivityKind.Server);
+        }
+    }
+}

--- a/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConstants.cs
+++ b/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConstants.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
@@ -14,5 +14,6 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
         internal const string OwnerNameEnvVar = "WEBSITE_OWNER_NAME";
         internal const string AzureFunctionsGroup = "azure.functions.group";
         internal const string HttpTriggerType = "http";
+        internal const string HostActivitySourceName = "Microsoft.Azure.WebJobs";
     }
 }

--- a/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConstants.cs
+++ b/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConstants.cs
@@ -15,5 +15,6 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
         internal const string AzureFunctionsGroup = "azure.functions.group";
         internal const string HttpTriggerType = "http";
         internal const string HostActivitySourceName = "Microsoft.Azure.WebJobs";
+        internal const string HostActivitySourceVersion = "1.0.0";
     }
 }

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Azure.WebJobs.Script
             builder.ConfigureWebJobs((context, webJobsBuilder) =>
             {
                 webJobsBuilder.Services.AddSingleton<IActivitySourceAbstraction>(provider =>
-                  new ActivitySourceWrapper(OpenTelemetryConstants.HostActivitySourceName));
+                  new ActivitySourceWrapper(OpenTelemetryConstants.HostActivitySourceName, OpenTelemetryConstants.HostActivitySourceVersion));
 
                 // Built in binding registrations
                 webJobsBuilder.AddExecutionContextBinding(o =>

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
 using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Host.Abstractions;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Hosting;
 using Microsoft.Azure.WebJobs.Logging;
@@ -219,6 +220,9 @@ namespace Microsoft.Azure.WebJobs.Script
 
             builder.ConfigureWebJobs((context, webJobsBuilder) =>
             {
+                webJobsBuilder.Services.AddSingleton<IActivitySourceAbstraction>(provider =>
+                  new ActivitySourceWrapper(OpenTelemetryConstants.HostActivitySourceName));
+
                 // Built in binding registrations
                 webJobsBuilder.AddExecutionContextBinding(o =>
                 {


### PR DESCRIPTION
In OpenTelemetry (OTel) mode, this wrapper initiates a request telemetry only when no existing activity is present. This behavior is exclusive to OTel scenarios and does not interfere with the legacy Application Insights integration. For further context, refer to the [updates ](https://github.com/Azure/azure-webjobs-sdk/pull/3146)in the WebJobs SDK.

Typically, instrumented triggers—such as HTTP, Service Bus, or Event Hub—automatically generate their own activities. However, in OTel mode, uninstrumented triggers leave Activity.Current unset. To maintain full telemetry correlation and enable distributed tracing, we create a root activity for the function execution. 

### Issue describing the changes in this PR

resolves #10718 

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
