### PR TITLE
Implement notification pattern for sync trigger operations

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,3 +5,4 @@
 -->
 - Log enum names instead of integers in options formatting for `TimerTriggerPlatformOptions` (#11689)
 - Update WebHostWorkerRuntimeResolver to always read from IConfiguration variable value for FWR (#11720)
+- Notify mesh server of triggers update via `NotifyTriggersChanged` (#11690)

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             }
         }
 
-        public async Task<TriggersOperationResult> TrySyncTriggersAsync(bool isBackgroundSync = false)
+        public virtual async Task<TriggersOperationResult> TrySyncTriggersAsync(bool isBackgroundSync = false)
         {
             var result = new TriggersOperationResult
             {
@@ -304,7 +304,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             return _hashBlobClient;
         }
 
-        private async Task<SyncTriggersPayload> GetSyncTriggersPayload()
+        protected async Task<SyncTriggersPayload> GetSyncTriggersPayload()
         {
             PrepareSyncTriggers();
 

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             }
         }
 
-        public virtual async Task<TriggersOperationResult> TrySyncTriggersAsync(bool isBackgroundSync = false)
+        public async Task<TriggersOperationResult> TrySyncTriggersAsync(bool isBackgroundSync = false)
         {
             var result = new TriggersOperationResult
             {
@@ -304,7 +304,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             return _hashBlobClient;
         }
 
-        protected async Task<SyncTriggersPayload> GetSyncTriggersPayload()
+        private async Task<SyncTriggersPayload> GetSyncTriggersPayload()
         {
             PrepareSyncTriggers();
 
@@ -730,7 +730,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
         // This function will call POST https://{app}.azurewebsites.net/operation/settriggers with the content
         // of triggers. It'll verify app ownership using a site token valid for 5 minutes. It should be plenty.
-        private async Task<(bool Success, string ErrorMessage)> SetTriggersAsync(string content)
+        protected virtual async Task<(bool Success, string ErrorMessage)> SetTriggersAsync(string content)
         {
             // sanitize the content before logging
             var sanitizedContent = JToken.Parse(content);

--- a/src/WebJobs.Script.WebHost/Management/IMeshServiceClient.cs
+++ b/src/WebJobs.Script.WebHost/Management/IMeshServiceClient.cs
@@ -22,6 +22,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
         Task CreateBindMount(string sourcePath, string targetPath);
 
-        Task NotifyTriggersChanged(string contentHash);
+        Task NotifyTriggersChanged();
     }
 }

--- a/src/WebJobs.Script.WebHost/Management/IMeshServiceClient.cs
+++ b/src/WebJobs.Script.WebHost/Management/IMeshServiceClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -21,5 +21,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         Task NotifyHealthEvent(ContainerHealthEventType healthEventType, Type source, string details);
 
         Task CreateBindMount(string sourcePath, string targetPath);
+
+        Task NotifyTriggersChanged(string contentHash);
     }
 }

--- a/src/WebJobs.Script.WebHost/Management/MeshServiceClient.cs
+++ b/src/WebJobs.Script.WebHost/Management/MeshServiceClient.cs
@@ -143,14 +143,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             response.EnsureSuccessStatusCode();
         }
 
-        public async Task NotifyTriggersChanged(string contentHash)
+        public async Task NotifyTriggersChanged()
         {
             _logger.LogDebug("Posting triggers changed notification to appserver.");
 
             var response = await SendAsync(
             [
-                KeyValuePair.Create(Operation, "update-triggers-timestamp"),
-                KeyValuePair.Create("content-hash", contentHash)
+                KeyValuePair.Create(Operation, "update-triggers-timestamp")
             ]);
 
             response.EnsureSuccessStatusCode();

--- a/src/WebJobs.Script.WebHost/Management/MeshServiceClient.cs
+++ b/src/WebJobs.Script.WebHost/Management/MeshServiceClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -140,6 +140,19 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             };
 
             var response = await SendAsync(operation);
