### PR TITLE
Fix stale hostname in ARM cache after slot swap

### DIFF
--- a/gh_user.txt
+++ b/gh_user.txt
@@ -1,0 +1,1 @@
+pagariyaalok

--- a/gh_user.txt
+++ b/gh_user.txt
@@ -1,1 +1,0 @@
-pagariyaalok

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,6 +3,7 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Fix stale hostname in ARM cache after slot swap by adding event-based re-sync when `HostNameProvider` detects a hostname change (#11629)
 - Refactor DiagnosticEventTableStorageRepository TableClient (#11611)
 - Improve resiliency of batch operations in TableStorageScaleMetricsRepository with Polly retry and exponential backoff (#11586)
 - Add support for propagating tags from the worker to the host and update the protobuf version to `v1.12.0-protofile` (#11575)

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -50,10 +50,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         private const string ManagedKubernetesBuildServiceName = "k8se-build-service";
         private const string ManagedKubernetesBuildServiceNamespace = "k8se-system";
 
-        // Debounce delay for hostname change re-sync (in milliseconds).
-        // This prevents rapid re-syncs during slot swap hostname flip-flop.
-        private const int HostNameChangeDebounceDelayMs = 5000;
-
         private readonly Regex versionRegex = new Regex(@"Version=(?<majorversion>\d)\.\d\.\d");
 
         private readonly IOptionsMonitor<ScriptApplicationHostOptions> _applicationHostOptions;
@@ -69,11 +65,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         private readonly IAzureBlobStorageProvider _azureBlobStorageProvider;
         private readonly IOptions<FunctionsHostingConfigOptions> _hostingConfigOptions;
         private readonly IScriptHostManager _scriptHostManager;
-        private readonly object _hostNameChangeLock = new object();
+        private readonly Func<Task> _syncTriggersAfterHostNameChange;
 
         private BlobClient _hashBlobClient;
-        private CancellationTokenSource _hostNameChangeDebounceCts;
-        private Task _hostNameChangeTask;
         private bool _disposed;
 
         public FunctionsSyncManager(IHostIdProvider hostIdProvider, IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, ILogger<FunctionsSyncManager> logger, IHttpClientFactory httpClientFactory, ISecretManagerProvider secretManagerProvider, IScriptWebHostEnvironment webHostEnvironment, IEnvironment environment, HostNameProvider hostNameProvider, IFunctionMetadataManager functionMetadataManager, IAzureBlobStorageProvider azureBlobStorageProvider, IOptions<FunctionsHostingConfigOptions> functionsHostingConfigOptions, IScriptHostManager scriptHostManager)
@@ -93,6 +87,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
             // Subscribe to hostname changes to trigger re-sync after slot swaps.
             // This ensures the ARM cache (invoke_url_template) is updated with the correct hostname.
+            Func<Task> syncAction = SyncTriggersAfterHostNameChangeAsync;
+            _syncTriggersAfterHostNameChange = syncAction.Debounce(milliseconds: 5000);
             _hostNameProvider.HostNameChanged += OnHostNameChanged;
         }
 
@@ -819,71 +815,58 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         /// </summary>
         private void OnHostNameChanged(object sender, HostNameChangedEventArgs e)
         {
+            if (_disposed)
+            {
+                return;
+            }
+
             _logger.LogInformation("Hostname changed from '{PreviousHostName}' to '{NewHostName}'. Scheduling background sync triggers update.",
                 e.PreviousHostName, e.NewHostName);
 
-            // Cancel any pending debounced re-sync and start a new one.
-            // This ensures we wait for hostname to stabilize before re-syncing.
-            CancellationTokenSource cts;
-            lock (_hostNameChangeLock)
-            {
-                if (_disposed)
-                {
-                    return;
-                }
+            _ = _syncTriggersAfterHostNameChange();
+        }
 
-                _hostNameChangeDebounceCts?.Cancel();
-                _hostNameChangeDebounceCts?.Dispose();
-                _hostNameChangeDebounceCts = new CancellationTokenSource();
-                cts = _hostNameChangeDebounceCts;
+        /// <summary>
+        /// Executes the background sync triggers after hostname change has stabilized.
+        /// This method is wrapped by <see cref="FuncExtensions.Debounce"/> to prevent rapid re-syncs.
+        /// </summary>
+        private async Task SyncTriggersAfterHostNameChangeAsync()
+        {
+            if (_disposed)
+            {
+                return;
             }
 
-            _hostNameChangeTask = Task.Run(async () =>
+            _logger.LogInformation("Executing background sync triggers after hostname change stabilized to '{NewHostName}'.",
+                _hostNameProvider.Value);
+
+            try
             {
-                try
+                var result = await TrySyncTriggersAsync(isBackgroundSync: true);
+                if (result.Success)
                 {
-                    // Wait for debounce period to allow hostname to stabilize
-                    await Task.Delay(HostNameChangeDebounceDelayMs, cts.Token);
-
-                    _logger.LogInformation("Executing background sync triggers after hostname change stabilized to '{NewHostName}'.",
-                        _hostNameProvider.Value);
-
-                    var result = await TrySyncTriggersAsync(isBackgroundSync: true);
-                    if (result.Success)
-                    {
-                        _logger.LogInformation("Background sync triggers completed successfully after hostname change.");
-                    }
-                    else
-                    {
-                        _logger.LogWarning("Background sync triggers failed after hostname change: {Error}", result.Error);
-                    }
+                    _logger.LogInformation("Background sync triggers completed successfully after hostname change.");
                 }
-                catch (Exception ex) when (ex is TaskCanceledException or ObjectDisposedException)
+                else
                 {
-                    // Another hostname change occurred or Dispose was called; this sync was superseded
-                    _logger.LogDebug("Background sync triggers cancelled due to subsequent hostname change or disposal.");
+                    _logger.LogWarning("Background sync triggers failed after hostname change: {Error}", result.Error);
                 }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Error during background sync triggers after hostname change.");
-                }
-            });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during background sync triggers after hostname change.");
+            }
         }
 
         public void Dispose()
         {
-            // Unsubscribe from hostname changes
-            _hostNameProvider.HostNameChanged -= OnHostNameChanged;
-
-            // Cancel and dispose of any pending debounced re-sync
-            lock (_hostNameChangeLock)
+            if (_disposed)
             {
-                _disposed = true;
-                _hostNameChangeDebounceCts?.Cancel();
-                _hostNameChangeDebounceCts?.Dispose();
-                _hostNameChangeDebounceCts = null;
+                return;
             }
 
+            _disposed = true;
+            _hostNameProvider.HostNameChanged -= OnHostNameChanged;
             _syncSemaphore.Dispose();
         }
 

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -809,7 +809,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         }
 
         /// <summary>
-        /// Handles hostname changes (e.g., after slot swap) by triggering a debounced background re-sync.
+        /// Handles hostname changes (e.g., after slot swap) by triggering a debounced re-sync.
         /// This ensures the ARM cache (invoke_url_template) is updated with the correct hostname.
         /// The debounce prevents rapid re-syncs during hostname flip-flop that can occur during slot swaps.
         /// </summary>
@@ -820,16 +820,34 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 return;
             }
 
