### PR TITLE
Add PowerShell 7.6 worker

### DIFF
--- a/eng/build/Workers.Powershell.props
+++ b/eng/build/Workers.Powershell.props
@@ -4,6 +4,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" VersionOverride="4.0.3148" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" VersionOverride="4.0.4025" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" VersionOverride="4.0.4581" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.6" VersionOverride="4.0.4757" />
   </ItemGroup>
 
   <Target Name="RemovePowershellWorkerRuntimes" BeforeTargets="AssignTargetPaths" Condition="'$(RuntimeIdentifier)' != ''">

--- a/eng/build/Workers.Powershell.props
+++ b/eng/build/Workers.Powershell.props
@@ -3,7 +3,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" VersionOverride="4.0.3148" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" VersionOverride="4.0.4025" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" VersionOverride="4.0.4581" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" VersionOverride="4.0.4759" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.6" VersionOverride="4.0.4757" />
   </ItemGroup>
 

--- a/eng/build/Workers.Powershell.props
+++ b/eng/build/Workers.Powershell.props
@@ -4,7 +4,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" VersionOverride="4.0.3148" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" VersionOverride="4.0.4025" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" VersionOverride="4.0.4759" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.6" VersionOverride="4.0.4757" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.6" VersionOverride="4.0.4778" />
   </ItemGroup>
 
   <Target Name="RemovePowershellWorkerRuntimes" BeforeTargets="AssignTargetPaths" Condition="'$(RuntimeIdentifier)' != ''">

--- a/release_notes.md
+++ b/release_notes.md
@@ -7,3 +7,5 @@
 - Add support for propagating tags from the worker to the host and update the protobuf version to `v1.12.0-protofile` (#11575)
 - Restart worker process if not disposed (shutting down) and exited with code 0 (#11576)
 - Fix race condition in SecretManager secret caching with double-check locking pattern (#11560)
+- Update PowerShell 7.4 worker to 4.0.4759
+- Add PowerShell 7.6 worker to supported runtimes

--- a/test/WebJobs.Script.Tests/Workers/Rpc/WorkerConfigurationProviderBaseTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/WorkerConfigurationProviderBaseTests.cs
@@ -248,6 +248,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Theory]
+        [InlineData("7.6", "7.6")]
         [InlineData("7.4", "7.4")]
         [InlineData("7.2", "7.2")]
         [InlineData(null, "7.4")]


### PR DESCRIPTION
Adds the PowerShell 7.6 worker to the Functions Host
Also updates PowerShell 7.4 worker to 4.0.4759

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