+            response.EnsureSuccessStatusCode();
+        }
+
+        public async Task NotifyTriggersChanged(string contentHash)
+        {
+            _logger.LogDebug("Posting triggers changed notification to appserver.");
+
+            var response = await SendAsync(
+            [
+                KeyValuePair.Create(Operation, "update-triggers-timestamp"),
+                KeyValuePair.Create("content-hash", contentHash)
+            ]);
+
             response.EnsureSuccessStatusCode();
         }
 

--- a/src/WebJobs.Script.WebHost/Management/NullMeshServiceClient.cs
+++ b/src/WebJobs.Script.WebHost/Management/NullMeshServiceClient.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             return Task.CompletedTask;
         }
 
-        public Task NotifyTriggersChanged(string contentHash)
+        public Task NotifyTriggersChanged()
         {
             return Task.CompletedTask;
         }

--- a/src/WebJobs.Script.WebHost/Management/NullMeshServiceClient.cs
+++ b/src/WebJobs.Script.WebHost/Management/NullMeshServiceClient.cs
@@ -52,5 +52,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         {
             return Task.CompletedTask;
         }
+
+        public Task NotifyTriggersChanged(string contentHash)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/WebJobs.Script.WebHost/Management/SignalBasedFunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/SignalBasedFunctionsSyncManager.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Net.Http;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Storage;
@@ -40,13 +38,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         }
 
         // Overrides the default settriggers HTTP call to instead notify the mesh service
-        // with a content hash of the triggers payload
         protected override async Task<(bool Success, string ErrorMessage)> SetTriggersAsync(string content)
         {
             try
             {
-                string contentHash = ComputeContentHash(content);
-                await _meshServiceClient.NotifyTriggersChanged(contentHash);
+                await _meshServiceClient.NotifyTriggersChanged();
 
                 return (true, null);
             }
@@ -57,13 +53,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 
                 return (false, message);
             }
