### PR TITLE
Update healthcheck unhealthy log to use JSON

### DIFF
--- a/src/WebJobs.Script/Diagnostics/HealthChecks/TelemetryHealthCheckPublisher.cs
+++ b/src/WebJobs.Script/Diagnostics/HealthChecks/TelemetryHealthCheckPublisher.cs
@@ -1,12 +1,12 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
 using System.Linq;
-using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Script.Pools;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 
@@ -58,29 +58,15 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
             }
             else
             {
-                // Construct string showing list of all health entries status and description for logs
-                using PoolRental<StringBuilder> rental = PoolFactory.SharedStringBuilderPool.Rent();
-                string separator = string.Empty;
                 foreach (var entry in report.Entries)
                 {
                     if (entry.Value.Status != HealthStatus.Healthy)
                     {
                         _metrics.UnhealthyHealthCheck.Record(entry.Key, entry.Value, tag);
                     }
-
-                    rental.Value.Append(separator)
-                        .Append(entry.Key)
-                        .Append(": {")
-                        .Append("status: ")
-                        .Append(entry.Value.Status.ToString())
-                        .Append(", description: ")
-                        .Append(entry.Value.Description)
-                        .Append('}');
-
-                    separator = ", ";
                 }
 
-                Log.Unhealthy(_logger, tag, report.Status, rental.Value);
+                Log.Unhealthy(_logger, tag, report.Status, new HealthEntries(report));
             }
 
             _metrics.HealthCheckReport.Record(report, tag);
@@ -92,14 +78,60 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
             return entry.Tags.Contains(_options.Tag);
         }
 
-        internal static partial class Log
+        /// <summary>
+        /// Wraps the health report entries for logging purposes.
+        /// </summary>
+        /// <param name="report">The report to log.</param>
+        /// <remarks>
+        /// By wrapping in a struct, we delay performing JSON serialization
+        /// until this is actually being logged (and not when it is filtered out).
+        /// </remarks>
+        private readonly struct HealthEntries(HealthReport report)
+        {
+            private static readonly JsonSerializerOptions _options
+                = new() { Converters = { new HealthEntriesConverter() } };
+
+            public override string ToString()
+            {
+                // We use a JSON serializer here to ensure proper escaping of values.
+                return JsonSerializer.Serialize(report, _options);
+            }
+        }
+
+        private class HealthEntriesConverter : JsonConverter<HealthReport>
+        {
+            public override HealthReport Read(
+                ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Write(
+                Utf8JsonWriter writer, HealthReport value, JsonSerializerOptions options)
+            {
+                writer.WriteStartObject();
+
+                foreach ((string name, HealthReportEntry entry) in value.Entries)
+                {
+                    writer.WritePropertyName(name);
+                    writer.WriteStartObject();
+                    writer.WriteString("status", entry.Status.ToString());
+                    writer.WriteString("description", entry.Description);
+                    writer.WriteEndObject();
+                }
+
+                writer.WriteEndObject();
+            }
+        }
+
+        private static partial class Log
         {
             [LoggerMessage(0, LogLevel.Warning, "[Tag='{Tag}'] Process reporting unhealthy: {Status}. Health check entries are {Entries}")]
             public static partial void Unhealthy(
                 ILogger logger,
                 string tag,
                 HealthStatus status,
-                StringBuilder entries);
+                HealthEntries entries);
 
             [LoggerMessage(1, LogLevel.Debug, "[Tag='{Tag}'] Process reporting healthy: {Status}.")]
             public static partial void Healthy(

--- a/test/WebJobs.Script.Tests/Diagnostics/HealthChecks/TelemetryHealthCheckPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/HealthChecks/TelemetryHealthCheckPublisherTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -33,7 +33,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
                 CreateOptions(true, null),
                 [HealthStatus.Degraded],
                 1,
-                "Process reporting unhealthy: Degraded. Health check entries are id0: {status: Degraded, description: desc0}",
+                @"Process reporting unhealthy: Degraded. Health check entries are " +
+                @"{""id0"":{""status"":""Degraded"",""description"":""desc0""}}",
                 LogLevel.Warning,
                 0.5
             },
@@ -41,7 +42,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
                 CreateOptions(false, null),
                 [HealthStatus.Unhealthy],
                 1,
-                "Process reporting unhealthy: Unhealthy. Health check entries are id0: {status: Unhealthy, description: desc0}",
+                "Process reporting unhealthy: Unhealthy. Health check entries are "
+                + @"{""id0"":{""status"":""Unhealthy"",""description"":""desc0""}}",
                 LogLevel.Warning,
                 0
             },
