### PR TITLE
Update Python Worker Version to 4.44.0

### DIFF
--- a/eng/build/Workers.Python.props
+++ b/eng/build/Workers.Python.props
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <!-- Python worker does not ship with the host for windows. -->
-    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" VersionOverride="4.43.0" Condition="!$(RuntimeIdentifier.StartsWith('win'))" />
+    <PackageReference Include="Microsoft.Azure.Functions.PythonWorker" VersionOverride="4.44.0" Condition="!$(RuntimeIdentifier.StartsWith('win'))" />
   </ItemGroup>
 
 </Project>

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,3 +6,4 @@
 - Refactor functions worker runtime retrieval to use `IWorkerRuntimeResolver` abstraction (#11511)
 - Suppress EventHub and Storage queue trigger polling noise from telemetry (#11603)
 - Add check for empty worker tag propagation to improve performance (#11656)
+- Update Python Worker Version to [4.44.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.44.0) (#11668)


### PR DESCRIPTION
### Issue describing the changes in this PR

Update Python Worker Version to 4.44.0

Python Worker Release note [4.44.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.44.0)

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the in-proc branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the in-proc branch is not required
    * [ ]Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to 
elease_notes.md
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
