### PR TITLE
Add container mode: Aspire harness runs all components in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# ── ComputeSeparation Docker ignore ──────────────────────────────────────────
+# Keeps the build context lean when building container images via Aspire.
+.git
+.vs
+.vscode
+out/
+test/
+sample/
+*.sln
+**/*.user
+**/bin/
+**/obj/

--- a/src/Functions.WorkerProxy/Dockerfile
+++ b/src/Functions.WorkerProxy/Dockerfile
@@ -1,0 +1,13 @@
+# Functions.WorkerProxy (gRPC relay + HTTP proxy)
+# Build context: repository root
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /repo
+COPY . .
+RUN dotnet publish src/Functions.WorkerProxy/Functions.WorkerProxy.csproj \
+    -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
+WORKDIR /app
+COPY --from=build /app/publish .
+EXPOSE 50051 50052 50053
+ENTRYPOINT ["dotnet", "Microsoft.Azure.Functions.WorkerProxy.dll"]

--- a/src/Functions.WorkerProxy/FunctionRpcRelay.cs
+++ b/src/Functions.WorkerProxy/FunctionRpcRelay.cs
@@ -14,7 +14,13 @@ namespace Microsoft.Azure.Functions.WorkerProxy;
 /// <param name="WorkerGrpcPort">Port the language worker connects to.</param>
 /// <param name="HttpProxyPort">Port the HTTP proxy listens on (rewritten into HttpUri capability).</param>
 /// <param name="HostJsonPath">Optional path to a host.json to inject into WorkerInitResponse capabilities.</param>
-internal record RelayOptions(int RuntimeGrpcPort, int WorkerGrpcPort, int HttpProxyPort, string? HostJsonPath);
+/// <param name="HttpProxyEndpoint">
+/// Full URL advertised in the <c>HttpUri</c> capability so the runtime routes HTTP
+/// requests through this proxy. Defaults to <c>http://localhost:{HttpProxyPort}</c>;
+/// override when running in containers where <c>localhost</c> is not reachable across
+/// container boundaries.
+/// </param>
+internal record RelayOptions(int RuntimeGrpcPort, int WorkerGrpcPort, int HttpProxyPort, string? HostJsonPath, string HttpProxyEndpoint);
 
 /// <summary>
 /// Relays <see cref="StreamingMessage"/> payloads bidirectionally between the
@@ -124,13 +130,12 @@ internal sealed class FunctionRpcRelay : FunctionRpc.FunctionRpcBase
                         _logger.LogInformation("Injected host.json into WorkerInitResponse capabilities");
                     }
 
-                    // Rewrite HttpUri to point at the proxy's HTTP port so the runtime
+                    // Rewrite HttpUri to point at the proxy's HTTP endpoint so the runtime
                     // routes HTTP requests through the proxy rather than directly to the worker.
                     if (message.WorkerInitResponse.Capabilities.ContainsKey("HttpUri"))
                     {
-                        string proxyHttpUri = $"http://localhost:{_options.HttpProxyPort}";
-                        message.WorkerInitResponse.Capabilities["HttpUri"] = proxyHttpUri;
-                        _logger.LogInformation("Rewrote HttpUri capability to {Uri}", proxyHttpUri);
+                        message.WorkerInitResponse.Capabilities["HttpUri"] = _options.HttpProxyEndpoint;
+                        _logger.LogInformation("Rewrote HttpUri capability to {Uri}", _options.HttpProxyEndpoint);
                     }
                 }
 

--- a/src/Functions.WorkerProxy/Program.cs
+++ b/src/Functions.WorkerProxy/Program.cs
@@ -16,8 +16,9 @@ int workerGrpcPort = GetIntArg(args, "--worker-grpc-port", 50052);
 int httpProxyPort = GetIntArg(args, "--http-proxy-port", 50053);
 string workerHttpEndpoint = GetStringArg(args, "--worker-http-endpoint", "http://localhost:8080");
 string? hostJsonPath = GetStringArgOrNull(args, "--host-json-path");
+string httpProxyEndpoint = GetStringArg(args, "--http-proxy-endpoint", $"http://localhost:{httpProxyPort}");
 
-builder.Services.AddSingleton(new RelayOptions(runtimeGrpcPort, workerGrpcPort, httpProxyPort, hostJsonPath));
+builder.Services.AddSingleton(new RelayOptions(runtimeGrpcPort, workerGrpcPort, httpProxyPort, hostJsonPath, httpProxyEndpoint));
 builder.Services.AddSingleton<FunctionRpcRelay>();
 builder.Services.AddGrpc();
 builder.Services.AddHttpForwarder();

