### PR TITLE
Updated code to disable Host v3 logs by default and allow enabling them via hosting config 

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,4 +3,5 @@
 - My change description (#PR)
 -->
 - Updating logic to disable Host V3 logs to allow logs to flow to App Insights and Logic Apps (#11245)
+- Updated code to disable Host v3 logs by default and allow enabling them via hosting config (#11348)
 *Please note we have reached end-of-life (EOL) support for v3.x.* For more information on supported runtime versions, please see [here.](https://learn.microsoft.com/en-us/azure/azure-functions/functions-versions?tabs=v4&pivots=programming-language-csharp)

--- a/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
+++ b/src/WebJobs.Script/Config/FunctionsHostingConfigOptions.cs
@@ -86,18 +86,18 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether non-critical logs should be disabled in the host.
+        /// Gets or sets a value indicating whether non-critical logs should be enabled in the host.
         /// </summary>
-        public bool RestrictHostLogs
+        public bool HostLogsEnabled
         {
             get
             {
-                return GetFeatureOrDefault(ScriptConstants.HostingConfigRestrictHostLogs, "0") == "1";
+                return GetFeatureOrDefault(ScriptConstants.HostingConfigHostLogsEnabled, "0") == "1";
             }
 
             set
             {
-                _features[ScriptConstants.HostingConfigRestrictHostLogs] = value ? "1" : "0";
+                _features[ScriptConstants.HostingConfigHostLogsEnabled] = value ? "1" : "0";
             }
         }
 

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FeatureFlagEnableHostLogs = "EnableHostLogs";
         public const string HostingConfigSwtAuthenticationEnabled = "SwtAuthenticationEnabled";
         public const string HostingConfigSwtIssuerEnabled = "SwtIssuerEnabled";
-        public const string HostingConfigRestrictHostLogs = "RestrictHostLogs";
+        public const string HostingConfigHostLogsEnabled = "EnableHostLogs";
 
         public const string SiteAzureFunctionsUriFormat = "https://{0}.azurewebsites.net/azurefunctions";
         public const string ScmSiteUriFormat = "https://{0}.scm.azurewebsites.net";

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -737,12 +737,7 @@ namespace Microsoft.Azure.WebJobs.Script
 
         internal static ImmutableArray<string> GetAllowedLogCategoryPrefixes(IEnvironment environment, IOptionsMonitor<FunctionsHostingConfigOptions> hostingConfigOptions)
         {
-            if (hostingConfigOptions.CurrentValue is null)
-            {
-                return ScriptConstants.SystemLogCategoryPrefixes;
-            }
-
-            bool enableHostLogs = FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableHostLogs, environment) || !hostingConfigOptions.CurrentValue.RestrictHostLogs;
+            bool enableHostLogs = FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableHostLogs, environment) || hostingConfigOptions.CurrentValue.HostLogsEnabled;
 
             return enableHostLogs ? ScriptConstants.SystemLogCategoryPrefixes : ScriptConstants.RestrictedSystemLogCategoryPrefixes;
         }

--- a/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
+++ b/test/WebJobs.Script.Tests/Configuration/FunctionsHostingConfigOptionsTest.cs
@@ -136,20 +136,28 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         }
 
         [Fact]
-        public void RestrictHostLogs_ReturnsExpectedValue()
+        public void EnableHostLogs_ReturnsExpectedValue()
         {
             FunctionsHostingConfigOptions options = new FunctionsHostingConfigOptions();
 
             // defaults to false
-            Assert.False(options.RestrictHostLogs);
+            Assert.False(options.HostLogsEnabled);
 
             // returns true when explicitly enabled
-            options.Features[ScriptConstants.HostingConfigRestrictHostLogs] = "1";
-            Assert.True(options.RestrictHostLogs);
+            options.Features[ScriptConstants.HostingConfigHostLogsEnabled] = "1";
+            Assert.True(options.HostLogsEnabled);
 
             // returns false when disabled
-            options.Features[ScriptConstants.HostingConfigRestrictHostLogs] = "0";
-            Assert.False(options.RestrictHostLogs);
+            options.Features[ScriptConstants.HostingConfigHostLogsEnabled] = "0";
+            Assert.False(options.HostLogsEnabled);
+
+            // returns false when disabled
+            options.Features[ScriptConstants.HostingConfigHostLogsEnabled] = null;
+            Assert.False(options.HostLogsEnabled);
+
+            // returns false when disabled
+            options.Features[ScriptConstants.HostingConfigHostLogsEnabled] = "test";
+            Assert.False(options.HostLogsEnabled);
         }
 
         internal static IHostBuilder GetScriptHostBuilder(string fileName, string fileContent, IEnvironment environment = null)

--- a/test/WebJobs.Script.Tests/Eventing/SystemLoggerProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Eventing/SystemLoggerProviderTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _debugStateProvider = new Mock<IDebugStateProvider>(MockBehavior.Strict);
             _debugStateProvider.Setup(p => p.InDiagnosticMode).Returns(() => _inDiagnosticMode);
 
-            var hostingConfigOptions = new FunctionsHostingConfigOptions { RestrictHostLogs = false };
+            var hostingConfigOptions = new FunctionsHostingConfigOptions { HostLogsEnabled = true };
             var factory = new TestOptionsFactory<FunctionsHostingConfigOptions>(hostingConfigOptions);
             var source = new TestChangeTokenSource<FunctionsHostingConfigOptions>();
             _optionsMonitor = new OptionsMonitor<FunctionsHostingConfigOptions>(factory, new[] { source }, factory);

--- a/test/WebJobs.Script.Tests/UtilityTests.cs
+++ b/test/WebJobs.Script.Tests/UtilityTests.cs
@@ -873,10 +873,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
-        [InlineData(false, false, true)] // RestrictHostLogs is false, FeatureFlag is not set, should result in unrestricted logs. This is the default behaviour of the host.
-        [InlineData(false, true, true)] // RestrictHostLogs is false, FeatureFlag is set, should result in unrestricted logs.
-        [InlineData(true, true, true)] // RestrictHostLogs is true, FeatureFlag is set, should result in unrestricted logs.
-        [InlineData(true, false, false)] // RestrictHostLogs is true, FeatureFlag is not set, should result in **restricted** logs.
+        [InlineData(false, false, false)] // HostLogsEnabled is false, FeatureFlag is not set, should result in **restricted** logs. This is the default behaviour of the host.
+        [InlineData(false, true, true)] // HostLogsEnabled is false, FeatureFlag is set, should result in unrestricted logs.
+        [InlineData(true, true, true)] // HostLogsEnabled is true, FeatureFlag is set, should result in unrestricted logs.
+        [InlineData(true, false, true)] // HostLogsEnabled is true, FeatureFlag is not set, should result in unrestricted logs.
         public void GetAllowedLogCategoryPrefixes_Returns_Expected(bool enableHostingConfig, bool enableHostLogs, bool systemLogCategoryPrefixes)
         {
             var environment = new TestEnvironment();
@@ -888,7 +888,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var hostingConfigOptions = new FunctionsHostingConfigOptions();
             if (enableHostingConfig)
             {
-                hostingConfigOptions = new FunctionsHostingConfigOptions { RestrictHostLogs = enableHostingConfig };
+                hostingConfigOptions = new FunctionsHostingConfigOptions { HostLogsEnabled = enableHostingConfig };
             }
 
             var factory = new TestOptionsFactory<FunctionsHostingConfigOptions>(hostingConfigOptions);


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #11312

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