-            _logger.LogInformation("Hostname changed from '{PreviousHostName}' to '{NewHostName}'. Scheduling background sync triggers update.",
+            // During standby mode, IsSyncTriggersEnvironment returns false and SetTriggers would be a no-op.
+            // Skip scheduling to avoid misleading log messages.
+            if (_webHostEnvironment.InStandbyMode)
+            {
+                return;
+            }
+
+            _logger.LogInformation("Hostname changed from '{PreviousHostName}' to '{NewHostName}'. Scheduling sync triggers update.",
                 e.PreviousHostName, e.NewHostName);
 
             _ = _syncTriggersAfterHostNameChange();
         }
 
         /// <summary>
-        /// Executes the background sync triggers after hostname change has stabilized.
+        /// Executes a non-background (authoritative) sync triggers after hostname change has stabilized.
+        /// Uses <c>isBackgroundSync: false</c> to force a <c>SetTriggers</c> call without hash-based de-duplication,
+        /// ensuring the ARM cache (e.g., invoke_url_template) is updated even when the trigger payload is unchanged.
         /// This method is wrapped by <see cref="FuncExtensions.Debounce"/> to prevent rapid re-syncs.
         /// </summary>
+        /// <remarks>
+        /// Trade-off: Using <c>isBackgroundSync: false</c> means that if the site temporarily has no functions
+        /// (e.g., transient file system issue during swap), an empty payload will be sent to SetTriggers, which
+        /// could cause ARM to think the app has no triggers. This is an acceptable trade-off because:
+        /// 1. It is extremely unlikely for functions to disappear during a swap.
+        /// 2. The regular background sync timer will eventually re-sync with the correct payload.
+        /// 3. The alternative (using background sync) would bypass SetTriggers due to hash de-dup, defeating
+        ///    the purpose of this fix entirely.
+        /// </remarks>
         private async Task SyncTriggersAfterHostNameChangeAsync()
         {
             if (_disposed)
@@ -837,24 +855,24 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 return;
             }
 
-            _logger.LogInformation("Executing background sync triggers after hostname change stabilized to '{NewHostName}'.",
+            _logger.LogInformation("Executing sync triggers after hostname change stabilized to '{NewHostName}'.",
                 _hostNameProvider.Value);
 
             try
             {
-                var result = await TrySyncTriggersAsync(isBackgroundSync: true);
+                var result = await TrySyncTriggersAsync(isBackgroundSync: false);
                 if (result.Success)
                 {
-                    _logger.LogInformation("Background sync triggers completed successfully after hostname change.");
+                    _logger.LogInformation("Sync triggers completed successfully after hostname change.");
                 }
                 else
                 {
-                    _logger.LogWarning("Background sync triggers failed after hostname change: {Error}", result.Error);
+                    _logger.LogWarning("Sync triggers failed after hostname change: {Error}", result.Error);
                 }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error during background sync triggers after hostname change.");
+                _logger.LogError(ex, "Error during sync triggers after hostname change.");
             }
         }
 

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -50,6 +50,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         private const string ManagedKubernetesBuildServiceName = "k8se-build-service";
         private const string ManagedKubernetesBuildServiceNamespace = "k8se-system";
 
+        // Debounce delay for hostname change re-sync (in milliseconds).
+        // This prevents rapid re-syncs during slot swap hostname flip-flop.
+        private const int HostNameChangeDebounceDelayMs = 5000;
+
         private readonly Regex versionRegex = new Regex(@"Version=(?<majorversion>\d)\.\d\.\d");
 
         private readonly IOptionsMonitor<ScriptApplicationHostOptions> _applicationHostOptions;
@@ -65,8 +69,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         private readonly IAzureBlobStorageProvider _azureBlobStorageProvider;
         private readonly IOptions<FunctionsHostingConfigOptions> _hostingConfigOptions;
         private readonly IScriptHostManager _scriptHostManager;
