### PR TITLE
Add exponential backoff retries for extension bundle download and reuse HttpClient

### DIFF
--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ using Microsoft.Azure.WebJobs.Host.Storage;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.ExtensionBundle;
 using Microsoft.Azure.WebJobs.Script.Grpc;
 using Microsoft.Azure.WebJobs.Script.Metrics;
 using Microsoft.Azure.WebJobs.Script.Middleware;
@@ -142,6 +143,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddSingleton<IFunctionMetadataManager, FunctionMetadataManager>();
             services.AddSingleton<IWebFunctionsManager, WebFunctionsManager>();
             services.AddHttpClient();
+
+            services.AddBundlesHttpClient();
+
             services.AddSingleton<StartupContextProvider>();
             services.AddSingleton<IFileSystem>(_ => FileUtility.Instance);
             services.AddTransient<VirtualFileSystem>();

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -144,7 +144,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddSingleton<IFunctionMetadataManager, FunctionMetadataManager>();
             services.AddSingleton<IWebFunctionsManager, WebFunctionsManager>();
             services.AddHttpClient();
-
             services.AddBundlesHttpClient();
 
             services.AddSingleton<StartupContextProvider>();

--- a/src/WebJobs.Script/Diagnostics/Extensions/ExtensionBundleLoggerExtension.cs
+++ b/src/WebJobs.Script/Diagnostics/Extensions/ExtensionBundleLoggerExtension.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;

--- a/src/WebJobs.Script/Diagnostics/Extensions/ExtensionBundleLoggerExtension.cs
+++ b/src/WebJobs.Script/Diagnostics/Extensions/ExtensionBundleLoggerExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -84,25 +84,25 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
             new EventId(111, nameof(MatchingBundleNotFound)),
             "Bundle version matching the {version} was not found");
 
-        private static readonly Action<ILogger, Uri, HttpStatusCode?, HttpRequestError?, string, string, string, Exception> _errorDownloadingExtensionBundleZipWithDiskSize =
+        private static readonly Action<ILogger, Uri, HttpStatusCode?, HttpRequestError?, string, string, string, Exception> _errorDownloadingExtensionBundleZipHttpRequest =
             LoggerMessage.Define<Uri, HttpStatusCode?, HttpRequestError?, string, string, string>(
             LogLevel.Error,
-            new EventId(112, nameof(ErrorDownloadingExtensionBundleZipDiskSize)),
-            "Error downloading extension bundle zip content {zip}. Status Code:{statusCode} RequestError:{requestError} FilePath:{filePath} Disk:{diskUsage} AzureRef:{azureRef}");
+            new EventId(112, nameof(ErrorDownloadingExtensionBundleZipHttpRequest)),
+            "Error downloading extension bundle zip content {zip}. Status Code:{statusCode}, RequestError:{requestError}, FilePath:{filePath}, Disk:{diskUsage}, AzureRef:{azureRef}");
 
         // Logs unexpected (non-HttpRequestException) failures during bundle download. No HTTP status/request error data.
         private static readonly Action<ILogger, Uri, string, string, string, Exception> _errorDownloadingExtensionBundleZipUnexpected =
             LoggerMessage.Define<Uri, string, string, string>(
             LogLevel.Error,
             new EventId(113, nameof(ErrorDownloadingExtensionBundleZipUnexpected)),
-            "Unexpected error downloading extension bundle Zip content {zip}. FilePath:{filePath} Disk:{diskUsage} AzureRef:{azureRef}");
+            "Unexpected error downloading extension bundle Zip content {zip}. FilePath:{filePath}, Disk:{diskUsage}, AzureRef:{azureRef}");
 
         // Logs IO-specific failures (e.g., disk full, device I/O issues) during bundle download.
         private static readonly Action<ILogger, Uri, string, string, string, Exception> _errorDownloadingExtensionBundleZipIO =
             LoggerMessage.Define<Uri, string, string, string>(
             LogLevel.Error,
             new EventId(114, nameof(ErrorDownloadingExtensionBundleZipIO)),
-            "IO error downloading extension bundle Zip content {zip}. FilePath:{filePath} Disk:{diskUsage} AzureRef:{azureRef}");
+            "IO error downloading extension bundle Zip content {zip}. FilePath:{filePath}, Disk:{diskUsage}, AzureRef:{azureRef}");
 
         public static void ContentProviderNotConfigured(this ILogger logger, string path)
         {
@@ -148,10 +148,10 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
             _errorDownloadingZip(logger, zip, statusCode, reasonPhrase, null);
         }
 
-        public static void ErrorDownloadingExtensionBundleZipDiskSize(this ILogger logger, Exception ex, Uri zipUri, HttpStatusCode? statusCode, HttpRequestError? httpRequestError, string filePath, string diskUsage, string azureRef)
+        public static void ErrorDownloadingExtensionBundleZipHttpRequest(this ILogger logger, Exception ex, Uri zipUri, HttpStatusCode? statusCode, HttpRequestError? httpRequestError, string filePath, string diskUsage, string azureRef)
         {
             // Avoid premature ToString allocations; LoggerMessage will format only if enabled.
-            _errorDownloadingExtensionBundleZipWithDiskSize(logger, zipUri, statusCode, httpRequestError, filePath, diskUsage, azureRef, ex);
+            _errorDownloadingExtensionBundleZipHttpRequest(logger, zipUri, statusCode, httpRequestError, filePath, diskUsage, azureRef, ex);
         }
 
         public static void ErrorDownloadingExtensionBundleZipUnexpected(this ILogger logger, Exception ex, Uri zipUri, string filePath, string diskUsage, string azureRef)

--- a/src/WebJobs.Script/Diagnostics/Extensions/ExtensionBundleLoggerExtension.cs
+++ b/src/WebJobs.Script/Diagnostics/Extensions/ExtensionBundleLoggerExtension.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Net;
 using System.Net.Http;
 using Microsoft.Extensions.Logging;
 
@@ -83,6 +84,26 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
             new EventId(111, nameof(MatchingBundleNotFound)),
             "Bundle version matching the {version} was not found");
 
+        private static readonly Action<ILogger, Uri, HttpStatusCode?, HttpRequestError?, string, string, string, Exception> _errorDownloadingExtensionBundleZipWithDiskSize =
+            LoggerMessage.Define<Uri, HttpStatusCode?, HttpRequestError?, string, string, string>(
+            LogLevel.Error,
+            new EventId(112, nameof(ErrorDownloadingExtensionBundleZipDiskSize)),
+            "Error downloading extension bundle zip content {zip}. Status Code:{statusCode} RequestError:{requestError} FilePath:{filePath} Disk:{diskUsage} AzureRef:{azureRef}");
+
+        // Logs unexpected (non-HttpRequestException) failures during bundle download. No HTTP status/request error data.
+        private static readonly Action<ILogger, Uri, string, string, string, Exception> _errorDownloadingExtensionBundleZipUnexpected =
+            LoggerMessage.Define<Uri, string, string, string>(
+            LogLevel.Error,
+            new EventId(113, nameof(ErrorDownloadingExtensionBundleZipUnexpected)),
+            "Unexpected error downloading extension bundle Zip content {zip}. FilePath:{filePath} Disk:{diskUsage} AzureRef:{azureRef}");
+
+        // Logs IO-specific failures (e.g., disk full, device I/O issues) during bundle download.
+        private static readonly Action<ILogger, Uri, string, string, string, Exception> _errorDownloadingExtensionBundleZipIO =
+            LoggerMessage.Define<Uri, string, string, string>(
+            LogLevel.Error,
+            new EventId(114, nameof(ErrorDownloadingExtensionBundleZipIO)),
+            "IO error downloading extension bundle Zip content {zip}. FilePath:{filePath} Disk:{diskUsage} AzureRef:{azureRef}");
+
         public static void ContentProviderNotConfigured(this ILogger logger, string path)
         {
             _contentProviderNotConfigured(logger, path, null);
@@ -125,6 +146,23 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions
             string statusCode = response.StatusCode.ToString();
             string reasonPhrase = response.ReasonPhrase.ToString();
             _errorDownloadingZip(logger, zip, statusCode, reasonPhrase, null);
+        }
+
+        public static void ErrorDownloadingExtensionBundleZipDiskSize(this ILogger logger, Exception ex, Uri zipUri, HttpStatusCode? statusCode, HttpRequestError? httpRequestError, string filePath, string diskUsage, string azureRef)
+        {
+            // Avoid premature ToString allocations; LoggerMessage will format only if enabled.
+            _errorDownloadingExtensionBundleZipWithDiskSize(logger, zipUri, statusCode, httpRequestError, filePath, diskUsage, azureRef, ex);
+        }
+
+        public static void ErrorDownloadingExtensionBundleZipUnexpected(this ILogger logger, Exception ex, Uri zipUri, string filePath, string diskUsage, string azureRef)
+        {
+            // Generic non-HTTP failure (e.g. IO, disk full, zip extraction issues).
+            _errorDownloadingExtensionBundleZipUnexpected(logger, zipUri, filePath, diskUsage, azureRef, ex);
+        }
+
+        public static void ErrorDownloadingExtensionBundleZipIO(this ILogger logger, Exception ex, Uri zipUri, string filePath, string diskUsage, string azureRef)
+        {
+            _errorDownloadingExtensionBundleZipIO(logger, zipUri, filePath, diskUsage, azureRef, ex);
         }
 
         public static void DownloadComplete(this ILogger logger, Uri zipUri, string filePath)

