### PR TITLE
Supporting configuration for extension webhook Authorization level

### DIFF
--- a/sample/CSharp/host.json
+++ b/sample/CSharp/host.json
@@ -24,6 +24,11 @@
         "queues": {
             "visibilityTimeout": "00:00:10",
             "maxDequeueCount": 3
-        }
+        },
+        "test2": {
+            "system": {
+                "webhookAuthorizationLevel": "anonymous"
+          }
+       }
     }
 }

--- a/src/WebJobs.Script.WebHost/Configuration/ExtensionSystemOptions.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/ExtensionSystemOptions.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Hosting;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
+
+/// <summary>
+/// Represents the system options for an individual extension.
+/// </summary>
+public sealed class ExtensionSystemOptions : IOptionsFormatter
+{
+    private AuthorizationLevel _webhookAuthorizationLevel = AuthorizationLevel.System;
+
+    /// <summary>
+    /// Gets or sets the name of the extension these options apply to.
+    /// </summary>
+    public string ExtensionName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default authorization level for the extension. Only applies to WebHook extensions.
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter<AuthorizationLevel>))]
+    public AuthorizationLevel WebhookAuthorizationLevel
+    {
+        get => _webhookAuthorizationLevel;
+        set
+        {
+            if (value != AuthorizationLevel.System && value != AuthorizationLevel.Anonymous)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), $"Invalid AuthorizationLevel: {value}");
+            }
+            _webhookAuthorizationLevel = value;
+        }
+    }
+
+    public string Format()
+    {
+        return JsonSerializer.Serialize(this, ExtensionSystemOptionsJsonSerializerContext.Default.ExtensionSystemOptions);
+    }
+}
+
+[JsonSourceGenerationOptions(WriteIndented = true, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(ExtensionSystemOptions))]
+internal partial class ExtensionSystemOptionsJsonSerializerContext : JsonSerializerContext;

--- a/src/WebJobs.Script.WebHost/Configuration/ExtensionSystemOptionsSetup.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/ExtensionSystemOptionsSetup.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Script.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
+
+public sealed class ExtensionSystemOptionsSetup : IConfigureNamedOptions<ExtensionSystemOptions>
+{
+    private const string SystemSectionName = "system";
+    private readonly IConfiguration _configuration;
+
+    public ExtensionSystemOptionsSetup(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public void Configure(string name, ExtensionSystemOptions options)
+    {
+        if (string.IsNullOrEmpty(name))
+        {
+            return;
+        }
+
+        string path = ConfigurationPath.Combine(ConfigurationSectionNames.JobHost, ConfigurationSectionNames.Extensions, name, SystemSectionName);
+        IConfigurationSection section = _configuration.GetSection(path);
+        section?.Bind(options);
+        options.ExtensionName = name;
+    }
+
+    public void Configure(ExtensionSystemOptions options)
+    {
+        Configure(Options.DefaultName, options);
+    }
+}

--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -518,7 +518,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         }
 
         [AcceptVerbs("GET", "PUT", "POST", "DELETE", "OPTIONS")]
-        [Authorize(Policy = PolicyNames.SystemKeyAuthLevel)]
+        [Authorize(Policy = PolicyNames.ExtensionWebhookInvoke)]
         [Route("runtime/webhooks/{extensionName}/{*extra}")]
         [RequiresRunningHost]
         public async Task<IActionResult> ExtensionWebHookHandler(string extensionName, CancellationToken token, [FromServices] IScriptWebHookProvider provider)

--- a/src/WebJobs.Script.WebHost/Security/Authorization/Policies/AuthorizationOptionsExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authorization/Policies/AuthorizationOptionsExtensions.cs
@@ -8,8 +8,9 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Script.Extensions;
 using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
-using Microsoft.Azure.WebJobs.Script.WebHost.Extensions;
+using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies
 {
@@ -35,33 +36,28 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies
                 });
             });
 
