### PR TITLE
Enable options logging for WebHost scoped options implementing IOptionsFormatter

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,14 +46,14 @@
 
   <!-- WebJobs packages -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Azure.WebJobs" Version="3.0.44" />
+    <PackageVersion Include="Microsoft.Azure.WebJobs" Version="3.0.45" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.2" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Rpc.Core" Version="3.0.44" />
+    <PackageVersion Include="Microsoft.Azure.WebJobs.Rpc.Core" Version="3.0.45" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions" Version="5.2.1" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.3.0" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Timers.Storage" Version="1.0.0-beta.1" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Script.Abstractions" Version="1.0.4-preview" />
-    <PackageVersion Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.44" />
+    <PackageVersion Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.45" />
   </ItemGroup>
 
   <!-- Telemetry packages -->

--- a/release_notes.md
+++ b/release_notes.md
@@ -10,5 +10,5 @@
 - Updating OTel related packages (#11568)
 - Fixed worker configuration cache invalidation to properly refresh language worker options during host restarts with extension bundles (#11582)
 - Logging environment value of LocalSitePackagesPath in RunFromPackageHandler (#11541)
-- Enable options logging for WebHost-level options by calling `AddFormattableOptionsLogging` and update `Microsoft.Azure.WebJobs` packages to `3.0.45`
+- Enable options logging for WebHost-level options by calling `AddFormattableOptionsLogging` and update `Microsoft.Azure.WebJobs` packages to `3.0.45` (#11615)
 - Improve timer trigger schedule validation for all consumption plans: accept 5 and 6-digit CRON expressions, apply validation to all consumption SKUs, and warn on non-CRON schedules for Linux Consumption (#11601)

--- a/release_notes.md
+++ b/release_notes.md
@@ -9,3 +9,4 @@
 - Fix race condition in SecretManager secret caching with double-check locking pattern (#11560)
 - Fixed worker configuration cache invalidation to properly refresh language worker options during host restarts with extension bundles (#11582)
 - Logging environment value of LocalSitePackagesPath in RunFromPackageHandler (#11541)
+- Enable options logging for WebHost-level options by calling `AddFormattableOptionsLogging` and update `Microsoft.Azure.WebJobs` packages to `3.0.45`

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Host.Storage;
+using Microsoft.Azure.WebJobs.Hosting;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
@@ -216,6 +217,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddSingleton<IHostedService, HostedServiceManager>();
 
             // Configuration
+
+            // Enable options logging for WebHost-level options that implement IOptionsFormatter.
+            services.AddFormattableOptionsLogging();
 
             // ScriptApplicationHostOptions are special in that they need to be reset on specialization, but the reset
             // must happen after the StandbyOptions have reset. For this reason, we have a special ChangeTokenSource that

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -19,7 +19,10 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Azure.Storage;
 using Microsoft.Azure.Storage.Queue;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Config;
+using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Azure.WebJobs.Host.Storage;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
@@ -28,8 +31,10 @@ using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Grpc;
 using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -230,6 +235,53 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     throw;
                 }
             }
+        }
+
+        [Fact]
+        public async Task Specialization_WebHostOptionsAreLogged()
+        {
+            const string optionsCategory = "Microsoft.Azure.WebJobs.Hosting.OptionsLoggingService";
+
+            var builder = CreateStandbyHostBuilder(_loggerProvider, "FunctionExecutionContext");
+
+            using var testServer = new TestServer(builder);
+            var client = testServer.CreateClient();
+
+            var response = await client.GetAsync("api/warmup");
+            response.EnsureSuccessStatusCode();
+
+            // Specialize
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+
+            response = await client.GetAsync("api/functionexecutioncontext");
+            response.EnsureSuccessStatusCode();
+
+            // Wait for the OptionsLoggingService to process all queued log entries.
+            await TestHelpers.Await(() =>
+                _loggerProvider.GetAllLogMessages()
+                    .Any(m => string.Equals(m.Category, optionsCategory, StringComparison.Ordinal)
+                           && m.FormattedMessage.StartsWith(nameof(ScriptJobHostOptions), StringComparison.Ordinal)));
+
+            var allOptionsLogs = _loggerProvider.GetAllLogMessages()
+                .Where(m => string.Equals(m.Category, optionsCategory, StringComparison.Ordinal))
+                .Select(m => m.FormattedMessage)
+                .ToList();
+
+            // WebHost-level options implementing IOptionsFormatter should be logged.
+            TestHelpers.AssertOptionLogged(allOptionsLogs, nameof(HttpBodyControlOptions));
+            TestHelpers.AssertOptionLogged(allOptionsLogs, nameof(ResponseCompressionOptions));
+            TestHelpers.AssertOptionLogged(allOptionsLogs, nameof(HostHealthMonitorOptions));
+            TestHelpers.AssertOptionLogged(allOptionsLogs, nameof(WorkerConfigurationResolverOptions));
+            TestHelpers.AssertOptionLogged(allOptionsLogs, nameof(LanguageWorkerOptions));
+
+            // ScriptHost-level options should also be present.
+            TestHelpers.AssertOptionLogged(allOptionsLogs, nameof(ScriptJobHostOptions));
+            TestHelpers.AssertOptionLogged(allOptionsLogs, nameof(FunctionResultAggregatorOptions));
+            TestHelpers.AssertOptionLogged(allOptionsLogs, nameof(ConcurrencyOptions));
+            TestHelpers.AssertOptionLogged(allOptionsLogs, nameof(SingletonOptions));
+            TestHelpers.AssertOptionLogged(allOptionsLogs, nameof(ScaleOptions));
+            TestHelpers.AssertOptionLogged(allOptionsLogs, nameof(HttpOptions));
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebHostStartupEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebHostStartupEndToEndTests.cs
@@ -2,18 +2,31 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc.Configuration;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.WebJobs.Script.Tests;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd;
 
 public class WebHostStartupEndToEndTests
 {
+    private static readonly string _scriptRootConfigPath = ConfigurationPath.Combine(ConfigurationSectionNames.WebHost, nameof(ScriptApplicationHostOptions.ScriptPath));
+
     [Fact]
     public async Task TransientError_DuringHostBuild_DoesNotDeadlock()
     {
@@ -52,6 +65,80 @@ public class WebHostStartupEndToEndTests
         {
             await fixture.DisposeAsync();
         }
+    }
+
+    [Fact]
+    public async Task WebHostOptionsAreLogged_WithoutPlaceholderMode()
+    {
+        // Validates that WebHost-level options implementing IOptionsFormatter are logged
+        // when the host starts directly without placeholder mode (no specialization).
+        const string optionsCategory = "Microsoft.Azure.WebJobs.Hosting.OptionsLoggingService";
+
+        var loggerProvider = new TestLoggerProvider();
+        var builder = CreateHostBuilder(loggerProvider, "FunctionExecutionContext");
+
+        using var testServer = new TestServer(builder);
+        var client = testServer.CreateClient();
+
+        var response = await client.GetAsync("api/functionexecutioncontext");
+        response.EnsureSuccessStatusCode();
+
+        // Wait for the OptionsLoggingService to process all queued log entries.
+        await TestHelpers.Await(() =>
+            loggerProvider.GetAllLogMessages()
+                .Any(m => string.Equals(m.Category, optionsCategory, StringComparison.Ordinal)
+                       && m.FormattedMessage.StartsWith(nameof(HttpBodyControlOptions), StringComparison.Ordinal)));
+
+        var allOptionsLogs = loggerProvider.GetAllLogMessages()
+            .Where(m => string.Equals(m.Category, optionsCategory, StringComparison.Ordinal))
+            .Select(m => m.FormattedMessage)
+            .ToList();
+
+        // WebHost-level options implementing IOptionsFormatter should be logged.
+        TestHelpers.AssertOptionLogged(allOptionsLogs, nameof(HttpBodyControlOptions));
+        TestHelpers.AssertOptionLogged(allOptionsLogs, nameof(ResponseCompressionOptions));
+        TestHelpers.AssertOptionLogged(allOptionsLogs, nameof(HostHealthMonitorOptions));
+        TestHelpers.AssertOptionLogged(allOptionsLogs, nameof(WorkerConfigurationResolverOptions));
+        TestHelpers.AssertOptionLogged(allOptionsLogs, nameof(LanguageWorkerOptions));
+    }
+
+    private static IWebHostBuilder CreateHostBuilder(TestLoggerProvider loggerProvider, params string[] functions)
+    {
+        var environment = new TestEnvironment(new Dictionary<string, string>
+        {
+            { EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0" },
+            { EnvironmentSettingNames.AzureWebsiteContainerReady, "1" },
+        });
+
+        return Program.CreateWebHostBuilder()
+            .ConfigureLogging(b =>
+            {
+                b.AddProvider(loggerProvider);
+                b.AddFilter<TestLoggerProvider>("Microsoft.Azure.WebJobs", LogLevel.Debug);
+            })
+            .ConfigureAppConfiguration(c =>
+            {
+                c.AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { _scriptRootConfigPath, @"TestScripts\CSharp" }
+                });
+            })
+            .ConfigureServices((bc, s) =>
+            {
+                s.AddSingleton<IEnvironment>(environment);
+            })
+            .ConfigureScriptHostServices(s =>
+            {
+                s.AddLogging(logging =>
+                {
+                    logging.AddProvider(loggerProvider);
+                });
+
+                s.PostConfigure<ScriptJobHostOptions>(o =>
+                {
+                    o.Functions = functions;
+                });
+            });
     }
 
     private class WebHostStartupEndToEndTestFixture : EndToEndTestFixture

--- a/test/WebJobs.Script.Tests.Shared/TestHelpers.OptionsLogging.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHelpers.OptionsLogging.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public static partial class TestHelpers
+    {
+        /// <summary>
+        /// Asserts that an options type with the given name appears in the collected options log entries.
+        /// Each entry is formatted as "OptionTypeName\n{ json }", so matching is done on the first line.
+        /// </summary>
+        public static void AssertOptionLogged(List<string> allOptionsLogs, string optionName)
+        {
+            var loggedOptionNames = allOptionsLogs.Select(GetOptionTypeName).ToList();
+
+            Assert.True(
+                allOptionsLogs.Any(m => m.StartsWith(optionName, StringComparison.Ordinal)),
+                $"{optionName} not found. Logged options: [{string.Join(", ", loggedOptionNames)}]");
+        }
+
+        /// <summary>
+        /// Extracts the options type name from a formatted options log entry.
+        /// Each entry is formatted as "OptionTypeName\n{ json }", so the type name is the first line.
+        /// </summary>
+        public static string GetOptionTypeName(string optionsLogEntry)
+        {
+            var firstLineEnd = optionsLogEntry.IndexOfAny(['\r', '\n']);
+
+            return firstLineEnd >= 0
+                ? optionsLogEntry[..firstLineEnd]
+                : optionsLogEntry;
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Configuration/WebHostOptionsLoggingTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/WebHostOptionsLoggingTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Azure.WebJobs.Hosting;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
+using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
+{
+    public class WebHostOptionsLoggingTests
+    {
+        [Fact]
+        public void WebHostContainer_RegistersWebJobsOptionsFactory_ForFormattableOptions()
+        {
+            var services = new ServiceCollection();
+            var startup = new Startup(null);
+            startup.ConfigureServices(services);
+
+            services.AddSingleton<IEnvironment>(_ => new TestEnvironment());
+
+            using var serviceProvider = services.BuildServiceProvider();
+
+            // Resolve the IOptionsFactory for a WebHost-level options type that implements IOptionsFormatter.
+            // AddFormattableOptionsLogging replaces the default OptionsFactory with WebJobsOptionsFactory,
+            // which will log the options when they are created.
+            var factory = serviceProvider.GetRequiredService<IOptionsFactory<ResponseCompressionOptions>>();
+            Assert.Equal("WebJobsOptionsFactory`1", factory.GetType().Name);
+        }
+
+        [Fact]
+        public void WebHostContainer_RegistersWebJobsOptionsFactory_ForHttpBodyControlOptions()
+        {
+            var services = new ServiceCollection();
+            var startup = new Startup(null);
+            startup.ConfigureServices(services);
+
+            services.AddSingleton<IEnvironment>(_ => new TestEnvironment());
+
+            using var serviceProvider = services.BuildServiceProvider();
+
+            var factory = serviceProvider.GetRequiredService<IOptionsFactory<HttpBodyControlOptions>>();
+            Assert.Equal("WebJobsOptionsFactory`1", factory.GetType().Name);
+        }
+
+        [Fact]
+        public void WebHostContainer_RegistersOptionsLoggingService()
+        {
+            var services = new ServiceCollection();
+            var startup = new Startup(null);
+            startup.ConfigureServices(services);
+
+            // Verify OptionsLoggingService is registered as an IHostedService via service descriptors.
+            Assert.Contains(services, d =>
+                d.ServiceType == typeof(IHostedService)
+                && d.ImplementationType is not null
+                && string.Equals(d.ImplementationType.Name, "OptionsLoggingService", System.StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void ChildContainer_GetsOwnOptionsLoggingSource()
+        {
+            // Both the WebHost and ScriptHost call AddFormattableOptionsLogging(), which registers
+            // an IOptionsLoggingSource backed by a BufferBlock<string>. Each OptionsLoggingService
+            // (IHostedService) reads from its container's IOptionsLoggingSource and writes to its
+            // container's ILogger. If both containers shared the same IOptionsLoggingSource, messages
+            // would be randomly consumed by either service (competing consumers), causing ScriptHost
+            // options to be logged by the WebHost logger (missing from App Insights) or vice versa.
+            //
+            // This test verifies that CreateChildContainer + the ScriptHost's own registration
+            // produces a separate IOptionsLoggingSource, so each pipeline is fully independent.
+            var rootServices = new ServiceCollection();
+            rootServices.AddFormattableOptionsLogging();
+
+            using var rootProvider = rootServices.BuildServiceProvider();
+
+            // Resolve IOptionsLoggingSource type via reflection (internal type).
+            Type optionsLoggingSourceType = typeof(IOptionsFormatter).Assembly
+                .GetTypes()
+                .Single(t => string.Equals(t.Name, "IOptionsLoggingSource", StringComparison.Ordinal));
+
+            var rootSource = rootProvider.GetService(optionsLoggingSourceType);
+            Assert.NotNull(rootSource);
+
+            // Create a child container the same way JobHostScopedServiceProviderFactory does.
+            var childServices = rootProvider.CreateChildContainer(rootServices);
+
+            // Simulate ScriptHost calling AddFormattableOptionsLogging via AddWebJobs.
+            // This adds a second IOptionsLoggingSource registration that wins over the cloned root one.
+            var scriptHostServices = new ServiceCollection();
+            scriptHostServices.AddFormattableOptionsLogging();
+
+            foreach (var service in scriptHostServices)
+            {
+                childServices.Add(service);
+            }
+
+            using var childProvider = childServices.BuildServiceProvider();
+
+            var childSource = childProvider.GetService(optionsLoggingSourceType);
+            Assert.NotNull(childSource);
+
+            // The child container must have its own IOptionsLoggingSource, not the root's.
+            Assert.NotSame(rootSource, childSource);
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
+++ b/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
@@ -991,14 +991,14 @@
           }
         }
       },
-      "Microsoft.Azure.WebJobs.Rpc.Core/3.0.44": {
+      "Microsoft.Azure.WebJobs.Rpc.Core/3.0.45": {
         "dependencies": {
-          "Microsoft.Azure.WebJobs": "3.0.44"
+          "Microsoft.Azure.WebJobs": "3.0.45"
         },
         "runtime": {
           "lib/net6.0/Microsoft.Azure.WebJobs.Rpc.Core.dll": {
-            "assemblyVersion": "3.0.44.0",
-            "fileVersion": "3.0.44.25605"
+            "assemblyVersion": "3.0.45.0",
+            "fileVersion": "3.0.45.26113"
           }
         }
       },
@@ -3033,7 +3033,7 @@
       "Microsoft.Azure.WebJobs.Script.Grpc/4.1048.100-pr.26110.4": {
         "dependencies": {
           "Grpc.AspNetCore": "2.55.0",
-          "Microsoft.Azure.WebJobs.Rpc.Core": "3.0.44",
+          "Microsoft.Azure.WebJobs.Rpc.Core": "3.0.45",
           "Microsoft.Azure.WebJobs.Script": "4.1048.100-pr.26110.4"
         },
         "runtime": {
@@ -3750,12 +3750,12 @@
       "path": "microsoft.azure.webjobs.logging.applicationinsights/3.0.44",
       "hashPath": "microsoft.azure.webjobs.logging.applicationinsights.3.0.44.nupkg.sha512"
     },
-    "Microsoft.Azure.WebJobs.Rpc.Core/3.0.44": {
+    "Microsoft.Azure.WebJobs.Rpc.Core/3.0.45": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-9ewFqg3cQ6N4ZsVYJYeSFkhFJXP/lmQT8bvyAkBxpmdXTn4+sa4VGbzzJVCdG7cksFG8XJ0xw+SFGvBp28Iv/w==",
-      "path": "microsoft.azure.webjobs.rpc.core/3.0.44",
-      "hashPath": "microsoft.azure.webjobs.rpc.core.3.0.44.nupkg.sha512"
+      "sha512": "sha512-C2/E80ouBqILZ/cG++dDcyJGH8Vvffw58jvg/+MREO1+kvWgKt84K9L4fVu8TJ9YzGsc9UlfWcJlI4s8idep4A==",
+      "path": "microsoft.azure.webjobs.rpc.core/3.0.45",
+      "hashPath": "microsoft.azure.webjobs.rpc.core.3.0.45.nupkg.sha512"
     },
     "Microsoft.Azure.WebJobs.Script.Abstractions/1.0.4-preview": {
       "type": "package",


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Resolves #11146

   Calls `AddFormattableOptionsLogging()` at the WebHost level so that options types implementing `IOptionsFormatter` (registered in the WebHost container) are logged via `OptionsLoggingService` during host startup. Previously, only ScriptHost-level options were logged through this mechanism.

   ### New WebHost-level options now logged

   - `HttpBodyControlOptions`
   - `ResponseCompressionOptions`
   - `HostHealthMonitorOptions`
   - `WorkerConfigurationResolverOptions`
   - `LanguageWorkerOptions`

   ### No impact to existing ScriptHost options logging

   The WebHost and ScriptHost each get their own `IOptionsLoggingSource` instance (separate `BufferBlock<string>` channels). The child container creation (`CreateChildContainer`) clones the root's singleton, but the ScriptHost's own `AddFormattableOptionsLogging()` call (via `AddWebJobs`) adds a second
  registration that wins via last-registration-wins semantics. This means:

   - **No competing consumers** — each `OptionsLoggingService` reads from its own buffer
   - **No cross-contamination** — WebHost options flow through the WebHost logger; ScriptHost options flow through the ScriptHost logger (including App Insights)
   - **No change to existing script host level Options logging** — existing ScriptHost options (`ScriptJobHostOptions`, `LoggerFilterOptions`, `FunctionResultAggregatorOptions`, `ConcurrencyOptions`, `SingletonOptions`, `ScaleOptions`, `HttpOptions`) continue to be logged as before

   ### Tests added

   | Test | File | Purpose |
   |------|------|---------|
   | `Specialization_WebHostOptionsAreLogged` | `SpecializationE2ETests.cs` | Verifies WebHost + ScriptHost options are logged in the placeholder → specialization flow |
   | `WebHostOptionsAreLogged_WithoutPlaceholderMode` | `WebHostStartupEndToEndTests.cs` | Verifies WebHost options are logged when the host starts directly (no placeholder mode) |
   | `ChildContainer_GetsOwnOptionsLoggingSource` | `WebHostOptionsLoggingTests.cs` | Unit test proving the WebHost and ScriptHost containers get separate `IOptionsLoggingSource` instances |
   | `WebHostContainer_RegistersWebJobsOptionsFactory_*` | `WebHostOptionsLoggingTests.cs` | Verifies `WebJobsOptionsFactory` and `OptionsLoggingService` are registered in the WebHost container |

   ### Shared test helpers

   Added `TestHelpers.OptionsLogging.cs` with `AssertOptionLogged()` and `GetOptionTypeName()` to avoid duplication across test files.

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