--- a/src/WebJobs.Script.WebHost/Dockerfile
+++ b/src/WebJobs.Script.WebHost/Dockerfile
@@ -1,0 +1,13 @@
+# WebJobs.Script.WebHost (Functions Runtime)
+# Build context: repository root
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /repo
+COPY . .
+RUN dotnet publish src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj \
+    -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
+WORKDIR /app
+COPY --from=build /app/publish .
+EXPOSE 7071
+ENTRYPOINT ["dotnet", "Microsoft.Azure.WebJobs.Script.WebHost.dll"]

--- a/tools/ComputeSeparation/AppHost/AppHost.csproj
+++ b/tools/ComputeSeparation/AppHost/AppHost.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting" Version="13.2.0" />
     <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.2.0" />
+    <PackageReference Include="Aspire.Hosting.Docker" Version="13.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/ComputeSeparation/AppHost/Program.cs
+++ b/tools/ComputeSeparation/AppHost/Program.cs
@@ -3,19 +3,23 @@
 //   1. Worker Proxy  – gRPC relay + HTTP proxy
 //   2. MockWorker – minimal gRPC worker
 //   3. Runtime  – Azure Functions host (WebJobs.Script.WebHost)
+//
+// Set the "UseContainers" configuration key (or USE_CONTAINERS env var) to "true"
+// to run all components as Docker containers instead of local projects.
+
+using Aspire.Hosting.Azure;
 
 var builder = DistributedApplication.CreateBuilder(args);
+
+bool useContainers = string.Equals(
+    builder.Configuration["UseContainers"], "true", StringComparison.OrdinalIgnoreCase);
 
 // --- Ports ---
 const int runtimeGrpcPort = 50051;
 const int workerGrpcPort = 50052;
 const int httpProxyPort = 50053;
 const int runtimePort = 7071;
-
-// --- Formatted endpoint strings ---
-string runtimeGrpcEndpoint = $"http://localhost:{runtimeGrpcPort}";
-string workerGrpcEndpoint = $"http://localhost:{workerGrpcPort}";
-string runtimeUrl = $"http://localhost:{runtimePort}";
+const int mockWorkerHttpPort = 8080;
 
 // Well-known Azurite storage emulator account key.
 // https://learn.microsoft.com/azure/storage/common/storage-use-azurite#well-known-storage-account-and-key
@@ -24,41 +28,130 @@ const string AzuriteAccountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IF
 var storage = builder.AddAzureStorage("storage")
     .RunAsEmulator();
 
-
-// --- Runtime ---
-// Note: Aspire's AddAzureFunctionsProject handles AzureWebJobsStorage injection
-// automatically via WithHostStorage. Since we use AddProject (the runtime isn't a
-// standard Functions project from Aspire's perspective), we wire it manually.
-// The emulator connection string is injected after the storage emulator starts.
-var runtime = builder.AddProject<Projects.WebJobs_Script_WebHost>("runtime")
-    .WithHttpEndpoint(runtimePort, runtimePort, name: "functions-http", isProxied: false)
-    .WithEnvironment("FUNCTIONS_WORKER_EXTERNAL_ENABLED", "true")
-    .WithEnvironment("FUNCTIONS_WORKER_EXTERNAL_GRPC_ENDPOINT", runtimeGrpcEndpoint)
-    .WithEnvironment("FUNCTIONS_WORKER_RUNTIME", "node")
-    .WithEnvironment("AZURE_FUNCTIONS_ENVIRONMENT", "Development")
-    .WithEnvironment("ASPNETCORE_URLS", runtimeUrl)
-    .WithEnvironment(context =>
-    {
-        var blob = storage.GetEndpoint("blob");
-        var queue = storage.GetEndpoint("queue");
-        var table = storage.GetEndpoint("table");
-        context.EnvironmentVariables["AzureWebJobsStorage"] =
-            ReferenceExpression.Create(
-                $"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey={AzuriteAccountKey};BlobEndpoint={blob.Property(EndpointProperty.Url)}/devstoreaccount1;QueueEndpoint={queue.Property(EndpointProperty.Url)}/devstoreaccount1;TableEndpoint={table.Property(EndpointProperty.Url)}/devstoreaccount1;");
-    })
-    .WaitFor(storage);
-
-// --- Worker Proxy ---
-var workerProxy = builder.AddProject<Projects.Functions_WorkerProxy>("worker-proxy")
-    .WithArgs(
-        "--runtime-grpc-port", runtimeGrpcPort.ToString(),
-        "--worker-grpc-port", workerGrpcPort.ToString(),
-        "--http-proxy-port", httpProxyPort.ToString())
-    .WaitFor(runtime);
-
-// --- Mock Worker ---
-var mockWorker = builder.AddProject<Projects.MockWorker>("mock-worker")
-    .WithArgs("--grpc-endpoint", workerGrpcEndpoint)
-    .WaitFor(workerProxy);
+if (useContainers)
+{
+    AddContainerResources(builder, storage);
+}
+else
+{
+    AddProjectResources(builder, storage);
+}
 
 builder.Build().Run();