+        private readonly object _hostNameChangeLock = new object();
 
         private BlobClient _hashBlobClient;
+        private CancellationTokenSource _hostNameChangeDebounceCts;
 
         public FunctionsSyncManager(IHostIdProvider hostIdProvider, IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, ILogger<FunctionsSyncManager> logger, IHttpClientFactory httpClientFactory, ISecretManagerProvider secretManagerProvider, IScriptWebHostEnvironment webHostEnvironment, IEnvironment environment, HostNameProvider hostNameProvider, IFunctionMetadataManager functionMetadataManager, IAzureBlobStorageProvider azureBlobStorageProvider, IOptions<FunctionsHostingConfigOptions> functionsHostingConfigOptions, IScriptHostManager scriptHostManager)
         {
@@ -82,6 +88,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             _azureBlobStorageProvider = azureBlobStorageProvider;
             _hostingConfigOptions = functionsHostingConfigOptions;
             _scriptHostManager = scriptHostManager;
+
+            // Subscribe to hostname changes to trigger re-sync after slot swaps.
+            // This ensures the ARM cache (invoke_url_template) is updated with the correct hostname.
+            _hostNameProvider.HostNameChanged += OnHostNameChanged;
         }
 
         internal bool ArmCacheEnabled
@@ -800,8 +810,76 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             return result;
         }
 
+        /// <summary>
+        /// Handles hostname changes (e.g., after slot swap) by triggering a debounced background re-sync.
+        /// This ensures the ARM cache (invoke_url_template) is updated with the correct hostname.
+        /// The debounce prevents rapid re-syncs during hostname flip-flop that can occur during slot swaps.
+        /// </summary>
+        private void OnHostNameChanged(object sender, HostNameChangedEventArgs e)
+        {
+            _logger.LogInformation("Hostname changed from '{PreviousHostName}' to '{NewHostName}'. Scheduling background sync triggers update.",
+                e.PreviousHostName, e.NewHostName);
+
+            // Cancel any pending debounced re-sync and start a new one.
+            // This ensures we wait for hostname to stabilize before re-syncing.
+            lock (_hostNameChangeLock)
+            {
+                _hostNameChangeDebounceCts?.Cancel();
+                _hostNameChangeDebounceCts?.Dispose();
+                _hostNameChangeDebounceCts = new CancellationTokenSource();
+            }
+
+            var cts = _hostNameChangeDebounceCts;
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    // Wait for debounce period to allow hostname to stabilize
+                    await Task.Delay(HostNameChangeDebounceDelayMs, cts.Token);
+
+                    if (cts.Token.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    _logger.LogInformation("Executing background sync triggers after hostname change stabilized to '{NewHostName}'.",
+                        _hostNameProvider.Value);
+
+                    var result = await TrySyncTriggersAsync(isBackgroundSync: true);
+                    if (result.Success)
+                    {
+                        _logger.LogInformation("Background sync triggers completed successfully after hostname change.");
+                    }
+                    else
+                    {
+                        _logger.LogWarning("Background sync triggers failed after hostname change: {Error}", result.Error);
+                    }
+                }
+                catch (TaskCanceledException)
+                {
+                    // Another hostname change occurred, this sync was superseded
+                    _logger.LogDebug("Background sync triggers cancelled due to subsequent hostname change.");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error during background sync triggers after hostname change.");
+                }
+            });
+        }
+
         public void Dispose()
         {
+            // Unsubscribe from hostname changes
+            _hostNameProvider.HostNameChanged -= OnHostNameChanged;
+
+            // Cancel and dispose of any pending debounced re-sync
+            lock (_hostNameChangeLock)
+            {
+                _hostNameChangeDebounceCts?.Cancel();
+                _hostNameChangeDebounceCts?.Dispose();
+                _hostNameChangeDebounceCts = null;
+            }
+
             _syncSemaphore.Dispose();
         }
 

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -73,6 +73,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
         private BlobClient _hashBlobClient;
         private CancellationTokenSource _hostNameChangeDebounceCts;
