### PR TITLE
Added support for MCP custom handler preview on Flex

### DIFF
--- a/WebJobs.Script.sln
+++ b/WebJobs.Script.sln
@@ -65,6 +65,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebJobsStartupTests", "test
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebJobs.Script.Tests.Shared", "test\WebJobs.Script.Tests.Shared\WebJobs.Script.Tests.Shared.csproj", "{6C6ABC17-1262-4AD8-8CDA-AF6819EF60EE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DotNetCustomHandler", "test\Resources\TestProjects\DotNetCustomHandler\DotNetCustomHandler.csproj", "{276857C1-88C8-994D-593E-AE6FA9B14556}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -145,6 +147,10 @@ Global
 		{6C6ABC17-1262-4AD8-8CDA-AF6819EF60EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6C6ABC17-1262-4AD8-8CDA-AF6819EF60EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6C6ABC17-1262-4AD8-8CDA-AF6819EF60EE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{276857C1-88C8-994D-593E-AE6FA9B14556}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{276857C1-88C8-994D-593E-AE6FA9B14556}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{276857C1-88C8-994D-593E-AE6FA9B14556}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{276857C1-88C8-994D-593E-AE6FA9B14556}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -171,6 +177,7 @@ Global
 		{98B2CC4A-33EB-4310-B08D-3DB58630E981} = {B2312621-6D0A-429F-9A45-06B45CE69691}
 		{3746E49F-DD26-4CBD-B961-0ADF6EA84909} = {B2312621-6D0A-429F-9A45-06B45CE69691}
 		{6C6ABC17-1262-4AD8-8CDA-AF6819EF60EE} = {AFB0F5F7-A612-4F4A-94DD-8B69CABF7970}
+		{276857C1-88C8-994D-593E-AE6FA9B14556} = {B2312621-6D0A-429F-9A45-06B45CE69691}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {85400884-5FFD-4C27-A571-58CB3C8CAAC5}

--- a/release_notes.md
+++ b/release_notes.md
@@ -18,3 +18,4 @@
 - Bug fix that fails in-flight invocations when a worker channel shuts down (#11159)
 - Adds WebHost and ScriptHost health checks. (#11341, #11183, #11178, #11173, #11161)
 - Update Node.js Worker Version to [3.12.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.12.0)
+- Added support for MCP custom handler. (#11355)

--- a/src/WebJobs.Script.WebHost/Standby/StandbyManager.cs
+++ b/src/WebJobs.Script.WebHost/Standby/StandbyManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -6,8 +6,8 @@ using System.IO;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Properties;
@@ -91,6 +91,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             // Go async immediately to ensure that any async context from
             // the PlaceholderSpecializationMiddleware is properly suppressed.
             await Task.Yield();
+
+            ApplyMcpCustomHandlerSettings();
 
             _logger.LogInformation(Resources.HostSpecializationTrace);
 
@@ -181,6 +183,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                         _semaphore.Release();
                     }
                 }
+            }
+        }
+
+        private void ApplyMcpCustomHandlerSettings()
+        {
+            // For Flex Consumption SKU: if MCP custom handler preview is enabled, set worker runtime env to "custom".
+            if (_environment.IsFlexConsumptionSku() && FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableMcpCustomHandlerPreview, _environment))
+            {
+                _environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, "custom");
+                _logger.LogInformation("MCP custom handler preview is enabled. Setting {envVar} to 'custom'", EnvironmentSettingNames.FunctionWorkerRuntime);
             }
         }
 

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FeatureFlagStrictHISModeWarn = "StrictHISModeWarn";
         public const string FeatureFlagEnableOrderedInvocationmessages = "EnableOrderedInvocationMessages";
         public const string FeatureFlagEnableResponseCompression = "EnableResponseCompression";
+        public const string FeatureFlagEnableMcpCustomHandlerPreview = "EnableMcpCustomHandlerPreview";
         public const string FeatureFlagDisableOrderedInvocationMessages = "DisableOrderedInvocationMessages";
         public const string FeatureFlagEnableAzureMonitorTimeIsoFormat = "EnableAzureMonitorTimeIsoFormat";
         public const string FeatureFlagEnableTestDataSuppression = "EnableTestDataSuppression";

