### PR TITLE
check for secret dir in ContainerApps

### DIFF
--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/ContainerAppsSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/ContainerAppsSecretsRepository.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -107,6 +107,12 @@ public class ContainerAppsSecretsRepository : ISecretsRepository
 
     private async Task<IDictionary<string, string>> GetFromFilesAsync(string path)
     {
+        if (!FileUtility.DirectoryExists(path))
+        {
+            _logger.LogDebug("Secrets path '{path}' does not exist.", path);
+            return new Dictionary<string, string>();
+        }
+
         string[] files = await FileUtility.GetFilesAsync(path, "*");
         var secrets = new Dictionary<string, string>(files.Length);
 

--- a/test/WebJobs.Script.Tests/Security/ContainerAppsSecretsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests/Security/ContainerAppsSecretsRepositoryTests.cs
@@ -28,14 +28,25 @@ public class ContainerAppsSecretsRepositoryTests : IDisposable
         var mockDirectory = new Mock<DirectoryBase>(MockBehavior.Strict);
 
         // Setup directory and file existence
-        mockDirectory.Setup(d => d.Exists(It.IsAny<string>())).Returns(true);
+        mockDirectory
+            .Setup(d => d.Exists(ContainerAppsSecretsRepository.ContainerAppsSecretsDir))
+            .Returns(() => _fileContentMap is not null);
         mockFileSystem.SetupGet(fs => fs.Directory).Returns(mockDirectory.Object);
         mockFileSystem.SetupGet(fs => fs.File).Returns(mockFile.Object);
 
         // Return all files when asked
         mockDirectory
             .Setup(d => d.GetFiles(ContainerAppsSecretsRepository.ContainerAppsSecretsDir, "*"))
-            .Returns(() => _fileContentMap.Keys.ToArray());
+            .Returns(() =>
+            {
+                // treat a null map as a missing directory
+                if (_fileContentMap is not null)
+                {
+                    return _fileContentMap.Keys.ToArray();
+                }
+
+                throw new DirectoryNotFoundException();
+            });
 
         // Setup file existence checks
         mockFile
@@ -74,6 +85,20 @@ public class ContainerAppsSecretsRepositoryTests : IDisposable
     }
 
     [Fact]
+    public async Task Read_Host_Secrets_MissingDirectory()
+    {
+        _fileContentMap = null;
+
+        var result = await _repo.ReadAsync(ScriptSecretsType.Host, null);
+
+        var hostSecrets = result as HostSecrets;
+        Assert.NotNull(hostSecrets);
+        Assert.Null(hostSecrets.MasterKey);
+        Assert.Empty(hostSecrets.FunctionKeys);
+        Assert.Empty(hostSecrets.SystemKeys);
+    }
+
+    [Fact]
     public async Task Read_Function_Secrets()
     {
         _fileContentMap = new()
@@ -96,6 +121,18 @@ public class ContainerAppsSecretsRepositoryTests : IDisposable
         Assert.NotNull(functionSecrets);
         Assert.Equal("f2k1", functionSecrets.GetFunctionKey("Key1", "funcTion2").Value);
         Assert.Equal("f2k2", functionSecrets.GetFunctionKey("key2", "function2").Value);
+    }
+
+    [Fact]
+    public async Task Read_Function_Secrets_MissingDirectory()
+    {
+        _fileContentMap = null;
+
+        var result = await _repo.ReadAsync(ScriptSecretsType.Function, "function1");
+
+        var functionSecrets = result as FunctionSecrets;
+        Assert.NotNull(functionSecrets);
+        Assert.Empty(functionSecrets.Keys);
     }
 
     [Fact]


### PR DESCRIPTION
Fixing a bug in `ContainerAppsSecretsRepository` where we'd throw a `DirectoryNotFoundException` if there was no directory.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)