+        private Task _hostNameChangeTask;
+        private bool _disposed;
 
         public FunctionsSyncManager(IHostIdProvider hostIdProvider, IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, ILogger<FunctionsSyncManager> logger, IHttpClientFactory httpClientFactory, ISecretManagerProvider secretManagerProvider, IScriptWebHostEnvironment webHostEnvironment, IEnvironment environment, HostNameProvider hostNameProvider, IFunctionMetadataManager functionMetadataManager, IAzureBlobStorageProvider azureBlobStorageProvider, IOptions<FunctionsHostingConfigOptions> functionsHostingConfigOptions, IScriptHostManager scriptHostManager)
         {
@@ -822,25 +824,26 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
             // Cancel any pending debounced re-sync and start a new one.
             // This ensures we wait for hostname to stabilize before re-syncing.
+            CancellationTokenSource cts;
             lock (_hostNameChangeLock)
             {
+                if (_disposed)
+                {
+                    return;
+                }
+
                 _hostNameChangeDebounceCts?.Cancel();
                 _hostNameChangeDebounceCts?.Dispose();
                 _hostNameChangeDebounceCts = new CancellationTokenSource();
+                cts = _hostNameChangeDebounceCts;
             }
 
-            var cts = _hostNameChangeDebounceCts;
-            _ = Task.Run(async () =>
+            _hostNameChangeTask = Task.Run(async () =>
             {
                 try
                 {
                     // Wait for debounce period to allow hostname to stabilize
                     await Task.Delay(HostNameChangeDebounceDelayMs, cts.Token);
-
-                    if (cts.Token.IsCancellationRequested)
-                    {
-                        return;
-                    }
 
                     _logger.LogInformation("Executing background sync triggers after hostname change stabilized to '{NewHostName}'.",
                         _hostNameProvider.Value);
@@ -855,10 +858,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                         _logger.LogWarning("Background sync triggers failed after hostname change: {Error}", result.Error);
                     }
                 }
-                catch (TaskCanceledException)
+                catch (Exception ex) when (ex is TaskCanceledException or ObjectDisposedException)
                 {
-                    // Another hostname change occurred, this sync was superseded
-                    _logger.LogDebug("Background sync triggers cancelled due to subsequent hostname change.");
+                    // Another hostname change occurred or Dispose was called; this sync was superseded
+                    _logger.LogDebug("Background sync triggers cancelled due to subsequent hostname change or disposal.");
                 }
                 catch (Exception ex)
                 {
@@ -875,6 +878,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             // Cancel and dispose of any pending debounced re-sync
             lock (_hostNameChangeLock)
             {
+                _disposed = true;
                 _hostNameChangeDebounceCts?.Cancel();
                 _hostNameChangeDebounceCts?.Dispose();
                 _hostNameChangeDebounceCts = null;

--- a/src/WebJobs.Script/HostNameChangedEventArgs.cs
+++ b/src/WebJobs.Script/HostNameChangedEventArgs.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Script
+{
+    /// <summary>
+    /// Event arguments for the <see cref="HostNameProvider.HostNameChanged"/> event.
+    /// </summary>
+    public sealed class HostNameChangedEventArgs : EventArgs
+    {
+        public HostNameChangedEventArgs(string previousHostName, string newHostName)
+        {
+            PreviousHostName = previousHostName;
+            NewHostName = newHostName;
+        }
+
+        /// <summary>
+        /// Gets the previous hostname before the change.
+        /// </summary>
+        public string PreviousHostName { get; }
+
+        /// <summary>
+        /// Gets the new hostname after the change.
+        /// </summary>
+        public string NewHostName { get; }
+    }
+}

--- a/src/WebJobs.Script/HostNameProvider.cs
+++ b/src/WebJobs.Script/HostNameProvider.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             string hostNameHeaderValue = request.Headers[ScriptConstants.AntaresDefaultHostNameHeader];
             if (!string.IsNullOrEmpty(hostNameHeaderValue) &&
-                string.Compare(Value, hostNameHeaderValue) != 0)
+                !string.Equals(Value, hostNameHeaderValue, StringComparison.OrdinalIgnoreCase))
             {
                 string previousHostName = Value;
                 logger.LogInformation("HostName updated from '{0}' to '{1}'", previousHostName, hostNameHeaderValue);

--- a/src/WebJobs.Script/HostNameProvider.cs
+++ b/src/WebJobs.Script/HostNameProvider.cs
@@ -28,6 +28,12 @@ namespace Microsoft.Azure.WebJobs.Script
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
         }
 
+        /// <summary>
+        /// Event raised when the hostname is updated (e.g., after a slot swap).
+        /// Subscribers should use this to refresh any cached hostname-dependent data.
+        /// </summary>
+        public event EventHandler<HostNameChangedEventArgs> HostNameChanged;
+
         public virtual string Value
         {
             get
@@ -56,14 +62,49 @@ namespace Microsoft.Azure.WebJobs.Script
             if (!string.IsNullOrEmpty(hostNameHeaderValue) &&
                 string.Compare(Value, hostNameHeaderValue) != 0)
             {
-                logger.LogInformation("HostName updated from '{0}' to '{1}'", Value, hostNameHeaderValue);
+                string previousHostName = Value;
+                logger.LogInformation("HostName updated from '{0}' to '{1}'", previousHostName, hostNameHeaderValue);
                 _hostName = hostNameHeaderValue;
+
+                // Raise event to notify subscribers (e.g., FunctionsSyncManager) that hostname has changed.
+                // This allows them to refresh any hostname-dependent cached data like invoke_url_template.
+                OnHostNameChanged(previousHostName, hostNameHeaderValue);
             }
+        }
+
+        /// <summary>
+        /// Raises the HostNameChanged event.
+        /// </summary>
+        protected virtual void OnHostNameChanged(string previousHostName, string newHostName)
+        {
+            HostNameChanged?.Invoke(this, new HostNameChangedEventArgs(previousHostName, newHostName));
         }
 
         internal void Reset()
         {
             _hostName = null;
         }
+    }
+
+    /// <summary>
+    /// Event arguments for the HostNameChanged event.
+    /// </summary>
+    public class HostNameChangedEventArgs : EventArgs
+    {
+        public HostNameChangedEventArgs(string previousHostName, string newHostName)
+        {
+            PreviousHostName = previousHostName;
+            NewHostName = newHostName;
+        }
+
+        /// <summary>
+        /// Gets the previous hostname before the change.
+        /// </summary>
+        public string PreviousHostName { get; }
+
+        /// <summary>
+        /// Gets the new hostname after the change.
+        /// </summary>
+        public string NewHostName { get; }
     }
 }

--- a/src/WebJobs.Script/HostNameProvider.cs
+++ b/src/WebJobs.Script/HostNameProvider.cs
@@ -66,9 +66,13 @@ namespace Microsoft.Azure.WebJobs.Script
                 logger.LogInformation("HostName updated from '{0}' to '{1}'", previousHostName, hostNameHeaderValue);
                 _hostName = hostNameHeaderValue;
 
-                // Raise event to notify subscribers (e.g., FunctionsSyncManager) that hostname has changed.
-                // This allows them to refresh any hostname-dependent cached data like invoke_url_template.
-                OnHostNameChanged(previousHostName, hostNameHeaderValue);
+                // Only raise the event when the previous hostname was already set.
+                // During specialization/scale-out, the first request sets the hostname from null/environment default
+                // to the real value — this is initial discovery, not a slot swap, and should not trigger a re-sync.
+                if (!string.IsNullOrEmpty(previousHostName))
+                {
+                    OnHostNameChanged(previousHostName, hostNameHeaderValue);
+                }
             }
         }
 

