### PR TITLE
Update Node.js Worker Version to 3.12.0

### DIFF
--- a/eng/build/Workers.Node.props
+++ b/eng/build/Workers.Node.props
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.11.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.11.0" />
   </ItemGroup>
 
 </Project>

--- a/eng/build/Workers.Node.props
+++ b/eng/build/Workers.Node.props
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.11.2" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.12.0" />
   </ItemGroup>
 
 </Project>

--- a/eng/build/Workers.Node.props
+++ b/eng/build/Workers.Node.props
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.11.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.11.1" />
   </ItemGroup>
 
 </Project>

--- a/eng/build/Workers.Node.props
+++ b/eng/build/Workers.Node.props
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.11.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" Version="3.11.2" />
   </ItemGroup>
 
 </Project>

--- a/release_notes.md
+++ b/release_notes.md
@@ -14,4 +14,4 @@
 - Reduce allocations in `Utility.IsAzureMonitorLoggingEnabled` (#11323)
 - Update PowerShell worker to [4.0.4581](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.4581)
 - Bug fix that fails in-flight invocations when a worker channel shuts down (#11159)
-- Update Node.js Worker Version to [3.11.1] (https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.11.1)
+- Update Node.js Worker Version to [3.11.1](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.11.1)

--- a/release_notes.md
+++ b/release_notes.md
@@ -14,4 +14,4 @@
 - Reduce allocations in `Utility.IsAzureMonitorLoggingEnabled` (#11323)
 - Update PowerShell worker to [4.0.4581](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.4581)
 - Bug fix that fails in-flight invocations when a worker channel shuts down (#11159)
-- Update Node.js Worker Version to [3.11.1](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.11.1)
+- Update Node.js Worker Version to [3.11.2](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.11.2)

--- a/release_notes.md
+++ b/release_notes.md
@@ -14,3 +14,4 @@
 - Reduce allocations in `Utility.IsAzureMonitorLoggingEnabled` (#11323)
 - Update PowerShell worker to [4.0.4581](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.4581)
 - Bug fix that fails in-flight invocations when a worker channel shuts down (#11159)
+- Update Node.js Worker Version to [3.11.1] (https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.11.1)

--- a/release_notes.md
+++ b/release_notes.md
@@ -14,4 +14,4 @@
 - Reduce allocations in `Utility.IsAzureMonitorLoggingEnabled` (#11323)
 - Update PowerShell worker to [4.0.4581](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.4581)
 - Bug fix that fails in-flight invocations when a worker channel shuts down (#11159)
-- Update Node.js Worker Version to [3.11.2](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.11.2)
+- Update Node.js Worker Version to [3.12.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.12.0)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Add EoL logging for worker startup

Release notes
https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.12.0

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [X] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [X] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [X] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [X] I have added all required tests (Unit tests, E2E tests)