-        }
-
-        private static string ComputeContentHash(string content)
-        {
-            byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(content));
-
-            return Convert.ToHexStringLower(hash);
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Management/SignalBasedFunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/SignalBasedFunctionsSyncManager.cs
@@ -1,0 +1,85 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Storage;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
+{
+    public class SignalBasedFunctionsSyncManager : FunctionsSyncManager
+    {
+        private readonly IMeshServiceClient _meshServiceClient;
+        private readonly ILogger _logger;
+        private readonly IScriptWebHostEnvironment _webHostEnvironment;
+        private readonly IEnvironment _environment;
+
+        public SignalBasedFunctionsSyncManager(
+            IHostIdProvider hostIdProvider,
+            IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions,
+            ILogger<SignalBasedFunctionsSyncManager> logger,
+            IHttpClientFactory httpClientFactory,
+            ISecretManagerProvider secretManagerProvider,
+            IScriptWebHostEnvironment webHostEnvironment,
+            IEnvironment environment,
+            HostNameProvider hostNameProvider,
+            IFunctionMetadataManager functionMetadataManager,
+            IAzureBlobStorageProvider azureBlobStorageProvider,
+            IOptions<FunctionsHostingConfigOptions> functionsHostingConfigOptions,
+            IScriptHostManager scriptHostManager,
+            IMeshServiceClient meshServiceClient)
+            : base(hostIdProvider, applicationHostOptions, logger, httpClientFactory, secretManagerProvider, webHostEnvironment, environment, hostNameProvider, functionMetadataManager, azureBlobStorageProvider, functionsHostingConfigOptions, scriptHostManager)
+        {
+            _meshServiceClient = meshServiceClient;
+            _logger = logger;
+            _webHostEnvironment = webHostEnvironment;
+            _environment = environment;
+        }
+
+        public override async Task<TriggersOperationResult> TrySyncTriggersAsync(bool isBackgroundSync = false)
+        {
+            var result = new TriggersOperationResult
+            {
+                Success = true
+            };
+
+            if (!IsSyncTriggersEnvironment(_webHostEnvironment, _environment))
+            {
+                result.Success = false;
+                result.Error = "Invalid environment for SyncTriggers operation.";
+                _logger.LogWarning(result.Error);
+
+                return result;
+            }
+
+            try
+            {
+                var payload = await GetSyncTriggersPayload();
+                string contentHash = ComputeContentHash(payload.Content);
+                await _meshServiceClient.NotifyTriggersChanged(contentHash);
+            }
+            catch (Exception ex)
+            {
+                result.Success = false;
+                result.Error = "Failed to notify triggers changed.";
+                _logger.LogError(ex, result.Error);
+            }
+
+            return result;
+        }
+
+        private static string ComputeContentHash(string content)
+        {
+            byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(content));
+
+            return Convert.ToHexStringLower(hash);
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Management/SignalBasedFunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/SignalBasedFunctionsSyncManager.cs
@@ -18,8 +18,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
     {
         private readonly IMeshServiceClient _meshServiceClient;
         private readonly ILogger _logger;
-        private readonly IScriptWebHostEnvironment _webHostEnvironment;
-        private readonly IEnvironment _environment;
 
         public SignalBasedFunctionsSyncManager(
             IHostIdProvider hostIdProvider,
@@ -39,40 +37,26 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         {
             _meshServiceClient = meshServiceClient;
             _logger = logger;
-            _webHostEnvironment = webHostEnvironment;
-            _environment = environment;
         }
 
-        public override async Task<TriggersOperationResult> TrySyncTriggersAsync(bool isBackgroundSync = false)
+        // Overrides the default settriggers HTTP call to instead notify the mesh service
+        // with a content hash of the triggers payload
+        protected override async Task<(bool Success, string ErrorMessage)> SetTriggersAsync(string content)
         {
-            var result = new TriggersOperationResult
-            {
-                Success = true
-            };
-
-            if (!IsSyncTriggersEnvironment(_webHostEnvironment, _environment))
-            {
-                result.Success = false;
-                result.Error = "Invalid environment for SyncTriggers operation.";
-                _logger.LogWarning(result.Error);
-
-                return result;
-            }
-
             try
             {
-                var payload = await GetSyncTriggersPayload();
-                string contentHash = ComputeContentHash(payload.Content);
+                string contentHash = ComputeContentHash(content);
                 await _meshServiceClient.NotifyTriggersChanged(contentHash);
+
+                return (true, null);
             }
             catch (Exception ex)
             {
-                result.Success = false;
-                result.Error = "Failed to notify triggers changed.";
-                _logger.LogError(ex, result.Error);
-            }
+                string message = "Failed to notify triggers changed.";
+                _logger.LogError(ex, message);
 
-            return result;
+                return (false, message);
+            }
         }
 
         private static string ComputeContentHash(string content)

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -144,7 +144,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             });
 
             // Management services
-            services.AddSingleton<IFunctionsSyncManager, FunctionsSyncManager>();
+            if (SystemEnvironment.Instance.IsTriggersSyncSignalEnabled())
+            {
+                services.AddSingleton<IFunctionsSyncManager, SignalBasedFunctionsSyncManager>();
+            }
+            else
+            {
+                services.AddSingleton<IFunctionsSyncManager, FunctionsSyncManager>();
+            }
+
             services.AddSingleton<IFunctionMetadataManager, FunctionMetadataManager>();
             services.AddSingleton<IWebFunctionsManager, WebFunctionsManager>();
             services.AddHttpClient();

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -372,6 +372,16 @@ namespace Microsoft.Azure.WebJobs.Script
         }
 
         /// <summary>
