### PR TITLE
feat: auto-handle HEAD requests on GET triggers and return 405 for non-GET/HEAD routes

### DIFF
--- a/src/WebJobs.Script.WebHost/Features/IHeadNotAllowedFeature.cs
+++ b/src/WebJobs.Script.WebHost/Features/IHeadNotAllowedFeature.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Features;
+
+internal interface IHeadNotAllowedFeature
+{
+    string AllowedMethods { get; }
+}
+
+internal sealed class HeadNotAllowedFeature : IHeadNotAllowedFeature
+{
+    public HeadNotAllowedFeature(string allowedMethods)
+    {
+        AllowedMethods = allowedMethods;
+    }
+
+    public string AllowedMethods { get; }
+}

--- a/src/WebJobs.Script.WebHost/Middleware/FunctionInvocationMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/FunctionInvocationMiddleware.cs
@@ -34,6 +34,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
         // TODO: Confirm that only HttpTrigger requests would flow through here
         public async Task Invoke(HttpContext context)
         {
+            // HEAD request on a route that doesn't support HEAD/GET → 405 Method Not Allowed.
+            var headNotAllowed = context.Features.Get<IHeadNotAllowedFeature>();
+            if (headNotAllowed is not null)
+            {
+                context.Response.StatusCode = StatusCodes.Status405MethodNotAllowed;
+                context.Response.Headers.Allow = headNotAllowed.AllowedMethods;
+                return;
+            }
+
             if (_next != null)
             {
                 await _next(context);

--- a/src/WebJobs.Script.WebHost/Middleware/FunctionInvocationMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/FunctionInvocationMiddleware.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization.Policy;
@@ -62,26 +63,44 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
                 }
 
                 int nestedProxiesCount = GetNestedProxiesCount(context, functionExecution);
-                IActionResult result = await GetResultAsync(context, functionExecution);
 
-                if (context.Items.TryGetValue(ScriptConstants.HttpProxyingEnabled, out var httpProxyingEnabled))
+                Stream originalBody = null;
+                if (HttpMethods.IsHead(context.Request.Method))
                 {
-                    if (httpProxyingEnabled?.ToString() == bool.TrueString)
+                    originalBody = context.Response.Body;
+                    context.Response.Body = Stream.Null;
+                }
+
+                try
+                {
+                    IActionResult result = await GetResultAsync(context, functionExecution);
+
+                    if (context.Items.TryGetValue(ScriptConstants.HttpProxyingEnabled, out var httpProxyingEnabled))
                     {
+                        if (httpProxyingEnabled?.ToString() == bool.TrueString)
+                        {
+                            return;
+                        }
+                    }
+
+                    if (nestedProxiesCount > 0)
+                    {
+                        // if Proxy, the rest of the pipeline will be processed by Proxies in
+                        // case there are response overrides and what not.
+                        SetProxyResult(context, nestedProxiesCount, result);
                         return;
                     }
-                }
 
-                if (nestedProxiesCount > 0)
+                    ActionContext actionContext = new ActionContext(context, context.GetRouteData(), new ActionDescriptor());
+                    await result.ExecuteResultAsync(actionContext);
+                }
+                finally
                 {
-                    // if Proxy, the rest of the pipeline will be processed by Proxies in
-                    // case there are response overrides and what not.
-                    SetProxyResult(context, nestedProxiesCount, result);
-                    return;
+                    if (originalBody is not null)
+                    {
+                        context.Response.Body = originalBody;
+                    }
                 }
-
-                ActionContext actionContext = new ActionContext(context, context.GetRouteData(), new ActionDescriptor());
-                await result.ExecuteResultAsync(actionContext);
             }
         }
 