--- a/src/WebJobs.Script/HostNameProvider.cs
+++ b/src/WebJobs.Script/HostNameProvider.cs
@@ -85,26 +85,4 @@ namespace Microsoft.Azure.WebJobs.Script
             _hostName = null;
         }
     }
-
-    /// <summary>
-    /// Event arguments for the HostNameChanged event.
-    /// </summary>
-    public class HostNameChangedEventArgs : EventArgs
-    {
-        public HostNameChangedEventArgs(string previousHostName, string newHostName)
-        {
-            PreviousHostName = previousHostName;
-            NewHostName = newHostName;
-        }
-
-        /// <summary>
-        /// Gets the previous hostname before the change.
-        /// </summary>
-        public string PreviousHostName { get; }
-
-        /// <summary>
-        /// Gets the new hostname after the change.
-        /// </summary>
-        public string NewHostName { get; }
-    }
 }

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -1307,7 +1307,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         }
 
         [Fact]
-        public async Task HostNameChange_TriggersBackgroundSyncTriggers()
+        public async Task HostNameChange_TriggersSyncTriggers()
         {
             using (var env = new TestScopedEnvironmentVariable(_vars))
             {
@@ -1323,12 +1323,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
                 Assert.Equal("newhost.azurewebsites.net", _hostNameProvider.Value);
 
-                // Wait for the debounced background sync to fire (5s debounce + buffer)
+                // Wait for the debounced sync to fire (5s debounce + buffer)
                 await Task.Delay(TimeSpan.FromSeconds(7));
 
                 var logs = _loggerProvider.GetAllLogMessages();
                 Assert.Contains(logs, l => l.FormattedMessage.Contains("Hostname changed from"));
-                Assert.Contains(logs, l => l.FormattedMessage.Contains("Executing background sync triggers after hostname change"));
+                Assert.Contains(logs, l => l.FormattedMessage.Contains("Executing sync triggers after hostname change"));
             }
         }
 
@@ -1359,7 +1359,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
                 // Only the final hostname sync should have executed, not the first one
                 var logs = _loggerProvider.GetAllLogMessages();
-                var syncExecutionLogs = logs.Where(l => l.FormattedMessage.Contains("Executing background sync triggers after hostname change")).ToList();
+                var syncExecutionLogs = logs.Where(l => l.FormattedMessage.Contains("Executing sync triggers after hostname change")).ToList();
                 Assert.Single(syncExecutionLogs);
                 Assert.Contains("production.azurewebsites.net", syncExecutionLogs[0].FormattedMessage);
             }
@@ -1385,9 +1385,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             await Task.Delay(500);
             var logs = _loggerProvider.GetAllLogMessages();
+
+            // Verify no sync was scheduled after dispose
             Assert.DoesNotContain(logs, l =>
                 l.Category == SyncManagerLogCategory &&
-                l.FormattedMessage.Contains("Scheduling background sync triggers"));
+                l.FormattedMessage.Contains("Hostname changed from"));
         }
 
         public void Dispose()

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -12,6 +12,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Azure.WebJobs.Host.Storage;
@@ -1303,6 +1304,99 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             });
 
             return fileSystem.Object;
