### PR TITLE
Adding AdminIsolation to logged host initialization settings

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceLoggerExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -364,7 +364,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
         public static void LogHostInitializationSettings(this ILogger logger, string originalFunctionWorkerRuntime, string functionWorkerRuntime,
             string originalFunctionWorkerRuntimeVersion, string functionsWorkerRuntimeVersion, string functionExtensionVersion, string hostDirectory,
             bool inStandbyMode, bool hasBeenSpecialized, bool usePlaceholderDotNetIsolated, string websiteSku, string featureFlags,
-            IDictionary<string, string> hostingConfig, string hisMode)
+            IDictionary<string, string> hostingConfig, string hisMode, bool adminIsolationEnabled)
         {
             // This is a dump of values for telemetry right now, but eventually we will refactor this
             // into a proper Options object
@@ -382,7 +382,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
                 WebSiteSku = websiteSku,
                 FeatureFlags = featureFlags,
                 HostingConfig = hostingConfig,
-                HISMode = hisMode
+                HISMode = hisMode,
+                AdminIsolationEnabled = adminIsolationEnabled
             };
 
             var options = new JsonSerializerOptions { WriteIndented = true };

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -798,34 +798,41 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 logger.InStandByMode(operationId);
             }
 
+            LogInitializationSettings(logger, _metricsLogger, _environment, _scriptWebHostEnvironment, _hostingConfigOptions.Value, _originalStandbyModeValue, _originalFunctionsWorkerRuntime, _originalFunctionsWorkerRuntimeVersion);
+        }
+
+        internal static void LogInitializationSettings(ILogger logger, IMetricsLogger metricsLogger, IEnvironment environment, IScriptWebHostEnvironment scriptWebHostEnvironment, FunctionsHostingConfigOptions hostingConfigOptions, bool originalStandbyModeValue,
+            string originalFunctionsWorkerRuntime, string originalFunctionsWorkerRuntimeVersion)
+        {
             // Log settings
-            var functionWorkerRuntime = _environment.GetEnvironmentVariable(FunctionWorkerRuntime);
-            var functionWorkerRuntimeVersion = _environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName);
-            var functionExtensionVersion = _environment.GetEnvironmentVariable(FunctionsExtensionVersion);
+            var functionWorkerRuntime = environment.GetEnvironmentVariable(FunctionWorkerRuntime);
+            var functionWorkerRuntimeVersion = environment.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName);
+            var functionExtensionVersion = environment.GetEnvironmentVariable(FunctionsExtensionVersion);
             var currentDirectory = Directory.GetCurrentDirectory();
-            var inStandbyMode = _scriptWebHostEnvironment.InStandbyMode;
-            var hasBeenSpecialized = _originalStandbyModeValue && !inStandbyMode;
-            var usePlaceholderDotNetIsolated = _environment.UsePlaceholderDotNetIsolated();
-            var websiteSku = _environment.GetEnvironmentVariable(AzureWebsiteSku);
-            var featureFlags = _environment.GetEnvironmentVariable(AzureWebJobsFeatureFlags);
-            var hostingConfigDict = _hostingConfigOptions.Value.Features;
+            var inStandbyMode = scriptWebHostEnvironment.InStandbyMode;
+            var hasBeenSpecialized = originalStandbyModeValue && !inStandbyMode;
+            var usePlaceholderDotNetIsolated = environment.UsePlaceholderDotNetIsolated();
+            var websiteSku = environment.GetEnvironmentVariable(AzureWebsiteSku);
+            var featureFlags = environment.GetEnvironmentVariable(AzureWebJobsFeatureFlags);
+            var hostingConfigDict = hostingConfigOptions.Features;
+            var adminIsolationEnabled = environment.IsAdminIsolationEnabled();
 
             string hisMode = "Disabled";
             if (FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagStrictHISModeEnabled))
             {
                 hisMode = "Strict";
-                _metricsLogger.LogEvent(MetricEventNames.HISStrictModeEnabled);
-                _logger.LogDebug($"HIS Strict mode enabled.");
+                metricsLogger.LogEvent(MetricEventNames.HISStrictModeEnabled);
+                logger.LogDebug($"HIS Strict mode enabled.");
             }
             else if (FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagStrictHISModeWarn))
             {
                 hisMode = "Warn";
-                _metricsLogger.LogEvent(MetricEventNames.HISStrictModeWarn);
-                _logger.LogDebug($"HIS Warn mode enabled.");
+                metricsLogger.LogEvent(MetricEventNames.HISStrictModeWarn);
+                logger.LogDebug($"HIS Warn mode enabled.");
             }
 
-            logger.LogHostInitializationSettings(_originalFunctionsWorkerRuntime, functionWorkerRuntime, _originalFunctionsWorkerRuntimeVersion, functionWorkerRuntimeVersion,
-                functionExtensionVersion, currentDirectory, inStandbyMode, hasBeenSpecialized, usePlaceholderDotNetIsolated, websiteSku, featureFlags, hostingConfigDict, hisMode);
+            logger.LogHostInitializationSettings(originalFunctionsWorkerRuntime, functionWorkerRuntime, originalFunctionsWorkerRuntimeVersion, functionWorkerRuntimeVersion,
+                functionExtensionVersion, currentDirectory, inStandbyMode, hasBeenSpecialized, usePlaceholderDotNetIsolated, websiteSku, featureFlags, hostingConfigDict, hisMode, adminIsolationEnabled);
         }
 
         private void OnHostHealthCheckTimer(object state)

