### PR TITLE
Refactor DiagnosticEventTableStorageRepository TableClient

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,6 +3,7 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Refactor DiagnosticEventTableStorageRepository TableClient (#11611)
 - Improve resiliency of batch operations in TableStorageScaleMetricsRepository with Polly retry and exponential backoff (#11586)
 - Add support for propagating tags from the worker to the host and update the protobuf version to `v1.12.0-protofile` (#11575)
 - Restart worker process if not disposed (shutting down) and exited with code 0 (#11576)

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
@@ -33,9 +33,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         private readonly ILogger<DiagnosticEventTableStorageRepository> _logger;
         private readonly IServiceProvider _serviceProvider;
         private readonly object _syncLock = new object();
+        private readonly SemaphoreSlim _initSemaphore = new SemaphoreSlim(1, 1);
 
         private ConcurrentDictionary<string, DiagnosticEvent> _events = new ConcurrentDictionary<string, DiagnosticEvent>();
         private TableServiceClient _tableClient;
+        private volatile bool _tableClientInitialized;
         private TableClient _diagnosticEventsTable;
         private string _hostId;
         private bool _disposed = false;
@@ -58,50 +60,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             IAzureTableStorageProvider azureTableStorageProvider, ILogger<DiagnosticEventTableStorageRepository> logger)
             : this(hostIdProvider, environment, scriptHost, azureTableStorageProvider, logger, LogFlushInterval) { }
 
-        internal TableServiceClient TableClient
-        {
-            get
-            {
-                if (_tableClient is null && !_environment.IsPlaceholderModeEnabled())
-                {
-                    if (!_azureTableStorageProvider.TryCreateHostingTableServiceClient(out _tableClient))
-                    {
-                        DisableService();
-                        Logger.ServiceDisabledFailedToCreateClient(_logger);
-                        return _tableClient;
-                    }
-
-                    try
-                    {
-                        // When using RBAC, we need "Storage Table Data Contributor" as we require to list, create and delete tables and query/insert/delete entities.
-                        // Testing permissions by listing tables, creating and deleting a test table.
-                        var testTable = _tableClient.GetTableClient($"{TableNamePrefix}Check");
-                        _ = TableStorageHelpers.TableExists(testTable, _tableClient);
-                        _ = testTable.CreateIfNotExists();
-                        _ = testTable.Delete();
-                    }
-                    catch (RequestFailedException rfe) when (rfe.Status == (int)HttpStatusCode.Conflict || rfe.ErrorCode == TableErrorCode.TableBeingDeleted)
-                    {
-                        // The table is being deleted or there could be a conflict for several instances initializing.
-                        // We can ignore this error as it is not a failure and we tested the permissions.
-                    }
-                    catch (RequestFailedException rfe) when (rfe.Status == (int)HttpStatusCode.Forbidden)
-                    {
-                        DisableService();
-                        Logger.ServiceDisabledUnauthorizedClient(_logger, rfe);
-                    }
-                    catch (Exception ex)
-                    {
-                        // We failed to connect to the table storage account. This could be due to a transient error or a configuration issue, such network issues.
-                        // We will disable the service.
-                        DisableService();
-                        Logger.ServiceDisabledUnableToConnectToStorage(_logger, ex);
-                    }
-                }
-
-                return _tableClient;
-            }
-        }
+        internal TableServiceClient TableClient => _tableClient;
 
         internal string HostId
         {
@@ -117,6 +76,62 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         internal ConcurrentDictionary<string, DiagnosticEvent> Events => _events;
 
+        internal async Task InitializeTableClientAsync()
+        {
+            if (_tableClientInitialized || _disposed)
+            {
+                return;
+            }
+
+            await _initSemaphore.WaitAsync();
+            try
+            {
+                if (_tableClientInitialized || _disposed)
+                {
+                    return;
+                }
+
+                if (!_azureTableStorageProvider.TryCreateHostingTableServiceClient(out _tableClient))
+                {
+                    DisableService();
+                    Logger.ServiceDisabledFailedToCreateClient(_logger);
+                    return;
+                }
+
+                try
+                {
+                    // When using RBAC, we need "Storage Table Data Contributor" as we require to list, create and delete tables and query/insert/delete entities.
+                    // Testing permissions by listing tables, creating and deleting a test table.
+                    var testTable = _tableClient.GetTableClient($"{TableNamePrefix}Check");
+                    _ = await TableStorageHelpers.TableExistAsync(testTable, _tableClient);
+                    _ = await testTable.CreateIfNotExistsAsync();
+                    await testTable.DeleteAsync();
+                }
+                catch (RequestFailedException rfe) when (rfe.Status == (int)HttpStatusCode.Conflict || rfe.ErrorCode == TableErrorCode.TableBeingDeleted)
+                {
+                    // The table is being deleted or there could be a conflict for several instances initializing.
+                    // We can ignore this error as it is not a failure and we tested the permissions.
+                }
+                catch (RequestFailedException rfe) when (rfe.Status == (int)HttpStatusCode.Forbidden)
+                {
+                    DisableService();
+                    Logger.ServiceDisabledUnauthorizedClient(_logger, rfe);
+                }
+                catch (Exception ex)
+                {
+                    // We failed to connect to the table storage account. This could be due to a transient error or a configuration issue, such network issues.
+                    // We will disable the service.
+                    DisableService();
+                    Logger.ServiceDisabledUnableToConnectToStorage(_logger, ex);
+                }
+            }
+            finally
+            {
+                _tableClientInitialized = true;
+                _initSemaphore.Release();
+            }
+        }
+
         private void DisableService()
         {
             _isEnabled = false;
@@ -126,7 +141,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         internal TableClient GetDiagnosticEventsTable(DateTime? now = null)
         {
-            if (TableClient != null)
+            if (_tableClient != null)
             {
                 now = now ?? DateTime.UtcNow;
                 string currentTableName = GetTableName(now.Value);
@@ -135,7 +150,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 if (_diagnosticEventsTable == null || currentTableName != _tableName)
                 {
                     _tableName = currentTableName;
-                    _diagnosticEventsTable = TableClient.GetTableClient(_tableName);
+                    _diagnosticEventsTable = _tableClient.GetTableClient(_tableName);
                 }
             }
 
@@ -162,7 +177,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             {
                 try
                 {
-                    var tables = (await TableStorageHelpers.ListTablesAsync(TableClient, TableNamePrefix)).ToList();
+                    var tables = (await TableStorageHelpers.ListTablesAsync(_tableClient, TableNamePrefix)).ToList();
 
                     foreach (var table in tables)
                     {
@@ -221,10 +236,17 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         internal virtual async Task FlushLogs(TableClient table = null)
         {
-            // TableClient is initialized lazily and it will stop the timer that schedules flush logs whenever it fails to initialize.
-            // We need to check if the TableClient is null before proceeding. This helps when the first time the property is accessed is as part of the FlushLogs method.
-            // We should not have any events stored pending to be written since WriteDiagnosticEvent will check for an initialized TableClient.
-            if (_environment.IsPlaceholderModeEnabled() || TableClient is null || !IsEnabled())
+            if (_environment.IsPlaceholderModeEnabled() || !IsEnabled())
+            {
+                return;
+            }
+
+            if (!_disposed)
+            {
+                await InitializeTableClientAsync();
+            }
+
+            if (_tableClient is null || !IsEnabled())
             {
                 return;
             }
@@ -245,11 +267,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                     return;
                 }
 
-                bool tableCreated = await TableStorageHelpers.CreateIfNotExistsAsync(table, TableClient, TableCreationMaxRetryCount);
+                bool tableCreated = await TableStorageHelpers.CreateIfNotExistsAsync(table, _tableClient, TableCreationMaxRetryCount);
                 if (tableCreated)
                 {
                     Logger.QueueingBackgroundTablePurge(_logger);
-                    TableStorageHelpers.QueueBackgroundTablePurge(table, TableClient, TableNamePrefix, _logger);
+                    TableStorageHelpers.QueueBackgroundTablePurge(table, _tableClient, TableNamePrefix, _logger);
                 }
             }
             catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.Forbidden)
@@ -272,10 +294,17 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 return;
             }
 
-            // Assigning a new empty directory to reset the event count in the new duration window.
+            // Swap the events dictionary to reset the event count for the new flush window.
             // All existing events are logged to other logging pipelines already.
-            ConcurrentDictionary<string, DiagnosticEvent> tempDictionary = _events;
-            _events = new ConcurrentDictionary<string, DiagnosticEvent>();
+            // Use the same lock as WriteDiagnosticEvent to prevent race conditions when
+            // concurrent writes happen during the swap operation.
+            ConcurrentDictionary<string, DiagnosticEvent> tempDictionary;
+            lock (_syncLock)
+            {
+                tempDictionary = _events;
+                _events = new ConcurrentDictionary<string, DiagnosticEvent>();
+            }
+
             if (!tempDictionary.IsEmpty)
             {
                 await ExecuteBatchAsync(tempDictionary, table);
@@ -317,9 +346,19 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public void WriteDiagnosticEvent(DateTime timestamp, string errorCode, LogLevel level, string message, string helpLink, Exception exception)
         {
-            if (TableClient is null || string.IsNullOrEmpty(HostId) || !IsEnabled())
+            if (!IsEnabled() || string.IsNullOrEmpty(HostId))
             {
                 return;
+            }
+
+            // If the table client hasn't been initialized yet, kick off initialization.
+            // This handles the case where the host was in placeholder mode during construction
+            // and has since specialized — the constructor skipped initialization, so we trigger it here.
+            if (!_tableClientInitialized)
+            {
+                _ = InitializeTableClientAsync().ContinueWith(
+                    t => Logger.ServiceDisabledUnableToConnectToStorage(_logger, t.Exception),
+                    TaskContinuationOptions.OnlyOnFaulted);
             }
 
             var diagnosticEvent = new DiagnosticEvent(HostId, timestamp)
@@ -332,12 +371,28 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 HitCount = 1
             };
 
-            if (!_events.TryAdd(errorCode, diagnosticEvent))
+            // Protect the entire add-or-update operation to prevent race conditions with FlushLogs.
+            // Without this lock, the following race can occur:
+            // 1. Thread A: TryAdd fails (key exists in dictionary)
+            // 2. FlushLogs: Swaps _events to new empty dictionary
+            // 3. Thread A: Tries to update _events[errorCode] but key is now in old dictionary or missing
+            // Result: Lost update or exception
+            // The lock is also used in FlushLogs when swapping dictionaries, ensuring atomicity.
+            lock (_syncLock)
             {
-                lock (_syncLock)
+                if (!_events.TryAdd(errorCode, diagnosticEvent))
                 {
-                    _events[errorCode].Timestamp = timestamp;
-                    _events[errorCode].HitCount++;
+                    if (_events.TryGetValue(errorCode, out var existingEvent))
+                    {
+                        existingEvent.Timestamp = timestamp;
+                        existingEvent.HitCount++;
+                    }
+                    else
+                    {
+                        // Key was removed (e.g., dictionary was swapped between TryAdd and acquiring lock)
+                        // Add the event to the current dictionary
+                        _events.TryAdd(errorCode, diagnosticEvent);
+                    }
                 }
             }
 
@@ -386,17 +441,22 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         {
             if (!_disposed)
             {
+                _disposed = true;
+
                 if (disposing)
                 {
-                    if (_flushLogsTimer?.Value != null)
+                    if (_flushLogsTimer.IsValueCreated)
                     {
-                        _flushLogsTimer?.Value?.Dispose();
+                        _flushLogsTimer.Value?.Dispose();
                     }
 
-                    FlushLogs().GetAwaiter().GetResult();
-                }
+                    if (_tableClient != null)
+                    {
+                        FlushLogs().GetAwaiter().GetResult();
+                    }
 
-                _disposed = true;
+                    _initSemaphore.Dispose();
+                }
             }
         }
 

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -153,19 +153,46 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             _events.Clear();
         }
 
-        internal TableClient GetDiagnosticEventsTable(DateTime? now = null)
+        private async Task<bool> EnsureInitializedAsync()
         {
-            if (_tableClient != null)
+            if (_environment.IsPlaceholderModeEnabled() || !IsEnabled())
             {
-                now = now ?? DateTime.UtcNow;
-                string currentTableName = GetTableName(now.Value);
+                return false;
+            }
 
-                // update the table reference when date rolls over to a new month
-                if (_diagnosticEventsTable == null || currentTableName != _tableName)
-                {
-                    _tableName = currentTableName;
-                    _diagnosticEventsTable = _tableClient.GetTableClient(_tableName);
-                }
+            if (!_disposed)
+            {
+                await InitializeTableClientAsync();
+            }
+
+            if (_tableClient is null || !_tableClientInitialized || !IsEnabled())
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        internal async Task<TableClient> GetDiagnosticEventsTableAsync(DateTime? now = null)
+        {
+            if (!await EnsureInitializedAsync())
+            {
+                return null;
+            }
+
+            return GetDiagnosticEventsTable(now);
+        }
+
+        private TableClient GetDiagnosticEventsTable(DateTime? now = null)
+        {
+            now = now ?? DateTime.UtcNow;
+            string currentTableName = GetTableName(now.Value);
+
+            // update the table reference when date rolls over to a new month
+            if (_diagnosticEventsTable == null || currentTableName != _tableName)
+            {
+                _tableName = currentTableName;
+                _diagnosticEventsTable = _tableClient.GetTableClient(_tableName);
             }
 
             return _diagnosticEventsTable;
@@ -250,17 +277,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         internal virtual async Task FlushLogs(TableClient table = null)
         {
-            if (_environment.IsPlaceholderModeEnabled() || !IsEnabled())
-            {
-                return;
-            }
-
-            if (!_disposed)
-            {
-                await InitializeTableClientAsync();
-            }
-
-            if (_tableClient is null || !IsEnabled())
+            if (!await EnsureInitializedAsync())
             {
                 return;
             }

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
@@ -32,7 +32,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         private readonly IAzureTableStorageProvider _azureTableStorageProvider;
         private readonly ILogger<DiagnosticEventTableStorageRepository> _logger;
         private readonly IServiceProvider _serviceProvider;
-        private readonly object _syncLock = new object();
         private readonly SemaphoreSlim _initSemaphore = new SemaphoreSlim(1, 1);
 
         private ConcurrentDictionary<string, DiagnosticEvent> _events = new ConcurrentDictionary<string, DiagnosticEvent>();
@@ -43,7 +42,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         private bool _disposed = false;
         private bool _purged = false;
         private string _tableName;
-        private bool _isEnabled = true;
+        private volatile bool _isEnabled = true;
 
         internal DiagnosticEventTableStorageRepository(IHostIdProvider hostIdProvider, IEnvironment environment, IScriptHostManager scriptHostManager,
             IAzureTableStorageProvider azureTableStorageProvider, ILogger<DiagnosticEventTableStorageRepository> logger, int logFlushInterval)
@@ -83,7 +82,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 return;
             }
 
-            await _initSemaphore.WaitAsync();
+            try
+            {
+                await _initSemaphore.WaitAsync();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Semaphore was disposed (race with disposal), exit early
+                return;
+            }
+
             try
             {
                 if (_tableClientInitialized || _disposed)
@@ -302,14 +310,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
             // Swap the events dictionary to reset the event count for the new flush window.
             // All existing events are logged to other logging pipelines already.
-            // Use the same lock as WriteDiagnosticEvent to prevent race conditions when
-            // concurrent writes happen during the swap operation.
-            ConcurrentDictionary<string, DiagnosticEvent> tempDictionary;
-            lock (_syncLock)
-            {
-                tempDictionary = _events;
-                _events = new ConcurrentDictionary<string, DiagnosticEvent>();
-            }
+            // Use Interlocked.Exchange to atomically swap dictionaries while preventing race conditions.
+            var tempDictionary = Interlocked.Exchange(ref _events, new ConcurrentDictionary<string, DiagnosticEvent>());
 
             if (!tempDictionary.IsEmpty)
             {
@@ -376,30 +378,20 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 HitCount = 1
             };
 
-            // Protect the entire add-or-update operation to prevent race conditions with FlushLogs.
-            // Without this lock, the following race can occur:
-            // 1. Thread A: TryAdd fails (key exists in dictionary)
-            // 2. FlushLogs: Swaps _events to new empty dictionary
-            // 3. Thread A: Tries to update _events[errorCode] but key is now in old dictionary or missing
-            // Result: Lost update or exception
-            // The lock is also used in FlushLogs when swapping dictionaries, ensuring atomicity.
-            lock (_syncLock)
-            {
-                if (!_events.TryAdd(errorCode, diagnosticEvent))
+            // Use AddOrUpdate for atomic add-or-update operation.
+            // ConcurrentDictionary ensures thread-safety for this operation.
+            // If the dictionary is swapped by FlushLogs during this call, the event will be added to whichever
+            // dictionary the reference points to at the time. Events added to the old dictionary after the swap
+            // will still be flushed in the current cycle.
+            _events.AddOrUpdate(
+                errorCode,
+                diagnosticEvent,
+                (key, existingEvent) =>
                 {
-                    if (_events.TryGetValue(errorCode, out var existingEvent))
-                    {
-                        existingEvent.Timestamp = timestamp;
-                        existingEvent.HitCount++;
-                    }
-                    else
-                    {
-                        // Key was removed (e.g., dictionary was swapped between TryAdd and acquiring lock)
-                        // Add the event to the current dictionary
-                        _events.TryAdd(errorCode, diagnosticEvent);
-                    }
-                }
-            }
+                    existingEvent.Timestamp = timestamp;
+                    existingEvent.HitCount++;
+                    return existingEvent;
+                });
 
             EnsureFlushLogsTimerInitialized();
         }

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
@@ -127,7 +127,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             }
             finally
             {
-                _tableClientInitialized = true;
+                // Once initialization has been attempted (whether successful or not), we mark the table client as initialized
+                // to avoid repeated initialization attempts. On failure paths, the service is disabled via DisableService().
+                // Don't set if disposed to prevent race with disposal.
+                if (!_disposed)
+                {
+                    _tableClientInitialized = true;
+                }
                 _initSemaphore.Release();
             }
         }
@@ -354,11 +360,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             // If the table client hasn't been initialized yet, kick off initialization.
             // This handles the case where the host was in placeholder mode during construction
             // and has since specialized — the constructor skipped initialization, so we trigger it here.
+            // Errors are handled within InitializeTableClientAsync, which disables the service on failure.
             if (!_tableClientInitialized)
             {
-                _ = InitializeTableClientAsync().ContinueWith(
-                    t => Logger.ServiceDisabledUnableToConnectToStorage(_logger, t.Exception),
-                    TaskContinuationOptions.OnlyOnFaulted);
+                _ = InitializeTableClientAsync();
             }
 
             var diagnosticEvent = new DiagnosticEvent(HostId, timestamp)
@@ -450,12 +455,22 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                         _flushLogsTimer.Value?.Dispose();
                     }
 
-                    if (_tableClient != null)
+                    if (_tableClient is not null)
                     {
                         FlushLogs().GetAwaiter().GetResult();
                     }
 
-                    _initSemaphore.Dispose();
+                    if (_initSemaphore is not null)
+                    {
+                        try
+                        {
+                            _initSemaphore.Dispose();
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            // Suppress exception if semaphore was already disposed or is being disposed by another thread
+                        }
+                    }
                 }
             }
         }

