### PR TITLE
Use defaults for AzureMonitorExporterOptions to allow configuration of sampling etc

### DIFF
--- a/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
+++ b/src/WebJobs.Script/Diagnostics/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
@@ -148,7 +148,19 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
             if (enableAzureMonitor)
             {
                 TokenCredential credential = GetTokenCredential(configuration);
-                builder.UseAzureMonitorExporter(options => ConfigureAzureMonitorOptions(options, azMonConnectionString, credential));
+
+                // Use defaults for AzureMonitorExporterOptions
+                builder.UseAzureMonitorExporter();
+
+                // Set credential and connection string explicitly
+                builder.Services.Configure<AzureMonitorExporterOptions>(options =>
+                {
+                    options.ConnectionString = azMonConnectionString;
+                    if (credential is not null)
+                    {
+                        options.Credential = credential;
+                    }
+                });
             }
 
             return builder;
@@ -267,15 +279,6 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry
             }
 
             return null;
-        }
-
-        private static void ConfigureAzureMonitorOptions(AzureMonitorExporterOptions options, string connectionString, TokenCredential credential)
-        {
-            options.ConnectionString = connectionString;
-            if (credential is not null)
-            {
-                options.Credential = credential;
-            }
         }
 
         private static TracerProviderBuilder AddSources(this TracerProviderBuilder builder, ReadOnlySpan<string> sources)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Currently when configuring the function host to use OpenTelemetry it adds Azure Monitor Exporter through `UseAzureMonitorExporter(this IOpenTelemetryBuilder builder, Action<AzureMonitorExporterOptions> configureAzureMonitor)` extension method. This unfortunately bypasses the nice defaults in [`DefaultAzureMonitorExporterOptions`](https://github.com/Azure/azure-sdk-for-net/blob/c1bf54a02e34b617d0a52faa8f8c70eedafb733f/sdk/monitor/Azure.Monitor.OpenTelemetry.Exporter/src/DefaultAzureMonitorExporterOptions.cs#L14) which configures sampling via the OTEL environment variables `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG`.

Should resolve #11496.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [X] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)


