### PR TITLE
Adding support to set `WorkingDirectory` while running a worker (#10690)

### DIFF
--- a/src/WebJobs.Script/Workers/ProcessManagement/WorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/ProcessManagement/WorkerDescription.cs
@@ -19,6 +19,13 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         public string DefaultExecutablePath { get; set; }
 
         /// <summary>
+        /// Gets or sets the working directory for worker executable. Defaults to the Function App root directory.
+        /// If set, it will be used as the working directory for the worker executable.
+        /// If not set, the Function App root directory will be used as the working directory for the worker executable.
+        /// </summary>
+        public string ExecutableWorkingDirectory { get; set; }
+
+        /// <summary>
         /// Gets or sets the default path to the worker.
         /// </summary>
         public string DefaultWorkerPath { get; set; }

--- a/src/WebJobs.Script/Workers/Profiles/WorkerDescriptionProfile.cs
+++ b/src/WebJobs.Script/Workers/Profiles/WorkerDescriptionProfile.cs
@@ -82,6 +82,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Profiles
             updatedDescription.Language = UseProfileOrDefault(ProfileDescription.Language, defaultWorkerDescription.Language);
             updatedDescription.WorkerDirectory = UseProfileOrDefault(ProfileDescription.WorkerDirectory, defaultWorkerDescription.WorkerDirectory);
             updatedDescription.IsDisabled = ProfileDescription.IsDisabled ?? defaultWorkerDescription.IsDisabled ?? false;
+            updatedDescription.ExecutableWorkingDirectory = UseProfileOrDefault(ProfileDescription.ExecutableWorkingDirectory, defaultWorkerDescription.ExecutableWorkingDirectory);
             return updatedDescription;
         }
 

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/RpcWorkerConfigFactory.cs
@@ -162,6 +162,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     if (ShouldAddWorkerConfig(workerDescription.Language))
                     {
                         workerDescription.FormatWorkerPathIfNeeded(_systemRuntimeInformation, _environment, _logger);
+                        workerDescription.FormatWorkingDirectoryIfNeeded();
                         workerDescription.FormatArgumentsIfNeeded(_logger);
                         workerDescription.ThrowIfFileNotExists(workerDescription.DefaultWorkerPath, nameof(workerDescription.DefaultWorkerPath));
                         workerDescription.ExpandEnvironmentVariables();

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerDescription.cs
@@ -262,5 +262,10 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
             return match.Value;
         }
+
+        internal void FormatWorkingDirectoryIfNeeded()
+        {
+            ExecutableWorkingDirectory = ExecutableWorkingDirectory?.Replace(RpcWorkerConstants.WorkerDirectoryPath, WorkerDirectory);
+        }
     }
 }

--- a/src/WebJobs.Script/Workers/Rpc/RpcWorkerProcess.cs
+++ b/src/WebJobs.Script/Workers/Rpc/RpcWorkerProcess.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         private readonly string _workerId;
         private readonly Uri _serverUri;
         private readonly string _scriptRootPath;
+        private readonly string _workerExecutableWorkingDirectory;
         private readonly WorkerProcessArguments _workerProcessArguments;
         private readonly string _workerDirectory;
         private readonly IOptions<FunctionsHostingConfigOptions> _hostingConfigOptions;
@@ -49,6 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             _workerId = workerId;
             _serverUri = serverUri;
             _scriptRootPath = rootScriptPath;
+            _workerExecutableWorkingDirectory = rpcWorkerConfig.Description.ExecutableWorkingDirectory ?? _scriptRootPath;
             _workerProcessArguments = rpcWorkerConfig.Arguments;
             _workerDirectory = rpcWorkerConfig.Description.WorkerDirectory;
             _hostingConfigOptions = hostingConfigOptions;