+
+
+/// <summary>
+/// Project mode – runs every component as a local .NET project (default).
+/// </summary>
+static void AddProjectResources(
+    IDistributedApplicationBuilder builder,
+    IResourceBuilder<AzureStorageResource> storage)
+{
+    string runtimeGrpcEndpoint = $"http://localhost:{runtimeGrpcPort}";
+    string workerGrpcEndpoint = $"http://localhost:{workerGrpcPort}";
+    string runtimeUrl = $"http://localhost:{runtimePort}";
+
+    var runtime = builder.AddProject<Projects.WebJobs_Script_WebHost>("runtime")
+        .WithHttpEndpoint(runtimePort, runtimePort, name: "functions-http", isProxied: false)
+        .WithEnvironment("FUNCTIONS_WORKER_EXTERNAL_ENABLED", "true")
+        .WithEnvironment("FUNCTIONS_WORKER_EXTERNAL_GRPC_ENDPOINT", runtimeGrpcEndpoint)
+        .WithEnvironment("FUNCTIONS_WORKER_RUNTIME", "node")
+        .WithEnvironment("AZURE_FUNCTIONS_ENVIRONMENT", "Development")
+        .WithEnvironment("ASPNETCORE_URLS", runtimeUrl)
+        .WithEnvironment(context =>
+        {
+            ConfigureStorageConnectionString(context, storage);
+        })
+        .WaitFor(storage);
+
+    var workerProxy = builder.AddProject<Projects.Functions_WorkerProxy>("worker-proxy")
+        .WithArgs(
+            "--runtime-grpc-port", runtimeGrpcPort.ToString(),
+            "--worker-grpc-port", workerGrpcPort.ToString(),
+            "--http-proxy-port", httpProxyPort.ToString())
+        .WaitFor(runtime);
+
+    var mockWorker = builder.AddProject<Projects.MockWorker>("mock-worker")
+        .WithArgs("--grpc-endpoint", workerGrpcEndpoint)
+        .WaitFor(workerProxy);
+}
+
+/// <summary>
+/// Container mode – builds Docker images for each component and runs them.
+/// Aspire manages a shared Docker network so containers can address each other
+/// by resource name rather than localhost.
+/// </summary>
+static void AddContainerResources(
+    IDistributedApplicationBuilder builder,
+    IResourceBuilder<AzureStorageResource> storage)
+{
+    // Build context is the repository root (relative to the AppHost project directory).
+    string repoRoot = Path.GetFullPath(Path.Combine(builder.AppHostDirectory, "..", "..", ".."));
+
+    // --- Worker Proxy (container) ---
+    var workerProxy = builder.AddDockerfile("worker-proxy", repoRoot, "src/Functions.WorkerProxy/Dockerfile")
+        .WithEndpoint(targetPort: runtimeGrpcPort, name: "proxy-runtime-grpc", scheme: "http")
+        .WithEndpoint(targetPort: workerGrpcPort, name: "proxy-worker-grpc", scheme: "http")
+        .WithEndpoint(targetPort: httpProxyPort, name: "http-proxy", scheme: "http")
+        .WithArgs(
+            "--runtime-grpc-port", runtimeGrpcPort.ToString(),
+            "--worker-grpc-port", workerGrpcPort.ToString(),
+            "--http-proxy-port", httpProxyPort.ToString());
+
+    // Tell the proxy its externally-reachable HTTP proxy URL (used in the HttpUri
+    // capability rewrite) and the mock worker's HTTP endpoint for reverse-proxying.
+    var proxyHttpEndpoint = workerProxy.GetEndpoint("http-proxy");
+
+    // --- Mock Worker (container) ---
+    var mockWorker = builder.AddDockerfile("mock-worker", repoRoot, "tools/ComputeSeparation/MockWorker/Dockerfile")
+        .WithEndpoint(targetPort: mockWorkerHttpPort, name: "mock-http", scheme: "http")
+        .WithEnvironment(context =>
+        {
+            var grpcEndpoint = workerProxy.GetEndpoint("proxy-worker-grpc");
+            context.EnvironmentVariables["FUNCTIONS_GRPC_HOST"] = grpcEndpoint.Property(EndpointProperty.Host);
+            context.EnvironmentVariables["FUNCTIONS_GRPC_PORT"] = grpcEndpoint.Property(EndpointProperty.Port);
+        })
+        .WaitFor(workerProxy);
+
+    // Wire proxy env vars that depend on mock-worker being defined.
+    var mockWorkerHttpEndpoint = mockWorker.GetEndpoint("mock-http");
+    workerProxy
+        .WithEnvironment(context =>
+        {
+            context.EnvironmentVariables["WORKER_HTTP_ENDPOINT"] = mockWorkerHttpEndpoint.Property(EndpointProperty.Url);
+            context.EnvironmentVariables["HTTP_PROXY_ENDPOINT"] = proxyHttpEndpoint.Property(EndpointProperty.Url);
+        });
+
+    // --- Runtime (container) ---
+    var runtime = builder.AddDockerfile("runtime", repoRoot, "src/WebJobs.Script.WebHost/Dockerfile")
+        .WithHttpEndpoint(runtimePort, runtimePort, name: "functions-http")
+        .WithEnvironment("FUNCTIONS_WORKER_EXTERNAL_ENABLED", "true")
+        .WithEnvironment(context =>
+        {
+            var runtimeGrpc = workerProxy.GetEndpoint("proxy-runtime-grpc");
+            context.EnvironmentVariables["FUNCTIONS_WORKER_EXTERNAL_GRPC_ENDPOINT"] = runtimeGrpc.Property(EndpointProperty.Url);
+        })
+        .WithEnvironment("FUNCTIONS_WORKER_RUNTIME", "node")
+        .WithEnvironment("AZURE_FUNCTIONS_ENVIRONMENT", "Development")
+        .WithEnvironment("ASPNETCORE_URLS", $"http://+:{runtimePort.ToString()}")
+        .WithEnvironment(context =>
+        {
+            ConfigureStorageConnectionString(context, storage);
+        })
+        .WaitFor(storage);
+
+    workerProxy.WaitFor(runtime);
+    mockWorker.WaitFor(workerProxy);
+}
+
+static void ConfigureStorageConnectionString(
+    EnvironmentCallbackContext context,
+    IResourceBuilder<AzureStorageResource> storage)
+{
+    var blob = storage.GetEndpoint("blob");
+    var queue = storage.GetEndpoint("queue");
+    var table = storage.GetEndpoint("table");
+    context.EnvironmentVariables["AzureWebJobsStorage"] =
+        ReferenceExpression.Create(
+            $"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey={AzuriteAccountKey};BlobEndpoint={blob.Property(EndpointProperty.Url)}/devstoreaccount1;QueueEndpoint={queue.Property(EndpointProperty.Url)}/devstoreaccount1;TableEndpoint={table.Property(EndpointProperty.Url)}/devstoreaccount1;");
+}