+        /// Returns a value indicating whether the triggers sync signal path is enabled.
+        /// </summary>
+        /// <param name="environment">The environment to verify.</param>
+        /// <returns><see cref="true"/> if triggers sync signal is enabled; otherwise, <see cref="false"/>.</returns>
+        public static bool IsTriggersSyncSignalEnabled(this IEnvironment environment)
+        {
+            return environment.GetEnvironmentVariable(FunctionsTriggersSyncSignalEnabled) == "1";
+        }
+
+        /// <summary>
         /// Checks both WEBSITE_SKU and WEBSITE_SKU_NAME and returns true IFF one is
         /// set to "Dynamic".
         /// </summary>

--- a/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentSettingNames.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string ContainerName = "CONTAINER_NAME";
         public const string WebsitePodName = "WEBSITE_POD_NAME";
         public const string LegionServiceHost = "LEGION_SERVICE_HOST";
+        public const string FunctionsTriggersSyncSignalEnabled = "FUNCTIONS_TRIGGERS_SYNC_SIGNAL_ENABLED";
         public const string WebSiteHomeStampName = "WEBSITE_HOME_STAMPNAME";
         public const string WebSiteStampDeploymentId = "WEBSITE_STAMP_DEPLOYMENT_ID";
         public const string WebSiteAuthEncryptionKey = "WEBSITE_AUTH_ENCRYPTION_KEY";

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -150,6 +150,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSlotName)).Returns((string)null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags)).Returns((string)null);
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku)).Returns(() => _sku);
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsTriggersSyncSignalEnabled)).Returns((string)null);
             _mockEnvironment.Setup(p => p.Platform).Returns(System.Runtime.InteropServices.OSPlatform.Windows);
 
             _hostNameProvider = new HostNameProvider(_mockEnvironment.Object);

--- a/test/WebJobs.Script.Tests.Integration/Management/MeshServiceClientTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/MeshServiceClientTests.cs
@@ -265,8 +265,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
         {
             var formData = request.Content.ReadAsFormDataAsync().Result;
             return string.Equals(MeshInitUri, request.RequestUri.AbsoluteUri) &&
-                   string.Equals("update-triggers-timestamp", formData["operation"]) &&
-                   !string.IsNullOrEmpty(formData["content-hash"]);
+                   string.Equals("update-triggers-timestamp", formData["operation"]);
         }
 
         [Fact]
@@ -279,7 +278,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
                 StatusCode = HttpStatusCode.OK
             });
 
-            await _meshServiceClient.NotifyTriggersChanged("abc123hash");
+            await _meshServiceClient.NotifyTriggersChanged();
 
             _handlerMock.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Once(),
                 ItExpr.Is<HttpRequestMessage>(r => IsNotifyTriggersChangedRequest(r)),

--- a/test/WebJobs.Script.Tests.Integration/Management/MeshServiceClientTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/MeshServiceClientTests.cs
@@ -261,6 +261,31 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             return expectedActivities.Aggregate(matchesOperation, (current, activity) => current && formData["content"].Contains(activity.FunctionName));
         }
 