--- a/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -126,6 +126,14 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public async Task SpecializeAsync()
         {
             _logger.LogInformation("Starting language worker channel specialization");
+
+            // For Flex Consumption SKU: if MCP custom handler preview is enabled, set worker runtime env to "custom".
+            if (_environment.IsFlexConsumptionSku() && FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableMcpCustomHandlerPreview, _environment))
+            {
+                _environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, "custom");
+                _logger.LogInformation("MCP custom handler preview is enabled. Setting {envVar} to 'custom'", EnvironmentSettingNames.FunctionWorkerRuntime);
+            }
+
             _workerRuntime = _environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime);
 
             IRpcWorkerChannel rpcWorkerChannel = await GetChannelAsync(_workerRuntime);

--- a/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -127,13 +127,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         {
             _logger.LogInformation("Starting language worker channel specialization");
 
-            // For Flex Consumption SKU: if MCP custom handler preview is enabled, set worker runtime env to "custom".
-            if (_environment.IsFlexConsumptionSku() && FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagEnableMcpCustomHandlerPreview, _environment))
-            {
-                _environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, "custom");
-                _logger.LogInformation("MCP custom handler preview is enabled. Setting {envVar} to 'custom'", EnvironmentSettingNames.FunctionWorkerRuntime);
-            }
-
             _workerRuntime = _environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime);
 
             IRpcWorkerChannel rpcWorkerChannel = await GetChannelAsync(_workerRuntime);

--- a/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script/Workers/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -126,7 +126,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         public async Task SpecializeAsync()
         {
             _logger.LogInformation("Starting language worker channel specialization");
-
             _workerRuntime = _environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime);
 
             IRpcWorkerChannel rpcWorkerChannel = await GetChannelAsync(_workerRuntime);

--- a/test/Resources/TestProjects/DotNetCustomHandler/DotNetCustomHandler.csproj
+++ b/test/Resources/TestProjects/DotNetCustomHandler/DotNetCustomHandler.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+</Project>

--- a/test/Resources/TestProjects/DotNetCustomHandler/DotNetCustomHandler.csproj
+++ b/test/Resources/TestProjects/DotNetCustomHandler/DotNetCustomHandler.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
+        <PublishAot>true</PublishAot>
     </PropertyGroup>
 
 </Project>

--- a/test/Resources/TestProjects/DotNetCustomHandler/Program.cs
+++ b/test/Resources/TestProjects/DotNetCustomHandler/Program.cs
@@ -1,19 +1,11 @@
-var builder = WebApplication.CreateBuilder(args);
+var app = WebApplication.CreateBuilder(args).Build();
 
-var app = builder.Build();
+var port = Environment.GetEnvironmentVariable("FUNCTIONS_CUSTOMHANDLER_PORT")
+           ?? throw new InvalidOperationException("FUNCTIONS_CUSTOMHANDLER_PORT environment variable is not set.");
 
-app.MapGet("/api/SimpleHttpTrigger", (HttpContext context) => "Hello from .NET custom handler");
+app.Urls.Add($"http://localhost:{port}");
 
-var customHandlerPort = Environment.GetEnvironmentVariable("FUNCTIONS_CUSTOMHANDLER_PORT");
-if (!string.IsNullOrEmpty(customHandlerPort))
-{
-    Console.WriteLine($"FUNCTIONS_CUSTOMHANDLER_PORT: {customHandlerPort}");
-    app.Urls.Add($"http://localhost:{customHandlerPort}");
-}
-else
-{
-    throw new InvalidOperationException("FUNCTIONS_CUSTOMHANDLER_PORT environment variable is not set.");
-}
+app.MapGet("/api/SimpleHttpTrigger", () => "Hello from .NET custom handler");
 
