### PR TITLE
improve timer trigger schedule validation for consumption plans

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -9,3 +9,4 @@
 - Fix race condition in SecretManager secret caching with double-check locking pattern (#11560)
 - Fixed worker configuration cache invalidation to properly refresh language worker options during host restarts with extension bundles (#11582)
 - Logging environment value of LocalSitePackagesPath in RunFromPackageHandler (#11541)
+- Improve timer trigger schedule validation for all consumption plans: accept 5 and 6-digit CRON expressions, apply validation to all consumption SKUs, and warn on non-CRON schedules for Linux Consumption (#11601)

--- a/src/WebJobs.Script/Binding/CoreExtensionsScriptBindingProvider.cs
+++ b/src/WebJobs.Script/Binding/CoreExtensionsScriptBindingProvider.cs
@@ -3,9 +3,11 @@
 using System;
 using System.Collections.ObjectModel;
 using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs.Script.Configuration;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Extensibility;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NCrontab;
 
 namespace Microsoft.Azure.WebJobs.Script.Binding
@@ -16,19 +18,19 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
     internal class CoreExtensionsScriptBindingProvider : ScriptBindingProvider
     {
         private readonly INameResolver _nameResolver;
-        private readonly IEnvironment _environment;
+        private readonly TimerTriggerPlatformOptions _platformOptions;
 
-        public CoreExtensionsScriptBindingProvider(INameResolver nameResolver, IEnvironment environment, ILogger<CoreExtensionsScriptBindingProvider> logger)
+        public CoreExtensionsScriptBindingProvider(INameResolver nameResolver, IOptions<TimerTriggerPlatformOptions> platformOptions, ILogger<CoreExtensionsScriptBindingProvider> logger)
             : base(logger)
         {
             _nameResolver = nameResolver ?? throw new ArgumentNullException(nameof(nameResolver));
-            _environment = environment ?? throw new ArgumentNullException(nameof(environment));
+            _platformOptions = (platformOptions ?? throw new ArgumentNullException(nameof(platformOptions))).Value;
         }
 
         /// <inheritdoc/>
         public override bool TryCreate(ScriptBindingContext context, out ScriptBinding binding)
         {
-            if (context == null)
+            if (context is null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
@@ -37,21 +39,23 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
 
             if (string.Equals(context.Type, "timerTrigger", StringComparison.OrdinalIgnoreCase))
             {
-                binding = new TimerTriggerScriptBinding(_nameResolver, _environment, context);
+                binding = new TimerTriggerScriptBinding(_nameResolver, _platformOptions, Logger, context);
             }
 
-            return binding != null;
+            return binding is not null;
         }
 
         internal class TimerTriggerScriptBinding : ScriptBinding
         {
             private readonly INameResolver _nameResolver;
-            private readonly IEnvironment _environment;
+            private readonly TimerTriggerPlatformOptions _platformOptions;
+            private readonly ILogger _logger;
 
-            public TimerTriggerScriptBinding(INameResolver nameResolver, IEnvironment environment, ScriptBindingContext context) : base(context)
+            public TimerTriggerScriptBinding(INameResolver nameResolver, TimerTriggerPlatformOptions platformOptions, ILogger logger, ScriptBindingContext context) : base(context)
             {
                 _nameResolver = nameResolver ?? throw new ArgumentNullException(nameof(nameResolver));
-                _environment = environment ?? throw new ArgumentNullException(nameof(environment));
+                _platformOptions = platformOptions ?? throw new ArgumentNullException(nameof(platformOptions));
+                _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             }
 
             public override Type DefaultType => typeof(TimerInfo);
@@ -63,18 +67,25 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
                 string schedule = Context.GetMetadataValue<string>("schedule");
                 bool runOnStartup = Context.GetMetadataValue<bool>("runOnStartup");
                 bool useMonitor = Context.GetMetadataValue<bool>("useMonitor", true);
-                if (_environment.IsWindowsConsumption())
+
+                if (_platformOptions.NonCronScheduleBehavior is not NonCronScheduleBehavior.Allow)
                 {
                     // pre-resolve app setting specifiers
                     schedule = _nameResolver.ResolveWholeString(schedule);
 
-                    var options = new CrontabSchedule.ParseOptions()
+                    // Accept both 5-digit and 6-digit (with seconds) CRON expressions.
+                    bool isCron = CrontabSchedule.TryParse(schedule) is not null
+                        || CrontabSchedule.TryParse(schedule, new CrontabSchedule.ParseOptions { IncludingSeconds = true }) is not null;
+
+                    if (!isCron)
                     {
-                        IncludingSeconds = true
-                    };
-                    if (CrontabSchedule.TryParse(schedule, options) == null)
-                    {
-                        throw new ArgumentException(string.Format("'{0}' is not a valid CRON expression.", schedule));
+                        if (_platformOptions.NonCronScheduleBehavior is NonCronScheduleBehavior.Error)
+                        {
+                            throw new ArgumentException(string.Format("'{0}' is not a valid CRON expression.", schedule));
+                        }
+
+                        string message = $"The timer schedule '{schedule}' is not a CRON expression. Non-CRON expressions are not supported by the scale controller and may cause scaling issues. Please use a CRON expression instead. See {DiagnosticEventConstants.TimerConstantExpressionWarningHelpLink} for more information.";
+                        _logger.LogDiagnosticEventWarning(DiagnosticEventConstants.TimerConstantExpressionWarningErrorCode, message, DiagnosticEventConstants.TimerConstantExpressionWarningHelpLink, null);
                     }
                 }
 

--- a/src/WebJobs.Script/Binding/CoreExtensionsScriptBindingProvider.cs
+++ b/src/WebJobs.Script/Binding/CoreExtensionsScriptBindingProvider.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
         private readonly INameResolver _nameResolver;
         private readonly TimerTriggerPlatformOptions _platformOptions;
 
-        public CoreExtensionsScriptBindingProvider(INameResolver nameResolver, IOptions<TimerTriggerPlatformOptions> platformOptions, ILogger<CoreExtensionsScriptBindingProvider> logger)
+        public CoreExtensionsScriptBindingProvider(
+            INameResolver nameResolver,
+            IOptions<TimerTriggerPlatformOptions> platformOptions,
+            ILogger<CoreExtensionsScriptBindingProvider> logger)
             : base(logger)
         {
             _nameResolver = nameResolver ?? throw new ArgumentNullException(nameof(nameResolver));
@@ -79,12 +82,15 @@ namespace Microsoft.Azure.WebJobs.Script.Binding
 
                     if (!isCron)
                     {
+                        string message = $"The timer schedule '{schedule}' is not a CRON expression. Non-CRON expressions are not supported by the scale controller and may cause scaling issues. Please use a CRON expression instead. See {DiagnosticEventConstants.TimerConstantExpressionWarningHelpLink} for more information.";
+
                         if (_platformOptions.NonCronScheduleBehavior is NonCronScheduleBehavior.Error)
                         {
-                            throw new ArgumentException(string.Format("'{0}' is not a valid CRON expression.", schedule));
+                            var exception = new ArgumentException(string.Format("'{0}' is not a valid CRON expression.", schedule));
+                            _logger.LogDiagnosticEventError(DiagnosticEventConstants.TimerConstantExpressionWarningErrorCode, message, DiagnosticEventConstants.TimerConstantExpressionWarningHelpLink, exception);
+                            throw exception;
                         }
 
-                        string message = $"The timer schedule '{schedule}' is not a CRON expression. Non-CRON expressions are not supported by the scale controller and may cause scaling issues. Please use a CRON expression instead. See {DiagnosticEventConstants.TimerConstantExpressionWarningHelpLink} for more information.";
                         _logger.LogDiagnosticEventWarning(DiagnosticEventConstants.TimerConstantExpressionWarningErrorCode, message, DiagnosticEventConstants.TimerConstantExpressionWarningHelpLink, null);
                     }
                 }

--- a/src/WebJobs.Script/Config/NonCronScheduleBehavior.cs
+++ b/src/WebJobs.Script/Config/NonCronScheduleBehavior.cs
@@ -1,0 +1,27 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script.Configuration;
+
+/// <summary>
+/// Specifies the behavior when a non-CRON schedule expression is detected for a timer trigger.
+/// </summary>
+public enum NonCronScheduleBehavior
+{
+    /// <summary>
+    /// Non-CRON expressions (e.g. TimeSpan) are allowed without any validation or warning.
+    /// </summary>
+    Allow,
+
+    /// <summary>
+    /// A diagnostic warning is logged when a non-CRON expression is used, but the timer is
+    /// still allowed to start. This is intended for platforms where the scale controller does
+    /// not support non-CRON expressions and customers should migrate.
+    /// </summary>
+    Warn,
+
+    /// <summary>
+    /// An error is thrown when a non-CRON expression is used, preventing the timer from starting.
+    /// </summary>
+    Error
+}

--- a/src/WebJobs.Script/Config/TimerTriggerPlatformOptions.cs
+++ b/src/WebJobs.Script/Config/TimerTriggerPlatformOptions.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script.Configuration;
+
+/// <summary>
+/// Options that describe platform-level capabilities for timer trigger bindings.
+/// </summary>
+public class TimerTriggerPlatformOptions
+{
+    /// <summary>
+    /// Gets or sets the behavior when a non-CRON schedule (e.g. TimeSpan) is detected
+    /// for a timer trigger.
+    /// </summary>
+    public NonCronScheduleBehavior NonCronScheduleBehavior { get; set; } = NonCronScheduleBehavior.Allow;
+}

--- a/src/WebJobs.Script/Config/TimerTriggerPlatformOptions.cs
+++ b/src/WebJobs.Script/Config/TimerTriggerPlatformOptions.cs
@@ -1,16 +1,30 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Azure.WebJobs.Hosting;
+
 namespace Microsoft.Azure.WebJobs.Script.Configuration;
 
 /// <summary>
 /// Options that describe platform-level capabilities for timer trigger bindings.
 /// </summary>
-public class TimerTriggerPlatformOptions
+public sealed class TimerTriggerPlatformOptions : IOptionsFormatter
 {
     /// <summary>
     /// Gets or sets the behavior when a non-CRON schedule (e.g. TimeSpan) is detected
     /// for a timer trigger.
     /// </summary>
     public NonCronScheduleBehavior NonCronScheduleBehavior { get; set; } = NonCronScheduleBehavior.Allow;
+
+    /// <inheritdoc/>
+    public string Format()
+    {
+        return JsonSerializer.Serialize(this, typeof(TimerTriggerPlatformOptions), TimerTriggerPlatformOptionsJsonContext.Default);
+    }
 }
+
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Serialization, WriteIndented = true)]
+[JsonSerializable(typeof(TimerTriggerPlatformOptions))]
+internal partial class TimerTriggerPlatformOptionsJsonContext : JsonSerializerContext;

--- a/src/WebJobs.Script/Config/TimerTriggerPlatformOptionsSetup.cs
+++ b/src/WebJobs.Script/Config/TimerTriggerPlatformOptionsSetup.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Script.Configuration;
 
-internal class TimerTriggerPlatformOptionsSetup : IConfigureOptions<TimerTriggerPlatformOptions>
+internal sealed class TimerTriggerPlatformOptionsSetup : IConfigureOptions<TimerTriggerPlatformOptions>
 {
     private readonly IEnvironment _environment;
 

--- a/src/WebJobs.Script/Config/TimerTriggerPlatformOptionsSetup.cs
+++ b/src/WebJobs.Script/Config/TimerTriggerPlatformOptionsSetup.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebJobs.Script.Configuration;
+
+internal class TimerTriggerPlatformOptionsSetup : IConfigureOptions<TimerTriggerPlatformOptions>
+{
+    private readonly IEnvironment _environment;
+
+    public TimerTriggerPlatformOptionsSetup(IEnvironment environment)
+    {
+        _environment = environment;
+    }
+
+    public void Configure(TimerTriggerPlatformOptions options)
+    {
+        if (_environment.IsLinuxConsumptionOnAtlas() || _environment.IsLinuxConsumptionOnLegion())
+        {
+            // These platforms technically allow constant expressions today, but the scale
+            // controller does not support them. Warn customers so they can migrate to CRON.
+            options.NonCronScheduleBehavior = NonCronScheduleBehavior.Warn;
+        }
+        else if (_environment.IsConsumptionSku())
+        {
+            // The scale controller on consumption plans only supports CRON expressions,
+            // so constant expressions (e.g. TimeSpan) are not allowed.
+            options.NonCronScheduleBehavior = NonCronScheduleBehavior.Error;
+        }
+    }
+}

--- a/src/WebJobs.Script/Diagnostics/DiagnosticEventConstants.cs
+++ b/src/WebJobs.Script/Diagnostics/DiagnosticEventConstants.cs
@@ -37,5 +37,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public const string DeprecatedProxiesErrorCode = "AZFD0014";
         public const string DeprecatedProxiesHelpLink = "https://aka.ms/functions-deprecated-proxies";
+
+        public const string TimerConstantExpressionWarningErrorCode = "AZFD0015";
+        public const string TimerConstantExpressionWarningHelpLink = "https://aka.ms/functions-timer-cron";
     }
 }

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public static bool IsWindowsConsumption(this IEnvironment environment)
         {
             string value = environment.GetEnvironmentVariable(AzureWebsiteSku);
-            return string.Equals(value, ScriptConstants.DynamicSku, StringComparison.OrdinalIgnoreCase);
+            return environment.Platform == OSPlatform.Windows && string.Equals(value, ScriptConstants.DynamicSku, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -301,7 +301,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <returns><see cref="true"/> if running in a Windows Azure managed hosting environment; otherwise, false.</returns>
         public static bool IsWindowsAzureManagedHosting(this IEnvironment environment)
         {
-            return environment.IsAppService() && RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            return environment.IsAppService() && environment.Platform == OSPlatform.Windows;
         }
 
         /// <summary>

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -203,8 +203,14 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <returns><see cref="true"/> if running in a Windows Consumption App Service app; otherwise, false.</returns>
         public static bool IsWindowsConsumption(this IEnvironment environment)
         {
+            if (environment.Platform != OSPlatform.Windows)
+            {
+                return false;
+            }
+
             string value = environment.GetEnvironmentVariable(AzureWebsiteSku);
-            return environment.Platform == OSPlatform.Windows && string.Equals(value, ScriptConstants.DynamicSku, StringComparison.OrdinalIgnoreCase);
+
+            return string.Equals(value, ScriptConstants.DynamicSku, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -301,7 +307,12 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <returns><see cref="true"/> if running in a Windows Azure managed hosting environment; otherwise, false.</returns>
         public static bool IsWindowsAzureManagedHosting(this IEnvironment environment)
         {
-            return environment.IsAppService() && environment.Platform == OSPlatform.Windows;
+            if (environment.Platform != OSPlatform.Windows)
+            {
+                return false;
+            }
+
+            return environment.IsAppService();
         }
 
         /// <summary>

--- a/src/WebJobs.Script/Environment/IEnvironment.cs
+++ b/src/WebJobs.Script/Environment/IEnvironment.cs
@@ -1,9 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Azure.WebJobs.Script
 {
@@ -16,6 +14,11 @@ namespace Microsoft.Azure.WebJobs.Script
         /// Gets a value indicating whether the current process is a 64-bit process.
         /// </summary>
         public bool Is64BitProcess { get; }
+
+        /// <summary>
+        /// Gets the <see cref="OSPlatform"/> that the current process is running on.
+        /// </summary>
+        public OSPlatform Platform { get; }
 
         /// <summary>
         /// Returns the value of an environment variable for the current <see cref="IEnvironment"/>.

--- a/src/WebJobs.Script/Environment/SystemEnvironment.cs
+++ b/src/WebJobs.Script/Environment/SystemEnvironment.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace Microsoft.Azure.WebJobs.Script
 {
@@ -37,21 +35,24 @@ namespace Microsoft.Azure.WebJobs.Script
             Environment.SetEnvironmentVariable(name, value);
         }
 
-        private static OSPlatform GetCurrentPlatform()
+        internal static OSPlatform GetCurrentPlatform()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (OperatingSystem.IsWindows())
             {
                 return OSPlatform.Windows;
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+
+            if (OperatingSystem.IsLinux())
             {
                 return OSPlatform.Linux;
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+
+            if (OperatingSystem.IsMacOS())
             {
                 return OSPlatform.OSX;
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+
+            if (OperatingSystem.IsFreeBSD())
             {
                 return OSPlatform.FreeBSD;
             }

--- a/src/WebJobs.Script/Environment/SystemEnvironment.cs
+++ b/src/WebJobs.Script/Environment/SystemEnvironment.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace Microsoft.Azure.WebJobs.Script
@@ -19,6 +20,8 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public bool Is64BitProcess => Environment.Is64BitProcess;
 
+        public OSPlatform Platform { get; } = GetCurrentPlatform();
+
         private static SystemEnvironment CreateInstance()
         {
             return new SystemEnvironment();
@@ -32,6 +35,28 @@ namespace Microsoft.Azure.WebJobs.Script
         public void SetEnvironmentVariable(string name, string value)
         {
             Environment.SetEnvironmentVariable(name, value);
+        }
+
+        private static OSPlatform GetCurrentPlatform()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return OSPlatform.Windows;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return OSPlatform.Linux;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return OSPlatform.OSX;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+            {
+                return OSPlatform.FreeBSD;
+            }
+
+            return OSPlatform.Create("Unknown");
         }
     }
 }

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -339,6 +339,7 @@ namespace Microsoft.Azure.WebJobs.Script
                          .Bind(o);
                     });
                 services.ConfigureOptions<ScaleOptionsSetup>();
+                services.ConfigureOptions<TimerTriggerPlatformOptionsSetup>();
 
                 services.AddSingleton<IFileLoggingStatusManager, FileLoggingStatusManager>();
 

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -150,6 +150,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSlotName)).Returns((string)null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags)).Returns((string)null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku)).Returns(() => _sku);
+            _mockEnvironment.Setup(p => p.Platform).Returns(System.Runtime.InteropServices.OSPlatform.Windows);
 
             _hostNameProvider = new HostNameProvider(_mockEnvironment.Object);
 

--- a/test/WebJobs.Script.Tests.Shared/TestEnvironment.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestEnvironment.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public bool Is64BitProcess => _is64BitProcess;
 
-        public OSPlatform Platform { get; set; } = OSPlatform.Windows;
+        public OSPlatform Platform { get; set; } = SystemEnvironment.GetCurrentPlatform();
 
         public string this[string key]
         {

--- a/test/WebJobs.Script.Tests.Shared/TestEnvironment.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestEnvironment.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
@@ -29,6 +30,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         public bool Is64BitProcess => _is64BitProcess;
+
+        public OSPlatform Platform { get; set; } = OSPlatform.Windows;
 
         public string this[string key]
         {

--- a/test/WebJobs.Script.Tests/Binding/CoreExtensionsScriptBindingProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Binding/CoreExtensionsScriptBindingProviderTests.cs
@@ -5,8 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Azure.WebJobs.Script.Binding;
+using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.Extensibility;
-using Moq;
+using Microsoft.Extensions.Logging;
+using Microsoft.WebJobs.Script.Tests;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -14,17 +16,30 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 {
     public class CoreExtensionsScriptBindingProviderTests
     {
+        private readonly TestLoggerProvider _loggerProvider = new TestLoggerProvider();
+        private readonly ILogger _logger;
+
+        public CoreExtensionsScriptBindingProviderTests()
+        {
+            var loggerFactory = new LoggerFactory();
+            loggerFactory.AddProvider(_loggerProvider);
+            _logger = loggerFactory.CreateLogger<CoreExtensionsScriptBindingProvider>();
+        }
+
         [Fact]
-        public void GetAttributes_DynamicSku_ValidatesScheduleExpression()
+        public void GetAttributes_Error_ValidatesScheduleExpression()
         {
             var vars = new Dictionary<string, string>
             {
-                { "TEST_SCHEDULE_CRON", "0 * * * * *" },
+                { "TEST_SCHEDULE_CRON_6", "0 * * * * *" },
+                { "TEST_SCHEDULE_CRON_5", "*/5 * * * *" },
                 { "TEST_SCHEDULE_TIMESPAN", "00:00:15" },
             };
 
-            var environment = new TestEnvironment();
-            environment.SetEnvironmentVariable("WEBSITE_SKU", "Dynamic");
+            var platformOptions = new TimerTriggerPlatformOptions
+            {
+                NonCronScheduleBehavior = NonCronScheduleBehavior.Error
+            };
 
             var nameResolver = new TestNameResolver(vars);
 
@@ -35,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     { "type", "timerTrigger" }
                 };
             var bindingContext = new ScriptBindingContext(triggerMetadata);
-            var binding = new CoreExtensionsScriptBindingProvider.TimerTriggerScriptBinding(nameResolver, environment, bindingContext);
+            var binding = new CoreExtensionsScriptBindingProvider.TimerTriggerScriptBinding(nameResolver, platformOptions, _logger, bindingContext);
 
             // TimeSpan expression is invalid
             triggerMetadata["schedule"] = "00:00:15";
@@ -47,15 +62,105 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             ex = Assert.Throws<ArgumentException>(() => binding.GetAttributes());
             Assert.Equal("'00:00:15' is not a valid CRON expression.", ex.Message);
 
-            //// Cron expression is valid
+            //// 6-digit Cron expression is valid
             triggerMetadata["schedule"] = "0 * * * * *";
             var timerAttribute = (TimerTriggerAttribute)binding.GetAttributes().Single();
             Assert.Equal("0 * * * * *", timerAttribute.ScheduleExpression);
 
-            //// Cron expression specified via app setting is valid
-            triggerMetadata["schedule"] = "%TEST_SCHEDULE_CRON%";
+            //// 6-digit Cron expression specified via app setting is valid
+            triggerMetadata["schedule"] = "%TEST_SCHEDULE_CRON_6%";
             timerAttribute = (TimerTriggerAttribute)binding.GetAttributes().Single();
             Assert.Equal("0 * * * * *", timerAttribute.ScheduleExpression);
+
+            //// 5-digit Cron expression is valid
+            triggerMetadata["schedule"] = "*/5 * * * *";
+            timerAttribute = (TimerTriggerAttribute)binding.GetAttributes().Single();
+            Assert.Equal("*/5 * * * *", timerAttribute.ScheduleExpression);
+
+            //// 5-digit Cron expression specified via app setting is valid
+            triggerMetadata["schedule"] = "%TEST_SCHEDULE_CRON_5%";
+            timerAttribute = (TimerTriggerAttribute)binding.GetAttributes().Single();
+            Assert.Equal("*/5 * * * *", timerAttribute.ScheduleExpression);
+        }
+
+        [Fact]
+        public void GetAttributes_Allow_SkipsValidation()
+        {
+            var platformOptions = new TimerTriggerPlatformOptions
+            {
+                NonCronScheduleBehavior = NonCronScheduleBehavior.Allow
+            };
+
+            var nameResolver = new TestNameResolver();
+
+            var triggerMetadata = new JObject
+                {
+                    { "direction", "in" },
+                    { "name", "timer" },
+                    { "type", "timerTrigger" },
+                    { "schedule", "00:00:15" }
+                };
+            var bindingContext = new ScriptBindingContext(triggerMetadata);
+            var binding = new CoreExtensionsScriptBindingProvider.TimerTriggerScriptBinding(nameResolver, platformOptions, _logger, bindingContext);
+
+            // TimeSpan expression passes when behavior is Allow
+            var timerAttribute = (TimerTriggerAttribute)binding.GetAttributes().Single();
+            Assert.Equal("00:00:15", timerAttribute.ScheduleExpression);
+        }
+
+        [Fact]
+        public void GetAttributes_Warn_LogsDiagnosticWarning()
+        {
+            var platformOptions = new TimerTriggerPlatformOptions
+            {
+                NonCronScheduleBehavior = NonCronScheduleBehavior.Warn
+            };
+
+            var nameResolver = new TestNameResolver();
+
+            var triggerMetadata = new JObject
+                {
+                    { "direction", "in" },
+                    { "name", "timer" },
+                    { "type", "timerTrigger" },
+                    { "schedule", "00:00:15" }
+                };
+            var bindingContext = new ScriptBindingContext(triggerMetadata);
+            var binding = new CoreExtensionsScriptBindingProvider.TimerTriggerScriptBinding(nameResolver, platformOptions, _logger, bindingContext);
+
+            // TimeSpan expression is allowed but should log a diagnostic warning
+            var timerAttribute = (TimerTriggerAttribute)binding.GetAttributes().Single();
+            Assert.Equal("00:00:15", timerAttribute.ScheduleExpression);
+
+            var warningLog = _loggerProvider.GetAllLogMessages().Single(m => m.Level == LogLevel.Warning);
+            Assert.Contains("'00:00:15' is not a CRON expression", warningLog.FormattedMessage);
+            Assert.Contains(DiagnosticEventConstants.TimerConstantExpressionWarningHelpLink, warningLog.FormattedMessage);
+        }
+
+        [Fact]
+        public void GetAttributes_Warn_CronDoesNotWarn()
+        {
+            var platformOptions = new TimerTriggerPlatformOptions
+            {
+                NonCronScheduleBehavior = NonCronScheduleBehavior.Warn
+            };
+
+            var nameResolver = new TestNameResolver();
+
+            var triggerMetadata = new JObject
+                {
+                    { "direction", "in" },
+                    { "name", "timer" },
+                    { "type", "timerTrigger" },
+                    { "schedule", "0 * * * * *" }
+                };
+            var bindingContext = new ScriptBindingContext(triggerMetadata);
+            var binding = new CoreExtensionsScriptBindingProvider.TimerTriggerScriptBinding(nameResolver, platformOptions, _logger, bindingContext);
+
+            var timerAttribute = (TimerTriggerAttribute)binding.GetAttributes().Single();
+            Assert.Equal("0 * * * * *", timerAttribute.ScheduleExpression);
+
+            Assert.Empty(_loggerProvider.GetAllLogMessages().Where(m => m.Level == LogLevel.Warning));
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Binding/CoreExtensionsScriptBindingProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Binding/CoreExtensionsScriptBindingProviderTests.cs
@@ -52,15 +52,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var bindingContext = new ScriptBindingContext(triggerMetadata);
             var binding = new CoreExtensionsScriptBindingProvider.TimerTriggerScriptBinding(nameResolver, platformOptions, _logger, bindingContext);
 
-            // TimeSpan expression is invalid
+            // TimeSpan expression is invalid and logs diagnostic error before throwing
             triggerMetadata["schedule"] = "00:00:15";
             var ex = Assert.Throws<ArgumentException>(() => binding.GetAttributes());
             Assert.Equal("'00:00:15' is not a valid CRON expression.", ex.Message);
+            Assert.Single(_loggerProvider.GetAllLogMessages().Where(m => m.Level == LogLevel.Error));
+            _loggerProvider.ClearAllLogMessages();
 
             // TimeSpan specified via app setting is invalid
             triggerMetadata["schedule"] = "%TEST_SCHEDULE_TIMESPAN%";
             ex = Assert.Throws<ArgumentException>(() => binding.GetAttributes());
             Assert.Equal("'00:00:15' is not a valid CRON expression.", ex.Message);
+            Assert.Single(_loggerProvider.GetAllLogMessages().Where(m => m.Level == LogLevel.Error));
+            _loggerProvider.ClearAllLogMessages();
 
             //// 6-digit Cron expression is valid
             triggerMetadata["schedule"] = "0 * * * * *";

--- a/test/WebJobs.Script.Tests/Configuration/HttpOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/HttpOptionsSetupTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Runtime.InteropServices;
 using System.Threading.Tasks.Dataflow;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
@@ -19,6 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku)).Returns(ScriptConstants.DynamicSku);
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsV2CompatibilityModeKey)).Returns<string>(null);
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsExtensionVersion)).Returns<string>(null);
+            mockEnvironment.Setup(p => p.Platform).Returns(OSPlatform.Windows);
 
             var setup = new HttpOptionsSetup(mockEnvironment.Object);
             var options = new HttpOptions();
@@ -37,6 +39,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku)).Returns(ScriptConstants.DynamicSku);
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsV2CompatibilityModeKey)).Returns<string>(null);
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsExtensionVersion)).Returns<string>(null);
+            mockEnvironment.Setup(p => p.Platform).Returns(OSPlatform.Windows);
 
             var setup = new HttpOptionsSetup(mockEnvironment.Object);
             var options = new HttpOptions();