+        private static bool IsNotifyTriggersChangedRequest(HttpRequestMessage request)
+        {
+            var formData = request.Content.ReadAsFormDataAsync().Result;
+            return string.Equals(MeshInitUri, request.RequestUri.AbsoluteUri) &&
+                   string.Equals("update-triggers-timestamp", formData["operation"]) &&
+                   !string.IsNullOrEmpty(formData["content-hash"]);
+        }
+
+        [Fact]
+        public async Task NotifyTriggersChanged()
+        {
+            _handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK
+            });
+
+            await _meshServiceClient.NotifyTriggersChanged("abc123hash");
+
+            _handlerMock.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Once(),
+                ItExpr.Is<HttpRequestMessage>(r => IsNotifyTriggersChangedRequest(r)),
+                ItExpr.IsAny<CancellationToken>());
+        }
+
         private class HelloWorldConverter : JsonConverter
         {
             public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/test/WebJobs.Script.Tests.Integration/Management/SignalBasedFunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/SignalBasedFunctionsSyncManagerTests.cs
@@ -1,0 +1,147 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Storage;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Management;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
+{
+    public class SignalBasedFunctionsSyncManagerTests
+    {
+        private readonly Dictionary<string, string> _vars;
+        private readonly Mock<IMeshServiceClient> _mockMeshServiceClient;
+        private readonly Mock<IScriptWebHostEnvironment> _mockWebHostEnvironment;
+        private readonly Mock<IEnvironment> _mockEnvironment;
+        private readonly Mock<IFunctionMetadataManager> _mockFunctionMetadataManager;
+        private readonly Mock<IHostIdProvider> _mockHostIdProvider;
+        private readonly IOptionsMonitor<ScriptApplicationHostOptions> _appHostOptions;
+        private readonly IOptions<FunctionsHostingConfigOptions> _hostingConfigOptions;
+        private readonly SignalBasedFunctionsSyncManager _signalSyncManager;
+
+        public SignalBasedFunctionsSyncManagerTests()
+        {
+            _vars = new Dictionary<string, string>
+            {
+                { EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestHelpers.GenerateKeyHexString() },
+                { EnvironmentSettingNames.AzureWebsiteHostName, "appName.azurewebsites.net" }
+            };
+
+            _mockWebHostEnvironment = new Mock<IScriptWebHostEnvironment>(MockBehavior.Strict);
+            _mockWebHostEnvironment.SetupGet(p => p.InStandbyMode).Returns(false);
+
+            _mockEnvironment = new Mock<IEnvironment>();
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(It.IsAny<string>())).Returns((string)null);
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey)).Returns("1");
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady)).Returns("1");
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName)).Returns("appName.azurewebsites.net");
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku)).Returns(ScriptConstants.FlexConsumptionSku);
+
+            _mockMeshServiceClient = new Mock<IMeshServiceClient>();
+            _mockFunctionMetadataManager = new Mock<IFunctionMetadataManager>();
+            _mockFunctionMetadataManager.Setup(p => p.GetFunctionMetadata(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Returns(ImmutableArray<FunctionMetadata>.Empty);
+            _mockHostIdProvider = new Mock<IHostIdProvider>();
+            _mockHostIdProvider.Setup(p => p.GetHostIdAsync(It.IsAny<CancellationToken>())).ReturnsAsync("testhostid");
+
+            var mockAppHostOptions = new Mock<IOptionsMonitor<ScriptApplicationHostOptions>>();
+            mockAppHostOptions.Setup(p => p.CurrentValue).Returns(new ScriptApplicationHostOptions
+            {
+                ScriptPath = "somePath"
+            });
+            _appHostOptions = mockAppHostOptions.Object;
+
+            var mockHostingConfigOptions = new Mock<IOptions<FunctionsHostingConfigOptions>>();
+            mockHostingConfigOptions.Setup(p => p.Value).Returns(new FunctionsHostingConfigOptions());
+            _hostingConfigOptions = mockHostingConfigOptions.Object;
+
+            _signalSyncManager = new SignalBasedFunctionsSyncManager(
+                _mockHostIdProvider.Object,
+                _appHostOptions,
+                NullLogger<SignalBasedFunctionsSyncManager>.Instance,
+                Mock.Of<IHttpClientFactory>(),
+                Mock.Of<ISecretManagerProvider>(),
+                _mockWebHostEnvironment.Object,
+                _mockEnvironment.Object,
+                new HostNameProvider(_mockEnvironment.Object),
+                _mockFunctionMetadataManager.Object,
+                Mock.Of<IAzureBlobStorageProvider>(),
+                _hostingConfigOptions,
+                Mock.Of<IScriptHostManager>(),
+                _mockMeshServiceClient.Object);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task TrySyncTriggers_NotifiesWithContentHash(bool isBackgroundSync)
+        {
+            var metadata = new FunctionMetadata
+            {
+                Name = "TestFunction",
+                ScriptFile = "file1.csx"
+            };
+            metadata.Bindings.Add(new BindingMetadata
+            {
+                Name = "req",
+                Type = "httpTrigger",
+                Direction = BindingDirection.In,
+                Raw = new JObject
+                {
+                    { "authLevel", "function" },
+                    { "type", "httpTrigger" },
+                    { "direction", "in" },
+                    { "name", "req" }
+                }
+            });
+
+            _mockFunctionMetadataManager.Setup(p => p.GetFunctionMetadata(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Returns(ImmutableArray.Create(metadata));
+
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteArmCacheEnabled)).Returns("0");
+
+            using (var env = new TestScopedEnvironmentVariable(_vars))
+            {
+                var syncResult = await _signalSyncManager.TrySyncTriggersAsync(isBackgroundSync);
+
+                Assert.True(syncResult.Success, syncResult.Error);
+                Assert.True(string.IsNullOrEmpty(syncResult.Error), "Error should be null or empty");
+
+                _mockMeshServiceClient.Verify(
+                    m => m.NotifyTriggersChanged(It.IsAny<string>()),
+                    Times.Once);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task TrySyncTriggers_NotifyFails_ReturnsError(bool isBackgroundSync)
+        {
+            _mockMeshServiceClient.Setup(m => m.NotifyTriggersChanged(It.IsAny<string>()))
+                .ThrowsAsync(new Exception("Connection refused"));
+
+            using (var env = new TestScopedEnvironmentVariable(_vars))
+            {
+                var syncResult = await _signalSyncManager.TrySyncTriggersAsync(isBackgroundSync);
+
+                Assert.False(syncResult.Success);
+                Assert.Equal("Failed to notify triggers changed.", syncResult.Error);
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/Management/SignalBasedFunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/SignalBasedFunctionsSyncManagerTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task TrySyncTriggers_NotifiesWithContentHash(bool isBackgroundSync)
+        public async Task TrySyncTriggers_NotifiesMeshService(bool isBackgroundSync)
         {
             using (var env = new TestScopedEnvironmentVariable(_vars))
             {
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 Assert.True(string.IsNullOrEmpty(syncResult.Error), "Error should be null or empty");
 
                 _mockMeshServiceClient.Verify(
-                    m => m.NotifyTriggersChanged(It.IsAny<string>()),
+                    m => m.NotifyTriggersChanged(),
                     Times.Once);
             }
         }
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         [InlineData(false)]
         public async Task TrySyncTriggers_NotifyFails_ReturnsError(bool isBackgroundSync)
         {
-            _mockMeshServiceClient.Setup(m => m.NotifyTriggersChanged(It.IsAny<string>()))
+            _mockMeshServiceClient.Setup(m => m.NotifyTriggersChanged())
                 .ThrowsAsync(new Exception("Connection refused"));
 
             using (var env = new TestScopedEnvironmentVariable(_vars))

--- a/test/WebJobs.Script.Tests.Integration/Management/SignalBasedFunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/SignalBasedFunctionsSyncManagerTests.cs
@@ -50,46 +50,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady)).Returns("1");
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName)).Returns("appName.azurewebsites.net");
             _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku)).Returns(ScriptConstants.FlexConsumptionSku);
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteArmCacheEnabled)).Returns("0");
 
             _mockMeshServiceClient = new Mock<IMeshServiceClient>();