-Console.WriteLine($".NET server Listening...on FUNCTIONS_CUSTOMHANDLER_PORT: {customHandlerPort}");
-app.Run();
+Console.WriteLine($".NET server listening on FUNCTIONS_CUSTOMHANDLER_PORT: {port}");
+await app.RunAsync();

--- a/test/Resources/TestProjects/DotNetCustomHandler/Program.cs
+++ b/test/Resources/TestProjects/DotNetCustomHandler/Program.cs
@@ -1,0 +1,19 @@
+var builder = WebApplication.CreateBuilder(args);
+
+var app = builder.Build();
+
+app.MapGet("/api/SimpleHttpTrigger", (HttpContext context) => "Hello from .NET custom handler");
+
+var customHandlerPort = Environment.GetEnvironmentVariable("FUNCTIONS_CUSTOMHANDLER_PORT");
+if (!string.IsNullOrEmpty(customHandlerPort))
+{
+    Console.WriteLine($"FUNCTIONS_CUSTOMHANDLER_PORT: {customHandlerPort}");
+    app.Urls.Add($"http://localhost:{customHandlerPort}");
+}
+else
+{
+    throw new InvalidOperationException("FUNCTIONS_CUSTOMHANDLER_PORT environment variable is not set.");
+}
+
+Console.WriteLine($".NET server Listening...on FUNCTIONS_CUSTOMHANDLER_PORT: {customHandlerPort}");
+app.Run();

--- a/test/Resources/TestProjects/DotNetCustomHandler/SimpleHttpTrigger/function.json
+++ b/test/Resources/TestProjects/DotNetCustomHandler/SimpleHttpTrigger/function.json
@@ -1,0 +1,19 @@
+{
+  "bindings": [
+    {
+      "type": "httpTrigger",
+      "direction": "in",
+      "authLevel": "anonymous",
+      "name": "req",
+      "methods": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/test/Resources/TestProjects/DotNetCustomHandler/host.json
+++ b/test/Resources/TestProjects/DotNetCustomHandler/host.json
@@ -8,6 +8,6 @@
     "description": {
       "defaultExecutablePath": "DotNetCustomHandler.exe"
     },
-    "enableForwardingHttpRequest": true
+    "enableProxyingHttpRequest": true
   }
 }

--- a/test/Resources/TestProjects/DotNetCustomHandler/host.json
+++ b/test/Resources/TestProjects/DotNetCustomHandler/host.json
@@ -1,0 +1,13 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  },
+  "customHandler": {
+    "description": {
+      "defaultExecutablePath": "DotNetCustomHandler.exe"
+    },
+    "enableForwardingHttpRequest": true
+  }
+}

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -810,7 +810,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [InlineData(ScriptConstants.DynamicSku, ScriptConstants.FeatureFlagEnableMcpCustomHandlerPreview, false)]
         [InlineData(ScriptConstants.DynamicSku, $"Feature1,{ScriptConstants.FeatureFlagEnableMcpCustomHandlerPreview}", false)]
         [InlineData(ScriptConstants.ElasticPremiumSku, null, false)]
-        [InlineData(ScriptConstants.ElasticPremiumSku, $"Feature1,{ScriptConstants.FeatureFlagEnableMcpCustomHandlerPreview}", true)]
+        [InlineData(ScriptConstants.ElasticPremiumSku, $"Feature1,{ScriptConstants.FeatureFlagEnableMcpCustomHandlerPreview}", false)]
         [InlineData("", null, false)]
         public async Task Specialization_FlexSku_McpPreview_SetsWorkerRuntimeToCustom(string websiteSku, string featureFlags, bool isExpectedToResetWorkerRuntime)
         {

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -1,16 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Runtime;
-using System.Threading;
-using System.Threading.Tasks;
 using Azure.Storage.Blobs;
 using Azure.Storage.Sas;
 using Microsoft.ApplicationInsights.Channel;
@@ -35,6 +25,16 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Runtime;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 using IApplicationLifetime = Microsoft.AspNetCore.Hosting.IApplicationLifetime;
@@ -54,6 +54,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         private static readonly string _dotnetIsolated60Path = Path.GetFullPath($@"..\..\DotNetIsolated60\{TestHelpers.BuildConfig}");
         private static readonly string _dotnetIsolatedUnsuppportedPath = Path.GetFullPath($@"..\..\DotNetIsolatedUnsupportedWorker\{TestHelpers.BuildConfig}");
         private static readonly string _dotnetIsolatedEmptyScriptRoot = Path.GetFullPath(@"..\..\..\..\EmptyScriptRoot");
+        private static readonly string _dotnetCustomHandlerPath = Path.GetFullPath($@"..\..\DotNetCustomHandler\{TestHelpers.BuildConfig}");
 
         private static Action<IServiceCollection> _customizeScriptHostServices;
 
@@ -800,10 +801,60 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
         }
 
