### PR TITLE
Updating App Service middleware to 1.5.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -498,3 +498,4 @@ local.settings.json
 /tools/ExtensionsMetadataGenerator/src/ExtensionsMetadataGenerator/runtimeassemblies.txt
 /tools/ExtensionsMetadataGenerator/test/ExtensionsMetadataGeneratorTests/runtimeAssemblies.txt
 BenchmarkDotNet.Artifacts/
+/test/Resources/TestProjects/DotNetCustomHandler/Properties/launchSettings.json

--- a/release_notes.md
+++ b/release_notes.md
@@ -8,3 +8,4 @@
 - Remove duplicate function names from sync triggers payload(#11371)
 - Avoid emitting empty tag values for health check metrics (#11393)
 - Functions host to take a customer specified port in Custom Handler scenario (#11408)
+- Updated to version 1.5.8 of Microsoft.Azure.AppService.Middleware.Functions (#11416)

--- a/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
+++ b/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
@@ -62,7 +62,7 @@
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.8" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Azure.AppService.Middleware.Functions" Version="1.5.7" />
+    <PackageReference Include="Microsoft.Azure.AppService.Middleware.Functions" Version="1.5.8" />
     <PackageReference Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.3.20240307.67" />
     <PackageReference Include="Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption" Version="1.0.5" />
     <PackageReference Include="Microsoft.Azure.Storage.File" Version="11.1.7" />


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This pull request updates the dependency on `Microsoft.Azure.AppService.Middleware.Functions` to version 1.5.8. This change ensures the project uses the latest features and fixes provided by the middleware package.