+        }
+
+        [Fact]
+        public async Task HostNameChange_TriggersBackgroundSyncTriggers()
+        {
+            // Arrange - set up environment for sync triggers
+            using (var env = new TestScopedEnvironmentVariable(_vars))
+            {
+                ResetMockFileSystem();
+
+                // Act - simulate a hostname change (e.g., after slot swap)
+                var request = new DefaultHttpContext().Request;
+                request.Headers.Add(ScriptConstants.AntaresDefaultHostNameHeader, "newhost.azurewebsites.net");
+
+                var loggerFactory = new LoggerFactory();
+                loggerFactory.AddProvider(_loggerProvider);
+                var logger = loggerFactory.CreateLogger<HostNameProvider>();
+                _hostNameProvider.Synchronize(request, logger);
+
+                // Assert - the hostname was updated
+                Assert.Equal("newhost.azurewebsites.net", _hostNameProvider.Value);
+
+                // Wait for the debounced background sync to fire (5s debounce + buffer)
+                await Task.Delay(TimeSpan.FromSeconds(7));
+
+                // Verify that logs indicate the background sync was attempted
+                var logs = _loggerProvider.GetAllLogMessages();
+                Assert.Contains(logs, l => l.FormattedMessage.Contains("Hostname changed from"));
+                Assert.Contains(logs, l => l.FormattedMessage.Contains("Executing background sync triggers after hostname change"));
+            }
+        }
+
+        [Fact]
+        public async Task HostNameChange_Debounces_MultipleChanges()
+        {
+            // Arrange
+            using (var env = new TestScopedEnvironmentVariable(_vars))
+            {
+                ResetMockFileSystem();
+                var loggerFactory = new LoggerFactory();
+                loggerFactory.AddProvider(_loggerProvider);
+                var logger = loggerFactory.CreateLogger<HostNameProvider>();
+
+                // Act - simulate rapid hostname flip-flop (as during slot swap)
+                var request1 = new DefaultHttpContext().Request;
+                request1.Headers.Add(ScriptConstants.AntaresDefaultHostNameHeader, "slot1.azurewebsites.net");
+                _hostNameProvider.Synchronize(request1, logger);
+
+                await Task.Delay(100); // Small delay between changes
+
+                var request2 = new DefaultHttpContext().Request;
+                request2.Headers.Add(ScriptConstants.AntaresDefaultHostNameHeader, "production.azurewebsites.net");
+                _hostNameProvider.Synchronize(request2, logger);
+
+                // Assert - only the final hostname should be used
+                Assert.Equal("production.azurewebsites.net", _hostNameProvider.Value);
+
+                // Wait for debounce to settle
+                await Task.Delay(TimeSpan.FromSeconds(7));
+
+                // The first sync should have been cancelled
+                var logs = _loggerProvider.GetAllLogMessages();
+                Assert.Contains(logs, l => l.FormattedMessage.Contains("cancelled due to subsequent hostname change"));
+            }
+        }
+
+        [Fact]
+        public void Dispose_CancelsHostNameChangeSyncAndUnsubscribes()
+        {
+            // Arrange - simulate a hostname change to start a background sync
+            var loggerFactory = new LoggerFactory();
+            loggerFactory.AddProvider(_loggerProvider);
+            var logger = loggerFactory.CreateLogger<HostNameProvider>();
+            var request = new DefaultHttpContext().Request;
+            request.Headers.Add(ScriptConstants.AntaresDefaultHostNameHeader, "newhost.azurewebsites.net");
+            _hostNameProvider.Synchronize(request, logger);
+
+            // Act - dispose immediately (before the 5s debounce fires)
+            _functionsSyncManager.Dispose();
+
+            // Assert - verify no exception occurs and event is unsubscribed
+            // A subsequent hostname change should not trigger the handler
+            _loggerProvider.ClearAllLogMessages();
+            var request2 = new DefaultHttpContext().Request;
+            request2.Headers.Add(ScriptConstants.AntaresDefaultHostNameHeader, "anotherhost.azurewebsites.net");
+            _hostNameProvider.Synchronize(request2, logger);
+
+            // Small delay to confirm no sync was scheduled
+            Task.Delay(500).Wait();
+            var logs = _loggerProvider.GetAllLogMessages();
+            Assert.DoesNotContain(logs, l =>
+                l.Category == SyncManagerLogCategory &&
+                l.FormattedMessage.Contains("Scheduling background sync triggers"));
         }
 
         public void Dispose()

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -1371,7 +1371,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         }
 
         [Fact]
