### PR TITLE
Enabling Admin Isolation for Flex Consumption

### DIFF
--- a/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs
+++ b/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs
@@ -78,7 +78,8 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
         public static bool IsAppServiceInternalRequest(this HttpRequest request, IEnvironment environment = null)
         {
             environment = GetEnvironment(request, environment);
-            if (!environment.IsAppService())
+
+            if (!FrontEndRoutingEnsured(environment))
             {
                 return false;
             }
@@ -92,7 +93,8 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
         public static bool IsPlatformInternalRequest(this HttpRequest request, IEnvironment environment = null)
         {
             environment = GetEnvironment(request, environment);
-            if (!environment.IsAppService())
+
+            if (!FrontEndRoutingEnsured(environment))
             {
                 return false;
             }
@@ -100,6 +102,13 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
             var header = request.Headers[ScriptConstants.AntaresPlatformInternal];
             string value = header.FirstOrDefault();
             return string.Compare(value, "true", StringComparison.OrdinalIgnoreCase) == 0;
+        }
+
+        private static bool FrontEndRoutingEnsured(this IEnvironment environment)
+        {
+            // Verify we're running on a sku that ensures all requests go through the
+            // Antares Front End.
+            return environment.IsAppService() || environment.IsFlexConsumptionSku();
         }
 
         private static IEnvironment GetEnvironment(HttpRequest request, IEnvironment environment = null)

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
@@ -211,24 +211,31 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 
         [Theory]
         [Trait(TestTraits.Group, TestTraits.AdminIsolationTests)]
-        [InlineData("admin/host/status", true, true, false, false, true, HttpStatusCode.Forbidden)]
-        [InlineData("admin/host/status", true, true, true, false, false, HttpStatusCode.Unauthorized)]
-        [InlineData("admin/host/status", true, true, true, true, true, HttpStatusCode.OK)]
-        [InlineData("admin/host/status", true, false, false, false, true, HttpStatusCode.OK)]
-        [InlineData("admin/host/status", true, false, false, true, true, HttpStatusCode.OK)]
-        [InlineData("admin/host/status", true, true, true, false, true, HttpStatusCode.OK)]
-        [InlineData("admin/host/status", false, true, false, true, true, HttpStatusCode.Forbidden)]
-        [InlineData("admin/host/extensionBundle/v1/templates", true, true, false, true, false, HttpStatusCode.Unauthorized)]
-        [InlineData("admin/host/extensionBundle/v1/templates", true, true, true, false, true, HttpStatusCode.NotFound)]
-        [InlineData("admin/host/extensionBundle/v1/templates", true, false, false, false, true, HttpStatusCode.NotFound)]
-        [InlineData("admin/host/extensionBundle/v1/templates", true, true, false, true, true, HttpStatusCode.NotFound)]
-        [InlineData("admin/vfs/host.json", true, true, true, false, true, HttpStatusCode.OK)]
-        [InlineData("admin/vfs/host.json", true, true, false, false, true, HttpStatusCode.Unauthorized)]
-        [InlineData("admin/vfs/host.json", true, true, true, false, false, HttpStatusCode.Unauthorized)]
-        public async Task AdminIsolation_ReturnsExpectedStatus(string uri, bool isAppService, bool enableIsolation, bool isPlatformInternal, bool bypassFE, bool addAuthKey, HttpStatusCode expectedStatus)
+        [InlineData("admin/host/status", ScriptConstants.DynamicSku, "1", true, false, false, true, HttpStatusCode.Forbidden)]
+        [InlineData("admin/host/status", ScriptConstants.DynamicSku, "1", true, true, false, false, HttpStatusCode.Unauthorized)]
+        [InlineData("admin/host/status", ScriptConstants.DynamicSku, "1", true, true, true, true, HttpStatusCode.OK)]
+        [InlineData("admin/host/status", ScriptConstants.DynamicSku, "1", false, false, false, true, HttpStatusCode.OK)]
+        [InlineData("admin/host/status", ScriptConstants.DynamicSku, "1", false, false, true, true, HttpStatusCode.OK)]
+        [InlineData("admin/host/status", ScriptConstants.DynamicSku, "1", true, true, false, true, HttpStatusCode.OK)]
+        [InlineData("admin/host/status", ScriptConstants.DynamicSku, null, true, false, true, true, HttpStatusCode.Forbidden)]
+        [InlineData("admin/host/extensionBundle/v1/templates", ScriptConstants.DynamicSku, "1", true, false, true, false, HttpStatusCode.Unauthorized)]
+        [InlineData("admin/host/extensionBundle/v1/templates", ScriptConstants.DynamicSku, "1", true, true, false, true, HttpStatusCode.NotFound)]
+        [InlineData("admin/host/extensionBundle/v1/templates", ScriptConstants.DynamicSku, "1", false, false, false, true, HttpStatusCode.NotFound)]
+        [InlineData("admin/host/extensionBundle/v1/templates", ScriptConstants.DynamicSku, "1", true, false, true, true, HttpStatusCode.NotFound)]
+        [InlineData("admin/vfs/host.json", ScriptConstants.DynamicSku, "1", true, true, false, true, HttpStatusCode.OK)]
+        [InlineData("admin/vfs/host.json", ScriptConstants.DynamicSku, "1", true, false, false, true, HttpStatusCode.Unauthorized)]
+        [InlineData("admin/vfs/host.json", ScriptConstants.DynamicSku, "1", true, true, false, false, HttpStatusCode.Unauthorized)]
+        [InlineData("admin/host/status", ScriptConstants.FlexConsumptionSku, null, true, true, false, true, HttpStatusCode.OK)]
+        [InlineData("admin/host/status", ScriptConstants.FlexConsumptionSku, null, true, false, true, true, HttpStatusCode.OK)]
+        [InlineData("admin/host/status", ScriptConstants.FlexConsumptionSku, null, true, false, false, true, HttpStatusCode.Forbidden)]
+        [InlineData("admin/host/status", ScriptConstants.FlexConsumptionSku, null, true, false, true, false, HttpStatusCode.Unauthorized)]
+        public async Task AdminIsolation_ReturnsExpectedStatus(string uri, string sku, string websiteInstanceId, bool enableIsolation, bool isPlatformInternal, bool bypassFE, bool addAuthKey, HttpStatusCode expectedStatus)
         {
             var environment = this._fixture.Host.WebHostServices.GetService<IEnvironment>();
-            string websiteInstanceId = environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId);
+            string originalWebsiteInstanceId = environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId);
+
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, sku);
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, websiteInstanceId);
 
             try
             {
@@ -236,16 +243,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                 {
                     environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionsAdminIsolationEnabled, "1");
                     Assert.True(environment.IsAdminIsolationEnabled());
-                }
-
-                if (!isAppService)
-                {
-                    environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, null);
-                    Assert.False(environment.IsAppService());
-                }
-                else
-                {
-                    Assert.True(environment.IsAppService());
                 }
 
                 HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
