### PR TITLE
Update Microsoft.Azure.Functions.DotNetIsolatedNativeHost to 1.0.14

### DIFF
--- a/eng/build/Workers.Dotnet.props
+++ b/eng/build/Workers.Dotnet.props
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" VersionOverride="1.0.13" />
+    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" VersionOverride="1.0.14" />
   </ItemGroup>
 
   <Target Name="CleanDotnetWorkerFiles" BeforeTargets="AssignTargetPaths" Condition="'$(RuntimeIdentifier)' != ''">

--- a/release_notes.md
+++ b/release_notes.md
@@ -10,3 +10,7 @@
 - Stop collecting telemetry from admin endpoint requests (#11544)
 - Add area & error code to script & web host health checks (#11552)
 - Log siteUpdateId during initialization to track rolling update progress (#11527)
+- Update `Microsoft.Azure.Functions.DotNetIsolatedNativeHost` to `1.0.14` (#11569)
+    - [Remove net6.0 prelaunch app.](https://github.com/Azure/azure-functions-dotnet-worker/pull/3299)
+    - [Add net10.0 prelaunch app.](https://github.com/Azure/azure-functions-dotnet-worker/pull/3297)
+    - [Build Linux artifacts using ubuntu 24.](https://github.com/Azure/azure-functions-dotnet-worker/pull/3285)


### PR DESCRIPTION
Updating `Microsoft.Azure.Functions.DotNetIsolatedNativeHost` to 1.0.14 which includes below changes:

  1. [Remove net6.0 prelaunch app.](https://github.com/Azure/azure-functions-dotnet-worker/pull/3299)
  2. [Add net10.0 prelaunch app.](https://github.com/Azure/azure-functions-dotnet-worker/pull/3297)
  3. [Build Linux artifacts using ubuntu 24.](https://github.com/Azure/azure-functions-dotnet-worker/pull/3285)

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)
