### PR TITLE
Fix tests failures by resetting Environment cache

### DIFF
--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public ScriptHostTests(TestFixture fixture)
         {
+            EnvironmentExtensions.ClearCache();
             Utility.ColdStartDelayMS = 50;
             _fixture = fixture;
             _settingsManager = ScriptSettingsManager.Instance;

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -35,7 +35,7 @@ using FunctionMetadata = Microsoft.Azure.WebJobs.Script.Description.FunctionMeta
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
-    public class ScriptHostTests : IClassFixture<ScriptHostTests.TestFixture>
+    public class ScriptHostTests : IClassFixture<ScriptHostTests.TestFixture>, IDisposable
     {
         private const string ID = "5a709861cab44e68bfed5d2c2fe7fc0c";
         private readonly TestFixture _fixture;
@@ -461,8 +461,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             string functionsWorkerRuntimeVersion,
             string expectedRuntimeStack)
         {
-            EnvironmentExtensions.ClearCache();
-
             try
             {
                 using (var tempDirectory = new TempDirectory())
@@ -1606,7 +1604,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [InlineData(null, "app.dll", "dotnet", DotNetScriptTypes.DotNetAssembly)] // if FUNCTIONS_WORKER_RUNTIME is missing, assume dotnet
         public async Task Initialize_MissingWorkerRuntime_SetsCorrectRuntimeFromFunctionMetadata(string functionsWorkerRuntime, string scriptFile, string expectedMetricLanguage, string expectedMetadataLanguage)
         {
-            EnvironmentExtensions.ClearCache();
             string workersDirPath = Path.Combine(AppContext.BaseDirectory, RpcWorkerConstants.DefaultWorkersDirectoryName);
 
             IFileSystem CreateFileSystem(string rootPath)
@@ -1776,6 +1773,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Assert.Empty(diagnosticEventRepository.Events);
                 Assert.Empty(testLoggerProvider.GetAllLogMessages().Where(m => m.Level == LogLevel.Warning));
             }
+        }
+
+        public void Dispose()
+        {
+            EnvironmentExtensions.ClearCache();
         }
 
         public class AssemblyMock : Assembly

--- a/test/WebJobs.Script.Tests/ScriptHostTests.cs
+++ b/test/WebJobs.Script.Tests/ScriptHostTests.cs
@@ -461,6 +461,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             string functionsWorkerRuntimeVersion,
             string expectedRuntimeStack)
         {
+            EnvironmentExtensions.ClearCache();
+
             try
             {
                 using (var tempDirectory = new TempDirectory())
@@ -1604,6 +1606,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [InlineData(null, "app.dll", "dotnet", DotNetScriptTypes.DotNetAssembly)] // if FUNCTIONS_WORKER_RUNTIME is missing, assume dotnet
         public async Task Initialize_MissingWorkerRuntime_SetsCorrectRuntimeFromFunctionMetadata(string functionsWorkerRuntime, string scriptFile, string expectedMetricLanguage, string expectedMetadataLanguage)
         {
+            EnvironmentExtensions.ClearCache();
             string workersDirPath = Path.Combine(AppContext.BaseDirectory, RpcWorkerConstants.DefaultWorkersDirectoryName);
 
             IFileSystem CreateFileSystem(string rootPath)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
