### PR TITLE
Fix flaky SecretsRepository KeyVault tests

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 string testFunctionName = secretsType == ScriptSecretsType.Host ? null : functionName;
 
                 // Ensure secrets are in an active state (not soft-deleted from a previous test run)
-                // before calling WriteAsync which has no 409 handling.
+                // before calling WriteAsync.
                 if (repositoryType == SecretsRepositoryType.KeyVault)
                 {
                     await _fixture.WriteSecret(testFunctionName ?? "host", secrets);

--- a/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
@@ -706,7 +706,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                         catch (RequestFailedException ex) when (ex.Status == 409)
                         {
                             // Secret is soft-deleted from a previous test run. Purge it (best-effort) and retry.
-                            try { await SecretClient.PurgeDeletedSecretAsync(key); } catch (RequestFailedException) { }
+                            try
+                            {
+                                await SecretClient.PurgeDeletedSecretAsync(key);
+                            }
+                            catch (RequestFailedException)
+                            {
+                            }
+                            
+                            // Allow purge to propagate before retrying
+                            await Task.Delay(TimeSpan.FromSeconds(1));
                             throw;
                         }
                     }, 4, TimeSpan.FromSeconds(1), ex => ex is RequestFailedException rfex && rfex.Status == 409);

--- a/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
@@ -528,7 +528,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             public Fixture()
             {
-                TestSiteName = "Test_test";
+                TestSiteName = $"Test_{Guid.NewGuid():N}";
                 Environment = new TestEnvironment();
 
                 var configuration = TestHelpers.GetTestConfiguration();
@@ -690,8 +690,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Dictionary<string, string> dictionary = KeyVaultSecretsRepository.GetDictionaryFromScriptSecrets(secrets, functionNameOrHost);
                 foreach (string key in dictionary.Keys)
                 {
-                    await Utility.InvokeWithRetriesWhenAsync(() => SecretClient.SetSecretAsync(key, dictionary[key]),
-                        5, TimeSpan.FromSeconds(1), (e) => e is RequestFailedException rfex && rfex.Status == 409);
+                    await SecretClient.SetSecretAsync(key, dictionary[key]);
                 }
             }
 

--- a/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
@@ -697,9 +697,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     catch (RequestFailedException ex) when (ex.Status == 409)
                     {
                         // Secret is soft-deleted (e.g. host--masterKey--master which has a fixed name).
-                        // Recover it, then overwrite its value.
-                        var operation = await SecretClient.StartRecoverDeletedSecretAsync(key);
-                        await operation.WaitForCompletionAsync();
+                        // Secret is soft-deleted from a previous test run. Purge it, then recreate.
+                        await SecretClient.PurgeDeletedSecretAsync(key);
                         await SecretClient.SetSecretAsync(key, dictionary[key]);
                     }
                 }

--- a/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
@@ -690,16 +690,28 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Dictionary<string, string> dictionary = KeyVaultSecretsRepository.GetDictionaryFromScriptSecrets(secrets, functionNameOrHost);
                 foreach (string key in dictionary.Keys)
                 {
-                    try
+                    // Secret may be soft-deleted from a previous test run.
+                    // Try purge first (best-effort), then retry SetSecret with backoff.
+                    for (int attempt = 0; attempt < 4; attempt++)
                     {
-                        await SecretClient.SetSecretAsync(key, dictionary[key]);
-                    }
-                    catch (RequestFailedException ex) when (ex.Status == 409)
-                    {
-                        // Secret is soft-deleted (e.g. host--masterKey--master which has a fixed name).
-                        // Secret is soft-deleted from a previous test run. Purge it, then recreate.
-                        await SecretClient.PurgeDeletedSecretAsync(key);
-                        await SecretClient.SetSecretAsync(key, dictionary[key]);
+                        try
+                        {
+                            await SecretClient.SetSecretAsync(key, dictionary[key]);
+                            break;
+                        }
+                        catch (RequestFailedException ex) when (ex.Status == 409 && attempt < 3)
+                        {
+                            try
+                            {
+                                await SecretClient.PurgeDeletedSecretAsync(key);
+                            }
+                            catch (RequestFailedException)
+                            {
+                                // Purge may 404 if delete hasn't propagated or already purged.
+                            }
+
+                            await Task.Delay(TimeSpan.FromSeconds(1));
+                        }
                     }
                 }
             }

