### PR TITLE
Removing obsolete auth policy

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
         [HttpGet]
         [Route("admin/host/status")]
-        [Authorize(Policy = PolicyNames.AdminAuthLevelOrInternal)]
+        [Authorize(Policy = PolicyNames.AdminAuthLevel)]
         [TypeFilter(typeof(EnableDebugModeFilter))]
         public async Task<IActionResult> GetHostStatus([FromServices] IScriptHostManager scriptHostManager, [FromServices] IHostIdProvider hostIdProvider, [FromServices] IServiceProvider serviceProvider = null)
         {
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         /// </summary>
         [HttpGet]
         [Route("admin/host/processes")]
-        [Authorize(Policy = PolicyNames.AdminAuthLevelOrInternal)]
+        [Authorize(Policy = PolicyNames.AdminAuthLevel)]
         public async Task<IActionResult> GetWorkerProcesses([FromServices] IScriptHostManager scriptHostManager)
         {
             if (!Utility.TryGetHostService(scriptHostManager, out IWebHostRpcWorkerChannelManager webHostLanguageWorkerChannelManager))
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
         [HttpPost]
         [Route("admin/host/drain")]
-        [Authorize(Policy = PolicyNames.AdminAuthLevelOrInternal)]
+        [Authorize(Policy = PolicyNames.AdminAuthLevel)]
         public async Task<IActionResult> Drain([FromServices] IScriptHostManager scriptHostManager, CancellationToken cancellation)
         {
             _logger.LogDebug("Received request to drain the host");
@@ -225,7 +225,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
         [HttpGet]
         [Route("admin/host/drain/status")]
-        [Authorize(Policy = PolicyNames.AdminAuthLevelOrInternal)]
+        [Authorize(Policy = PolicyNames.AdminAuthLevel)]
         public IActionResult DrainStatus([FromServices] IScriptHostManager scriptHostManager)
         {
             if (Utility.TryGetHostService(scriptHostManager, out IFunctionActivityStatusProvider functionActivityStatusProvider) &&
@@ -259,7 +259,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
         [HttpPost]
         [Route("admin/host/resume")]
-        [Authorize(Policy = PolicyNames.AdminAuthLevelOrInternal)]
+        [Authorize(Policy = PolicyNames.AdminAuthLevel)]
         public async Task<IActionResult> Resume([FromServices] IScriptHostManager scriptHostManager, CancellationToken cancellation)
         {
             try
@@ -327,7 +327,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
         [HttpPost]
         [Route("admin/host/scale/status")]
-        [Authorize(Policy = PolicyNames.AdminAuthLevelOrInternal)]
+        [Authorize(Policy = PolicyNames.AdminAuthLevel)]
         [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
         [RequiresRunningHost]
         public async Task<IActionResult> GetScaleStatus([FromBody] ScaleStatusContext context, [FromServices] IScriptHostManager scriptHostManager)
@@ -356,7 +356,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
         [HttpPost]
         [Route("admin/host/log")]
-        [Authorize(Policy = PolicyNames.AdminAuthLevelOrInternal)]
+        [Authorize(Policy = PolicyNames.AdminAuthLevel)]
         public IActionResult Log([FromBody] IEnumerable<HostLogEntry> logEntries)
         {
             if (logEntries == null)
@@ -407,7 +407,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
         [HttpPost]
         [Route("admin/host/synctriggers")]
-        [Authorize(Policy = PolicyNames.AdminAuthLevelOrInternal)]
+        [Authorize(Policy = PolicyNames.AdminAuthLevel)]
         [RequiresRunningHost]
         public async Task<IActionResult> SyncTriggers()
         {
@@ -423,7 +423,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
         [HttpGet]
         [Route("admin/host/triggers")]
-        [Authorize(Policy = PolicyNames.AdminAuthLevelOrInternal)]
+        [Authorize(Policy = PolicyNames.AdminAuthLevel)]
         [ResourceContainsSecrets]
         [RequiresRunningHost]
         public async Task<IActionResult> GetTriggers()
@@ -539,7 +539,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
         [HttpGet]
         [Route("admin/host/config")]
-        [Authorize(Policy = PolicyNames.AdminAuthLevelOrInternal)]
+        [Authorize(Policy = PolicyNames.AdminAuthLevel)]
         [RequiresRunningHost]
         public IActionResult GetConfig([FromServices] IScriptHostManager scriptHostManager)
         {

--- a/src/WebJobs.Script.WebHost/Middleware/VirtualFileSystemMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/VirtualFileSystemMiddleware.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
             var authorizationPolicyProvider = context.RequestServices.GetRequiredService<IAuthorizationPolicyProvider>();
             var policyEvaluator = context.RequestServices.GetRequiredService<IPolicyEvaluator>();
 
-            if (!AuthorizationOptionsExtensions.CheckPlatformInternal(context, allowAppServiceInternal: false))
+            if (!AuthorizationOptionsExtensions.EnforceAdminIsolation(context, allowAppServiceInternal: false))
             {
                 return false;
             }

--- a/src/WebJobs.Script.WebHost/Security/Authorization/Policies/AuthorizationOptionsExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authorization/Policies/AuthorizationOptionsExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies
                 {
                     if (c.Resource is AuthorizationFilterContext filterContext)
                     {
-                        if (!CheckPlatformInternal(filterContext.HttpContext, allowAppServiceInternal: false))
+                        if (!EnforceAdminIsolation(filterContext.HttpContext, allowAppServiceInternal: true))
                         {
                             return false;
                         }
@@ -41,34 +41,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies
                 p.AddRequirements(new AuthLevelRequirement(AuthorizationLevel.System));
             });
 
-            options.AddPolicy(PolicyNames.AdminAuthLevelOrInternal, p =>
-            {
-                p.AddScriptAuthenticationSchemes();
-                p.RequireAssertion(async c =>
-                {
-                    if (c.Resource is AuthorizationFilterContext filterContext)
-                    {
-                        if (!CheckPlatformInternal(filterContext.HttpContext, allowAppServiceInternal: true))
-                        {
-                            return false;
-                        }
-
-                        if (filterContext.HttpContext.Request.IsAppServiceInternalRequest() &&
-                            filterContext.HttpContext.Request.IsInternalAuthAllowed())
-                        {
-                            return true;
-                        }
-
-                        var authorizationService = filterContext.HttpContext.RequestServices.GetRequiredService<IAuthorizationService>();
-                        AuthorizationResult result = await authorizationService.AuthorizeAsync(c.User, PolicyNames.AdminAuthLevel);
-
-                        return result.Succeeded;
-                    }
-
-                    return false;
-                });
-            });
-
             options.AddPolicy(PolicyNames.SystemKeyAuthLevel, p =>
             {
                 p.AddScriptAuthenticationSchemes();
@@ -76,12 +48,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies
                 {
                     if (c.Resource is AuthorizationFilterContext filterContext)
                     {
-                        if (filterContext.HttpContext.Request.IsAppServiceInternalRequest() &&
-                            filterContext.HttpContext.Request.IsInternalAuthAllowed())
-                        {
-                            return true;
-                        }
-
                         string keyName = null;
                         object keyNameObject = filterContext.RouteData.Values["extensionName"];
                         if (keyNameObject != null)
@@ -114,9 +80,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies
             builder.AuthenticationSchemes.Add(JwtBearerDefaults.AuthenticationScheme);
         }
 
-        internal static bool CheckPlatformInternal(HttpContext httpContext, bool allowAppServiceInternal)
+        /// <summary>
+        /// When AdminIsolation is enabled, performs platform internal request verification on the specified HTTP context.
+        /// </summary>
+        /// <param name="httpContext">The <see cref="HttpContext"/> to check.</param>
+        /// <param name="allowAppServiceInternal">True if App Service internal requests should also be allowed; otherwise, false.</param>
+        /// <returns>True if the request passes isolation checks, false otherwise.</returns>
+        internal static bool EnforceAdminIsolation(HttpContext httpContext, bool allowAppServiceInternal)
         {
-            // when AdminIsolation is enabled, verify the request is platform internal
             var environment = httpContext.RequestServices.GetRequiredService<IEnvironment>();
             if (environment.IsAdminIsolationEnabled() &&
                 !(httpContext.Request.IsPlatformInternalRequest(environment) || (allowAppServiceInternal && httpContext.Request.IsAppServiceInternalRequest())))

--- a/src/WebJobs.Script.WebHost/Security/Authorization/Policies/PolicyNames.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authorization/Policies/PolicyNames.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -11,7 +11,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies
     public static class PolicyNames
     {
         public const string AdminAuthLevel = "AuthLevelAdmin";
-        public const string AdminAuthLevelOrInternal = "InternalAuthLevelAdmin";
         public const string SystemAuthLevel = "AuthLevelSystem";
         public const string FunctionAuthLevel = "AuthLevelFunction";
         public const string SystemKeyAuthLevel = "AuthLevelSystemKey";

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -1,10 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 
 namespace Microsoft.Azure.WebJobs.Script.Config
@@ -12,7 +10,6 @@ namespace Microsoft.Azure.WebJobs.Script.Config
     public class FunctionsHostingConfigOptions
     {
         private readonly Dictionary<string, string> _features;
-        private PathString[] _allowedInternalAuthApis;
 
         public FunctionsHostingConfigOptions()
         {
@@ -59,24 +56,6 @@ namespace Microsoft.Azure.WebJobs.Script.Config
             set
             {
                 _features[RpcWorkerConstants.ShutdownWebhostWorkerChannelsOnHostShutdown] = value ? "1" : "0";
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a string delimited by '|' that contains a list of admin APIs that are allowed to
-        /// be invoked internally by platform components.
-        /// </summary>
-        internal string InternalAuthApisAllowList
-        {
-            get
-            {
-                return GetFeature(ScriptConstants.HostingConfigInternalAuthApisAllowList);
-            }
-
-            set
-            {
-                _allowedInternalAuthApis = null;
-                _features[ScriptConstants.HostingConfigInternalAuthApisAllowList] = value;
             }
         }
 
@@ -256,33 +235,6 @@ namespace Microsoft.Azure.WebJobs.Script.Config
                 return parsedInt != 0;
             }
             return defaultValue;
-        }
-
-        internal bool CheckInternalAuthAllowList(HttpRequest httpRequest)
-        {
-            if (InternalAuthApisAllowList != null && _allowedInternalAuthApis == null)
-            {
-                // initialize our cached allow list on demand
-                _allowedInternalAuthApis = InternalAuthApisAllowList.Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries).Select(p => new PathString(p)).ToArray();
-            }
-
-            if (_allowedInternalAuthApis != null)
-            {
-                // An allow list is configured, so we ensure that the current request
-                // matches any of the allowed APIs.
-                foreach (PathString ps in _allowedInternalAuthApis)
-                {
-                    if (httpRequest.Path.StartsWithSegments(ps, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
-
-            // no allow list configured
-            return true;
         }
     }
 }

--- a/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs
+++ b/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -13,9 +13,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Azure.WebJobs.Extensions.Http;
-using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -102,13 +100,6 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
             var header = request.Headers[ScriptConstants.AntaresPlatformInternal];
             string value = header.FirstOrDefault();
             return string.Compare(value, "true", StringComparison.OrdinalIgnoreCase) == 0;
-        }
-
-        public static bool IsInternalAuthAllowed(this HttpRequest httpRequest)
-        {
-            // Check to see if the specific API is allowed based on any configured allow list
-            var options = httpRequest.HttpContext.RequestServices.GetService<IOptions<FunctionsHostingConfigOptions>>().Value;
-            return options.CheckInternalAuthAllowList(httpRequest);
         }
 
         private static IEnvironment GetEnvironment(HttpRequest request, IEnvironment environment = null)

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -145,7 +145,6 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string HostingConfigDisableLinuxAppServiceDetailedExecutionEvents = "DisableLinuxExecutionDetails";
         public const string HostingConfigDisableLinuxAppServiceExecutionEventLogBackoff = "DisableLinuxLogBackoff";
         public const string FeatureFlagEnableLegacyDurableVersionCheck = "EnableLegacyDurableVersionCheck";
-        public const string HostingConfigInternalAuthApisAllowList = "InternalAuthApisAllowList";
         public const string HostingConfigDotNetInProcDisabled = "DotNetInProcDisabled";
 
         public const string SiteAzureFunctionsUriFormat = "https://{0}.azurewebsites.net/azurefunctions";

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -220,7 +220,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         [InlineData("admin/host/extensionBundle/v1/templates", true, true, false, true, false, HttpStatusCode.Unauthorized)]
         [InlineData("admin/host/extensionBundle/v1/templates", true, true, true, false, true, HttpStatusCode.NotFound)]
         [InlineData("admin/host/extensionBundle/v1/templates", true, false, false, false, true, HttpStatusCode.NotFound)]
-        [InlineData("admin/host/extensionBundle/v1/templates", true, true, false, true, true, HttpStatusCode.Forbidden)]
+        [InlineData("admin/host/extensionBundle/v1/templates", true, true, false, true, true, HttpStatusCode.NotFound)]
         [InlineData("admin/vfs/host.json", true, true, true, false, true, HttpStatusCode.OK)]
         [InlineData("admin/vfs/host.json", true, true, false, false, true, HttpStatusCode.Unauthorized)]
         [InlineData("admin/vfs/host.json", true, true, true, false, false, HttpStatusCode.Unauthorized)]
@@ -450,46 +450,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         }
 
         [Fact]
-        public async Task SyncTriggers_InternalAuth_Succeeds()
+        public async Task SyncTriggers_AdminTokenProvided_Succeeds()
         {
             using (var httpClient = _fixture.Host.CreateHttpClient())
             {
                 string uri = "admin/host/synctriggers";
+                string token = _fixture.Host.GenerateAdminJwtToken(issuer: ScriptConstants.AppServiceCoreUri);
                 HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
+                request.Headers.Add(ScriptConstants.SiteTokenHeaderName, token);
                 HttpResponseMessage response = await httpClient.SendAsync(request);
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             }
         }
 
-        [Theory]
-        [InlineData("", HttpStatusCode.Unauthorized)]
-        [InlineData("|", HttpStatusCode.Unauthorized)]
-        [InlineData("/admin/host/foo|/admin/host/bar", HttpStatusCode.Unauthorized)]
-        [InlineData("/admin/host/status|/admin/host/synctriggers", HttpStatusCode.OK)]
-        public async Task SyncTriggers_InternalAuth_AllowListSpecified_ReturnsExpectedResult(string allowList, HttpStatusCode expected)
-        {
-            var options = _fixture.Host.WebHostServices.GetService<IOptions<FunctionsHostingConfigOptions>>().Value;
-
-            try
-            {
-                options.InternalAuthApisAllowList = allowList;
-
-                using (var httpClient = _fixture.Host.CreateHttpClient())
-                {
-                    string uri = "admin/host/synctriggers";
-                    HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
-                    HttpResponseMessage response = await httpClient.SendAsync(request);
-                    Assert.Equal(expected, response.StatusCode);
-                }
-            }
-            finally
-            {
-                options.InternalAuthApisAllowList = null;
-            }
-        }
-
         [Fact]
-        public async Task SyncTriggers_ExternalUnauthorized_ReturnsUnauthorized()
+        public async Task SyncTriggers_NoAuthentication_ReturnsUnauthorized()
         {
             string uri = "admin/host/synctriggers";
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
@@ -498,7 +473,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         }
 
         [Fact]
-        public async Task SyncTriggers_AdminLevel_Succeeds()
+        public async Task SyncTriggers_MasterKeyProvided_Succeeds()
         {
             string uri = "admin/host/synctriggers";
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, uri);
@@ -515,23 +490,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
             var response = await _fixture.Host.HttpClient.SendAsync(request);
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-        }
-
-        [Fact]
-        public async Task HostLog_PlatformInternal_Succeeds()
-        {
-            var environment = _fixture.Host.JobHostServices.GetService<IEnvironment>();
-            Assert.True(environment.IsAppService());
-
-            using (var httpClient = _fixture.Host.CreateHttpClient())
-            {
-                // no x-arr-log-id header makes this request platform internal
-                var request = new HttpRequestMessage(HttpMethod.Post, "admin/host/log");
-                request.Content = new StringContent("[]");
-                request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-                var response = await httpClient.SendAsync(request);
-                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            }
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -59,9 +59,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
                 yield return [nameof(FunctionsHostingConfigOptions.WorkerIndexingDisabledApps), "WORKER_INDEXING_DISABLED_APPS=teststring", "teststring"];
                 yield return [nameof(FunctionsHostingConfigOptions.WorkerIndexingEnabled), "WORKER_INDEXING_ENABLED=1", true];
                 yield return [nameof(FunctionsHostingConfigOptions.WorkerRuntimeStrictValidationEnabled), "WORKER_RUNTIME_STRICT_VALIDATION_ENABLED=1", true];
-
-                yield return [nameof(FunctionsHostingConfigOptions.InternalAuthApisAllowList), "InternalAuthApisAllowList=|", "|"];
-                yield return [nameof(FunctionsHostingConfigOptions.InternalAuthApisAllowList), "InternalAuthApisAllowList=/admin/host/foo|/admin/host/bar", "/admin/host/foo|/admin/host/bar"];
 
                 yield return [nameof(FunctionsHostingConfigOptions.IsDotNetInProcDisabled), "DotNetInProcDisabled=False", false];
                 yield return [nameof(FunctionsHostingConfigOptions.IsDotNetInProcDisabled), "DotNetInProcDisabled=True", true];
@@ -197,20 +194,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             {
                 return testService.Monitor.CurrentValue.GetFeature("feature1") == "value1_updated";
             });
-        }
-
-        [Fact]
-        public void InternalAuthApisAllowList_ReturnsExpectedValue()
-        {
-            FunctionsHostingConfigOptions options = new();
-
-            Assert.Null(options.InternalAuthApisAllowList);
-
-            options.InternalAuthApisAllowList = string.Empty;
-            Assert.Equal(string.Empty, options.InternalAuthApisAllowList);
-
-            options.InternalAuthApisAllowList = "/admin/host/synctriggers|/admin/host/status";
-            Assert.Equal("/admin/host/synctriggers|/admin/host/status", options.InternalAuthApisAllowList);
         }
 
         internal static IHostBuilder GetScriptHostBuilder(string fileName, string fileContent)

--- a/test/WebJobs.Script.Tests/Extensions/HttpRequestExtensionsTest.cs
+++ b/test/WebJobs.Script.Tests/Extensions/HttpRequestExtensionsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -10,10 +10,8 @@ using System.Security.Principal;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.WebUtilities;
-using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Extensions;
 using Microsoft.Azure.WebJobs.Script.Tests.HttpWorker;
-using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
 using Moq;
 using Xunit;
@@ -68,36 +66,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
                 request.HttpContext.RequestServices = servicesMock.Object;
                 Assert.True(request.IsPlatformInternalRequest());
             }
-        }
-
-        [Theory]
-        [InlineData("/admin/host/drain", null, true)] // no allow list
-        [InlineData("/admin/host/drain", "", false)] // empty allow list
-        [InlineData("/admin/host/drain", "|", false)] // empty allow list
-        [InlineData("/admin/host/drain", "/admin/host/foo|/admin/host/bar", false)] // target not in allow list
-        [InlineData("/admin/host/synctriggers", "/admin/host/status|/admin/host/synctriggers", true)] // target in allow list
-        [InlineData("/runtime/webhooks/foo/", "/admin/host/status|/admin/host/synctriggers|/runtime/webhooks", true)] // target in allow list
-        [InlineData("/runtime/webhooks/foo/bar?foo=1&bar=2", "/admin/host/status|/admin/host/synctriggers|/runtime/webhooks", true)] // target in allow list
-        [InlineData("/runtime/webhooks/foo/bar/", "/admin/host/status|/admin/host/synctriggers|/runtime/webhooks", true)] // target in allow list
-        [InlineData("/runtime/webhooks/foo/bar/", "/admin/host/status|/admin/host/synctriggers", false)] // target not in allow list
-        public void IsInternalAuthAllowed_ReturnsExpectedResult(string targetPath, string allowList, bool expected)
-        {
-            var options = new FunctionsHostingConfigOptions();
-
-            if (allowList != null)
-            {
-                options.InternalAuthApisAllowList = allowList;
-            }
-
-            var request = HttpTestHelpers.CreateHttpRequest("GET", $"http://host{targetPath}");
-
-            var environment = SystemEnvironment.Instance;
-            var servicesMock = new Mock<IServiceProvider>();
-            servicesMock.Setup(s => s.GetService(typeof(IEnvironment))).Returns(environment);
-            servicesMock.Setup(s => s.GetService(typeof(IOptions<FunctionsHostingConfigOptions>))).Returns(new OptionsWrapper<FunctionsHostingConfigOptions>(options));
-            request.HttpContext.RequestServices = servicesMock.Object;
-
-            Assert.Equal(expected, request.IsInternalAuthAllowed());
         }
 
         [Fact]


### PR DESCRIPTION
Removing an obsolete authentication policy. See work item https://msazure.visualstudio.com/Antares/_workitems/edit/34690848. Plan is to also backport this to in-proc.

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * In-Proc: https://github.com/Azure/azure-functions-host/pull/11335
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
