### PR TITLE
[Compute Separation] M2: ConnectedWorkerChannel + channel manager + invocation dispatcher

### DIFF
--- a/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerChannel.cs
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.Http;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
+{
+    /// <summary>
+    /// A worker channel for a worker that connected inbound — the host did not spawn a process.
+    /// Lifecycle: the gRPC stream IS the lifecycle; disconnection → WorkerErrorEvent.
+    /// </summary>
+    internal sealed class ConnectedWorkerChannel : WorkerChannelBase
+    {
+        internal ConnectedWorkerChannel(
+            string workerId,
+            IScriptEventManager eventManager,
+            IScriptHostManager hostManager,
+            RpcWorkerConfig workerConfig,
+            ILogger logger,
+            IMetricsLogger metricsLogger,
+            IEnvironment environment,
+            IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions,
+            ISharedMemoryManager sharedMemoryManager,
+            IOptions<WorkerConcurrencyOptions> workerConcurrencyOptions,
+            IOptions<FunctionsHostingConfigOptions> hostingConfigOptions,
+            IHttpProxyService httpProxyService)
+            : base(workerId, eventManager, hostManager, workerConfig, logger, metricsLogger,
+                   attemptCount: 0, environment, applicationHostOptions, sharedMemoryManager,
+                   workerConcurrencyOptions, hostingConfigOptions, httpProxyService)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override IWorkerProcess WorkerProcess => null;
+
+        /// <inheritdoc/>
+        public override Task StartWorkerProcessAsync(CancellationToken cancellationToken)
+        {
+            BeginInboundProcessing(startStreamTimeout: TimeSpan.FromSeconds(30));
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
+        protected override void OnDisposing()
+        {
+        }
+
+        /// <inheritdoc/>
+        protected override void DisposeWorkerResources()
+        {
+        }
+    }
+}

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerChannel.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
     /// A worker channel for a worker that connected inbound — the host did not spawn a process.
     /// Lifecycle: the gRPC stream IS the lifecycle; disconnection → WorkerErrorEvent.
     /// </summary>
-    internal sealed class ConnectedWorkerChannel : WorkerChannelBase
+    internal sealed class ConnectedWorkerChannel : WorkerChannel
     {
         internal ConnectedWorkerChannel(
             string workerId,
@@ -49,11 +49,6 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
         {
             BeginInboundProcessing(startStreamTimeout: TimeSpan.FromSeconds(30));
             return Task.CompletedTask;
-        }
-
-        /// <inheritdoc/>
-        protected override void OnDisposing()
-        {
         }
 
         /// <inheritdoc/>

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerChannelFactory.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerChannelFactory.cs
@@ -1,0 +1,69 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.Http;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
+{
+    /// <summary>
+    /// Factory for creating <see cref="ConnectedWorkerChannel"/> instances.
+    /// </summary>
+    internal class ConnectedWorkerChannelFactory
+    {
+        private readonly IScriptEventManager _eventManager;
+        private readonly IScriptHostManager _hostManager;
+        private readonly IEnvironment _environment;
+        private readonly IOptionsMonitor<ScriptApplicationHostOptions> _applicationHostOptions;
+        private readonly ISharedMemoryManager _sharedMemoryManager;
+        private readonly IOptions<WorkerConcurrencyOptions> _workerConcurrencyOptions;
+        private readonly IOptions<FunctionsHostingConfigOptions> _hostingConfigOptions;
+        private readonly IHttpProxyService _httpProxyService;
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly IMetricsLogger _metricsLogger;
+
+        public ConnectedWorkerChannelFactory(
+            IScriptEventManager eventManager,
+            IScriptHostManager hostManager,
+            IEnvironment environment,
+            IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions,
+            ISharedMemoryManager sharedMemoryManager,
+            IOptions<WorkerConcurrencyOptions> workerConcurrencyOptions,
+            IOptions<FunctionsHostingConfigOptions> hostingConfigOptions,
+            IHttpProxyService httpProxyService,
+            ILoggerFactory loggerFactory,
+            IMetricsLogger metricsLogger)
+        {
+            _eventManager = eventManager;
+            _hostManager = hostManager;
+            _environment = environment;
+            _applicationHostOptions = applicationHostOptions;
+            _sharedMemoryManager = sharedMemoryManager;
+            _workerConcurrencyOptions = workerConcurrencyOptions;
+            _hostingConfigOptions = hostingConfigOptions;
+            _httpProxyService = httpProxyService;
+            _loggerFactory = loggerFactory;
+            _metricsLogger = metricsLogger;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ConnectedWorkerChannel"/> for an externally-connected worker.
+        /// </summary>
+        public ConnectedWorkerChannel Create(string workerId, RpcWorkerConfig workerConfig)
+        {
+            var logger = _loggerFactory.CreateLogger($"Worker.{workerId}");
+            return new ConnectedWorkerChannel(
+                workerId, _eventManager, _hostManager, workerConfig,
+                logger, _metricsLogger, _environment, _applicationHostOptions,
+                _sharedMemoryManager, _workerConcurrencyOptions,
+                _hostingConfigOptions, _httpProxyService);
+        }
+    }
+}

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerChannelManager.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerChannelManager.cs
@@ -1,0 +1,71 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+
+namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
+{
+    /// <summary>
+    /// Manages <see cref="ConnectedWorkerChannel"/> instances for externally-connected workers.
+    /// Thread-safe. Supports blocking waits for the first available channel.
+    /// </summary>
+    internal class ConnectedWorkerChannelManager : IConnectedWorkerChannelManager
+    {
+        private readonly ConcurrentDictionary<string, ConnectedWorkerChannel> _channels = new();
+        private TaskCompletionSource<IRpcWorkerChannel> _firstChannelReady = new();
+
+        /// <inheritdoc/>
+        public void AddChannel(string workerId, ConnectedWorkerChannel channel)
+        {
+            _channels[workerId] = channel;
+            _firstChannelReady.TrySetResult(channel);
+        }
+
+        /// <inheritdoc/>
+        public ConnectedWorkerChannel GetChannel(string workerId)
+            => _channels.TryGetValue(workerId, out var ch) ? ch : null;
+
+        /// <inheritdoc/>
+        public IReadOnlyDictionary<string, ConnectedWorkerChannel> GetChannels()
+            => _channels;
+
+        /// <inheritdoc/>
+        public async Task ShutdownChannelAsync(string workerId)
+        {
+            if (_channels.TryRemove(workerId, out var channel))
+            {
+                await channel.DrainInvocationsAsync();
+                channel.Dispose();
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task<IRpcWorkerChannel> WaitForChannelAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
+        {
+            var ready = _channels.Values.FirstOrDefault(c => c.IsChannelReadyForInvocations());
+            if (ready is not null)
+            {
+                return ready;
+            }
+
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(timeout);
+
+            try
+            {
+                return await _firstChannelReady.Task.WaitAsync(cts.Token);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException(
+                    $"No external worker connected within {timeout.TotalSeconds} seconds.");
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerChannelManager.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerChannelManager.cs
@@ -82,7 +82,6 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
                             return channel;
                         }
 
-                        _channelAvailable = new TaskCompletionSource();
                         waitTask = _channelAvailable.Task;
                     }
 

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerChannelManager.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerChannelManager.cs
@@ -18,13 +18,17 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
     internal class ConnectedWorkerChannelManager : IConnectedWorkerChannelManager
     {
         private readonly ConcurrentDictionary<string, ConnectedWorkerChannel> _channels = new();
-        private TaskCompletionSource<IRpcWorkerChannel> _firstChannelReady = new();
+        private readonly object _channelAvailableLock = new();
+        private TaskCompletionSource _channelAvailable = new();
 
         /// <inheritdoc/>
         public void AddChannel(string workerId, ConnectedWorkerChannel channel)
         {
-            _channels[workerId] = channel;
-            _firstChannelReady.TrySetResult(channel);
+            lock (_channelAvailableLock)
+            {
+                _channels[workerId] = channel;
+                _channelAvailable.TrySetResult();
+            }
         }
 
         /// <inheritdoc/>
@@ -38,7 +42,19 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
         /// <inheritdoc/>
         public async Task ShutdownChannelAsync(string workerId)
         {
-            if (_channels.TryRemove(workerId, out var channel))
+            ConnectedWorkerChannel channel = null;
+
+            lock (_channelAvailableLock)
+            {
+                _channels.TryRemove(workerId, out channel);
+
+                if (channel is not null && _channels.IsEmpty)
+                {
+                    _channelAvailable = new TaskCompletionSource();
+                }
+            }
+
+            if (channel is not null)
             {
                 await channel.DrainInvocationsAsync();
                 channel.Dispose();
@@ -59,7 +75,10 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
 
             try
             {
-                return await _firstChannelReady.Task.WaitAsync(cts.Token);
+                await _channelAvailable.Task.WaitAsync(cts.Token);
+
+                return _channels.Values.FirstOrDefault(c => c.IsChannelReadyForInvocations())
+                    ?? _channels.Values.First();
             }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerChannelManager.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerChannelManager.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
     /// </summary>
     internal class ConnectedWorkerChannelManager : IConnectedWorkerChannelManager
     {
-        private readonly ConcurrentDictionary<string, ConnectedWorkerChannel> _channels = new();
+        private readonly ConcurrentDictionary<string, IRpcWorkerChannel> _channels = new();
         private readonly object _channelAvailableLock = new();
         private TaskCompletionSource _channelAvailable = new();
 
         /// <inheritdoc/>
-        public void AddChannel(string workerId, ConnectedWorkerChannel channel)
+        public void AddChannel(string workerId, IRpcWorkerChannel channel)
         {
             lock (_channelAvailableLock)
             {
@@ -32,17 +32,17 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
         }
 
         /// <inheritdoc/>
-        public ConnectedWorkerChannel GetChannel(string workerId)
+        public IRpcWorkerChannel GetChannel(string workerId)
             => _channels.TryGetValue(workerId, out var ch) ? ch : null;
 
         /// <inheritdoc/>
-        public IReadOnlyDictionary<string, ConnectedWorkerChannel> GetChannels()
+        public IReadOnlyDictionary<string, IRpcWorkerChannel> GetChannels()
             => _channels;
 
         /// <inheritdoc/>
         public async Task ShutdownChannelAsync(string workerId)
         {
-            ConnectedWorkerChannel channel = null;
+            IRpcWorkerChannel channel = null;
 
             lock (_channelAvailableLock)
             {
@@ -57,28 +57,37 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
             if (channel is not null)
             {
                 await channel.DrainInvocationsAsync();
-                channel.Dispose();
+                (channel as IDisposable)?.Dispose();
             }
         }
 
         /// <inheritdoc/>
         public async Task<IRpcWorkerChannel> WaitForChannelAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
         {
-            var ready = _channels.Values.FirstOrDefault(c => c.IsChannelReadyForInvocations());
-            if (ready is not null)
-            {
-                return ready;
-            }
-
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             cts.CancelAfter(timeout);
 
             try
             {
-                await _channelAvailable.Task.WaitAsync(cts.Token);
+                while (true)
+                {
+                    cts.Token.ThrowIfCancellationRequested();
 
-                return _channels.Values.FirstOrDefault(c => c.IsChannelReadyForInvocations())
-                    ?? _channels.Values.First();
+                    Task waitTask;
+                    lock (_channelAvailableLock)
+                    {
+                        var channel = _channels.Values.FirstOrDefault();
+                        if (channel is not null)
+                        {
+                            return channel;
+                        }
+
+                        _channelAvailable = new TaskCompletionSource();
+                        waitTask = _channelAvailable.Task;
+                    }
+
+                    await waitTask.WaitAsync(cts.Token);
+                }
             }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerInvocationDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerInvocationDispatcher.cs
@@ -6,8 +6,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
@@ -21,6 +23,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
     {
         private readonly IConnectedWorkerChannelManager _channelManager;
         private readonly ILogger<ConnectedWorkerInvocationDispatcher> _logger;
+        private int _roundRobinCounter;
+        private IEnumerable<FunctionMetadata> _functions;
 
         public ConnectedWorkerInvocationDispatcher(
             IConnectedWorkerChannelManager channelManager,
@@ -50,25 +54,74 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
         /// <inheritdoc/>
         public async Task InvokeAsync(ScriptInvocationContext invocationContext)
         {
-            var channels = _channelManager.GetChannels();
-            var channel = channels.Values
-                .FirstOrDefault(c => c.IsChannelReadyForInvocations());
+            var readyChannels = _channelManager.GetChannels().Values
+                .Where(c => c.IsChannelReadyForInvocations())
+                .ToList();
 
-            if (channel is null)
+            if (readyChannels.Count == 0)
             {
                 throw new InvalidOperationException("No connected worker channel is ready for invocations.");
             }
 
-            _logger.LogDebug("Dispatching invocation to external worker {workerId}", channel.Id);
-            await channel.SendInvocationRequest(invocationContext);
+            IRpcWorkerChannel channel;
+            if (readyChannels.Count == 1)
+            {
+                channel = readyChannels[0];
+            }
+            else
+            {
+                int index = Interlocked.Increment(ref _roundRobinCounter) % readyChannels.Count;
+                if (_roundRobinCounter < 0 || index < 0)
+                {
+                    _roundRobinCounter = 0;
+                    index = 0;
+                }
+
+                channel = readyChannels[index];
+            }
+
+            string functionId = invocationContext.FunctionMetadata.GetFunctionId();
+            if (channel.FunctionInputBuffers.TryGetValue(functionId, out BufferBlock<ScriptInvocationContext> bufferBlock))
+            {
+                _logger.LogDebug("Dispatching invocation to external worker {workerId}", channel.Id);
+                bufferBlock.Post(invocationContext);
+            }
+            else
+            {
+                throw new InvalidOperationException(
+                    $"Function:{invocationContext.FunctionMetadata.Name} is not loaded by the external worker: {channel.Id}");
+            }
+
+            await Task.CompletedTask;
         }
 
         /// <inheritdoc/>
         public Task InitializeAsync(IEnumerable<FunctionMetadata> functions, CancellationToken cancellationToken = default)
         {
-            // No-op: external workers provide their own metadata and are already connected.
-            // Function load requests will be sent when the channel is ready.
+            _functions = functions;
+
+            foreach (var channel in _channelManager.GetChannels().Values)
+            {
+                SetupChannel(channel);
+            }
+
             return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Sets up function invocation buffers and sends function load requests on a channel.
+        /// Called during <see cref="InitializeAsync"/> for existing channels, and can be called
+        /// when new channels connect after initialization.
+        /// </summary>
+        internal void SetupChannel(IRpcWorkerChannel channel)
+        {
+            if (_functions is null)
+            {
+                return;
+            }
+
+            channel.SetupFunctionInvocationBuffers(_functions);
+            channel.SendFunctionLoadRequests(managedDependencyOptions: null, functionTimeout: null);
         }
 
         /// <inheritdoc/>
@@ -92,14 +145,12 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
         /// <inheritdoc/>
         public Task<bool> RestartWorkerWithInvocationIdAsync(string invocationId, Exception exception)
         {
-            // External workers cannot be restarted by the host.
             return Task.FromResult(false);
         }
 
         /// <inheritdoc/>
         public Task StartWorkerChannel()
         {
-            // No-op: workers connect inbound; the host does not start them.
             return Task.CompletedTask;
         }
 

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerInvocationDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerInvocationDispatcher.cs
@@ -32,24 +32,9 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
             : base(loadBalancer, scriptJobHostOptions, logger)
         {
             _channelManager = channelManager ?? throw new ArgumentNullException(nameof(channelManager));
+            State = FunctionInvocationDispatcherState.Default;
+            ErrorEventsThreshold = 3;
         }
-
-        /// <inheritdoc/>
-        public override FunctionInvocationDispatcherState State
-        {
-            get
-            {
-                bool anyReady = _channelManager.GetChannels().Values
-                    .Any(c => c.IsChannelReadyForInvocations());
-
-                return anyReady
-                    ? FunctionInvocationDispatcherState.Initialized
-                    : FunctionInvocationDispatcherState.Initializing;
-            }
-        }
-
-        /// <inheritdoc/>
-        public override int ErrorEventsThreshold => int.MaxValue;
 
         /// <inheritdoc/>
         protected override Task<IEnumerable<IRpcWorkerChannel>> GetReadyChannelsAsync(ScriptInvocationContext invocationContext)
@@ -71,6 +56,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
                 return Task.CompletedTask;
             }
 
+            State = FunctionInvocationDispatcherState.Initializing;
+
             _functions = functions;
 
             foreach (var channel in _channelManager.GetChannels().Values)
@@ -79,6 +66,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
             }
 
             AddLogUserCategory(functions);
+
+            State = FunctionInvocationDispatcherState.Initialized;
 
             return Task.CompletedTask;
         }

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerInvocationDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerInvocationDispatcher.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
         public override int ErrorEventsThreshold => int.MaxValue;
 
         /// <inheritdoc/>
-        protected override Task<IEnumerable<IRpcWorkerChannel>> GetReadyChannelsAsync()
+        protected override Task<IEnumerable<IRpcWorkerChannel>> GetReadyChannelsAsync(ScriptInvocationContext invocationContext)
         {
             IEnumerable<IRpcWorkerChannel> channels = _channelManager.GetChannels().Values
                 .Where(c => c.IsChannelReadyForInvocations());

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerInvocationDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerInvocationDispatcher.cs
@@ -40,7 +40,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
         protected override Task<IEnumerable<IRpcWorkerChannel>> GetReadyChannelsAsync(ScriptInvocationContext invocationContext)
         {
             IEnumerable<IRpcWorkerChannel> channels = _channelManager.GetChannels().Values
-                .Where(c => c.IsChannelReadyForInvocations());
+                .Where(c => c.IsChannelReadyForInvocations())
+                .ToList();
 
             return Task.FromResult(channels);
         }

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerInvocationDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerInvocationDispatcher.cs
@@ -1,0 +1,116 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
+{
+    /// <summary>
+    /// Invocation dispatcher for external (separately-hosted) workers.
+    /// Only does routing — no process management, no restart logic.
+    /// Registered as <see cref="IFunctionInvocationDispatcher"/> in external worker mode.
+    /// </summary>
+    internal class ConnectedWorkerInvocationDispatcher : IFunctionInvocationDispatcher
+    {
+        private readonly IConnectedWorkerChannelManager _channelManager;
+        private readonly ILogger<ConnectedWorkerInvocationDispatcher> _logger;
+
+        public ConnectedWorkerInvocationDispatcher(
+            IConnectedWorkerChannelManager channelManager,
+            ILogger<ConnectedWorkerInvocationDispatcher> logger)
+        {
+            _channelManager = channelManager ?? throw new ArgumentNullException(nameof(channelManager));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <inheritdoc/>
+        public FunctionInvocationDispatcherState State
+        {
+            get
+            {
+                bool anyReady = _channelManager.GetChannels().Values
+                    .Any(c => c.IsChannelReadyForInvocations());
+
+                return anyReady
+                    ? FunctionInvocationDispatcherState.Initialized
+                    : FunctionInvocationDispatcherState.Initializing;
+            }
+        }
+
+        /// <inheritdoc/>
+        public int ErrorEventsThreshold => int.MaxValue;
+
+        /// <inheritdoc/>
+        public async Task InvokeAsync(ScriptInvocationContext invocationContext)
+        {
+            var channels = _channelManager.GetChannels();
+            var channel = channels.Values
+                .FirstOrDefault(c => c.IsChannelReadyForInvocations());
+
+            if (channel is null)
+            {
+                throw new InvalidOperationException("No connected worker channel is ready for invocations.");
+            }
+
+            _logger.LogDebug("Dispatching invocation to external worker {workerId}", channel.Id);
+            await channel.SendInvocationRequest(invocationContext);
+        }
+
+        /// <inheritdoc/>
+        public Task InitializeAsync(IEnumerable<FunctionMetadata> functions, CancellationToken cancellationToken = default)
+        {
+            // No-op: external workers provide their own metadata and are already connected.
+            // Function load requests will be sent when the channel is ready.
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
+        public async Task<IDictionary<string, WorkerStatus>> GetWorkerStatusesAsync()
+        {
+            var result = new Dictionary<string, WorkerStatus>();
+            foreach (var (id, channel) in _channelManager.GetChannels())
+            {
+                result[id] = await channel.GetWorkerStatusAsync();
+            }
+
+            return result;
+        }
+
+        /// <inheritdoc/>
+        public Task ShutdownAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
+        public Task<bool> RestartWorkerWithInvocationIdAsync(string invocationId, Exception exception)
+        {
+            // External workers cannot be restarted by the host.
+            return Task.FromResult(false);
+        }
+
+        /// <inheritdoc/>
+        public Task StartWorkerChannel()
+        {
+            // No-op: workers connect inbound; the host does not start them.
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
+        public void PreShutdown()
+        {
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerInvocationDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerInvocationDispatcher.cs
@@ -6,11 +6,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Threading.Tasks.Dataflow;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
 {
@@ -19,23 +19,23 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
     /// Only does routing — no process management, no restart logic.
     /// Registered as <see cref="IFunctionInvocationDispatcher"/> in external worker mode.
     /// </summary>
-    internal class ConnectedWorkerInvocationDispatcher : IFunctionInvocationDispatcher
+    internal class ConnectedWorkerInvocationDispatcher : FunctionInvocationDispatcher
     {
         private readonly IConnectedWorkerChannelManager _channelManager;
-        private readonly ILogger<ConnectedWorkerInvocationDispatcher> _logger;
-        private int _roundRobinCounter;
         private IEnumerable<FunctionMetadata> _functions;
 
         public ConnectedWorkerInvocationDispatcher(
             IConnectedWorkerChannelManager channelManager,
+            IRpcFunctionInvocationDispatcherLoadBalancer loadBalancer,
+            IOptions<ScriptJobHostOptions> scriptJobHostOptions,
             ILogger<ConnectedWorkerInvocationDispatcher> logger)
+            : base(loadBalancer, scriptJobHostOptions, logger)
         {
             _channelManager = channelManager ?? throw new ArgumentNullException(nameof(channelManager));
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         /// <inheritdoc/>
-        public FunctionInvocationDispatcherState State
+        public override FunctionInvocationDispatcherState State
         {
             get
             {
@@ -49,61 +49,36 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
         }
 
         /// <inheritdoc/>
-        public int ErrorEventsThreshold => int.MaxValue;
+        public override int ErrorEventsThreshold => int.MaxValue;
 
         /// <inheritdoc/>
-        public async Task InvokeAsync(ScriptInvocationContext invocationContext)
+        protected override Task<IEnumerable<IRpcWorkerChannel>> GetReadyChannelsAsync()
         {
-            var readyChannels = _channelManager.GetChannels().Values
-                .Where(c => c.IsChannelReadyForInvocations())
-                .ToList();
+            IEnumerable<IRpcWorkerChannel> channels = _channelManager.GetChannels().Values
+                .Where(c => c.IsChannelReadyForInvocations());
 
-            if (readyChannels.Count == 0)
-            {
-                throw new InvalidOperationException("No connected worker channel is ready for invocations.");
-            }
-
-            IRpcWorkerChannel channel;
-            if (readyChannels.Count == 1)
-            {
-                channel = readyChannels[0];
-            }
-            else
-            {
-                int index = Interlocked.Increment(ref _roundRobinCounter) % readyChannels.Count;
-                if (_roundRobinCounter < 0 || index < 0)
-                {
-                    _roundRobinCounter = 0;
-                    index = 0;
-                }
-
-                channel = readyChannels[index];
-            }
-
-            string functionId = invocationContext.FunctionMetadata.GetFunctionId();
-            if (channel.FunctionInputBuffers.TryGetValue(functionId, out BufferBlock<ScriptInvocationContext> bufferBlock))
-            {
-                _logger.LogDebug("Dispatching invocation to external worker {workerId}", channel.Id);
-                bufferBlock.Post(invocationContext);
-            }
-            else
-            {
-                throw new InvalidOperationException(
-                    $"Function:{invocationContext.FunctionMetadata.Name} is not loaded by the external worker: {channel.Id}");
-            }
-
-            await Task.CompletedTask;
+            return Task.FromResult(channels);
         }
 
         /// <inheritdoc/>
-        public Task InitializeAsync(IEnumerable<FunctionMetadata> functions, CancellationToken cancellationToken = default)
+        public override Task InitializeAsync(IEnumerable<FunctionMetadata> functions, CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (functions is null || !functions.Any())
+            {
+                Logger.LogDebug($"{nameof(ConnectedWorkerInvocationDispatcher)} received no functions");
+                return Task.CompletedTask;
+            }
+
             _functions = functions;
 
             foreach (var channel in _channelManager.GetChannels().Values)
             {
                 SetupChannel(channel);
             }
+
+            AddLogUserCategory(functions);
 
             return Task.CompletedTask;
         }
@@ -125,7 +100,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
         }
 
         /// <inheritdoc/>
-        public async Task<IDictionary<string, WorkerStatus>> GetWorkerStatusesAsync()
+        public override async Task<IDictionary<string, WorkerStatus>> GetWorkerStatusesAsync()
         {
             var result = new Dictionary<string, WorkerStatus>();
             foreach (var (id, channel) in _channelManager.GetChannels())
@@ -137,31 +112,27 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
         }
 
         /// <inheritdoc/>
-        public Task ShutdownAsync()
-        {
-            return Task.CompletedTask;
-        }
-
-        /// <inheritdoc/>
-        public Task<bool> RestartWorkerWithInvocationIdAsync(string invocationId, Exception exception)
+        public override Task<bool> RestartWorkerWithInvocationIdAsync(string invocationId, Exception exception)
         {
             return Task.FromResult(false);
         }
 
         /// <inheritdoc/>
-        public Task StartWorkerChannel()
+        public override Task StartWorkerChannel()
         {
             return Task.CompletedTask;
         }
 
         /// <inheritdoc/>
-        public void PreShutdown()
+        public override void PreShutdown()
         {
         }
 
         /// <inheritdoc/>
-        public void Dispose()
+        public override void Dispose()
         {
+            State = FunctionInvocationDispatcherState.Disposing;
+            State = FunctionInvocationDispatcherState.Disposed;
         }
     }
 }

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/IConnectedWorkerChannelManager.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/IConnectedWorkerChannelManager.cs
@@ -17,17 +17,17 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
         /// <summary>
         /// Registers a fully-initialized channel for an external worker.
         /// </summary>
-        void AddChannel(string workerId, ConnectedWorkerChannel channel);
+        void AddChannel(string workerId, IRpcWorkerChannel channel);
 
         /// <summary>
         /// Gets a specific channel by worker ID, or null if not found.
         /// </summary>
-        ConnectedWorkerChannel GetChannel(string workerId);
+        IRpcWorkerChannel GetChannel(string workerId);
 
         /// <summary>
         /// Gets all currently registered channels.
         /// </summary>
-        IReadOnlyDictionary<string, ConnectedWorkerChannel> GetChannels();
+        IReadOnlyDictionary<string, IRpcWorkerChannel> GetChannels();
 
         /// <summary>
         /// Shuts down and removes a specific channel, draining in-flight invocations first.

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/IConnectedWorkerChannelManager.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/IConnectedWorkerChannelManager.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+
+namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
+{
+    /// <summary>
+    /// Manages <see cref="ConnectedWorkerChannel"/> instances for externally-connected workers.
+    /// </summary>
+    internal interface IConnectedWorkerChannelManager
+    {
+        /// <summary>
+        /// Registers a fully-initialized channel for an external worker.
+        /// </summary>
+        void AddChannel(string workerId, ConnectedWorkerChannel channel);
+
+        /// <summary>
+        /// Gets a specific channel by worker ID, or null if not found.
+        /// </summary>
+        ConnectedWorkerChannel GetChannel(string workerId);
+
+        /// <summary>
+        /// Gets all currently registered channels.
+        /// </summary>
+        IReadOnlyDictionary<string, ConnectedWorkerChannel> GetChannels();
+
+        /// <summary>
+        /// Shuts down and removes a specific channel, draining in-flight invocations first.
+        /// </summary>
+        Task ShutdownChannelAsync(string workerId);
+
+        /// <summary>
+        /// Waits until at least one fully-initialized channel is available.
+        /// Used by <c>ConnectedWorkerFunctionMetadataProvider</c> to block metadata retrieval
+        /// until an external worker has connected and completed the init handshake.
+        /// Signaled internally when <see cref="AddChannel"/> is called.
+        /// </summary>
+        Task<IRpcWorkerChannel> WaitForChannelAsync(TimeSpan timeout, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/WebJobs.Script.Grpc/FunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/FunctionInvocationDispatcher.cs
@@ -1,0 +1,145 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using Microsoft.Azure.WebJobs.Host.Executors.Internal;
+using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebJobs.Script.Workers
+{
+    /// <summary>
+    /// Abstract base class for function invocation dispatchers. Provides the shared
+    /// invoke path: system scope → channel selection (round-robin) → buffer post,
+    /// and the shared shutdown path: drain invocations with timeout.
+    /// Subclasses implement <see cref="GetReadyChannelsAsync"/> to resolve channels
+    /// from their respective channel managers.
+    /// </summary>
+    internal abstract class FunctionInvocationDispatcher : IFunctionInvocationDispatcher
+    {
+        private static readonly TimeSpan DefaultShutdownTimeout = TimeSpan.FromSeconds(10);
+
+        private readonly IRpcFunctionInvocationDispatcherLoadBalancer _loadBalancer;
+        private readonly IOptions<ScriptJobHostOptions> _scriptJobHostOptions;
+
+        protected FunctionInvocationDispatcher(
+            IRpcFunctionInvocationDispatcherLoadBalancer loadBalancer,
+            IOptions<ScriptJobHostOptions> scriptJobHostOptions,
+            ILogger logger)
+        {
+            _loadBalancer = loadBalancer ?? throw new ArgumentNullException(nameof(loadBalancer));
+            _scriptJobHostOptions = scriptJobHostOptions ?? throw new ArgumentNullException(nameof(scriptJobHostOptions));
+            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        protected ILogger Logger { get; }
+
+        /// <summary>
+        /// Gets the timeout for draining invocations during shutdown.
+        /// Subclasses can override to use a configured value.
+        /// </summary>
+        protected virtual TimeSpan ShutdownTimeout => DefaultShutdownTimeout;
+
+        /// <inheritdoc/>
+        public virtual FunctionInvocationDispatcherState State { get; set; }
+
+        /// <inheritdoc/>
+        public virtual int ErrorEventsThreshold { get; set; }
+
+        /// <inheritdoc/>
+        public async Task InvokeAsync(ScriptInvocationContext invocationContext)
+        {
+            using FunctionInvoker.Scope scope = FunctionInvoker.BeginSystemScope();
+
+            IEnumerable<IRpcWorkerChannel> workerChannels = await GetReadyChannelsAsync();
+            var channel = _loadBalancer.GetLanguageWorkerChannel(workerChannels);
+            string functionId = invocationContext.FunctionMetadata.GetFunctionId();
+
+            if (channel.FunctionInputBuffers.TryGetValue(functionId, out BufferBlock<ScriptInvocationContext> bufferBlock))
+            {
+                if (Logger.IsEnabled(LogLevel.Trace))
+                {
+                    Logger.LogTrace("Posting invocation id:{InvocationId} on workerId:{workerChannelId}",
+                        invocationContext.ExecutionContext.InvocationId, channel.Id);
+                }
+
+                bufferBlock.Post(invocationContext);
+            }
+            else
+            {
+                throw new InvalidOperationException(
+                    $"Function:{invocationContext.FunctionMetadata.Name} is not loaded by the worker: {channel.Id}");
+            }
+        }
+
+        /// <inheritdoc/>
+        public virtual async Task ShutdownAsync()
+        {
+            Logger.LogDebug("Waiting for {dispatcher} to shutdown", GetType().Name);
+
+            var channels = await GetReadyChannelsAsync();
+            var drainTasks = channels.Select(c => c.DrainInvocationsAsync()).ToList();
+
+            if (drainTasks.Count > 0)
+            {
+                Task completedTask = await Task.WhenAny(
+                    Task.WhenAll(drainTasks),
+                    Task.Delay(ShutdownTimeout));
+
+                if (completedTask is not Task<Task>)
+                {
+                    Logger.LogDebug("Draining invocations from worker channels completed during shutdown");
+                }
+                else
+                {
+                    Logger.LogDebug("Draining invocations from worker channels timed out during shutdown");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Resolves the set of ready worker channels.
+        /// Each subclass resolves channels from its own channel manager.
+        /// </summary>
+        protected abstract Task<IEnumerable<IRpcWorkerChannel>> GetReadyChannelsAsync();
+
+        /// <inheritdoc/>
+        public abstract Task InitializeAsync(IEnumerable<FunctionMetadata> functions, CancellationToken cancellationToken = default);
+
+        /// <inheritdoc/>
+        public abstract Task<IDictionary<string, WorkerStatus>> GetWorkerStatusesAsync();
+
+        /// <inheritdoc/>
+        public abstract Task<bool> RestartWorkerWithInvocationIdAsync(string invocationId, Exception exception);
+
+        /// <inheritdoc/>
+        public abstract Task StartWorkerChannel();
+
+        /// <inheritdoc/>
+        public abstract void PreShutdown();
+
+        /// <inheritdoc/>
+        public abstract void Dispose();
+
+        /// <summary>
+        /// Enriches function metadata with log correlation properties.
+        /// Must be called during <see cref="InitializeAsync"/> to ensure proper log categorization.
+        /// </summary>
+        protected void AddLogUserCategory(IEnumerable<FunctionMetadata> functions)
+        {
+            foreach (FunctionMetadata metadata in functions)
+            {
+                metadata.Properties[LogConstants.CategoryNameKey] = LogCategories.CreateFunctionUserCategory(metadata.Name);
+                metadata.Properties[ScriptConstants.LogPropertyHostInstanceIdKey] = _scriptJobHostOptions.Value.InstanceId;
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script.Grpc/FunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/FunctionInvocationDispatcher.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         {
             using FunctionInvoker.Scope scope = FunctionInvoker.BeginSystemScope();
 
-            IEnumerable<IRpcWorkerChannel> workerChannels = await GetReadyChannelsAsync();
+            IEnumerable<IRpcWorkerChannel> workerChannels = await GetReadyChannelsAsync(invocationContext);
             var channel = _loadBalancer.GetLanguageWorkerChannel(workerChannels);
             string functionId = invocationContext.FunctionMetadata.GetFunctionId();
 
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         {
             Logger.LogDebug("Waiting for {dispatcher} to shutdown", GetType().Name);
 
-            var channels = await GetReadyChannelsAsync();
+            var channels = await GetReadyChannelsAsync(invocationContext: null);
             var drainTasks = channels.Select(c => c.DrainInvocationsAsync()).ToList();
 
             if (drainTasks.Count > 0)
@@ -109,7 +109,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         /// Resolves the set of ready worker channels.
         /// Each subclass resolves channels from its own channel manager.
         /// </summary>
-        protected abstract Task<IEnumerable<IRpcWorkerChannel>> GetReadyChannelsAsync();
+        /// <param name="invocationContext">
+        /// The invocation context, used by subclasses that need per-function language routing.
+        /// May be <see langword="null"/> when called outside of invocation (e.g., during shutdown).
+        /// </param>
+        protected abstract Task<IEnumerable<IRpcWorkerChannel>> GetReadyChannelsAsync(ScriptInvocationContext invocationContext);
 
         /// <inheritdoc/>
         public abstract Task InitializeAsync(IEnumerable<FunctionMetadata> functions, CancellationToken cancellationToken = default);

--- a/src/WebJobs.Script.Grpc/FunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/FunctionInvocationDispatcher.cs
@@ -49,10 +49,10 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         protected virtual TimeSpan ShutdownTimeout => DefaultShutdownTimeout;
 
         /// <inheritdoc/>
-        public virtual FunctionInvocationDispatcherState State { get; set; }
+        public virtual FunctionInvocationDispatcherState State { get; protected set; }
 
         /// <inheritdoc/>
-        public virtual int ErrorEventsThreshold { get; set; }
+        public virtual int ErrorEventsThreshold { get; protected set; }
 
         /// <inheritdoc/>
         public async Task InvokeAsync(ScriptInvocationContext invocationContext)

--- a/src/WebJobs.Script.Grpc/FunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/FunctionInvocationDispatcher.cs
@@ -90,17 +90,17 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
 
             if (drainTasks.Count > 0)
             {
-                Task completedTask = await Task.WhenAny(
-                    Task.WhenAll(drainTasks),
-                    Task.Delay(ShutdownTimeout));
+                Task drainAll = Task.WhenAll(drainTasks);
+                Task timeout = Task.Delay(ShutdownTimeout);
+                Task completedTask = await Task.WhenAny(drainAll, timeout);
 
-                if (completedTask is not Task<Task>)
+                if (completedTask.Equals(timeout))
                 {
-                    Logger.LogDebug("Draining invocations from worker channels completed during shutdown");
+                    Logger.LogDebug("Draining invocations from worker channels timed out during shutdown");
                 }
                 else
                 {
-                    Logger.LogDebug("Draining invocations from worker channels timed out during shutdown");
+                    Logger.LogDebug("Draining invocations from worker channels completed during shutdown");
                 }
             }
         }

--- a/src/WebJobs.Script.Grpc/FunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/FunctionInvocationDispatcher.cs
@@ -49,10 +49,10 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         protected virtual TimeSpan ShutdownTimeout => DefaultShutdownTimeout;
 
         /// <inheritdoc/>
-        public virtual FunctionInvocationDispatcherState State { get; protected set; }
+        public FunctionInvocationDispatcherState State { get; protected set; }
 
         /// <inheritdoc/>
-        public virtual int ErrorEventsThreshold { get; protected set; }
+        public int ErrorEventsThreshold { get; protected set; }
 
         /// <inheritdoc/>
         public async Task InvokeAsync(ScriptInvocationContext invocationContext)

--- a/src/WebJobs.Script.Grpc/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -115,9 +115,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         internal Task<int> MaxProcessCount => _maxProcessCount.Value;
 
-        public override FunctionInvocationDispatcherState State { get; set; }
+        public override FunctionInvocationDispatcherState State { get; protected set; }
 
-        public override int ErrorEventsThreshold { get; set; }
+        public override int ErrorEventsThreshold { get; protected set; }
 
         protected override TimeSpan ShutdownTimeout => _shutdownTimeout;
 

--- a/src/WebJobs.Script.Grpc/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -24,7 +24,7 @@ using FunctionMetadata = Microsoft.Azure.WebJobs.Script.Description.FunctionMeta
 
 namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 {
-    internal class RpcFunctionInvocationDispatcher : IFunctionInvocationDispatcher
+    internal class RpcFunctionInvocationDispatcher : FunctionInvocationDispatcher
     {
         private static readonly int MultiLanguageDefaultProcessCount = 1;
 
@@ -80,7 +80,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             IOptions<FunctionsHostingConfigOptions> hostingConfigOptions,
             IHostMetrics hostMetrics,
             IWorkerRuntimeResolver workerRuntimeResolver)
+            : base(functionDispatcherLoadBalancer, scriptHostOptions, loggerFactory.CreateLogger<RpcFunctionInvocationDispatcher>())
         {
+            _logger = Logger;
             _metricsLogger = metricsLogger;
             _scriptOptions = scriptHostOptions.Value;
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
@@ -94,7 +96,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             // Using IOptionsMonitor here to get the same cached version used by other copmponents and avoid a new instance initialization.
             _workerConfigs = workerOptions?.CurrentValue?.WorkerConfigs ?? throw new ArgumentNullException(nameof(workerOptions));
             _managedDependencyOptions = managedDependencyOptions ?? throw new ArgumentNullException(nameof(managedDependencyOptions));
-            _logger = loggerFactory.CreateLogger<RpcFunctionInvocationDispatcher>();
             _rpcWorkerChannelFactory = rpcWorkerChannelFactory;
             _workerRuntime = (workerRuntimeResolver ?? throw new ArgumentNullException(nameof(workerRuntimeResolver))).GetWorkerRuntime();
             _functionDispatcherLoadBalancer = functionDispatcherLoadBalancer;
@@ -114,9 +115,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         internal Task<int> MaxProcessCount => _maxProcessCount.Value;
 
-        public FunctionInvocationDispatcherState State { get; private set; }
+        public override FunctionInvocationDispatcherState State { get; set; }
 
-        public int ErrorEventsThreshold { get; private set; }
+        public override int ErrorEventsThreshold { get; set; }
+
+        protected override TimeSpan ShutdownTimeout => _shutdownTimeout;
 
         public IJobHostRpcWorkerChannelManager JobHostLanguageWorkerChannelManager => _jobHostLanguageWorkerChannelManager;
 
@@ -253,7 +256,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             }, _processStartCancellationToken.Token);
         }
 
-        public async Task InitializeAsync(IEnumerable<FunctionMetadata> functions, CancellationToken cancellationToken = default)
+        public override async Task InitializeAsync(IEnumerable<FunctionMetadata> functions, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -367,7 +370,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             AddLogUserCategory(functions);
         }
 
-        public async Task<IDictionary<string, WorkerStatus>> GetWorkerStatusesAsync()
+        public override async Task<IDictionary<string, WorkerStatus>> GetWorkerStatusesAsync()
         {
             var workerChannels = (await GetInitializedWorkerChannelsAsync()).ToArray();
             _logger.LogDebug($"[HostMonitor] Checking worker statuses (Count={workerChannels.Length})");
@@ -393,45 +396,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             return workerStatuses;
         }
 
-        public async Task ShutdownAsync()
+        protected override async Task<IEnumerable<IRpcWorkerChannel>> GetReadyChannelsAsync()
         {
-            _logger.LogDebug($"Waiting for {nameof(RpcFunctionInvocationDispatcher)} to shutdown");
-            Task timeoutTask = Task.Delay(_shutdownTimeout);
-            IList<Task> workerChannelTasks = (await GetInitializedWorkerChannelsAsync()).Select(a => a.DrainInvocationsAsync()).ToList();
-            Task completedTask = await Task.WhenAny(timeoutTask, Task.WhenAll(workerChannelTasks));
-
-            if (completedTask.Equals(timeoutTask))
-            {
-                _logger.LogDebug($"Draining invocations from language worker channel timed out. Shutting down '{nameof(RpcFunctionInvocationDispatcher)}'");
-            }
-            else
-            {
-                _logger.LogDebug($"Draining invocations from language worker channel completed. Shutting down '{nameof(RpcFunctionInvocationDispatcher)}'");
-            }
-        }
-
-        public async Task InvokeAsync(ScriptInvocationContext invocationContext)
-        {
-            // We have entered back into a system scope, ensure our logs are captured as such.
-            using FunctionInvoker.Scope scope = FunctionInvoker.BeginSystemScope();
-
-            // This could throw if no initialized workers are found. Shut down instance and retry.
-            IEnumerable<IRpcWorkerChannel> workerChannels = await GetInitializedWorkerChannelsAsync(invocationContext.FunctionMetadata.Language ?? _workerRuntime);
-            var rpcWorkerChannel = _functionDispatcherLoadBalancer.GetLanguageWorkerChannel(workerChannels);
-            string functionId = invocationContext.FunctionMetadata.GetFunctionId();
-            if (rpcWorkerChannel.FunctionInputBuffers.TryGetValue(functionId, out BufferBlock<ScriptInvocationContext> bufferBlock))
-            {
-                if (_logger.IsEnabled(LogLevel.Trace))
-                {
-                    _logger.LogTrace("Posting invocation id:{InvocationId} on workerId:{workerChannelId}", invocationContext.ExecutionContext.InvocationId, rpcWorkerChannel.Id);
-                }
-
-                bufferBlock.Post(invocationContext);
-            }
-            else
-            {
-                throw new InvalidOperationException($"Function:{invocationContext.FunctionMetadata.Name} is not loaded by the language worker: {rpcWorkerChannel.Id}");
-            }
+            return await GetInitializedWorkerChannelsAsync(_workerRuntime);
         }
 
         internal async Task<IEnumerable<IRpcWorkerChannel>> GetAllWorkerChannelsAsync(string language = null)
@@ -519,7 +486,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             }
         }
 
-        public async Task StartWorkerChannel()
+        public override async Task StartWorkerChannel()
         {
             await StartWorkerChannel(null);
         }
@@ -670,14 +637,14 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             }
         }
 
-        public void Dispose()
+        public override void Dispose()
         {
             _disposing = true;
             State = FunctionInvocationDispatcherState.Disposing;
             Dispose(true);
         }
 
-        public async Task<bool> RestartWorkerWithInvocationIdAsync(string invocationId, Exception exception = null)
+        public override async Task<bool> RestartWorkerWithInvocationIdAsync(string invocationId, Exception exception = null)
         {
             // Dispose and restart errored channel with the particular invocation id
             var channels = await GetInitializedWorkerChannelsAsync();
@@ -696,16 +663,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             return false;
         }
 
-        private void AddLogUserCategory(IEnumerable<FunctionMetadata> functions)
-        {
-            foreach (FunctionMetadata metadata in functions)
-            {
-                metadata.Properties[LogConstants.CategoryNameKey] = LogCategories.CreateFunctionUserCategory(metadata.Name);
-                metadata.Properties[ScriptConstants.LogPropertyHostInstanceIdKey] = _scriptOptions.InstanceId;
-            }
-        }
-
-        public void PreShutdown()
+        public override void PreShutdown()
         {
             // It's important to prevent any new workers from starting on the orphaned host. The
             // only way to guarantee this is to signal to the dispatcher that it's done with process

--- a/src/WebJobs.Script.Grpc/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -396,9 +396,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             return workerStatuses;
         }
 
-        protected override async Task<IEnumerable<IRpcWorkerChannel>> GetReadyChannelsAsync()
+        protected override async Task<IEnumerable<IRpcWorkerChannel>> GetReadyChannelsAsync(ScriptInvocationContext invocationContext)
         {
-            return await GetInitializedWorkerChannelsAsync(_workerRuntime);
+            string language = invocationContext?.FunctionMetadata.Language ?? _workerRuntime;
+
+            return await GetInitializedWorkerChannelsAsync(language);
         }
 
         internal async Task<IEnumerable<IRpcWorkerChannel>> GetAllWorkerChannelsAsync(string language = null)

--- a/src/WebJobs.Script.Grpc/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -115,10 +115,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         internal Task<int> MaxProcessCount => _maxProcessCount.Value;
 
-        public override FunctionInvocationDispatcherState State { get; protected set; }
-
-        public override int ErrorEventsThreshold { get; protected set; }
-
         protected override TimeSpan ShutdownTimeout => _shutdownTimeout;
 
         public IJobHostRpcWorkerChannelManager JobHostLanguageWorkerChannelManager => _jobHostLanguageWorkerChannelManager;

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CustomHandlerRetry.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CustomHandlerRetry.cs
@@ -34,9 +34,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
             string uri = $"api/{functionName}";
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
             var response = await _fixture.Host.HttpClient.SendAsync(request);
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             string responseContent = await response.Content.ReadAsStringAsync();
-            Assert.Equal(responseContent, "Retry Count:2 Max Retry Count:2");
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                string hostLogs = _fixture.Host.GetLog();
+                Assert.True(false, $"Expected OK but got {response.StatusCode}.\nResponse body: {responseContent}\nHost logs:\n{hostLogs}");
+            }
+
+            Assert.Equal("Retry Count:2 Max Retry Count:2", responseContent);
         }
 
         public class TestFixture : EndToEndTestFixture

--- a/test/WebJobs.Script.Tests/Workers/ExternalWorkers/ConnectedWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ExternalWorkers/ConnectedWorkerChannelManagerTests.cs
@@ -1,0 +1,143 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.Grpc.Eventing;
+using Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers;
+using Microsoft.Azure.WebJobs.Script.Http;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
+{
+    public class ConnectedWorkerChannelManagerTests
+    {
+        private readonly ConnectedWorkerChannelManager _manager = new();
+
+        private static ConnectedWorkerChannel CreateTestChannel(string workerId)
+        {
+            var eventManager = new ScriptEventManager();
+            eventManager.AddGrpcChannels(workerId);
+
+            var workerConfig = TestHelpers.GetTestWorkerConfigs().First();
+            var mockHostOptions = new Mock<IOptionsMonitor<ScriptApplicationHostOptions>>();
+            mockHostOptions.Setup(o => o.CurrentValue).Returns(new ScriptApplicationHostOptions { ScriptPath = @"c:\testdir" });
+
+            return new ConnectedWorkerChannel(
+                workerId,
+                eventManager,
+                new Mock<IScriptHostManager>().Object,
+                workerConfig,
+                NullLogger.Instance,
+                new Mock<IMetricsLogger>().Object,
+                new TestEnvironment(),
+                mockHostOptions.Object,
+                new Mock<ISharedMemoryManager>().Object,
+                Options.Create(new WorkerConcurrencyOptions()),
+                Options.Create(new FunctionsHostingConfigOptions()),
+                new Mock<IHttpProxyService>().Object);
+        }
+
+        [Fact]
+        public async Task AddChannel_SignalsWaitForChannelAsync()
+        {
+            var channel = CreateTestChannel("worker1");
+            _manager.AddChannel("worker1", channel);
+
+            var result = await _manager.WaitForChannelAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Same(channel, result);
+        }
+
+        [Fact]
+        public async Task WaitForChannelAsync_BlocksUntilChannelAdded()
+        {
+            var waitTask = _manager.WaitForChannelAsync(TimeSpan.FromSeconds(5));
+
+            await Task.Delay(50);
+            Assert.False(waitTask.IsCompleted);
+
+            var channel = CreateTestChannel("worker1");
+            _manager.AddChannel("worker1", channel);
+
+            var result = await waitTask;
+
+            Assert.Same(channel, result);
+        }
+
+        [Fact]
+        public async Task WaitForChannelAsync_TimesOut()
+        {
+            await Assert.ThrowsAsync<TimeoutException>(
+                () => _manager.WaitForChannelAsync(TimeSpan.FromMilliseconds(100)));
+        }
+
+        [Fact]
+        public async Task WaitForChannelAsync_ReturnsCachedChannel()
+        {
+            var channel = CreateTestChannel("worker1");
+            _manager.AddChannel("worker1", channel);
+
+            var result1 = await _manager.WaitForChannelAsync(TimeSpan.FromSeconds(5));
+            var result2 = await _manager.WaitForChannelAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Same(channel, result1);
+            Assert.Same(channel, result2);
+        }
+
+        [Fact]
+        public void GetChannel_ReturnsNull_WhenNotFound()
+        {
+            var result = _manager.GetChannel("unknown");
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetChannel_ReturnsChannel_WhenFound()
+        {
+            var channel = CreateTestChannel("worker1");
+            _manager.AddChannel("worker1", channel);
+
+            var result = _manager.GetChannel("worker1");
+
+            Assert.Same(channel, result);
+        }
+
+        [Fact]
+        public void GetChannels_ReturnsAllChannels()
+        {
+            var channel1 = CreateTestChannel("worker1");
+            var channel2 = CreateTestChannel("worker2");
+            _manager.AddChannel("worker1", channel1);
+            _manager.AddChannel("worker2", channel2);
+
+            var result = _manager.GetChannels();
+
+            Assert.Equal(2, result.Count);
+            Assert.Same(channel1, result["worker1"]);
+            Assert.Same(channel2, result["worker2"]);
+        }
+
+        [Fact]
+        public async Task ShutdownChannelAsync_RemovesChannel()
+        {
+            var channel = CreateTestChannel("worker1");
+            _manager.AddChannel("worker1", channel);
+            Assert.NotNull(_manager.GetChannel("worker1"));
+
+            await _manager.ShutdownChannelAsync("worker1");
+
+            Assert.Null(_manager.GetChannel("worker1"));
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Workers/ExternalWorkers/ConnectedWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ExternalWorkers/ConnectedWorkerChannelManagerTests.cs
@@ -2,18 +2,9 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs.Script.Config;
-using Microsoft.Azure.WebJobs.Script.Diagnostics;
-using Microsoft.Azure.WebJobs.Script.Eventing;
-using Microsoft.Azure.WebJobs.Script.Grpc.Eventing;
 using Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers;
-using Microsoft.Azure.WebJobs.Script.Http;
-using Microsoft.Azure.WebJobs.Script.Workers;
-using Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Moq;
 using Xunit;
 
@@ -23,39 +14,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
     {
         private readonly ConnectedWorkerChannelManager _manager = new();
 
-        private static ConnectedWorkerChannel CreateTestChannel(string workerId)
+        private static Mock<IRpcWorkerChannel> CreateMockChannel(string workerId, bool ready = false)
         {
-            var eventManager = new ScriptEventManager();
-            eventManager.AddGrpcChannels(workerId);
-
-            var workerConfig = TestHelpers.GetTestWorkerConfigs().First();
-            var mockHostOptions = new Mock<IOptionsMonitor<ScriptApplicationHostOptions>>();
-            mockHostOptions.Setup(o => o.CurrentValue).Returns(new ScriptApplicationHostOptions { ScriptPath = @"c:\testdir" });
-
-            return new ConnectedWorkerChannel(
-                workerId,
-                eventManager,
-                new Mock<IScriptHostManager>().Object,
-                workerConfig,
-                NullLogger.Instance,
-                new Mock<IMetricsLogger>().Object,
-                new TestEnvironment(),
-                mockHostOptions.Object,
-                new Mock<ISharedMemoryManager>().Object,
-                Options.Create(new WorkerConcurrencyOptions()),
-                Options.Create(new FunctionsHostingConfigOptions()),
-                new Mock<IHttpProxyService>().Object);
+            var mock = new Mock<IRpcWorkerChannel>();
+            mock.Setup(c => c.Id).Returns(workerId);
+            mock.Setup(c => c.IsChannelReadyForInvocations()).Returns(ready);
+            return mock;
         }
 
         [Fact]
         public async Task AddChannel_SignalsWaitForChannelAsync()
         {
-            var channel = CreateTestChannel("worker1");
-            _manager.AddChannel("worker1", channel);
+            var channel = CreateMockChannel("worker1", ready: true);
+            _manager.AddChannel("worker1", channel.Object);
 
             var result = await _manager.WaitForChannelAsync(TimeSpan.FromSeconds(5));
 
-            Assert.Same(channel, result);
+            Assert.Same(channel.Object, result);
         }
 
         [Fact]
@@ -66,12 +41,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
             await Task.Delay(50);
             Assert.False(waitTask.IsCompleted);
 
-            var channel = CreateTestChannel("worker1");
-            _manager.AddChannel("worker1", channel);
+            var channel = CreateMockChannel("worker1", ready: true);
+            _manager.AddChannel("worker1", channel.Object);
 
             var result = await waitTask;
 
-            Assert.Same(channel, result);
+            Assert.Same(channel.Object, result);
         }
 
         [Fact]
@@ -84,14 +59,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
         [Fact]
         public async Task WaitForChannelAsync_ReturnsCachedChannel()
         {
-            var channel = CreateTestChannel("worker1");
-            _manager.AddChannel("worker1", channel);
+            var channel = CreateMockChannel("worker1", ready: true);
+            _manager.AddChannel("worker1", channel.Object);
 
             var result1 = await _manager.WaitForChannelAsync(TimeSpan.FromSeconds(5));
             var result2 = await _manager.WaitForChannelAsync(TimeSpan.FromSeconds(5));
 
-            Assert.Same(channel, result1);
-            Assert.Same(channel, result2);
+            Assert.Same(channel.Object, result1);
+            Assert.Same(channel.Object, result2);
         }
 
         [Fact]
@@ -105,34 +80,34 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
         [Fact]
         public void GetChannel_ReturnsChannel_WhenFound()
         {
-            var channel = CreateTestChannel("worker1");
-            _manager.AddChannel("worker1", channel);
+            var channel = CreateMockChannel("worker1");
+            _manager.AddChannel("worker1", channel.Object);
 
             var result = _manager.GetChannel("worker1");
 
-            Assert.Same(channel, result);
+            Assert.Same(channel.Object, result);
         }
 
         [Fact]
         public void GetChannels_ReturnsAllChannels()
         {
-            var channel1 = CreateTestChannel("worker1");
-            var channel2 = CreateTestChannel("worker2");
-            _manager.AddChannel("worker1", channel1);
-            _manager.AddChannel("worker2", channel2);
+            var channel1 = CreateMockChannel("worker1");
+            var channel2 = CreateMockChannel("worker2");
+            _manager.AddChannel("worker1", channel1.Object);
+            _manager.AddChannel("worker2", channel2.Object);
 
             var result = _manager.GetChannels();
 
             Assert.Equal(2, result.Count);
-            Assert.Same(channel1, result["worker1"]);
-            Assert.Same(channel2, result["worker2"]);
+            Assert.Same(channel1.Object, result["worker1"]);
+            Assert.Same(channel2.Object, result["worker2"]);
         }
 
         [Fact]
         public async Task ShutdownChannelAsync_RemovesChannel()
         {
-            var channel = CreateTestChannel("worker1");
-            _manager.AddChannel("worker1", channel);
+            var channel = CreateMockChannel("worker1");
+            _manager.AddChannel("worker1", channel.Object);
             Assert.NotNull(_manager.GetChannel("worker1"));
 
             await _manager.ShutdownChannelAsync("worker1");
@@ -143,11 +118,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
         [Fact]
         public async Task WaitForChannelAsync_AfterShutdownAndReconnect_ReturnsNewChannel()
         {
-            var channelA = CreateTestChannel("workerA");
-            _manager.AddChannel("workerA", channelA);
+            var channelA = CreateMockChannel("workerA", ready: true);
+            _manager.AddChannel("workerA", channelA.Object);
 
             var result1 = await _manager.WaitForChannelAsync(TimeSpan.FromSeconds(5));
-            Assert.Same(channelA, result1);
+            Assert.Same(channelA.Object, result1);
 
             await _manager.ShutdownChannelAsync("workerA");
 
@@ -155,27 +130,40 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
             await Task.Delay(50);
             Assert.False(waitTask.IsCompleted, "WaitForChannelAsync should block after all channels are shut down");
 
-            var channelB = CreateTestChannel("workerB");
-            _manager.AddChannel("workerB", channelB);
+            var channelB = CreateMockChannel("workerB", ready: true);
+            _manager.AddChannel("workerB", channelB.Object);
 
             var result2 = await waitTask;
-            Assert.Same(channelB, result2);
+            Assert.Same(channelB.Object, result2);
         }
 
         [Fact]
         public async Task WaitForChannelAsync_AfterPartialShutdown_StillReturnsRemainingChannel()
         {
-            var channelA = CreateTestChannel("workerA");
-            var channelB = CreateTestChannel("workerB");
-            _manager.AddChannel("workerA", channelA);
-            _manager.AddChannel("workerB", channelB);
+            var channelA = CreateMockChannel("workerA", ready: true);
+            var channelB = CreateMockChannel("workerB", ready: true);
+            _manager.AddChannel("workerA", channelA.Object);
+            _manager.AddChannel("workerB", channelB.Object);
 
             await _manager.ShutdownChannelAsync("workerA");
 
-            // TCS should not have been reset since channelB is still active
             var result = await _manager.WaitForChannelAsync(TimeSpan.FromSeconds(5));
             Assert.NotNull(result);
-            Assert.Same(channelB, result);
+            Assert.Same(channelB.Object, result);
+        }
+
+        [Fact]
+        public async Task WaitForChannelAsync_ChannelAddedButNotReady_ReturnsChannel()
+        {
+            // WaitForChannelAsync returns any connected channel — readiness
+            // for invocations is the dispatcher's concern, not the manager's.
+            var channel = CreateMockChannel("worker1", ready: false);
+            _manager.AddChannel("worker1", channel.Object);
+
+            var result = await _manager.WaitForChannelAsync(TimeSpan.FromSeconds(5));
+
+            Assert.NotNull(result);
+            Assert.Same(channel.Object, result);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/ExternalWorkers/ConnectedWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ExternalWorkers/ConnectedWorkerChannelManagerTests.cs
@@ -165,5 +165,27 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
             Assert.NotNull(result);
             Assert.Same(channel.Object, result);
         }
+
+        [Fact]
+        public async Task WaitForChannelAsync_ConcurrentWaiters_BothReceiveChannel()
+        {
+            // Two callers wait concurrently. When a channel is added,
+            // both should wake up — neither should block until timeout.
+            var waitTask1 = _manager.WaitForChannelAsync(TimeSpan.FromSeconds(5));
+            var waitTask2 = _manager.WaitForChannelAsync(TimeSpan.FromSeconds(5));
+
+            await Task.Delay(50);
+            Assert.False(waitTask1.IsCompleted);
+            Assert.False(waitTask2.IsCompleted);
+
+            var channel = CreateMockChannel("worker1");
+            _manager.AddChannel("worker1", channel.Object);
+
+            // Both must complete within a reasonable time — not timeout.
+            var results = await Task.WhenAll(waitTask1, waitTask2);
+
+            Assert.Same(channel.Object, results[0]);
+            Assert.Same(channel.Object, results[1]);
+        }
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/ExternalWorkers/ConnectedWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ExternalWorkers/ConnectedWorkerChannelManagerTests.cs
@@ -139,5 +139,43 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
 
             Assert.Null(_manager.GetChannel("worker1"));
         }
+
+        [Fact]
+        public async Task WaitForChannelAsync_AfterShutdownAndReconnect_ReturnsNewChannel()
+        {
+            var channelA = CreateTestChannel("workerA");
+            _manager.AddChannel("workerA", channelA);
+
+            var result1 = await _manager.WaitForChannelAsync(TimeSpan.FromSeconds(5));
+            Assert.Same(channelA, result1);
+
+            await _manager.ShutdownChannelAsync("workerA");
+
+            var waitTask = _manager.WaitForChannelAsync(TimeSpan.FromSeconds(5));
+            await Task.Delay(50);
+            Assert.False(waitTask.IsCompleted, "WaitForChannelAsync should block after all channels are shut down");
+
+            var channelB = CreateTestChannel("workerB");
+            _manager.AddChannel("workerB", channelB);
+
+            var result2 = await waitTask;
+            Assert.Same(channelB, result2);
+        }
+
+        [Fact]
+        public async Task WaitForChannelAsync_AfterPartialShutdown_StillReturnsRemainingChannel()
+        {
+            var channelA = CreateTestChannel("workerA");
+            var channelB = CreateTestChannel("workerB");
+            _manager.AddChannel("workerA", channelA);
+            _manager.AddChannel("workerB", channelB);
+
+            await _manager.ShutdownChannelAsync("workerA");
+
+            // TCS should not have been reset since channelB is still active
+            var result = await _manager.WaitForChannelAsync(TimeSpan.FromSeconds(5));
+            Assert.NotNull(result);
+            Assert.Same(channelB, result);
+        }
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/ExternalWorkers/ConnectedWorkerInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ExternalWorkers/ConnectedWorkerInvocationDispatcherTests.cs
@@ -1,0 +1,110 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.Grpc.Eventing;
+using Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers;
+using Microsoft.Azure.WebJobs.Script.Http;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
+{
+    public class ConnectedWorkerInvocationDispatcherTests
+    {
+        private readonly Mock<IConnectedWorkerChannelManager> _mockChannelManager = new();
+        private readonly ConnectedWorkerInvocationDispatcher _dispatcher;
+
+        public ConnectedWorkerInvocationDispatcherTests()
+        {
+            _mockChannelManager.Setup(m => m.GetChannels())
+                .Returns(new Dictionary<string, ConnectedWorkerChannel>());
+
+            _dispatcher = new ConnectedWorkerInvocationDispatcher(
+                _mockChannelManager.Object,
+                NullLogger<ConnectedWorkerInvocationDispatcher>.Instance);
+        }
+
+        private static ConnectedWorkerChannel CreateReadyChannel(string workerId)
+        {
+            var eventManager = new ScriptEventManager();
+            eventManager.AddGrpcChannels(workerId);
+
+            var workerConfig = TestHelpers.GetTestWorkerConfigs().First();
+            var mockHostOptions = new Mock<IOptionsMonitor<ScriptApplicationHostOptions>>();
+            mockHostOptions.Setup(o => o.CurrentValue).Returns(new ScriptApplicationHostOptions { ScriptPath = @"c:\testdir" });
+
+            var channel = new ConnectedWorkerChannel(
+                workerId,
+                eventManager,
+                new Mock<IScriptHostManager>().Object,
+                workerConfig,
+                NullLogger.Instance,
+                new Mock<IMetricsLogger>().Object,
+                new TestEnvironment(),
+                mockHostOptions.Object,
+                new Mock<ISharedMemoryManager>().Object,
+                Options.Create(new WorkerConcurrencyOptions()),
+                Options.Create(new FunctionsHostingConfigOptions()),
+                new Mock<IHttpProxyService>().Object);
+
+            // Use reflection to set the internal state flags so IsChannelReadyForInvocations() returns true.
+            // RpcWorkerChannelState.InvocationBuffersInitialized (1 << 1) | Initialized (1 << 3)
+            var stateField = typeof(ConnectedWorkerChannel).BaseType
+                .GetField("_state", BindingFlags.NonPublic | BindingFlags.Instance);
+            var readyValue = Enum.ToObject(stateField.FieldType, (1 << 1) | (1 << 3));
+            stateField.SetValue(channel, readyValue);
+
+            return channel;
+        }
+
+        [Fact]
+        public void State_ReturnsInitializing_WhenNoChannels()
+        {
+            Assert.Equal(FunctionInvocationDispatcherState.Initializing, _dispatcher.State);
+        }
+
+        [Fact]
+        public void State_ReturnsInitialized_WhenChannelReady()
+        {
+            var channel = CreateReadyChannel("worker1");
+            _mockChannelManager.Setup(m => m.GetChannels())
+                .Returns(new Dictionary<string, ConnectedWorkerChannel> { ["worker1"] = channel });
+
+            Assert.Equal(FunctionInvocationDispatcherState.Initialized, _dispatcher.State);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_ThrowsWhenNoReadyChannel()
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => _dispatcher.InvokeAsync(null));
+        }
+
+        [Fact]
+        public async Task RestartWorkerWithInvocationIdAsync_ReturnsFalse()
+        {
+            var result = await _dispatcher.RestartWorkerWithInvocationIdAsync("invocation1", new Exception("test"));
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void ErrorEventsThreshold_ReturnsMaxValue()
+        {
+            Assert.Equal(int.MaxValue, _dispatcher.ErrorEventsThreshold);
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Workers/ExternalWorkers/ConnectedWorkerInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ExternalWorkers/ConnectedWorkerInvocationDispatcherTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Azure.WebJobs.Script.Grpc.Eventing;
 using Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers;
 using Microsoft.Azure.WebJobs.Script.Http;
 using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -36,6 +37,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
 
             _dispatcher = new ConnectedWorkerInvocationDispatcher(
                 _mockChannelManager.Object,
+                new RpcFunctionInvocationDispatcherLoadBalancer(),
+                Options.Create(new ScriptJobHostOptions()),
                 NullLogger<ConnectedWorkerInvocationDispatcher>.Instance);
         }
 

--- a/test/WebJobs.Script.Tests/Workers/ExternalWorkers/ConnectedWorkerInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ExternalWorkers/ConnectedWorkerInvocationDispatcherTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
         public ConnectedWorkerInvocationDispatcherTests()
         {
             _mockChannelManager.Setup(m => m.GetChannels())
-                .Returns(new Dictionary<string, ConnectedWorkerChannel>());
+                .Returns(new Dictionary<string, IRpcWorkerChannel>());
 
             _dispatcher = new ConnectedWorkerInvocationDispatcher(
                 _mockChannelManager.Object,
@@ -102,17 +102,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
         }
 
         [Fact]
-        public void State_ReturnsInitializing_WhenNoChannels()
+        public void State_ReturnsDefault_WhenConstructed()
         {
-            Assert.Equal(FunctionInvocationDispatcherState.Initializing, _dispatcher.State);
+            Assert.Equal(FunctionInvocationDispatcherState.Default, _dispatcher.State);
         }
 
         [Fact]
-        public void State_ReturnsInitialized_WhenChannelReady()
+        public async Task State_ReturnsInitialized_AfterInitializeAsync()
         {
-            var channel = CreateReadyChannel("worker1");
-            _mockChannelManager.Setup(m => m.GetChannels())
-                .Returns(new Dictionary<string, ConnectedWorkerChannel> { ["worker1"] = channel });
+            var function = new FunctionMetadata { Name = "TestFunction" };
+
+            await _dispatcher.InitializeAsync(new[] { function });
 
             Assert.Equal(FunctionInvocationDispatcherState.Initialized, _dispatcher.State);
         }
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
             var function = new FunctionMetadata { Name = "TestFunction" };
             var functionId = function.GetFunctionId();
 
-            var channels = new Dictionary<string, ConnectedWorkerChannel>();
+            var channels = new Dictionary<string, IRpcWorkerChannel>();
             for (int i = 0; i < 3; i++)
             {
                 var ch = CreateReadyChannelWithBuffers($"worker{i}", new[] { function });
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
 
             var channel = CreateReadyChannelWithBuffers("worker1", new[] { function });
             _mockChannelManager.Setup(m => m.GetChannels())
-                .Returns(new Dictionary<string, ConnectedWorkerChannel> { ["worker1"] = channel });
+                .Returns(new Dictionary<string, IRpcWorkerChannel> { ["worker1"] = channel });
 
             var context = CreateInvocationContext(function);
             await _dispatcher.InvokeAsync(context);
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
         {
             var channel = CreateReadyChannel("worker1");
             _mockChannelManager.Setup(m => m.GetChannels())
-                .Returns(new Dictionary<string, ConnectedWorkerChannel> { ["worker1"] = channel });
+                .Returns(new Dictionary<string, IRpcWorkerChannel> { ["worker1"] = channel });
 
             var function = new FunctionMetadata { Name = "NonExistentFunction" };
             var context = CreateInvocationContext(function);
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
             var function = new FunctionMetadata { Name = "TestFunction" };
             var functionId = function.GetFunctionId();
 
-            var channels = new Dictionary<string, ConnectedWorkerChannel>
+            var channels = new Dictionary<string, IRpcWorkerChannel>
             {
                 ["worker1"] = CreateTestChannel("worker1"),
                 ["worker2"] = CreateTestChannel("worker2")
@@ -210,7 +210,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
             var functionId = function.GetFunctionId();
 
             _mockChannelManager.Setup(m => m.GetChannels())
-                .Returns(new Dictionary<string, ConnectedWorkerChannel>());
+                .Returns(new Dictionary<string, IRpcWorkerChannel>());
 
             await _dispatcher.InitializeAsync(new[] { function });
 
@@ -229,9 +229,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
         }
 
         [Fact]
-        public void ErrorEventsThreshold_ReturnsMaxValue()
+        public void ErrorEventsThreshold_Returns3()
         {
-            Assert.Equal(int.MaxValue, _dispatcher.ErrorEventsThreshold);
+            Assert.Equal(3, _dispatcher.ErrorEventsThreshold);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/ExternalWorkers/ConnectedWorkerInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ExternalWorkers/ConnectedWorkerInvocationDispatcherTests.cs
@@ -6,7 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
 using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Eventing;
 using Microsoft.Azure.WebJobs.Script.Grpc.Eventing;
@@ -37,7 +39,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
                 NullLogger<ConnectedWorkerInvocationDispatcher>.Instance);
         }
 
-        private static ConnectedWorkerChannel CreateReadyChannel(string workerId)
+        private static ConnectedWorkerChannel CreateTestChannel(string workerId)
         {
             var eventManager = new ScriptEventManager();
             eventManager.AddGrpcChannels(workerId);
@@ -46,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
             var mockHostOptions = new Mock<IOptionsMonitor<ScriptApplicationHostOptions>>();
             mockHostOptions.Setup(o => o.CurrentValue).Returns(new ScriptApplicationHostOptions { ScriptPath = @"c:\testdir" });
 
-            var channel = new ConnectedWorkerChannel(
+            return new ConnectedWorkerChannel(
                 workerId,
                 eventManager,
                 new Mock<IScriptHostManager>().Object,
@@ -59,15 +61,41 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
                 Options.Create(new WorkerConcurrencyOptions()),
                 Options.Create(new FunctionsHostingConfigOptions()),
                 new Mock<IHttpProxyService>().Object);
+        }
 
+        private static ConnectedWorkerChannel CreateReadyChannel(string workerId)
+        {
+            var channel = CreateTestChannel(workerId);
+            SetChannelReady(channel);
+
+            return channel;
+        }
+
+        private static ConnectedWorkerChannel CreateReadyChannelWithBuffers(string workerId, IEnumerable<FunctionMetadata> functions)
+        {
+            var channel = CreateReadyChannel(workerId);
+            channel.SetupFunctionInvocationBuffers(functions);
+
+            return channel;
+        }
+
+        private static void SetChannelReady(ConnectedWorkerChannel channel)
+        {
             // Use reflection to set the internal state flags so IsChannelReadyForInvocations() returns true.
             // RpcWorkerChannelState.InvocationBuffersInitialized (1 << 1) | Initialized (1 << 3)
             var stateField = typeof(ConnectedWorkerChannel).BaseType
                 .GetField("_state", BindingFlags.NonPublic | BindingFlags.Instance);
             var readyValue = Enum.ToObject(stateField.FieldType, (1 << 1) | (1 << 3));
             stateField.SetValue(channel, readyValue);
+        }
 
-            return channel;
+        private static ScriptInvocationContext CreateInvocationContext(FunctionMetadata function)
+        {
+            return new ScriptInvocationContext
+            {
+                FunctionMetadata = function,
+                ResultSource = new TaskCompletionSource<ScriptInvocationResult>()
+            };
         }
 
         [Fact]
@@ -91,6 +119,102 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
         {
             await Assert.ThrowsAsync<InvalidOperationException>(
                 () => _dispatcher.InvokeAsync(null));
+        }
+
+        [Fact]
+        public async Task InvokeAsync_RoundRobinDistribution()
+        {
+            var function = new FunctionMetadata { Name = "TestFunction" };
+            var functionId = function.GetFunctionId();
+
+            var channels = new Dictionary<string, ConnectedWorkerChannel>();
+            for (int i = 0; i < 3; i++)
+            {
+                var ch = CreateReadyChannelWithBuffers($"worker{i}", new[] { function });
+                channels[$"worker{i}"] = ch;
+            }
+
+            _mockChannelManager.Setup(m => m.GetChannels()).Returns(channels);
+
+            for (int i = 0; i < 6; i++)
+            {
+                await _dispatcher.InvokeAsync(CreateInvocationContext(function));
+            }
+
+            foreach (var ch in channels.Values)
+            {
+                Assert.Equal(2, ch.FunctionInputBuffers[functionId].Count);
+            }
+        }
+
+        [Fact]
+        public async Task InvokeAsync_UsesFunctionInputBuffer()
+        {
+            var function = new FunctionMetadata { Name = "TestFunction" };
+            var functionId = function.GetFunctionId();
+
+            var channel = CreateReadyChannelWithBuffers("worker1", new[] { function });
+            _mockChannelManager.Setup(m => m.GetChannels())
+                .Returns(new Dictionary<string, ConnectedWorkerChannel> { ["worker1"] = channel });
+
+            var context = CreateInvocationContext(function);
+            await _dispatcher.InvokeAsync(context);
+
+            Assert.True(channel.FunctionInputBuffers[functionId].TryReceive(out var received));
+            Assert.Same(context, received);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_ThrowsWhenFunctionNotLoaded()
+        {
+            var channel = CreateReadyChannel("worker1");
+            _mockChannelManager.Setup(m => m.GetChannels())
+                .Returns(new Dictionary<string, ConnectedWorkerChannel> { ["worker1"] = channel });
+
+            var function = new FunctionMetadata { Name = "NonExistentFunction" };
+            var context = CreateInvocationContext(function);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => _dispatcher.InvokeAsync(context));
+        }
+
+        [Fact]
+        public async Task InitializeAsync_SetsFunctionBuffersOnChannels()
+        {
+            var function = new FunctionMetadata { Name = "TestFunction" };
+            var functionId = function.GetFunctionId();
+
+            var channels = new Dictionary<string, ConnectedWorkerChannel>
+            {
+                ["worker1"] = CreateTestChannel("worker1"),
+                ["worker2"] = CreateTestChannel("worker2")
+            };
+
+            _mockChannelManager.Setup(m => m.GetChannels()).Returns(channels);
+
+            await _dispatcher.InitializeAsync(new[] { function });
+
+            foreach (var ch in channels.Values)
+            {
+                Assert.True(ch.FunctionInputBuffers.ContainsKey(functionId));
+            }
+        }
+
+        [Fact]
+        public async Task InitializeAsync_NewChannelAfterInit_GetsSetup()
+        {
+            var function = new FunctionMetadata { Name = "TestFunction" };
+            var functionId = function.GetFunctionId();
+
+            _mockChannelManager.Setup(m => m.GetChannels())
+                .Returns(new Dictionary<string, ConnectedWorkerChannel>());
+
+            await _dispatcher.InitializeAsync(new[] { function });
+
+            var newChannel = CreateTestChannel("worker-new");
+            _dispatcher.SetupChannel(newChannel);
+
+            Assert.True(newChannel.FunctionInputBuffers.ContainsKey(functionId));
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
@@ -225,6 +225,31 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             {
                 Assert.True(((TestRpcWorkerChannel)currChannel).ExecutionContexts.Count > 0);
             }
+
+            var logMessages = _testLoggerProvider.GetAllLogMessages().Select(m => m.FormattedMessage).ToList();
+            Assert.Contains(logMessages, m => m.Contains("timed out"));
+            Assert.DoesNotContain(logMessages, m => m.Contains("completed during shutdown"));
+        }
+
+        [Fact]
+        public async Task ShutdownTests_WhenDrainCompletes_LogsCompleted()
+        {
+            int expectedProcessCount = 2;
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(expectedProcessCount, runtime: RpcWorkerConstants.NodeLanguageWorkerName);
+            await functionDispatcher.InitializeAsync(GetTestFunctionsList(RpcWorkerConstants.NodeLanguageWorkerName));
+            await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount);
+
+            foreach (var currChannel in functionDispatcher.JobHostLanguageWorkerChannelManager.GetChannels())
+            {
+                var initializedChannel = (TestRpcWorkerChannel)currChannel;
+                initializedChannel.ExecutionContexts.Add(Task.Factory.StartNew(() => { }));
+            }
+
+            await functionDispatcher.ShutdownAsync();
+
+            var logMessages = _testLoggerProvider.GetAllLogMessages().Select(m => m.FormattedMessage).ToList();
+            Assert.Contains(logMessages, m => m.Contains("completed during shutdown"));
+            Assert.DoesNotContain(logMessages, m => m.Contains("timed out"));
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

New types for the separated compute model — channel, manager, factory, and dispatcher for externally-connected workers. All additive, no DI wiring (that comes in M4).

Resolves #11643

## New Files

| File | Purpose |
|---|---|
| `ExternalWorkers/ConnectedWorkerChannel.cs` | Inherits `WorkerChannelBase`, no process management — gRPC stream IS the lifecycle |
| `ExternalWorkers/ConnectedWorkerChannelFactory.cs` | DI factory for creating channels |
| `ExternalWorkers/IConnectedWorkerChannelManager.cs` | Interface with `WaitForChannelAsync` |
| `ExternalWorkers/ConnectedWorkerChannelManager.cs` | `ConcurrentDictionary` + `TaskCompletionSource` blocking |
| `ExternalWorkers/ConnectedWorkerInvocationDispatcher.cs` | Routes invocations to connected channels, no restart logic |
| `Workers/ExternalWorkers/ConnectedWorkerChannelManagerTests.cs` | 8 unit tests |
| `Workers/ExternalWorkers/ConnectedWorkerInvocationDispatcherTests.cs` | 5 unit tests |

## Testing

- Full solution builds with 0 errors
- 85/85 GrpcWorkerChannel tests pass (unchanged)
- 13/13 new ExternalWorkers tests pass
- 3,228/3,230 full unit suite (2 pre-existing CPU-count failures)