### PR TITLE
Add Golang Worker NuGet package reference

### DIFF
--- a/eng/build/Workers.Golang.props
+++ b/eng/build/Workers.Golang.props
@@ -1,0 +1,7 @@
+<Project>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.GolangWorker" VersionOverride="0.1.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Changes

- Add `eng/build/Workers.Golang.props` with PackageReference to `Microsoft.Azure.Functions.GolangWorker`
- Auto-imported by the existing glob in `Workers.props`        

## Related PRs
- azure-functions-golang-worker: https://github.com/Azure/azure-functions-golang-worker/pull/15
- AAPT-Antares-Functions-Docker: ahmedmuhsin/add-golang-dockerfiles