### PR TITLE
Updated ScriptJobHostOptions to implement IOptionsFormatter

### DIFF
--- a/src/WebJobs.Script/Config/ScriptJobHostOptions.cs
+++ b/src/WebJobs.Script/Config/ScriptJobHostOptions.cs
@@ -1,17 +1,26 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Azure.WebJobs.Hosting;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry;
 
 namespace Microsoft.Azure.WebJobs.Script
 {
-    public class ScriptJobHostOptions
+    public class ScriptJobHostOptions : IOptionsFormatter
     {
+        private static readonly JsonSerializerOptions _serializerOptions = new()
+        {
+            Converters = { new ScriptJobHostOptionsConverter() },
+            WriteIndented = true,
+        };
+
         private string _rootScriptPath;
         private ImmutableArray<string> _directorySnapshot;
 
@@ -145,5 +154,30 @@ namespace Microsoft.Azure.WebJobs.Script
         /// Gets or sets a value indicating the timeout duration for the function metadata provider.
         /// </summary>
         public TimeSpan MetadataProviderTimeout { get; set; } = TimeSpan.Zero;
+
+        public string Format()
+        {
+            return JsonSerializer.Serialize(this, _serializerOptions);
+        }
+
+        private class ScriptJobHostOptionsConverter : JsonConverter<ScriptJobHostOptions>
+        {
+            public override ScriptJobHostOptions Read(
+                ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Write(
+                Utf8JsonWriter writer, ScriptJobHostOptions value, JsonSerializerOptions options)
+            {
+                writer.WriteStartObject();
+                writer.WriteBoolean(nameof(value.FileWatchingEnabled), value.FileWatchingEnabled);
+                writer.WriteString(nameof(value.FileLoggingMode), value.FileLoggingMode.ToString());
+                writer.WriteString(nameof(value.FunctionTimeout), value.FunctionTimeout?.ToString());
+                writer.WriteString(nameof(value.TelemetryMode), value.TelemetryMode.ToString());
+                writer.WriteEndObject();
+            }
+        }
     }
 }

--- a/test/WebJobs.Script.Tests/Configuration/ScriptJobHostOptionsTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ScriptJobHostOptionsTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
+{
+    public class ScriptJobHostOptionsTests
+    {
+        [Theory]
+        [InlineData(FileLoggingMode.Always, 10, true, "Always", "00:10:00", "ApplicationInsights")]
+        [InlineData(FileLoggingMode.Never, 5, false, "Never", "00:05:00", "OpenTelemetry")]
+        [InlineData(FileLoggingMode.DebugOnly, 0.5, true, "DebugOnly", "00:00:30", "ApplicationInsights")]
+        public void Format_SerializesOptionsToJson(
+            FileLoggingMode loggingMode,
+            double timeoutMinutes,
+            bool fileWatchingEnabled,
+            string expectedLoggingMode,
+            string expectedTimeout,
+            string expectedTelemetryMode)
+        {
+            var options = new ScriptJobHostOptions
+            {
+                FileLoggingMode = loggingMode,
+                FunctionTimeout = TimeSpan.FromMinutes(timeoutMinutes),
+                FileWatchingEnabled = fileWatchingEnabled,
+                TelemetryMode = Enum.Parse<TelemetryMode>(expectedTelemetryMode)
+            };
+
+            string json = options.Format();
+            var root = JsonDocument.Parse(json).RootElement;
+
+            root.TryGetProperty("FileWatchingEnabled", out var fileWatchingProperty).Should().BeTrue();
+            fileWatchingProperty.GetBoolean().Should().Be(fileWatchingEnabled);
+
+            root.TryGetProperty("FileLoggingMode", out var fileLoggingProperty).Should().BeTrue();
+            fileLoggingProperty.GetString().Should().Be(expectedLoggingMode);
+
+            root.TryGetProperty("FunctionTimeout", out var timeoutProperty).Should().BeTrue();
+            timeoutProperty.GetString().Should().Be(expectedTimeout);
+
+            root.TryGetProperty("TelemetryMode", out var telemetryModeProperty).Should().BeTrue();
+            telemetryModeProperty.GetString().Should().Be(expectedTelemetryMode);
+        }
+
+        [Fact]
+        public void Format_WithNullFunctionTimeout_SerializesAsNull()
+        {
+            var options = new ScriptJobHostOptions
+            {
+                FileLoggingMode = FileLoggingMode.Never,
+                FileWatchingEnabled = true,
+                FunctionTimeout = null
+            };
+
+            string json = options.Format();
+            var root = JsonDocument.Parse(json).RootElement;
+
+            root.TryGetProperty("FunctionTimeout", out var timeoutProperty).Should().BeTrue();
+            timeoutProperty.ValueKind.Should().Be(JsonValueKind.Null);
+        }
+
+        [Fact]
+        public void Format_ReturnsValidIndentedJson()
+        {
+            var options = new ScriptJobHostOptions
+            {
+                FileLoggingMode = FileLoggingMode.Always,
+                FileWatchingEnabled = true,
+                FunctionTimeout = TimeSpan.FromMinutes(5)
+            };
+
+            string json = options.Format();
+
+            // Should be valid JSON
+            var exception = Record.Exception(() => JsonDocument.Parse(json));
+            exception.Should().BeNull();
+
+            // Should be indented (contains newlines)
+            json.Should().Contain(Environment.NewLine);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This PR implements `IOptionsFormatter` for `ScriptJobHostOptions`:

```json
{
  "FileWatchingEnabled": true,
  "FileLoggingMode": "DebugOnly",
  "FunctionTimeout": "01:00:00",
  "TelemetryMode": "ApplicationInsights"
}
```

resolves #11460 

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