--- a/src/WebJobs.Script/ExtensionBundle/BundlesServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script/ExtensionBundle/BundlesServiceCollectionExtensions.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.Extensions.Http;
+
+namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
+{
+    public static class BundlesServiceCollectionExtensions
+    {
+        public static IServiceCollection AddBundlesHttpClient(this IServiceCollection services)
+        {
+            services.AddHttpClient(nameof(ExtensionBundleManager), client =>
+            {
+                var hostVersion = typeof(ExtensionBundleManager).Assembly.GetName().Version?.ToString() ?? "unknown";
+                var os = RuntimeInformation.OSDescription.Replace('(', '[').Replace(')', ']'); // avoid nesting parentheses issues
+                var arch = RuntimeInformation.ProcessArchitecture.ToString();
+                client.DefaultRequestHeaders.UserAgent.ParseAdd($"FunctionsExtensionBundle/{hostVersion} ({os}; {arch})");
+            })
+                .AddPolicyHandler((sp, request) =>
+                {
+                    var logger = sp.GetRequiredService<ILogger<ExtensionBundleManager>>();
+
+                    var policyBuilder = HttpPolicyExtensions
+                    .HandleTransientHttpError()
+                    .OrResult(resp => resp.StatusCode == HttpStatusCode.TooManyRequests);
+
+                    return policyBuilder.WaitAndRetryAsync(
+                        retryCount: 4,
+                        sleepDurationProvider: attempt => TimeSpan.FromSeconds(Math.Pow(2, attempt)),
+                        onRetry: (outcome, delay, attempt, ctx) =>
+                        {
+                            var statusCode = outcome.Result?.StatusCode;
+                            var statusCodeDisplay = statusCode.HasValue ? ((int)statusCode.Value).ToString() : "None";
+                            string azureRef = outcome.Result?.GetAzureRef();
+                            logger.LogWarning(
+                                outcome.Exception,
+                                "Extension bundle download failure. Status: {StatusCode}, Attempt: {Attempt}, Uri: {Uri}, AzureRef: {AzureRef}. Retrying after {DelayMs}ms.",
+                                statusCodeDisplay,
+                                attempt,
+                                request?.RequestUri,
+                                azureRef,
+                                delay.TotalMilliseconds);
+                        });
+                });
+            return services;
+        }
+    }
+}

