### PR TITLE
Updating round-robin issue assignment workflow for debugging

### DIFF
--- a/.github/workflows/round-robin-assign.yml
+++ b/.github/workflows/round-robin-assign.yml
@@ -49,9 +49,9 @@ jobs:
           # Assign the issue
           gh api -X POST -H "Accept: application/vnd.github+json" \
             /repos/$REPO/issues/$ISSUE_NUMBER/assignees \
-            -f assignees[]="$assignee" >/dev/null
+            -f assignees[]="$assignee"
 
           # Persist updated index back to the repo variable
           gh api -X PATCH -H "Accept: application/vnd.github+json" \
             /repos/$REPO/actions/variables/RR_LAST_INDEX \
-            -f name="RR_LAST_INDEX" -f value="$next_index" >/dev/null
+            -f name="RR_LAST_INDEX" -f value="$next_index"


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

This pull request makes a minor update to the `.github/workflows/round-robin-assign.yml` workflow file. The change removes redirection of command output to `/dev/null` for two `gh api` commands, allowing their output to be visible in the workflow logs.

- Removed output redirection to `/dev/null` from the `gh api` commands that assign issues and update the round-robin index, so their responses will now be shown in the logs.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
