### PR TITLE
Restart worker process on exit if not disposing

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,5 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+
+- Restart worker process if not disposed (shutting down) and exited with code 0 (#11576)

--- a/src/WebJobs.Script.Grpc/ProcessManagement/WorkerProcess.cs
+++ b/src/WebJobs.Script.Grpc/ProcessManagement/WorkerProcess.cs
@@ -126,6 +126,52 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             throw new InvalidOperationException("Process has not been started yet.");
         }
 
+        public void WaitForProcessExitInMilliSeconds(int waitTime)
+        {
+            try
+            {
+                if (!Process.HasExited)
+                {
+                    Process.WaitForExit(waitTime);
+                }
+            }
+            catch (Exception ex)
+            {
+                _workerProcessLogger.LogDebug(ex, "An exception was thrown while waiting for a worker process to exit. It is possible that the process had already exited and this can be ignored.");
+            }
+        }
+
+        public void Dispose()
+        {
+            Disposing = true;
+            // best effort process disposal
+
+            ProcessWaitingForTermination.SetResult(false);
+
+            try
+            {
+                _eventSubscription?.Dispose();
+
+                if (Process != null)
+                {
+                    if (!Process.HasExited)
+                    {
+                        Process.Kill();
+                        if (!Process.WaitForExit(processExitTimeoutInMilliseconds))
+                        {
+                            _workerProcessLogger.LogWarning("Worker process {processId} has not exited despite waiting for {processExitTimeoutInMilliseconds} ms", Process?.Id, processExitTimeoutInMilliseconds);
+                        }
+                    }
+                    Process.Dispose();
+                }
+            }
+            catch (Exception exc)
+            {
+                _workerProcessLogger?.LogDebug(exc, "Exception on worker disposal.");
+                //ignore
+            }
+        }
+
         private void OnErrorDataReceived(object sender, DataReceivedEventArgs e)
         {
             if (e.Data != null)
@@ -185,13 +231,10 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
                 ThrowIfExitError();
 
                 exit = Process.ExitCode;
-                if (Process.ExitCode == WorkerConstants.SuccessExitCode)
+                if (exit is WorkerConstants.IntentionalRestartExitCode or WorkerConstants.SuccessExitCode)
                 {
                     Process.WaitForExit();
                     Process.Close();
-                }
-                else if (Process.ExitCode == WorkerConstants.IntentionalRestartExitCode)
-                {
                     HandleWorkerProcessRestart();
                 }
             }
@@ -273,52 +316,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         internal abstract void HandleWorkerProcessExitError(WorkerProcessExitException langExc);
 
         internal abstract void HandleWorkerProcessRestart();
-
-        public void WaitForProcessExitInMilliSeconds(int waitTime)
-        {
-            try
-            {
-                if (!Process.HasExited)
-                {
-                    Process.WaitForExit(waitTime);
-                }
-            }
-            catch (Exception ex)
-            {
-                _workerProcessLogger.LogDebug(ex, "An exception was thrown while waiting for a worker process to exit. It is possible that the process had already exited and this can be ignored.");
-            }
-        }
-
-        public void Dispose()
-        {
-            Disposing = true;
-            // best effort process disposal
-
-            ProcessWaitingForTermination.SetResult(false);
-
-            try
-            {
-                _eventSubscription?.Dispose();
-
-                if (Process != null)
-                {
-                    if (!Process.HasExited)
-                    {
-                        Process.Kill();
-                        if (!Process.WaitForExit(processExitTimeoutInMilliseconds))
-                        {
-                            _workerProcessLogger.LogWarning("Worker process {processId} has not exited despite waiting for {processExitTimeoutInMilliseconds} ms", Process?.Id, processExitTimeoutInMilliseconds);
-                        }
-                    }
-                    Process.Dispose();
-                }
-            }
-            catch (Exception exc)
-            {
-                _workerProcessLogger?.LogDebug(exc, "Exception on worker disposal.");
-                //ignore
-            }
-        }
 
         internal void OnHostStart(HostStartEvent evt)
         {

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerProcessTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerProcessTests.cs
@@ -187,11 +187,24 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.False(WorkerProcessUtilities.IsConsoleLog(msg));
         }
 
-        [Fact]
-        public void HandleWorkerProcessExitError_PublishesWorkerRestartEvent_OnIntentionalRestartExitCode()
+        [Theory]
+        [InlineData(WorkerConstants.IntentionalRestartExitCode)]
+        [InlineData(WorkerConstants.SuccessExitCode)]
+        public async Task HandleWorkerProcessExit_PublishesWorkerRestartEvent(int exitCode)
         {
-            var rpcWorkerProcess = GetRpcWorkerConfigProcess(TestHelpers.GetTestWorkerConfigs().ElementAt(0));
-            rpcWorkerProcess.HandleWorkerProcessRestart();
+            // arrange
+            using Process process = GetProcess(exitCode);
+            _hostProcessMonitorMock.Setup(m => m.RegisterChildProcess(process));
+            _hostProcessMonitorMock.Setup(m => m.UnregisterChildProcess(process));
+            _workerProcessFactory.Setup(m => m.CreateWorkerProcess(It.IsNotNull<WorkerContext>())).Returns(process);
+            using var rpcWorkerProcess = GetRpcWorkerConfigProcess(
+                TestHelpers.GetTestWorkerConfigsWithExecutableWorkingDirectory().ElementAt(0));
+
+            // act
+            await rpcWorkerProcess.StartProcessAsync();
+
+            // assert
+            await rpcWorkerProcess.WaitForExitAsync();
 
             _eventManager.Verify(_ => _.Publish(It.IsAny<WorkerRestartEvent>()), Times.Once());
             _eventManager.Verify(_ => _.Publish(It.IsAny<WorkerErrorEvent>()), Times.Never());


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #11500 

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This PR updates `WorkerProcess` to signal for worker restart on exit code 0 (as well as the current exit code 200).
