### PR TITLE
Adding a web app custom handler configuration profile.

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Adding a "web app" configuration profile (#11447)

--- a/src/WebJobs.Script/Config/HostConfigurationProfile.cs
+++ b/src/WebJobs.Script/Config/HostConfigurationProfile.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.WebJobs.Script.Configuration
@@ -16,23 +15,25 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
         // This ensures tests will fail if these values are changed without updating the test also.
         private const string DefaultProfile = "default";
 
-        private const string McpCustomerHandlerProfile = "mcp-custom-handler";
+        private const string McpCustomHandlerProfile = "mcp-custom-handler";
+
+        private const string WebAppCustomHandlerProfile = "web-app-custom-handler";
 
         // Make sure to update this as new profiles are added.
-        private const string SupportedValues = $"'', '{DefaultProfile}', '{McpCustomerHandlerProfile}'";
+        private const string SupportedValues = $"'', '{DefaultProfile}', '{McpCustomHandlerProfile}', '{WebAppCustomHandlerProfile}'";
+
+        private static readonly Dictionary<string, string> CommonHttpCustomHandlerConfiguration = new()
+        {
+            { ConfigurationPath.Combine(ConfigurationSectionNames.CustomHandler, ScriptConstants.EnableProxyingHttpRequest), "true" },
+            { ConfigurationPath.Combine(ConfigurationSectionNames.Http, "routePrefix"), string.Empty },
+            { ConfigurationPath.Combine(ConfigurationSectionNames.CustomHandler, "http", "routes", "0", "route"), "{*route}" },
+        };
 
         public static readonly HostConfigurationProfile Default = new(DefaultProfile, []);
 
-        public static readonly HostConfigurationProfile McpCustomHandler = new(
-            McpCustomerHandlerProfile,
-            [
-                KeyValuePair.Create(ConfigurationPath.Combine(
-                    ConfigurationSectionNames.CustomHandler, ScriptConstants.EnableProxyingHttpRequest), "true"),
-                KeyValuePair.Create(ConfigurationPath.Combine(
-                    ConfigurationSectionNames.Http, "routePrefix"), string.Empty),
-                KeyValuePair.Create(ConfigurationPath.Combine(
-                    ConfigurationSectionNames.CustomHandler, "http", "routes", "0", "route"), "{*route}"),
-            ]);
+        public static readonly HostConfigurationProfile McpCustomHandler = new(McpCustomHandlerProfile, CommonHttpCustomHandlerConfiguration);
+
+        public static readonly HostConfigurationProfile WebAppCustomHandler = new(WebAppCustomHandlerProfile, CommonHttpCustomHandlerConfiguration);
 
         private HostConfigurationProfile(
             string name,
@@ -49,9 +50,11 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
         public static HostConfigurationProfile Get(string name)
         {
             ArgumentNullException.ThrowIfNull(name);
+
             return name.ToLowerInvariant() switch
             {
-                McpCustomerHandlerProfile => McpCustomHandler,
+                McpCustomHandlerProfile => McpCustomHandler,
+                WebAppCustomHandlerProfile => WebAppCustomHandler,
                 "" or DefaultProfile => Default,
                 _ => throw new NotSupportedException(
                         $"Configuration profile '{name}' is not supported. Supported values: {SupportedValues}."),

--- a/src/WebJobs.Script/Config/HostConfigurationProfile.cs
+++ b/src/WebJobs.Script/Config/HostConfigurationProfile.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
 {
     public sealed class HostConfigurationProfile
     {
-        public const string SectionKey = "configurationProfile";
+        private const string SectionKey = "configurationProfile";
 
         // note: profile name consts are intentionally private.
         // This ensures tests will fail if these values are changed without updating the test also.
@@ -24,9 +24,9 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
 
         private static readonly Dictionary<string, string> CommonHttpCustomHandlerConfiguration = new()
         {
-            { ConfigurationPath.Combine(ConfigurationSectionNames.CustomHandler, ScriptConstants.EnableProxyingHttpRequest), "true" },
-            { ConfigurationPath.Combine(ConfigurationSectionNames.Http, "routePrefix"), string.Empty },
-            { ConfigurationPath.Combine(ConfigurationSectionNames.CustomHandler, "http", "routes", "0", "route"), "{*route}" },
+            [ConfigurationPath.Combine(ConfigurationSectionNames.CustomHandler, ScriptConstants.EnableProxyingHttpRequest)] = "true",
+            [ConfigurationPath.Combine(ConfigurationSectionNames.Http, "routePrefix")] = string.Empty,
+            [ConfigurationPath.Combine(ConfigurationSectionNames.CustomHandler, "http", "routes", "0", "route")] = "{*route}"
         };
 
         public static readonly HostConfigurationProfile Default = new(DefaultProfile, []);

--- a/test/WebJobs.Script.Tests/Configuration/HostConfigurationProfileTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/HostConfigurationProfileTests.cs
@@ -29,15 +29,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
         [Theory]
         [InlineData("mcp-custom-handler")]
         [InlineData("MCP-Custom-Handler")]
-        public void Get_Mcp_ReturnsExpectedProfile(string name)
+        [InlineData("web-app-Custom-Handler")]
+        [InlineData("WEB-App-Custom-Handler")]
+        public void Get_HttpBasedHandler_ReturnsExpectedProfile(string name)
         {
-            HostConfigurationProfile profile = HostConfigurationProfile.Get(name);
+            var expectedProfileName = name.ToLowerInvariant();
 
+            HostConfigurationProfile profile = HostConfigurationProfile.Get(name);
             Dictionary<string, string> configDict = new(profile.Configuration);
-            profile.Name.Should().Be("mcp-custom-handler");
+            profile.Name.Should().Be(expectedProfileName);
             configDict.Should().HaveCount(4);
             configDict.Should().ContainKey("configurationProfile")
-                .WhoseValue.Should().Be("mcp-custom-handler");
+                .WhoseValue.Should().Be(expectedProfileName);
             configDict.Should().ContainKey("customHandler:enableProxyingHttpRequest")
                 .WhoseValue.Should().Be("true");
             configDict.Should().ContainKey("extensions:http:routePrefix")
@@ -60,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 
             action.Should()
                 .ThrowExactly<NotSupportedException>()
-                .WithMessage("Configuration profile 'invalid' is not supported. Supported values: '', 'default', 'mcp-custom-handler'.");
+                .WithMessage("Configuration profile 'invalid' is not supported. Supported values: '', 'default', 'mcp-custom-handler', 'web-app-custom-handler'.");
         }
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This pull request adds support for a new configuration profile, `web-app-custom-handler`, alongside the existing `mcp-custom-handler` profile in the `HostConfigurationProfile` class. It refactors shared configuration logic for HTTP custom handlers, updates the profile selection logic, and expands the relevant tests to cover the new profile.
