### PR TITLE
Logging environment value of LocalSitePackagesPath in RunFromPackageHandler

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,3 +5,4 @@
 -->
 - Add JitTrace Files for v4.1046
 - Update Java Worker Version to [2.19.4](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.4)
+- Logging environment value of LocalSitePackagesPath in RunFromPackageHandler (#11541)

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
@@ -45,15 +45,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
         {
             try
             {
-                var localSitePackagesEnv = _environment.GetEnvironmentVariable(EnvironmentSettingNames.LocalSitePackages);
-                _logger.LogInformation($"Environment variable '{EnvironmentSettingNames.LocalSitePackages}' value: '{localSitePackagesEnv}'");
-
                 // If Azure Files are mounted, /home will point to a shared remote dir
                 // So extracting to /home/site/wwwroot can interfere with other running instances
                 // Instead extract to localSitePackagesPath and bind to /home/site/wwwroot
                 // home will continue to point to azure file share
-                var resolvedLocalSitePackages = localSitePackagesEnv ?? EnvironmentSettingNames.DefaultLocalSitePackagesPath;
-                var localSitePackagesPath = azureFilesMounted ? resolvedLocalSitePackages : string.Empty;
+                var localSitePackagesEnvValue = _environment.GetEnvironmentVariable(EnvironmentSettingNames.LocalSitePackages);
+                var resolvedLocalSitePackagesPath = localSitePackagesEnvValue ?? EnvironmentSettingNames.DefaultLocalSitePackagesPath;
+                _logger.LogInformation($"Environment variable '{EnvironmentSettingNames.LocalSitePackages}' value: '{localSitePackagesEnvValue}'. Resolved path: '{resolvedLocalSitePackagesPath}'");
+
+                var localSitePackagesPath = azureFilesMounted ? resolvedLocalSitePackagesPath : string.Empty;
 
                 // download zip
                 string filePath = await _packageDownloadHandler.Download(pkgContext);

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
@@ -45,13 +45,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
         {
             try
             {
+                var localSitePackagesEnv = _environment.GetEnvironmentVariable(EnvironmentSettingNames.LocalSitePackages);
+                _logger.LogInformation($"Environment variable '{EnvironmentSettingNames.LocalSitePackages}' value: '{localSitePackagesEnv}'");
+
                 // If Azure Files are mounted, /home will point to a shared remote dir
                 // So extracting to /home/site/wwwroot can interfere with other running instances
                 // Instead extract to localSitePackagesPath and bind to /home/site/wwwroot
                 // home will continue to point to azure file share
-                var localSitePackagesEnv = _environment.GetEnvironmentVariable(EnvironmentSettingNames.LocalSitePackages);
-                _logger.LogInformation($"Environment variable '{EnvironmentSettingNames.LocalSitePackages}' value: '{localSitePackagesEnv}'");
-
                 var resolvedLocalSitePackages = localSitePackagesEnv ?? EnvironmentSettingNames.DefaultLocalSitePackagesPath;
                 var localSitePackagesPath = azureFilesMounted ? resolvedLocalSitePackages : string.Empty;
 

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -49,10 +49,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
                 // So extracting to /home/site/wwwroot can interfere with other running instances
                 // Instead extract to localSitePackagesPath and bind to /home/site/wwwroot
                 // home will continue to point to azure file share
-                var localSitePackagesPath = azureFilesMounted
-                    ? _environment.GetEnvironmentVariableOrDefault(EnvironmentSettingNames.LocalSitePackages,
-                        EnvironmentSettingNames.DefaultLocalSitePackagesPath)
-                    : string.Empty;
+                var localSitePackagesEnv = _environment.GetEnvironmentVariable(EnvironmentSettingNames.LocalSitePackages);
+                _logger.LogInformation($"Environment variable '{EnvironmentSettingNames.LocalSitePackages}' value: '{localSitePackagesEnv}'");
+
+                var resolvedLocalSitePackages = localSitePackagesEnv ?? EnvironmentSettingNames.DefaultLocalSitePackagesPath;
+                var localSitePackagesPath = azureFilesMounted ? resolvedLocalSitePackages : string.Empty;
 
                 // download zip
                 string filePath = await _packageDownloadHandler.Download(pkgContext);

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
                 // home will continue to point to azure file share
                 var localSitePackagesEnvValue = _environment.GetEnvironmentVariable(EnvironmentSettingNames.LocalSitePackages);
                 var resolvedLocalSitePackagesPath = localSitePackagesEnvValue ?? EnvironmentSettingNames.DefaultLocalSitePackagesPath;
-                _logger.LogInformation($"Environment variable '{EnvironmentSettingNames.LocalSitePackages}' value: '{localSitePackagesEnvValue}'. Resolved path: '{resolvedLocalSitePackagesPath}'");
+                _logger.LogInformation("Environment variable '{LocalSitePackagesEnvVarName}' value: '{LocalSitePackagesEnvValue}'. Resolved path: '{ResolvedLocalSitePackagesPath}'", EnvironmentSettingNames.LocalSitePackages, localSitePackagesEnvValue, resolvedLocalSitePackagesPath);
 
                 var localSitePackagesPath = azureFilesMounted ? resolvedLocalSitePackagesPath : string.Empty;
 

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
                 // home will continue to point to azure file share
                 var localSitePackagesEnvValue = _environment.GetEnvironmentVariable(EnvironmentSettingNames.LocalSitePackages);
                 var resolvedLocalSitePackagesPath = localSitePackagesEnvValue ?? EnvironmentSettingNames.DefaultLocalSitePackagesPath;
-                _logger.LogInformation($"Environment variable '{EnvironmentSettingNames.LocalSitePackages}' value: '{localSitePackagesEnvValue}'. Resolved path: '{resolvedLocalSitePackagesPath}'");
+                _logger.LogDebug($"Environment variable '{EnvironmentSettingNames.LocalSitePackages}' value: '{localSitePackagesEnvValue}'. Resolved path: '{resolvedLocalSitePackagesPath}'");
 
                 var localSitePackagesPath = azureFilesMounted ? resolvedLocalSitePackagesPath : string.Empty;
 

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -222,12 +222,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             var logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
 
-            if (logs.Length == 10)
+            if (logs.Length == 11)
             {
                 Assert.Collection(logs,
                     p => Assert.StartsWith("Starting Assignment", p),
                     p => Assert.StartsWith("Applying 1 app setting(s)", p),
                     p => Assert.EndsWith("points to an existing blob: True", p),
+                    p => Assert.StartsWith("Environment variable 'LocalSitePackagesPath'", p),
                     p => Assert.StartsWith("Unsquashing remote zip", p),
                     p => Assert.StartsWith("Running: ", p),
                     p => Assert.StartsWith("Output:", p),
@@ -1606,12 +1607,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             var logs = _loggerProvider.GetAllLogMessages().Select(p => p.FormattedMessage).ToArray();
 
-            if (logs.Length == 10)
+            if (logs.Length == 11)
             {
                 Assert.Collection(logs,
                     p => Assert.StartsWith("Starting Assignment", p),
                     p => Assert.StartsWith("Applying 1 app setting(s)", p),
                     p => Assert.EndsWith("points to an existing blob: True", p),
+                    p => Assert.StartsWith("Environment variable 'LocalSitePackagesPath'", p),
                     p => Assert.StartsWith("Unsquashing remote zip", p),
                     p => Assert.StartsWith("Running: ", p),
                     p => Assert.StartsWith("Output:", p),


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves https://dev.azure.com/azfunc/internal/_workitems/edit/4428

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Adding a log to check whether any component is setting the environment variable "LocalSitePackagesPath" to a value other than "/local/sitepackages".