--- a/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
@@ -690,29 +690,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Dictionary<string, string> dictionary = KeyVaultSecretsRepository.GetDictionaryFromScriptSecrets(secrets, functionNameOrHost);
                 foreach (string key in dictionary.Keys)
                 {
-                    // Secret may be soft-deleted from a previous test run.
-                    // Try purge first (best-effort), then retry SetSecret with backoff.
-                    for (int attempt = 0; attempt < 4; attempt++)
+                    await Utility.InvokeWithRetriesWhenAsync(async () =>
                     {
                         try
                         {
                             await SecretClient.SetSecretAsync(key, dictionary[key]);
-                            break;
                         }
-                        catch (RequestFailedException ex) when (ex.Status == 409 && attempt < 3)
+                        catch (RequestFailedException ex) when (ex.Status == 409)
                         {
-                            try
-                            {
-                                await SecretClient.PurgeDeletedSecretAsync(key);
-                            }
-                            catch (RequestFailedException)
-                            {
-                                // Purge may 404 if delete hasn't propagated or already purged.
-                            }
-
-                            await Task.Delay(TimeSpan.FromSeconds(1));
+                            // Secret is soft-deleted from a previous test run. Purge it (best-effort) and retry.
+                            try { await SecretClient.PurgeDeletedSecretAsync(key); } catch (RequestFailedException) { }
+                            throw;
                         }
-                    }
+                    }, 4, TimeSpan.FromSeconds(1), ex => ex is RequestFailedException rfex && rfex.Status == 409);
                 }
             }
 