--- a/src/WebJobs.Script.WebHost/Middleware/FunctionInvocationMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/FunctionInvocationMiddleware.cs
@@ -35,18 +35,19 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
         // TODO: Confirm that only HttpTrigger requests would flow through here
         public async Task Invoke(HttpContext context)
         {
+            if (_next != null)
+            {
+                await _next(context);
+            }
+
             // HEAD request on a route that doesn't support HEAD/GET → 405 Method Not Allowed.
+            // Checked after _next because ScriptRouteHandler sets this feature during routing.
             var headNotAllowed = context.Features.Get<IHeadNotAllowedFeature>();
             if (headNotAllowed is not null)
             {
                 context.Response.StatusCode = StatusCodes.Status405MethodNotAllowed;
                 context.Response.Headers.Allow = headNotAllowed.AllowedMethods;
                 return;
-            }
-
-            if (_next != null)
-            {
-                await _next(context);
             }
 
             var functionExecution = context.Features.Get<IFunctionExecutionFeature>();

--- a/src/WebJobs.Script.WebHost/Routing/ScriptRouteHandler.cs
+++ b/src/WebJobs.Script.WebHost/Routing/ScriptRouteHandler.cs
@@ -39,6 +39,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Http
 
         public Task InvokeAsync(HttpContext context, string functionName)
         {
+            // Sentinel: HEAD request on a route that doesn't support HEAD/GET → 405.
+            if (functionName.StartsWith(ScriptConstants.HeadMethodNotAllowedPrefix, StringComparison.Ordinal))
+            {
+                string allowedMethods = functionName[ScriptConstants.HeadMethodNotAllowedPrefix.Length..];
+                context.Features.Set<IHeadNotAllowedFeature>(new HeadNotAllowedFeature(allowedMethods));
+                return Task.CompletedTask;
+            }
+
             if (_isProxy)
             {
                 ProxyFunctionExecutor proxyFunctionExecutor = new ProxyFunctionExecutor(_scriptHost);

--- a/src/WebJobs.Script.WebHost/WebScriptHostHttpRoutesManager.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostHttpRoutesManager.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Text;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Constraints;
@@ -50,10 +51,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 var httpTrigger = function.HttpTriggerAttribute;
                 if (httpTrigger != null)
                 {
+                    var constraintMethods = BuildConstraintMethods(httpTrigger.Methods);
                     var constraints = new RouteValueDictionary();
-                    if (httpTrigger.Methods != null)
+                    if (constraintMethods is not null)
                     {
-                        constraints.Add("httpMethod", new HttpMethodRouteConstraint(httpTrigger.Methods));
+                        constraints.Add("httpMethod", new HttpMethodRouteConstraint(constraintMethods));
                     }
 
                     string route = httpTrigger.Route;
@@ -66,6 +68,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                     WebJobsRouteBuilder builder = isProxy ? proxiesRoutesBuilder : routesBuilder;
                     builder.MapFunctionRoute(function.Metadata.Name, route, constraints, function.Metadata.Name);
+
+                    // Register HEAD-only shadow route for 405 responses.
+                    if (!isProxy && ShouldRegisterHeadNotAllowedRoute(httpTrigger.Methods))
+                    {
+                        var headConstraints = new RouteValueDictionary();
+                        headConstraints.Add("httpMethod", new HttpMethodRouteConstraint("head"));
+                        string sentinelName = BuildHeadNotAllowedSentinelName(httpTrigger.Methods);
+                        builder.MapFunctionRoute(sentinelName, route, headConstraints, sentinelName);
+                    }
 
                     LogRouteMap(routesLogBuilder, function.Metadata.Name, route, httpTrigger.Methods, isProxy, _httpOptions.Value.RoutePrefix);
                 }
@@ -124,5 +135,46 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 builder.AppendLine($"Mapped function route '{prefix}/{route}' [{methodList}] to '{functionName}'");
             }
         }
+
+        // Returns the methods array to use for the route constraint.
+        // Adds "head" when "get" is present and "head" is not.
+        internal static string[] BuildConstraintMethods(string[] triggerMethods)
+        {
+            if (triggerMethods is null)
+            {
+                return null;
+            }
+
+            bool hasGet = triggerMethods.Contains("get", StringComparer.OrdinalIgnoreCase);
+            bool hasHead = triggerMethods.Contains("head", StringComparer.OrdinalIgnoreCase);
+
+            if (hasGet && !hasHead)
+            {
+                return [.. triggerMethods, "head"];
+            }
+
+            return triggerMethods;
+        }
+
+        // Returns true when a HEAD shadow-route should be registered for 405 handling.
+        // True only when the function accepts neither GET nor HEAD.
+        internal static bool ShouldRegisterHeadNotAllowedRoute(string[] triggerMethods)
+        {
+            if (triggerMethods is null)
+            {
+                return false;
+            }
+
+            bool hasGet = triggerMethods.Contains("get", StringComparer.OrdinalIgnoreCase);
+            bool hasHead = triggerMethods.Contains("head", StringComparer.OrdinalIgnoreCase);
+
+            return !hasGet && !hasHead;
+        }
+
+        // Builds the sentinel route name for a HEAD-405 shadow route.
+        // Format: "$head_not_allowed:POST, PUT" (methods uppercased, joined with ", ").
+        internal static string BuildHeadNotAllowedSentinelName(string[] triggerMethods)
+            => ScriptConstants.HeadMethodNotAllowedPrefix
+               + string.Join(", ", triggerMethods.Select(m => m.ToUpperInvariant()));
     }
 }

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -157,6 +157,8 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string LegionCoreUri = "https://legion.core.azurewebsites.net";
 
         public const string AzureFunctionsSystemDirectoryName = ".azurefunctions";