--- a/src/WebJobs.Script/ExtensionBundle/BundlesServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script/ExtensionBundle/BundlesServiceCollectionExtensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
             services.AddHttpClient(nameof(ExtensionBundleManager), client =>
             {
                 var hostVersion = ScriptHost.Version;
-                client.DefaultRequestHeaders.UserAgent.ParseAdd($"AzureFunctionsHost/{hostVersion};");
+                client.DefaultRequestHeaders.UserAgent.ParseAdd($"AzureFunctionsHost/{hostVersion}");
             })
                 .AddPolicyHandler((sp, request) =>
                 {

--- a/src/WebJobs.Script/ExtensionBundle/BundlesServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script/ExtensionBundle/BundlesServiceCollectionExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
                         {
                             var statusCode = outcome.Result?.StatusCode;
                             var statusCodeDisplay = statusCode.HasValue ? ((int)statusCode.Value).ToString() : "None";
-                            string azureRef = outcome.Result?.GetAzureRef();
+                            outcome.Result?.TryGetAzureRef(out string azureRef);
                             logger.LogWarning(
                                 outcome.Exception,
                                 "Extension bundle download failure. Status: {StatusCode}, Attempt: {Attempt}, Uri: {Uri}, AzureRef: {AzureRef}. Retrying after {DelayMs}ms.",

--- a/src/WebJobs.Script/ExtensionBundle/BundlesServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script/ExtensionBundle/BundlesServiceCollectionExtensions.cs
@@ -18,10 +18,8 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
         {
             services.AddHttpClient(nameof(ExtensionBundleManager), client =>
             {
-                var hostVersion = typeof(ExtensionBundleManager).Assembly.GetName().Version?.ToString() ?? "unknown";
-                var os = RuntimeInformation.OSDescription.Replace('(', '[').Replace(')', ']'); // avoid nesting parentheses issues
-                var arch = RuntimeInformation.ProcessArchitecture.ToString();
-                client.DefaultRequestHeaders.UserAgent.ParseAdd($"FunctionsExtensionBundle/{hostVersion} ({os}; {arch})");
+                var hostVersion = ScriptHost.Version;
+                client.DefaultRequestHeaders.UserAgent.ParseAdd($"AzureFunctionsHost/{hostVersion};");
             })
                 .AddPolicyHandler((sp, request) =>
                 {
@@ -38,7 +36,8 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
                         {
                             var statusCode = outcome.Result?.StatusCode;
                             var statusCodeDisplay = statusCode.HasValue ? ((int)statusCode.Value).ToString() : "None";
-                            outcome.Result?.TryGetAzureRef(out string azureRef);
+                            string azureRef = null;
+                            outcome.Result?.TryGetAzureRef(out azureRef);
                             logger.LogWarning(
                                 outcome.Exception,
                                 "Extension bundle download failure. Status: {StatusCode}, Attempt: {Attempt}, Uri: {Uri}, AzureRef: {AzureRef}. Retrying after {DelayMs}ms.",

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleHttpExtensions.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleHttpExtensions.cs
@@ -18,25 +18,19 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
 
         internal static bool TryGetAzureRef(this HttpResponseMessage response, out string azureRef)
         {
-            azureRef = null;
+            ArgumentNullException.ThrowIfNull(response);
+
             try
             {
-                if (response is null)
-                {
-                    return false;
-                }
-
-                if (response.Headers != null &&
+                if (response.Headers is not null &&
                     response.Headers.TryGetValues(AzureRefHeaderName, out var values))
                 {
                     azureRef = values.FirstOrDefault();
                     return !string.IsNullOrEmpty(azureRef);
                 }
             }
-            catch
+            catch (Exception)
             {
-                azureRef = null;
-                return false;
             }
 
             azureRef = null;

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleHttpExtensions.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleHttpExtensions.cs
@@ -1,73 +1,46 @@
-// Centralized helper for reading and sanitizing the x-azure-ref header for Extension Bundle downloads.
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 using System;
 using System.Linq;
 using System.Net.Http;
-using System.Text;
 
 namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
 {
     internal static class ExtensionBundleHttpExtensions
     {
-        internal const string AzureRefHeaderName = "x-azure-ref";
-        private const int MaxAzureRefLength = 128;
+        // The X-Azure-Ref header is added by Azure Front Door for requests that traverse Front Door to the origin.
+        // Documentation: https://learn.microsoft.com/en-us/azure/frontdoor/front-door-http-headers-protocol#from-the-front-door-to-the-backend
+        // We capture and log this value (sanitized + length bounded) with extension bundle download failures
+        // to enable end-to-end correlation and root cause analysis on the Front Door side when diagnosing
+        // CDN/edge or networking issues impacting bundle retrieval.
+        internal const string AzureRefHeaderName = "X-Azure-Ref";
 
-        internal static string GetAzureRef(this HttpResponseMessage response)
+        internal static bool TryGetAzureRef(this HttpResponseMessage response, out string azureRef)
         {
+            azureRef = null;
             try
             {
-                if (response == null)
+                if (response is null)
                 {
-                    return null;
+                    return false;
                 }
 
                 if (response.Headers != null &&
                     response.Headers.TryGetValues(AzureRefHeaderName, out var values))
                 {
-                    return Sanitize(values.FirstOrDefault());
-                }
-
-                if (response.Content?.Headers != null &&
-                    response.Content.Headers.TryGetValues(AzureRefHeaderName, out var contentValues))
-                {
-                    return Sanitize(contentValues.FirstOrDefault());
+                    azureRef = values.FirstOrDefault();
+                    return !string.IsNullOrEmpty(azureRef);
                 }
             }
             catch
             {
-                // Ignore header parsing issues.
+                azureRef = null;
+                return false;
             }
 
-            return null;
-        }
-
-        private static string Sanitize(string value)
-        {
-            if (string.IsNullOrEmpty(value))
-            {
-                return null;
-            }
-
-            var sb = new StringBuilder(value.Length);
-            foreach (var ch in value)
-            {
-                if (!char.IsControl(ch))
-                {
-                    sb.Append(ch);
-                }
-            }
-
-            var cleaned = sb.ToString().Trim();
-            if (cleaned.Length == 0)
-            {
-                return null;
-            }
-
-            if (cleaned.Length > MaxAzureRefLength)
-            {
-                cleaned = cleaned.Substring(0, MaxAzureRefLength);
-            }
-
-            return cleaned;
+            azureRef = null;
+            return false;
         }
     }
 }

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleHttpExtensions.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleHttpExtensions.cs
@@ -1,0 +1,73 @@
+// Centralized helper for reading and sanitizing the x-azure-ref header for Extension Bundle downloads.
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+
+namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
+{
+    internal static class ExtensionBundleHttpExtensions
+    {
+        internal const string AzureRefHeaderName = "x-azure-ref";
+        private const int MaxAzureRefLength = 128;
+
+        internal static string GetAzureRef(this HttpResponseMessage response)
+        {
+            try
+            {
+                if (response == null)
+                {
+                    return null;
+                }
+
+                if (response.Headers != null &&
+                    response.Headers.TryGetValues(AzureRefHeaderName, out var values))
+                {
+                    return Sanitize(values.FirstOrDefault());
+                }
+
+                if (response.Content?.Headers != null &&
+                    response.Content.Headers.TryGetValues(AzureRefHeaderName, out var contentValues))
+                {
+                    return Sanitize(contentValues.FirstOrDefault());
+                }
+            }
+            catch
+            {
+                // Ignore header parsing issues.
+            }
+
+            return null;
+        }
+
+        private static string Sanitize(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return null;
+            }
+
+            var sb = new StringBuilder(value.Length);
+            foreach (var ch in value)
+            {
+                if (!char.IsControl(ch))
+                {
+                    sb.Append(ch);
+                }
+            }
+
+            var cleaned = sb.ToString().Trim();
+            if (cleaned.Length == 0)
+            {
+                return null;
+            }
+
+            if (cleaned.Length > MaxAzureRefLength)
+            {
+                cleaned = cleaned.Substring(0, MaxAzureRefLength);
+            }
+
+            return cleaned;
+        }
+    }
+}

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
                 using var response = await httpClient.GetAsync(zipUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
 
                 // Log AzureRef header if present (debug level to avoid noise in normal operations)
-                azureRef = response.GetAzureRef();
+                response.TryGetAzureRef(out azureRef);
 
                 response.EnsureSuccessStatusCode();
 

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -212,7 +212,7 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
 
                 // Log AzureRef header if present (debug level to avoid noise in normal operations)
                 azureRef = response.GetAzureRef();
- 
+
                 response.EnsureSuccessStatusCode();
 
                 using var fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096, useAsync: true);

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Configuration;
@@ -22,15 +23,17 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
 {
     public class ExtensionBundleManager : IExtensionBundleManager
     {
+        private const string ExtensionBundleClientName = nameof(ExtensionBundleManager);
         private readonly IEnvironment _environment;
         private readonly ExtensionBundleOptions _options;
         private readonly FunctionsHostingConfigOptions _configOption;
         private readonly ILogger _logger;
         private readonly string _cdnUri;
         private readonly string _platformReleaseChannel;
+        private readonly IHttpClientFactory _httpClientFactory;
         private string _extensionBundleVersion;
 
-        public ExtensionBundleManager(ExtensionBundleOptions options, IEnvironment environment, ILoggerFactory loggerFactory, FunctionsHostingConfigOptions configOption)
+        public ExtensionBundleManager(ExtensionBundleOptions options, IEnvironment environment, ILoggerFactory loggerFactory, FunctionsHostingConfigOptions configOption, IHttpClientFactory httpClientFactory)
         {
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
             _logger = loggerFactory.CreateLogger<ExtensionBundleManager>() ?? throw new ArgumentNullException(nameof(loggerFactory));
@@ -38,6 +41,7 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
             _configOption = configOption ?? throw new ArgumentNullException(nameof(configOption));
             _cdnUri = _environment.GetEnvironmentVariable(EnvironmentSettingNames.ExtensionBundleSourceUri) ?? ScriptConstants.ExtensionBundleDefaultSourceUri;
             _platformReleaseChannel = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AntaresPlatformReleaseChannel) ?? ScriptConstants.LatestPlatformChannelNameUpper;
+            _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
         }
 
         public async Task<ExtensionBundleDetails> GetExtensionBundleDetails()
@@ -79,10 +83,8 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
         /// <returns>Path of the extension bundle.</returns>
         public async Task<string> GetExtensionBundlePath()
         {
-            using (var httpClient = new HttpClient())
-            {
-                return await GetBundle(httpClient);
-            }
+            var client = _httpClientFactory.CreateClient(ExtensionBundleClientName);
+            return await GetBundle(client);
         }
 
         /// <summary>
@@ -199,32 +201,101 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
             return ScriptConstants.ExtensionBundleForNonAppServiceEnvironment;
         }
 
-        private async Task<bool> TryDownloadZipFileAsync(Uri zipUri, string filePath, HttpClient httpClient)
+        private async Task<bool> TryDownloadZipFileAsync(Uri zipUri, string filePath, HttpClient httpClient, CancellationToken cancellationToken = default)
         {
-            _logger.DownloadingZip(zipUri, filePath);
-            var response = await httpClient.GetAsync(zipUri);
-            if (!response.IsSuccessStatusCode)
+            string azureRef = string.Empty;
+            try
             {
-                _logger.ErrorDownloadingZip(zipUri, response);
+                _logger.DownloadingZip(zipUri, filePath);
+
+                using var response = await httpClient.GetAsync(zipUri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+
+                // Log AzureRef header if present (debug level to avoid noise in normal operations)
+                azureRef = response.GetAzureRef();
+ 
+                response.EnsureSuccessStatusCode();
+
+                using var fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096, useAsync: true);
+                await response.Content.CopyToAsync(fileStream, cancellationToken);
+                await fileStream.FlushAsync(cancellationToken);
+
+                _logger.DownloadComplete(zipUri, filePath);
+
+                return true;
+            }
+            catch (HttpRequestException ex)
+            {
+                var statusCode = ex.StatusCode;
+                _logger.ErrorDownloadingExtensionBundleZipDiskSize(
+                    ex,
+                    zipUri,
+                    statusCode,
+                    ex.HttpRequestError,
+                    filePath,
+                    GetDiskUsageSafe(filePath),
+                    azureRef);
                 return false;
             }
-
-            using (var content = await response.Content.ReadAsStreamAsync())
-            using (var stream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize: 4096, useAsync: true))
+            catch (IOException ex)
             {
-                await content.CopyToAsync(stream);
+                _logger.ErrorDownloadingExtensionBundleZipIO(
+                    ex,
+                    zipUri,
+                    filePath,
+                    GetDiskUsageSafe(filePath),
+                    azureRef);
+                return false;
             }
+            catch (Exception ex)
+            {
+                // Non-HttpRequestException path: log as unexpected without HTTP-specific fields.
+                _logger.ErrorDownloadingExtensionBundleZipUnexpected(
+                    ex,
+                    zipUri,
+                    filePath,
+                    GetDiskUsageSafe(filePath),
+                    azureRef);
 
-            _logger.DownloadComplete(zipUri, filePath);
-            return true;
+                return false;
+            }
+        }
+
+        private string GetDiskUsageSafe(string path)
+        {
+            try
+            {
+                var root = Path.GetPathRoot(path);
+                if (string.IsNullOrEmpty(root))
+                {
+                    return "error=RootPathNotFound";
+                }
+
+                var di = new DriveInfo(root);
+                const double BytesPerMB = 1024d * 1024d;
+                double freeMb = di.AvailableFreeSpace / BytesPerMB;
+                double totalMb = di.TotalSize / BytesPerMB;
+                return $"free={freeMb:F2}MB total={totalMb:F2}MB";
+            }
+            catch (Exception ex)
+            {
+                return FormatDiskError(ex);
+            }
+        }
+
+        private static string FormatDiskError(Exception ex)
+        {
+            var msg = ex.Message?.Replace(Environment.NewLine, " ").Trim();
+            if (!string.IsNullOrEmpty(msg) && msg.Length > 200)
+            {
+                msg = msg.Substring(0, 200) + "...";
+            }
+            return $"error={ex.GetType().Name}: {msg}";
         }
 
         private async Task<string> GetLatestMatchingBundleVersionAsync()
         {
-            using (var httpClient = new HttpClient())
-            {
-                return await GetLatestMatchingBundleVersionAsync(httpClient);
-            }
+            var client = _httpClientFactory.CreateClient(ExtensionBundleClientName);
+            return await GetLatestMatchingBundleVersionAsync(client);
         }
 
         private async Task<string> GetLatestMatchingBundleVersionAsync(HttpClient httpClient)

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -226,7 +226,7 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
             catch (HttpRequestException ex)
             {
                 var statusCode = ex.StatusCode;
-                _logger.ErrorDownloadingExtensionBundleZipDiskSize(
+                _logger.ErrorDownloadingExtensionBundleZipHttpRequest(
                     ex,
                     zipUri,
                     statusCode,

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.Tracing;
+using System.Net.Http;
 using System.Runtime.InteropServices;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
@@ -136,7 +137,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
                 var extensionRequirementOptions = applicationOptions.RootServiceProvider.GetService<IOptions<ExtensionRequirementOptions>>();
 
-                var bundleManager = new ExtensionBundleManager(extensionBundleOptions, SystemEnvironment.Instance, loggerFactory, configOption);
+                var httpClientFactory = applicationOptions.RootServiceProvider.GetService<IHttpClientFactory>();
+                var bundleManager = new ExtensionBundleManager(extensionBundleOptions, SystemEnvironment.Instance, loggerFactory, configOption, httpClientFactory);
                 var metadataServiceManager = applicationOptions.RootServiceProvider.GetService<IFunctionMetadataManager>();
 
                 var locator = new ScriptStartupTypeLocator(applicationOptions.ScriptPath, loggerFactory.CreateLogger<ScriptStartupTypeLocator>(), bundleManager, metadataServiceManager, metricsLogger, extensionRequirementOptions);

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -50,6 +50,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.6" />
     <PackageReference Include="Microsoft.Extensions.Telemetry.Abstractions" Version="9.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.7" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NuGet.ProjectModel" Version="5.11.6" />

--- a/src/WebJobs.Script/runtimeassemblies.json
+++ b/src/WebJobs.Script/runtimeassemblies.json
@@ -673,7 +673,7 @@
     },
     {
       "name": "Microsoft.Extensions.Diagnostics",
-      "resolutionPolicy": "minorMatchOrLower"
+      "resolutionPolicy": "private"
     },
     {
       "name": "Microsoft.Extensions.Diagnostics.HealthChecks",

--- a/src/WebJobs.Script/runtimeassemblies.json
+++ b/src/WebJobs.Script/runtimeassemblies.json
@@ -672,6 +672,10 @@
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
+      "name": "Microsoft.Extensions.Diagnostics",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
       "name": "Microsoft.Extensions.Diagnostics.HealthChecks",
       "resolutionPolicy": "minorMatchOrLower"
     },
@@ -714,6 +718,10 @@
     {
       "name": "Microsoft.Extensions.Http",
       "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
+      "name": "Microsoft.Extensions.Http.Polly",
+      "resolutionPolicy": "private"
     },
     {
       "name": "Microsoft.Extensions.Identity.Core",
@@ -1629,6 +1637,14 @@
     },
     {
       "name": "protobuf-net",
+      "resolutionPolicy": "private"
+    },
+    {
+      "name": "Polly",
+      "resolutionPolicy": "private"
+    },
+    {
+      "name": "Polly.Extensions.Http",
       "resolutionPolicy": "private"
     },
     {

--- a/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
@@ -12,6 +12,7 @@ using Microsoft.Azure.WebJobs.Host.Storage;
 using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.ExtensionBundle;
 using Microsoft.Azure.WebJobs.Script.Grpc;
 using Microsoft.Azure.WebJobs.Script.Metrics;
 using Microsoft.Azure.WebJobs.Script.Tests;
@@ -61,6 +62,10 @@ namespace Microsoft.WebJobs.Script.Tests
                     o.ScriptPath = webHostOptions.ScriptPath;
                     o.LogPath = webHostOptions.LogPath;
                 });
+
+            // Sets up the HttpClient for ExtensionBundleManager.
+            services.AddHttpClient(nameof(ExtensionBundleManager));
+
             AddMockedSingleton<IDebugStateProvider>(services);
             AddMockedSingleton<IScriptHostManager>(services);
             AddMockedSingleton<IEnvironment>(services);

--- a/test/WebJobs.Script.Tests/Description/FunctionAppValidationServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Description/FunctionAppValidationServiceTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Config;
@@ -178,7 +179,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var options = new ExtensionBundleOptions { Id = bundleId };
             var env = new TestEnvironment();
             var config = new FunctionsHostingConfigOptions();
-            var manager = new ExtensionBundleManager(options, env, _loggerFactory, config);
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            httpClientFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(new HttpClient());
+            var manager = new ExtensionBundleManager(options, env, _loggerFactory, config, httpClientFactory.Object);
 
             // Set the private _extensionBundleVersion field using reflection
             typeof(ExtensionBundleManager)

--- a/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleHttpExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleHttpExtensionsTests.cs
@@ -1,0 +1,42 @@
+using System.Net.Http;
+using Xunit;
+using Microsoft.Azure.WebJobs.Script.ExtensionBundle;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
+{
+    public class ExtensionBundleHttpExtensionsTests
+    {
+        [Fact]
+        public void GetAzureRef_ReturnsOfficialSampleValue()
+        {
+            var headerValue = "0zxV+XAAAAABKMMOjBv2NT4TY6SQVjC0zV1NURURHRTA2MTkANDM3YzgyY2QtMzYwYS00YTU0LTk0YzMtNWZmNzA3NjQ3Nzgz";
+            var resp = new HttpResponseMessage(System.Net.HttpStatusCode.OK);
+            resp.Headers.Add(ExtensionBundleHttpExtensions.AzureRefHeaderName, headerValue);
+
+            var result = resp.GetAzureRef();
+            Assert.Equal(headerValue, result);
+        }
+
+        [Fact]
+        public void GetAzureRef_TruncatesAndSanitizes()
+        {
+            var longVal = new string('a', 140);
+            var noisy = "\t" + longVal + "\n";
+            var resp = new HttpResponseMessage(System.Net.HttpStatusCode.OK);
+            resp.Headers.Add(ExtensionBundleHttpExtensions.AzureRefHeaderName, noisy);
+
+            var result = resp.GetAzureRef();
+            Assert.NotNull(result);
+            Assert.Equal(128, result.Length);
+            Assert.DoesNotContain('\n', result);
+            Assert.DoesNotContain('\t', result);
+        }
+
+        [Fact]
+        public void GetAzureRef_Absent_ReturnsNull()
+        {
+            var resp = new HttpResponseMessage(System.Net.HttpStatusCode.OK);
+            Assert.Null(resp.GetAzureRef());
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleHttpExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleHttpExtensionsTests.cs
@@ -10,36 +10,32 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
     public class ExtensionBundleHttpExtensionsTests
     {
         [Fact]
-        public void GetAzureRef_ReturnsOfficialSampleValue()
+        public void TryGetAzureRef_ReturnsOfficialSampleValue()
         {
             var headerValue = "0zxV+XAAAAABKMMOjBv2NT4TY6SQVjC0zV1NURURHRTA2MTkANDM3YzgyY2QtMzYwYS00YTU0LTk0YzMtNWZmNzA3NjQ3Nzgz";
             var resp = new HttpResponseMessage(System.Net.HttpStatusCode.OK);
             resp.Headers.Add(ExtensionBundleHttpExtensions.AzureRefHeaderName, headerValue);
-
-            var result = resp.GetAzureRef();
+            Assert.True(resp.TryGetAzureRef(out var result));
             Assert.Equal(headerValue, result);
         }
 
+        // Sanitization/length truncation removed: ensure full value is returned.
         [Fact]
-        public void GetAzureRef_TruncatesAndSanitizes()
+        public void TryGetAzureRef_LongValue_Preserved()
         {
             var longVal = new string('a', 140);
-            var noisy = "\t" + longVal + "\n";
             var resp = new HttpResponseMessage(System.Net.HttpStatusCode.OK);
-            resp.Headers.Add(ExtensionBundleHttpExtensions.AzureRefHeaderName, noisy);
-
-            var result = resp.GetAzureRef();
-            Assert.NotNull(result);
-            Assert.Equal(128, result.Length);
-            Assert.DoesNotContain('\n', result);
-            Assert.DoesNotContain('\t', result);
+            resp.Headers.Add(ExtensionBundleHttpExtensions.AzureRefHeaderName, longVal);
+            Assert.True(resp.TryGetAzureRef(out var result));
+            Assert.Equal(longVal, result);
         }
 
         [Fact]
-        public void GetAzureRef_Absent_ReturnsNull()
+        public void TryGetAzureRef_Absent_ReturnsFalse()
         {
             var resp = new HttpResponseMessage(System.Net.HttpStatusCode.OK);
-            Assert.Null(resp.GetAzureRef());
+            Assert.False(resp.TryGetAzureRef(out var result));
+            Assert.Null(result);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleHttpExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleHttpExtensionsTests.cs
@@ -1,6 +1,9 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 using System.Net.Http;
-using Xunit;
 using Microsoft.Azure.WebJobs.Script.ExtensionBundle;
+using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
 {

--- a/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleHttpExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleHttpExtensionsTests.cs
@@ -37,5 +37,24 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
             Assert.False(resp.TryGetAzureRef(out var result));
             Assert.Null(result);
         }
+
+        [Fact]
+        public void TryGetAzureRef_MultipleValues_PicksFirst()
+        {
+            var resp = new HttpResponseMessage(System.Net.HttpStatusCode.OK);
+            resp.Headers.Add(
+                ExtensionBundleHttpExtensions.AzureRefHeaderName,
+                new[] { "first-value", "second-value" });
+
+            Assert.True(resp.TryGetAzureRef(out var result));
+            Assert.Equal("first-value", result);
+        }
+
+        [Fact]
+        public void TryGetAzureRef_NullResponse_Throws()
+        {
+            HttpResponseMessage resp = null;
+            Assert.Throws<System.ArgumentNullException>(() => ExtensionBundleHttpExtensions.TryGetAzureRef(resp, out _));
+        }
     }
 }

--- a/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
@@ -576,6 +576,68 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
             Assert.False(Directory.Exists(Path.Combine(options.DownloadPath, version)));
         }
 
+        [Fact]
+        public async Task TryDownloadZip_HttpFailure_LogsAzureRef_AndReturnsNull()
+        {
+            var options = GetTestExtensionBundleOptions(BundleId, "[2.*, 3.0.0)");
+            var environment = GetTestAppServiceEnvironment();
+
+            const string version = "2.0.1";
+            const string azureRef = "test-ref-http-123";
+
+            var capturingLogger = new CapturingLogger();
+            var capturingFactory = new CapturingLoggerFactory(capturingLogger);
+
+            var manager = GetExtensionBundleManager(options, environment, new Mock<ILoggerFactory>());
+            // Override with capturing factory
+            manager = new ExtensionBundleManager(options, environment, capturingFactory, new FunctionsHostingConfigOptions(), new Mock<IHttpClientFactory>().Object);
+
+            using var http = new HttpClient(new HttpFailureWithAzureRefHandler(version, azureRef));
+            var path = await manager.GetExtensionBundlePath(http);
+
+            Assert.Null(path);
+            Assert.Contains(capturingLogger.Entries, e => e.Level == LogLevel.Error && e.State.TryGetValue("azureRef", out var v) && string.Equals(v?.ToString(), azureRef, StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public async Task TryDownloadZip_IOFailure_LogsAzureRef_AndReturnsNull()
+        {
+            var options = GetTestExtensionBundleOptions(BundleId, "[2.*, 3.0.0)");
+            var environment = GetTestAppServiceEnvironment();
+
+            const string version = "2.0.1";
+            const string azureRef = "test-ref-io-456";
+
+            var capturingLogger = new CapturingLogger();
+            var capturingFactory = new CapturingLoggerFactory(capturingLogger);
+
+            var manager = new ExtensionBundleManager(options, environment, capturingFactory, new FunctionsHostingConfigOptions(), new Mock<IHttpClientFactory>().Object);
+
+            using var http = new HttpClient(new IoFailureWithAzureRefHandler(version, azureRef));
+            var path = await manager.GetExtensionBundlePath(http);
+
+            Assert.Null(path);
+            Assert.Contains(capturingLogger.Entries, e => e.Level == LogLevel.Error && e.State.TryGetValue("azureRef", out var v) && string.Equals(v?.ToString(), azureRef, StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public async Task TryDownloadZip_UnexpectedFailure_LogsUnexpected_AndReturnsNull()
+        {
+            var options = GetTestExtensionBundleOptions(BundleId, "[2.*, 3.0.0)");
+            var environment = GetTestAppServiceEnvironment();
+
+            var capturingLogger = new CapturingLogger();
+            var capturingFactory = new CapturingLoggerFactory(capturingLogger);
+
+            var manager = new ExtensionBundleManager(options, environment, capturingFactory, new FunctionsHostingConfigOptions(), new Mock<IHttpClientFactory>().Object);
+
+            using var http = new HttpClient(new UnexpectedContentHandler("2.0.1"));
+            var path = await manager.GetExtensionBundlePath(http);
+
+            Assert.Null(path);
+            Assert.Contains(capturingLogger.Entries, e => e.Level == LogLevel.Error && e.Message.Contains("Unexpected error downloading extension bundle Zip content", StringComparison.Ordinal));
+        }
+
         private ExtensionBundleManager GetExtensionBundleManager(ExtensionBundleOptions bundleOptions, TestEnvironment environment = null, Mock<ILoggerFactory> mockLoggerFactory = null)
         {
             environment = environment ?? new TestEnvironment();
@@ -656,6 +718,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
         private Mock<ILogger> GetVerifiableMockLogger(string stringToVerify, LogLevel logLevel)
         {
             var mockLogger = new Mock<ILogger>();
+            mockLogger.Setup(l => l.IsEnabled(logLevel)).Returns(true);
             mockLogger
                 .Setup(x => x.Log(
                     logLevel,
@@ -779,6 +842,147 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
                 ms.Seek(0, SeekOrigin.Begin);
                 return new StreamContent(ms);
             }
+        }
+
+        // Insert new helper sealed classes immediately after the existing sealed class.
+        private sealed class HttpFailureWithAzureRefHandler(string version, string azureRef) : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var path = request.RequestUri.AbsolutePath;
+
+                if (path.IndexOf("index.json", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("[ \"2.0.1\" ]")
+                    });
+                }
+
+                if (path.Contains($"{BundleId}.{version}", StringComparison.OrdinalIgnoreCase))
+                {
+                    var resp = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+                    resp.Headers.Add(ExtensionBundleHttpExtensions.AzureRefHeaderName, azureRef);
+                    return Task.FromResult(resp);
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }
+        }
+
+        private sealed class IoFailureWithAzureRefHandler(string version, string azureRef) : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var path = request.RequestUri.AbsolutePath;
+
+                if (path.EndsWith("index.json", StringComparison.OrdinalIgnoreCase))
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("[ \"2.0.1\" ]")
+                    });
+                }
+
+                if (path.Contains($"{BundleId}.{version}", StringComparison.OrdinalIgnoreCase))
+                {
+                    var resp = new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new ThrowingContent()
+                    };
+                    resp.Headers.Add(ExtensionBundleHttpExtensions.AzureRefHeaderName, azureRef);
+                    return Task.FromResult(resp);
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }
+        }
+
+        private sealed class ThrowingContent : HttpContent
+        {
+            protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+                => throw new IOException("Simulated IO failure during content copy.");
+
+            protected override bool TryComputeLength(out long length)
+            {
+                length = 0;
+                return false;
+            }
+        }
+
+        private sealed class ThrowingContentUnexpected : HttpContent
+        {
+            protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+                => throw new InvalidOperationException("Simulated unexpected failure during content copy.");
+
+            protected override bool TryComputeLength(out long length)
+            {
+                length = 0;
+                return false;
+            }
+        }
+
+        private sealed class UnexpectedContentHandler(string version) : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var path = request.RequestUri.AbsolutePath;
+                if (path.IndexOf("index.json", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("[ \"" + version + "\" ]")
+                    });
+                }
+
+                if (path.Contains($"{BundleId}.{version}", StringComparison.OrdinalIgnoreCase))
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new ThrowingContentUnexpected()
+                    });
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }
+        }
+
+        private sealed class CapturingLogger : ILogger
+        {
+            public List<(LogLevel Level, Dictionary<string, object> State, Exception Exception, string Message)> Entries { get; } = new();
+
+            public IDisposable BeginScope<TState>(TState state) => NullDisposable.Instance;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                var dict = new Dictionary<string, object>(StringComparer.Ordinal);
+                if (state is IEnumerable<KeyValuePair<string, object>> kvps)
+                {
+                    foreach (var kv in kvps)
+                    {
+                        dict[kv.Key] = kv.Value;
+                    }
+                }
+                Entries.Add((logLevel, dict, exception, formatter?.Invoke(state, exception) ?? state?.ToString()));
+            }
+
+            private sealed class NullDisposable : IDisposable
+            {
+                public static readonly NullDisposable Instance = new NullDisposable();
+
+                public void Dispose() { }
+            }
+        }
+
+        private sealed class CapturingLoggerFactory(CapturingLogger logger) : ILoggerFactory
+        {
+            public void AddProvider(ILoggerProvider provider) { }
+
+            public ILogger CreateLogger(string categoryName) => logger;
+
+            public void Dispose() { }
         }
     }
 }

--- a/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
@@ -724,23 +724,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
                 stream.Seek(0, SeekOrigin.Begin);
                 return new StreamContent(stream);
             }
-        }
+        }       
 
         // Primary handler simulating transient zip download failures to exercise retry policy.
-        private sealed class TransientZipFailureHandler : HttpMessageHandler
+        private sealed class TransientZipFailureHandler(string version, int zipFailuresBeforeSuccess) : HttpMessageHandler
         {
-            private readonly string _version;
-            private int _zipFailuresRemaining;
+            private readonly string _version = version;
+            private int _zipFailuresRemaining = zipFailuresBeforeSuccess;
 
             public int IndexAttempts { get; private set; }
 
             public int ZipAttempts { get; private set; }
-
-            public TransientZipFailureHandler(string version, int zipFailuresBeforeSuccess)
-            {
-                _version = version;
-                _zipFailuresRemaining = zipFailuresBeforeSuccess;
-            }
 
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {

--- a/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
@@ -724,7 +724,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
                 stream.Seek(0, SeekOrigin.Begin);
                 return new StreamContent(stream);
             }
-        }       
+        }
 
         // Primary handler simulating transient zip download failures to exercise retry policy.
         private sealed class TransientZipFailureHandler(string version, int zipFailuresBeforeSuccess) : HttpMessageHandler

--- a/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -505,6 +505,73 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
             mockLogger.Verify();
         }
 