@@ -55,6 +58,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku)).Returns("Dedicated");
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsV2CompatibilityModeKey)).Returns<string>(null);
             mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsExtensionVersion)).Returns<string>(null);
+            mockEnvironment.Setup(p => p.Platform).Returns(OSPlatform.Windows);
 
             var setup = new HttpOptionsSetup(mockEnvironment.Object);
             var options = new HttpOptions();

--- a/test/WebJobs.Script.Tests/Configuration/TimerTriggerPlatformOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/TimerTriggerPlatformOptionsSetupTests.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Runtime.InteropServices;
+using Microsoft.Azure.WebJobs.Script.Configuration;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
+{
+    public class TimerTriggerPlatformOptionsSetupTests
+    {
+        [Fact]
+        public void Configure_WindowsConsumption_SetsError()
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, ScriptConstants.DynamicSku);
+            environment.Platform = OSPlatform.Windows;
+
+            var options = ConfigureOptions(environment);
+
+            Assert.Equal(NonCronScheduleBehavior.Error, options.NonCronScheduleBehavior);
+        }
+
+        [Fact]
+        public void Configure_FlexConsumption_SetsError()
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, ScriptConstants.FlexConsumptionSku);
+
+            var options = ConfigureOptions(environment);
+
+            Assert.Equal(NonCronScheduleBehavior.Error, options.NonCronScheduleBehavior);
+        }
+
+        [Fact]
+        public void Configure_LinuxConsumptionOnAtlas_SetsWarn()
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "test-container");
+            environment.Platform = OSPlatform.Linux;
+
+            var options = ConfigureOptions(environment);
+
+            Assert.Equal(NonCronScheduleBehavior.Warn, options.NonCronScheduleBehavior);
+        }
+
+        [Fact]
+        public void Configure_LinuxConsumptionOnLegion_SetsWarn()
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "test-container");
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.LegionServiceHost, "legion-host");
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, ScriptConstants.DynamicSku);
+            environment.Platform = OSPlatform.Linux;
+
+            var options = ConfigureOptions(environment);
+
+            Assert.Equal(NonCronScheduleBehavior.Warn, options.NonCronScheduleBehavior);
+        }
+
+        [Fact]
+        public void Configure_NonConsumption_SetsAllow()
+        {
+            var environment = new TestEnvironment();
+
+            var options = ConfigureOptions(environment);
+
+            Assert.Equal(NonCronScheduleBehavior.Allow, options.NonCronScheduleBehavior);
+        }
+
+        [Fact]
+        public void Configure_DedicatedAppService_SetsAllow()
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, "some-instance");
+            environment.Platform = OSPlatform.Windows;
+
+            var options = ConfigureOptions(environment);
+
+            Assert.Equal(NonCronScheduleBehavior.Allow, options.NonCronScheduleBehavior);
+        }
+
+        private static TimerTriggerPlatformOptions ConfigureOptions(TestEnvironment environment)
+        {
+            var setup = new TimerTriggerPlatformOptionsSetup(environment);
+            var options = new TimerTriggerPlatformOptions();
+            setup.Configure(options);
+
+            return options;
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/FunctionsSyncServiceTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionsSyncServiceTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Hosting;
@@ -201,6 +202,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady)).Returns(containerReady ? "1" : null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ManagedEnvironment)).Returns(isManagedAppEnvironment ? "1" : null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.WebsitePodName)).Returns(isConsumptionLinuxOnLegion ? "RandomPodName" : null);
+            _mockEnvironment.Setup(p => p.Platform).Returns(OSPlatform.Windows);
 
             var result = FunctionsSyncManager.IsSyncTriggersEnvironment(_mockWebHostEnvironment.Object, _mockEnvironment.Object);
             Assert.Equal(expected, result);