@@ -274,7 +271,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             finally
             {
                 environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionsAdminIsolationEnabled, null);
-                environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, websiteInstanceId);
+                environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, originalWebsiteInstanceId);
             }
         }
 

--- a/test/WebJobs.Script.Tests/Extensions/HttpRequestExtensionsTest.cs
+++ b/test/WebJobs.Script.Tests/Extensions/HttpRequestExtensionsTest.cs
@@ -20,77 +20,73 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
 {
     public class HttpRequestExtensionsTest
     {
-        [Fact]
+        [Theory]
         [Trait(TestTraits.Group, TestTraits.AdminIsolationTests)]
-        public void IsPlatformInternalRequest_ReturnsExpectedResult()
+        [InlineData(ScriptConstants.DynamicSku, null, "True", false)]
+        [InlineData(ScriptConstants.DynamicSku, "1", "True", true)]
+        [InlineData(ScriptConstants.DynamicSku, "1", "true", true)]
+        [InlineData(ScriptConstants.DynamicSku, "1", "False", false)]
+        [InlineData(ScriptConstants.DynamicSku, "1", null, false)]
+        [InlineData(ScriptConstants.FlexConsumptionSku, null, "True", true)]
+        [InlineData(ScriptConstants.FlexConsumptionSku, null, null, false)]
+        public void IsPlatformInternalRequest_ReturnsExpectedResult(string sku, string websiteInstanceId, string platformInternalHeaderValue, bool expected)
         {
-            // not running under Azure
-            TestEnvironment testEnvironment = new TestEnvironment();
-            var request = HttpTestHelpers.CreateHttpRequest("GET", "http://foobar");
-            Assert.False(request.IsPlatformInternalRequest(testEnvironment));
-
-            // running under Azure
             var vars = new Dictionary<string, string>
             {
-                { EnvironmentSettingNames.AzureWebsiteInstanceId, "123" }
+                { EnvironmentSettingNames.AzureWebsiteInstanceId, websiteInstanceId },
+                { EnvironmentSettingNames.AzureWebsiteSku, sku }
             };
             using (var env = new TestScopedEnvironmentVariable(vars))
             {
                 var environment = SystemEnvironment.Instance;
-                Assert.True(environment.IsAppService());
 
                 var headers = new HeaderDictionary();
-                request = HttpTestHelpers.CreateHttpRequest("GET", "http://foobar", headers);
-                Assert.False(request.IsPlatformInternalRequest(testEnvironment));
+                headers.Add(ScriptConstants.AntaresPlatformInternal, platformInternalHeaderValue);
 
-                headers.Clear();
-                headers.Add(ScriptConstants.AntaresPlatformInternal, "False");
-                request = HttpTestHelpers.CreateHttpRequest("GET", "http://foobar", headers);
-                Assert.False(request.IsPlatformInternalRequest(environment));
+                // verify using explicit environment
+                var request = HttpTestHelpers.CreateHttpRequest("GET", "http://foobar", headers);
+                Assert.Equal(expected, request.IsPlatformInternalRequest(environment));
 
-                headers.Clear();
-                headers.Add(ScriptConstants.AntaresPlatformInternal, "True");
-                request = HttpTestHelpers.CreateHttpRequest("GET", "http://foobar", headers);
-                Assert.True(request.IsPlatformInternalRequest(environment));
-
-                headers.Clear();
-                headers.Add(ScriptConstants.AntaresPlatformInternal, "true");
-                request = HttpTestHelpers.CreateHttpRequest("GET", "http://foobar", headers);
-                Assert.True(request.IsPlatformInternalRequest(environment));
-
-                headers.Clear();
-                headers.Add(ScriptConstants.AntaresPlatformInternal, "True");
+                // verify using request services environment
                 request = HttpTestHelpers.CreateHttpRequest("GET", "http://foobar", headers);
                 var servicesMock = new Mock<IServiceProvider>();
                 servicesMock.Setup(s => s.GetService(typeof(IEnvironment))).Returns(environment);
                 request.HttpContext.RequestServices = servicesMock.Object;
-                Assert.True(request.IsPlatformInternalRequest());
+                Assert.Equal(expected, request.IsPlatformInternalRequest());
             }
         }
 
-        [Fact]
-        public void IsAppServiceInternalRequest_ReturnsExpectedResult()
+        [Theory]
+        [InlineData(ScriptConstants.DynamicSku, true, true, false)]
+        [InlineData(ScriptConstants.DynamicSku, true, false, true)]
+        [InlineData(ScriptConstants.DynamicSku, false, true, false)]
+        [InlineData(ScriptConstants.DynamicSku, false, false, false)]
+        [InlineData(ScriptConstants.FlexConsumptionSku, false, true, false)]
+        [InlineData(ScriptConstants.FlexConsumptionSku, false, false, true)]
+        public void IsAppServiceInternalRequest_ReturnsExpectedResult(string sku, bool includeWebsiteInstanceId, bool includeLogIdHeader, bool expected)
         {
-            // not running under Azure
             var request = HttpTestHelpers.CreateHttpRequest("GET", "http://foobar");
-            Assert.False(request.IsAppServiceInternalRequest());
 
-            // running under Azure
-            var vars = new Dictionary<string, string>
+            var vars = new Dictionary<string, string>();
+            vars.Add(EnvironmentSettingNames.AzureWebsiteSku, sku);
+            if (includeWebsiteInstanceId)
             {
-                { EnvironmentSettingNames.AzureWebsiteInstanceId, "123" }
-            };
+                // container running in App Service
+                vars.Add(EnvironmentSettingNames.AzureWebsiteInstanceId, "123");
+            }
+
             using (var env = new TestScopedEnvironmentVariable(vars))
             {
-                // with header
                 var headers = new HeaderDictionary();
-                headers.Add(ScriptConstants.AntaresLogIdHeaderName, "123");
+
+                if (includeLogIdHeader)
+                {
+                    // include the FE log id header
+                    headers.Add(ScriptConstants.AntaresLogIdHeaderName, "123");
+                }
 
                 request = HttpTestHelpers.CreateHttpRequest("GET", "http://foobar", headers);
-                Assert.False(request.IsAppServiceInternalRequest());
-
-                request = HttpTestHelpers.CreateHttpRequest("GET", "http://foobar");
-                Assert.True(request.IsAppServiceInternalRequest());
+                Assert.Equal(expected, request.IsAppServiceInternalRequest());
             }
         }
 


### PR DESCRIPTION
Work has already been done on the platform side to enable Admin Isolation to work on Flex. The right environment state is flowed to the container on specialization (FUNCTIONS_ADMIN_ISOLATION_ENABLED). The work remaining was to fix the "platform internal" environmental checks so they work in the Flex worker environment.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

