### PR TITLE
Adding HttpWorkerFunctionProvider functions to synctrigger payload

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -14,3 +14,4 @@
 - Functions host to take a customer specified port in Custom Handler scenario (#11408)
 - Updated to version 1.5.8 of Microsoft.Azure.AppService.Middleware.Functions (#11416)
 - Enabling worker indexing for Logic Apps app kind behind an enviornment setting
+- Adding HttpWorkerFunctionProvider functions to synctrigger payload (#11430)

--- a/src/WebJobs.Script/Workers/Http/HttpWorkerFunctionProvider.cs
+++ b/src/WebJobs.Script/Workers/Http/HttpWorkerFunctionProvider.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Http
 
             metadata.Bindings.Add(BindingMetadata.Create(trigger));
             metadata.Bindings.Add(BindingMetadata.Create(output));
-
+            metadata.SetIsCodeless(false);
             return metadata;
         }
     }

--- a/test/WebJobs.Script.Tests/Workers/Http/HttpWorkerFunctionProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Http/HttpWorkerFunctionProviderTests.cs
@@ -187,6 +187,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
             var methods = (JArray)trigger1.Raw["methods"];
             Assert.Contains("get", methods.Select(m => m.ToString()), StringComparer.OrdinalIgnoreCase);
 
+            Assert.True(result[0].IsCodelessSet());
+            Assert.False(result[0].IsCodeless());
+            Assert.True(result[1].IsCodelessSet());
+            Assert.False(result[1].IsCodeless());
+
             hostMeta.Verify(m => m.GetFunctionMetadataAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), false), Times.Once);
         }
 
@@ -224,6 +229,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
 
             Assert.Single(result);
             Assert.Equal("http-handler1", result[0].Name);
+
+            Assert.True(result[0].IsCodelessSet());
+            Assert.False(result[0].IsCodeless());
 
             var errors = provider.FunctionErrors;
             Assert.True(errors.ContainsKey("http-handler2"));
@@ -268,6 +276,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Http
             {
                 Assert.Single(result);
                 Assert.Empty(provider.FunctionErrors);
+                Assert.True(result[0].IsCodelessSet());
+                Assert.False(result[0].IsCodeless());
             }
             else
             {


### PR DESCRIPTION
### Updated HttpWorkerFunctionProvider to mark its functions as non-codeless. This change ensures these functions are included in the sync triggers payload and visible in the Azure portal.

### Issue describing the changes in this PR

resolves #11427

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
