### PR TITLE
Adding test coverage for `Utility.IsAzureMonitorLoggingEnabled`

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -9,3 +9,4 @@
 - Add JitTrace Files for v4.1043 (#11281)
 - Update `Microsoft.Azure.WebJobs` reference to `3.0.42` (#11309)
 - Adding Activity wrapper to create a function-level request telemetry when none exists (#11311)
+- Adding test coverage for `Utility.IsAzureMonitorLoggingEnabled` (#11322)

--- a/test/WebJobs.Script.Tests/UtilityTests.cs
+++ b/test/WebJobs.Script.Tests/UtilityTests.cs
@@ -1110,6 +1110,27 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Utility.ValidateRetryOptions(retryOptions);
         }
 
+        [Theory]
+        // Null input should enable logging.
+        [InlineData(null, true)]
+        // Only Default category(ScriptConstants.DefaultAzureMonitorCategories) disables logging.
+        [InlineData(ScriptConstants.DefaultAzureMonitorCategories, false)]
+        // No presence of ScriptConstants.AzureMonitorTraceCategory category disables logging
+        [InlineData("SomeOtherCategory", false)]
+        // Only ScriptConstants.AzureMonitorTraceCategory category enables logging
+        [InlineData(ScriptConstants.AzureMonitorTraceCategory, true)]
+        // ScriptConstants.AzureMonitorTraceCategory category present among others enables logging
+        [InlineData($"{ScriptConstants.DefaultAzureMonitorCategories},{ScriptConstants.AzureMonitorTraceCategory}", true)]
+        [InlineData($"{ScriptConstants.AzureMonitorTraceCategory},{ScriptConstants.DefaultAzureMonitorCategories}", true)]
+        [InlineData($"{ScriptConstants.DefaultAzureMonitorCategories},{ScriptConstants.AzureMonitorTraceCategory},Other", true)]
+        // Empty string disables logging (no Trace category present)
+        [InlineData("", false)]
+        public void IsAzureMonitorLoggingEnabled_ReturnsExpected(string subscribedCategories, bool expectedResult)
+        {
+            var result = Utility.IsAzureMonitorLoggingEnabled(subscribedCategories);
+            Assert.Equal(expectedResult, result);
+        }
+
         private static void VerifyLogLevel(IList<LogMessage> allLogs, string msg, LogLevel expectedLevel)
         {
             var message = allLogs.FirstOrDefault(l => l.FormattedMessage.Contains(msg));

--- a/test/WebJobs.Script.Tests/UtilityTests.cs
+++ b/test/WebJobs.Script.Tests/UtilityTests.cs
@@ -1115,7 +1115,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [InlineData(null, true)]
         // Only Default category(ScriptConstants.DefaultAzureMonitorCategories) disables logging.
         [InlineData(ScriptConstants.DefaultAzureMonitorCategories, false)]
-        // No presence of ScriptConstants.AzureMonitorTraceCategory category disables logging
+        // Absence of ScriptConstants.AzureMonitorTraceCategory category disables logging
         [InlineData("SomeOtherCategory", false)]
         // Only ScriptConstants.AzureMonitorTraceCategory category enables logging
         [InlineData(ScriptConstants.AzureMonitorTraceCategory, true)]


### PR DESCRIPTION
Adding test coverage for `Utility.IsAzureMonitorLoggingEnabled` method.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
