### PR TITLE
Changing the FunctionTimeoutAbortExceptionMessage

### DIFF
--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -1560,8 +1560,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
             if (workerException is null || workerException is FunctionTimeoutException)
             {
-                string exceptionMessagePrefix = workerException?.Message is not null ? workerException.Message + ". " : string.Empty;
-                shutdownException = new FunctionTimeoutAbortException(exceptionMessagePrefix + "Worker channel is shutting down. Aborting function.", workerException);
+                string exceptionMessageSuffix = workerException?.Message is not null ? "Reason: " + workerException.Message : string.Empty;
+                shutdownException = new FunctionTimeoutAbortException("Worker channel is shutting down. Aborting function." + exceptionMessageSuffix, workerException);
             }
 
             foreach (var invocation in _executingInvocations?.Values)

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -1560,7 +1560,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
             if (workerException is null || workerException is FunctionTimeoutException)
             {
-                shutdownException = new FunctionTimeoutAbortException(workerException?.Message ?? "Worker channel is shutting down. Aborting function.", workerException);
+                string exceptionMessagePrefix = workerException?.Message is not null ? workerException.Message + ". " : string.Empty;
+                shutdownException = new FunctionTimeoutAbortException(exceptionMessagePrefix + "Worker channel is shutting down. Aborting function.", workerException);
             }
 
             foreach (var invocation in _executingInvocations?.Values)

--- a/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/GrpcWorkerChannel.cs
@@ -1560,7 +1560,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
             if (workerException is null || workerException is FunctionTimeoutException)
             {
-                string exceptionMessageSuffix = workerException?.Message is not null ? "Reason: " + workerException.Message : string.Empty;
+                string exceptionMessageSuffix = workerException?.Message is not null ? " Reason: " + workerException.Message : string.Empty;
                 shutdownException = new FunctionTimeoutAbortException("Worker channel is shutting down. Aborting function." + exceptionMessageSuffix, workerException);
             }
 


### PR DESCRIPTION
Currently, the exception message when a function's execution is aborted due to another function timing out is deceptive. The logs look like 
```
Function.SecondActivity[3]
      Executed 'Functions.SecondActivity' (Failed, Id=da722530-c308-4960-8fcf-5c43a00edc07, Duration=12660ms)
      Microsoft.Azure.WebJobs.Host.FunctionTimeoutAbortException: Timeout value of 00:00:20 was exceeded by function: Functions.FirstActivity
```

This can be misleading to customers since unless they read the exception message carefully, it seems like the Function's execution is being aborted due to a timeout (when in reality its execution is aborted because _another_ Function on this worker timed out). In an attempt to mitigate this, the proposal is to append the exception message that is used when the worker's exception is null. The new log would look like

```
Microsoft.Azure.WebJobs.Host.FunctionTimeoutAbortException: Timeout value of 00:00:20 was exceeded by function: Functions.FirstActivity. Worker channel is shutting down. Aborting function.
```
This is building on top of the work done in https://github.com/Azure/azure-functions-host/pull/11159


### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)