+        [Fact]
+        public async Task GetExtensionBundle_RetriesZipDownload_SucceedsAfterTransientFailures()
+        {
+            var options = GetTestExtensionBundleOptions(BundleId, "[4.*, 5.0.0)");
+            var environment = GetTestAppServiceEnvironment();
+            var version = "4.2.0";
+
+            var handler = new TransientZipFailureHandler(version, zipFailuresBeforeSuccess: 2);
+            var services = new ServiceCollection();
+            services.AddLogging();
+
+            // Register named client identical to production name so manager picks up retry policy.
+            services.AddHttpClient(nameof(ExtensionBundleManager))
+                .ConfigurePrimaryHttpMessageHandler(() => handler)
+                .AddPolicyHandler(HttpPolicyExtensions
+                    .HandleTransientHttpError()
+                    .OrResult(resp => resp.StatusCode == HttpStatusCode.TooManyRequests)
+                    .WaitAndRetryAsync(
+                        retryCount: 4,
+                        sleepDurationProvider: _ => TimeSpan.Zero,
+                        onRetry: (_, __, ___, ____) => { }));
+
+            var provider = services.BuildServiceProvider();
+            var factory = provider.GetRequiredService<IHttpClientFactory>();
+            var manager = new ExtensionBundleManager(options, environment, MockNullLoggerFactory.CreateLoggerFactory(), new FunctionsHostingConfigOptions(), factory);
+
+            var path = await manager.GetExtensionBundlePath();
+
+            Assert.NotNull(path);
+            Assert.True(Directory.Exists(Path.Combine(options.DownloadPath, version)));
+            Assert.Equal(1, handler.IndexAttempts); // index.json fetched once
+            Assert.Equal(3, handler.ZipAttempts);   // 2 failures + 1 success
+        }
+
+        [Fact]
+        public async Task GetExtensionBundle_RetriesZipDownload_ExhaustsAndFails()
+        {
+            var options = GetTestExtensionBundleOptions(BundleId, "[4.*, 5.0.0)");
+            var environment = GetTestAppServiceEnvironment();
+            var version = "4.2.0";
+
+            var handler = new TransientZipFailureHandler(version, zipFailuresBeforeSuccess: 10); // exceed retry budget
+            var services = new ServiceCollection();
+            services.AddLogging();
+
+            services.AddHttpClient(nameof(ExtensionBundleManager))
+                .ConfigurePrimaryHttpMessageHandler(() => handler)
+                .AddPolicyHandler(HttpPolicyExtensions
+                    .HandleTransientHttpError()
+                    .OrResult(resp => resp.StatusCode == HttpStatusCode.TooManyRequests)
+                    .WaitAndRetryAsync(
+                        retryCount: 4,
+                        sleepDurationProvider: _ => TimeSpan.Zero,
+                        onRetry: (_, __, ___, ____) => { }));
+
+            var provider = services.BuildServiceProvider();
+            var factory = provider.GetRequiredService<IHttpClientFactory>();
+            var manager = new ExtensionBundleManager(options, environment, MockNullLoggerFactory.CreateLoggerFactory(), new FunctionsHostingConfigOptions(), factory);
+
+            var path = await manager.GetExtensionBundlePath();
+
+            Assert.Null(path);
+            Assert.Equal(1, handler.IndexAttempts);
+            Assert.Equal(5, handler.ZipAttempts); // initial + 4 retries
+            Assert.False(Directory.Exists(Path.Combine(options.DownloadPath, version)));
+        }
+
         private ExtensionBundleManager GetExtensionBundleManager(ExtensionBundleOptions bundleOptions, TestEnvironment environment = null, Mock<ILoggerFactory> mockLoggerFactory = null)
         {
             environment = environment ?? new TestEnvironment();
@@ -653,73 +720,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
                 stream.Seek(0, SeekOrigin.Begin);
                 return new StreamContent(stream);
             }
