### PR TITLE
Add config to disable console logging in Functions on ACA

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/KubernetesEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/KubernetesEventGenerator.cs
@@ -15,19 +15,21 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         private const int MaxDetailsLength = 10000;
         private readonly Action<string> _writeEvent;
 
-        public KubernetesEventGenerator(IOptions<ConsoleLoggingOptions> consoleLoggingOptions, Action<string> writeEvent = null)
+        public KubernetesEventGenerator(IOptions<ConsoleLoggingOptions> consoleLoggingOptions)
         {
-            if (writeEvent != null)
+            var opts = consoleLoggingOptions.Value;
+
+            if (opts.LoggingDisabled)
             {
-                _writeEvent = writeEvent;
+                _writeEvent = _ => { };
             }
-            else if (consoleLoggingOptions.Value.LoggingDisabled)
+            else if (opts.CustomWriterEnabled)
             {
-                _writeEvent = (string s) => { };
+                _writeEvent = opts.Writer.WriteLine;
             }
             else
             {
-                _writeEvent = ConsoleWriter;
+                _writeEvent = Console.WriteLine;
             }
         }
 
@@ -113,11 +115,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             azMonEvent.Add("Properties", NormalizeString(properties.Replace("'", string.Empty)));
 
             _writeEvent(azMonEvent.ToString(Formatting.None));