+        [Theory]
+        [InlineData(ScriptConstants.FlexConsumptionSku)]
+        [InlineData(ScriptConstants.DynamicSku)]
+        [InlineData(ScriptConstants.ElasticPremiumSku)]
+        [InlineData("")]
+        public async Task Specialization_FlexSku_McpPreview_SetsWorkerRuntimeToCustom(string websiteSku)
+        {
+            var environmentVariables = new Dictionary<string, string>
+            {
+                { EnvironmentSettingNames.AzureWebsiteSku, websiteSku }
+            };
+            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetCustomHandlerPath, functions: "SimpleHttpTrigger", environmentVariables: environmentVariables);
+
+            using var testServer = new TestServer(builder);
+            var client = testServer.CreateClient();
+            var response = await client.GetAsync("api/warmup");
+            response.EnsureSuccessStatusCode();
+
+            // Validate that the channel is set up with native worker
+            var webChannelManager = testServer.Services.GetService<IWebHostRpcWorkerChannelManager>();
+            //var channel = await webChannelManager.GetChannels("python").FirstOrDefault().Value.Task;
+            var placeholderChannel = await webChannelManager.GetChannels("dotnet-isolated").Single().Value.Task;
+            Assert.Contains("FunctionsNetHost.exe", placeholderChannel.WorkerProcess.Process.StartInfo.FileName);
+            Assert.NotNull(placeholderChannel.WorkerProcess.Process.Id);
+
+            // Simulate specialization of custom handler payload with MCP CustomHandlerPreview enabled
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagEnableMcpCustomHandlerPreview);
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+
+            response = await client.GetAsync("api/SimpleHttpTrigger");
+            response.EnsureSuccessStatusCode();
+
+            var log = _loggerProvider.GetLog();
+
+            if (string.Equals(websiteSku, ScriptConstants.FlexConsumptionSku, StringComparison.OrdinalIgnoreCase))
+            {
+                // Verify expected logs when running the custom handler executable.
+                Assert.Contains("MCP custom handler preview is enabled. Setting FUNCTIONS_WORKER_RUNTIME to 'custom'", log);
+                Assert.Contains("Mapped function route 'api/SimpleHttpTrigger'", log);
+            }
+            else
+            {
+                Assert.DoesNotContain("MCP custom handler preview is enabled. Setting FUNCTIONS_WORKER_RUNTIME to 'custom'", log);
+            }
+
+            // Ensure the original placeholder channel was not used.
+            Assert.DoesNotContain("UsePlaceholderDotNetIsolated: True", log);
+        }
+
         [Fact]
         public async Task DotNetIsolated_PlaceholderHit()
         {
-            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, "HttpRequestDataFunction");
+            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, functions: "HttpRequestDataFunction");
 
             using var testServer = new TestServer(builder);
 
@@ -845,7 +896,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [InlineData("", null)]
         public async Task ResponseCompressionWorksAfterSpecialization(string acceptEncodingRequestHeaderValue, string expectedContentEncodingResponseHeaderValue)
         {
-            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, "HttpRequestDataFunction");
+            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, functions: "HttpRequestDataFunction");
 
             using var testServer = new TestServer(builder);
 