-        }
-
-        [Fact]
-        public async Task GetExtensionBundle_RetriesZipDownload_Succeeds_AfterTransientFailures()
-        {
-            var options = GetTestExtensionBundleOptions(BundleId, "[4.*, 5.0.0)");
-            var environment = GetTestAppServiceEnvironment();
-            var version = "4.2.0";
-
-            var handler = new TransientZipFailureHandler(version, zipFailuresBeforeSuccess: 2);
-            var services = new ServiceCollection();
-            services.AddLogging();
-
-            // Register named client identical to production name so manager picks up retry policy.
-            services.AddHttpClient(nameof(ExtensionBundleManager))
-                .ConfigurePrimaryHttpMessageHandler(() => handler)
-                .AddPolicyHandler(HttpPolicyExtensions
-                    .HandleTransientHttpError()
-                    .OrResult(resp => resp.StatusCode == HttpStatusCode.TooManyRequests)
-                    .WaitAndRetryAsync(
-                        retryCount: 4,
-                        sleepDurationProvider: _ => TimeSpan.Zero,
-                        onRetry: (_, __, ___, ____) => { }));
-
-            var provider = services.BuildServiceProvider();
-            var factory = provider.GetRequiredService<IHttpClientFactory>();
-            var manager = new ExtensionBundleManager(options, environment, MockNullLoggerFactory.CreateLoggerFactory(), new FunctionsHostingConfigOptions(), factory);
-
-            var path = await manager.GetExtensionBundlePath();
-
-            Assert.NotNull(path);
-            Assert.True(Directory.Exists(Path.Combine(options.DownloadPath, version)));
-            Assert.Equal(1, handler.IndexAttempts); // index.json fetched once
-            Assert.Equal(3, handler.ZipAttempts);   // 2 failures + 1 success
-        }
-
-        [Fact]
-        public async Task GetExtensionBundle_RetriesZipDownload_ExhaustsAndFails()
-        {
-            var options = GetTestExtensionBundleOptions(BundleId, "[4.*, 5.0.0)");
-            var environment = GetTestAppServiceEnvironment();
-            var version = "4.2.0";
-
-            var handler = new TransientZipFailureHandler(version, zipFailuresBeforeSuccess: 10); // exceed retry budget
-            var services = new ServiceCollection();
-            services.AddLogging();
-
-            services.AddHttpClient(nameof(ExtensionBundleManager))
-                .ConfigurePrimaryHttpMessageHandler(() => handler)
-                .AddPolicyHandler(HttpPolicyExtensions
-                    .HandleTransientHttpError()
-                    .OrResult(resp => resp.StatusCode == HttpStatusCode.TooManyRequests)
-                    .WaitAndRetryAsync(
-                        retryCount: 4,
-                        sleepDurationProvider: _ => TimeSpan.Zero,
-                        onRetry: (_, __, ___, ____) => { }));
-
-            var provider = services.BuildServiceProvider();
-            var factory = provider.GetRequiredService<IHttpClientFactory>();
-            var manager = new ExtensionBundleManager(options, environment, MockNullLoggerFactory.CreateLoggerFactory(), new FunctionsHostingConfigOptions(), factory);
-
-            var path = await manager.GetExtensionBundlePath();
-
-            Assert.Null(path);
-            Assert.Equal(1, handler.IndexAttempts);
-            Assert.Equal(5, handler.ZipAttempts); // initial + 4 retries
-            Assert.False(Directory.Exists(Path.Combine(options.DownloadPath, version)));
         }
 
         // Primary handler simulating transient zip download failures to exercise retry policy.