@@ -217,6 +219,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey)).Returns("1");
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.ContainerName)).Returns((string)null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady)).Returns("1");
+            _mockEnvironment.Setup(p => p.Platform).Returns(OSPlatform.Windows);
 
             var result = FunctionsSyncManager.IsSyncTriggersEnvironment(_mockWebHostEnvironment.Object, _mockEnvironment.Object);
             Assert.Equal(expected, result);


### PR DESCRIPTION
Resolves #11555 

Improve timer trigger schedule validation for consumption plans

   - Replace direct IEnvironment dependency with IOptions<TimerTriggerPlatformOptions>
   - Accept both 5 and 6-digit CRON expressions
   - Apply CRON-only validation to all consumption SKUs, not just Windows
   - Warn (instead of block) on non-CRON schedules for Linux Consumption (ACI/Legion)
   - Add IEnvironment.Platform property for OS detection
   
CRON Expression Support

   | Platform                        | Before               | After            |
   |---------------------------------|-----------------------|------------------|
   | Windows Consumption             | 6-digit only          | 5 and 6-digit    |
   | Flex Consumption                | 6-digit only¹         | 5 and 6-digit    |
   | Linux Consumption (ACI/Atlas)   | Any (no validation)   | 5 and 6-digit    |
   | Linux Consumption (Legion)      | Any (no validation)   | 5 and 6-digit    |

  Non-CRON Schedule Behavior (e.g. TimeSpan)

   | Platform                        | Before    | After    |
   |---------------------------------|-----------|----------|
   | Windows Consumption             | Error     | Error    |
   | Flex Consumption                | Error¹    | Error    |
   | Linux Consumption (ACI/Atlas)   | Allow     | Warn     |
   | Linux Consumption (Legion)      | Allow     | Warn     |

   ¹ Flex was incorrectly caught by the IsWindowsConsumption() check, which only looked at WEBSITE_SKU == "Dynamic" without verifying the OS.


### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * [x] Otherwise: I have added/updated all related diagnostic events and their documentation ([Documentation issue linked to PR](https://github.com/MicrosoftDocs/azure-docs-pr/pull/311654))
* [x] I have added all required tests (Unit tests, E2E tests)