--- a/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -27,8 +27,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
     public class SecretsRepositoryTests : IClassFixture<SecretsRepositoryTests.Fixture>
     {
         private readonly SecretsRepositoryTests.Fixture _fixture;
+        private static readonly string _uniqueRunId = Guid.NewGuid().ToString("N")[..8];
         private readonly string functionName = "Test_test";
-        public static string KeyName = "Te!@#st!1-te_st";
+        public static string KeyName = $"Te!@#st!1-te_st{_uniqueRunId}";
+        private static readonly string MasterKeyName = $"master{_uniqueRunId}";
 
         private ITestOutputHelper _output;
 
@@ -101,7 +103,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 testSecrets = new HostSecrets()
                 {
-                    MasterKey = new("master", "test"),
+                    MasterKey = new(MasterKeyName, "test"),
                     FunctionKeys = [new(KeyName, "test")],
                     SystemKeys = [new(KeyName, "test")]
                 };
@@ -123,7 +125,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             if (secretsType == ScriptSecretsType.Host)
             {
-                Assert.Equal((secretsContent as HostSecrets).MasterKey.Name, "master");
+                Assert.Equal((secretsContent as HostSecrets).MasterKey.Name, MasterKeyName);
                 Assert.Equal((secretsContent as HostSecrets).MasterKey.Value, "test");
                 Assert.Equal((secretsContent as HostSecrets).FunctionKeys[0].Name, KeyName);
                 Assert.Equal((secretsContent as HostSecrets).FunctionKeys[0].Value, "test");
@@ -158,7 +160,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 {
                     testSecrets = new HostSecrets()
                     {
-                        MasterKey = new Key("master", "test"),
+                        MasterKey = new Key(MasterKeyName, "test"),
                         FunctionKeys = functionKeys,
                         SystemKeys = new List<Key>() { new Key(KeyName, "test") }
                     };
@@ -180,7 +182,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
                 if (secretsType == ScriptSecretsType.Host)
                 {
-                    Assert.Equal((secretsContent as HostSecrets).MasterKey.Name, "master");
+                    Assert.Equal((secretsContent as HostSecrets).MasterKey.Name, MasterKeyName);
                     Assert.Equal((secretsContent as HostSecrets).MasterKey.Value, "test");
 
                     Assert.Equal((secretsContent as HostSecrets).FunctionKeys.Count, functionKeys.Count);
@@ -228,7 +230,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 {
                     secrets = new HostSecrets()
                     {
-                        MasterKey = new Key("master", "test"),
+                        MasterKey = new Key(MasterKeyName, "test"),
                         FunctionKeys = new List<Key>() { new Key(KeyName, "test") },
                         SystemKeys = new List<Key>() { new Key(KeyName, "test") }
                     };
@@ -256,7 +258,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 if (secretsType == ScriptSecretsType.Host)
                 {
 
-                    Assert.Equal((secrets1 as HostSecrets).MasterKey.Name, "master");
+                    Assert.Equal((secrets1 as HostSecrets).MasterKey.Name, MasterKeyName);
                     Assert.Equal((secrets1 as HostSecrets).MasterKey.Value, "test");
                     Assert.Equal((secrets1 as HostSecrets).FunctionKeys[0].Name, KeyName);
                     Assert.Equal((secrets1 as HostSecrets).FunctionKeys[0].Value, "test");
@@ -528,7 +530,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             public Fixture()
             {
-                TestSiteName = $"Test_{Guid.NewGuid():N}";
+                TestSiteName = "Test_test";
                 Environment = new TestEnvironment();
 
                 var configuration = TestHelpers.GetTestConfiguration();
@@ -751,7 +753,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                         FunctionKeys = new List<Key>() { new Key(GetSecretName(functionKeyBundle.Name), functionKeyBundle.Value) },
                         SystemKeys = new List<Key>() { new Key(GetSecretName(systemKeyBundle.Name), systemKeyBundle.Value) }
                     };
-                    hostSecrets.MasterKey = new Key("master", masterBundle.Value);
+                    hostSecrets.MasterKey = new Key(GetSecretName(masterBundle.Name), masterBundle.Value);
                     return hostSecrets;
                 }
                 else

--- a/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
@@ -27,10 +27,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
     public class SecretsRepositoryTests : IClassFixture<SecretsRepositoryTests.Fixture>
     {
         private readonly SecretsRepositoryTests.Fixture _fixture;
-        private static readonly string _uniqueRunId = Guid.NewGuid().ToString("N")[..8];
         private readonly string functionName = "Test_test";
-        public static string KeyName = $"Te!@#st!1-te_st{_uniqueRunId}";
-        private static readonly string MasterKeyName = $"master{_uniqueRunId}";
+        public static string KeyName = "Te!@#st!1-te_st";
 
         private ITestOutputHelper _output;
 
@@ -103,7 +101,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 testSecrets = new HostSecrets()
                 {
-                    MasterKey = new(MasterKeyName, "test"),
+                    MasterKey = new("master", "test"),
                     FunctionKeys = [new(KeyName, "test")],
                     SystemKeys = [new(KeyName, "test")]
                 };
@@ -125,7 +123,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             if (secretsType == ScriptSecretsType.Host)
             {
-                Assert.Equal((secretsContent as HostSecrets).MasterKey.Name, MasterKeyName);
+                Assert.Equal((secretsContent as HostSecrets).MasterKey.Name, "master");
                 Assert.Equal((secretsContent as HostSecrets).MasterKey.Value, "test");
                 Assert.Equal((secretsContent as HostSecrets).FunctionKeys[0].Name, KeyName);
                 Assert.Equal((secretsContent as HostSecrets).FunctionKeys[0].Value, "test");
@@ -160,7 +158,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 {
                     testSecrets = new HostSecrets()
                     {
-                        MasterKey = new Key(MasterKeyName, "test"),
+                        MasterKey = new Key("master", "test"),
                         FunctionKeys = functionKeys,
                         SystemKeys = new List<Key>() { new Key(KeyName, "test") }
                     };
@@ -182,7 +180,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
                 if (secretsType == ScriptSecretsType.Host)
                 {
-                    Assert.Equal((secretsContent as HostSecrets).MasterKey.Name, MasterKeyName);
+                    Assert.Equal((secretsContent as HostSecrets).MasterKey.Name, "master");
                     Assert.Equal((secretsContent as HostSecrets).MasterKey.Value, "test");
 
                     Assert.Equal((secretsContent as HostSecrets).FunctionKeys.Count, functionKeys.Count);
@@ -230,7 +228,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 {
                     secrets = new HostSecrets()
                     {
-                        MasterKey = new Key(MasterKeyName, "test"),
+                        MasterKey = new Key("master", "test"),
                         FunctionKeys = new List<Key>() { new Key(KeyName, "test") },
                         SystemKeys = new List<Key>() { new Key(KeyName, "test") }
                     };
@@ -258,7 +256,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 if (secretsType == ScriptSecretsType.Host)
                 {
 
-                    Assert.Equal((secrets1 as HostSecrets).MasterKey.Name, MasterKeyName);
+                    Assert.Equal((secrets1 as HostSecrets).MasterKey.Name, "master");
                     Assert.Equal((secrets1 as HostSecrets).MasterKey.Value, "test");
                     Assert.Equal((secrets1 as HostSecrets).FunctionKeys[0].Name, KeyName);
                     Assert.Equal((secrets1 as HostSecrets).FunctionKeys[0].Value, "test");
@@ -692,7 +690,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Dictionary<string, string> dictionary = KeyVaultSecretsRepository.GetDictionaryFromScriptSecrets(secrets, functionNameOrHost);
                 foreach (string key in dictionary.Keys)
                 {
-                    await SecretClient.SetSecretAsync(key, dictionary[key]);
+                    try
+                    {
+                        await SecretClient.SetSecretAsync(key, dictionary[key]);
+                    }
+                    catch (RequestFailedException ex) when (ex.Status == 409)
+                    {
+                        // Secret is soft-deleted (e.g. host--masterKey--master which has a fixed name).
+                        // Recover it, then overwrite its value.
+                        var operation = await SecretClient.StartRecoverDeletedSecretAsync(key);
+                        await operation.WaitForCompletionAsync();
+                        await SecretClient.SetSecretAsync(key, dictionary[key]);
+                    }
                 }
             }
 
@@ -753,7 +762,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                         FunctionKeys = new List<Key>() { new Key(GetSecretName(functionKeyBundle.Name), functionKeyBundle.Value) },
                         SystemKeys = new List<Key>() { new Key(GetSecretName(systemKeyBundle.Name), systemKeyBundle.Value) }
                     };
-                    hostSecrets.MasterKey = new Key(GetSecretName(masterBundle.Name), masterBundle.Value);
+                    hostSecrets.MasterKey = new Key("master", masterBundle.Value);
                     return hostSecrets;
                 }
                 else

--- a/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/SecretsRepositoryTests.cs
@@ -242,6 +242,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 }
                 string testFunctionName = secretsType == ScriptSecretsType.Host ? null : functionName;
 
+                // Ensure secrets are in an active state (not soft-deleted from a previous test run)
+                // before calling WriteAsync which has no 409 handling.
+                if (repositoryType == SecretsRepositoryType.KeyVault)
+                {
+                    await _fixture.WriteSecret(testFunctionName ?? "host", secrets);
+                }
+
                 var target = _fixture.GetNewSecretRepository();
                 await target.WriteAsync(secretsType, testFunctionName, secrets);
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -317,7 +317,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         [Fact]
         public void SetupFunctionBuffers_Verify_ReadyForInvocation_Returns_False()
         {
-            CreateDefaultWorkerChannel();
+            CreateDefaultWorkerChannel(autoStart: false);
             Assert.False(_workerChannel.IsChannelReadyForInvocations());
             _workerChannel.SetupFunctionInvocationBuffers(GetTestFunctionsList("node"));
             Assert.False(_workerChannel.IsChannelReadyForInvocations());


### PR DESCRIPTION
<!-- Please provide all the information below.  -->
 Flaky KeyVault integration tests (`WriteAsync_CreatesExpectedFile`, `ReadAsync_ReadsExpectedFile`,
    `ReadAsync_ReadsExpectedKeyVaultPages`) that fail with `409 Conflict` due to Key Vault soft-delete

  The `Fixture` class used a hardcoded Key Vault secret names across test runs. When a previous run's cleanup deletes
  these secrets, Key Vault's mandatory soft-delete puts them in a "deleted but recoverable" state.
  The next run's `SetSecretAsync` then fails with:

  > Secret host--masterKey--master is currently in a deleted but recoverable state, and its name cannot
  > be reused; in this state, the secret can only be recovered or purged.

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