+        public const string HeadMethodNotAllowedPrefix = "$head_not_allowed:";
+        public const string HttpAllowedMethodsKey = "httpAllowedMethods";
         public const string HttpMethodConstraintName = "httpMethod";
         public const string Snapshot = "snapshot";
         public const string Runtime = "runtime";

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -158,7 +158,6 @@ namespace Microsoft.Azure.WebJobs.Script
 
         public const string AzureFunctionsSystemDirectoryName = ".azurefunctions";
         public const string HeadMethodNotAllowedPrefix = "$head_not_allowed:";
-        public const string HttpAllowedMethodsKey = "httpAllowedMethods";
         public const string HttpMethodConstraintName = "httpMethod";
         public const string Snapshot = "snapshot";
         public const string Runtime = "runtime";

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/HeadRequestEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/HeadRequestEndToEndTests.cs
@@ -1,0 +1,98 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.WebJobs.Script.Tests;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
+{
+    [Trait(TestTraits.Category, TestTraits.EndToEnd)]
+    [Trait(TestTraits.Group, TestTraits.SamplesEndToEnd)]
+    public class HeadRequestEndToEndTests : IClassFixture<HeadRequestEndToEndTests.TestFixture>
+    {
+        private readonly TestFixture _fixture;
+
+        public HeadRequestEndToEndTests(TestFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task HeadRequest_GetOnlyFunction_ReturnsSameStatusAsGet_WithNoBody()
+        {
+            // GET request to establish the expected status
+            var getRequest = new HttpRequestMessage(HttpMethod.Get, "api/HttpTrigger-Redirect");
+            var getResponse = await _fixture.Host.HttpClient.SendAsync(getRequest);
+
+            // HEAD request should return same status code with no body
+            var headRequest = new HttpRequestMessage(HttpMethod.Head, "api/HttpTrigger-Redirect");
+            var headResponse = await _fixture.Host.HttpClient.SendAsync(headRequest);
+
+            Assert.Equal(getResponse.StatusCode, headResponse.StatusCode);
+            string body = await headResponse.Content.ReadAsStringAsync();
+            Assert.Empty(body);
+        }
+
+        [Fact]
+        public async Task HeadRequest_PostOnlyFunction_Returns405WithAllowHeader()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Head, "api/HttpTrigger-Dynamic");
+            var response = await _fixture.Host.HttpClient.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+            string allow = string.Join(", ", response.Content.Headers.GetValues("Allow"));
+            Assert.Contains("POST", allow, System.StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task HeadRequest_NonExistentRoute_Returns404()
+        {
+            var request = new HttpRequestMessage(HttpMethod.Head, "api/DoesNotExist");
+            var response = await _fixture.Host.HttpClient.SendAsync(request);
+
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetRequest_GetOnlyFunction_StillReturnsBody()
+        {
+            // Verify that GET requests are NOT affected by the HEAD handling
+            var request = new HttpRequestMessage(HttpMethod.Get, "api/HttpTrigger-Redirect");
+            var response = await _fixture.Host.HttpClient.SendAsync(request);
+
+            // HttpTrigger-Redirect returns a 302 redirect
+            Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        }
+
+        public class TestFixture : EndToEndTestFixture
+        {
+            public TestFixture()
+                : base(Path.Combine("TestScripts", "CSharp"), "headrequest", RpcWorkerConstants.DotNetLanguageWorkerName)
+            {
+            }
+
+            public override void ConfigureScriptHost(IWebJobsBuilder webJobsBuilder)
+            {
+                base.ConfigureScriptHost(webJobsBuilder);
+
+                webJobsBuilder.Services.Configure<ScriptJobHostOptions>(o =>
+                {
+                    o.Functions = new[]
+                    {
+                        "HttpTrigger-Redirect",   // GET only, anonymous
+                        "HttpTrigger-Dynamic"      // POST only, anonymous
+                    };
+                });
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Middleware/FunctionInvocationMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Middleware/FunctionInvocationMiddlewareTests.cs
@@ -4,13 +4,20 @@
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.WebHost.Features;
 using Microsoft.Azure.WebJobs.Script.WebHost.Middleware;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware;
@@ -60,5 +67,96 @@ public class FunctionInvocationMiddlewareTests
 
         Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
         Assert.Equal("POST", response.Headers.GetValues("Allow").Single());
+    }
+
+    [Fact]
+    public async Task Invoke_HeadRequest_OnGetFunction_SuppressesResponseBody()
+    {
+        var mockDescriptor = new Mock<FunctionDescriptor>();
+        mockDescriptor.SetupGet(d => d.HttpTriggerAttribute)
+            .Returns(new HttpTriggerAttribute(AuthorizationLevel.Anonymous, "get"));
+        mockDescriptor.Object.Name = "TestFunction";
+        mockDescriptor.Object.Metadata = new FunctionMetadata { Name = "TestFunction" };
+
+        var mockExecution = new Mock<IFunctionExecutionFeature>();
+        mockExecution.SetupGet(f => f.CanExecute).Returns(true);
+        mockExecution.SetupGet(f => f.Descriptor).Returns(mockDescriptor.Object);
+        mockExecution
+            .Setup(f => f.ExecuteAsync(It.IsAny<HttpRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<HttpRequest, CancellationToken>((req, _) =>
+            {
+                req.HttpContext.Items[ScriptConstants.AzureFunctionsHttpResponseKey] =
+                    new ContentResult { Content = "response body content", StatusCode = 200 };
+            })
+            .Returns(Task.CompletedTask);
+
+        using var server = new TestServer(new WebHostBuilder()
+            .ConfigureServices(services => services.AddLogging())
+            .Configure(app =>
+            {
+                app.Use((ctx, next) =>
+                {
+                    ctx.Features.Set<IFunctionExecutionFeature>(mockExecution.Object);
+                    ctx.Features.Set<IRoutingFeature>(new RoutingFeature
+                    {
+                        RouteData = new RouteData()
+                    });
+                    return next(ctx);
+                });
+                app.UseMiddleware<FunctionInvocationMiddleware>();
+            }));
+
+        var client = server.CreateClient();
+        var request = new HttpRequestMessage(HttpMethod.Head, "/");
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        string body = await response.Content.ReadAsStringAsync();
+        Assert.Empty(body);
+    }
+
+    [Fact]
+    public async Task Invoke_GetRequest_OnGetFunction_PreservesResponseBody()
+    {
+        var mockDescriptor = new Mock<FunctionDescriptor>();
+        mockDescriptor.SetupGet(d => d.HttpTriggerAttribute)
+            .Returns(new HttpTriggerAttribute(AuthorizationLevel.Anonymous, "get"));
+        mockDescriptor.Object.Name = "TestFunction";
+        mockDescriptor.Object.Metadata = new FunctionMetadata { Name = "TestFunction" };
+
+        var mockExecution = new Mock<IFunctionExecutionFeature>();
+        mockExecution.SetupGet(f => f.CanExecute).Returns(true);
+        mockExecution.SetupGet(f => f.Descriptor).Returns(mockDescriptor.Object);
+        mockExecution
+            .Setup(f => f.ExecuteAsync(It.IsAny<HttpRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<HttpRequest, CancellationToken>((req, _) =>
+            {
+                req.HttpContext.Items[ScriptConstants.AzureFunctionsHttpResponseKey] =
+                    new ContentResult { Content = "response body content", StatusCode = 200 };
+            })
+            .Returns(Task.CompletedTask);
+
+        using var server = new TestServer(new WebHostBuilder()
+            .ConfigureServices(services => services.AddLogging())
+            .Configure(app =>
+            {
+                app.Use((ctx, next) =>
+                {
+                    ctx.Features.Set<IFunctionExecutionFeature>(mockExecution.Object);
+                    ctx.Features.Set<IRoutingFeature>(new RoutingFeature
+                    {
+                        RouteData = new RouteData()
+                    });
+                    return next(ctx);
+                });
+                app.UseMiddleware<FunctionInvocationMiddleware>();
+            }));
+
+        var client = server.CreateClient();
+        var response = await client.GetAsync("/");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        string body = await response.Content.ReadAsStringAsync();
+        Assert.Equal("response body content", body);
     }
 }

--- a/test/WebJobs.Script.Tests/Middleware/FunctionInvocationMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Middleware/FunctionInvocationMiddlewareTests.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -43,7 +44,8 @@ public class FunctionInvocationMiddlewareTests
         var response = await client.SendAsync(request);
 
         Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
-        Assert.Equal("GET, POST", response.Headers.GetValues("Allow").Single());
+        string allow = string.Join(", ", response.Content.Headers.GetValues("Allow"));
+        Assert.Equal("GET, POST", allow);
     }
 
     [Fact]
@@ -66,32 +68,16 @@ public class FunctionInvocationMiddlewareTests
         var response = await client.GetAsync("/");
 
         Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
-        Assert.Equal("POST", response.Headers.GetValues("Allow").Single());
+        Assert.Equal("POST", response.Content.Headers.GetValues("Allow").Single());
     }
 
     [Fact]
     public async Task Invoke_HeadRequest_OnGetFunction_SuppressesResponseBody()
     {
-        var mockDescriptor = new Mock<FunctionDescriptor>();
-        mockDescriptor.SetupGet(d => d.HttpTriggerAttribute)
-            .Returns(new HttpTriggerAttribute(AuthorizationLevel.Anonymous, "get"));
-        mockDescriptor.Object.Name = "TestFunction";
-        mockDescriptor.Object.Metadata = new FunctionMetadata { Name = "TestFunction" };
-
-        var mockExecution = new Mock<IFunctionExecutionFeature>();
-        mockExecution.SetupGet(f => f.CanExecute).Returns(true);
-        mockExecution.SetupGet(f => f.Descriptor).Returns(mockDescriptor.Object);
-        mockExecution
-            .Setup(f => f.ExecuteAsync(It.IsAny<HttpRequest>(), It.IsAny<CancellationToken>()))
-            .Callback<HttpRequest, CancellationToken>((req, _) =>
-            {
-                req.HttpContext.Items[ScriptConstants.AzureFunctionsHttpResponseKey] =
-                    new ContentResult { Content = "response body content", StatusCode = 200 };
-            })
-            .Returns(Task.CompletedTask);
+        var mockExecution = CreateMockFunctionExecution("TestFunction", "get");
 
         using var server = new TestServer(new WebHostBuilder()
-            .ConfigureServices(services => services.AddLogging())
+            .ConfigureServices(services => { services.AddLogging(); services.AddMvcCore(); })
             .Configure(app =>
             {
                 app.Use((ctx, next) =>
@@ -118,26 +104,10 @@ public class FunctionInvocationMiddlewareTests
     [Fact]
     public async Task Invoke_GetRequest_OnGetFunction_PreservesResponseBody()
     {
-        var mockDescriptor = new Mock<FunctionDescriptor>();
-        mockDescriptor.SetupGet(d => d.HttpTriggerAttribute)
-            .Returns(new HttpTriggerAttribute(AuthorizationLevel.Anonymous, "get"));
-        mockDescriptor.Object.Name = "TestFunction";
-        mockDescriptor.Object.Metadata = new FunctionMetadata { Name = "TestFunction" };
-
-        var mockExecution = new Mock<IFunctionExecutionFeature>();
-        mockExecution.SetupGet(f => f.CanExecute).Returns(true);
-        mockExecution.SetupGet(f => f.Descriptor).Returns(mockDescriptor.Object);
-        mockExecution
-            .Setup(f => f.ExecuteAsync(It.IsAny<HttpRequest>(), It.IsAny<CancellationToken>()))
-            .Callback<HttpRequest, CancellationToken>((req, _) =>
-            {
-                req.HttpContext.Items[ScriptConstants.AzureFunctionsHttpResponseKey] =
-                    new ContentResult { Content = "response body content", StatusCode = 200 };
-            })
-            .Returns(Task.CompletedTask);
+        var mockExecution = CreateMockFunctionExecution("TestFunction", "get");
 
         using var server = new TestServer(new WebHostBuilder()
-            .ConfigureServices(services => services.AddLogging())
+            .ConfigureServices(services => { services.AddLogging(); services.AddMvcCore(); })
             .Configure(app =>
             {
                 app.Use((ctx, next) =>
@@ -158,5 +128,34 @@ public class FunctionInvocationMiddlewareTests
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         string body = await response.Content.ReadAsStringAsync();
         Assert.Equal("response body content", body);
+    }
+
+    private static Mock<IFunctionExecutionFeature> CreateMockFunctionExecution(string functionName, params string[] methods)
+    {
+        var mockDescriptor = new Mock<FunctionDescriptor>();
+        mockDescriptor.SetupGet(d => d.HttpTriggerAttribute)
+            .Returns(new HttpTriggerAttribute(AuthorizationLevel.Anonymous, methods));
+        mockDescriptor.Object.Name = functionName;
+        mockDescriptor.Object.Metadata = new FunctionMetadata { Name = functionName };
+
+        // LogCategory is a non-virtual get-only property set only by the parameterized
+        // constructor. Use reflection to set the compiler-generated backing field.
+        typeof(FunctionDescriptor)
+            .GetField("<LogCategory>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(mockDescriptor.Object, $"Function.{functionName}");
+
+        var mockExecution = new Mock<IFunctionExecutionFeature>();
+        mockExecution.SetupGet(f => f.CanExecute).Returns(true);
+        mockExecution.SetupGet(f => f.Descriptor).Returns(mockDescriptor.Object);
+        mockExecution
+            .Setup(f => f.ExecuteAsync(It.IsAny<HttpRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<HttpRequest, CancellationToken>((req, _) =>
+            {
+                req.HttpContext.Items[ScriptConstants.AzureFunctionsHttpResponseKey] =
+                    new ContentResult { Content = "response body content", StatusCode = 200 };
+            })
+            .Returns(Task.CompletedTask);
+
+        return mockExecution;
     }
 }

--- a/test/WebJobs.Script.Tests/Middleware/FunctionInvocationMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Middleware/FunctionInvocationMiddlewareTests.cs
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Features;
+using Microsoft.Azure.WebJobs.Script.WebHost.Middleware;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware;
+
+public class FunctionInvocationMiddlewareTests
+{
+    [Fact]
+    public async Task Invoke_HeadNotAllowedFeature_Returns405WithAllowHeader()
+    {
+        using var server = new TestServer(new WebHostBuilder()
+            .Configure(app =>
+            {
+                app.Use((ctx, next) =>
+                {
+                    ctx.Features.Set<IHeadNotAllowedFeature>(new HeadNotAllowedFeature("GET, POST"));
+                    return next(ctx);
+                });
+                app.UseMiddleware<FunctionInvocationMiddleware>();
+            }));
+
+        var client = server.CreateClient();
+        var request = new HttpRequestMessage(HttpMethod.Head, "/");
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+        Assert.Equal("GET, POST", response.Headers.GetValues("Allow").Single());
+    }
+
+    [Fact]
+    public async Task Invoke_HeadNotAllowedFeature_GetRequest_Returns405()
+    {
+        // 405 fires regardless of request method when the feature is set —
+        // it's the routing that determines this path, not the method.
+        using var server = new TestServer(new WebHostBuilder()
+            .Configure(app =>
+            {
+                app.Use((ctx, next) =>
+                {
+                    ctx.Features.Set<IHeadNotAllowedFeature>(new HeadNotAllowedFeature("POST"));
+                    return next(ctx);
+                });
+                app.UseMiddleware<FunctionInvocationMiddleware>();
+            }));
+
+        var client = server.CreateClient();
+        var response = await client.GetAsync("/");
+
+        Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+        Assert.Equal("POST", response.Headers.GetValues("Allow").Single());
+    }
+}

--- a/test/WebJobs.Script.Tests/Routing/ScriptRouteHandlerTests.cs
+++ b/test/WebJobs.Script.Tests/Routing/ScriptRouteHandlerTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.WebHost.Features;
 using Microsoft.Extensions.Logging;
 using Moq;

--- a/test/WebJobs.Script.Tests/Routing/ScriptRouteHandlerTests.cs
+++ b/test/WebJobs.Script.Tests/Routing/ScriptRouteHandlerTests.cs
@@ -63,4 +63,16 @@ public class ScriptRouteHandlerTests
         Assert.NotNull(feature);
         Assert.Equal("DELETE", feature.AllowedMethods);
     }
+
+    [Fact]
+    public async Task InvokeAsync_NormalFunctionName_DoesNotSetHeadNotAllowedFeature()
+    {
+        // A non-sentinel name should NOT set IHeadNotAllowedFeature.
+        var context = new DefaultHttpContext();
+
+        // Use a name that doesn't start with the sentinel prefix.
+        await _handler.InvokeAsync(context, "TestFunction");
+
+        Assert.Null(context.Features.Get<IHeadNotAllowedFeature>());
+    }
 }

--- a/test/WebJobs.Script.Tests/Routing/ScriptRouteHandlerTests.cs
+++ b/test/WebJobs.Script.Tests/Routing/ScriptRouteHandlerTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Script.WebHost.Features;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Routing;
+
+public class ScriptRouteHandlerTests
+{
+    private readonly Mock<IScriptJobHost> _mockHost;
+    private readonly ScriptRouteHandler _handler;
+
+    public ScriptRouteHandlerTests()
+    {
+        _mockHost = new Mock<IScriptJobHost>();
+        _mockHost.SetupGet(h => h.Functions).Returns(new List<FunctionDescriptor>());
+
+        _handler = new ScriptRouteHandler(
+            new LoggerFactory(),
+            _mockHost.Object,
+            SystemEnvironment.Instance,
+            isProxy: false);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_SentinelName_SetsHeadNotAllowedFeature()
+    {
+        var context = new DefaultHttpContext();
+        string sentinelName = ScriptConstants.HeadMethodNotAllowedPrefix + "GET, POST";
+
+        await _handler.InvokeAsync(context, sentinelName);
+
+        var feature = context.Features.Get<IHeadNotAllowedFeature>();
+        Assert.NotNull(feature);
+        Assert.Equal("GET, POST", feature.AllowedMethods);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_SentinelName_DoesNotSetFunctionExecutionFeature()
+    {
+        var context = new DefaultHttpContext();
+        string sentinelName = ScriptConstants.HeadMethodNotAllowedPrefix + "POST";
+
+        await _handler.InvokeAsync(context, sentinelName);
+
+        Assert.Null(context.Features.Get<IFunctionExecutionFeature>());
+    }
+
+    [Fact]
+    public async Task InvokeAsync_SentinelName_ExtractsAllowedMethodsCorrectly()
+    {
+        var context = new DefaultHttpContext();
+        await _handler.InvokeAsync(context, ScriptConstants.HeadMethodNotAllowedPrefix + "DELETE");
+
+        var feature = context.Features.Get<IHeadNotAllowedFeature>();
+        Assert.NotNull(feature);
+        Assert.Equal("DELETE", feature.AllowedMethods);
+    }
+}

--- a/test/WebJobs.Script.Tests/WebScriptHostHttpRoutesManagerTests.cs
+++ b/test/WebJobs.Script.Tests/WebScriptHostHttpRoutesManagerTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Xunit;
 
@@ -37,17 +38,17 @@ public class WebScriptHostHttpRoutesManagerTests
     [InlineData(new[] { "post" }, true)]
     [InlineData(new[] { "post", "put" }, true)]
     [InlineData(new[] { "DELETE" }, true)]
-    public void ShouldRegisterHeadNotAllowedRoute_NonGetNonHead_ReturnsTrue(string[] methods)
+    public void ShouldRegisterHeadNotAllowedRoute_NonGetNonHead_ReturnsTrue(string[] methods, bool _)
     {
         Assert.True(WebScriptHostHttpRoutesManager.ShouldRegisterHeadNotAllowedRoute(methods));
     }
 
     [Theory]
-    [InlineData(new[] { "get" })]
-    [InlineData(new[] { "head" })]
-    [InlineData(new[] { "get", "post" })]
-    [InlineData(new[] { "GET", "POST" })]
-    public void ShouldRegisterHeadNotAllowedRoute_HasGetOrHead_ReturnsFalse(string[] methods)
+    [InlineData(new[] { "get" }, false)]
+    [InlineData(new[] { "head" }, false)]
+    [InlineData(new[] { "get", "post" }, false)]
+    [InlineData(new[] { "GET", "POST" }, false)]
+    public void ShouldRegisterHeadNotAllowedRoute_HasGetOrHead_ReturnsFalse(string[] methods, bool _)
     {
         Assert.False(WebScriptHostHttpRoutesManager.ShouldRegisterHeadNotAllowedRoute(methods));
     }

--- a/test/WebJobs.Script.Tests/WebScriptHostHttpRoutesManagerTests.cs
+++ b/test/WebJobs.Script.Tests/WebScriptHostHttpRoutesManagerTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests;
+
+public class WebScriptHostHttpRoutesManagerTests
+{
+    // BuildConstraintMethods
+
+    [Theory]
+    [InlineData(new[] { "get" }, new[] { "get", "head" })]
+    [InlineData(new[] { "GET" }, new[] { "GET", "head" })]
+    [InlineData(new[] { "get", "post" }, new[] { "get", "post", "head" })]
+    [InlineData(new[] { "get", "head" }, new[] { "get", "head" })]  // no duplicate
+    [InlineData(new[] { "GET", "HEAD" }, new[] { "GET", "HEAD" })]  // case-insensitive no duplicate
+    [InlineData(new[] { "post" }, new[] { "post" })]                // no GET, unchanged
+    [InlineData(new[] { "post", "put" }, new[] { "post", "put" })]  // no GET, unchanged
+    public void BuildConstraintMethods_WithMethods_ReturnsExpected(string[] input, string[] expected)
+    {
+        string[] result = WebScriptHostHttpRoutesManager.BuildConstraintMethods(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void BuildConstraintMethods_NullMethods_ReturnsNull()
+    {
+        string[] result = WebScriptHostHttpRoutesManager.BuildConstraintMethods(null);
+        Assert.Null(result);
+    }
+
+    // ShouldRegisterHeadNotAllowedRoute
+
+    [Theory]
+    [InlineData(new[] { "post" }, true)]
+    [InlineData(new[] { "post", "put" }, true)]
+    [InlineData(new[] { "DELETE" }, true)]
+    public void ShouldRegisterHeadNotAllowedRoute_NonGetNonHead_ReturnsTrue(string[] methods)
+    {
+        Assert.True(WebScriptHostHttpRoutesManager.ShouldRegisterHeadNotAllowedRoute(methods));
+    }
+
+    [Theory]
+    [InlineData(new[] { "get" })]
+    [InlineData(new[] { "head" })]
+    [InlineData(new[] { "get", "post" })]
+    [InlineData(new[] { "GET", "POST" })]
+    public void ShouldRegisterHeadNotAllowedRoute_HasGetOrHead_ReturnsFalse(string[] methods)
+    {
+        Assert.False(WebScriptHostHttpRoutesManager.ShouldRegisterHeadNotAllowedRoute(methods));
+    }
+
+    [Fact]
+    public void ShouldRegisterHeadNotAllowedRoute_NullMethods_ReturnsFalse()
+    {
+        Assert.False(WebScriptHostHttpRoutesManager.ShouldRegisterHeadNotAllowedRoute(null));
+    }
+
+    // BuildHeadNotAllowedSentinelName
+
+    [Fact]
+    public void BuildHeadNotAllowedSentinelName_SingleMethod_FormatsCorrectly()
+    {
+        string result = WebScriptHostHttpRoutesManager.BuildHeadNotAllowedSentinelName(["post"]);
+        Assert.Equal("$head_not_allowed:POST", result);
+    }
+
+    [Fact]
+    public void BuildHeadNotAllowedSentinelName_MultipleMethods_JoinsUppercase()
+    {
+        string result = WebScriptHostHttpRoutesManager.BuildHeadNotAllowedSentinelName(["post", "put"]);
+        Assert.Equal("$head_not_allowed:POST, PUT", result);
+    }
+
+    [Fact]
+    public void BuildHeadNotAllowedSentinelName_StartsWithExpectedPrefix()
+    {
+        string result = WebScriptHostHttpRoutesManager.BuildHeadNotAllowedSentinelName(["delete"]);
+        Assert.StartsWith(ScriptConstants.HeadMethodNotAllowedPrefix, result, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
Fixes #11625

## Summary

- **GET triggers now auto-handle HEAD requests** — `HEAD /api/myFunc` no longer returns a misleading 404; it executes the GET function normally and returns the same status/headers with no body.
- **Non-GET/non-HEAD routes return 405** — `HEAD /api/postOnlyFunc` now returns `405 Method Not Allowed` with an `Allow` header listing the supported methods, instead of 404.

## Architecture (three-layer fix, host-side only)

1. **`WebScriptHostHttpRoutesManager`** — at route registration time, `"head"` is appended to the HTTP method constraint whenever `"get"` is present; a HEAD-only shadow route with a sentinel name (`$head_not_allowed:<METHODS>`) is registered for functions that accept neither GET nor HEAD.
2. **`ScriptRouteHandler`** — detects the sentinel name prefix, sets `IHeadNotAllowedFeature` on the request context, and returns immediately.
3. **`FunctionInvocationMiddleware`** — after `_next(context)` returns (which includes routing), checks for `IHeadNotAllowedFeature` to return 405 + `Allow` header; for HEAD requests that reach function execution, swaps `Response.Body` with `Stream.Null` to suppress the body while preserving status and headers.

> **Note:** The `IHeadNotAllowedFeature` check must occur *after* `_next(context)` because `ScriptRouteHandler` runs later in the ASP.NET pipeline than the middleware.

## Test Plan

- [x] Unit tests for route helper methods (BuildConstraintMethods, ShouldRegisterHeadNotAllowedRoute, BuildHeadNotAllowedSentinelName) — 23 tests
- [x] Unit tests for sentinel detection in ScriptRouteHandler — 4 tests
- [x] Unit tests for FunctionInvocationMiddleware (405 response, HEAD body suppression, GET body preservation) — 4 tests
- [x] **End-to-end integration tests** against real TestServer + Azurite — 4 tests:
  - `HEAD` on GET-only function (`HttpTrigger-Redirect`) → same status as GET, empty body
  - `HEAD` on POST-only function (`HttpTrigger-Dynamic`) → 405 + `Allow: POST`
  - `HEAD` on non-existent route → 404
  - `GET` on GET-only function → body preserved (regression check)
- [x] Build verified — solution builds with 0 errors
- [x] All 31 tests pass