### PR TITLE
Improvements to specialization simulation. 

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -18,3 +18,4 @@
 - Bug fix that fails in-flight invocations when a worker channel shuts down (#11159)
 - Adds WebHost and ScriptHost health checks. (#11341, #11183, #11178, #11173, #11161)
 - Update Node.js Worker Version to [3.12.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.12.0)
+- Improvements to specialization simulation (#11349)

--- a/src/WebJobs.Script.WebHost/Middleware/SpecializationSimulatorMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/SpecializationSimulatorMiddleware.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
                     var scriptRootForSpecialization = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsScriptRootForSpecializationSimulation);
                     if (string.IsNullOrWhiteSpace(scriptRootForSpecialization))
                     {
-                        const string error = $"Invalid script root. Provide the function function app payload location via {EnvironmentSettingNames.AzureWebJobsScriptRootForSpecializationSimulation} environment variable";
+                        const string error = $"Invalid script root. Provide the function app payload location via {EnvironmentSettingNames.AzureWebJobsScriptRootForSpecializationSimulation} environment variable";
                         throw new InvalidOperationException(error);
                     }
 

--- a/src/WebJobs.Script.WebHost/Middleware/SpecializationSimulatorMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/SpecializationSimulatorMiddleware.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -35,13 +35,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
 
                 if (Interlocked.Exchange(ref _specializationDone, 1) == 0)
                 {
-                    var scriptRoot = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsScriptRoot);
-                    if (string.IsNullOrWhiteSpace(scriptRoot))
+                    var scriptRootForSpecialization = _environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsScriptRootForSpecializationSimulation);
+                    if (string.IsNullOrWhiteSpace(scriptRootForSpecialization))
                     {
-                        const string error = $"Invalid script root. Provide the function function app payload location via {EnvironmentSettingNames.AzureWebJobsScriptRoot} environment variable";
+                        const string error = $"Invalid script root. Provide the function function app payload location via {EnvironmentSettingNames.AzureWebJobsScriptRootForSpecializationSimulation} environment variable";
                         throw new InvalidOperationException(error);
                     }
 
+                    _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsScriptRoot, scriptRootForSpecialization);
                     _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteUsePlaceholderDotNetIsolated, "1");
                     _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
                     _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 namespace Microsoft.Azure.WebJobs.Script
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string InitializedFromPlaceholder = "INITIALIZED_FROM_PLACEHOLDER";
         public const string AzureWebsiteHomePath = "HOME";
         public const string AzureWebJobsScriptRoot = "AzureWebJobsScriptRoot";
+        public const string AzureWebJobsScriptRootForSpecializationSimulation = "SpecializationSimulationAzureWebJobsScriptRoot";
         public const string CompilationReleaseMode = "AzureWebJobsDotNetReleaseCompilation";
         public const string AzureWebJobsDisableHomepage = "AzureWebJobsDisableHomepage";
         public const string TypeScriptCompilerPath = "AzureWebJobs_TypeScriptPath";


### PR DESCRIPTION
Improvements to specialization simulation. The new version will use `SpecializationSimulationAzureWebJobsScriptRoot` environment variable value and set that to `AzureWebJobsScriptRoot` only when specialization happens.

Here is an example launchsettings with the environment variables to use when simulating placeholder and specialization flow.

```
{
  "profiles": {
    "WebJobs.Script.WebHost": {
      "commandName": "Project",
      "launchBrowser": true,
      "environmentVariables": {
        "AzureWebJobsScriptRootForSpecialization":  "C:\\apps\\HelloHttpNet9",
        "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
        "AZURE_FUNCTIONS_ENVIRONMENT": "Development"
      },
      "applicationUrl": "http://localhost:5000"
    }
  }
}
```

Previously, we relied on `AzureWebJobsScriptRoot` for this flow (see example below). While this worked for our main cold start request scenario, its presence even in placeholder mode caused certain code paths to behave differently. We’re correcting that behavior now.

```
{
  "profiles": {
    "WebJobs.Script.WebHost": {
      "commandName": "Project",
      "launchBrowser": true,
      "environmentVariables": {
        "AzureWebJobsScriptRoot": "C:\\apps\\HelloHttpNet9",
        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
        "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
      },
      "applicationUrl": "http://localhost:5000"
    }
  }
}
```
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ x Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
