### PR TITLE
[HealthChecks] Add Area and ErrorCode to ScriptHost/WebHost health checks

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,3 +5,4 @@
 -->
 - Add JitTrace Files for v4.1046
 - Update Java Worker Version to [2.19.4](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.4)
+- Add area & error code to script & web host health checks (#11552)

--- a/src/WebJobs.Script/Diagnostics/HealthChecks/HealthCheckData.cs
+++ b/src/WebJobs.Script/Diagnostics/HealthChecks/HealthCheckData.cs
@@ -110,6 +110,13 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
 
             return defaultValue;
         }
+
+        public static class Areas
+        {
+            public const string Configuration = "configuration";
+            public const string Connectivity = "connectivity";
+            public const string Lifecycle = "lifecycle";
+        }
     }
 
     // Partial class down here to separate IReadOnlyDictionary implementation details.

--- a/src/WebJobs.Script/Diagnostics/HealthChecks/ScriptHostHealthCheck.cs
+++ b/src/WebJobs.Script/Diagnostics/HealthChecks/ScriptHostHealthCheck.cs
@@ -20,22 +20,22 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
             Task.FromResult(HealthCheckResult.Healthy());
 
         private static readonly Task<HealthCheckResult> _unhealthyNoScriptHost =
-            Task.FromResult(HealthCheckResult.Unhealthy("No script host available"));
+            CreateUnhealthyResult("No script host available", "NoScriptHost");
 
         private static readonly Task<HealthCheckResult> _unhealthyNotStarted =
-            Task.FromResult(HealthCheckResult.Unhealthy("Script host not started"));
+            CreateUnhealthyResult("Script host not started", "Starting");
 
         private static readonly Task<HealthCheckResult> _unhealthyStopping =
-            Task.FromResult(HealthCheckResult.Unhealthy("Script host stopping"));
+            CreateUnhealthyResult("Script host stopping", "Stopping");
 
         private static readonly Task<HealthCheckResult> _unhealthyStopped =
-            Task.FromResult(HealthCheckResult.Unhealthy("Script host stopped"));
+            CreateUnhealthyResult("Script host stopped", "Stopped");
 
         private static readonly Task<HealthCheckResult> _unhealthyOffline =
-            Task.FromResult(HealthCheckResult.Unhealthy("Script host offline"));
+            CreateUnhealthyResult("Script host offline", "Offline");
 
         private static readonly Task<HealthCheckResult> _unhealthyUnknown =
-            Task.FromResult(HealthCheckResult.Unhealthy("Script host in unknown state"));
+            CreateUnhealthyResult("Script host in unknown state", "Unknown");
 
         /// <inheritdoc />
         public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
@@ -52,6 +52,16 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
             };
 
         private static Task<HealthCheckResult> UnhealthyError(Exception ex)
-            => Task.FromResult(HealthCheckResult.Unhealthy($"Script host in error state: {Environment.NewLine}{ex.Message}", ex));
+        {
+            HealthCheckData data = new() { Area = HealthCheckData.Areas.Lifecycle, ErrorCode = "Faulted" };
+            return Task.FromResult(HealthCheckResult.Unhealthy(
+                $"Script host in error state: {Environment.NewLine}{ex.Message}", ex, data));
+        }
+
+        private static Task<HealthCheckResult> CreateUnhealthyResult(string reason, string errorCode)
+        {
+            return Task.FromResult(HealthCheckResult.Unhealthy(
+                reason, data: new HealthCheckData() { Area = HealthCheckData.Areas.Lifecycle, ErrorCode = errorCode }));
+        }
     }
 }

--- a/src/WebJobs.Script/Diagnostics/HealthChecks/WebHostHealthCheck.cs
+++ b/src/WebJobs.Script/Diagnostics/HealthChecks/WebHostHealthCheck.cs
@@ -15,9 +15,9 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
     internal class WebHostHealthCheck(IHostApplicationLifetime lifetime) : IHealthCheck
     {
         private static readonly Task<HealthCheckResult> _healthy = Task.FromResult(HealthCheckResult.Healthy());
-        private static readonly Task<HealthCheckResult> _unhealthyNotStarted = Task.FromResult(HealthCheckResult.Unhealthy("Not Started"));
-        private static readonly Task<HealthCheckResult> _unhealthyStopping = Task.FromResult(HealthCheckResult.Unhealthy("Stopping"));
-        private static readonly Task<HealthCheckResult> _unhealthyStopped = Task.FromResult(HealthCheckResult.Unhealthy("Stopped"));
+        private static readonly Task<HealthCheckResult> _unhealthyNotStarted = CreateUnhealthyResult("Not Started", "NotStarted");
+        private static readonly Task<HealthCheckResult> _unhealthyStopping = CreateUnhealthyResult("Stopping", "Stopping");
+        private static readonly Task<HealthCheckResult> _unhealthyStopped = CreateUnhealthyResult("Stopped", "Stopped");
 
         /// <inheritdoc />
         public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
@@ -41,6 +41,12 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
             }
 
             return _healthy;
