### PR TITLE
Add round-robin issue assignment workflow

### DIFF
--- a/.github/workflows/round-robin-assign.yml
+++ b/.github/workflows/round-robin-assign.yml
@@ -1,0 +1,57 @@
+name: Round-robin issue assignment
+
+on:
+  issues:
+    types: [opened]
+
+# Important: avoid race conditions if multiple issues are opened close together.
+# This serializes runs in the same "group" instead of running in parallel.
+concurrency:
+  group: rr-issue-assignment
+  cancel-in-progress: false
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+
+    # Needed for assigning the issue if you use GITHUB_TOKEN in any step.
+    # In this workflow we use the PAT for both reading/updating vars and assigning,
+    # but keeping issues:write is still fine.
+    permissions:
+      issues: write
+      contents: read
+
+    steps:
+      - name: Round-robin assign and persist last index
+        env:
+          GH_TOKEN: ${{ secrets.RR_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+
+          # Read the assignee list variable
+          assignees_json=$(gh api -H "Accept: application/vnd.github+json" \
+            /repos/$REPO/actions/variables/RR_ASSIGNEES --jq .value)
+
+          # Read the last index variable
+          last_index=$(gh api -H "Accept: application/vnd.github+json" \
+            /repos/$REPO/actions/variables/RR_LAST_INDEX --jq .value)
+
+          # Compute next index (wrap around)
+          count=$(echo "$assignees_json" | jq 'length')
+          next_index=$(( (last_index + 1) % count ))
+
+          assignee=$(echo "$assignees_json" | jq -r ".[$next_index]")
+
+          echo "Assigning issue #$ISSUE_NUMBER to $assignee (index $next_index of $count)"
+
+          # Assign the issue
+          gh api -X POST -H "Accept: application/vnd.github+json" \
+            /repos/$REPO/issues/$ISSUE_NUMBER/assignees \
+            -f assignees[]="$assignee" >/dev/null
+
+          # Persist updated index back to the repo variable
+          gh api -X PATCH -H "Accept: application/vnd.github+json" \
+            /repos/$REPO/actions/variables/RR_LAST_INDEX \
+            -f name="RR_LAST_INDEX" -f value="$next_index" >/dev/null


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

This pull request introduces a new GitHub Actions workflow to automate round-robin assignment of issues when they are opened. The workflow ensures that each new issue is assigned to the next person in a predefined list, and it persists the last assigned index to maintain the rotation order, even if multiple issues are opened in quick succession.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)