### PR TITLE
Add feature/* branches to CI pipeline triggers

### DIFF
--- a/eng/ci/integration-tests.yml
+++ b/eng/ci/integration-tests.yml
@@ -6,6 +6,7 @@ pr:
     - dev
     - in-proc
     - release/*
+    - feature/*
 
 resources:
   repositories:

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -6,7 +6,6 @@ trigger:
     - in-proc
     - release/*
     - internal/release/*
-    - feature/*
 
 schedules:
 # Ensure we build nightly to catch any new CVEs and report SDL often.

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -6,6 +6,7 @@ trigger:
     - in-proc
     - release/*
     - internal/release/*
+    - feature/*
 
 schedules:
 # Ensure we build nightly to catch any new CVEs and report SDL often.

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -13,6 +13,7 @@ trigger:
     - dev
     - in-proc
     - release/*
+    - feature/*
 
 schedules:
   # Ensure we build nightly to catch any new CVEs and report SDL often.
@@ -30,6 +31,7 @@ pr:
     - dev
     - in-proc
     - release/*
+    - feature/*
 
 resources:
   repositories:


### PR DESCRIPTION
### Issue describing the changes in this PR

Enable CI pipeline coverage for `feature/*` branches so long-lived feature branches (e.g., `feature/compute_separation`) get the same CI validation as `dev`.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
* [x] My changes **do not** require documentation changes
* [x] My changes **should not** be added to the release notes for the next release
* [x] My changes **do not** need to be backported to a previous version
* [x] My changes **do not** require diagnostic events changes
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

Adds `feature/*` to branch includes in:
- `eng/ci/public-build.yml` — trigger + PR validation
- `eng/ci/official-build.yml` — trigger (CI only, no PR)
- `eng/ci/integration-tests.yml` — PR validation