### PR TITLE
Log siteUpdateId during initialization

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,3 +6,4 @@
 - Add JitTrace Files for v4.1046
 - Update Java Worker Version to [2.19.4](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.4)
 - Add area & error code to script & web host health checks (#11552)
+- Log siteUpdateId during initialization to track rolling update progress (#11527)

--- a/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
@@ -364,7 +364,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
         public static void LogHostInitializationSettings(this ILogger logger, string originalFunctionWorkerRuntime, string functionWorkerRuntime,
             string originalFunctionWorkerRuntimeVersion, string functionsWorkerRuntimeVersion, string functionExtensionVersion, string hostDirectory,
             bool inStandbyMode, bool hasBeenSpecialized, bool usePlaceholderDotNetIsolated, string websiteSku, string featureFlags,
-            IDictionary<string, string> hostingConfig, string hisMode, bool adminIsolationEnabled)
+            IDictionary<string, string> hostingConfig, string hisMode, bool adminIsolationEnabled, string functionsSiteUpdateId)
         {
             // This is a dump of values for telemetry right now, but eventually we will refactor this
             // into a proper Options object
@@ -383,7 +383,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
                 FeatureFlags = featureFlags,
                 HostingConfig = hostingConfig,
                 HISMode = hisMode,
-                AdminIsolationEnabled = adminIsolationEnabled
+                AdminIsolationEnabled = adminIsolationEnabled,
+                FunctionsSiteUpdateId = functionsSiteUpdateId
             };
 
             var options = new JsonSerializerOptions { WriteIndented = true };

--- a/src/WebJobs.Script.WebHost/Models/HostAssignmentContext.cs
+++ b/src/WebJobs.Script.WebHost/Models/HostAssignmentContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -23,6 +23,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
 
         [JsonProperty("lastModifiedTime")]
         public DateTime LastModifiedTime { get; set; }
+
+        [JsonProperty("siteUpdateId")]
+        public long SiteUpdateId { get; set; }
 
         [JsonProperty("MSISpecializationPayload")]
         public MSIContext MSIContext { get; set; }
@@ -164,6 +167,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
                 }
                 environment.SetEnvironmentVariable(EnvironmentSettingNames.EasyAuthClientId, EasyAuthSettings.SiteAuthClientId);
             }
+
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionsSiteUpdateId, SiteUpdateId.ToString());
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -816,6 +816,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             var featureFlags = environment.GetEnvironmentVariable(AzureWebJobsFeatureFlags);
             var hostingConfigDict = hostingConfigOptions.Features;
             var adminIsolationEnabled = environment.IsAdminIsolationEnabled();
+            var functionsSiteUpdateId = environment.GetFunctionsSiteUpdateId();
 
             string hisMode = "Disabled";
             if (FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagStrictHISModeEnabled))
@@ -832,7 +833,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
 
             logger.LogHostInitializationSettings(originalFunctionsWorkerRuntime, functionWorkerRuntime, originalFunctionsWorkerRuntimeVersion, functionWorkerRuntimeVersion,
-                functionExtensionVersion, currentDirectory, inStandbyMode, hasBeenSpecialized, usePlaceholderDotNetIsolated, websiteSku, featureFlags, hostingConfigDict, hisMode, adminIsolationEnabled);
+                functionExtensionVersion, currentDirectory, inStandbyMode, hasBeenSpecialized, usePlaceholderDotNetIsolated, websiteSku, featureFlags, hostingConfigDict, hisMode, adminIsolationEnabled,
+                functionsSiteUpdateId);
         }
 
         private void OnHostHealthCheckTimer(object state)

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -653,6 +653,11 @@ namespace Microsoft.Azure.WebJobs.Script
             return environment.GetEnvironmentVariableOrDefault(FunctionWorkerRuntime, string.Empty);
         }
 
+        public static string GetFunctionsSiteUpdateId(this IEnvironment environment)
+        {
+            return environment.GetEnvironmentVariableOrDefault(FunctionsSiteUpdateId, string.Empty);
+        }
+
         /// <summary>
         /// Gets a value indicating whether AzureFileShare should be mounted when specializing Linux Consumption workers.
         /// </summary>

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string AppInsightsAgent = "APPLICATIONINSIGHTS_ENABLE_AGENT";
         public const string FunctionsExtensionVersion = "FUNCTIONS_EXTENSION_VERSION";
         public const string FunctionWorkerRuntime = "FUNCTIONS_WORKER_RUNTIME";
+        public const string FunctionsSiteUpdateId = "FUNCTIONS_SITE_UPDATE_ID";
         public const string WorkerProbingPaths = "WORKER_PROBING_PATHS";
         public const string ContainerName = "CONTAINER_NAME";
         public const string WebsitePodName = "WEBSITE_POD_NAME";

--- a/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
@@ -595,6 +595,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             string functionExtensionVersion = "~4";
             string websiteSku = "Dynamic";
             string featureFlags = "EnableWorkerIndexing";
+            string functionsSiteUpdateId = "1767996105";
 
             mockEnvironment.Setup(e => e.GetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime)).Returns(functionWorkerRuntime);
             mockEnvironment.Setup(e => e.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName)).Returns(functionsWorkerRuntimeVersion);
@@ -603,6 +604,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             mockEnvironment.Setup(e => e.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags)).Returns(featureFlags);
             mockEnvironment.Setup(e => e.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteUsePlaceholderDotNetIsolated)).Returns("1");
             mockEnvironment.Setup(e => e.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsAdminIsolationEnabled)).Returns("1");
+            mockEnvironment.Setup(e => e.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsSiteUpdateId)).Returns(functionsSiteUpdateId);
 
             mockScriptWebHostEnvironment.Setup(e => e.InStandbyMode).Returns(false);
 
@@ -630,6 +632,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.True(result.GetProperty("UsePlaceholderDotNetIsolated").GetBoolean());
             Assert.Equal(websiteSku, result.GetProperty("WebSiteSku").GetString());
             Assert.Equal(featureFlags, result.GetProperty("FeatureFlags").GetString());
+            Assert.Equal(functionsSiteUpdateId, result.GetProperty("FunctionsSiteUpdateId").GetString());
 
             var hostingConfig = result.GetProperty("HostingConfig");
             Assert.Equal("TestValue1", hostingConfig.GetProperty("TestFeature1").GetString());


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

As part of the rolling updates feature, customers would like to track how their rolling update is progressing (i.e. how many v1 vs v2 instances they have up and running). In order to achieve this, we want to add a log during initialization that will indicate what version the worker is running on. In Legion, this systemVersion attribute is sent as a long representation of the MAX(configLastModifiedTime, contentLastModifiedTime) where configLastModifiedTime is the last timestamp when the site configuration was updated, and contentLastModifiedTime is the last timestamp when the code deployment was triggered for the app. 

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * [x] Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
