### PR TITLE
Add ErrorCode to health check telemetry

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -10,3 +10,4 @@
 - Fix `webPubSubTrigger`'s for Flex consumption sku (#11489)
 - Suppress execution context flow into script host start (#11498)
 - Add AzureWebJobsStorage health check (#11471)
+- Add `ErrorCode` to health check telemetry (#11505)

--- a/src/WebJobs.Script/Diagnostics/HealthChecks/HealthCheckExtensions.cs
+++ b/src/WebJobs.Script/Diagnostics/HealthChecks/HealthCheckExtensions.cs
@@ -163,5 +163,16 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
 
             return new HealthReport(newEntries, result.TotalDuration);
         }
+
+        /// <summary>
+        /// Tries to get the error code from a health report entry.
+        /// </summary>
+        /// <param name="entry">The entry to get the error code from.</param>
+        /// <param name="errorCode">The error code, if found.</param>
+        /// <returns><c>true</c> if the error code was found; otherwise, <c>false</c>.</returns>
+        public static bool TryGetErrorCode(this HealthReportEntry entry, out object errorCode)
+        {
+            return entry.Data.TryGetValue(nameof(HealthCheckData.ErrorCode), out errorCode);
+        }
     }
 }

--- a/src/WebJobs.Script/Diagnostics/HealthChecks/HealthCheckMetrics.cs
+++ b/src/WebJobs.Script/Diagnostics/HealthChecks/HealthCheckMetrics.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Microsoft.Azure.WebJobs.Script.Metrics;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -63,6 +64,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
             public const string UnhealthyMetricName = Prefix + "health_check.unhealthy_checks";
             public const string HealthCheckTagTag = Prefix + "health_check.tag"; // Yes, tag tag. A metric tag with 'tag' in the name.
             public const string HealthCheckNameTag = Prefix + "health_check.name";
+            public const string HealthCheckErrorCodeTag = Prefix + "health_check.error_code";
         }
 
         public class HealthCheckReportHistogram(Meter meter)
@@ -70,18 +72,15 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
             private readonly Histogram<double> _histogram
                 = meter.CreateHistogram<double>(Constants.ReportMetricName);
 
-            public void Record(HealthReport report)
-                => _histogram.Record(ToMetricValue(report.Status));
-
-            public void Record(HealthReport report, string tag)
+            public void Record(HealthReport report, string? tag = null)
             {
-                if (string.IsNullOrWhiteSpace(tag))
-                {
-                    Record(report);
-                    return;
-                }
+                _histogram.Record(ToMetricValue(report.Status), GetTags(tag));
+            }
 
-                _histogram.Record(ToMetricValue(report.Status), Tag(Constants.HealthCheckTagTag, tag));
+            private static TagList GetTags(string? tag)
+            {
+                return string.IsNullOrWhiteSpace(tag)
+                    ? default : new(Tag(Constants.HealthCheckTagTag, tag));
             }
         }
 
@@ -90,21 +89,25 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
             private readonly Histogram<double> _histogram
                 = meter.CreateHistogram<double>(Constants.UnhealthyMetricName);
 
-            public void Record(string name, HealthReportEntry entry)
-                => _histogram.Record(ToMetricValue(entry.Status), Tag(Constants.HealthCheckNameTag, name));
-
-            public void Record(string name, HealthReportEntry entry, string tag)
+            public void Record(string name, HealthReportEntry entry, string? tag = null)
             {
-                if (string.IsNullOrWhiteSpace(tag))
+                _histogram.Record(ToMetricValue(entry.Status), GetTags(name, entry, tag));
+            }
+
+            private static TagList GetTags(string name, HealthReportEntry entry, string? tag)
+            {
+                TagList tags = new(Tag(Constants.HealthCheckNameTag, name));
+                if (!string.IsNullOrWhiteSpace(tag))
                 {
-                    Record(name, entry);
-                    return;
+                    tags.Add(Tag(Constants.HealthCheckTagTag, tag));
                 }
 
-                _histogram.Record(
-                    ToMetricValue(entry.Status),
-                    Tag(Constants.HealthCheckNameTag, name),
-                    Tag(Constants.HealthCheckTagTag, tag));
+                if (entry.TryGetErrorCode(out object errorCode))
+                {
+                    tags.Add(Tag(Constants.HealthCheckErrorCodeTag, errorCode));
+                }
+
+                return tags;
             }
         }
     }

--- a/src/WebJobs.Script/Diagnostics/HealthChecks/HealthCheckMetrics.cs
+++ b/src/WebJobs.Script/Diagnostics/HealthChecks/HealthCheckMetrics.cs
@@ -57,6 +57,13 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
                 _ => throw new NotSupportedException($"Unexpected HealthStatus value: {status}"),
             };
 
