### PR TITLE
Update Java Worker Version to 2.19.4

### DIFF
--- a/eng/build/Workers.Java.props
+++ b/eng/build/Workers.Java.props
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" VersionOverride="2.19.2" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" VersionOverride="2.19.4" />
   </ItemGroup>
 
 </Project>

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,5 +3,5 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-- Update Java Worker Version to [2.19.4](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.4)
 - Add JitTrace Files for v4.1046
+- Update Java Worker Version to [2.19.4](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.4)

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,4 +3,5 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Update Java Worker Version to [2.19.4](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.4)
 - Add JitTrace Files for v4.1046

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>

--- a/src/WebJobs.Script/WebJobs.Script.csproj
+++ b/src/WebJobs.Script/WebJobs.Script.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>


### PR DESCRIPTION
### Issue describing the changes in this PR

Update Java Worker Version to 2.19.4

Java Worker Release note [2.19.4](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.4)

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the in-proc branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the in-proc branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to elease_notes.md
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