-            _mockFunctionMetadataManager = new Mock<IFunctionMetadataManager>();
-            _mockFunctionMetadataManager.Setup(p => p.GetFunctionMetadata(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
-                .Returns(ImmutableArray<FunctionMetadata>.Empty);
-            _mockHostIdProvider = new Mock<IHostIdProvider>();
-            _mockHostIdProvider.Setup(p => p.GetHostIdAsync(It.IsAny<CancellationToken>())).ReturnsAsync("testhostid");
 
-            var mockAppHostOptions = new Mock<IOptionsMonitor<ScriptApplicationHostOptions>>();
-            mockAppHostOptions.Setup(p => p.CurrentValue).Returns(new ScriptApplicationHostOptions
-            {
-                ScriptPath = "somePath"
-            });
-            _appHostOptions = mockAppHostOptions.Object;
-
-            var mockHostingConfigOptions = new Mock<IOptions<FunctionsHostingConfigOptions>>();
-            mockHostingConfigOptions.Setup(p => p.Value).Returns(new FunctionsHostingConfigOptions());
-            _hostingConfigOptions = mockHostingConfigOptions.Object;
-
-            _signalSyncManager = new SignalBasedFunctionsSyncManager(
-                _mockHostIdProvider.Object,
-                _appHostOptions,
-                NullLogger<SignalBasedFunctionsSyncManager>.Instance,
-                Mock.Of<IHttpClientFactory>(),
-                Mock.Of<ISecretManagerProvider>(),
-                _mockWebHostEnvironment.Object,
-                _mockEnvironment.Object,
-                new HostNameProvider(_mockEnvironment.Object),
-                _mockFunctionMetadataManager.Object,
-                Mock.Of<IAzureBlobStorageProvider>(),
-                _hostingConfigOptions,
-                Mock.Of<IScriptHostManager>(),
-                _mockMeshServiceClient.Object);
-        }
-
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task TrySyncTriggers_NotifiesWithContentHash(bool isBackgroundSync)
-        {
             var metadata = new FunctionMetadata
             {
                 Name = "TestFunction",
@@ -109,11 +73,48 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 }
             });
 