--- a/tools/ComputeSeparation/AppHost/Properties/launchSettings.json
+++ b/tools/ComputeSeparation/AppHost/Properties/launchSettings.json
@@ -24,6 +24,19 @@
         "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16888",
         "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
       }
+    },
+    "containers": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15060",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16888",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
+        "UseContainers": "true"
+      }
     }
   }
 }

--- a/tools/ComputeSeparation/MockWorker/Dockerfile
+++ b/tools/ComputeSeparation/MockWorker/Dockerfile
@@ -1,0 +1,13 @@
+# MockWorker (minimal gRPC language worker)
+# Build context: repository root
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /repo
+COPY . .
+RUN dotnet publish tools/ComputeSeparation/MockWorker/MockWorker.csproj \
+    -c Release -o /app/publish
+
+FROM mcr.microsoft.com/dotnet/runtime:8.0
+WORKDIR /app
+COPY --from=build /app/publish .
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "MockWorker.dll"]

--- a/tools/ComputeSeparation/README.md
+++ b/tools/ComputeSeparation/README.md
@@ -32,7 +32,7 @@ graph LR
 ## Prerequisites
 
 - .NET SDK 8.0 (see `global.json`)
-- Docker (for the Azurite storage emulator container)
+- Docker (for the Azurite storage emulator container; also required for container mode)
 
 ## Quick Start
 
@@ -52,6 +52,24 @@ curl http://localhost:7071/api/HttpTrigger
 ```
 
 The Aspire dashboard is available at `http://localhost:15888` with logs and traces for all three processes.
+
+### Container Mode
+
+To run all components as Docker containers instead of local projects, use the
+**containers** launch profile or set `UseContainers=true`:
+
+```powershell
+# Via launch profile
+dotnet run --project tools/ComputeSeparation/AppHost/AppHost.csproj --launch-profile containers
+
+# Via environment variable
+$env:UseContainers = "true"
+dotnet run --project tools/ComputeSeparation/AppHost/AppHost.csproj
+```
+
+Aspire builds Dockerfiles for each component, creates a shared Docker network,
+and resolves endpoint references automatically — containers address each other by
+resource name rather than `localhost`.
 
 ## E2E Integration Test
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

This pull request adds support for running the ComputeSeparation Aspire sample in two modes: as local .NET projects (the default) or as Docker containers for each component. It introduces Dockerfiles for all major components, updates the orchestration logic to support both modes, and provides documentation and launch profile updates for easy switching. Additionally, it enhances configuration flexibility for cross-container networking.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)