-        }
-
-        private void ConsoleWriter(string evt)
-        {
-            Console.WriteLine(evt);
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/KubernetesEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/KubernetesEventGenerator.cs
@@ -17,13 +17,17 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public KubernetesEventGenerator(IOptions<ConsoleLoggingOptions> consoleLoggingOptions, Action<string> writeEvent = null)
         {
-            if (consoleLoggingOptions.Value.LoggingDisabled)
+            if (writeEvent != null)
+            {
+                _writeEvent = writeEvent;
+            }
+            else if (consoleLoggingOptions.Value.LoggingDisabled)
             {
                 _writeEvent = (string s) => { };
             }
             else
             {
-                _writeEvent = writeEvent ?? ConsoleWriter;
+                _writeEvent = ConsoleWriter;
             }
         }
 

--- a/src/WebJobs.Script.WebHost/Diagnostics/KubernetesEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/KubernetesEventGenerator.cs
@@ -17,13 +17,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public KubernetesEventGenerator(IOptions<ConsoleLoggingOptions> consoleLoggingOptions)
         {
-            var opts = consoleLoggingOptions.Value;
-
-            _writeEvent = opts.LoggingDisabled
-                ? _ => { }
-                : opts.CustomWriterEnabled
-                    ? opts.Writer.WriteLine
-                    : Console.WriteLine;
+            _writeEvent = consoleLoggingOptions.Value.LoggingDisabled
+                ? _ => { } // no-op
+                : consoleLoggingOptions.Value.Writer.WriteLine;
         }
 
         public override void LogFunctionTraceEvent(LogLevel level, string subscriptionId, string appName, string functionName, string eventName, string source, string details, string summary, string exceptionType, string exceptionMessage, string functionInvocationId, string hostInstanceId, string activityId, string runtimeSiteName, string slotName, DateTime eventTimestamp)

--- a/src/WebJobs.Script.WebHost/Diagnostics/KubernetesEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/KubernetesEventGenerator.cs
@@ -1,8 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -13,9 +15,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         private const int MaxDetailsLength = 10000;
         private readonly Action<string> _writeEvent;
 
-        public KubernetesEventGenerator(Action<string> writeEvent = null)
+        public KubernetesEventGenerator(IOptions<ConsoleLoggingOptions> consoleLoggingOptions, Action<string> writeEvent = null)
         {
-            _writeEvent = writeEvent ?? ConsoleWriter;
+            if (consoleLoggingOptions.Value.LoggingDisabled)
+            {
+                _writeEvent = (string s) => { };
+            }
+            else
+            {
+                _writeEvent = writeEvent ?? ConsoleWriter;
+            }
         }
 
         public override void LogFunctionTraceEvent(LogLevel level, string subscriptionId, string appName, string functionName, string eventName, string source, string details, string summary, string exceptionType, string exceptionMessage, string functionInvocationId, string hostInstanceId, string activityId, string runtimeSiteName, string slotName, DateTime eventTimestamp)

--- a/src/WebJobs.Script.WebHost/Diagnostics/KubernetesEventGenerator.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/KubernetesEventGenerator.cs
@@ -19,18 +19,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         {
             var opts = consoleLoggingOptions.Value;
 
-            if (opts.LoggingDisabled)
-            {
-                _writeEvent = _ => { };
-            }
-            else if (opts.CustomWriterEnabled)
-            {
-                _writeEvent = opts.Writer.WriteLine;
-            }
-            else
-            {
-                _writeEvent = Console.WriteLine;
-            }
+            _writeEvent = opts.LoggingDisabled
+                ? _ => { }
+                : opts.CustomWriterEnabled
+                    ? opts.Writer.WriteLine
+                    : Console.WriteLine;
         }
 
         public override void LogFunctionTraceEvent(LogLevel level, string subscriptionId, string appName, string functionName, string eventName, string source, string details, string summary, string exceptionType, string exceptionMessage, string functionInvocationId, string hostInstanceId, string activityId, string runtimeSiteName, string slotName, DateTime eventTimestamp)

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -129,7 +129,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 }
                 else if (environment.IsAnyKubernetesEnvironment())
                 {
-                    return new KubernetesEventGenerator();
+                    var consoleLoggingOptions = p.GetService<IOptions<ConsoleLoggingOptions>>();
+                    return new KubernetesEventGenerator(consoleLoggingOptions);
                 }
                 else
                 {

--- a/src/WebJobs.Script/Config/ConsoleLoggingOptions.cs
+++ b/src/WebJobs.Script/Config/ConsoleLoggingOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -19,6 +19,9 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         public bool BufferEnabled { get; set; } = true;
 
         public int BufferSize { get; set; } = DefaultBufferSize;
+
+        // primarily for KubernetesEventGenerator unit tests to enable the custom Writer
+        public bool CustomWriterEnabled { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the <see cref="TextWriter"/> to write logs to.

--- a/src/WebJobs.Script/Config/ConsoleLoggingOptions.cs
+++ b/src/WebJobs.Script/Config/ConsoleLoggingOptions.cs
@@ -20,12 +20,8 @@ namespace Microsoft.Azure.WebJobs.Script.Config
 
         public int BufferSize { get; set; } = DefaultBufferSize;
 
-        // primarily for KubernetesEventGenerator unit tests to enable the custom Writer
-        public bool CustomWriterEnabled { get; set; } = false;
-
         /// <summary>
         /// Gets or sets the <see cref="TextWriter"/> to write logs to.
-        /// IMPORTANT: this is primarily for unit tests to redirect logs to a different writer.
         /// </summary>
         internal TextWriter Writer { get; set; } = Console.Out;
     }

--- a/test/WebJobs.Script.Tests/Diagnostics/KubernetesEventGeneratorTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/KubernetesEventGeneratorTests.cs
@@ -129,7 +129,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         {
             ConsoleLoggingOptions options = new()
             {
-                CustomWriterEnabled = true,
                 Writer = _writer
             };
 

--- a/test/WebJobs.Script.Tests/Diagnostics/KubernetesEventGeneratorTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/KubernetesEventGeneratorTests.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
@@ -13,34 +13,42 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
 {
-    public class KubernetesEventGeneratorTests
+    public sealed class KubernetesEventGeneratorTests : IDisposable
     {
-        private readonly KubernetesEventGenerator _generator;
-        private readonly List<string> _events;
+        private readonly StringWriter _writer = new();
 
-        public KubernetesEventGeneratorTests()
+        public void Dispose()
         {
-            _events = new List<string>();
-            Action<string> writer = (s) =>
-            {
-                _events.Add(s);
-            };
+            _writer.Dispose();
+        }
 
-            _generator = new KubernetesEventGenerator(Options.Create(new ConsoleLoggingOptions()), writer);
+        [Theory]
+        [MemberData(nameof(LinuxEventGeneratorTestData.GetLogEvents), MemberType = typeof(LinuxEventGeneratorTestData))]
+        public void LoggingDisabled(LogLevel level, string subscriptionId, string appName, string functionName, string eventName, string source, string details, string summary, string exceptionType, string exceptionMessage, string functionInvocationId, string hostInstanceId, string activityId, string runtimeSiteName, string slotName)
+        {
+            var options = CreateLoggingOptions(consoleDisabled: true);
+            var generator = new KubernetesEventGenerator(options);
+
+            generator.LogFunctionTraceEvent(level, subscriptionId, appName, functionName, eventName, source, details, summary, exceptionType, exceptionMessage, functionInvocationId, hostInstanceId, activityId, runtimeSiteName, slotName, DateTime.UtcNow);
+
+            string output = _writer.ToString().Trim();
+
+            Assert.True(string.IsNullOrEmpty(output));
         }
 
         [Theory]
         [MemberData(nameof(LinuxEventGeneratorTestData.GetLogEvents), MemberType = typeof(LinuxEventGeneratorTestData))]
         public void ParseLogEvents(LogLevel level, string subscriptionId, string appName, string functionName, string eventName, string source, string details, string summary, string exceptionType, string exceptionMessage, string functionInvocationId, string hostInstanceId, string activityId, string runtimeSiteName, string slotName)
         {
-            _generator.LogFunctionTraceEvent(level, subscriptionId, appName, functionName, eventName, source, details, summary, exceptionType, exceptionMessage, functionInvocationId, hostInstanceId, activityId, runtimeSiteName, slotName, DateTime.UtcNow);
+            var options = CreateLoggingOptions(consoleDisabled: false);
+            var generator = new KubernetesEventGenerator(options);
 
-            string evt = _events.Single();
-            var jObject = JObject.Parse(evt);
+            generator.LogFunctionTraceEvent(level, subscriptionId, appName, functionName, eventName, source, details, summary, exceptionType, exceptionMessage, functionInvocationId, hostInstanceId, activityId, runtimeSiteName, slotName, DateTime.UtcNow);
+
+            string output = _writer.ToString().Trim();
+            var jObject = JObject.Parse(output);
 
             Assert.Equal(18, jObject.Properties().Count());
-
-            DateTime dt;
             Assert.Collection(jObject.Properties(),
                 p => Assert.Equal(ScriptConstants.LinuxLogEventStreamName, p.Value),
                 p => Assert.Equal((int)LinuxEventGenerator.ToEventLevel(level), int.Parse(p.Value.ToString())),
@@ -52,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
                 p => Assert.Equal(LinuxEventGenerator.NormalizeString(details, addEnclosingQuotes: false), p.Value.ToString()),
                 p => Assert.Equal(LinuxEventGenerator.NormalizeString(summary, addEnclosingQuotes: false), p.Value.ToString()),
                 p => Assert.Equal(ScriptHost.Version, p.Value),
-                p => Assert.True(DateTime.TryParse(p.Value.ToString(), out dt)),
+                p => Assert.True(DateTime.TryParse(p.Value.ToString(), out DateTime dt)),
                 p => Assert.Equal(exceptionType, p.Value.ToString()),
                 p => Assert.Equal(LinuxEventGenerator.NormalizeString(exceptionMessage, addEnclosingQuotes: false), p.Value.ToString()),
                 p => Assert.Equal(functionInvocationId, p.Value.ToString()),
@@ -66,14 +74,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         [MemberData(nameof(LinuxEventGeneratorTestData.GetMetricEvents), MemberType = typeof(LinuxEventGeneratorTestData))]
         public void ParseMetricEvents(string subscriptionId, string appName, string functionName, string eventName, long average, long minimum, long maximum, long count, string data, string runtimeSiteName, string slotName)
         {
-            _generator.LogFunctionMetricEvent(subscriptionId, appName, functionName, eventName, average, minimum, maximum, count, DateTime.Now, data, runtimeSiteName, slotName);
+            var options = CreateLoggingOptions(consoleDisabled: false);
+            var generator = new KubernetesEventGenerator(options);
 
-            string evt = _events.Single();
-            var jObject = JObject.Parse(evt);
+            generator.LogFunctionMetricEvent(subscriptionId, appName, functionName, eventName, average, minimum, maximum, count, DateTime.Now, data, runtimeSiteName, slotName);
+
+            string output = _writer.ToString().Trim();
+            var jObject = JObject.Parse(output);
 
             Assert.Equal(14, jObject.Properties().Count());
 
-            DateTime dt;
             Assert.Collection(jObject.Properties(),
                 p => Assert.Equal(ScriptConstants.LinuxMetricEventStreamName, p.Value),
                 p => Assert.Equal(subscriptionId, p.Value),
@@ -85,7 +95,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
                 p => Assert.Equal(maximum, long.Parse(p.Value.ToString())),
                 p => Assert.Equal(count, long.Parse(p.Value.ToString())),
                 p => Assert.Equal(ScriptHost.Version, p.Value),
-                p => Assert.True(DateTime.TryParse(p.Value.ToString(), out dt)),
+                p => Assert.True(DateTime.TryParse(p.Value.ToString(), out DateTime dt)),
                 p => Assert.Equal(LinuxEventGenerator.NormalizeString(data), p.Value),
                 p => Assert.Equal(runtimeSiteName, p.Value),
                 p => Assert.Equal(slotName, p.Value));
@@ -95,10 +105,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
         [MemberData(nameof(LinuxEventGeneratorTestData.GetAzureMonitorEvents), MemberType = typeof(LinuxEventGeneratorTestData))]
         public void ParseAzureMonitoringEvents(LogLevel level, string resourceId, string operationName, string category, string regionName, string properties)
         {
-            _generator.LogAzureMonitorDiagnosticLogEvent(level, resourceId, operationName, category, regionName, properties);
+            var options = CreateLoggingOptions(consoleDisabled: false);
+            var generator = new KubernetesEventGenerator(options);
 
-            string evt = _events.Single();
-            var jObject = JObject.Parse(evt);
+            generator.LogAzureMonitorDiagnosticLogEvent(level, resourceId, operationName, category, regionName, properties);
+
+            string output = _writer.ToString().Trim();
+            var jObject = JObject.Parse(output);
 
             Assert.Equal(7, jObject.Properties().Count());
 
@@ -110,6 +123,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
                 p => Assert.Equal(category, p.Value),
                 p => Assert.Equal(regionName, p.Value),
                 p => Assert.Equal(LinuxEventGenerator.NormalizeString(properties), p.Value));
+        }
+
+        private IOptions<ConsoleLoggingOptions> CreateLoggingOptions(bool? consoleDisabled = null)
+        {
+            ConsoleLoggingOptions options = new()
+            {
+                CustomWriterEnabled = true,
+                Writer = _writer
+            };
+
+            if (consoleDisabled.HasValue)
+            {
+                options.LoggingDisabled = consoleDisabled.Value;
+            }
+
+            return Options.Create(options);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Diagnostics/KubernetesEventGeneratorTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/KubernetesEventGeneratorTests.cs
@@ -1,11 +1,13 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -24,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
                 _events.Add(s);
             };
 
-            _generator = new KubernetesEventGenerator(writer);
+            _generator = new KubernetesEventGenerator(Options.Create(new ConsoleLoggingOptions()), writer);
         }
 
         [Theory]

--- a/test/WebJobs.Script.Tests/Diagnostics/KubernetesEventGeneratorTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/KubernetesEventGeneratorTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
                 p => Assert.Equal(LinuxEventGenerator.NormalizeString(details, addEnclosingQuotes: false), p.Value.ToString()),
                 p => Assert.Equal(LinuxEventGenerator.NormalizeString(summary, addEnclosingQuotes: false), p.Value.ToString()),
                 p => Assert.Equal(ScriptHost.Version, p.Value),
-                p => Assert.True(DateTime.TryParse(p.Value.ToString(), out DateTime dt)),
+                p => Assert.True(DateTime.TryParse(p.Value.ToString(), out _)),
                 p => Assert.Equal(exceptionType, p.Value.ToString()),
                 p => Assert.Equal(LinuxEventGenerator.NormalizeString(exceptionMessage, addEnclosingQuotes: false), p.Value.ToString()),
                 p => Assert.Equal(functionInvocationId, p.Value.ToString()),
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics
                 p => Assert.Equal(maximum, long.Parse(p.Value.ToString())),
                 p => Assert.Equal(count, long.Parse(p.Value.ToString())),
                 p => Assert.Equal(ScriptHost.Version, p.Value),
-                p => Assert.True(DateTime.TryParse(p.Value.ToString(), out DateTime dt)),
+                p => Assert.True(DateTime.TryParse(p.Value.ToString(), out _)),
                 p => Assert.Equal(LinuxEventGenerator.NormalizeString(data), p.Value),
                 p => Assert.Equal(runtimeSiteName, p.Value),
                 p => Assert.Equal(slotName, p.Value));


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR
resolves #11339

Honour `consoleLoggingOptions.Value.LoggingDisabled` config in `KubernetesEventGenerator`. Similar change present in `LinuxContainerEventGenerator` 
https://github.com/Azure/azure-functions-host/blob/e92314d7610acbb495f672068069c9ce855d8819/src/WebJobs.Script.WebHost/Diagnostics/LinuxContainerEventGenerator.cs#L26-L29


### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