-            options.AddPolicy(PolicyNames.SystemAuthLevel, p =>
-            {
-                p.AddScriptAuthenticationSchemes();
-                p.AddRequirements(new AuthLevelRequirement(AuthorizationLevel.System));
-            });
-
-            options.AddPolicy(PolicyNames.SystemKeyAuthLevel, p =>
+            options.AddPolicy(PolicyNames.ExtensionWebhookInvoke, p =>
             {
                 p.AddScriptAuthenticationSchemes();
                 p.RequireAssertion(c =>
                 {
                     if (c.Resource is AuthorizationFilterContext filterContext)
                     {
-                        string keyName = null;
-                        object keyNameObject = filterContext.RouteData.Values["extensionName"];
-                        if (keyNameObject != null)
+                        string extensionName = filterContext.RouteData.Values["extensionName"]?.ToString();
+
+                        // First check to see if anonymous access has been configured for the webhook.
+                        // E.g. this might be configured for a Webhook extension in an app where App Service
+                        // authentication is being used.
+                        var snapshot = filterContext.HttpContext.RequestServices.GetRequiredService<IOptionsSnapshot<ExtensionSystemOptions>>();
+                        var extensionSystemOptions = snapshot.Get(extensionName);
+                        if (!string.IsNullOrEmpty(extensionName) && extensionSystemOptions?.WebhookAuthorizationLevel == AuthorizationLevel.Anonymous)
                         {
-                            keyName = DefaultScriptWebHookProvider.GetKeyName(keyNameObject.ToString());
+                            return true;
                         }
-                        else
-                        {
-                            keyNameObject = filterContext.RouteData.Values["keyName"];
-                            if (keyNameObject != null)
-                            {
-                                keyName = keyNameObject.ToString();
-                            }
-                        }
+
+                        string keyName = !string.IsNullOrEmpty(extensionName)
+                            ? DefaultScriptWebHookProvider.GetKeyName(extensionName)
+                            : filterContext.RouteData.Values["keyName"]?.ToString();
 
                         if (!string.IsNullOrEmpty(keyName) && AuthUtility.PrincipalHasAuthLevelClaim(filterContext.HttpContext.User, AuthorizationLevel.System, keyName))
                         {

--- a/src/WebJobs.Script.WebHost/Security/Authorization/Policies/PolicyNames.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authorization/Policies/PolicyNames.cs
@@ -1,18 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies
 {
     public static class PolicyNames
     {
         public const string AdminAuthLevel = "AuthLevelAdmin";
-        public const string SystemAuthLevel = "AuthLevelSystem";
-        public const string FunctionAuthLevel = "AuthLevelFunction";
-        public const string SystemKeyAuthLevel = "AuthLevelSystemKey";
+        public const string ExtensionWebhookInvoke = "Extension.Webhook.Invoke";
     }
 }

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -58,6 +58,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     services.ConfigureOptions<AppServiceOptionsSetup>();
                     services.ConfigureOptions<HostEasyAuthOptionsSetup>();
                     services.ConfigureOptions<PrimaryHostCoordinatorOptionsSetup>();
+                    services.ConfigureOptions<ExtensionSystemOptionsSetup>();
                 })
                 .AddScriptHost(webHostOptions, configLoggerFactory, metricsLogger, webJobsBuilder =>
                 {

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
@@ -163,6 +163,38 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         }
 
         [Fact]
+        [Trait(TestTraits.Group, TestTraits.WebhookTests)]
+        public async Task ExtensionWebHook_AuthorizationLevelOverride_Succeeds()
+        {
+            // configure a mock webhook handler for the "test2" extension
+            // for which we've overridden the auth level to "Anonymous"
+            Mock<IAsyncConverter<HttpRequestMessage, HttpResponseMessage>> mockHandler = new Mock<IAsyncConverter<HttpRequestMessage, HttpResponseMessage>>(MockBehavior.Strict);
+            mockHandler.Setup(p => p.ConvertAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK));
+            var handler = mockHandler.Object;
+            _fixture.MockWebHookProvider.Setup(p => p.TryGetHandler("test2", out handler)).Returns(true);
+
+            // Verify that if the valid system key is specified, the request succeeds
+            string uri = "runtime/webhooks/test2?code=SystemValue4";
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
+            HttpResponseMessage response = await _fixture.Host.HttpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            // Verify that if an invalid system key is specified, the request also succeeds, since auth is not required
+            uri = "runtime/webhooks/test2?code=invalid";
+            request = new HttpRequestMessage(HttpMethod.Get, uri);
+            response = await _fixture.Host.HttpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            // No key provided, the request succeeds
+            uri = "runtime/webhooks/test2";
+            request = new HttpRequestMessage(HttpMethod.Get, uri);
+            response = await _fixture.Host.HttpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        [Trait(TestTraits.Group, TestTraits.WebhookTests)]
         public async Task ExtensionWebHook_Succeeds()
         {
             // configure a mock webhook handler for the "test" extension

--- a/test/WebJobs.Script.Tests.Shared/TestSecretManager.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestSecretManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -87,6 +87,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 { "SystemKey1", "SystemValue1" },
                 { "SystemKey2", "SystemValue2" },
                 { "Test_Extension", "SystemValue3" },
+                { "Test2_Extension", "SystemValue4" }
             };
         }
 

--- a/test/WebJobs.Script.Tests.Shared/TestTraits.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestTraits.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 namespace Microsoft.WebJobs.Script.Tests
@@ -63,5 +63,7 @@ namespace Microsoft.WebJobs.Script.Tests
         public const string HostMetricsTests = "HostMetricsTests";
 
         public const string HISSecretsTests = "HISSecretsTests";
+
+        public const string WebhookTests = "WebhookTests";
     }
 }

--- a/test/WebJobs.Script.Tests/Configuration/ExtensionsSystemOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ExtensionsSystemOptionsSetupTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.WebJobs.Script.Tests;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration;
+
+[Trait(TestTraits.Group, TestTraits.WebhookTests)]
+public class ExtensionsSystemOptionsSetupTests
+{
+    [Theory]
+    [InlineData("mcp", AuthorizationLevel.Anonymous)]
+    [InlineData("eventGrid", AuthorizationLevel.System)]
+    [InlineData("myext", AuthorizationLevel.System)]
+    public void Configure_BindsNamedOptions(string extensionName, AuthorizationLevel expectedAuthorizationLevel)
+    {
+        var inMemorySettings = new Dictionary<string, string>
+        {
+            ["AzureFunctionsJobHost:extensions:mcp:system:webhookAuthorizationLevel"] = "Anonymous",
+            ["AzureFunctionsJobHost:extensions:eventGrid:system:webhookAuthorizationLevel"] = "System",
+            ["AzureFunctionsJobHost:extensions:myext:someOtherKey"] = "shouldBeIgnored"
+        };
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(inMemorySettings)
+            .Build();
+
+        var setup = new ExtensionSystemOptionsSetup(config);
+
+        var options = new ExtensionSystemOptions();
+        setup.Configure(extensionName, options);
+
+        Assert.Equal(extensionName, options.ExtensionName);
+        Assert.Equal(expectedAuthorizationLevel, options.WebhookAuthorizationLevel);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Configure_NameNullOrEmpty_ReturnsDefaultOptions(string name)
+    {
+        var inMemorySettings = new Dictionary<string, string>
+        {
+            ["AzureFunctionsJobHost:extensions:mcp:system:webhookAuthorizationLevel"] = "Anonymous",
+            ["AzureFunctionsJobHost:extensions:eventGrid:system:webhookAuthorizationLevel"] = "System",
+            ["AzureFunctionsJobHost:extensions:myext:someOtherKey"] = "shouldBeIgnored"
+        };
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(inMemorySettings)
+            .Build();
+
+        var setup = new ExtensionSystemOptionsSetup(config);
+
+        var options = new ExtensionSystemOptions();
+        setup.Configure(name, options);
+
+        VerifyDefaults(options);
+    }
+
+    [Fact]
+    public void Configure_NoNameOverload_ReturnsDefaultOptions()
+    {
+        var configMock = new Mock<IConfiguration>();
+        var setup = new ExtensionSystemOptionsSetup(configMock.Object);
+
+        var options = new ExtensionSystemOptions();
+        setup.Configure(options);
+
+        VerifyDefaults(options);
+    }
+
+    private void VerifyDefaults(ExtensionSystemOptions options)
+    {
+        Assert.Null(options.ExtensionName);
+        Assert.Equal(AuthorizationLevel.System, options.WebhookAuthorizationLevel);
+    }
+}

--- a/test/WebJobs.Script.Tests/Configuration/ExtensionsSystemOptionsTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ExtensionsSystemOptionsTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
+using Microsoft.WebJobs.Script.Tests;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration;
+
+[Trait(TestTraits.Group, TestTraits.WebhookTests)]
+public class ExtensionsSystemOptionsTests
+{
+    [Fact]
+    public void Format_ReturnsExpectedJson()
+    {
+        var options = new ExtensionSystemOptions
+        {
+            ExtensionName = "myext",
+            WebhookAuthorizationLevel = AuthorizationLevel.Anonymous
+        };
+
+        var formatted = options.Format();
+        var parsed = JObject.Parse(formatted);
+
+        Assert.Equal(2, parsed.Count);
+        Assert.Equal("myext", parsed["extensionName"]);
+        Assert.Equal("Anonymous", parsed["webhookAuthorizationLevel"]);
+    }
+
+    [Theory]
+    [InlineData(AuthorizationLevel.System)]
+    [InlineData(AuthorizationLevel.Anonymous)]
+    public void WebhookAuthorizationLevel_Set_ValidValues_DoesNotThrow(AuthorizationLevel level)
+    {
+        var options = new ExtensionSystemOptions
+        {
+            WebhookAuthorizationLevel = level
+        };
+
+        Assert.Equal(level, options.WebhookAuthorizationLevel);
+    }
+
+    [Theory]
+    [InlineData(AuthorizationLevel.Function)]
+    [InlineData(AuthorizationLevel.Admin)]
+    [InlineData(AuthorizationLevel.User)]
+    [InlineData((AuthorizationLevel)999)]
+    public void WebhookAuthorizationLevel_Set_InvalidValues_ThrowsArgumentOutOfRangeException(AuthorizationLevel level)
+    {
+        var options = new ExtensionSystemOptions();
+
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => options.WebhookAuthorizationLevel = level);
+
+        Assert.Contains("Invalid AuthorizationLevel", ex.Message, StringComparison.Ordinal);
+    }
+}

--- a/test/WebJobs.Script.Tests/DefaultScriptWebHookProviderTests.cs
+++ b/test/WebJobs.Script.Tests/DefaultScriptWebHookProviderTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Description;
 using Microsoft.Azure.WebJobs.Host.Config;
-using Microsoft.Azure.WebJobs.Script.Tests.Security;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security;
 using Microsoft.Extensions.Logging;
@@ -18,6 +17,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
+    [Trait(TestTraits.Group, TestTraits.WebhookTests)]
     public class DefaultScriptWebHookProviderTests
     {
         private const string TestHostName = "test.azurewebsites.net";


### PR DESCRIPTION
We want to provide a way for customers who are using App Service authentication at the app level to disable default system key auth for their webhooks.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
