### PR TITLE
Don't apply bundle version limits if host is in placeholder mode

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,3 +6,4 @@
 - Add JitTrace files for v4.43 (#11277)
 - Cap v4.x extension bundle versions on .NET 6 to the range (>4.2.0, <4.22.0) by default (#11289)
 - Update `Microsoft.Azure.WebJobs` reference to `3.0.42` (#11310)
+- Don't apply bundle version limits if host is in placeholder mode (#11316)

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -281,9 +281,11 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
         }
 
         // Applies bundle version limits for .NET 6, using the default bundle if referencing a v4 major bundle version.
+        // Does not apply version limit in placeholder mode. This will prevent bundle download in placeholder mode as long as a matching bundle is available.
         private VersionRange GetAdjustedVersion(int dotnetVersion, VersionRange versionRange, string bundleId)
         {
-            if (dotnetVersion != 6
+            if (_environment.IsPlaceholderModeEnabled()
+                || dotnetVersion != 6
                 || !string.Equals(bundleId, ScriptConstants.DefaultExtensionBundleId, StringComparison.OrdinalIgnoreCase)
                 || versionRange.MinVersion.Major != ScriptConstants.ExtensionBundleV4MajorVersion)
             {

--- a/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
@@ -684,6 +684,48 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
 #endif
 
 #if NET6_0
+
+        [Fact]
+        public void FindBestVersionMatch_V4Range_PlaceholderMode_AllowsPreviouslyCappedMin()
+        {
+            // Without placeholder mode, only version "4.2.0" would be excluded by the adjusted open interval (4.2.0, 4.22.0),
+            // resulting in a null match (covered by existing test FindBestVersionMatch_V4Range_AllFiltered_ReturnsNull).
+            // With placeholder mode enabled, adjustment is skipped and "4.2.0" is valid and should be selected.
+            var range = VersionRange.Parse("[4.0.0, 5.0.0)");
+            var versions = new List<string> { "4.2.0" };
+
+            var options = GetTestExtensionBundleOptions(BundleId, "[4.*,5.0.0)");
+            var env = GetTestAppServiceEnvironment();
+            env.SetEnvironmentVariable(AzureWebsitePlaceholderMode, "1"); // enable placeholder mode
+
+            var manager = GetExtensionBundleManager(options, env);
+
+            var resolved = manager.FindBestVersionMatch(range, versions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            Assert.Equal("4.2.0", resolved);
+        }
+
+        [Fact]
+        public void FindBestVersionMatch_V4Range_PlaceholderMode_AllowsPreviouslyCappedOuterVersions()
+        {
+            // Version adjustment on .NET 6 would cap effective range to (4.2.0, 4.22.0) (exclusive on both ends),
+            // excluding 4.2.0, 4.22.0, and anything above (e.g., 4.23.0). Normal (non-placeholder) selection (with provided list)
+            // would therefore choose 4.21.9 (if present) or next highest inside interval.
+            // With placeholder mode enabled, no adjustment occurs and the highest (4.23.0) should be selected.
+            var range = VersionRange.Parse("[4.0.0, 5.0.0)");
+            var versions = new List<string> { "4.2.0", "4.3.0", "4.21.9", "4.22.0", "4.23.0" };
+
+            var options = GetTestExtensionBundleOptions(BundleId, "[4.*,5.0.0)");
+            var env = GetTestAppServiceEnvironment();
+            env.SetEnvironmentVariable(AzureWebsitePlaceholderMode, "1"); // enable placeholder mode
+
+            var manager = GetExtensionBundleManager(options, env);
+
+            var resolved = manager.FindBestVersionMatch(range, versions, ScriptConstants.DefaultExtensionBundleId, new FunctionsHostingConfigOptions());
+
+            Assert.Equal("4.23.0", resolved);
+        }
+
         [Fact]
         public void FindBestVersionMatch_V4Range_MinCapApplied_ExcludesCappedMin()
         {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Do not apply bundle version limit ihn placeholder mode. This will prevent bundle download when the host is in placeholder mode.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