--- a/test/WebJobs.Script.Tests.Integration/Diagnostics/DiagnosticEventTableStorageRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Diagnostics/DiagnosticEventTableStorageRepositoryTests.cs
@@ -194,8 +194,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             DiagnosticEventTableStorageRepository repository =
                 new DiagnosticEventTableStorageRepository(_hostIdProvider, testEnvironment, _scriptHostMock.Object, localStorageProvider, _logger);
 
-            // FlushLogs triggers initialization, which will fail and disable the service
+            // Service should start enabled
             Assert.True(repository.IsEnabled());
+
+            // FlushLogs triggers initialization, which will fail and disable the service
             await repository.FlushLogs();
 
             DateTime dateTime = new DateTime(2021, 1, 1);
@@ -492,6 +494,26 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
                 new DiagnosticEventTableStorageRepository(_hostIdProvider, testEnvironment, _scriptHostMock.Object, storageProviderMock.Object, _logger);
 
             // Dispose should not trigger any storage calls when in placeholder mode (never initialized)
+            repository.Dispose();
+
+            storageProviderMock.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void Dispose_DoesNotInvokeStorageProvider_WhenNotInPlaceholderModeAndNotInitialized()
+        {
+            IEnvironment testEnvironment = new TestEnvironment();
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+
+            var storageProviderMock = new Mock<IAzureTableStorageProvider>(MockBehavior.Strict);
+
+            DiagnosticEventTableStorageRepository repository =
+                new DiagnosticEventTableStorageRepository(_hostIdProvider, testEnvironment, _scriptHostMock.Object, storageProviderMock.Object, _logger);
+
+            // Repository has never been initialized, so the TableClient should be null
+            Assert.Null(repository.TableClient);
+
+            // Dispose should not trigger any storage calls or initialization when not in placeholder mode but never initialized
             repository.Dispose();
 
             storageProviderMock.VerifyNoOtherCalls();

--- a/test/WebJobs.Script.Tests.Integration/Diagnostics/DiagnosticEventTableStorageRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Diagnostics/DiagnosticEventTableStorageRepositoryTests.cs
@@ -173,11 +173,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             DiagnosticEventTableStorageRepository repository =
                 new DiagnosticEventTableStorageRepository(_hostIdProvider, testEnvironment, _scriptHostMock.Object, _azureTableStorageProvider, _logger);
             
-            // Initialize the table client
-            await repository.InitializeTableClientAsync();
-            
             DateTime dateTime = new DateTime(2021, 1, 1);
-            var cloudTable = repository.GetDiagnosticEventsTable(dateTime);
+            var cloudTable = await repository.GetDiagnosticEventsTableAsync(dateTime);
             Assert.NotNull(cloudTable);
             Assert.NotNull(repository.TableClient);
             Assert.Equal(cloudTable.Name, $"{DiagnosticEventTableStorageRepository.TableNamePrefix}202101");
@@ -201,7 +198,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             await repository.FlushLogs();
 
             DateTime dateTime = new DateTime(2021, 1, 1);
-            var cloudTable = repository.GetDiagnosticEventsTable(dateTime);
+            var cloudTable = await repository.GetDiagnosticEventsTableAsync(dateTime);
             Assert.Null(cloudTable);
             Assert.False(repository.IsEnabled());
 
@@ -219,12 +216,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             DiagnosticEventTableStorageRepository repository =
                 new DiagnosticEventTableStorageRepository(_hostIdProvider, testEnvironment, _scriptHostMock.Object, _azureTableStorageProvider, _logger);
 
-            // Initialize the table client
-            await repository.InitializeTableClientAsync();
-
             // delete any existing non-current diagnostics events tables
             string tablePrefix = DiagnosticEventTableStorageRepository.TableNamePrefix;
-            var currentTable = repository.GetDiagnosticEventsTable();
+            var currentTable = await repository.GetDiagnosticEventsTableAsync();
             var tables = await TableStorageHelpers.ListOldTablesAsync(currentTable, repository.TableClient, tablePrefix);
             foreach (var table in tables)
             {
@@ -263,12 +257,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             DiagnosticEventTableStorageRepository repository =
                 new DiagnosticEventTableStorageRepository(_hostIdProvider, testEnvironment, _scriptHostMock.Object, _azureTableStorageProvider, _logger);
 
-            // Initialize the table client
-            await repository.InitializeTableClientAsync();
-
             // delete any existing non-current diagnostics events tables
             string tablePrefix = DiagnosticEventTableStorageRepository.TableNamePrefix;
-            var currentTable = repository.GetDiagnosticEventsTable();
+            var currentTable = await repository.GetDiagnosticEventsTableAsync();
             var tables = await TableStorageHelpers.ListOldTablesAsync(currentTable, repository.TableClient, tablePrefix);
             foreach (var table in tables)
             {
@@ -361,12 +352,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             DiagnosticEventTableStorageRepository repository =
                 new DiagnosticEventTableStorageRepository(_hostIdProvider, testEnvironment, scriptHostMock.Object, _azureTableStorageProvider, _logger);
 
-            // Initialize the table client
-            await repository.InitializeTableClientAsync();
-
             // delete existing tables
             string tablePrefix = DiagnosticEventTableStorageRepository.TableNamePrefix;
-            var currentTable = repository.GetDiagnosticEventsTable();
+            var currentTable = await repository.GetDiagnosticEventsTableAsync();
             var tables = await TableStorageHelpers.ListOldTablesAsync(currentTable, repository.TableClient, tablePrefix);
             foreach (var table in tables)
             {
@@ -414,10 +402,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             DiagnosticEventTableStorageRepository repository =
                 new DiagnosticEventTableStorageRepository(_hostIdProvider, testEnvironment, _scriptHostMock.Object, _azureTableStorageProvider, _logger);
 
-            // Initialize the table client
-            await repository.InitializeTableClientAsync();
-
-            var table = repository.GetDiagnosticEventsTable();
+            var table = await repository.GetDiagnosticEventsTableAsync();
             await TableStorageHelpers.CreateIfNotExistsAsync(table, repository.TableClient, 2);
             await EmptyTableAsync(table);
 
@@ -440,10 +425,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             DiagnosticEventTableStorageRepository repository =
                 new DiagnosticEventTableStorageRepository(_hostIdProvider, testEnvironment, _scriptHostMock.Object, _azureTableStorageProvider, _logger);
 
-            // Initialize the table client
-            await repository.InitializeTableClientAsync();
-
-            var table = repository.GetDiagnosticEventsTable();
+            var table = await repository.GetDiagnosticEventsTableAsync();
             await TableStorageHelpers.CreateIfNotExistsAsync(table, repository.TableClient, 2);
             await EmptyTableAsync(table);
 
@@ -465,8 +447,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             DiagnosticEventTableStorageRepository repository =
                 new DiagnosticEventTableStorageRepository(_hostIdProvider, testEnvironment, _scriptHostMock.Object, _azureTableStorageProvider, _logger);
 
-            // Initialize the table client
-            await repository.InitializeTableClientAsync();
+            // Ensure initialization happens by calling the async method
+            await repository.GetDiagnosticEventsTableAsync();
 
             var tableClient = repository.TableClient;
             var table = tableClient.GetTableClient("aa");

--- a/test/WebJobs.Script.Tests.Integration/Diagnostics/DiagnosticEventTableStorageRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Diagnostics/DiagnosticEventTableStorageRepositoryTests.cs
@@ -165,13 +165,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
         }
 
         [Fact]
-        public void GetDiagnosticEventsTable_ReturnsExpectedValue_WhenSpecialized()
+        public async Task GetDiagnosticEventsTable_ReturnsExpectedValue_WhenSpecialized()
         {
             IEnvironment testEnvironment = new TestEnvironment();
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
 
             DiagnosticEventTableStorageRepository repository =
                 new DiagnosticEventTableStorageRepository(_hostIdProvider, testEnvironment, _scriptHostMock.Object, _azureTableStorageProvider, _logger);
+            
+            // Initialize the table client
+            await repository.InitializeTableClientAsync();
+            
             DateTime dateTime = new DateTime(2021, 1, 1);
             var cloudTable = repository.GetDiagnosticEventsTable(dateTime);
             Assert.NotNull(cloudTable);
@@ -180,7 +184,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
         }
 
         [Fact]
-        public void GetDiagnosticEventsTable_LogsError_StorageConnectionStringIsNotPresent()
+        public async Task GetDiagnosticEventsTable_LogsError_StorageConnectionStringIsNotPresent()
         {
             IEnvironment testEnvironment = new TestEnvironment();
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
@@ -190,15 +194,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             DiagnosticEventTableStorageRepository repository =
                 new DiagnosticEventTableStorageRepository(_hostIdProvider, testEnvironment, _scriptHostMock.Object, localStorageProvider, _logger);
 
-            // The repository should be initially enabled and then disabled after TableServiceClient failure.
+            // FlushLogs triggers initialization, which will fail and disable the service
             Assert.True(repository.IsEnabled());
+            await repository.FlushLogs();
+
             DateTime dateTime = new DateTime(2021, 1, 1);
             var cloudTable = repository.GetDiagnosticEventsTable(dateTime);
             Assert.Null(cloudTable);
-            var messages = _loggerProvider.GetAllLogMessages();
-            var errorIntializingPresent = messages.Any(m => m.FormattedMessage.Contains("We couldn’t initialize the Table Storage Client using the 'AzureWebJobsStorage' connection string. We are unable to record diagnostic events, so the diagnostic logging service is being stopped. Please check the 'AzureWebJobsStorage' connection string in Application Settings."));
-            Assert.True(errorIntializingPresent);
             Assert.False(repository.IsEnabled());
+
+            var messages = _loggerProvider.GetAllLogMessages();
+            var errorIntializingPresent = messages.Any(m => m.FormattedMessage.Contains("We couldn\u2019t initialize the Table Storage Client"));
+            Assert.True(errorIntializingPresent);
         }
 
         [Fact]
@@ -209,6 +216,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
 
             DiagnosticEventTableStorageRepository repository =
                 new DiagnosticEventTableStorageRepository(_hostIdProvider, testEnvironment, _scriptHostMock.Object, _azureTableStorageProvider, _logger);
+
+            // Initialize the table client
+            await repository.InitializeTableClientAsync();
 
             // delete any existing non-current diagnostics events tables
             string tablePrefix = DiagnosticEventTableStorageRepository.TableNamePrefix;
@@ -250,6 +260,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
 
             DiagnosticEventTableStorageRepository repository =
                 new DiagnosticEventTableStorageRepository(_hostIdProvider, testEnvironment, _scriptHostMock.Object, _azureTableStorageProvider, _logger);
+
+            // Initialize the table client
+            await repository.InitializeTableClientAsync();
 
             // delete any existing non-current diagnostics events tables
             string tablePrefix = DiagnosticEventTableStorageRepository.TableNamePrefix;
@@ -346,6 +359,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             DiagnosticEventTableStorageRepository repository =
                 new DiagnosticEventTableStorageRepository(_hostIdProvider, testEnvironment, scriptHostMock.Object, _azureTableStorageProvider, _logger);
 
+            // Initialize the table client
+            await repository.InitializeTableClientAsync();
+
             // delete existing tables
             string tablePrefix = DiagnosticEventTableStorageRepository.TableNamePrefix;
             var currentTable = repository.GetDiagnosticEventsTable();
@@ -396,6 +412,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             DiagnosticEventTableStorageRepository repository =
                 new DiagnosticEventTableStorageRepository(_hostIdProvider, testEnvironment, _scriptHostMock.Object, _azureTableStorageProvider, _logger);
 
+            // Initialize the table client
+            await repository.InitializeTableClientAsync();
+
             var table = repository.GetDiagnosticEventsTable();
             await TableStorageHelpers.CreateIfNotExistsAsync(table, repository.TableClient, 2);
             await EmptyTableAsync(table);
@@ -419,6 +438,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             DiagnosticEventTableStorageRepository repository =
                 new DiagnosticEventTableStorageRepository(_hostIdProvider, testEnvironment, _scriptHostMock.Object, _azureTableStorageProvider, _logger);
 
+            // Initialize the table client
+            await repository.InitializeTableClientAsync();
+
             var table = repository.GetDiagnosticEventsTable();
             await TableStorageHelpers.CreateIfNotExistsAsync(table, repository.TableClient, 2);
             await EmptyTableAsync(table);
@@ -441,6 +463,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
             DiagnosticEventTableStorageRepository repository =
                 new DiagnosticEventTableStorageRepository(_hostIdProvider, testEnvironment, _scriptHostMock.Object, _azureTableStorageProvider, _logger);
 
+            // Initialize the table client
+            await repository.InitializeTableClientAsync();
+
             var tableClient = repository.TableClient;
             var table = tableClient.GetTableClient("aa");
 
@@ -453,6 +478,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Diagnostics
 
             string message = _loggerProvider.GetAllLogMessages()[0].FormattedMessage;
             Assert.True(message.StartsWith("Unable to write diagnostic events to table storage"));
+        }
+
+        [Fact]
+        public void Dispose_DoesNotInvokeStorageProvider()
+        {
+            IEnvironment testEnvironment = new TestEnvironment();
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
+
+            var storageProviderMock = new Mock<IAzureTableStorageProvider>(MockBehavior.Strict);
+
+            DiagnosticEventTableStorageRepository repository =
+                new DiagnosticEventTableStorageRepository(_hostIdProvider, testEnvironment, _scriptHostMock.Object, storageProviderMock.Object, _logger);
+
+            // Dispose should not trigger any storage calls when in placeholder mode (never initialized)
+            repository.Dispose();
+
+            storageProviderMock.VerifyNoOtherCalls();
         }
 
         [Fact]


### PR DESCRIPTION
This pull request refactors the `DiagnosticEventTableStorageRepository` to improve thread safety, asynchronous initialization, and testability. The changes migrate from lock-based synchronization to `SemaphoreSlim`, introduce atomic operations for event handling, and update the public API to support async table client initialization. Several tests are also updated to use the new async methods.

**Repository refactoring and thread safety:**

* Replaces lock-based synchronization with a `SemaphoreSlim` for initializing the table client, ensuring thread-safe, asynchronous, and idempotent initialization (`DiagnosticEventTableStorageRepository.cs`). [[1]](diffhunk://#diff-76bee56cc44bd0539a1f7b4af8358cee5f5fee80b75fa772fb00ebdf30710a7fL35-R45) [[2]](diffhunk://#diff-76bee56cc44bd0539a1f7b4af8358cee5f5fee80b75fa772fb00ebdf30710a7fL61-R116) [[3]](diffhunk://#diff-76bee56cc44bd0539a1f7b4af8358cee5f5fee80b75fa772fb00ebdf30710a7fL101-R186)
* Uses `volatile` and atomic operations for `_tableClientInitialized` and `_isEnabled` to improve thread safety (`DiagnosticEventTableStorageRepository.cs`).
* Swaps the `_events` dictionary atomically using `Interlocked.Exchange` during flush to prevent race conditions (`DiagnosticEventTableStorageRepository.cs`).

**Async API and code modernization:**

* Adds async initialization and retrieval methods (`InitializeTableClientAsync`, `EnsureInitializedAsync`, `GetDiagnosticEventsTableAsync`), and updates internal logic to use these methods for better reliability and testability (`DiagnosticEventTableStorageRepository.cs`). [[1]](diffhunk://#diff-76bee56cc44bd0539a1f7b4af8358cee5f5fee80b75fa772fb00ebdf30710a7fL61-R116) [[2]](diffhunk://#diff-76bee56cc44bd0539a1f7b4af8358cee5f5fee80b75fa772fb00ebdf30710a7fL101-R186) [[3]](diffhunk://#diff-76bee56cc44bd0539a1f7b4af8358cee5f5fee80b75fa772fb00ebdf30710a7fL224-R280)

**Performance and correctness improvements:**

* Replaces lock-based event updates with `ConcurrentDictionary.AddOrUpdate` for atomic, thread-safe event aggregation (`DiagnosticEventTableStorageRepository.cs`).
* Ensures proper disposal of resources by disposing the semaphore and timer safely, and flushing logs on disposal (`DiagnosticEventTableStorageRepository.cs`).

**Test updates:**

* Refactors tests to use async versions of table retrieval and log flushing, and verifies correct service enable/disable behavior and error logging (`DiagnosticEventTableStorageRepositoryTests.cs`). [[1]](diffhunk://#diff-2c25f81b3f369634e157518921140171c64a7b77a8c392c74543cce300217166L168-R184) [[2]](diffhunk://#diff-2c25f81b3f369634e157518921140171c64a7b77a8c392c74543cce300217166L193-L201) [[3]](diffhunk://#diff-2c25f81b3f369634e157518921140171c64a7b77a8c392c74543cce300217166L215-R221) [[4]](diffhunk://#diff-2c25f81b3f369634e157518921140171c64a7b77a8c392c74543cce300217166L256-R262) [[5]](diffhunk://#diff-2c25f81b3f369634e157518921140171c64a7b77a8c392c74543cce300217166L351-R357)

**Documentation:**

* Adds a release note describing the refactor of `DiagnosticEventTableStorageRepository` and its `TableClient` logic (`release_notes.md`).

resolves https://github.com/Azure/azure-functions-host/issues/11198

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