@@ -57,7 +59,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
                 CreateOptions(true, null),
                 [HealthStatus.Healthy, HealthStatus.Unhealthy],
                 1,
-                "Process reporting unhealthy: Unhealthy. Health check entries are id0: {status: Healthy, description: desc0}, id1: {status: Unhealthy, description: desc1}",
+                "Process reporting unhealthy: Unhealthy. Health check entries are "
+                + @"{""id0"":{""status"":""Healthy"",""description"":""desc0""},""id1"":{""status"":""Unhealthy"",""description"":""desc1""}}",
                 LogLevel.Warning,
                 0
             },
@@ -65,7 +68,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
                 CreateOptions(true, null),
                 [HealthStatus.Healthy, (HealthStatus.Unhealthy, "some.tag")],
                 1,
-                "Process reporting unhealthy: Unhealthy. Health check entries are id0: {status: Healthy, description: desc0}, id1: {status: Unhealthy, description: desc1}",
+                "Process reporting unhealthy: Unhealthy. Health check entries are " +
+                @"{""id0"":{""status"":""Healthy"",""description"":""desc0""},""id1"":{""status"":""Unhealthy"",""description"":""desc1""}}",
                 LogLevel.Warning,
                 0
             },
@@ -74,7 +78,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
                 [HealthStatus.Healthy, (HealthStatus.Degraded, "some.tag"), HealthStatus.Unhealthy],
                 1,
                 "Process reporting unhealthy: Unhealthy. Health check entries are " +
-                "id0: {status: Healthy, description: desc0}, id1: {status: Degraded, description: desc1}, id2: {status: Unhealthy, description: desc2}",
+                @"{""id0"":{""status"":""Healthy"",""description"":""desc0""},""id1"":{""status"":""Degraded"",""description"":""desc1""},""id2"":{""status"":""Unhealthy"",""description"":""desc2""}}",
                 LogLevel.Warning,
                 0
             },
@@ -91,7 +95,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
                 [HealthStatus.Healthy, (HealthStatus.Degraded, "some.tag"), HealthStatus.Unhealthy],
                 1,
                 "Process reporting unhealthy: Degraded. Health check entries are " +
-                "id1: {status: Degraded, description: desc1}",
+                @"{""id1"":{""status"":""Degraded"",""description"":""desc1""}}",
                 LogLevel.Warning,
                 0.5
             },
@@ -100,7 +104,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
                 [(HealthStatus.Healthy, "some.tag"), (HealthStatus.Degraded, "some.tag"), (HealthStatus.Unhealthy, "some.other.tag"), (HealthStatus.Unhealthy, "some.tag")],
                 1,
                 "Process reporting unhealthy: Unhealthy. Health check entries are " +
-                "id0: {status: Healthy, description: desc0}, id1: {status: Degraded, description: desc1}, id3: {status: Unhealthy, description: desc3}",
+                @"{""id0"":{""status"":""Healthy"",""description"":""desc0""},""id1"":{""status"":""Degraded"",""description"":""desc1""},""id3"":{""status"":""Unhealthy"",""description"":""desc3""}}",
                 LogLevel.Warning,
                 0
             }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Updates the `Entries` property for health check unhealthy log to be valid JSON. This will allow for easier parsing in KQL or other automation systems.
