### PR TITLE
Adding empty remote message check in the SystemLogger

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,3 +5,4 @@
 -->
 - Adding a "web app" configuration profile (#11447)
 - Add JitTrace Files for v4.1045
+- Adding empty remote message check in the SystemLogger (#11473)

--- a/src/WebJobs.Script.WebHost/Extensions/ExceptionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Extensions/ExceptionExtensions.cs
@@ -63,15 +63,18 @@ namespace System
             var formattedDetails = exception.ToFormattedString();
 
             if (exception is FunctionInvocationException && baseException is RpcException { RemoteMessage: var remoteMsg }
-                && remoteMsg is not null)
+                && !string.IsNullOrWhiteSpace(remoteMsg))
             {
                 var redacted = GetRedactedExceptionMessage(remoteMsg);
 
-                var innerExceptionMessage = Sanitizer.Sanitize(
-                    originalMessage.Replace(remoteMsg, redacted, StringComparison.Ordinal));
+                var innerExceptionMessage = string.IsNullOrWhiteSpace(originalMessage)
+                            ? string.Empty
+                            : Sanitizer.Sanitize(originalMessage.Replace(remoteMsg, redacted, StringComparison.Ordinal));
 
-                var detailsSanitized = Sanitizer.Sanitize(
-                    formattedDetails.Replace(remoteMsg, redacted, StringComparison.Ordinal));
+
+                var detailsSanitized = string.IsNullOrWhiteSpace(formattedDetails)
+                            ? string.Empty
+                            : Sanitizer.Sanitize(formattedDetails.Replace(remoteMsg, redacted, StringComparison.Ordinal));
 
                 return (innerType, innerExceptionMessage, detailsSanitized, formattedMessage);
             }

--- a/src/WebJobs.Script.WebHost/Extensions/ExceptionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Extensions/ExceptionExtensions.cs
@@ -68,13 +68,12 @@ namespace System
                 var redacted = GetRedactedExceptionMessage(remoteMsg);
 
                 var innerExceptionMessage = string.IsNullOrWhiteSpace(originalMessage)
-                            ? string.Empty
-                            : Sanitizer.Sanitize(originalMessage.Replace(remoteMsg, redacted, StringComparison.Ordinal));
-
+                    ? string.Empty
+                    : Sanitizer.Sanitize(originalMessage.Replace(remoteMsg, redacted, StringComparison.Ordinal));
 
                 var detailsSanitized = string.IsNullOrWhiteSpace(formattedDetails)
-                            ? string.Empty
-                            : Sanitizer.Sanitize(formattedDetails.Replace(remoteMsg, redacted, StringComparison.Ordinal));
+                    ? string.Empty
+                    : Sanitizer.Sanitize(formattedDetails.Replace(remoteMsg, redacted, StringComparison.Ordinal));
 
                 return (innerType, innerExceptionMessage, detailsSanitized, formattedMessage);
             }

--- a/test/WebJobs.Script.Tests/Extensions/ExceptionExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/ExceptionExtensionsTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
             Assert.Contains("System.Exception : some outer exception ---> System.InvalidOperationException : Some inner exception", exceptionDetails);
             Assert.Contains("End of inner exception", exceptionDetails);
             Assert.Contains("at Microsoft.Azure.WebJobs.Script.Tests.Extensions.ExceptionExtensionsTests.GetExceptionDetails_ReturnsExpectedResult()", exceptionDetails);
-            Assert.Contains("ExceptionExtensionsTests.cs : 20", exceptionDetails);
+            Assert.Contains("ExceptionExtensionsTests.cs", exceptionDetails);
         }
 
         [Fact]
@@ -58,6 +58,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
             Assert.Equal("Microsoft.Azure.WebJobs.Script.Workers.Rpc.RpcException", exceptionType);
             Assert.DoesNotContain(rpcMessage, exceptionMessage);
             Assert.DoesNotContain(rpcMessage, exceptionDetails);
+            Assert.Contains("safe text", formattedText);
         }
 
         [Fact]
@@ -76,7 +77,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
                 fullException = e;
             }
 
-            (string exceptionType, string exceptionMessage, string exceptionDetails, string formattedText) = fullException.GetSanitizedExceptionDetails("safe text");
+            (string exceptionType, string exceptionMessage, _, string formattedText) = fullException.GetSanitizedExceptionDetails("safe text");
 
             Assert.Equal("Microsoft.Azure.WebJobs.Script.Workers.Rpc.RpcException", exceptionType);
             Assert.Equal("Result: \nType: \nException: \nStack: ", exceptionMessage);

--- a/test/WebJobs.Script.Tests/Extensions/ExceptionExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/ExceptionExtensionsTests.cs
@@ -1,7 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
@@ -32,6 +34,53 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
             Assert.Contains("End of inner exception", exceptionDetails);
             Assert.Contains("at Microsoft.Azure.WebJobs.Script.Tests.Extensions.ExceptionExtensionsTests.GetExceptionDetails_ReturnsExpectedResult()", exceptionDetails);
             Assert.Contains("ExceptionExtensionsTests.cs : 20", exceptionDetails);
+        }
+
+        [Fact]
+        public void GetExceptionDetails_Rpc()
+        {
+            string rpcMessage = "rpcMessage";
+            Exception innerException = new RpcException("result", rpcMessage, "stack");
+            Exception outerException = new FunctionInvocationException("message", innerException);
+            Exception fullException;
+
+            try
+            {
+                throw outerException;
+            }
+            catch (Exception e)
+            {
+                fullException = e;
+            }
+
+            (string exceptionType, string exceptionMessage, string exceptionDetails, string formattedText) = fullException.GetSanitizedExceptionDetails("safe text");
+
+            Assert.Equal("Microsoft.Azure.WebJobs.Script.Workers.Rpc.RpcException", exceptionType);
+            Assert.DoesNotContain(rpcMessage, exceptionMessage);
+            Assert.DoesNotContain(rpcMessage, exceptionDetails);
+        }
+
+        [Fact]
+        public void GetExceptionDetails_Rpc_Empty()
+        {
+            Exception innerException = new RpcException(string.Empty, string.Empty, string.Empty);
+            Exception outerException = new FunctionInvocationException(string.Empty, innerException);
+            Exception fullException;
+
+            try
+            {
+                throw outerException;
+            }
+            catch (Exception e)
+            {
+                fullException = e;
+            }
+
+            (string exceptionType, string exceptionMessage, string exceptionDetails, string formattedText) = fullException.GetSanitizedExceptionDetails("safe text");
+
+            Assert.Equal("Microsoft.Azure.WebJobs.Script.Workers.Rpc.RpcException", exceptionType);
+            Assert.Equal("Result: \nType: \nException: \nStack: ", exceptionMessage);
+            Assert.Contains("safe text", formattedText);
         }
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

string.Replace is throwing exception if the remote message is empty.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
