### PR TITLE
Fixing custom worker specialization flow (hotfix cherry-pick of #11678)

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,3 +7,4 @@
 - Suppress EventHub and Storage queue trigger polling noise from telemetry (#11603)
 - Add check for empty worker tag propagation to improve performance (#11656)
 - Update Python Worker Version to [4.44.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.44.0) (#11668)
+- Fixed an issue where custom handler apps with extension bundles would fail to load binding types after specialization (#11676)

--- a/sample/CustomHandler/EventHubTriggerFunction/function.json
+++ b/sample/CustomHandler/EventHubTriggerFunction/function.json
@@ -1,0 +1,12 @@
+{
+  "bindings": [
+    {
+      "type": "eventHubTrigger",
+      "name": "event",
+      "direction": "in",
+      "connection": "EventHubConnection",
+      "eventHubName": "test-hub",
+      "consumerGroup": "$Default"
+    }
+  ]
+}

--- a/sample/CustomHandler/ServiceBusTriggerFunction/function.json
+++ b/sample/CustomHandler/ServiceBusTriggerFunction/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "type": "serviceBusTrigger",
+      "name": "trigger",
+      "direction": "in",
+      "queueName": "test-queue"
+    }
+  ]
+}

--- a/sample/CustomHandler/host.json
+++ b/sample/CustomHandler/host.json
@@ -1,5 +1,9 @@
 {
   "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  },
   "customHandler": {
     "enableForwardingHttpRequest": true,
     "description": {

--- a/src/WebJobs.Script/Host/FunctionMetadataManager.cs
+++ b/src/WebJobs.Script/Host/FunctionMetadataManager.cs
@@ -36,6 +36,11 @@ namespace Microsoft.Azure.WebJobs.Script
         private Dictionary<string, ICollection<string>> _functionErrors = new Dictionary<string, ICollection<string>>();
         private ConcurrentDictionary<string, FunctionMetadata> _functionMetadataMap = new ConcurrentDictionary<string, FunctionMetadata>(StringComparer.OrdinalIgnoreCase);
 
+        // Some services are pulled from the ScriptHost when it is built. But it can also be shut down and there are periods
+        // where metadata is retrieved without any active host. Some checks in this class need to know this to know whether it can
+        // trust the services it is using.
+        private bool _scriptHostInitialized = false;
+
         public FunctionMetadataManager(
             IOptions<ScriptJobHostOptions> scriptOptions,
             IFunctionMetadataProvider functionMetadataProvider,
@@ -61,7 +66,12 @@ namespace Microsoft.Azure.WebJobs.Script
             {
                 if (e.NewHost is not null)
                 {
+                    _scriptHostInitialized = true;
                     InitializeServices();
+                }
+                else
+                {
+                    _scriptHostInitialized = false;
                 }
             };
         }
@@ -196,7 +206,9 @@ namespace Microsoft.Azure.WebJobs.Script
 
         internal bool IsScriptFileDetermined(FunctionMetadata functionMetadata)
         {
-            if (string.IsNullOrEmpty(functionMetadata.ScriptFile) && !_metadataOptions.Value.SkipScriptFileValidation && !functionMetadata.IsProxy() && _servicesReset)
+            // If we do not have an initialized scriptHost, we cannot trust the _metadataOptions, so simply return true. This happens during bundle evaluation, for example, when
+            // we do not yet have a built scriptHost.
+            if (_scriptHostInitialized && string.IsNullOrEmpty(functionMetadata.ScriptFile) && !_metadataOptions.Value.SkipScriptFileValidation && !functionMetadata.IsProxy() && _servicesReset)
             {
                 // for functions in error, log the error and don't
                 // add to the functions collection

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         private static readonly string _dotnetIsolatedEmptyScriptRoot = Path.GetFullPath(@"..\..\..\..\EmptyScriptRoot");
         private static readonly string _dotnetCustomHandlerPath = Path.GetFullPath($@"..\..\DotNetCustomHandler\{TestHelpers.BuildConfig}");
         private static readonly string _dotnetIsolatedWithBundlesPath = Path.GetFullPath($@"..\..\DotNetIsolatedWithBundles\{TestHelpers.BuildConfig}");
+        private static readonly string _customHandlerWithBundlesPath = Path.GetFullPath(@"..\..\..\..\sample\CustomHandler");
 
         private static Action<IServiceCollection> _customizeScriptHostServices;
 
@@ -1036,6 +1037,71 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             // This is not really a valid scenario, but we need to ensure it keeps working. Customers should not use
             // bundles with dotnet-isolated.
             AssertLanguageWorkerOptionsSetupCount(4);
+        }
+
+        /// <summary>
+        /// Regression test for https://github.com/Azure/azure-functions-host/issues/11676.        
+        /// </summary>
+        [Fact]
+        public async Task Specialization_DotNetIsolatedToCustomHandler_BundleExtensionsLoadCorrectly()
+        {
+            // Forces download of bundles.            
+            string downloadPath = $"{ConfigurationSectionNames.JobHost}__{ConfigurationSectionNames.ExtensionBundle}__DownloadPath";
+            using var path = new TestScopedEnvironmentVariable(downloadPath, Path.Combine(Path.GetTempPath(), "BundlesTests"));
+            using var coreTools = new TestScopedEnvironmentVariable(EnvironmentSettingNames.CoreToolsEnvironment, "1");
+
+            // Start in placeholder mode as dotnet-isolated
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, "dotnet-isolated");
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagEnableWorkerIndexing);
+
+            var builder = CreateStandbyHostBuilder(_loggerProvider, "HttpTrigger", "ServiceBusTriggerFunction", "EventHubTriggerFunction");
+
+            // Override the specialized script root to point to our custom handler app with bundles
+            builder.ConfigureAppConfiguration(config =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { _scriptRootConfigPath, _customHandlerWithBundlesPath },
+                });
+            });
+
+            using var testServer = new TestServer(builder);
+            var client = testServer.CreateClient();
+
+            // Warm up the placeholder
+            var response = await client.GetAsync("api/warmup");
+            Assert.True(response.IsSuccessStatusCode, _loggerProvider.GetLog());
+
+            // Specialize into a custom handler app
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, "custom");
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+
+
+            // Issue a request to trigger specialization. The custom handler won't respond, but
+            // this forces the host through the full specialization + extension loading flow.
+            response = await client.GetAsync("api/warmup");
+
+            // Wait for the host to settle after specialization
+            await TestHelpers.Await(() =>
+                    {
+                        var log = _loggerProvider.GetLog();
+                        // Wait until we see evidence that the specialized host has started
+                        return log.Contains("Host started") || log.Contains("function is in error") || log.Contains("No job functions found");
+                    }, timeout: 30000);
+
+            var log = _loggerProvider.GetLog();
+
+            // Verify the specialized host found our custom handler functions.
+            Assert.Contains("3 functions found (Host)", log);
+
+            // The critical check: after IsScriptFileDetermined runs, functions must NOT be excluded.
+            // With the bug, we'd see "0 functions loaded" from the ScriptStartupTypeLocator call
+            // because IsScriptFileDetermined excludes custom handler functions (no scriptFile).
+            Assert.DoesNotContain("0 functions loaded", log);
+
+            // The binding types from function.json must NOT be missing from the extension bundle.
+            Assert.DoesNotContain("were not found in the configured extension bundle", log);
         }
 
         [Theory]

