### PR TITLE
Add WebPubSubTrigger to WebHookTriggers

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,3 +7,4 @@
 - Add JitTrace Files for v4.1045
 - Throw exception instead of timing out when worker channel exits before initializing gRPC (#10937)
 - Adding empty remote message check in the SystemLogger (#11473)
+- Fix `webPubSubTrigger`'s for Flex consumption sku (#11489)

--- a/src/WebJobs.Script/Extensions/BindingMetadataExtensions.cs
+++ b/src/WebJobs.Script/Extensions/BindingMetadataExtensions.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
         private const string HttpTrigger = "httpTrigger";
         private const string EventGridTrigger = "eventGridTrigger";
         private const string SignalRTrigger = "signalRTrigger";
+        private const string WebPubSubTrigger = "webPubSubTrigger";
         public const string AssistantSkillTrigger = "assistantSkillTrigger";
         private const string BlobTrigger = "blobTrigger";
 
@@ -24,6 +25,7 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
             EventGridTrigger,
             SignalRTrigger,
             AssistantSkillTrigger,
+            WebPubSubTrigger,
         };
 
         private static readonly HashSet<string> DurableTriggers = new(StringComparer.OrdinalIgnoreCase)
@@ -40,11 +42,7 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
         /// <returns><c>true</c> if an HTTP trigger, <c>false</c> otherwise.</returns>
         public static bool IsHttpTrigger(this BindingMetadata binding)
         {
-            if (binding is null)
-            {
-                throw new ArgumentNullException(nameof(binding));
-            }
-
+            ArgumentNullException.ThrowIfNull(binding);
             return string.Equals(HttpTrigger, binding.Type, StringComparison.OrdinalIgnoreCase);
         }
 
@@ -58,11 +56,7 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
         /// </remarks>
         public static bool IsWebHookTrigger(this BindingMetadata binding)
         {
-            if (binding is null)
-            {
-                throw new ArgumentNullException(nameof(binding));
-            }
-
+            ArgumentNullException.ThrowIfNull(binding);
             return WebHookTriggers.Contains(binding.Type);
         }
 
@@ -73,11 +67,7 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
         /// <returns><c>true</c> if a durable trigger, <c>false</c> otherwise.</returns>
         public static bool IsDurableTrigger(this BindingMetadata binding)
         {
-            if (binding is null)
-            {
-                throw new ArgumentNullException(nameof(binding));
-            }
-
+            ArgumentNullException.ThrowIfNull(binding);
             return DurableTriggers.Contains(binding.Type);
         }
 
@@ -88,11 +78,7 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
         /// <returns><c>true</c> if a EventGrid sourced blob trigger, <c>false</c> otherwise.</returns>
         public static bool IsEventGridBlobTrigger(this BindingMetadata binding)
         {
-            if (binding is null)
-            {
-                throw new ArgumentNullException(nameof(binding));
-            }
-
+            ArgumentNullException.ThrowIfNull(binding);
             if (string.Equals(BlobTrigger, binding.Type, StringComparison.OrdinalIgnoreCase))
             {
                 if (binding.Raw is { } obj)

--- a/test/WebJobs.Script.Tests/Extensions/BindingMetadataExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/BindingMetadataExtensionsTests.cs
@@ -43,7 +43,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
             JObject bindingJObject = JObject.Parse(rawJson);
             var bindingMetadata = BindingMetadata.Create(bindingJObject);
             bool result = bindingMetadata.SkipDeferredBinding();
-            Assert.Equal(expectedResult, result);
             result.Should().Be(expectedResult);
         }
 

--- a/test/WebJobs.Script.Tests/Extensions/BindingMetadataExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/BindingMetadataExtensionsTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
+using AwesomeAssertions;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Extensions;
 using Newtonsoft.Json.Linq;
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
             JObject bindingJObject = JObject.Parse(rawJson);
             var bindingMetadata = BindingMetadata.Create(bindingJObject);
             bool result = bindingMetadata.SupportsDeferredBinding();
-            Assert.Equal(expectedResult, result);
+            result.Should().Be(expectedResult);
         }
 
         [Fact]
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
             JObject bindingJObject = JObject.Parse("{\"name\":\"book\",\"direction\":\"In\",\"type\":\"blobTrigger\",\"blobPath\":\"expression-trigger\",\"connection\":\"AzureWebJobsStorage\",\"properties\":{\"skipDeferredBinding\":\"blah\"}}");
             var bindingMetadata = BindingMetadata.Create(bindingJObject);
             bool result = bindingMetadata.SupportsDeferredBinding();
-            Assert.False(result);
+            result.Should().BeFalse();
         }
 
         [Theory]
@@ -44,6 +44,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
             var bindingMetadata = BindingMetadata.Create(bindingJObject);
             bool result = bindingMetadata.SkipDeferredBinding();
             Assert.Equal(expectedResult, result);
+            result.Should().Be(expectedResult);
         }
 
         [Fact]
@@ -52,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
             JObject bindingJObject = JObject.Parse("{\"name\":\"book\",\"direction\":\"In\",\"type\":\"blobTrigger\",\"blobPath\":\"expression-trigger\",\"connection\":\"AzureWebJobsStorage\",\"properties\":{\"skipDeferredBinding\":\"blah\"}}");
             var bindingMetadata = BindingMetadata.Create(bindingJObject);
             bool result = bindingMetadata.SkipDeferredBinding();
-            Assert.False(result);
+            result.Should().BeFalse();
         }
 
         [Theory]
@@ -67,13 +68,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
                 Type = type,
             };
 
-            Assert.Equal(expected, bindingMetadata.IsHttpTrigger());
+            bindingMetadata.IsHttpTrigger().Should().Be(expected);
         }
 
         [Theory]
         [InlineData("eventGridTrigger", true)]
         [InlineData("signalRTrigger", true)]
         [InlineData("assistantSkillTrigger", true)]
+        [InlineData("webPubSubTrigger", true)]
         [InlineData("blobTrigger", false, "eventGrid")]
         [InlineData("blobTrigger", false, "other")]
         [InlineData("httpTrigger", false)]
@@ -93,7 +95,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
                 };
             }
 
-            Assert.Equal(expected, bindingMetadata.IsWebHookTrigger());
+            bindingMetadata.IsWebHookTrigger().Should().Be(expected);
         }
 
         [Theory]
@@ -109,7 +111,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
                 Type = type,
             };
 
-            Assert.Equal(expected, bindingMetadata.IsDurableTrigger());
+            bindingMetadata.IsDurableTrigger().Should().Be(expected);
         }
 
         [Theory]
@@ -134,7 +136,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
                 };
             }
 
-            Assert.Equal(expected, bindingMetadata.IsEventGridBlobTrigger());
+            bindingMetadata.IsEventGridBlobTrigger().Should().Be(expected);
         }
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #11493

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Adds `webPubSubTrigger` to list of known webhook triggers, fixing this trigger in flex skus.

Also includes:
- switch to `ArgumentNullException.ThrowIfNull` in `BindingMetadataExtensions.cs`
- switch to AwesomeAssertions in `BindingMetadataExtensionsTests.cs`