--- a/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
@@ -517,7 +517,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
             services.AddLogging();
 
             // Register named client identical to production name so manager picks up retry policy.
-            services.AddHttpClient(nameof(ExtensionBundleManager))
+#pragma warning disable SA1313 // Parameter names should begin with lower-case letter
+            _ = services.AddHttpClient(nameof(ExtensionBundleManager))
                 .ConfigurePrimaryHttpMessageHandler(() => handler)
                 .AddPolicyHandler(HttpPolicyExtensions
                     .HandleTransientHttpError()
@@ -526,6 +527,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
                         retryCount: 4,
                         sleepDurationProvider: _ => TimeSpan.Zero,
                         onRetry: (_, __, ___, ____) => { }));
+#pragma warning restore SA1313 // Parameter names should begin with lower-case letter
 
             var provider = services.BuildServiceProvider();
             var factory = provider.GetRequiredService<IHttpClientFactory>();
@@ -550,6 +552,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
             var services = new ServiceCollection();
             services.AddLogging();
 
+#pragma warning disable SA1313 // Parameter names should begin with lower-case letter
             services.AddHttpClient(nameof(ExtensionBundleManager))
                 .ConfigurePrimaryHttpMessageHandler(() => handler)
                 .AddPolicyHandler(HttpPolicyExtensions
@@ -559,6 +562,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
                         retryCount: 4,
                         sleepDurationProvider: _ => TimeSpan.Zero,
                         onRetry: (_, __, ___, ____) => { }));
+#pragma warning restore SA1313 // Parameter names should begin with lower-case letter
 
             var provider = services.BuildServiceProvider();
             var factory = provider.GetRequiredService<IHttpClientFactory>();

--- a/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
@@ -15,9 +15,12 @@ using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.ExtensionBundle;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NuGet.Versioning;
+using Polly;
+using Polly.Extensions.Http;
 using Xunit;
 using static Microsoft.Azure.WebJobs.Script.EnvironmentSettingNames;
 
@@ -506,13 +509,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
         {
             environment = environment ?? new TestEnvironment();
 
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+            httpClientFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(new HttpClient());
+
             if (mockLoggerFactory is null)
             {
-                return new ExtensionBundleManager(bundleOptions, environment, MockNullLoggerFactory.CreateLoggerFactory(), new FunctionsHostingConfigOptions());
+                return new ExtensionBundleManager(bundleOptions, environment, MockNullLoggerFactory.CreateLoggerFactory(), new FunctionsHostingConfigOptions(), httpClientFactory.Object);
             }
             else
             {
-                return new ExtensionBundleManager(bundleOptions, environment, mockLoggerFactory.Object, new FunctionsHostingConfigOptions());
+                return new ExtensionBundleManager(bundleOptions, environment, mockLoggerFactory.Object, new FunctionsHostingConfigOptions(), httpClientFactory.Object);
             }
         }
 
@@ -646,6 +652,134 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
                 }
                 stream.Seek(0, SeekOrigin.Begin);
                 return new StreamContent(stream);
+            }
+        }
+
+        [Fact]
+        public async Task GetExtensionBundle_RetriesZipDownload_Succeeds_AfterTransientFailures()
+        {
+            var options = GetTestExtensionBundleOptions(BundleId, "[4.*, 5.0.0)");
+            var environment = GetTestAppServiceEnvironment();
+            var version = "4.2.0";
+
+            var handler = new TransientZipFailureHandler(version, zipFailuresBeforeSuccess: 2);
+            var services = new ServiceCollection();
+            services.AddLogging();
+
+            // Register named client identical to production name so manager picks up retry policy.
+            services.AddHttpClient(nameof(ExtensionBundleManager))
+                .ConfigurePrimaryHttpMessageHandler(() => handler)
+                .AddPolicyHandler(HttpPolicyExtensions
+                    .HandleTransientHttpError()
+                    .OrResult(resp => resp.StatusCode == HttpStatusCode.TooManyRequests)
+                    .WaitAndRetryAsync(
+                        retryCount: 4,
+                        sleepDurationProvider: _ => TimeSpan.Zero,
+                        onRetry: (_, __, ___, ____) => { }));
+
+            var provider = services.BuildServiceProvider();
+            var factory = provider.GetRequiredService<IHttpClientFactory>();
+            var manager = new ExtensionBundleManager(options, environment, MockNullLoggerFactory.CreateLoggerFactory(), new FunctionsHostingConfigOptions(), factory);
+
+            var path = await manager.GetExtensionBundlePath();
+
+            Assert.NotNull(path);
+            Assert.True(Directory.Exists(Path.Combine(options.DownloadPath, version)));
+            Assert.Equal(1, handler.IndexAttempts); // index.json fetched once
+            Assert.Equal(3, handler.ZipAttempts);   // 2 failures + 1 success
+        }
+
+        [Fact]
+        public async Task GetExtensionBundle_RetriesZipDownload_ExhaustsAndFails()
+        {
+            var options = GetTestExtensionBundleOptions(BundleId, "[4.*, 5.0.0)");
+            var environment = GetTestAppServiceEnvironment();
+            var version = "4.2.0";
+
+            var handler = new TransientZipFailureHandler(version, zipFailuresBeforeSuccess: 10); // exceed retry budget
+            var services = new ServiceCollection();
+            services.AddLogging();
+
+            services.AddHttpClient(nameof(ExtensionBundleManager))
+                .ConfigurePrimaryHttpMessageHandler(() => handler)
+                .AddPolicyHandler(HttpPolicyExtensions
+                    .HandleTransientHttpError()
+                    .OrResult(resp => resp.StatusCode == HttpStatusCode.TooManyRequests)
+                    .WaitAndRetryAsync(
+                        retryCount: 4,
+                        sleepDurationProvider: _ => TimeSpan.Zero,
+                        onRetry: (_, __, ___, ____) => { }));
+
+            var provider = services.BuildServiceProvider();
+            var factory = provider.GetRequiredService<IHttpClientFactory>();
+            var manager = new ExtensionBundleManager(options, environment, MockNullLoggerFactory.CreateLoggerFactory(), new FunctionsHostingConfigOptions(), factory);
+
+            var path = await manager.GetExtensionBundlePath();
+
+            Assert.Null(path);
+            Assert.Equal(1, handler.IndexAttempts);
+            Assert.Equal(5, handler.ZipAttempts); // initial + 4 retries
+            Assert.False(Directory.Exists(Path.Combine(options.DownloadPath, version)));
+        }
+
+        // Primary handler simulating transient zip download failures to exercise retry policy.
+        private sealed class TransientZipFailureHandler : HttpMessageHandler
+        {
+            private readonly string _version;
+            private int _zipFailuresRemaining;
+
+            public int IndexAttempts { get; private set; }
+
+            public int ZipAttempts { get; private set; }
+
+            public TransientZipFailureHandler(string version, int zipFailuresBeforeSuccess)
+            {
+                _version = version;
+                _zipFailuresRemaining = zipFailuresBeforeSuccess;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var path = request.RequestUri.AbsolutePath;
+                if (path.EndsWith("index.json", StringComparison.OrdinalIgnoreCase))
+                {
+                    IndexAttempts++;
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("[ \"4.1.0\", \"4.2.0\" ]")
+                    });
+                }
+
+                if (path.Contains($"{BundleId}.{_version}", StringComparison.OrdinalIgnoreCase))
+                {
+                    ZipAttempts++;
+                    if (_zipFailuresRemaining > 0)
+                    {
+                        _zipFailuresRemaining--;
+                        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError));
+                    }
+
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = CreateBundleZipContent()
+                    });
+                }
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+            }
+
+            private static HttpContent CreateBundleZipContent()
+            {
+                var ms = new MemoryStream();
+                using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, true))
+                {
+                    var entry = zip.CreateEntry("bundle.json");
+                    using var entryStream = entry.Open();
+                    using var sw = new StreamWriter(entryStream);
+                    sw.Write("{ id: \"Microsoft.Azure.Functions.ExtensionBundle\" }");
+                }
+                ms.Seek(0, SeekOrigin.Begin);
+                return new StreamContent(ms);
             }
         }
     }