--- a/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
@@ -5,8 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
@@ -568,6 +570,73 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             done = true;
             await listenerTask;
+        }
+
+        [Fact]
+        public void LogInitializationSettings_LogsExpectedSettings()
+        {
+            using var loggerProvider = new TestLoggerProvider();
+            using var loggerFactory = new LoggerFactory();
+            loggerFactory.AddProvider(loggerProvider);
+            var logger = loggerFactory.CreateLogger(LogCategories.Startup);
+
+            var mockMetricsLogger = new Mock<IMetricsLogger>();
+            var mockEnvironment = new Mock<IEnvironment>();
+            var mockScriptWebHostEnvironment = new Mock<IScriptWebHostEnvironment>();
+
+            var hostingConfigOptions = new FunctionsHostingConfigOptions();
+            hostingConfigOptions.Features["TestFeature1"] = "TestValue1";
+            hostingConfigOptions.Features["TestFeature2"] = "TestValue2";
+
+            string originalFunctionWorkerRuntime = "node";
+            string functionWorkerRuntime = "node";
+            string originalFunctionWorkerRuntimeVersion = "18";
+            string functionsWorkerRuntimeVersion = "20";
+            string functionExtensionVersion = "~4";
+            string websiteSku = "Dynamic";
+            string featureFlags = "EnableWorkerIndexing";
+
+            mockEnvironment.Setup(e => e.GetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime)).Returns(functionWorkerRuntime);
+            mockEnvironment.Setup(e => e.GetEnvironmentVariable(RpcWorkerConstants.FunctionWorkerRuntimeVersionSettingName)).Returns(functionsWorkerRuntimeVersion);
+            mockEnvironment.Setup(e => e.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsExtensionVersion)).Returns(functionExtensionVersion);
+            mockEnvironment.Setup(e => e.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku)).Returns(websiteSku);
+            mockEnvironment.Setup(e => e.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags)).Returns(featureFlags);
+            mockEnvironment.Setup(e => e.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteUsePlaceholderDotNetIsolated)).Returns("1");
+            mockEnvironment.Setup(e => e.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsAdminIsolationEnabled)).Returns("1");
+
+            mockScriptWebHostEnvironment.Setup(e => e.InStandbyMode).Returns(false);
+
+            WebJobsScriptHostService.LogInitializationSettings(logger, mockMetricsLogger.Object, mockEnvironment.Object, mockScriptWebHostEnvironment.Object,
+                hostingConfigOptions, true, originalFunctionWorkerRuntime, originalFunctionWorkerRuntimeVersion);
+
+            var logMessages = loggerProvider.GetAllLogMessages();
+            var initializationLogMessage = logMessages.SingleOrDefault(m => m.EventId.Id == 530);
+
+            Assert.NotNull(initializationLogMessage);
+            Assert.Equal(LogLevel.Debug, initializationLogMessage.Level);
+            Assert.Equal("LogHostInitializationSettings", initializationLogMessage.EventId.Name);
+
+            // Deserialize the JSON log message
+            var result = JsonSerializer.Deserialize<JsonElement>(initializationLogMessage.FormattedMessage);
+
+            Assert.Equal(originalFunctionWorkerRuntime, result.GetProperty("OriginalFunctionWorkerRuntime").GetString());
+            Assert.Equal(functionWorkerRuntime, result.GetProperty("FunctionsWorkerRuntime").GetString());
+            Assert.Equal(originalFunctionWorkerRuntimeVersion, result.GetProperty("OriginalFunctionWorkerRuntimeVersion").GetString());
+            Assert.Equal(functionsWorkerRuntimeVersion, result.GetProperty("FunctionsWorkerRuntimeVersion").GetString());
+            Assert.Equal(functionExtensionVersion, result.GetProperty("FunctionsExtensionVesion").GetString());
+            Assert.NotNull(result.GetProperty("HostDirectory").GetString());
+            Assert.False(result.GetProperty("InStandbyMode").GetBoolean());
+            Assert.True(result.GetProperty("HasBeenSpecialized").GetBoolean());
+            Assert.True(result.GetProperty("UsePlaceholderDotNetIsolated").GetBoolean());
+            Assert.Equal(websiteSku, result.GetProperty("WebSiteSku").GetString());
+            Assert.Equal(featureFlags, result.GetProperty("FeatureFlags").GetString());
+
+            var hostingConfig = result.GetProperty("HostingConfig");
+            Assert.Equal("TestValue1", hostingConfig.GetProperty("TestFeature1").GetString());
+            Assert.Equal("TestValue2", hostingConfig.GetProperty("TestFeature2").GetString());
+
+            Assert.Equal("Disabled", result.GetProperty("HISMode").GetString());
+            Assert.True(result.GetProperty("AdminIsolationEnabled").GetBoolean());
         }
 
         public Task SpecializeHostAsync()


### PR DESCRIPTION
Adding admin isolation enablement state to our host initialization log output. During a recent CRI investigation, it would have been useful for me to know this for the app. In order to determine it, I had to use ACIS.