### PR TITLE
Removing bundles reference from default bundle creation

### DIFF
--- a/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/HostJsonFileConfigurationSource.cs
@@ -227,15 +227,15 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
                         // So a newly created function app from the portal would have no host.json. In that case we need to
                         // create a new function app with host.json that includes a matching extension bundle based on the app kind.
                         hostConfigObject = GetDefaultHostConfigObject();
-                        string bundleId = _configurationSource.Environment.IsLogicApp() ?
-                                            ScriptConstants.WorkFlowExtensionBundleId :
-                                            ScriptConstants.DefaultExtensionBundleId;
 
-                        string bundleVersion = _configurationSource.Environment.IsLogicApp() ?
-                                            ScriptConstants.LogicAppDefaultExtensionBundleVersion :
-                                            ScriptConstants.DefaultExtensionBundleVersion;
+                        // Add a default extension bundle for Logic Apps if one doesn't exist.
+                        if (_configurationSource.Environment.IsLogicApp())
+                        {
+                            hostConfigObject = TryAddBundleConfiguration(hostConfigObject,
+                                                                         ScriptConstants.WorkFlowExtensionBundleId,
+                                                                         ScriptConstants.LogicAppDefaultExtensionBundleVersion);
+                        }
 
-                        hostConfigObject = TryAddBundleConfiguration(hostConfigObject, bundleId, bundleVersion);
                         // Add bundle configuration if no file exists and file system is not read only
                         TryWriteHostJson(configFilePath, hostConfigObject);
                     }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->
Removing bundles reference from default bundle creation

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)


