### PR TITLE
Disable Azure Devops dependabot

### DIFF
--- a/.azuredevops/dependabot.yml
+++ b/.azuredevops/dependabot.yml
@@ -1,0 +1,4 @@
+# Mirrored repository. We use dependabot via GitHub, not Azure DevOps.
+version: 2
+enable-security-updates: false
+enable-campaigned-updates: false


### PR DESCRIPTION
Disables dependabot in Azure Devops. We use dependabot via GitHub and do not want PRs directly to Azure Devops.