### PR TITLE
Exclude /admin/health subpaths from otel

### DIFF
--- a/src/WebJobs.Script/Diagnostics/HealthChecks/DynamicHealthCheckService.cs
+++ b/src/WebJobs.Script/Diagnostics/HealthChecks/DynamicHealthCheckService.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
 
         private static partial class Log
         {
-            [LoggerMessage(0, LogLevel.Debug, "Script host does not have a health check service. Skipping script host health checks.")]
+            [LoggerMessage(0, LogLevel.Trace, "Script host does not have a health check service. Skipping script host health checks.")]
             public static partial void ScriptHostNoHealthCheckService(ILogger logger);
 
             [LoggerMessage(1, LogLevel.Warning, "Duplicate health check entry '{HealthCheck}' found when merging health check reports. Keeping the first entry.")]

--- a/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
+++ b/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
@@ -138,23 +138,23 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
                                 return false;
                             }
 
-                            // Exclude GET admin/warmup
+                            // Exclude GET /admin/warmup
                             if (string.Equals(context.Request.Method, HttpMethods.Get, StringComparison.OrdinalIgnoreCase)
                                 && context.Request.Path.Equals("/admin/warmup", StringComparison.OrdinalIgnoreCase))
                             {
                                 return false;
                             }
 
-                            // Exclude GET admin/host/status
+                            // Exclude GET /admin/host/status
                             if (string.Equals(context.Request.Method, HttpMethods.Get, StringComparison.OrdinalIgnoreCase)
                                 && context.Request.Path.Equals("/admin/host/status", StringComparison.OrdinalIgnoreCase))
                             {
                                 return false;
                             }
 
-                            // Exclude GET /admin/health
+                            // Exclude GET /admin/health and its sub-paths
                             if (string.Equals(context.Request.Method, HttpMethods.Get, StringComparison.OrdinalIgnoreCase)
-                                && context.Request.Path.Equals("/admin/health", StringComparison.OrdinalIgnoreCase))
+                                && context.Request.Path.StartsWithSegments("/admin/health", StringComparison.OrdinalIgnoreCase))
                             {
                                 return false;
                             }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Quick change to suppress `/admin/health` sub paths from OTel request collection. Also moves a health check log to trace level (from debug), as it shouldn't be needed unless explicitly included.