--- a/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
+++ b/test/WebJobs.Script.Tests/FunctionMetadataManagerTests.cs
@@ -7,7 +7,6 @@ using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Workers.Http;
@@ -584,6 +583,64 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 WorkerConfigs = TestHelpers.GetTestWorkerConfigs()
             };
+        }
+
+        /// <summary>
+        /// Regression test for https://github.com/Azure/azure-functions-host/issues/11676.
+        /// </summary>
+        [Fact]
+        public void LoadFunctionMetadata_AfterActiveHostChanged_CustomHandlerFunctionsWithNoScriptFile_AreNotExcluded()
+        {
+            // Arrange: create functions with trigger bindings but NO scriptFile (custom handler pattern)
+            var functionMetadataCollection = new Collection<FunctionMetadata>();
+
+            var eventHubFunction = new FunctionMetadata { Name = "event_hub_producer" };
+            eventHubFunction.Bindings.Add(new BindingMetadata { Type = "eventHubTrigger", Direction = BindingDirection.In });
+            // ScriptFile is intentionally null — custom handlers don't have one
+            functionMetadataCollection.Add(eventHubFunction);
+
+            var serviceBusFunction = new FunctionMetadata { Name = "failed_event_handler" };
+            serviceBusFunction.Bindings.Add(new BindingMetadata { Type = "serviceBusTrigger", Direction = BindingDirection.In });
+            functionMetadataCollection.Add(serviceBusFunction);
+
+            var mockFunctionErrors = new Dictionary<string, ICollection<string>>()
+                .ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.ToImmutableArray());
+            var mockFunctionMetadataProvider = new Mock<IFunctionMetadataProvider>();
+            mockFunctionMetadataProvider
+                .Setup(m => m.GetFunctionMetadataAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), It.IsAny<bool>()))
+                .Returns(Task.FromResult(functionMetadataCollection.ToImmutableArray()));
+            mockFunctionMetadataProvider
+                .Setup(m => m.FunctionErrors).Returns(mockFunctionErrors);
+
+            var managerMock = new Mock<IScriptHostManager>();
+
+            // Key: SkipScriptFileValidation = false, simulating the placeholder host
+            // (which never registered RpcFunctionMetadataOptionsSetup)
+            FunctionMetadataManager testManager = TestFunctionMetadataManager.GetFunctionMetadataManager(
+                new OptionsWrapper<ScriptJobHostOptions>(_scriptJobHostOptions),
+                managerMock,
+                mockFunctionMetadataProvider.Object,
+                new List<IFunctionProvider>(),
+                MockNullLoggerFactory.CreateLoggerFactory(),
+                new TestOptionsMonitor<LanguageWorkerOptions>(TestHelpers.GetTestLanguageWorkerOptions()));
+
+            // Simulate placeholder host build completing: ActiveHostChanged fires with non-null host
+            managerMock.Raise(m => m.ActiveHostChanged += null, new ActiveHostChangedEventArgs(null, new Mock<IHost>().Object));
+
+            // Simulate host teardown before specialization: ActiveHostChanged fires with null host
+            // This sets _scriptHostInitialized = false, so IsScriptFileDetermined won't enforce scriptFile validation
+            managerMock.Raise(m => m.ActiveHostChanged += null, new ActiveHostChangedEventArgs(new Mock<IHost>().Object, null));
+
+            // Act: this is what ScriptStartupTypeLocator calls during the specialization build
+            var result = testManager.LoadFunctionMetadata(forceRefresh: true, includeCustomProviders: false);
+
+            // Assert: both functions should be loaded despite having no scriptFile.
+            // The bindings (eventHubTrigger, serviceBusTrigger) must be present for
+            // ScriptStartupTypeLocator to include the correct bundle extensions.
+            Assert.Equal(2, result.Length);
+            Assert.Contains(result, f => string.Equals(f.Name, "event_hub_producer", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(result, f => string.Equals(f.Name, "failed_event_handler", StringComparison.OrdinalIgnoreCase));
+            Assert.Empty(testManager.Errors);
         }
 
         private static FunctionMetadata GetTestFunctionMetadata(string scriptFile, string name = "testFunction")


### PR DESCRIPTION
hotfix cherry-pick of #11678

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)
