### PR TITLE
Reduce instances to 3 when generating JIT traces to prevent YAML size failures

### DIFF
--- a/eng/ci/host.coldstart.yml
+++ b/eng/ci/host.coldstart.yml
@@ -41,6 +41,10 @@ parameters:
   displayName: Create Jit trace (Ensure "Collect DotNet trace" is set to true)
   type: boolean
   default: false
+- name: useReducedInstancesForJitTrace
+  displayName: Use reduced instances (3) for JIT trace generation (reduces YAML size for releases)
+  type: boolean
+  default: false
 
 - name: collectPerfViewProfileOnWindows
   displayName: Collect PerfView Profile (on Windows)
@@ -70,6 +74,11 @@ variables:
       value: true
     ${{ if ne(variables['Build.Reason'], 'Schedule') }}:
       value: ${{ parameters.collectPerfViewProfileOnWindows }}
+  - name: effectiveRunInstances
+    ${{ if and(eq(parameters.createJitTrace, true), eq(parameters.useReducedInstancesForJitTrace, true)) }}:
+      value: ${{ variables.jitReleaseInstances }}
+    ${{ else }}:
+      value: ${{ variables.runInstances }}
 
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
@@ -83,7 +92,7 @@ extends:
     - stage: RunWindows
       displayName: Record latency(Windows)
       jobs:
-      - ${{ each appId in split(variables.runInstances, ',') }}:
+      - ${{ each appId in split(variables.effectiveRunInstances, ',') }}:
         - ${{ if eq(parameters.includeHelloHttpNet9, true) }}:
           - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
             parameters:
@@ -129,28 +138,28 @@ extends:
             functionAppName: HelloHttpNet9
             description: .NET9 Web Application
             runInstances: 
-              items: ${{ split(variables.runInstances, ',') }}
+              items: ${{ split(variables.effectiveRunInstances, ',') }}
       - ${{ if eq(parameters.includeHelloHttpNet9NoProxy, true) }}:
         - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
           parameters:
             functionAppName: HelloHttpNet9NoProxy
             description: .NET9 Worker Application
             runInstances: 
-              items: ${{ split(variables.runInstances, ',') }}
+              items: ${{ split(variables.effectiveRunInstances, ',') }}
       - ${{ if eq(parameters.includeHelloHttpNode, true) }}:
         - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
           parameters:
             functionAppName: HelloHttpNode
             description: Node Application
             runInstances: 
-              items: ${{ split(variables.runInstances, ',') }}
+              items: ${{ split(variables.effectiveRunInstances, ',') }}
 
 # # LINUX
     - stage: RunLinux
       dependsOn: []
       displayName:  Record latency(Linux)
       jobs:
-      - ${{ each appId in split(variables.runInstances, ',') }}:
+      - ${{ each appId in split(variables.effectiveRunInstances, ',') }}:
         - ${{ if eq(parameters.includeHelloHttpNet9, true) }}:
           - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
             parameters:
@@ -194,7 +203,7 @@ extends:
             description: .NET9 Web Application
             os: Linux
             runInstances: 
-              items: ${{ split(variables.runInstances, ',') }}
+              items: ${{ split(variables.effectiveRunInstances, ',') }}
       - ${{ if eq(parameters.includeHelloHttpNet9NoProxy, true) }}:
         - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
           parameters:
@@ -202,7 +211,7 @@ extends:
             description: .NET9 Worker Application
             os: Linux
             runInstances: 
-              items: ${{ split(variables.runInstances, ',') }}
+              items: ${{ split(variables.effectiveRunInstances, ',') }}
       - ${{ if eq(parameters.includeHelloHttpNode, true) }}:
         - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
           parameters:
@@ -210,7 +219,7 @@ extends:
             description: Node Application
             os: Linux
             runInstances: 
-              items: ${{ split(variables.runInstances, ',') }}
+              items: ${{ split(variables.effectiveRunInstances, ',') }}
 
 # Merge JIT traces from different function apps and dedupe.
     - stage: MergeWindowsJitTraceFiles

--- a/eng/ci/host.coldstart.yml
+++ b/eng/ci/host.coldstart.yml
@@ -41,10 +41,6 @@ parameters:
   displayName: Create Jit trace (Ensure "Collect DotNet trace" is set to true)
   type: boolean
   default: false
-- name: useReducedInstancesForJitTrace
-  displayName: Use reduced instances (3) for JIT trace generation (reduces YAML size for releases)
-  type: boolean
-  default: false
 
 - name: collectPerfViewProfileOnWindows
   displayName: Collect PerfView Profile (on Windows)
@@ -75,7 +71,7 @@ variables:
     ${{ if ne(variables['Build.Reason'], 'Schedule') }}:
       value: ${{ parameters.collectPerfViewProfileOnWindows }}
   - name: effectiveRunInstances
-    ${{ if and(eq(parameters.createJitTrace, true), eq(parameters.useReducedInstancesForJitTrace, true)) }}:
+    ${{ if eq(parameters.createJitTrace, true) }}:
       value: ${{ variables.jitReleaseInstances }}
     ${{ else }}:
       value: ${{ variables.runInstances }}

--- a/eng/ci/templates/variables/coldstart.yml
+++ b/eng/ci/templates/variables/coldstart.yml
@@ -2,3 +2,6 @@ variables:
 # This controls how many cold start samples are collected for each app+OS combination.
 - name: runInstances
   value: "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20"
+# Reduced instance count for JIT trace generation to minimize YAML size
+- name: jitReleaseInstances
+  value: "1,2,3"


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This PR optimizes the cold start pipeline to automatically use a reduced number of instances (3 instead of 20) when generating JIT traces, preventing pipeline failures caused by excessively large YAML files.

**Problem**
The pipeline currently uses 20 instances from `coldstart.yml` for all runs. When generating JIT traces for releases with `createJitTrace: true`, this creates very large YAML files that exceed size limitations and cause pipeline failures.

**Solution**
Introduced a variable `effectiveRunInstances` that automatically selects the appropriate instance count based on the `createJitTrace` parameter:
- When `createJitTrace: true` -> uses 3 instances (1,2,3) for JIT trace generation
- When `createJitTrace: false` -> uses 20 instances for comprehensive cold start data collection
