### PR TITLE
Filter out dependency telemetry for localhost calls

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -10,3 +10,4 @@
 - Updating OTel related packages (#11568)
 - Fixed worker configuration cache invalidation to properly refresh language worker options during host restarts with extension bundles (#11582)
 - Logging environment value of LocalSitePackagesPath in RunFromPackageHandler (#11541)
+- Filter out dependency telemetry for localhost calls (#11609)

--- a/release_notes.md
+++ b/release_notes.md
@@ -11,7 +11,6 @@
 - Updating OTel related packages (#11568)
 - Fixed worker configuration cache invalidation to properly refresh language worker options during host restarts with extension bundles (#11582)
 - Logging environment value of LocalSitePackagesPath in RunFromPackageHandler (#11541)
-- Improve timer trigger schedule validation for all consumption plans: accept 5 and 6-digit CRON expressions, apply validation to all consumption SKUs, and warn on non-CRON schedules for Linux Consumption (#11601)
 - Enable options logging for WebHost-level options by calling `AddFormattableOptionsLogging` and update `Microsoft.Azure.WebJobs` packages to `3.0.45` (#11615)
 - Improve timer trigger schedule validation for all consumption plans: accept 5 and 6-digit CRON expressions, apply validation to all consumption SKUs, and warn on non-CRON schedules for Linux Consumption (#11601)
 - Update NodeJS Worker Version to [3.13.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.13.0)

--- a/src/WebJobs.Script/Config/ScriptTelemetryProcessor.cs
+++ b/src/WebJobs.Script/Config/ScriptTelemetryProcessor.cs
@@ -21,8 +21,10 @@ namespace Microsoft.Azure.WebJobs.Script.Config
 
         public void Process(ITelemetry item)
         {
-            // Filter out dependency telemetry for localhost calls (host-to-worker interactions).
-            if (item is DependencyTelemetry dependencyTelemetry && IsLocalhostDependency(dependencyTelemetry))
+            // Filter out all outgoing HTTP dependency telemetry. In out-of-proc scenarios the host's
+            // only HTTP dependency is the loopback call to the worker.
+            if (item is DependencyTelemetry dep
+                && string.Equals(dep.Type, "Http", StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }
@@ -35,22 +37,6 @@ namespace Microsoft.Azure.WebJobs.Script.Config
                 item = ToUserException(rpcException, item);
             }
             this.Next.Process(item);
-        }
-
-        private static bool IsLocalhostDependency(DependencyTelemetry dependencyTelemetry)
-        {
-            if (string.IsNullOrEmpty(dependencyTelemetry.Data))
-            {
-                return false;
-            }
-
-            if (string.Equals(dependencyTelemetry.Type, "Http", StringComparison.OrdinalIgnoreCase)
-                && Uri.TryCreate(dependencyTelemetry.Data, UriKind.Absolute, out var uri))
-            {
-                return uri.IsLoopback;
-            }
-
-            return false;
         }
 
         private ITelemetry ToUserException(RpcException rpcException, ITelemetry originalItem)

--- a/src/WebJobs.Script/Config/ScriptTelemetryProcessor.cs
+++ b/src/WebJobs.Script/Config/ScriptTelemetryProcessor.cs
@@ -44,7 +44,8 @@ namespace Microsoft.Azure.WebJobs.Script.Config
                 return false;
             }
 
-            if (string.Equals(dependencyTelemetry.Type, "Http", StringComparison.OrdinalIgnoreCase) && Uri.TryCreate(dependencyTelemetry.Data, UriKind.Absolute, out var uri))
+            if (string.Equals(dependencyTelemetry.Type, "Http", StringComparison.OrdinalIgnoreCase)
+                && Uri.TryCreate(dependencyTelemetry.Data, UriKind.Absolute, out var uri))
             {
                 return uri.IsLoopback;
             }

--- a/src/WebJobs.Script/Config/ScriptTelemetryProcessor.cs
+++ b/src/WebJobs.Script/Config/ScriptTelemetryProcessor.cs
@@ -21,6 +21,12 @@ namespace Microsoft.Azure.WebJobs.Script.Config
 
         public void Process(ITelemetry item)
         {
+            // Filter out dependency telemetry for localhost calls (host-to-worker interactions).
+            if (item is DependencyTelemetry dependencyTelemetry && IsLocalhostDependency(dependencyTelemetry))
+            {
+                return;
+            }
+
             // Only process if exception is thrown by user code (if IsUserException is true).
             if (item is ExceptionTelemetry exceptionTelemetry
                 && exceptionTelemetry?.Exception?.InnerException is RpcException rpcException
@@ -29,6 +35,21 @@ namespace Microsoft.Azure.WebJobs.Script.Config
                 item = ToUserException(rpcException, item);
             }
             this.Next.Process(item);
+        }
+
+        private static bool IsLocalhostDependency(DependencyTelemetry dependencyTelemetry)
+        {
+            if (string.IsNullOrEmpty(dependencyTelemetry.Data))
+            {
+                return false;
+            }
+
+            if (string.Equals(dependencyTelemetry.Type, "Http", StringComparison.OrdinalIgnoreCase) && Uri.TryCreate(dependencyTelemetry.Data, UriKind.Absolute, out var uri))
+            {
+                return uri.IsLoopback;
+            }
+
+            return false;
         }
 
         private ITelemetry ToUserException(RpcException rpcException, ITelemetry originalItem)

--- a/src/WebJobs.Script/Config/ScriptTelemetryProcessor.cs
+++ b/src/WebJobs.Script/Config/ScriptTelemetryProcessor.cs
@@ -25,8 +25,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         {
             // Filter out HTTP dependency telemetry originating from the host's proxy calls to
             // out-of-proc workers.
-            if (item is DependencyTelemetry
-                && IsHostProxyForwarding.Value)
+            if (item is DependencyTelemetry && IsHostProxyForwarding.Value)
             {
                 return;
             }

--- a/src/WebJobs.Script/Config/ScriptTelemetryProcessor.cs
+++ b/src/WebJobs.Script/Config/ScriptTelemetryProcessor.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
 {
     internal class ScriptTelemetryProcessor : ITelemetryProcessor
     {
-        internal static readonly AsyncLocal<bool> IsHostProxyForwarding = new();
+        internal static readonly AsyncLocal<bool> SuppressDependencyTelemetry = new();
 
         public ScriptTelemetryProcessor(ITelemetryProcessor next)
         {
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config
         {
             // Filter out HTTP dependency telemetry originating from the host's proxy calls to
             // out-of-proc workers.
-            if (item is DependencyTelemetry && IsHostProxyForwarding.Value)
+            if (item is DependencyTelemetry && SuppressDependencyTelemetry.Value)
             {
                 return;
             }

--- a/src/WebJobs.Script/Config/ScriptTelemetryProcessor.cs
+++ b/src/WebJobs.Script/Config/ScriptTelemetryProcessor.cs
@@ -1,8 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
@@ -12,6 +12,8 @@ namespace Microsoft.Azure.WebJobs.Script.Config
 {
     internal class ScriptTelemetryProcessor : ITelemetryProcessor
     {
+        internal static readonly AsyncLocal<bool> IsHostProxyForwarding = new();
+
         public ScriptTelemetryProcessor(ITelemetryProcessor next)
         {
             this.Next = next;
@@ -21,10 +23,10 @@ namespace Microsoft.Azure.WebJobs.Script.Config
 
         public void Process(ITelemetry item)
         {
-            // Filter out all outgoing HTTP dependency telemetry. In out-of-proc scenarios the host's
-            // only HTTP dependency is the loopback call to the worker.
-            if (item is DependencyTelemetry dep
-                && string.Equals(dep.Type, "Http", StringComparison.OrdinalIgnoreCase))
+            // Filter out HTTP dependency telemetry originating from the host's proxy calls to
+            // out-of-proc workers.
+            if (item is DependencyTelemetry
+                && IsHostProxyForwarding.Value)
             {
                 return;
             }

--- a/src/WebJobs.Script/Http/DefaultHttpProxyService.cs
+++ b/src/WebJobs.Script/Http/DefaultHttpProxyService.cs
@@ -104,18 +104,25 @@ namespace Microsoft.Azure.WebJobs.Script.Http
             // This helps track failures/cancellations that should halt retrying the http request.
             httpContext.Items[ScriptConstants.HttpProxyScriptInvocationContext] = context;
 
-            Task<ForwarderError> forwardingTask;
+            Task<ForwarderError> forwardingTask = ForwardWithSuppressedTelemetryAsync(httpContext, httpUri.ToString());
+            context.Properties[ScriptConstants.HttpProxyTask] = forwardingTask;
+        }
+
+        private async Task<ForwarderError> ForwardWithSuppressedTelemetryAsync(HttpContext httpContext, string uri)
+        {
+            // Task.Yield() ensures we enter a fresh async scope before setting the AsyncLocal value,
+            // preventing cross-scope contamination into the synchronous calling context.
+            await Task.Yield();
+
             try
             {
                 ScriptTelemetryProcessor.SuppressDependencyTelemetry.Value = true;
-                forwardingTask = _httpForwarder.SendAsync(httpContext, httpUri.ToString(), _messageInvoker, _forwarderRequestConfig, _httpTransformer).AsTask();
+                return await _httpForwarder.SendAsync(httpContext, uri, _messageInvoker, _forwarderRequestConfig, _httpTransformer);
             }
             finally
             {
                 ScriptTelemetryProcessor.SuppressDependencyTelemetry.Value = false;
             }
-
-            context.Properties[ScriptConstants.HttpProxyTask] = forwardingTask;
         }
     }
 }

--- a/src/WebJobs.Script/Http/DefaultHttpProxyService.cs
+++ b/src/WebJobs.Script/Http/DefaultHttpProxyService.cs
@@ -104,9 +104,16 @@ namespace Microsoft.Azure.WebJobs.Script.Http
             // This helps track failures/cancellations that should halt retrying the http request.
             httpContext.Items[ScriptConstants.HttpProxyScriptInvocationContext] = context;
 
-            ScriptTelemetryProcessor.IsHostProxyForwarding.Value = true;
-            var forwardingTask = _httpForwarder.SendAsync(httpContext, httpUri.ToString(), _messageInvoker, _forwarderRequestConfig, _httpTransformer).AsTask();
-            ScriptTelemetryProcessor.IsHostProxyForwarding.Value = false;
+            Task<ForwarderError> forwardingTask;
+            try
+            {
+                ScriptTelemetryProcessor.SuppressDependencyTelemetry.Value = true;
+                forwardingTask = _httpForwarder.SendAsync(httpContext, httpUri.ToString(), _messageInvoker, _forwarderRequestConfig, _httpTransformer).AsTask();
+            }
+            finally
+            {
+                ScriptTelemetryProcessor.SuppressDependencyTelemetry.Value = false;
+            }
 
             context.Properties[ScriptConstants.HttpProxyTask] = forwardingTask;
         }

--- a/src/WebJobs.Script/Http/DefaultHttpProxyService.cs
+++ b/src/WebJobs.Script/Http/DefaultHttpProxyService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Exceptions;
 using Microsoft.Azure.WebJobs.Script.Workers;
@@ -103,7 +104,10 @@ namespace Microsoft.Azure.WebJobs.Script.Http
             // This helps track failures/cancellations that should halt retrying the http request.
             httpContext.Items[ScriptConstants.HttpProxyScriptInvocationContext] = context;
 
+            ScriptTelemetryProcessor.IsHostProxyForwarding.Value = true;
             var forwardingTask = _httpForwarder.SendAsync(httpContext, httpUri.ToString(), _messageInvoker, _forwarderRequestConfig, _httpTransformer).AsTask();
+            ScriptTelemetryProcessor.IsHostProxyForwarding.Value = false;
+
             context.Properties[ScriptConstants.HttpProxyTask] = forwardingTask;
         }
     }

--- a/test/WebJobs.Script.Tests/Configuration/ScriptTelemetryProcessorTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ScriptTelemetryProcessorTests.cs
@@ -17,30 +17,59 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
     public class ScriptTelemetryProcessorTests
     {
         [Theory]
-        [InlineData("Http", true)]
-        [InlineData("HTTP", true)]
-        [InlineData("http", true)]
-        [InlineData("Azure blob", false)]
-        [InlineData("Azure Service Bus", false)]
-        [InlineData("Azure Event Hubs", false)]
-        [InlineData("SQL", false)]
-        [InlineData(null, false)]
-        [InlineData("", false)]
-        public void Process_FiltersHttpDependencies(string type, bool shouldFilter)
+        [InlineData("Http")]
+        [InlineData("HTTP")]
+        [InlineData("http")]
+        public void Process_HttpDependency_ProxyRequest_IsFiltered(string type)
         {
             var items = new List<ITelemetry>();
             var processor = new ScriptTelemetryProcessor(new TestTelemetryProcessor(items));
 
+            ScriptTelemetryProcessor.IsHostProxyForwarding.Value = true;
+            try
+            {
+                processor.Process(new DependencyTelemetry { Type = type });
+            }
+            finally
+            {
+                ScriptTelemetryProcessor.IsHostProxyForwarding.Value = false;
+            }
+
+            Assert.Empty(items);
+        }
+
+        [Theory]
+        [InlineData("Http")]
+        [InlineData("HTTP")]
+        [InlineData("http")]
+        public void Process_HttpDependency_NotProxyRequest_IsNotFiltered(string type)
+        {
+            var items = new List<ITelemetry>();
+            var processor = new ScriptTelemetryProcessor(new TestTelemetryProcessor(items));
+
+            // IsHostProxyForwarding defaults to false — simulates user code making an external HTTP call
             processor.Process(new DependencyTelemetry { Type = type });
 
-            if (shouldFilter)
+            Assert.Single(items);
+        }
+
+        [Fact]
+        public void Process_NonDependencyTelemetry_ProxyRequest_IsNotFiltered()
+        {
+            var items = new List<ITelemetry>();
+            var processor = new ScriptTelemetryProcessor(new TestTelemetryProcessor(items));
+
+            ScriptTelemetryProcessor.IsHostProxyForwarding.Value = true;
+            try
             {
-                Assert.Empty(items);
+                processor.Process(new TraceTelemetry("test"));
             }
-            else
+            finally
             {
-                Assert.Single(items);
+                ScriptTelemetryProcessor.IsHostProxyForwarding.Value = false;
             }
+
+            Assert.Single(items);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Configuration/ScriptTelemetryProcessorTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ScriptTelemetryProcessorTests.cs
@@ -1,9 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ApplicationInsights;
@@ -11,16 +9,40 @@ using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Azure.WebJobs.Script.Config;
-using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
 {
     public class ScriptTelemetryProcessorTests
     {
+        [Theory]
+        [InlineData("Http", true)]
+        [InlineData("HTTP", true)]
+        [InlineData("http", true)]
+        [InlineData("Azure blob", false)]
+        [InlineData("Azure Service Bus", false)]
+        [InlineData("Azure Event Hubs", false)]
+        [InlineData("SQL", false)]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        public void Process_FiltersHttpDependencies(string type, bool shouldFilter)
+        {
+            var items = new List<ITelemetry>();
+            var processor = new ScriptTelemetryProcessor(new TestTelemetryProcessor(items));
+
+            processor.Process(new DependencyTelemetry { Type = type });
+
+            if (shouldFilter)
+            {
+                Assert.Empty(items);
+            }
+            else
+            {
+                Assert.Single(items);
+            }
+        }
+
         [Fact]
         public async Task Test_TelemetryProcessor_AppInsights()
         {
@@ -33,49 +55,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             TelemetryClient client = new TelemetryClient(config);
             client.TrackException(oldEt);
             await client.FlushAsync(CancellationToken.None);
-        }
-
-        [Theory]
-        [InlineData("Http", "http://localhost:5000/api/func", true)]
-        [InlineData("Http", "http://localhost/api/func", true)]
-        [InlineData("Http", "https://localhost:7071/api/func", true)]
-        [InlineData("Http", "http://127.0.0.1:5000/api/func", true)]
-        [InlineData("Http", "http://127.0.0.1/api/func", true)]
-        [InlineData("Http", "http://127.0.0.2:5000/api/func", true)]
-        [InlineData("Http", "http://[::1]:5000/api/func", true)]
-        [InlineData("Http", "http://[::1]/api/func", true)]
-        [InlineData("HTTP", "http://localhost:5000/api/func", true)]
-        [InlineData("http", "http://localhost:5000/api/func", true)]
-        [InlineData("Http", "https://myapp.azurewebsites.net/api/func", false)]
-        [InlineData("Http", "https://storage.blob.core.windows.net/container", false)]
-        [InlineData("Http", "", false)]
-        [InlineData("Http", null, false)]
-        [InlineData("Http", "not-a-uri", false)]
-        [InlineData("SQL", "http://localhost:5000/api/func", false)]
-        [InlineData("Azure Service Bus", "http://localhost:5000/api/func", false)]
-        [InlineData(null, "http://localhost:5000/api/func", false)]
-        [InlineData("", "http://localhost:5000/api/func", false)]
-        public void Process_FiltersLocalhostDependencies(string type, string data, bool shouldFilter)
-        {
-            var items = new List<ITelemetry>();
-            var processor = new ScriptTelemetryProcessor(new TestTelemetryProcessor(items));
-
-            var dependency = new DependencyTelemetry
-            {
-                Type = type,
-                Data = data
-            };
-
-            processor.Process(dependency);
-
-            if (shouldFilter)
-            {
-                Assert.Empty(items);
-            }
-            else
-            {
-                Assert.Single(items);
-            }
         }
 
         private class TestTelemetryProcessor : ITelemetryProcessor

--- a/test/WebJobs.Script.Tests/Configuration/ScriptTelemetryProcessorTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ScriptTelemetryProcessorTests.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             var items = new List<ITelemetry>();
             var processor = new ScriptTelemetryProcessor(new TestTelemetryProcessor(items));
 
-            ScriptTelemetryProcessor.IsHostProxyForwarding.Value = true;
+            ScriptTelemetryProcessor.SuppressDependencyTelemetry.Value = true;
             try
             {
                 processor.Process(new DependencyTelemetry { Type = type });
             }
             finally
             {
-                ScriptTelemetryProcessor.IsHostProxyForwarding.Value = false;
+                ScriptTelemetryProcessor.SuppressDependencyTelemetry.Value = false;
             }
 
             Assert.Empty(items);
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             var items = new List<ITelemetry>();
             var processor = new ScriptTelemetryProcessor(new TestTelemetryProcessor(items));
 
-            // IsHostProxyForwarding defaults to false — simulates user code making an external HTTP call
+            // SuppressDependencyTelemetry defaults to false — simulates user code making an external HTTP call
             processor.Process(new DependencyTelemetry { Type = type });
 
             Assert.Single(items);
@@ -59,14 +59,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             var items = new List<ITelemetry>();
             var processor = new ScriptTelemetryProcessor(new TestTelemetryProcessor(items));
 
-            ScriptTelemetryProcessor.IsHostProxyForwarding.Value = true;
+            ScriptTelemetryProcessor.SuppressDependencyTelemetry.Value = true;
             try
             {
                 processor.Process(new TraceTelemetry("test"));
             }
             finally
             {
-                ScriptTelemetryProcessor.IsHostProxyForwarding.Value = false;
+                ScriptTelemetryProcessor.SuppressDependencyTelemetry.Value = false;
             }
 
             Assert.Single(items);

--- a/test/WebJobs.Script.Tests/Configuration/ScriptTelemetryProcessorTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ScriptTelemetryProcessorTests.cs
@@ -35,6 +35,64 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             await client.FlushAsync(CancellationToken.None);
         }
 
+        [Theory]
+        [InlineData("Http", "http://localhost:5000/api/func", true)]
+        [InlineData("Http", "http://localhost/api/func", true)]
+        [InlineData("Http", "https://localhost:7071/api/func", true)]
+        [InlineData("Http", "http://127.0.0.1:5000/api/func", true)]
+        [InlineData("Http", "http://127.0.0.1/api/func", true)]
+        [InlineData("Http", "http://127.0.0.2:5000/api/func", true)]
+        [InlineData("Http", "http://[::1]:5000/api/func", true)]
+        [InlineData("Http", "http://[::1]/api/func", true)]
+        [InlineData("HTTP", "http://localhost:5000/api/func", true)]
+        [InlineData("http", "http://localhost:5000/api/func", true)]
+        [InlineData("Http", "https://myapp.azurewebsites.net/api/func", false)]
+        [InlineData("Http", "https://storage.blob.core.windows.net/container", false)]
+        [InlineData("Http", "", false)]
+        [InlineData("Http", null, false)]
+        [InlineData("Http", "not-a-uri", false)]
+        [InlineData("SQL", "http://localhost:5000/api/func", false)]
+        [InlineData("Azure Service Bus", "http://localhost:5000/api/func", false)]
+        [InlineData(null, "http://localhost:5000/api/func", false)]
+        [InlineData("", "http://localhost:5000/api/func", false)]
+        public void Process_FiltersLocalhostDependencies(string type, string data, bool shouldFilter)
+        {
+            var items = new List<ITelemetry>();
+            var processor = new ScriptTelemetryProcessor(new TestTelemetryProcessor(items));
+
+            var dependency = new DependencyTelemetry
+            {
+                Type = type,
+                Data = data
+            };
+
+            processor.Process(dependency);
+
+            if (shouldFilter)
+            {
+                Assert.Empty(items);
+            }
+            else
+            {
+                Assert.Single(items);
+            }
+        }
+
+        private class TestTelemetryProcessor : ITelemetryProcessor
+        {
+            private readonly List<ITelemetry> _items;
+
+            public TestTelemetryProcessor(List<ITelemetry> items)
+            {
+                _items = items;
+            }
+
+            public void Process(ITelemetry item)
+            {
+                _items.Add(item);
+            }
+        }
+
         public class MyCustomTelemetryProcessor : ITelemetryProcessor
         {
             public MyCustomTelemetryProcessor(ITelemetryProcessor item)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

This prevents host-to-worker HTTP proxy calls from appearing as dependency telemetry in Application Insights.

resolves #11602 

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
