### PR TITLE
Remove unofficial pivot on host.official pipeline

### DIFF
--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -59,7 +59,6 @@ extends:
       - template: /eng/ci/templates/official/jobs/build-artifacts-windows.yml@self
       - template: /eng/ci/templates/official/jobs/build-artifacts-linux.yml@self
 
-    # tests are always ran for official branches
     - stage: Test
       dependsOn: ''
 

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -1,17 +1,3 @@
-parameters:
-- name: forceOfficial # this is used for testing the official CI from non-official branches.
-  displayName: Use official templates for non-official branches
-  type: boolean
-  default: false
-- name: runTests
-  displayName: Run tests (ignored for official branches)
-  type: boolean
-  default: true
-- name: signFiles
-  displayName: Sign files (ignored for official branches)
-  type: boolean
-  default: false
-
 trigger:
   batch: true
   branches:
@@ -48,19 +34,9 @@ resources:
 variables:
 - template: /eng/ci/templates/variables/build.yml@self
 - template: /ci/variables/cfs.yml@eng
-- name: OfficialBranch
-  value: ${{ or(eq(variables['Build.SourceBranch'], 'refs/heads/dev'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/internal/release/')) }}
-- name: SignFiles # variable for access in other templates
-  value: ${{ or(eq(variables.OfficialBranch, true), eq(parameters.signFiles, true)) }}
-- name: '1ESTemplate'
-  # force official to be true if an official branch. Otherwise respect the official parameter.
-  ${{ if or(eq(variables.OfficialBranch, true), eq(parameters.forceOfficial, true)) }}:
-    value: 'v1/1ES.Official.PipelineTemplate.yml@1es'
-  ${{ else }}:
-    value: 'v1/1ES.Unofficial.PipelineTemplate.yml@1es'
 
 extends:
-  template: ${{ variables['1ESTemplate'] }}
+  template: v1/1ES.Official.PipelineTemplate.yml@1es
   parameters:
     pool:
       name: 1es-pool-azfunc
@@ -85,7 +61,6 @@ extends:
 
     # tests are always ran for official branches
     - stage: Test
-      condition: ${{ or(eq(variables.OfficialBranch, true), eq(parameters.runTests, true)) }}
       dependsOn: ''
 
       jobs:

--- a/eng/ci/templates/official/jobs/build-artifacts-windows.yml
+++ b/eng/ci/templates/official/jobs/build-artifacts-windows.yml
@@ -53,13 +53,12 @@ jobs:
         **/ExtensionsMetadataGenerator.csproj
         **/WebJobs.Script.Abstractions.csproj
 
-  - ${{ if eq(variables.SignFiles, true) }}:
-    - template: ci/sign-files.yml@eng
-      parameters:
-        displayName: Sign Abstractions assemblies
-        folderPath: out/bin/WebJobs.Script.Abstractions/release
-        pattern: Microsoft.Azure.WebJobs.Script.Abstractions*.dll
-        signType: dll
+  - template: ci/sign-files.yml@eng
+    parameters:
+      displayName: Sign Abstractions assemblies
+      folderPath: out/bin/WebJobs.Script.Abstractions/release
+      pattern: Microsoft.Azure.WebJobs.Script.Abstractions*.dll
+      signType: dll
 
   - task: DotNetCoreCLI@2
     displayName: Pack Abstractions
@@ -70,13 +69,12 @@ jobs:
       projects: |
         **/WebJobs.Script.Abstractions.csproj
 
-  - ${{ if eq(variables.SignFiles, true) }}:
-    - template: ci/sign-files.yml@eng
-      parameters:
-        displayName: Sign ExtensionsMetadataGenerator assemblies
-        folderPath: out/bin/ExtensionsMetadataGenerator
-        pattern: Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator*.dll
-        signType: dll-strong-name
+  - template: ci/sign-files.yml@eng
+    parameters:
+      displayName: Sign ExtensionsMetadataGenerator assemblies
+      folderPath: out/bin/ExtensionsMetadataGenerator
+      pattern: Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator*.dll
+      signType: dll-strong-name
 
   - task: DotNetCoreCLI@2
     displayName: Pack ExtensionsMetadataGenerator
@@ -87,20 +85,19 @@ jobs:
       projects: |
         **/ExtensionsMetadataGenerator.csproj
 
-  - ${{ if eq(variables.SignFiles, true) }}:
-    - template: ci/sign-files.yml@eng
-      parameters:
-        displayName: Sign NugetPackages
-        folderPath: $(nuget_package_path)
-        pattern: '*.nupkg'
-        signType: nuget
+  - template: ci/sign-files.yml@eng
+    parameters:
+      displayName: Sign NugetPackages
+      folderPath: $(nuget_package_path)
+      pattern: '*.nupkg'
+      signType: nuget
 
-    - task: DeleteFiles@1
-      displayName: Delete CodeSignSummary files
-      inputs:
-        contents: '**/CodeSignSummary-*.md'
+  - task: DeleteFiles@1
+    displayName: Delete CodeSignSummary files
+    inputs:
+      contents: '**/CodeSignSummary-*.md'
 
-    - task: DeleteFiles@1
-      displayName: Delete CodeSignSummary files
-      inputs:
-        contents: '$(nuget_package_path)/**/CodeSignSummary-*.md'
+  - task: DeleteFiles@1
+    displayName: Delete CodeSignSummary files
+    inputs:
+      contents: '$(nuget_package_path)/**/CodeSignSummary-*.md'


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Undoes some previous host.official pipeline changes that were meant to speed up testing. 1ES has requirements now we only use official template on these pipelines (which makes the unofficial template serve what purpose?)