@@ -865,7 +916,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
-            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags , ScriptConstants.FeatureFlagEnableResponseCompression);
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagEnableResponseCompression);
 
             response = await client.GetAsync("api/HttpRequestDataFunction");
             response.EnsureSuccessStatusCode();
@@ -918,7 +969,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             // This test ensures that capabilities are correctly applied in EnvironmentReload during
             // specialization
-            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, "HttpRequestFunction");
+            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, functions: "HttpRequestFunction");
 
             using var testServer = new TestServer(builder);
 
@@ -1052,7 +1103,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             await queue.CreateIfNotExistsAsync();
             await queue.ClearAsync();
 
-            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, "HttpRequestDataFunction", "QueueFunction");
+            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, functions: ["HttpRequestDataFunction", "QueueFunction"]);
 
             using var testServer = new TestServer(builder);
 
@@ -1128,7 +1179,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 s.AddSingleton<ILoggerProvider>(testLoggerProvider);
             };
 
-            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, "HttpRequestDataFunction", "QueueFunction");
+            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, functions: ["HttpRequestDataFunction", "QueueFunction"]);
             var storageValue = TestHelpers.GetTestConfiguration().GetWebJobsConnectionString("AzureWebJobsStorage");
 
             using var testServer = new TestServer(builder);
@@ -1167,7 +1218,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         private async Task DotNetIsolatedPlaceholderMiss(string scriptRootPath, Action additionalSpecializedSetup = null)
         {
-            var builder = InitializeDotNetIsolatedPlaceholderBuilder(scriptRootPath, "HttpRequestDataFunction");
+            var builder = InitializeDotNetIsolatedPlaceholderBuilder(scriptRootPath, functions: "HttpRequestDataFunction");
 
             // remove WEBSITE_USE_PLACEHOLDER_DOTNETISOLATED
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteUsePlaceholderDotNetIsolated, null);
@@ -1215,12 +1266,37 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
         }
 
-        private IWebHostBuilder InitializeDotNetIsolatedPlaceholderBuilder(string scriptRootPath, params string[] functions)
+        private IWebHostBuilder InitializeDotNetIsolatedPlaceholderBuilder(string scriptRootPath, Dictionary<string, string> environmentVariables = null, params string[] functions)
         {
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, "dotnet-isolated");
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteUsePlaceholderDotNetIsolated, "1");
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagEnableWorkerIndexing);
             _environment.SetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName, "6.0");
+
+            if (environmentVariables is not null)
+            {
+                foreach (var kvp in environmentVariables)
+                {
+                    _environment.SetEnvironmentVariable(kvp.Key, kvp.Value);
+                }
+            }
+
+            var builder = CreateStandbyHostBuilder(functions);
+
+            builder.ConfigureAppConfiguration(config =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { _scriptRootConfigPath, scriptRootPath },
+                });
+            });
+
+            return builder;
+        }
+
+        private IWebHostBuilder InitializePythonPlaceholderBuilder(string scriptRootPath, params string[] functions)
+        {
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, "python");
 
             var builder = CreateStandbyHostBuilder(functions);
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -812,7 +812,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 { EnvironmentSettingNames.AzureWebsiteSku, websiteSku }
             };
-            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetCustomHandlerPath, functions: "SimpleHttpTrigger", environmentVariables: environmentVariables);
+            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetCustomHandlerPath, environmentVariables, "SimpleHttpTrigger");
 
             using var testServer = new TestServer(builder);
             var client = testServer.CreateClient();
@@ -845,15 +845,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 Assert.DoesNotContain("MCP custom handler preview is enabled. Setting FUNCTIONS_WORKER_RUNTIME to 'custom'", log);
             }
-
-            // Ensure the original placeholder channel was not used.
-            Assert.DoesNotContain("UsePlaceholderDotNetIsolated: True", log);
         }
 
         [Fact]
         public async Task DotNetIsolated_PlaceholderHit()
         {
-            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, functions: "HttpRequestDataFunction");
+            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, "HttpRequestDataFunction");
 
             using var testServer = new TestServer(builder);
 