-        public void Dispose_CancelsHostNameChangeSyncAndUnsubscribes()
+        public async Task Dispose_CancelsHostNameChangeSyncAndUnsubscribes()
         {
             // Arrange - simulate a hostname change to start a background sync
             var loggerFactory = new LoggerFactory();
@@ -1392,7 +1392,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             _hostNameProvider.Synchronize(request2, logger);
 
             // Small delay to confirm no sync was scheduled
-            Task.Delay(500).Wait();
+            await Task.Delay(500);
             var logs = _loggerProvider.GetAllLogMessages();
             Assert.DoesNotContain(logs, l =>
                 l.Category == SyncManagerLogCategory &&

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -1309,12 +1309,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         [Fact]
         public async Task HostNameChange_TriggersBackgroundSyncTriggers()
         {
-            // Arrange - set up environment for sync triggers
             using (var env = new TestScopedEnvironmentVariable(_vars))
             {
                 ResetMockFileSystem();
 
-                // Act - simulate a hostname change (e.g., after slot swap)
                 var request = new DefaultHttpContext().Request;
                 request.Headers.Add(ScriptConstants.AntaresDefaultHostNameHeader, "newhost.azurewebsites.net");
 
@@ -1323,13 +1321,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 var logger = loggerFactory.CreateLogger<HostNameProvider>();
                 _hostNameProvider.Synchronize(request, logger);
 
-                // Assert - the hostname was updated
                 Assert.Equal("newhost.azurewebsites.net", _hostNameProvider.Value);
 
                 // Wait for the debounced background sync to fire (5s debounce + buffer)
                 await Task.Delay(TimeSpan.FromSeconds(7));
 
-                // Verify that logs indicate the background sync was attempted
                 var logs = _loggerProvider.GetAllLogMessages();
                 Assert.Contains(logs, l => l.FormattedMessage.Contains("Hostname changed from"));
                 Assert.Contains(logs, l => l.FormattedMessage.Contains("Executing background sync triggers after hostname change"));
@@ -1339,7 +1335,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         [Fact]
         public async Task HostNameChange_Debounces_MultipleChanges()
         {
-            // Arrange
             using (var env = new TestScopedEnvironmentVariable(_vars))
             {
                 ResetMockFileSystem();
@@ -1347,7 +1342,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 loggerFactory.AddProvider(_loggerProvider);
                 var logger = loggerFactory.CreateLogger<HostNameProvider>();
 
-                // Act - simulate rapid hostname flip-flop (as during slot swap)
                 var request1 = new DefaultHttpContext().Request;
                 request1.Headers.Add(ScriptConstants.AntaresDefaultHostNameHeader, "slot1.azurewebsites.net");
                 _hostNameProvider.Synchronize(request1, logger);
@@ -1358,22 +1352,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 request2.Headers.Add(ScriptConstants.AntaresDefaultHostNameHeader, "production.azurewebsites.net");
                 _hostNameProvider.Synchronize(request2, logger);
 
-                // Assert - only the final hostname should be used
                 Assert.Equal("production.azurewebsites.net", _hostNameProvider.Value);
 
                 // Wait for debounce to settle
                 await Task.Delay(TimeSpan.FromSeconds(7));
 
-                // The first sync should have been cancelled
+                // Only the final hostname sync should have executed, not the first one
                 var logs = _loggerProvider.GetAllLogMessages();
-                Assert.Contains(logs, l => l.FormattedMessage.Contains("cancelled due to subsequent hostname change"));
+                var syncExecutionLogs = logs.Where(l => l.FormattedMessage.Contains("Executing background sync triggers after hostname change")).ToList();
+                Assert.Single(syncExecutionLogs);
+                Assert.Contains("production.azurewebsites.net", syncExecutionLogs[0].FormattedMessage);
             }
         }
 
         [Fact]
         public async Task Dispose_CancelsHostNameChangeSyncAndUnsubscribes()
         {
-            // Arrange - simulate a hostname change to start a background sync
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(_loggerProvider);
             var logger = loggerFactory.CreateLogger<HostNameProvider>();
@@ -1381,17 +1375,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             request.Headers.Add(ScriptConstants.AntaresDefaultHostNameHeader, "newhost.azurewebsites.net");
             _hostNameProvider.Synchronize(request, logger);
 
-            // Act - dispose immediately (before the 5s debounce fires)
             _functionsSyncManager.Dispose();
 
-            // Assert - verify no exception occurs and event is unsubscribed
             // A subsequent hostname change should not trigger the handler
             _loggerProvider.ClearAllLogMessages();
             var request2 = new DefaultHttpContext().Request;
             request2.Headers.Add(ScriptConstants.AntaresDefaultHostNameHeader, "anotherhost.azurewebsites.net");
             _hostNameProvider.Synchronize(request2, logger);
 
-            // Small delay to confirm no sync was scheduled
             await Task.Delay(500);
             var logs = _loggerProvider.GetAllLogMessages();
             Assert.DoesNotContain(logs, l =>

--- a/test/WebJobs.Script.Tests/HostNameProviderTests.cs
+++ b/test/WebJobs.Script.Tests/HostNameProviderTests.cs
@@ -90,5 +90,68 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(1, logs.Count);
             Assert.Equal("HostName updated from 'test.azurewebsites.net' to 'test2.azurewebsites.net'", logs[0].FormattedMessage);
         }
+
+        [Fact]
+        public void Synchronize_RaisesHostNameChangedEvent_WhenHostNameChanges()
+        {
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName)).Returns((string)null);
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)).Returns((string)null);
+
+            var eventRaisedCount = 0;
+            string capturedPreviousHostName = null;
+            string capturedNewHostName = null;
+
+            _hostNameProvider.HostNameChanged += (sender, args) =>
+            {
+                eventRaisedCount++;
+                capturedPreviousHostName = args.PreviousHostName;
+                capturedNewHostName = args.NewHostName;
+            };
+
+            // Initial sync - should raise event (null -> test.azurewebsites.net)
+            HttpRequest request = new DefaultHttpContext().Request;
+            request.Headers.Add(ScriptConstants.AntaresDefaultHostNameHeader, "test.azurewebsites.net");
+            _hostNameProvider.Synchronize(request, _logger);
+
+            Assert.Equal(1, eventRaisedCount);
+            Assert.Null(capturedPreviousHostName);
+            Assert.Equal("test.azurewebsites.net", capturedNewHostName);
+
+            // Same hostname - should NOT raise event
+            _hostNameProvider.Synchronize(request, _logger);
+            Assert.Equal(1, eventRaisedCount);
+
+            // Different hostname - should raise event
+            request = new DefaultHttpContext().Request;
+            request.Headers.Add(ScriptConstants.AntaresDefaultHostNameHeader, "test2.azurewebsites.net");
+            _hostNameProvider.Synchronize(request, _logger);
+
+            Assert.Equal(2, eventRaisedCount);
+            Assert.Equal("test.azurewebsites.net", capturedPreviousHostName);
+            Assert.Equal("test2.azurewebsites.net", capturedNewHostName);
+        }
+
+        [Fact]
+        public void Synchronize_DoesNotRaiseEvent_WhenHostNameIsEmptyOrNull()
+        {
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName)).Returns((string)null);
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName)).Returns((string)null);
+
+            var eventRaisedCount = 0;
+            _hostNameProvider.HostNameChanged += (sender, args) => eventRaisedCount++;
+
+            // Empty header - should NOT raise event
+            HttpRequest request = new DefaultHttpContext().Request;
+            request.Headers.Add(ScriptConstants.AntaresDefaultHostNameHeader, string.Empty);
+            _hostNameProvider.Synchronize(request, _logger);
+
+            Assert.Equal(0, eventRaisedCount);
+
+            // No header - should NOT raise event
+            request = new DefaultHttpContext().Request;
+            _hostNameProvider.Synchronize(request, _logger);
+
+            Assert.Equal(0, eventRaisedCount);
+        }
     }
 }

--- a/test/WebJobs.Script.Tests/HostNameProviderTests.cs
+++ b/test/WebJobs.Script.Tests/HostNameProviderTests.cs
@@ -108,25 +108,24 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 capturedNewHostName = args.NewHostName;
             };
 
