### PR TITLE
Do Not Modify Function Language for dotnet-isolated worker runtime in workflowApp

### DIFF
--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -799,7 +799,7 @@ namespace Microsoft.Azure.WebJobs.Script
                     bool payloadMatchesWorkerRuntime = ValidateAndLogRuntimeMismatch(functions, workerRuntime, _hostingConfigOptions, _logger);
                     if (!payloadMatchesWorkerRuntime)
                     {
-                        UpdateFunctionMetadataLanguageForDotnetAssembly(functions, workerRuntime);
+                        UpdateFunctionMetadataLanguageForDotnetAssembly(functions, workerRuntime, _environment.IsLogicApp());
                         throwOnWorkerRuntimeAndPayloadMetadataMismatch = false; // we do not want to throw an exception in this case
                     }
                 }
@@ -860,8 +860,14 @@ namespace Microsoft.Azure.WebJobs.Script
             return functionDescriptors;
         }
 
-        private static void UpdateFunctionMetadataLanguageForDotnetAssembly(IEnumerable<FunctionMetadata> functions, string workerRuntime)
+        private static void UpdateFunctionMetadataLanguageForDotnetAssembly(IEnumerable<FunctionMetadata> functions, string workerRuntime, bool isLogicApp)
         {
+            if (isLogicApp)
+            {
+                // For Logic Apps, we want to keep the language as DotNetAssembly to avoid breaking changes.
+                return;
+            }
+
             foreach (var function in functions)
             {
                 if (function.Language == DotNetScriptTypes.DotNetAssembly)

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -791,15 +791,15 @@ namespace Microsoft.Azure.WebJobs.Script
             Collection<FunctionDescriptor> functionDescriptors = new Collection<FunctionDescriptor>();
             if (!cancellationToken.IsCancellationRequested)
             {
-                bool throwOnWorkerRuntimeAndPayloadMetadataMismatch = !(_environment.IsLogicApp() && _environment.IsLogicAppCodefulModeEnabled());
+                bool throwOnWorkerRuntimeAndPayloadMetadataMismatch = !_environment.IsLogicApp();
 
                 // this dotnet isolated specific logic is temporary to ensure in-proc payload compatibility with "dotnet-isolated" as the FUNCTIONS_WORKER_RUNTIME value.
-                if (string.Equals(workerRuntime, RpcWorkerConstants.DotNetIsolatedLanguageWorkerName, StringComparison.OrdinalIgnoreCase) && !_environment.IsPlaceholderModeEnabled())
+                if (!_environment.IsLogicApp() && string.Equals(workerRuntime, RpcWorkerConstants.DotNetIsolatedLanguageWorkerName, StringComparison.OrdinalIgnoreCase) && !_environment.IsPlaceholderModeEnabled())
                 {
                     bool payloadMatchesWorkerRuntime = ValidateAndLogRuntimeMismatch(functions, workerRuntime, _hostingConfigOptions, _logger);
                     if (!payloadMatchesWorkerRuntime)
                     {
-                        UpdateFunctionMetadataLanguageForDotnetAssembly(functions, workerRuntime, _environment.IsLogicApp());
+                        UpdateFunctionMetadataLanguageForDotnetAssembly(functions, workerRuntime);
                         throwOnWorkerRuntimeAndPayloadMetadataMismatch = false; // we do not want to throw an exception in this case
                     }
                 }
@@ -860,14 +860,8 @@ namespace Microsoft.Azure.WebJobs.Script
             return functionDescriptors;
         }
 
-        private static void UpdateFunctionMetadataLanguageForDotnetAssembly(IEnumerable<FunctionMetadata> functions, string workerRuntime, bool isLogicApp)
+        private static void UpdateFunctionMetadataLanguageForDotnetAssembly(IEnumerable<FunctionMetadata> functions, string workerRuntime)
         {
-            if (isLogicApp)
-            {
-                // For Logic Apps, we want to keep the language as DotNetAssembly to avoid breaking changes.
-                return;
-            }
-
             foreach (var function in functions)
             {
                 if (function.Language == DotNetScriptTypes.DotNetAssembly)

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/MultiLanguageEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/MultiLanguageEndToEndTests.cs
@@ -123,14 +123,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
         /// Runs tests with Node language provider function.
         /// </summary>
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task CodelessFunction_CanUse_SingleJavascriptLanguageProviders(bool enableDynamicWorkerResolution)
+        [InlineData(true, "dotnet")]
+        [InlineData(false, "dotnet")]
+        [InlineData(true, "dotnet-isolated")]
+        [InlineData(false, "dotnet-isolated")]
+        public async Task CodelessFunction_CanUse_SingleJavascriptLanguageProviders(bool enableDynamicWorkerResolution, string functionWorkerRuntime)
         {
             var sourceFunctionApp = Path.Combine(Environment.CurrentDirectory, "TestScripts", "NoFunction");
             var settings = new Dictionary<string, string>()
             {
                 [EnvironmentSettingNames.AppKind] = "workflowApp",
+                [EnvironmentSettingNames.FunctionWorkerRuntime] = functionWorkerRuntime,
             };
             var testEnvironment = new TestEnvironment(settings);
 


### PR DESCRIPTION
Logic App runs as a multi-language Function App. Today, Logic Apps use different values for the FUNCTIONS_WORKER_RUNTIME app setting, though most are configured with DotNet. Some existing Logic Apps already use dotnet-isolated, and Flex Consumption Logic Apps are also planned to adopt dotnet-isolated.

When FUNCTIONS_WORKER_RUNTIME=dotnet-isolated and none of the indexed Logic App functions declare their language as dotnet-isolated, the current behavior rewrites functions with language DotNetAssembly to dotnet-isolated. However, functions marked as DotNetAssembly are meant to be processed by DotNetFunctionDescriptorProvider.
Once functions with the language  DotNetAssembly is changed to dotnet-isolated, the system incorrectly uses MultiLanguageFunctionDescriptorProvider instead of DotNetFunctionDescriptorProvider to create bindings, resulting in binding failures. 
Here is the error message:

Error indexing method 'Functions.WorkflowDispatcher'
      Microsoft.Azure.WebJobs.Host.Indexers.FunctionIndexingException: Error indexing method 'Functions.WorkflowDispatcher'
       ---> System.InvalidOperationException: Can't bind EdgeWorkflowRuntimeTrigger to type 'System.Object'.
         at Microsoft.Azure.WebJobs.Host.Bindings.GenericCompositeBindingProvider`1.TryCreateAsync(BindingProviderContext context) in c:\git1\azure-webjobs-sdk\src\Microsoft.Azure.WebJobs.Host\Bindings\BindingProviders\GenericCompositeBindingProvider.cs:line 89
         at Microsoft.Azure.WebJobs.Host.Bindings.CompositeBindingProvider.TryCreateAsync(BindingProviderContext context) in c:\git1\azure-webjobs-sdk\src\Microsoft.Azure.WebJobs.Host\Bindings\BindingProviders\CompositeBindingProvider.cs:line 25
         at Microsoft.Azure.WebJobs.Host.Indexers.FunctionIndexer.IndexMethodAsyncCore(MethodInfo method, IFunctionIndexCollector index, CancellationToken cancellationToken) in c:\git1\azure-webjobs-sdk\src\Microsoft.Azure.WebJobs.Host\Indexers\FunctionIndexer.cs:line 198
         at Microsoft.Azure.WebJobs.Host.Indexers.FunctionIndexer.IndexMethodAsync(MethodInfo method, IFunctionIndexCollector index, CancellationToken cancellationToken) in c:\git1\azure-webjobs-sdk\src\Microsoft.Azure.WebJobs.Host\Indexers\FunctionIndexer.cs:line 149
         --- End of inner exception stack trace ---
         at Microsoft.Azure.WebJobs.Host.Indexers.FunctionIndexer.IndexMethodAsync(MethodInfo method, IFunctionIndexCollector index, CancellationToken cancellationToken) in c:\git1\azure-webjobs-sdk\src\Microsoft.Azure.WebJobs.Host\Indexers\FunctionIndexer.cs:line 157
         at Microsoft.Azure.WebJobs.Host.Indexers.FunctionIndexer.IndexTypeAsync(Type type, IFunctionIndexCollector index, CancellationToken cancellationToken) in c:\git1\azure-webjobs-sdk\src\Microsoft.Azure.WebJobs.Host\Indexers\FunctionIndexer.cs:line 85

To avoid these failures, the language property of Logic App–indexed functions must not be modified during processing.