@@ -895,7 +892,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [InlineData("", null)]
         public async Task ResponseCompressionWorksAfterSpecialization(string acceptEncodingRequestHeaderValue, string expectedContentEncodingResponseHeaderValue)
         {
-            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, functions: "HttpRequestDataFunction");
+            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, "HttpRequestDataFunction");
 
             using var testServer = new TestServer(builder);
 
@@ -968,7 +965,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             // This test ensures that capabilities are correctly applied in EnvironmentReload during
             // specialization
-            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, functions: "HttpRequestFunction");
+            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, "HttpRequestFunction");
 
             using var testServer = new TestServer(builder);
 
@@ -1102,7 +1099,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             await queue.CreateIfNotExistsAsync();
             await queue.ClearAsync();
 
-            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, functions: ["HttpRequestDataFunction", "QueueFunction"]);
+            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, "HttpRequestDataFunction", "QueueFunction");
 
             using var testServer = new TestServer(builder);
 
@@ -1178,7 +1175,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 s.AddSingleton<ILoggerProvider>(testLoggerProvider);
             };
 
-            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, functions: ["HttpRequestDataFunction", "QueueFunction"]);
+            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, "HttpRequestDataFunction", "QueueFunction");
             var storageValue = TestHelpers.GetTestConfiguration().GetWebJobsConnectionString("AzureWebJobsStorage");
 
             using var testServer = new TestServer(builder);
@@ -1217,7 +1214,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         private async Task DotNetIsolatedPlaceholderMiss(string scriptRootPath, Action additionalSpecializedSetup = null)
         {
-            var builder = InitializeDotNetIsolatedPlaceholderBuilder(scriptRootPath, functions: "HttpRequestDataFunction");
+            var builder = InitializeDotNetIsolatedPlaceholderBuilder(scriptRootPath, "HttpRequestDataFunction");
 
             // remove WEBSITE_USE_PLACEHOLDER_DOTNETISOLATED
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteUsePlaceholderDotNetIsolated, null);
@@ -1265,7 +1262,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
         }
 
-        private IWebHostBuilder InitializeDotNetIsolatedPlaceholderBuilder(string scriptRootPath, Dictionary<string, string> environmentVariables = null, params string[] functions)
+        private IWebHostBuilder InitializeDotNetIsolatedPlaceholderBuilder(string scriptRootPath, params string[] functions)
+        {
+            return InitializeDotNetIsolatedPlaceholderBuilder(scriptRootPath, null, functions);
+        }
+
+        private IWebHostBuilder InitializeDotNetIsolatedPlaceholderBuilder(string scriptRootPath, Dictionary<string, string> environmentVariables, params string[] functions)
         {
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, "dotnet-isolated");
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteUsePlaceholderDotNetIsolated, "1");
@@ -1274,9 +1276,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             if (environmentVariables is not null)
             {
-                foreach (var entry in environmentVariables)
+                foreach (var (key, value) in environmentVariables)
                 {
-                    _environment.SetEnvironmentVariable(entry.Key, entry.Value);
+                    _environment.SetEnvironmentVariable(key, value);
                 }
             }
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -821,7 +821,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             // Validate that the channel is set up with native worker
             var webChannelManager = testServer.Services.GetService<IWebHostRpcWorkerChannelManager>();
-            //var channel = await webChannelManager.GetChannels("python").FirstOrDefault().Value.Task;
             var placeholderChannel = await webChannelManager.GetChannels("dotnet-isolated").Single().Value.Task;
             Assert.Contains("FunctionsNetHost.exe", placeholderChannel.WorkerProcess.Process.StartInfo.FileName);
             Assert.NotNull(placeholderChannel.WorkerProcess.Process.Id);
@@ -1275,9 +1274,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             if (environmentVariables is not null)
             {
-                foreach (var kvp in environmentVariables)
+                foreach (var entry in environmentVariables)
                 {
-                    _environment.SetEnvironmentVariable(kvp.Key, kvp.Value);
+                    _environment.SetEnvironmentVariable(entry.Key, entry.Value);
                 }
             }
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -1,6 +1,15 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Runtime;
+using System.Threading;
+using System.Threading.Tasks;
 using Azure.Storage.Blobs;
 using Azure.Storage.Sas;
 using Microsoft.ApplicationInsights.Channel;
