### PR TITLE
Thread safe hitcount Increment

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEvent.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEvent.cs
@@ -51,6 +51,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public int Level { get; set; }
 
+        public string Details { get; set; }
+
         [IgnoreDataMember]
         public LogLevel LogLevel
         {
@@ -62,7 +64,5 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         {
             Interlocked.Increment(ref _hitCount);
         }
-
-        public string Details { get; set; }
     }
 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEvent.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEvent.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
 using System.Runtime.Serialization;
+using System.Threading;
 using Azure;
 using Azure.Data.Tables;
 using Microsoft.Azure.WebJobs.Script.WebHost.Helpers;
@@ -12,6 +13,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 {
     public class DiagnosticEvent : ITableEntity
     {
+        private int _hitCount;
+
         internal const string CurrentEventVersion = "2024-05-01";
 
         public DiagnosticEvent() { }
@@ -34,7 +37,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public string EventVersion { get; set; }
 
-        public int HitCount { get; set; }
+        public int HitCount
+        {
+            get => _hitCount;
+            set => _hitCount = value;
+        }
 
         public string Message { get; set; }
 
@@ -49,6 +56,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         {
             get { return (LogLevel)Level; }
             set { Level = (int)value; }
+        }
+
+        internal void IncrementHitCount()
+        {
+            Interlocked.Increment(ref _hitCount);
         }
 
         public string Details { get; set; }

--- a/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DiagnosticEventTableStorageRepository.cs
@@ -406,7 +406,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 (key, existingEvent) =>
                 {
                     existingEvent.Timestamp = timestamp;
-                    existingEvent.HitCount++;
+                    existingEvent.IncrementHitCount();
                     return existingEvent;
                 });
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

This pull request introduces a thread-safe approach to incrementing the `HitCount` property in the `DiagnosticEvent` class by replacing direct increment operations with atomic operations. This change helps prevent race conditions when multiple threads update the same event.

**Thread-safety improvements:**

* Refactored the `HitCount` property in `DiagnosticEvent` to use a private backing field and provided an `IncrementHitCount` method that uses `Interlocked.Increment` for atomic updates.
* Updated the code in `DiagnosticEventTableStorageRepository` to use the new `IncrementHitCount` method instead of directly incrementing the property, ensuring thread-safe updates.

**Dependency updates:**

* Added `System.Threading` namespace import in `DiagnosticEvent.cs` to support atomic operations.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
