### PR TITLE
Enabling worker indexing for Logic Apps app kind behind an enviornment setting

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -10,3 +10,4 @@
 - Avoid emitting empty tag values for health check metrics (#11393)
 - Functions host to take a customer specified port in Custom Handler scenario (#11408)
 - Updated to version 1.5.8 of Microsoft.Azure.AppService.Middleware.Functions (#11416)
+- Enabling worker indexing for Logic Apps app kind behind an enviornment setting

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -478,7 +478,7 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             if (!isMultiLanguageEnabled.HasValue)
             {
-                isMultiLanguageEnabled = environment.IsLogicApp();
+                isMultiLanguageEnabled = environment.IsLogicApp() && !environment.IsLogicAppCodefulModeEnabled();
             }
             return isMultiLanguageEnabled.Value;
         }

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -463,6 +463,15 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
+        /// Gets if codeful mode is enabled for Logic App app kind.
+        /// </summary>
+        public static bool IsLogicAppCodefulModeEnabled(this IEnvironment environment)
+        {
+            bool.TryParse(environment.GetEnvironmentVariable(EnvironmentSettingNames.LogicAppCodefulModeEnabled), out bool logicAppCodefulModeEnabled);
+            return logicAppCodefulModeEnabled;
+        }
+
+        /// <summary>
         /// Gets if runtime environment needs multi language.
         /// </summary>
         public static bool IsMultiLanguageRuntimeEnvironment(this IEnvironment environment)

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 namespace Microsoft.Azure.WebJobs.Script
@@ -154,6 +154,8 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AntaresComputerName = "COMPUTERNAME";
 
         public const string AppKind = "APP_KIND";
+
+        public const string LogicAppCodefulModeEnabled = "WORKFLOW_CODEFUL_ENABLED";
 
         public const string DrainOnApplicationStopping = "FUNCTIONS_ENABLE_DRAIN_ON_APP_STOPPING";
     }

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -804,6 +804,7 @@ namespace Microsoft.Azure.WebJobs.Script
             if (!cancellationToken.IsCancellationRequested)
             {
                 bool throwOnWorkerRuntimeAndPayloadMetadataMismatch = !(_environment.IsLogicApp() && _environment.IsLogicAppCodefulModeEnabled());
+
                 // this dotnet isolated specific logic is temporary to ensure in-proc payload compatibility with "dotnet-isolated" as the FUNCTIONS_WORKER_RUNTIME value.
                 if (string.Equals(workerRuntime, RpcWorkerConstants.DotNetIsolatedLanguageWorkerName, StringComparison.OrdinalIgnoreCase) && !_environment.IsPlaceholderModeEnabled())
                 {

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -803,7 +803,7 @@ namespace Microsoft.Azure.WebJobs.Script
             Collection<FunctionDescriptor> functionDescriptors = new Collection<FunctionDescriptor>();
             if (!cancellationToken.IsCancellationRequested)
             {
-                bool throwOnWorkerRuntimeAndPayloadMetadataMismatch = true;
+                bool throwOnWorkerRuntimeAndPayloadMetadataMismatch = !(_environment.IsLogicApp() && _environment.IsLogicAppCodefulModeEnabled());
                 // this dotnet isolated specific logic is temporary to ensure in-proc payload compatibility with "dotnet-isolated" as the FUNCTIONS_WORKER_RUNTIME value.
                 if (string.Equals(workerRuntime, RpcWorkerConstants.DotNetIsolatedLanguageWorkerName, StringComparison.OrdinalIgnoreCase) && !_environment.IsPlaceholderModeEnabled())
                 {

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -1034,7 +1034,7 @@ namespace Microsoft.Azure.WebJobs.Script
         // WORKER_INDEXING_DISABLED contains the customers app name worker indexing is then disabled for that customer only
         public static bool CanWorkerIndex(IEnumerable<RpcWorkerConfig> workerConfigs, IEnvironment environment, FunctionsHostingConfigOptions functionsHostingConfigOptions)
         {
-            // NOTE(apseth): Enabling the worker indexing for Logic Apps with codeful mode enabled.
+            // NOTE: Enabling the worker indexing for Logic Apps with codeful mode enabled.
             if (environment.IsLogicApp() && !environment.IsLogicAppCodefulModeEnabled())
             {
                 return false;

--- a/src/WebJobs.Script/Utility.cs
+++ b/src/WebJobs.Script/Utility.cs
@@ -1034,7 +1034,8 @@ namespace Microsoft.Azure.WebJobs.Script
         // WORKER_INDEXING_DISABLED contains the customers app name worker indexing is then disabled for that customer only
         public static bool CanWorkerIndex(IEnumerable<RpcWorkerConfig> workerConfigs, IEnvironment environment, FunctionsHostingConfigOptions functionsHostingConfigOptions)
         {
-            if (environment.IsLogicApp())
+            // NOTE(apseth): Enabling the worker indexing for Logic Apps with codeful mode enabled.
+            if (environment.IsLogicApp() && !environment.IsLogicAppCodefulModeEnabled())
             {
                 return false;
             }

--- a/test/WebJobs.Script.Tests/UtilityTests.cs
+++ b/test/WebJobs.Script.Tests/UtilityTests.cs
@@ -961,28 +961,29 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
-        [InlineData(true, true, true)]
-        [InlineData(true, false, false)]
-        public void WorkerIndexingDecisionLogic_LogicApps(bool workerIndexingFeatureFlag, bool enableIndexingForCodeful, bool expected)
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void WorkerIndexingDecisionLogic_LogicApps(bool enableIndexingForCodeful, bool expected)
         {
-            var testEnv = new TestEnvironment();
-            testEnv.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, RpcWorkerConstants.DotNetExecutableName);
-            testEnv.SetEnvironmentVariable(EnvironmentSettingNames.AppKind, ScriptConstants.WorkFlowAppKind);
-
-            if (workerIndexingFeatureFlag)
-            {
-                testEnv.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagEnableWorkerIndexing);
-            }
-
+            var environmentVariables = new Dictionary<string, string>
+                {
+                    { EnvironmentSettingNames.FunctionWorkerRuntime, RpcWorkerConstants.DotNetExecutableName },
+                    { EnvironmentSettingNames.AppKind, ScriptConstants.WorkFlowAppKind },
+                    { EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagEnableWorkerIndexing },
+                };
             if (enableIndexingForCodeful)
             {
-                testEnv.SetEnvironmentVariable(EnvironmentSettingNames.LogicAppCodefulModeEnabled, "true");
+                environmentVariables.Add(EnvironmentSettingNames.LogicAppCodefulModeEnabled, "true");
             }
+
+            var testEnv = new TestEnvironment(environmentVariables);
 
             RpcWorkerConfig workerConfig = new RpcWorkerConfig() { Description = TestHelpers.GetTestWorkerDescription("dotnet", "none", true) };
 
             bool workerShouldIndex = Utility.CanWorkerIndex(new List<RpcWorkerConfig>() { workerConfig }, testEnv, new FunctionsHostingConfigOptions());
             Assert.Equal(expected, workerShouldIndex);
+
+            testEnv.Clear();
         }
 
         [Theory]

--- a/test/WebJobs.Script.Tests/UtilityTests.cs
+++ b/test/WebJobs.Script.Tests/UtilityTests.cs
@@ -961,6 +961,31 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, false)]
+        public void WorkerIndexingDecisionLogic_LogicApps(bool workerIndexingFeatureFlag, bool enableIndexingForCodeful, bool expected)
+        {
+            var testEnv = new TestEnvironment();
+            testEnv.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, RpcWorkerConstants.DotNetExecutableName);
+            testEnv.SetEnvironmentVariable(EnvironmentSettingNames.AppKind, ScriptConstants.WorkFlowAppKind);
+
+            if (workerIndexingFeatureFlag)
+            {
+                testEnv.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagEnableWorkerIndexing);
+            }
+
+            if (enableIndexingForCodeful)
+            {
+                testEnv.SetEnvironmentVariable(EnvironmentSettingNames.LogicAppCodefulModeEnabled, "true");
+            }
+
+            RpcWorkerConfig workerConfig = new RpcWorkerConfig() { Description = TestHelpers.GetTestWorkerDescription("dotnet", "none", true) };
+
+            bool workerShouldIndex = Utility.CanWorkerIndex(new List<RpcWorkerConfig>() { workerConfig }, testEnv, new FunctionsHostingConfigOptions());
+            Assert.Equal(expected, workerShouldIndex);
+        }
+
+        [Theory]
         [InlineData(true, false)]
         [InlineData(false, false)]
         public void WorkerIndexingDecisionLogic_NullConfig(bool workerIndexingFeatureFlag, bool expected)


### PR DESCRIPTION
This is to enable worker indexing for Logic Apps workflow app kind behind an environment variable. The settings used by Logic Apps are "FUNCTIONS_INPROC_NET8_ENABLED": "1", "FUNCTIONS_WORKER_RUNTIME": "dotnet" and we are bringing up a "dotnet" worker.


resolves #11386

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: https://github.com/Azure/azure-functions-host/pull/11377
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