--- a/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
+++ b/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
@@ -6,7 +6,7 @@
   "compilationOptions": {},
   "targets": {
     ".NETCoreApp,Version=v8.0": {
-      "Microsoft.Azure.WebJobs.Script.WebHost/4.1044.100-pr.25452.4": {
+      "Microsoft.Azure.WebJobs.Script.WebHost/4.1044.100-pr.25462.4": {
         "dependencies": {
           "AspNetCore.HealthChecks.UI.Client": "9.0.0",
           "Azure.Data.Tables": "12.8.3",
@@ -31,11 +31,12 @@
           "Microsoft.Azure.Functions.PowerShellWorker.PS7.4": "4.0.4206",
           "Microsoft.Azure.Functions.PythonWorker": "4.39.2",
           "Microsoft.Azure.Storage.File": "11.1.7",
-          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Azure.WebJobs": "3.0.42",
           "Microsoft.Azure.WebJobs.Host.Storage": "5.0.1",
-          "Microsoft.Azure.WebJobs.Script": "4.1044.100-pr.25452.4",
-          "Microsoft.Azure.WebJobs.Script.Grpc": "4.1044.100-pr.25452.4",
+          "Microsoft.Azure.WebJobs.Script": "4.1044.100-pr.25462.4",
+          "Microsoft.Azure.WebJobs.Script.Grpc": "4.1044.100-pr.25462.4",
           "Microsoft.Azure.WebSites.DataProtection": "2.1.91-alpha",
+          "Microsoft.Extensions.Http.Polly": "8.0.7",
           "Microsoft.IdentityModel.Protocols.OpenIdConnect": "6.35.0",
           "Microsoft.IdentityModel.Tokens": "6.35.0",
           "Microsoft.Security.Utilities": "1.3.0",
@@ -241,7 +242,7 @@
       "Grpc.Net.ClientFactory/2.55.0": {
         "dependencies": {
           "Grpc.Net.Client": "2.55.0",
-          "Microsoft.Extensions.Http": "3.0.3"
+          "Microsoft.Extensions.Http": "8.0.0"
         },
         "runtime": {
           "lib/net7.0/Grpc.Net.ClientFactory.dll": {
@@ -898,9 +899,9 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs/3.0.41": {
+      "Microsoft.Azure.WebJobs/3.0.42": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Core": "3.0.41",
+          "Microsoft.Azure.WebJobs.Core": "3.0.42",
           "Microsoft.Extensions.Configuration": "9.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
           "Microsoft.Extensions.Configuration.EnvironmentVariables": "2.1.1",
@@ -915,12 +916,12 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Host.dll": {
-            "assemblyVersion": "3.0.41.0",
-            "fileVersion": "3.0.41.0"
+            "assemblyVersion": "3.0.42.0",
+            "fileVersion": "3.0.42.25458"
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Core/3.0.41": {
+      "Microsoft.Azure.WebJobs.Core/3.0.42": {
         "dependencies": {
           "System.ComponentModel.Annotations": "4.5.0",
           "System.Diagnostics.TraceSource": "4.3.0",
@@ -928,14 +929,14 @@
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.dll": {
-            "assemblyVersion": "3.0.41.0",
-            "fileVersion": "3.0.41.0"
+            "assemblyVersion": "3.0.42.0",
+            "fileVersion": "3.0.42.25458"
           }
         }
       },
       "Microsoft.Azure.WebJobs.Extensions/5.2.0-12287": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Azure.WebJobs": "3.0.42",
           "NCrontab.Signed": "3.3.3"
         },
         "runtime": {
@@ -952,7 +953,7 @@
           "Microsoft.AspNetCore.Mvc.Formatters.Json": "2.2.0",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
           "Microsoft.AspNetCore.Routing": "2.2.2",
-          "Microsoft.Azure.WebJobs": "3.0.41"
+          "Microsoft.Azure.WebJobs": "3.0.42"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.WebJobs.Extensions.Http.dll": {
@@ -977,7 +978,7 @@
       "Microsoft.Azure.WebJobs.Host.Storage/5.0.1": {
         "dependencies": {
           "Azure.Storage.Blobs": "12.19.1",
-          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Azure.WebJobs": "3.0.42",
           "Microsoft.Extensions.Azure": "1.12.0"
         },
         "runtime": {
@@ -999,7 +1000,7 @@
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.22.0",
           "Microsoft.AspNetCore.Http.Abstractions": "2.2.0",
           "Microsoft.AspNetCore.Http.Extensions": "2.2.0",
-          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Azure.WebJobs": "3.0.42",
           "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
           "System.Diagnostics.TraceSource": "4.3.0",
           "System.Threading": "4.3.0",
@@ -1014,7 +1015,7 @@
       },
       "Microsoft.Azure.WebJobs.Rpc.Core/3.0.37": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.41"
+          "Microsoft.Azure.WebJobs": "3.0.42"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Rpc.Core.dll": {
@@ -1441,6 +1442,13 @@
           }
         }
       },
+      "Microsoft.Extensions.Diagnostics/8.0.0": {
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "9.0.0",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "9.0.0"
+        }
+      },
       "Microsoft.Extensions.Diagnostics.Abstractions/9.0.6": {
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
@@ -1523,11 +1531,27 @@
           }
         }
       },
-      "Microsoft.Extensions.Http/3.0.3": {
+      "Microsoft.Extensions.Http/8.0.0": {
         "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "9.0.6",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Diagnostics": "8.0.0",
           "Microsoft.Extensions.Logging": "9.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.6",
           "Microsoft.Extensions.Options": "9.0.6"
+        }
+      },
+      "Microsoft.Extensions.Http.Polly/8.0.7": {
+        "dependencies": {
+          "Microsoft.Extensions.Http": "8.0.0",
+          "Polly": "7.2.4",
+          "Polly.Extensions.Http": "3.0.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.Http.Polly.dll": {
+            "assemblyVersion": "8.0.7.0",
+            "fileVersion": "8.0.724.31402"
+          }
         }
       },
       "Microsoft.Extensions.Localization/2.2.0": {
@@ -2169,6 +2193,25 @@
           "lib/netstandard2.0/OpenTelemetry.PersistentStorage.FileSystem.dll": {
             "assemblyVersion": "1.0.1.378",
             "fileVersion": "1.0.1.378"
+          }
+        }
+      },
+      "Polly/7.2.4": {
+        "runtime": {
+          "lib/netstandard2.0/Polly.dll": {
+            "assemblyVersion": "7.0.0.0",
+            "fileVersion": "7.2.4.982"
+          }
+        }
+      },
+      "Polly.Extensions.Http/3.0.0": {
+        "dependencies": {
+          "Polly": "7.2.4"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Polly.Extensions.Http.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.0"
           }
         }
       },
@@ -3032,7 +3075,7 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Script/4.1044.100-pr.25452.4": {
+      "Microsoft.Azure.WebJobs.Script/4.1044.100-pr.25462.4": {
         "dependencies": {
           "Azure.Core": "1.47.1",
           "Azure.Data.Tables": "12.8.3",
@@ -3046,7 +3089,7 @@
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.22.0",
           "Microsoft.AspNetCore.Mvc.WebApiCompatShim": "2.2.0",
           "Microsoft.Azure.AppService.Proxy.Client": "2.3.20240307.67",
-          "Microsoft.Azure.WebJobs": "3.0.41",
+          "Microsoft.Azure.WebJobs": "3.0.42",
           "Microsoft.Azure.WebJobs.Extensions": "5.2.0-12287",
           "Microsoft.Azure.WebJobs.Extensions.Http": "3.2.0",
           "Microsoft.Azure.WebJobs.Extensions.Timers.Storage": "1.0.0-beta.1",
@@ -3056,6 +3099,7 @@
           "Microsoft.CodeAnalysis.CSharp.Scripting": "3.3.1",
           "Microsoft.Extensions.Azure": "1.12.0",
           "Microsoft.Extensions.Hosting.Abstractions": "9.0.6",
+          "Microsoft.Extensions.Http": "8.0.0",
           "Microsoft.Extensions.Logging.Console": "8.0.0",
           "Microsoft.Extensions.Telemetry.Abstractions": "9.8.0",
           "Mono.Posix.NETStandard": "1.0.0",
@@ -3087,7 +3131,7 @@
           "Microsoft.Azure.WebJobs.Script.dll": {}
         }
       },
