### PR TITLE
Update abstractions pipeline

### DIFF
--- a/eng/ci/templates/official/pipelines/release.yml
+++ b/eng/ci/templates/official/pipelines/release.yml
@@ -6,6 +6,11 @@ parameters:
 - name: public
   type: boolean
   default: false
+- name: packages
+  type: string
+  default: |
+    **/*.nupkg
+    !**/*.symbols.nupkg
 
 stages:
 - stage: Validate
@@ -51,9 +56,7 @@ stages:
       approvers: '[internal]\Azure Functions Core'
       artifact: drop_packages
       stagingFeed: public/pre-release
-      packages: |
-        **/*.nupkg
-        !**/*.symbols.nupkg
+      packages: ${{ parameters.packages }}
       ${{ if eq(parameters.public, true) }}:
         partnerDrop:
           serviceConnection: azure-sdk-partner-drops

--- a/eng/ci/webjobs-script-abstractions-release.yml
+++ b/eng/ci/webjobs-script-abstractions-release.yml
@@ -39,6 +39,9 @@ extends:
       parameters:
         public: ${{ parameters.public }}
         folder: azure-webjobs-script-abstractions
+        packages: |
+          **/*Abstractions*.nupkg
+          !**/*.symbols.nupkg
         downloadSteps:
         - task: DownloadPipelineArtifact@2
           displayName: Download Abstractions packages from host.official

--- a/eng/ci/webjobs-script-abstractions-release.yml
+++ b/eng/ci/webjobs-script-abstractions-release.yml
@@ -20,6 +20,7 @@ resources:
   pipelines:
   - pipeline: OfficialBuild
     source: host.official
+    branch: release
 
 variables:
 - template: /eng/ci/templates/variables/build.yml@self
@@ -48,7 +49,5 @@ extends:
             buildVersionToDownload: specific
             runId: $(resources.pipeline.OfficialBuild.runID)
             artifact: drop_nuget
-            patterns: |
-              **/*Abstractions*.nupkg
-              !**/*.symbols.nupkg
+            patterns: '**/*Abstractions*.nupkg'
             path: $(Build.ArtifactStagingDirectory)/packages

--- a/eng/ci/webjobs-script-abstractions-release.yml
+++ b/eng/ci/webjobs-script-abstractions-release.yml
@@ -20,7 +20,6 @@ resources:
   pipelines:
   - pipeline: OfficialBuild
     source: host.official
-    branch: release
 
 variables:
 - template: /eng/ci/templates/variables/build.yml@self
@@ -43,6 +42,15 @@ extends:
           **/*Abstractions*.nupkg
           !**/*.symbols.nupkg
         downloadSteps:
+        - pwsh: |
+            $branch = "$(resources.pipeline.OfficialBuild.sourceBranch)"
+            Write-Host "OfficialBuild source branch: $branch"
+            if (!($branch -like "refs/heads/release/*" -or $branch -like "refs/heads/internal/release/*" -or $branch -like "refs/tags/*-v*" -or $branch -like "refs/tags/v*"))
+            {
+              Write-Host "##vso[task.logissue type=error]Selected host.official run is from branch '$branch'. Only runs from release branches (release/*, internal/release/*) or release tags (*-v*, v*) produce stable packages."
+              exit 1
+            }
+          displayName: Validate OfficialBuild source branch
         - task: DownloadPipelineArtifact@2
           displayName: Download Abstractions packages from host.official
           inputs:

--- a/eng/ci/webjobs-script-abstractions-release.yml
+++ b/eng/ci/webjobs-script-abstractions-release.yml
@@ -52,5 +52,7 @@ extends:
             buildVersionToDownload: specific
             runId: $(resources.pipeline.OfficialBuild.runID)
             artifact: drop_nuget
-            patterns: '**/*Abstractions*.nupkg'
+            patterns: |
+              **/*Abstractions*.nupkg
+              !**/*.symbols.nupkg
             path: $(Build.ArtifactStagingDirectory)/packages


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Need to download from release branch, otherwise there will always be a `-preview` suffix attached to the abstractions package (since it is built from `host.official`). Also updated to filter packages at the release stage in addition to existing filter at download stage.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional Information

- [Example run](https://dev.azure.com/azfunc/internal/_build/results?buildId=268670&view=logs&j=cf8b9a3d-f8c6-5e54-3882-2b528c4fcabe&t=8de9c44f-e188-59ff-9204-cdf44b456af6).
