### PR TITLE
properly canceling StartupOperation

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -317,7 +317,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 }
                 finally
                 {
-                    activeOperation.Dispose();
+                    EndStartupOperation(activeOperation);
                     _hostStartSemaphore.Release();
                 }
             }


### PR DESCRIPTION
Missed something in #10854 that resulted in a (tiny) leak. We'd properly dispose/cancel previous operations, but not remove them from the "active" collection, resulting in a confusing message of "Canceling startup operation '{operationId}' to unblock restart.", which isn't really doing anything.

This properly cleans it up.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)