### PR TITLE
Upload host linux artifacts as .tar.gz to preserve file permissions

### DIFF
--- a/eng/ci/templates/official/jobs/build-artifacts-linux.yml
+++ b/eng/ci/templates/official/jobs/build-artifacts-linux.yml
@@ -6,6 +6,7 @@ jobs:
     project: src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
     configuration: release
     runtime: linux-x64
+    intermediate_path: $(Agent.TempDirectory)/linux_host
     drop_path: $(Build.ArtifactStagingDirectory)
     linux_drop_path: $(drop_path)/linux
     build_args: '-v m -c $(configuration) -r $(runtime) --self-contained true'
@@ -58,4 +59,15 @@ jobs:
       zipAfterPublish: false # we use our own zip logic
       modifyOutputPath: false
       projects: $(project)
-      arguments: '$(build_args) --no-build -o $(linux_drop_path)/host'
+      arguments: '$(build_args) --no-build -o $(intermediate_path)'
+
+  # Pipeline artifacts do not retain file metadata and lose file permission bits.
+  # As a workaround, we tar/gzip the files to retain the permission bits.
+  - task: ArchiveFiles@2
+    displayName: Archive Linux Artifacts
+    inputs:
+      rootFolderOrFile: $(intermediate_path)
+      includeRootFolder: false
+      archiveType: tar
+      tarCompression: gz
+      archiveFile: $(linux_drop_path)/host.linux-x64.tar.gz


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves N/A

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR -- TODO
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Produces linux artifacts as a `.tar.gz` to preserve file permission data.