+        private static TagList CreateTagList(string key, object? value)
+        {
+            // CI has an old dotnet SDK which doesn't support the params ctor.
+            // This helper is to workaround that.
+            return new(default) { Tag(key, value) };
+        }
+
         public static class Constants
         {
             private const string Prefix = "azure.functions.";
@@ -80,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
             private static TagList GetTags(string? tag)
             {
                 return string.IsNullOrWhiteSpace(tag)
-                    ? default : new(Tag(Constants.HealthCheckTagTag, tag));
+                    ? default : CreateTagList(Constants.HealthCheckTagTag, tag);
             }
         }
 
@@ -96,7 +103,8 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
 
             private static TagList GetTags(string name, HealthReportEntry entry, string? tag)
             {
-                TagList tags = new(Tag(Constants.HealthCheckNameTag, name));
+                TagList tags = CreateTagList(Constants.HealthCheckNameTag, name);
+
                 if (!string.IsNullOrWhiteSpace(tag))
                 {
                     tags.Add(Tag(Constants.HealthCheckTagTag, tag));

--- a/src/WebJobs.Script/Diagnostics/HealthChecks/TelemetryHealthCheckPublisher.cs
+++ b/src/WebJobs.Script/Diagnostics/HealthChecks/TelemetryHealthCheckPublisher.cs
@@ -117,6 +117,12 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
                     writer.WriteStartObject();
                     writer.WriteString("status", entry.Status.ToString());
                     writer.WriteString("description", entry.Description);
+
+                    if (entry.TryGetErrorCode(out object errorCode))
+                    {
+                        writer.WriteString("errorCode", errorCode?.ToString());
+                    }
+
                     writer.WriteEndObject();
                 }
 

--- a/test/WebJobs.Script.Tests/Diagnostics/HealthChecks/TelemetryHealthCheckPublisherTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/HealthChecks/TelemetryHealthCheckPublisherTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
-using System.Drawing.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using AwesomeAssertions;
@@ -67,10 +66,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
             },
             {
                 CreateOptions(true, null),
-                [HealthStatus.Healthy, (HealthStatus.Unhealthy, "some.tag")],
+                [HealthStatus.Healthy, (HealthStatus.Unhealthy, "some.tag", "ExampleCode")],
                 1,
                 "Process reporting unhealthy: Unhealthy. Health check entries are " +
-                @"{""id0"":{""status"":""Healthy"",""description"":""desc0""},""id1"":{""status"":""Unhealthy"",""description"":""desc1""}}",
+                @"{""id0"":{""status"":""Healthy"",""description"":""desc0""},""id1"":{""status"":""Unhealthy"",""description"":""desc1"",""errorCode"":""ExampleCode""}}",
                 LogLevel.Warning,
                 0
             },
@@ -259,7 +258,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
             foreach (CheckDescriptor check in checks)
             {
                 IEnumerable<string> tags = check.Tag is null ? [] : [check.Tag];
-                HealthReportEntry entry = new(check.Status, $"desc{index}", TimeSpan.Zero, null, null, tags);
+                HealthReportEntry entry = new(check.Status, $"desc{index}", TimeSpan.Zero, null, check.GetData(), tags);
                 healthStatusRecords.Add(GetKey(index), entry);
                 index++;
             }
@@ -285,11 +284,26 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
                 _ => throw new NotSupportedException($"Unexpected HealthStatus value: {status}"),
             };
 
-        public record CheckDescriptor(HealthStatus Status, string Tag)
+        public record CheckDescriptor(HealthStatus Status, string Tag, string ErrorCode)
         {
-            public static implicit operator CheckDescriptor(HealthStatus status) => new(status, null);
+            public static implicit operator CheckDescriptor(HealthStatus status)
+                => new(status, null, null);
 
-            public static implicit operator CheckDescriptor((HealthStatus Status, string Tag) tuple) => new(tuple.Status, tuple.Tag);
+            public static implicit operator CheckDescriptor((HealthStatus Status, string Tag) tuple)
+                => new(tuple.Status, tuple.Tag, null);
+
+            public static implicit operator CheckDescriptor((HealthStatus Status, string Tag, string ErrorCode) tuple)
+                => new(tuple.Status, tuple.Tag, tuple.ErrorCode);
+
+            public Dictionary<string, object> GetData()
+            {
+                if (ErrorCode == null)
+                {
+                    return null;
+                }
+
+                return new() { [nameof(ErrorCode)] = ErrorCode };
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #11504

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Adds error code attribute to health check telemetry. This gives an improved view in telemetry. Example for azure storage with app insights. The `/AuthenticationFailed` in `azure.functions.webjobs.storage/AuthenticationFailed` is possible with this PR

``` KQL
customMetrics
| where timestamp > ago(10m)
| where name startswith "azure.functions.health_check."
| where customDimensions["azure.functions.health_check.tag"] == ""
| extend key = customDimensions["azure.functions.health_check.name"]
| extend key = iff(key == "", "aggregate", key)
| extend error = customDimensions["azure.functions.health_check.error_code"]
| extend key = iff(error == "", key, strcat(key, "/", error))
| summarize min(valueMin) by timestamp, key
| render timechart
```

<img width="1914" height="673" alt="image" src="https://github.com/user-attachments/assets/2c6d37a1-9c44-438e-8bbc-b50793ec4b0b" />