### PR TITLE
Log enum name instead of integer for TimerTriggerPlatformOptions

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,10 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+-->
+- Refactor functions worker runtime retrieval to use `IWorkerRuntimeResolver` abstraction (#11511)
+- Suppress EventHub and Storage queue trigger polling noise from telemetry (#11603)
+- Add check for empty worker tag propagation to improve performance (#11656)
+- Update Python Worker Version to [4.44.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.44.0) (#11668)
+- Fixed an issue where custom handler apps with extension bundles would fail to load binding types after specialization (#11676)
+- Log enum names instead of integers in options formatting for `TimerTriggerPlatformOptions` (#11689)

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,10 +3,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
--->
-- Refactor functions worker runtime retrieval to use `IWorkerRuntimeResolver` abstraction (#11511)
-- Suppress EventHub and Storage queue trigger polling noise from telemetry (#11603)
-- Add check for empty worker tag propagation to improve performance (#11656)
-- Update Python Worker Version to [4.44.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.44.0) (#11668)
-- Fixed an issue where custom handler apps with extension bundles would fail to load binding types after specialization (#11676)
 - Log enum names instead of integers in options formatting for `TimerTriggerPlatformOptions` (#11689)

--- a/src/WebJobs.Script/Config/TimerTriggerPlatformOptions.cs
+++ b/src/WebJobs.Script/Config/TimerTriggerPlatformOptions.cs
@@ -25,6 +25,6 @@ public sealed class TimerTriggerPlatformOptions : IOptionsFormatter
     }
 }
 
-[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Serialization, WriteIndented = true)]
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Serialization, WriteIndented = true, UseStringEnumConverter = true)]
 [JsonSerializable(typeof(TimerTriggerPlatformOptions))]
 internal partial class TimerTriggerPlatformOptionsJsonContext : JsonSerializerContext;

--- a/test/WebJobs.Script.Tests/Configuration/TimerTriggerPlatformOptionsSetupTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/TimerTriggerPlatformOptionsSetupTests.cs
@@ -80,6 +80,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             Assert.Equal(NonCronScheduleBehavior.Allow, options.NonCronScheduleBehavior);
         }
 
+        [Theory]
+        [InlineData(NonCronScheduleBehavior.Allow, "\"Allow\"")]
+        [InlineData(NonCronScheduleBehavior.Warn, "\"Warn\"")]
+        [InlineData(NonCronScheduleBehavior.Error, "\"Error\"")]
+        public void Format_SerializesEnumAsString(NonCronScheduleBehavior behavior, string expected)
+        {
+            var options = new TimerTriggerPlatformOptions { NonCronScheduleBehavior = behavior };
+
+            string result = options.Format();
+
+            Assert.Contains(expected, result);
+        }
+
         private static TimerTriggerPlatformOptions ConfigureOptions(TestEnvironment environment)
         {
             var setup = new TimerTriggerPlatformOptionsSetup(environment);


### PR DESCRIPTION
Tiny fix so that instead of logging:
```
TimerTriggerPlatformOptions { "NonCronScheduleBehavior": 2 }
```

we'll log 
```
TimerTriggerPlatformOptions { "NonCronScheduleBehavior": "Error" }
```

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)