### PR TITLE
Removing the Flex-only filter.

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -16,3 +16,4 @@
 - Updated to version 1.5.8 of Microsoft.Azure.AppService.Middleware.Functions (#11416)
 - Enabling worker indexing for Logic Apps app kind behind an enviornment setting
 - Adding HttpWorkerFunctionProvider functions to synctrigger payload (#11430)
+- Remove the Flex-only AzureMonitorDiagnosticLoggerProvider filter (#11431)

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -90,21 +90,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 .ConfigureLogging(loggingBuilder =>
                 {
                     loggingBuilder.Services.AddSingleton<ILoggerFactory, ScriptLoggerFactory>();
-
                     loggingBuilder.AddWebJobsSystem<SystemLoggerProvider>();
+
                     if (environment.IsAzureMonitorEnabled())
                     {
-                        if (environment.IsConsumptionOnLegion())
-                        {
-                            loggingBuilder.Services.AddOptions<LoggerFilterOptions>()
-                                .Configure<IOptionsMonitor<AppServiceOptions>>((filters, options) =>
-                                {
-                                    filters.AddFilter<AzureMonitorDiagnosticLoggerProvider>((category, level) =>
-                                    {
-                                        return options.CurrentValue.IsAzureMonitorLoggingEnabled;
-                                    });
-                                });
-                        }
                         loggingBuilder.Services.AddSingleton<ILoggerProvider, AzureMonitorDiagnosticLoggerProvider>();
                     }
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

resolves #11434 

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