@@ -25,16 +34,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Runtime;
-using System.Threading;
-using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 using IApplicationLifetime = Microsoft.AspNetCore.Hosting.IApplicationLifetime;

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -802,11 +802,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
-        [InlineData(ScriptConstants.FlexConsumptionSku)]
-        [InlineData(ScriptConstants.DynamicSku)]
-        [InlineData(ScriptConstants.ElasticPremiumSku)]
-        [InlineData("")]
-        public async Task Specialization_FlexSku_McpPreview_SetsWorkerRuntimeToCustom(string websiteSku)
+        [InlineData(ScriptConstants.FlexConsumptionSku, ScriptConstants.FeatureFlagEnableMcpCustomHandlerPreview, true)]
+        [InlineData(ScriptConstants.FlexConsumptionSku, $"Feature1,{ScriptConstants.FeatureFlagEnableMcpCustomHandlerPreview}", true)]
+        [InlineData(ScriptConstants.FlexConsumptionSku, "Feature1", false)]
+        [InlineData(ScriptConstants.FlexConsumptionSku, null, false)]
+        [InlineData(ScriptConstants.DynamicSku, null, false)]
+        [InlineData(ScriptConstants.DynamicSku, ScriptConstants.FeatureFlagEnableMcpCustomHandlerPreview, false)]
+        [InlineData(ScriptConstants.DynamicSku, $"Feature1,{ScriptConstants.FeatureFlagEnableMcpCustomHandlerPreview}", false)]
+        [InlineData(ScriptConstants.ElasticPremiumSku, null, false)]
+        [InlineData(ScriptConstants.ElasticPremiumSku, $"Feature1,{ScriptConstants.FeatureFlagEnableMcpCustomHandlerPreview}", true)]
+        [InlineData("", null, false)]
+        public async Task Specialization_FlexSku_McpPreview_SetsWorkerRuntimeToCustom(string websiteSku, string featureFlags, bool isExpectedToResetWorkerRuntime)
         {
             var environmentVariables = new Dictionary<string, string>
             {
@@ -825,8 +831,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Contains("FunctionsNetHost.exe", placeholderChannel.WorkerProcess.Process.StartInfo.FileName);
             Assert.NotNull(placeholderChannel.WorkerProcess.Process.Id);
 
-            // Simulate specialization of custom handler payload with MCP CustomHandlerPreview enabled
-            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagEnableMcpCustomHandlerPreview);
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, featureFlags);
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
 
@@ -835,7 +840,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             var log = _loggerProvider.GetLog();
 
-            if (string.Equals(websiteSku, ScriptConstants.FlexConsumptionSku, StringComparison.OrdinalIgnoreCase))
+            if (isExpectedToResetWorkerRuntime)
             {
                 // Verify expected logs when running the custom handler executable.
                 Assert.Contains("MCP custom handler preview is enabled. Setting FUNCTIONS_WORKER_RUNTIME to 'custom'", log);

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -1294,23 +1294,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             return builder;
         }
 
-        private IWebHostBuilder InitializePythonPlaceholderBuilder(string scriptRootPath, params string[] functions)
-        {
-            _environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, "python");
-
-            var builder = CreateStandbyHostBuilder(functions);
-
-            builder.ConfigureAppConfiguration(config =>
-            {
-                config.AddInMemoryCollection(new Dictionary<string, string>
-                {
-                    { _scriptRootConfigPath, scriptRootPath },
-                });
-            });
-
-            return builder;
-        }
-
         private IWebHostBuilder CreateStandbyHostBuilder(params string[] functions)
         {
             var builder = Program.CreateWebHostBuilder()

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;


### PR DESCRIPTION
Added support for MCP custom handler preview on Flex. The change will look for the feature flag "EnableMcpCustomHandlerPreview" and if present, it will overwrite the functions worker runtime environment setting value to "custom".

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