-      "Microsoft.Azure.WebJobs.Script.Grpc/4.1044.100-pr.25452.4": {
+      "Microsoft.Azure.WebJobs.Script.Grpc/4.1044.100-pr.25462.4": {
         "dependencies": {
           "Grpc.AspNetCore": "2.55.0",
           "Microsoft.ApplicationInsights": "2.22.0",
@@ -3096,7 +3140,7 @@
           "Microsoft.ApplicationInsights.WindowsServer": "2.22.0",
           "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.22.0",
           "Microsoft.Azure.WebJobs.Rpc.Core": "3.0.37",
-          "Microsoft.Azure.WebJobs.Script": "4.1044.100-pr.25452.4",
+          "Microsoft.Azure.WebJobs.Script": "4.1044.100-pr.25462.4",
           "System.IO.FileSystem.Primitives": "4.3.0",
           "System.Threading.Channels": "8.0.0"
         },
@@ -3108,7 +3152,7 @@
         "runtime": {
           "Microsoft.Azure.WebJobs.Script.dll": {
             "assemblyVersion": "4.1044.0.0",
-            "fileVersion": "4.1044.100.25452"
+            "fileVersion": "4.1044.100.25462"
           }
         }
       },
@@ -3116,14 +3160,14 @@
         "runtime": {
           "Microsoft.Azure.WebJobs.Script.Grpc.dll": {
             "assemblyVersion": "4.1044.0.0",
-            "fileVersion": "4.1044.100.25452"
+            "fileVersion": "4.1044.100.25462"
           }
         }
       }
     }
   },
   "libraries": {
-    "Microsoft.Azure.WebJobs.Script.WebHost/4.1044.100-pr.25452.4": {
+    "Microsoft.Azure.WebJobs.Script.WebHost/4.1044.100-pr.25462.4": {
       "type": "project",
       "serviceable": false,
       "sha512": ""
@@ -3765,19 +3809,19 @@
       "path": "microsoft.azure.storage.file/11.1.7",
       "hashPath": "microsoft.azure.storage.file.11.1.7.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs/3.0.41": {
+    "Microsoft.Azure.WebJobs/3.0.42": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-nprqeSOAkhFrpIW1KVkXQb6BZCbnS8d1ytq0nUzIYnpkmbvmfkcQlJE9zp3Dbo26Q/0h0JdPSQ3BaVVBNPOUZg==",
-      "path": "microsoft.azure.webjobs/3.0.41",
-      "hashPath": "microsoft.azure.webjobs.3.0.41.nupkg.sha512"
+      "sha512": "sha512-Nk24VvZNRkM5jV/KXn7+jqRuoXjeyFs58ILPw/imrft6Y9R9xMYSiPaPC2z8SlWXnqZu7amWaGUnXGvIvwlRhg==",
+      "path": "microsoft.azure.webjobs/3.0.42",
+      "hashPath": "microsoft.azure.webjobs.3.0.42.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Core/3.0.41": {
+    "Microsoft.Azure.WebJobs.Core/3.0.42": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-nNW4I8m5GEhOxxD/NVZGjT6ZARGSy7wi8q+ihvKDin4IY4zYLpTy/GakZeGgbi7vPxcPHL5Z65n9DAV+goasqA==",
-      "path": "microsoft.azure.webjobs.core/3.0.41",
-      "hashPath": "microsoft.azure.webjobs.core.3.0.41.nupkg.sha512"
+      "sha512": "sha512-om1PWPfOCVIWYqQWSoufBRcyXFfairoQIDfHsu7+4xCV2S8DrDehymruLi65CuU7FwEopsq5apxkgTrS8grrtw==",
+      "path": "microsoft.azure.webjobs.core/3.0.42",
+      "hashPath": "microsoft.azure.webjobs.core.3.0.42.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Extensions/5.2.0-12287": {
       "type": "package",
@@ -3989,6 +4033,13 @@
       "path": "microsoft.extensions.dependencymodel/2.1.0",
       "hashPath": "microsoft.extensions.dependencymodel.2.1.0.nupkg.sha512"
     },
+    "Microsoft.Extensions.Diagnostics/8.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-3PZp/YSkIXrF7QK7PfC1bkyRYwqOHpWFad8Qx+4wkuumAeXo1NHaxpS9LboNA9OvNSAu+QOVlXbMyoY+pHSqcw==",
+      "path": "microsoft.extensions.diagnostics/8.0.0",
+      "hashPath": "microsoft.extensions.diagnostics.8.0.0.nupkg.sha512"
+    },
     "Microsoft.Extensions.Diagnostics.Abstractions/9.0.6": {
       "type": "package",
       "serviceable": true,
@@ -4052,12 +4103,19 @@
       "path": "microsoft.extensions.hosting.abstractions/9.0.6",
       "hashPath": "microsoft.extensions.hosting.abstractions.9.0.6.nupkg.sha512"
     },
-    "Microsoft.Extensions.Http/3.0.3": {
+    "Microsoft.Extensions.Http/8.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-dcyB8szIcSynjVZRuFgqkZpPgTc5zeRSj1HMXSmNqWbHYKiPYJl8ZQgBHz6wmZNSUUNGpCs5uxUg8DZHHDC1Ew==",
-      "path": "microsoft.extensions.http/3.0.3",
-      "hashPath": "microsoft.extensions.http.3.0.3.nupkg.sha512"
+      "sha512": "sha512-cWz4caHwvx0emoYe7NkHPxII/KkTI8R/LC9qdqJqnKv2poTJ4e2qqPGQqvRoQ5kaSA4FU5IV3qFAuLuOhoqULQ==",
+      "path": "microsoft.extensions.http/8.0.0",
+      "hashPath": "microsoft.extensions.http.8.0.0.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Http.Polly/8.0.7": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Sdsed6CqGrHNbjRAu3ECppuzLaleudsyJsJuo8HB3CTUvaPw32aS/YyqgKOfUccY5uVfoICnYaC7vhzVvOQR3w==",
+      "path": "microsoft.extensions.http.polly/8.0.7",
+      "hashPath": "microsoft.extensions.http.polly.8.0.7.nupkg.sha512"
     },
     "Microsoft.Extensions.Localization/2.2.0": {
       "type": "package",
@@ -4429,6 +4487,20 @@
       "sha512": "sha512-RR1UziU+PYWYe+cwGZtSpdF43zv60GPP+WU0epR8xzZuA5FoxceCa+tYTh8iDqTYvy6F+jUzRe74dg/YAZ437Q==",
       "path": "opentelemetry.persistentstorage.filesystem/1.0.1",
       "hashPath": "opentelemetry.persistentstorage.filesystem.1.0.1.nupkg.sha512"
+    },
+    "Polly/7.2.4": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-bw00Ck5sh6ekduDE3mnCo1ohzuad946uslCDEENu3091+6UKnBuKLo4e+yaNcCzXxOZCXWY2gV4a35+K1d4LDA==",
+      "path": "polly/7.2.4",
+      "hashPath": "polly.7.2.4.nupkg.sha512"
+    },
+    "Polly.Extensions.Http/3.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-drrG+hB3pYFY7w1c3BD+lSGYvH2oIclH8GRSehgfyP5kjnFnHKQuuBhuHLv+PWyFuaTDyk/vfRpnxOzd11+J8g==",
+      "path": "polly.extensions.http/3.0.0",
+      "hashPath": "polly.extensions.http.3.0.0.nupkg.sha512"
     },
     "protobuf-net/2.3.3": {
       "type": "package",
@@ -5165,12 +5237,12 @@
       "path": "yarp.reverseproxy/2.0.1",
       "hashPath": "yarp.reverseproxy.2.0.1.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Script/4.1044.100-pr.25452.4": {
+    "Microsoft.Azure.WebJobs.Script/4.1044.100-pr.25462.4": {
       "type": "project",
       "serviceable": false,
       "sha512": ""
     },
-    "Microsoft.Azure.WebJobs.Script.Grpc/4.1044.100-pr.25452.4": {
+    "Microsoft.Azure.WebJobs.Script.Grpc/4.1044.100-pr.25462.4": {
       "type": "project",
       "serviceable": false,
       "sha512": ""


### PR DESCRIPTION
### Issue describing the changes in this PR
This pull request enhances the reliability of extension bundle downloads in `ExtensionBundleManager` by introducing retry logic with exponential backoff, improving error handling and diagnostics, and adding corresponding unit tests. The main focus is to make bundle downloads more resilient to transient failures by retrying failed attempts and logging detailed errors.

Fix: https://github.com/Azure/azure-functions-host/issues/11323
Addresses: #9571

**Reliability improvements for extension bundle downloads:**

* Refactored `TryDownloadZipFileAsync` in `ExtensionBundleManager.cs` to use a new retry mechanism with exponential backoff (`Utility.InvokeWithRetriesBackoffAsync`), improving resilience to transient download errors and providing better error logging, including disk usage diagnostics. [[1]](diffhunk://#diff-85b762965162c1552dcb464ef2ab520b03ddbb1fabad4cc85bef3180b5a5c0dbR201-R209) [[2]](diffhunk://#diff-85b762965162c1552dcb464ef2ab520b03ddbb1fabad4cc85bef3180b5a5c0dbR219-R259)
* Replaced per-call `HttpClient` instantiations with a shared static instance (`_sharedHttpClient`) in `ExtensionBundleManager` to prevent socket exhaustion and improve performance. [[1]](diffhunk://#diff-85b762965162c1552dcb464ef2ab520b03ddbb1fabad4cc85bef3180b5a5c0dbR32) [[2]](diffhunk://#diff-85b762965162c1552dcb464ef2ab520b03ddbb1fabad4cc85bef3180b5a5c0dbL82-R83) [[3]](diffhunk://#diff-85b762965162c1552dcb464ef2ab520b03ddbb1fabad4cc85bef3180b5a5c0dbR219-R259)

**Utility enhancements:**

* Added `InvokeWithRetriesBackoffAsync` to `Utility.cs`, providing a reusable method for retrying asynchronous actions with exponential backoff, optional logging, and configurable timing parameters.

**Testing improvements:**

* Added unit tests in `UtilityTests.cs` to verify the new retry logic, including scenarios for success after retries and for proper exception throwing after exceeding the retry limit.
Checklist
- [x] Resilient download with backoff
- [x] Static HttpClient reuse
- [x] New internal utility + tests
- [x] Minimal diff in `ExtensionBundleManager`
- [x] Added disk usage logging on terminal failure

Let me know if you’d like a shorter version or to add issue links / release notes formatting.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
