### PR TITLE
Update Python Worker Version to 4.41.1

### DIFF
--- a/eng/build/Workers.Python.props
+++ b/eng/build/Workers.Python.props
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <!-- Python worker does not ship with the host for windows. -->
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" VersionOverride="4.40.2" Condition="!$(RuntimeIdentifier.StartsWith('win'))" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" VersionOverride="4.41.1" Condition="!$(RuntimeIdentifier.StartsWith('win'))" />
   </ItemGroup>
 
 </Project>

--- a/eng/ci/templates/official/jobs/run-integration-tests.yml
+++ b/eng/ci/templates/official/jobs/run-integration-tests.yml
@@ -21,7 +21,7 @@ jobs:
 
   - task: UsePythonVersion@0
     inputs:
-      versionSpec: '3.7'
+      versionSpec: '3.13'
       addToPath: true
 
   - task: JavaToolInstaller@0

--- a/release_notes.md
+++ b/release_notes.md
@@ -11,5 +11,4 @@
 - Suppress execution context flow into script host start (#11498)
 - Add AzureWebJobsStorage health check (#11471)
 - Add `ErrorCode` to health check telemetry (#11505)
-
 - Update Python Worker Version to [4.41.1](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.41.1)

--- a/release_notes.md
+++ b/release_notes.md
@@ -11,3 +11,5 @@
 - Suppress execution context flow into script host start (#11498)
 - Add AzureWebJobsStorage health check (#11471)
 - Add `ErrorCode` to health check telemetry (#11505)
+
+- Update Python Worker Version to [4.41.1](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.41.1)

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Python.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Python.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             }
 
             public TestFixture()
-                : base(Path.Combine(Environment.CurrentDirectory, @"..", "..", "..", "..", "sample", "Python"), "samples", RpcWorkerConstants.PythonLanguageWorkerName, 1, "3.7")
+                : base(Path.Combine(Environment.CurrentDirectory, @"..", "..", "..", "..", "sample", "Python"), "samples", RpcWorkerConstants.PythonLanguageWorkerName, 1, "3.13")
             {
             }
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/WorkerConfigurationProviderBaseTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/WorkerConfigurationProviderBaseTests.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Theory]
-        [InlineData("3.8", "3.8")]
+        [InlineData("3.9", "3.9")]
         [InlineData(null, "3.12")]
         public void DefaultWorkerConfigs_Overrides_DefaultWorkerRuntimeVersion_AppSetting(string setting, string output)
         {


### PR DESCRIPTION
### Issue describing the changes in this PR

- Update Python Worker Version to [4.41.1](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.41.1)
- Update Python unit and integration tests to use later Python version

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the in-proc branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the in-proc branch is not required
    * [ ]Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to 
elease_notes.md
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