+        }
+
+        private static Task<HealthCheckResult> CreateUnhealthyResult(string reason, string errorCode)
+        {
+            return Task.FromResult(HealthCheckResult.Unhealthy(
+                reason, data: new HealthCheckData() { Area = HealthCheckData.Areas.Lifecycle, ErrorCode = errorCode }));
         }
     }
 }

--- a/src/WebJobs.Script/Diagnostics/HealthChecks/WebJobsStorageHealthCheck.cs
+++ b/src/WebJobs.Script/Diagnostics/HealthChecks/WebJobsStorageHealthCheck.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
             }
             catch (Exception ex) when (!ex.IsFatal())
             {
-                HealthCheckData data = GetData(ex, "connectivity");
+                HealthCheckData data = GetData(ex, HealthCheckData.Areas.Connectivity);
                 return HealthCheckResult.Unhealthy($"Unable to access {ConfigSection}", ex, data);
             }
         }
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
             catch (Exception ex) when (!ex.IsFatal())
             {
                 client = null;
-                HealthCheckData data = GetData(ex, "configuration");
+                HealthCheckData data = GetData(ex, HealthCheckData.Areas.Configuration);
                 result = HealthCheckResult.Unhealthy($"Unable to create client for {ConfigSection}", ex, data);
                 return false;
             }

--- a/test/WebJobs.Script.Tests/Diagnostics/HealthChecks/ScriptHostHealthCheckTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/HealthChecks/ScriptHostHealthCheckTests.cs
@@ -37,6 +37,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
             result.Status.Should().Be(status);
             result.Description.Should().Be(description);
             result.Exception.Should().BeNull();
+
+            if (status == HealthStatus.Healthy)
+            {
+                result.Data.Should().BeNullOrEmpty();
+            }
+            else
+            {
+                result.Data.Should().Contain(nameof(HealthCheckData.Area), HealthCheckData.Areas.Lifecycle);
+                result.Data.Should().Contain(nameof(HealthCheckData.ErrorCode), GetErrorCode(state));
+            }
         }
 
         [Fact]
@@ -56,6 +66,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
             result.Status.Should().Be(HealthStatus.Unhealthy);
             result.Description.Should().Be($"Script host in error state: {Environment.NewLine}{error.Message}");
             result.Exception.Should().Be(error);
+            result.Data.Should().Contain(nameof(HealthCheckData.Area), HealthCheckData.Areas.Lifecycle);
+            result.Data.Should().Contain(nameof(HealthCheckData.ErrorCode), "Faulted");
         }
+
+        private static string GetErrorCode(ScriptHostState state) => state switch
+        {
+            ScriptHostState.Default => "NoScriptHost",
+            ScriptHostState.Starting => "Starting",
+            ScriptHostState.Initialized or ScriptHostState.Running => null,
+            ScriptHostState.Stopping => "Stopping",
+            ScriptHostState.Stopped => "Stopped",
+            ScriptHostState.Offline => "Offline",
+            _ => "Unknown",
+        };
     }
 }

--- a/test/WebJobs.Script.Tests/Diagnostics/HealthChecks/WebHostHealthCheckTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/HealthChecks/WebHostHealthCheckTests.cs
@@ -40,6 +40,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
             result.Status.Should().Be(expected);
             result.Exception.Should().BeNull();
             result.Description.Should().Be(description);
+
+            if (expected == HealthStatus.Healthy)
+            {
+                result.Data.Should().BeNullOrEmpty();
+            }
+            else
+            {
+                result.Data.Should().Contain(nameof(HealthCheckData.Area), HealthCheckData.Areas.Lifecycle);
+                result.Data.Should().Contain(nameof(HealthCheckData.ErrorCode), state.ToString());
+            }
         }
 
         private static IHostApplicationLifetime CreateLifetime(


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #11551

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Adds `Area` and `ErrorCode` data to the web & script host health checks, giving a quick-look reason for why they are unhealthy (if unhealthy).