+            _mockFunctionMetadataManager = new Mock<IFunctionMetadataManager>();
             _mockFunctionMetadataManager.Setup(p => p.GetFunctionMetadata(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
                 .Returns(ImmutableArray.Create(metadata));
 
-            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteArmCacheEnabled)).Returns("0");
+            _mockHostIdProvider = new Mock<IHostIdProvider>();
+            _mockHostIdProvider.Setup(p => p.GetHostIdAsync(It.IsAny<CancellationToken>())).ReturnsAsync("testhostid");
 
+            var mockAppHostOptions = new Mock<IOptionsMonitor<ScriptApplicationHostOptions>>();
+            mockAppHostOptions.Setup(p => p.CurrentValue).Returns(new ScriptApplicationHostOptions
+            {
+                ScriptPath = "somePath"
+            });
+            _appHostOptions = mockAppHostOptions.Object;
+
+            var mockHostingConfigOptions = new Mock<IOptions<FunctionsHostingConfigOptions>>();
+            mockHostingConfigOptions.Setup(p => p.Value).Returns(new FunctionsHostingConfigOptions());
+            _hostingConfigOptions = mockHostingConfigOptions.Object;
+
+            var configuration = ScriptSettingsManager.BuildDefaultConfiguration();
+            var azureBlobStorageProvider = TestHelpers.GetAzureBlobStorageProvider(configuration);
+
+            _signalSyncManager = new SignalBasedFunctionsSyncManager(
+                _mockHostIdProvider.Object,
+                _appHostOptions,
+                NullLogger<SignalBasedFunctionsSyncManager>.Instance,
+                Mock.Of<IHttpClientFactory>(),
+                Mock.Of<ISecretManagerProvider>(),
+                _mockWebHostEnvironment.Object,
+                _mockEnvironment.Object,
+                new HostNameProvider(_mockEnvironment.Object),
+                _mockFunctionMetadataManager.Object,
+                azureBlobStorageProvider,
+                _hostingConfigOptions,
+                Mock.Of<IScriptHostManager>(),
+                _mockMeshServiceClient.Object);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task TrySyncTriggers_NotifiesWithContentHash(bool isBackgroundSync)
+        {
             using (var env = new TestScopedEnvironmentVariable(_vars))
             {
                 var syncResult = await _signalSyncManager.TrySyncTriggersAsync(isBackgroundSync);


### PR DESCRIPTION
### Issue describing the changes in this PR

Implement a new notification pattern for Flex Consumption sync trigger operations

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)


