### PR TITLE
Reduce allocations in `Utility.IsAzureMonitorLoggingEnabled`

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -10,3 +10,4 @@
 - Update `Microsoft.Azure.WebJobs` reference to `3.0.42` (#11309)
 - Adding Activity wrapper to create a function-level request telemetry when none exists (#11311)
 - Adding test coverage for `Utility.IsAzureMonitorLoggingEnabled` (#11322)
+- Reduce allocations in `Utility.IsAzureMonitorLoggingEnabled` (#11323)

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -21,6 +21,7 @@ using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics.Extensions;
+using Microsoft.Azure.WebJobs.Script.Extensions;
 using Microsoft.Azure.WebJobs.Script.Models;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.DependencyInjection;
@@ -1157,8 +1158,8 @@ namespace Microsoft.Azure.WebJobs.Script
                 // This is set when customer does not subscribe any category.
                 return false;
             }
-            string[] categories = azureMonitorcategoriesSubscribed.Split(',');
-            return categories.Contains(ScriptConstants.AzureMonitorTraceCategory);
+
+            return azureMonitorcategoriesSubscribed.ContainsToken(token: ScriptConstants.AzureMonitorTraceCategory, separator: ',');
         }
 
         private class FilteredExpandoObjectConverter : ExpandoObjectConverter


### PR DESCRIPTION
Reduce allocations in `Utility.IsAzureMonitorLoggingEnabled` by replacing the `string.Split` + `Contains` pattern with `ContainsToken` (added in #11076), which performs the same check without creating intermediate allocations.

Test coverage was added to this method in https://github.com/Azure/azure-functions-host/pull/11322


### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)