-            // Initial sync - should raise event (null -> test.azurewebsites.net)
+            // Initial sync (null -> test.azurewebsites.net) should NOT raise event.
+            // This is hostname discovery during specialization/scale-out, not a slot swap.
             HttpRequest request = new DefaultHttpContext().Request;
             request.Headers.Add(ScriptConstants.AntaresDefaultHostNameHeader, "test.azurewebsites.net");
             _hostNameProvider.Synchronize(request, _logger);
 
-            Assert.Equal(1, eventRaisedCount);
-            Assert.Null(capturedPreviousHostName);
-            Assert.Equal("test.azurewebsites.net", capturedNewHostName);
+            Assert.Equal(0, eventRaisedCount);
 
             // Same hostname - should NOT raise event
             _hostNameProvider.Synchronize(request, _logger);
-            Assert.Equal(1, eventRaisedCount);
+            Assert.Equal(0, eventRaisedCount);
 
-            // Different hostname - should raise event
+            // Different hostname (slot swap) - SHOULD raise event
             request = new DefaultHttpContext().Request;
             request.Headers.Add(ScriptConstants.AntaresDefaultHostNameHeader, "test2.azurewebsites.net");
             _hostNameProvider.Synchronize(request, _logger);
 
-            Assert.Equal(2, eventRaisedCount);
+            Assert.Equal(1, eventRaisedCount);
             Assert.Equal("test.azurewebsites.net", capturedPreviousHostName);
             Assert.Equal("test2.azurewebsites.net", capturedNewHostName);
         }


### PR DESCRIPTION
### Issue describing the changes in this PR

Partially addresses #9908 (see [Limitations](#limitations) below)
Related to #7710

**Summary:** Fix stale hostname persisting in ARM cache after slot swap, which causes wrong keys on `ListKeys` / Geo, and `UnresolvableHostName` errors when Logic Apps or other services invoke the function.

### Root Cause

After a slot swap, the Antares FE flips the hostname→site mapping, but worker processes are **not recycled**. `HostNameProvider.Value` retains the old (pre-swap) hostname in memory. When `FunctionsSyncManager` fires a background sync:

1. **`GetSyncTriggersPayload()`** builds `invoke_url_template` using the stale hostname (e.g., `https://myapp-staging.azurewebsites.net/api/func`)
2. The payload also includes **secrets/keys** from the current worker
3. **`BuildSetTriggersRequest()`** sends `POST https://{stale-hostname}/operations/settriggers` to the FE
4. The FE routes based on the hostname in the URL — which **now points to the other slot** after the swap
5. The ARM cache is updated **for the wrong site** with the wrong keys and wrong `invoke_url_template`

**Result:** `ListKeys` through ARM/Geo returns the wrong slot's keys. `invoke_url_template` points to the staging hostname, which may later be deleted — causing `UnresolvableHostName` errors for Logic Apps and other consumers that cached it.

### Fix

Add an event-based re-sync mechanism:

1. `HostNameProvider` now raises a `HostNameChanged` event when `Synchronize()` detects a hostname change via the `WAS_DEFAULT_HOSTNAME` header on an incoming HTTP request
2. `FunctionsSyncManager` subscribes to this event and triggers a **debounced (5-second)** background `TrySyncTriggersAsync()`
3. The debounce allows the hostname to stabilize after the swap before re-syncing
4. The re-sync sends the corrected payload to the correct FE endpoint, fixing the ARM cache

The `HostNameProvider.HostNameChanged` event also enables extensions (e.g., Logic Apps `WorkflowExtensionProvider`) to subscribe and re-register workers with the correct production hostname after a swap completes.

### Limitations

This PR **does not fully resolve #9908**. Specifically:

| Gap | Explanation |
|-----|-------------|
| **Non-HTTP apps** (timer, queue, Service Bus triggers only) | No HTTP request ever arrives after the swap → `Synchronize()` is never called → `HostNameChanged` never fires → ARM cache stays stale indefinitely |
| **Timing window** before first HTTP request | If a background sync fires before any request carries the new `WAS_DEFAULT_HOSTNAME` header, it still uses the stale hostname. Self-corrects once the first HTTP request arrives |
| **Very low-traffic apps** | Could be minutes or hours before the first HTTP request post-swap, extending the stale cache window |

A **complete** fix would require the swap infrastructure (Antares FE / site controller) to push a signal to the runtime when a swap completes, rather than relying on a header piggy-backed on the next HTTP request. That platform-level signal is what #9908 originally requested.

Related: ADO Task 4760001, ICM 21000000866148, ICM 654088427, ICM 510101424

### Pull request checklist

- [x] My changes **do not** require backporting to the `in-proc` branch
- [x] My changes do not require documentation changes
- [ ] My changes should not be added to the release notes for the next release
- [x] My changes do not require backporting to a previous version
- [x] My changes do not require diagnostic events changes
- [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

**Files changed:**

| File | Description |
|------|-------------|
| `src/WebJobs.Script/HostNameProvider.cs` | Added `HostNameChanged` event, `OnHostNameChanged` method, fixed `string.Compare` → `string.Equals` with `StringComparison.OrdinalIgnoreCase` |
| `src/WebJobs.Script/HostNameChangedEventArgs.cs` | New sealed `HostNameChangedEventArgs` class (extracted per codebase convention) |
| `src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs` | Added event subscription with debounced background re-sync handler, improved `Dispose()` |
| `test/WebJobs.Script.Tests/HostNameProviderTests.cs` | 2 new unit tests for the event mechanism |
| `test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs` | 3 new integration tests for hostname change sync behavior |