@@ -57,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         internal override Process CreateWorkerProcess()
         {
-            var workerContext = new RpcWorkerContext(Guid.NewGuid().ToString(), RpcWorkerConstants.DefaultMaxMessageLengthBytes, _workerId, _workerProcessArguments, _scriptRootPath, _serverUri);
+            var workerContext = new RpcWorkerContext(Guid.NewGuid().ToString(), RpcWorkerConstants.DefaultMaxMessageLengthBytes, _workerId, _workerProcessArguments, _workerExecutableWorkingDirectory, _serverUri);
             workerContext.EnvironmentVariables.Add(WorkerConstants.FunctionsWorkerDirectorySettingName, _workerDirectory);
             workerContext.EnvironmentVariables.Add(WorkerConstants.FunctionsApplicationDirectorySettingName, _scriptRootPath);
             workerContext.EnvironmentVariables.Add(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName, _environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName));

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.cs
@@ -356,6 +356,26 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             };
         }
 
+        public static IList<RpcWorkerConfig> GetTestWorkerConfigsWithExecutableWorkingDirectory()
+        {
+            return new List<RpcWorkerConfig>()
+            {
+                new RpcWorkerConfig
+                {
+                    Description = new RpcWorkerDescription
+                    {
+                        Extensions = new List<string>()
+                        {
+                            { ".jar" }
+                        },
+                        Language = "java",
+                        WorkerDirectory = "testDir",
+                        ExecutableWorkingDirectory = "executableDirectory"
+                    }
+                },
+            };
+        }
+
         public static string CreateOfflineFile()
         {
             // create a test offline file

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerProcessTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerProcessTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.Azure.WebJobs.Host.Scale;
@@ -18,53 +20,51 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 {
     public class RpcWorkerProcessTests
     {
-        private readonly Mock<IWorkerProcessFactory> _workerProcessFactory;
-        private RpcWorkerProcess _rpcWorkerProcess;
-        private Mock<IScriptEventManager> _eventManager;
-        private Mock<IHostProcessMonitor> _hostProcessMonitorMock;
-        private TestLogger _logger = new TestLogger("test");
-        private IOptions<FunctionsHostingConfigOptions> _functionsHostingConfigOptions;
+        private readonly Mock<IWorkerProcessFactory> _workerProcessFactory = new Mock<IWorkerProcessFactory>();
+        private readonly Mock<IScriptEventManager> _eventManager = new Mock<IScriptEventManager>();
+        private readonly TestLogger _logger = new TestLogger("test");
+        private readonly IOptions<FunctionsHostingConfigOptions> _functionsHostingConfigOptions;
+        private readonly Mock<IProcessRegistry> _processRegistry = new Mock<IProcessRegistry>();
+        private readonly TestRpcServer _rpcServer = new TestRpcServer();
+        private readonly Mock<IWorkerConsoleLogSource> _languageWorkerConsoleLogSource = new Mock<IWorkerConsoleLogSource>();
+        private readonly TestEnvironment _testEnv = new TestEnvironment();
+        private readonly Mock<IServiceProvider> _serviceProviderMock = new Mock<IServiceProvider>(MockBehavior.Strict);
+        private readonly TestOptionsMonitor<ScriptApplicationHostOptions> _scriptApplicationHostOptions = new TestOptionsMonitor<ScriptApplicationHostOptions>();
+        private Mock<IHostProcessMonitor> _hostProcessMonitorMock = new Mock<IHostProcessMonitor>(MockBehavior.Strict);
 
         public RpcWorkerProcessTests()
         {
-            _eventManager = new Mock<IScriptEventManager>();
-            _workerProcessFactory = new Mock<IWorkerProcessFactory>();
-            var processRegistry = new Mock<IProcessRegistry>();
-            var rpcServer = new TestRpcServer();
-            var languageWorkerConsoleLogSource = new Mock<IWorkerConsoleLogSource>();
-            var testEnv = new TestEnvironment();
-            var testWorkerConfigs = TestHelpers.GetTestWorkerConfigs();
-
-            _hostProcessMonitorMock = new Mock<IHostProcessMonitor>(MockBehavior.Strict);
             var scriptHostManagerMock = new Mock<IScriptHostManager>(MockBehavior.Strict);
             var scriptHostServiceProviderMock = scriptHostManagerMock.As<IServiceProvider>();
             scriptHostServiceProviderMock.Setup(p => p.GetService(typeof(IHostProcessMonitor))).Returns(() => _hostProcessMonitorMock.Object);
-
-            var serviceProviderMock = new Mock<IServiceProvider>(MockBehavior.Strict);
-            serviceProviderMock.Setup(p => p.GetService(typeof(IScriptHostManager))).Returns(scriptHostManagerMock.Object);
-
+            _serviceProviderMock.Setup(p => p.GetService(typeof(IScriptHostManager))).Returns(scriptHostManagerMock.Object);
             _functionsHostingConfigOptions = Options.Create(new FunctionsHostingConfigOptions());
+        }
 
-            _rpcWorkerProcess = new RpcWorkerProcess("node",
+        private RpcWorkerProcess GetRpcWorkerConfigProcess(RpcWorkerConfig workerConfig)
+        {
+            return new RpcWorkerProcess("node",
                 "testworkerId",
                 "testrootPath",
-                rpcServer.Uri,
-                testWorkerConfigs.ElementAt(0),
+                _rpcServer.Uri,
+                workerConfig,
                 _eventManager.Object,
                 _workerProcessFactory.Object,
-                processRegistry.Object,
+                _processRegistry.Object,
                 _logger,
-                languageWorkerConsoleLogSource.Object,
+                _languageWorkerConsoleLogSource.Object,
                 new TestMetricsLogger(),
-                serviceProviderMock.Object,
+                _serviceProviderMock.Object,
                 _functionsHostingConfigOptions,
-                testEnv,
+                _testEnv,
+                _scriptApplicationHostOptions,
                 new LoggerFactory());
         }
 
         [Fact]
         public void Constructor_RegistersHostStartedEvent()
         {
+            GetRpcWorkerConfigProcess(TestHelpers.GetTestWorkerConfigs().ElementAt(0));
             Func<IObserver<ScriptEvent>, bool> validate = p =>
             {
                 // validate the internal reactive ISink<HostStartEvent> implementation that
@@ -79,87 +79,93 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         [Fact]
         public void OnHostStart_RegistersProcessWithMonitor()
         {
+            var rpcWorkerProcess = GetRpcWorkerConfigProcess(TestHelpers.GetTestWorkerConfigs().ElementAt(0));
             Process process = Process.GetCurrentProcess();
-            _rpcWorkerProcess.Process = process;
+            rpcWorkerProcess.Process = process;
 
             _hostProcessMonitorMock.Setup(p => p.RegisterChildProcess(process));
 
             HostStartEvent evt = new HostStartEvent();
-            _rpcWorkerProcess.OnHostStart(evt);
+            rpcWorkerProcess.OnHostStart(evt);
             _hostProcessMonitorMock.Verify(p => p.RegisterChildProcess(process), Times.Once);
         }
 
         [Fact]
         public void RegisterWithProcessMonitor_Succeeds()
         {
+            var rpcWorkerProcess = GetRpcWorkerConfigProcess(TestHelpers.GetTestWorkerConfigs().ElementAt(0));
             Process process = Process.GetCurrentProcess();
-            _rpcWorkerProcess.Process = process;
+            rpcWorkerProcess.Process = process;
 
             _hostProcessMonitorMock.Setup(p => p.RegisterChildProcess(process));
 
-            _rpcWorkerProcess.RegisterWithProcessMonitor();
+            rpcWorkerProcess.RegisterWithProcessMonitor();
             _hostProcessMonitorMock.Verify(p => p.RegisterChildProcess(process), Times.Once);
 
             // registration is skipped if attempted again for the same monitor
-            _rpcWorkerProcess.RegisterWithProcessMonitor();
+            rpcWorkerProcess.RegisterWithProcessMonitor();
             _hostProcessMonitorMock.Verify(p => p.RegisterChildProcess(process), Times.Once);
 
             // if the monitor changes (e.g. due to a host restart)
             // registration is performed
             _hostProcessMonitorMock = new Mock<IHostProcessMonitor>(MockBehavior.Strict);
             _hostProcessMonitorMock.Setup(p => p.RegisterChildProcess(process));
-            _rpcWorkerProcess.RegisterWithProcessMonitor();
+            rpcWorkerProcess.RegisterWithProcessMonitor();
             _hostProcessMonitorMock.Verify(p => p.RegisterChildProcess(process), Times.Once);
         }
 
         [Fact]
         public void UnregisterFromProcessMonitor_Succeeds()
         {
+            var rpcWorkerProcess = GetRpcWorkerConfigProcess(TestHelpers.GetTestWorkerConfigs().ElementAt(0));
             Process process = Process.GetCurrentProcess();
-            _rpcWorkerProcess.Process = process;
+            rpcWorkerProcess.Process = process;
 
             _hostProcessMonitorMock.Setup(p => p.RegisterChildProcess(process));
             _hostProcessMonitorMock.Setup(p => p.UnregisterChildProcess(process));
 
             // not yet registered so noop
-            _rpcWorkerProcess.UnregisterFromProcessMonitor();
+            rpcWorkerProcess.UnregisterFromProcessMonitor();
             _hostProcessMonitorMock.Verify(p => p.UnregisterChildProcess(process), Times.Never);
 
-            _rpcWorkerProcess.RegisterWithProcessMonitor();
-            _rpcWorkerProcess.UnregisterFromProcessMonitor();
+            rpcWorkerProcess.RegisterWithProcessMonitor();
+            rpcWorkerProcess.UnregisterFromProcessMonitor();
             _hostProcessMonitorMock.Verify(p => p.UnregisterChildProcess(process), Times.Once);
 
             // attempting to unregister again is a noop
-            _rpcWorkerProcess.UnregisterFromProcessMonitor();
+            rpcWorkerProcess.UnregisterFromProcessMonitor();
             _hostProcessMonitorMock.Verify(p => p.UnregisterChildProcess(process), Times.Once);
         }
 
         [Fact]
         public void ErrorMessageQueue_Empty()
         {
-            Assert.Empty(_rpcWorkerProcess.ProcessStdErrDataQueue);
+            var rpcWorkerProcess = GetRpcWorkerConfigProcess(TestHelpers.GetTestWorkerConfigs().ElementAt(0));
+            Assert.Empty(rpcWorkerProcess.ProcessStdErrDataQueue);
         }
 
         [Fact]
         public void ErrorMessageQueue_Enqueue_Success()
         {
-            WorkerProcessUtilities.AddStdErrMessage(_rpcWorkerProcess.ProcessStdErrDataQueue, "Error1");
-            WorkerProcessUtilities.AddStdErrMessage(_rpcWorkerProcess.ProcessStdErrDataQueue, "Error2");
+            var rpcWorkerProcess = GetRpcWorkerConfigProcess(TestHelpers.GetTestWorkerConfigs().ElementAt(0));
+            WorkerProcessUtilities.AddStdErrMessage(rpcWorkerProcess.ProcessStdErrDataQueue, "Error1");
+            WorkerProcessUtilities.AddStdErrMessage(rpcWorkerProcess.ProcessStdErrDataQueue, "Error2");
 
-            Assert.True(_rpcWorkerProcess.ProcessStdErrDataQueue.Count == 2);
-            string exceptionMessage = string.Join(",", _rpcWorkerProcess.ProcessStdErrDataQueue.Where(s => !string.IsNullOrEmpty(s)));
+            Assert.True(rpcWorkerProcess.ProcessStdErrDataQueue.Count == 2);
+            string exceptionMessage = string.Join(",", rpcWorkerProcess.ProcessStdErrDataQueue.Where(s => !string.IsNullOrEmpty(s)));
             Assert.Equal("Error1,Error2", exceptionMessage);
         }
 
         [Fact]
         public void ErrorMessageQueue_Full_Enqueue_Success()
         {
-            WorkerProcessUtilities.AddStdErrMessage(_rpcWorkerProcess.ProcessStdErrDataQueue, "Error1");
-            WorkerProcessUtilities.AddStdErrMessage(_rpcWorkerProcess.ProcessStdErrDataQueue, "Error2");
-            WorkerProcessUtilities.AddStdErrMessage(_rpcWorkerProcess.ProcessStdErrDataQueue, "Error3");
-            WorkerProcessUtilities.AddStdErrMessage(_rpcWorkerProcess.ProcessStdErrDataQueue, "Error4");
-            Assert.True(_rpcWorkerProcess.ProcessStdErrDataQueue.Count == 3);
-            string exceptionMessage = string.Join(",", _rpcWorkerProcess.ProcessStdErrDataQueue.Where(s => !string.IsNullOrEmpty(s)));
+            var rpcWorkerProcess = GetRpcWorkerConfigProcess(TestHelpers.GetTestWorkerConfigs().ElementAt(0));
+            WorkerProcessUtilities.AddStdErrMessage(rpcWorkerProcess.ProcessStdErrDataQueue, "Error1");
+            WorkerProcessUtilities.AddStdErrMessage(rpcWorkerProcess.ProcessStdErrDataQueue, "Error2");
+            WorkerProcessUtilities.AddStdErrMessage(rpcWorkerProcess.ProcessStdErrDataQueue, "Error3");
+            WorkerProcessUtilities.AddStdErrMessage(rpcWorkerProcess.ProcessStdErrDataQueue, "Error4");
+            Assert.True(rpcWorkerProcess.ProcessStdErrDataQueue.Count == 3);
+            string exceptionMessage = string.Join(",", rpcWorkerProcess.ProcessStdErrDataQueue.Where(s => !string.IsNullOrEmpty(s)));
             Assert.Equal("Error2,Error3,Error4", exceptionMessage);
         }
 
@@ -185,7 +191,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         [Fact]
         public void HandleWorkerProcessExitError_PublishesWorkerRestartEvent_OnIntentionalRestartExitCode()
         {
-            _rpcWorkerProcess.HandleWorkerProcessRestart();
+            var rpcWorkerProcess = GetRpcWorkerConfigProcess(TestHelpers.GetTestWorkerConfigs().ElementAt(0));
+            rpcWorkerProcess.HandleWorkerProcessRestart();
 
             _eventManager.Verify(_ => _.Publish(It.IsAny<WorkerRestartEvent>()), Times.Once());
             _eventManager.Verify(_ => _.Publish(It.IsAny<WorkerErrorEvent>()), Times.Never());
@@ -194,6 +201,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         [Fact]
         public void WorkerProcess_Dispose()
         {
+            var rpcWorkerProcess = GetRpcWorkerConfigProcess(TestHelpers.GetTestWorkerConfigs().ElementAt(0));
             Process process = new Process();
             ProcessStartInfo startInfo = new ProcessStartInfo();
             startInfo.WindowStyle = ProcessWindowStyle.Hidden;
@@ -202,8 +210,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             process.StartInfo = startInfo;
             process.Start();
 
-            _rpcWorkerProcess.Process = process;
-            _rpcWorkerProcess.Dispose();
+            rpcWorkerProcess.Process = process;
+            rpcWorkerProcess.Dispose();
             var traces = _logger.GetLogMessages();
             var disposeLogs = traces.Where(m => string.Equals(m.FormattedMessage, "Worker process has not exited despite waiting for 1000 ms"));
             Assert.False(disposeLogs.Any());
@@ -212,15 +220,26 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         [Fact]
         public void CreateWorkerProcess_AddsHostingConfiguration()
         {
+            var rpcWorkerProcess = GetRpcWorkerConfigProcess(TestHelpers.GetTestWorkerConfigs().ElementAt(0));
             _functionsHostingConfigOptions.Value.Features["feature1"] = "1";
-            var process = _rpcWorkerProcess.CreateWorkerProcess();
+            var process = rpcWorkerProcess.CreateWorkerProcess();
 
             _workerProcessFactory.Verify(x => x.CreateWorkerProcess(It.Is<WorkerContext>(c => c.EnvironmentVariables["feature1"] == "1")));
         }
 
         [Fact]
+        public void CreateWorkerProcess_AddsExecutableWorkingDirectory()
+        {
+            var rpcWorkerProcess = GetRpcWorkerConfigProcess(TestHelpers.GetTestWorkerConfigsWithExecutableWorkingDirectory().First());
+            var process = rpcWorkerProcess.CreateWorkerProcess();
+
+            _workerProcessFactory.Verify(x => x.CreateWorkerProcess(It.Is<WorkerContext>(c => c.WorkingDirectory == "executableDirectory")));
+        }
+
+        [Fact]
         public void WorkerProcess_WaitForExit_AfterExit_DoesNotThrow()
         {
+            var rpcWorkerProcess = GetRpcWorkerConfigProcess(TestHelpers.GetTestWorkerConfigsWithExecutableWorkingDirectory().ElementAt(0));
             Process process = new Process();
             ProcessStartInfo startInfo = new ProcessStartInfo();
             startInfo.WindowStyle = ProcessWindowStyle.Hidden;
@@ -229,10 +248,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             process.StartInfo = startInfo;
             process.Start();
 
-            _rpcWorkerProcess.Process = process;
-            _rpcWorkerProcess.Dispose();
+            rpcWorkerProcess.Process = process;
+            rpcWorkerProcess.Dispose();
 
-            _rpcWorkerProcess.WaitForProcessExitInMilliSeconds(1);
+            rpcWorkerProcess.WaitForProcessExitInMilliSeconds(1);
 
             var traces = _logger.GetLogMessages();
             string msg = traces.Single().FormattedMessage;

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerProcessTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerProcessTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         private readonly Mock<IWorkerConsoleLogSource> _languageWorkerConsoleLogSource = new Mock<IWorkerConsoleLogSource>();
         private readonly TestEnvironment _testEnv = new TestEnvironment();
         private readonly Mock<IServiceProvider> _serviceProviderMock = new Mock<IServiceProvider>(MockBehavior.Strict);
-        private readonly TestOptionsMonitor<ScriptApplicationHostOptions> _scriptApplicationHostOptions = new TestOptionsMonitor<ScriptApplicationHostOptions>();
+        private readonly TestOptionsMonitor<ScriptApplicationHostOptions> _scriptApplicationHostOptions = new TestOptionsMonitor<ScriptApplicationHostOptions>(new ScriptApplicationHostOptions());
         private Mock<IHostProcessMonitor> _hostProcessMonitorMock = new Mock<IHostProcessMonitor>(MockBehavior.Strict);
 
         public RpcWorkerProcessTests()
@@ -57,7 +57,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 _serviceProviderMock.Object,
                 _functionsHostingConfigOptions,
                 _testEnv,
-                _scriptApplicationHostOptions,
                 new LoggerFactory());
         }
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Backport of old PR: https://github.com/Azure/azure-functions-host/pull/10690

### Issue describing the changes in this PR
Logic app needs this supper because PAL worker we are running as part of our PAL project, looks for `.spf` libraries in either in `CurrentDirectory` or `CurrentDirectory/lib`.
So we need a support in functions app to set the working directory of a worker process. Currently it defaults to function app's location.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

We have tested the changes using a worker config like below to run a pal process in Linux. Test branch `la-hybrid/v4.636.1`
```json
{
  "description": {
    "language": "dotnet-isolated",
    "extensions": [
      ".dll"
    ],
    "defaultExecutablePath": "{workerDirectoryPath}lapalfe",
    "executableWorkingDirectory": "{workerDirectoryPath}",
    "defaultWorkerPath": "lapalfe"
  },
  "processOptions": {
    "initializationTimeout": "00:00:30",
    "environmentReloadTimeout": "00:00:30"
  }
}
```
