### PR TITLE
Fix spelling error in HostConfigurationProfile

### DIFF
--- a/src/WebJobs.Script/Config/HostConfigurationProfile.cs
+++ b/src/WebJobs.Script/Config/HostConfigurationProfile.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             McpCustomerHandlerProfile,
             [
                 KeyValuePair.Create(ConfigurationPath.Combine(
-                    ConfigurationSectionNames.CustomHandler, "enableHttpProxyingRequest"), "true"),
+                    ConfigurationSectionNames.CustomHandler, ScriptConstants.EnableProxyingHttpRequest), "true"),
                 KeyValuePair.Create(ConfigurationPath.Combine(
                     ConfigurationSectionNames.Http, "routePrefix"), string.Empty),
                 KeyValuePair.Create(ConfigurationPath.Combine(

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -266,6 +266,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public static readonly string HttpProxyCorrelationHeader = "x-ms-invocation-id";
         public static readonly string HttpProxyTask = "HttpProxyTask";
         public static readonly string HttpProxyScriptInvocationContext = "HttpProxyScriptInvocationContext";
+        public static readonly string EnableProxyingHttpRequest = "enableProxyingHttpRequest";
 
         public static readonly string OperationNameKey = "OperationName";
 

--- a/test/WebJobs.Script.Tests/Configuration/HostConfigurationProfileTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/HostConfigurationProfileTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             configDict.Should().HaveCount(4);
             configDict.Should().ContainKey("configurationProfile")
                 .WhoseValue.Should().Be("mcp-custom-handler");
-            configDict.Should().ContainKey("customHandler:enableHttpProxyingRequest")
+            configDict.Should().ContainKey("customHandler:enableProxyingHttpRequest")
                 .WhoseValue.Should().Be("true");
             configDict.Should().ContainKey("extensions:http:routePrefix")
                 .WhoseValue.Should().Be(string.Empty);


### PR DESCRIPTION
Fixing a misspelling in host configuration profile

Resolves #11423
### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
