### PR TITLE
FileSystemReadOnly when functions running in ACA environment

### DIFF
--- a/src/WebJobs.Script.WebHost/Configuration/ScriptApplicationHostOptionsSetup.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/ScriptApplicationHostOptionsSetup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -75,6 +75,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
             // Flex consumption does not support mutable filesystems, and therefore always counts as zip deployment. It does not use scmRunFromPackage.
             // TODO: revisit whether this flex consumption path should return false when in placeholder mode? Thats how it appears to work for other SKUs.
             if (_environment.IsFlexConsumptionSku())
+            {
+                isScmRunFromPackage = false;
+                return true;
+            }
+
+            // Functions on Container Apps always have a read-only filesystem
+            if (_environment.IsManagedAppEnvironment())
             {
                 isScmRunFromPackage = false;
                 return true;

--- a/src/WebJobs.Script.WebHost/Configuration/ScriptApplicationHostOptionsSetup.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/ScriptApplicationHostOptionsSetup.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
                 options.IsStandbyConfiguration = true;
             }
 
-            options.IsFileSystemReadOnly |= IsZipDeployment(out bool isScmRunFromPackage);
+            options.IsFileSystemReadOnly |= IsZipDeployment(out bool isScmRunFromPackage) || _environment.IsManagedAppEnvironment();
             options.IsScmRunFromPackage = isScmRunFromPackage;
         }
 
@@ -75,13 +75,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
             // Flex consumption does not support mutable filesystems, and therefore always counts as zip deployment. It does not use scmRunFromPackage.
             // TODO: revisit whether this flex consumption path should return false when in placeholder mode? Thats how it appears to work for other SKUs.
             if (_environment.IsFlexConsumptionSku())
-            {
-                isScmRunFromPackage = false;
-                return true;
-            }
-
-            // Functions on Container Apps always have a read-only filesystem
-            if (_environment.IsManagedAppEnvironment())
             {
                 isScmRunFromPackage = false;
                 return true;

--- a/src/WebJobs.Script.WebHost/Configuration/ScriptApplicationHostOptionsSetup.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/ScriptApplicationHostOptionsSetup.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
                 options.IsStandbyConfiguration = true;
             }
 
-            options.IsFileSystemReadOnly |= IsZipDeployment(out bool isScmRunFromPackage) || _environment.IsManagedAppEnvironment();
+            options.IsFileSystemReadOnly |= IsZipDeployment(out bool isScmRunFromPackage);
             options.IsScmRunFromPackage = isScmRunFromPackage;
         }
 
@@ -75,6 +75,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
             // Flex consumption does not support mutable filesystems, and therefore always counts as zip deployment. It does not use scmRunFromPackage.
             // TODO: revisit whether this flex consumption path should return false when in placeholder mode? Thats how it appears to work for other SKUs.
             if (_environment.IsFlexConsumptionSku())
+            {
+                isScmRunFromPackage = false;
+                return true;
+            }
+
+            // Functions on Container Apps always have a read-only filesystem
+            if (_environment.IsManagedAppEnvironment())
             {
                 isScmRunFromPackage = false;
                 return true;

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -305,7 +305,7 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
-        /// Gets a value indicating whether the application is running in Managed App environment.
+        /// Gets a value indicating whether the application is running in Managed App environment (Azure Container Apps environment).
         /// </summary>
         /// <param name="environment">The environment to verify.</param>
         /// <returns><see cref="true"/> if running in Managed App environment; otherwise, false.</returns>

--- a/test/WebJobs.Script.Tests/Configuration/ScriptApplicationHostOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ScriptApplicationHostOptionsSetupTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -106,6 +106,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         {
             var environment = new TestEnvironment();
             environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, ScriptConstants.FlexConsumptionSku);
+
+            ScriptApplicationHostOptions options = new ScriptApplicationHostOptions();
+            ConfiguredOptions(options, inStandbyMode: false, environment);
+
+            Assert.Equal(options.IsFileSystemReadOnly, true);
+        }
+
+        [Fact]
+        public void IsFileSystemReadOnly_AlwaysAppliesForContainerAppsEnvironment()
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.ManagedEnvironment, "true");
 
             ScriptApplicationHostOptions options = new ScriptApplicationHostOptions();
             ConfiguredOptions(options, inStandbyMode: false, environment);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
Set IsFileSystemReadOnly to true by default for Functions on Container Apps to prevent unintended file system behaviours

resolves #11337

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
