### PR TITLE
[in-proc] Cap bundles for net8 in-proc

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,5 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+
+- Add a bundle version cap of `< 4.33.0` to net8 in-proc (#11694)

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -20,6 +20,13 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
 {
     public class ExtensionBundleManager : IExtensionBundleManager
     {
+        private static readonly IReadOnlyDictionary<int, VersionRange> _allowedBundleVersionRanges =
+            new Dictionary<int, VersionRange>()
+            {
+                [6] = new VersionRange(new NuGetVersion("4.2.0"), true, new NuGetVersion("4.22.0"), true),
+                [8] = new VersionRange(new NuGetVersion("4.2.0"), true, new NuGetVersion("4.32.0"), true),
+            };
+
         private readonly IEnvironment _environment;
         private readonly ExtensionBundleOptions _options;
         private readonly FunctionsHostingConfigOptions _configOption;
@@ -253,16 +260,7 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
         internal string FindBestVersionMatch(VersionRange versionRange, IEnumerable<string> versions, string bundleId, FunctionsHostingConfigOptions configOption)
         {
             int dotnetVersion = typeof(string).Assembly.GetName().Version.Major;
-
-            // Limit the version range for v4.x bundles on .NET 6 to be between 4.2.0 and 4.22.0
-            // Return original version range if not .NET 6 or not v4.x bundle
-            var effectiveVersionRange = GetAdjustedVersion(dotnetVersion, versionRange, bundleId);
-
-            // Check if there is a max version configured in hosting config for the current dotnet version and bundle major version
-            if (TryGetMaxBundleVersionFromHostingConfig(bundleId, versionRange.MinVersion.Major, dotnetVersion, configOption, out NuGetVersion maxBundleVersion))
-            {
-                effectiveVersionRange = new VersionRange(effectiveVersionRange.MinVersion, effectiveVersionRange.IsMinInclusive, maxBundleVersion, true);
-            }
+            var effectiveVersionRange = GetAdjustedVersion(dotnetVersion, versionRange, bundleId, configOption);
 
             var bundleVersions = versions.Select(p =>
             {
@@ -280,29 +278,30 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
             return matchingVersion?.ToString();
         }
 
-        // Applies bundle version limits for .NET 6, using the default bundle if referencing a v4 major bundle version.
+        // Applies bundle version limits for apps based on .NET version and hosting config, using the default bundle if referencing a v4 major bundle version.
         // Does not apply version limit in placeholder mode. This will prevent bundle download in placeholder mode as long as a matching bundle is available.
-        private VersionRange GetAdjustedVersion(int dotnetVersion, VersionRange versionRange, string bundleId)
+        private VersionRange GetAdjustedVersion(int dotnetVersion, VersionRange versionRange, string bundleId, FunctionsHostingConfigOptions configOption)
         {
             if (_environment.IsPlaceholderModeEnabled()
-                || dotnetVersion != 6
                 || !string.Equals(bundleId, ScriptConstants.DefaultExtensionBundleId, StringComparison.OrdinalIgnoreCase)
                 || versionRange.MinVersion.Major != ScriptConstants.ExtensionBundleV4MajorVersion)
             {
                 return versionRange;
             }
 
-            var effectiveMinVersion = new NuGetVersion(ScriptConstants.Net6MinimumV4BundleVersion);
-            var effectiveMaxVersion = new NuGetVersion(ScriptConstants.Net6MaximumV4BundleVersion);
+            VersionRange configRange = null;
+            if (TryGetMaxBundleVersionFromHostingConfig(bundleId, versionRange.MinVersion.Major, dotnetVersion, configOption, out NuGetVersion maxBundleVersion))
+            {
+                configRange = new VersionRange(versionRange.MinVersion, versionRange.IsMinInclusive, maxBundleVersion, true);
+            }
 
-            var minVersion = versionRange.MinVersion < effectiveMinVersion ? effectiveMinVersion : versionRange.MinVersion;
-            var maxVersion = versionRange.MaxVersion > effectiveMaxVersion ? effectiveMaxVersion : versionRange.MaxVersion;
+            if (_allowedBundleVersionRanges.TryGetValue(dotnetVersion, out VersionRange allowedRange))
+            {
+                versionRange = configRange is null
+                    ? VersionRange.CommonSubSet([versionRange, allowedRange])
+                    : VersionRange.CommonSubSet([versionRange, allowedRange, configRange]);
+            }
 
-            // Use the original inclusion values if it is within the min or max range.
-            bool isMinInclusive = versionRange.MinVersion > effectiveMinVersion && versionRange.IsMinInclusive;
-            bool isMaxInclusive = versionRange.MaxVersion < effectiveMaxVersion && versionRange.IsMaxInclusive;
-
-            versionRange = new VersionRange(minVersion, isMinInclusive, maxVersion, isMaxInclusive);
             return versionRange;
         }
 

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -16,15 +16,17 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using NuGet.Versioning;
 
+using BundleRangeId = (int DotnetMajor, int BundleMajor);
+
 namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
 {
     public class ExtensionBundleManager : IExtensionBundleManager
     {
-        private static readonly IReadOnlyDictionary<int, VersionRange> _allowedBundleVersionRanges =
-            new Dictionary<int, VersionRange>()
+        private static readonly IReadOnlyDictionary<BundleRangeId, VersionRange> _allowedBundleVersionRanges =
+            new Dictionary<BundleRangeId, VersionRange>()
             {
-                [6] = new VersionRange(new NuGetVersion("4.2.0"), false, new NuGetVersion("4.22.0"), false),
-                [8] = new VersionRange(null, false, new NuGetVersion("4.33.0"), false),
+                [(6, 4)] = new VersionRange(new NuGetVersion("4.2.0"), false, new NuGetVersion("4.22.0"), false),
+                [(8, 4)] = new VersionRange(null, false, new NuGetVersion("4.33.0"), false),
             };
 
         private readonly IEnvironment _environment;
@@ -283,37 +285,44 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
         private VersionRange GetAdjustedVersion(int dotnetVersion, VersionRange versionRange, string bundleId, FunctionsHostingConfigOptions configOption)
         {
             if (_environment.IsPlaceholderModeEnabled()
-                || !string.Equals(bundleId, ScriptConstants.DefaultExtensionBundleId, StringComparison.OrdinalIgnoreCase)
-                || versionRange.MinVersion.Major != ScriptConstants.ExtensionBundleV4MajorVersion)
+                || !string.Equals(bundleId, ScriptConstants.DefaultExtensionBundleId, StringComparison.OrdinalIgnoreCase))
             {
                 return versionRange;
             }
 
-            _allowedBundleVersionRanges.TryGetValue(dotnetVersion, out VersionRange allowedRange);
-            if (TryGetMaxBundleVersionFromHostingConfig(bundleId, versionRange.MinVersion.Major, dotnetVersion, configOption, out NuGetVersion maxBundleVersion))
+            static bool TryGetMaxBundleVersionFromHostingConfig(
+                BundleRangeId id, FunctionsHostingConfigOptions configOption, out NuGetVersion maxVersion)
             {
-                if (allowedRange != null)
+                string hostingConfig = $"Net{id.DotnetMajor}MaximumBundleV{id.BundleMajor}Version";
+                string hostingConfigValue = configOption.GetFeature(hostingConfig);
+                return NuGetVersion.TryParse(hostingConfigValue, out maxVersion);
+            }
+
+            BundleRangeId id = (dotnetVersion, versionRange.MinVersion.Major);
+            if (_allowedBundleVersionRanges.TryGetValue(id, out VersionRange allowedRange))
+            {
+                VersionRange intersection = VersionRange.CommonSubSet([allowedRange, versionRange]);
+                if (intersection.Equals(VersionRange.None))
                 {
-                    allowedRange = new VersionRange(allowedRange.MinVersion, allowedRange.IsMinInclusive, maxBundleVersion, false);
+                    // Rare case where there is 0 intersections between the allowed range and the user specified range.
+                    // In this case, we will force usage of the allowed range.
+                    _logger.LogWarning(
+                        "The specified extension bundle version range {userVersionRange} does not intersect with the allowed bundle version range {allowedVersionRange:} for .NET {dotnetMajor} and bundle major version {bundleMajor}. The allowed bundle version range will be used.",
+                        versionRange, allowedRange, id.DotnetMajor, id.BundleMajor);
+                    versionRange = allowedRange;
                 }
                 else
                 {
-                    allowedRange = new VersionRange(null, false, maxBundleVersion, false);
+                    versionRange = intersection;
                 }
             }
 
-            return allowedRange != null ? VersionRange.CommonSubSet([allowedRange, versionRange]) : versionRange;
-        }
+            if (TryGetMaxBundleVersionFromHostingConfig(id, configOption, out NuGetVersion maxBundleVersion))
+            {
+                versionRange = new VersionRange(versionRange.MinVersion, versionRange.IsMinInclusive, maxBundleVersion, true);
+            }
 
-        private bool TryGetMaxBundleVersionFromHostingConfig(string bundleId, int bundleVersion, int dotnetVersion, FunctionsHostingConfigOptions configOption, out NuGetVersion maxVersion)
-        {
-            maxVersion = null;
-            string hostingConfig = $"Net{dotnetVersion}MaximumBundleV{bundleVersion}Version";
-            string hostingConfigValue = configOption.GetFeature(hostingConfig);
-
-            return string.Equals(bundleId, ScriptConstants.DefaultExtensionBundleId, StringComparison.OrdinalIgnoreCase)
-                && !string.IsNullOrEmpty(hostingConfigValue)
-                && NuGetVersion.TryParse(hostingConfigValue, out maxVersion);
+            return versionRange;
         }
 
         private NuGetVersion ResolvePlatformReleaseChannelVersion(IList<NuGetVersion> orderedByDescBundles) => _platformReleaseChannel.ToUpper() switch

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -301,6 +301,10 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
                     ? VersionRange.CommonSubSet([versionRange, allowedRange])
                     : VersionRange.CommonSubSet([versionRange, allowedRange, configRange]);
             }
+            else
+            {
+                versionRange = VersionRange.CommonSubSet([versionRange, configRange]);
+            }
 
             return versionRange;
         }

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -301,20 +301,7 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
             BundleRangeId id = (dotnetVersion, versionRange.MinVersion.Major);
             if (_allowedBundleVersionRanges.TryGetValue(id, out VersionRange allowedRange))
             {
-                VersionRange intersection = VersionRange.CommonSubSet([allowedRange, versionRange]);
-                if (intersection.Equals(VersionRange.None))
-                {
-                    // Rare case where there is 0 intersections between the allowed range and the user specified range.
-                    // In this case, we will force usage of the allowed range.
-                    _logger.LogWarning(
-                        "The specified extension bundle version range {userVersionRange} does not intersect with the allowed bundle version range {allowedVersionRange:} for .NET {dotnetMajor} and bundle major version {bundleMajor}. The allowed bundle version range will be used.",
-                        versionRange, allowedRange, id.DotnetMajor, id.BundleMajor);
-                    versionRange = allowedRange;
-                }
-                else
-                {
-                    versionRange = intersection;
-                }
+                versionRange = VersionRange.CommonSubSet([allowedRange, versionRange]);
             }
 
             if (TryGetMaxBundleVersionFromHostingConfig(id, configOption, out NuGetVersion maxBundleVersion))

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -23,8 +23,8 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
         private static readonly IReadOnlyDictionary<int, VersionRange> _allowedBundleVersionRanges =
             new Dictionary<int, VersionRange>()
             {
-                [6] = new VersionRange(new NuGetVersion("4.2.0"), true, new NuGetVersion("4.22.0"), true),
-                [8] = new VersionRange(new NuGetVersion("4.2.0"), true, new NuGetVersion("4.32.0"), true),
+                [6] = new VersionRange(new NuGetVersion("4.2.0"), false, new NuGetVersion("4.22.0"), false),
+                [8] = new VersionRange(null, false, new NuGetVersion("4.33.0"), false),
             };
 
         private readonly IEnvironment _environment;

--- a/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
+++ b/src/WebJobs.Script/ExtensionBundle/ExtensionBundleManager.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
         internal bool TryLocateExtensionBundle(out string bundlePath)
         {
             bundlePath = null;
-            string bundleMetatdataFile = null;
+            string bundleMetadataFile = null;
             var paths = new List<string>(_options.ProbingPaths)
                 {
                     _options.DownloadPath
@@ -143,8 +143,8 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
                     if (!string.IsNullOrEmpty(version))
                     {
                         bundlePath = Path.Combine(path, version);
-                        bundleMetatdataFile = Path.Combine(bundlePath, ScriptConstants.ExtensionBundleMetadataFile);
-                        if (!string.IsNullOrEmpty(bundleMetatdataFile) && FileUtility.FileExists(bundleMetatdataFile))
+                        bundleMetadataFile = Path.Combine(bundlePath, ScriptConstants.ExtensionBundleMetadataFile);
+                        if (!string.IsNullOrEmpty(bundleMetadataFile) && FileUtility.FileExists(bundleMetadataFile))
                         {
                             _logger.ExtensionBundleFound(bundlePath);
                             break;
@@ -161,9 +161,9 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
 
         private async Task<string> DownloadExtensionBundleAsync(string version, HttpClient httpClient)
         {
-            string bundleMetatdataFile = Path.Combine(_options.DownloadPath, version, ScriptConstants.ExtensionBundleMetadataFile);
+            string bundleMetadataFile = Path.Combine(_options.DownloadPath, version, ScriptConstants.ExtensionBundleMetadataFile);
             string bundlePath = Path.Combine(_options.DownloadPath, version);
-            if (FileUtility.FileExists(bundleMetatdataFile))
+            if (FileUtility.FileExists(bundleMetadataFile))
             {
                 _logger.LogInformation($"Skipping bundle download since it already exists at path {bundlePath}");
                 return bundlePath;
@@ -186,7 +186,7 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
                 ZipFile.ExtractToDirectory(zipFilePath, bundlePath);
                 _logger.ZipExtractionComplete();
             }
-            return FileUtility.FileExists(bundleMetatdataFile) ? bundlePath : null;
+            return FileUtility.FileExists(bundleMetadataFile) ? bundlePath : null;
         }
 
         private string GetBundleFlavorForCurrentEnvironment()
@@ -289,24 +289,20 @@ namespace Microsoft.Azure.WebJobs.Script.ExtensionBundle
                 return versionRange;
             }
 
-            VersionRange configRange = null;
+            _allowedBundleVersionRanges.TryGetValue(dotnetVersion, out VersionRange allowedRange);
             if (TryGetMaxBundleVersionFromHostingConfig(bundleId, versionRange.MinVersion.Major, dotnetVersion, configOption, out NuGetVersion maxBundleVersion))
             {
-                configRange = new VersionRange(versionRange.MinVersion, versionRange.IsMinInclusive, maxBundleVersion, true);
+                if (allowedRange != null)
+                {
+                    allowedRange = new VersionRange(allowedRange.MinVersion, allowedRange.IsMinInclusive, maxBundleVersion, false);
+                }
+                else
+                {
+                    allowedRange = new VersionRange(null, false, maxBundleVersion, false);
+                }
             }
 
-            if (_allowedBundleVersionRanges.TryGetValue(dotnetVersion, out VersionRange allowedRange))
-            {
-                versionRange = configRange is null
-                    ? VersionRange.CommonSubSet([versionRange, allowedRange])
-                    : VersionRange.CommonSubSet([versionRange, allowedRange, configRange]);
-            }
-            else
-            {
-                versionRange = VersionRange.CommonSubSet([versionRange, configRange]);
-            }
-
-            return versionRange;
+            return allowedRange != null ? VersionRange.CommonSubSet([allowedRange, versionRange]) : versionRange;
         }
 
         private bool TryGetMaxBundleVersionFromHostingConfig(string bundleId, int bundleVersion, int dotnetVersion, FunctionsHostingConfigOptions configOption, out NuGetVersion maxVersion)

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -248,8 +248,6 @@ namespace Microsoft.Azure.WebJobs.Script
         public static readonly string LiveLogsSessionAIKey = "#AzFuncLiveLogsSessionId";
 
         public static readonly string FunctionsHostingConfigSectionName = "FunctionsHostingConfig";
-        public static readonly string Net6MinimumV4BundleVersion = "4.2.0";
-        public static readonly string Net6MaximumV4BundleVersion = "4.22.0";
 
         // HTTP Proxying constants
         public static readonly string HttpProxyingEnabled = "HttpProxyingEnabled";

--- a/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
@@ -412,7 +412,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
 
         [Theory]
 #if NET8_0
-        // No host-config, built in cap of 4.32.0.
+        // No host-config, built in cap of 4.32.*.
         [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.32.0")]
         [InlineData("latest", "[4.*, 5.0.0)", null, "4.32.0")]
         [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.23.0")]

--- a/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
@@ -386,9 +386,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
         [InlineData("[4.*, 4.3.0)", "4.30.0", "4.23.0")] // Existing behavior. We will override customers max range.
 #if NET6_0
         [InlineData("[4.*, 5.0.0)", null, "4.3.0")]
-        [InlineData("[4.*, 4.1.0)", null, "4.3.0")] // No overlap. Enforced net6 range will be used.
+        [InlineData("[4.*, 4.1.0)", null, null)] // No overlap. Bundle will fail to resolve.
 #elif NET8_0
         [InlineData("[4.*, 5.0.0)", null, "4.32.0")]
+        [InlineData("[4.33.0, 5.0.0)", null, null)] // No overlap. Bundle will fail to resolve.
 #endif
         public void LimitMaxVersion(string versionRange, string hostConfigVersion, string expectedVersion)
         {

--- a/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -383,10 +383,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
         [Theory]
         [InlineData("[3.*, 4.0.0)", "3.19.0", "3.19.0")]
         [InlineData("[4.*, 5.0.0)", "4.3.0", "4.3.0")]
+        [InlineData("[4.*, 4.3.0)", "4.30.0", "4.23.0")] // Existing behavior. We will override customers max range.
 #if NET6_0
         [InlineData("[4.*, 5.0.0)", null, "4.3.0")]
+        [InlineData("[4.*, 4.1.0)", null, "4.3.0")] // No overlap. Enforced net6 range will be used.
 #elif NET8_0
-        [InlineData("[4.*, 5.0.0)", null, "4.23.0")]
+        [InlineData("[4.*, 5.0.0)", null, "4.32.0")]
 #endif
         public void LimitMaxVersion(string versionRange, string hostConfigVersion, string expectedVersion)
         {
@@ -410,13 +412,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
 
         [Theory]
 #if NET8_0
-        // No host-config max (full list available, no caps applied on .NET 8)
-        [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.23.0")]
-        [InlineData("latest", "[4.*, 5.0.0)", null, "4.23.0")]
-        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.22.1")]
-        [InlineData("standard", "[4.*, 5.0.0)", null, "4.22.1")]
-        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.22.1")]
-        [InlineData("extended", "[4.*, 5.0.0)", null, "4.22.1")]
+        // No host-config, built in cap of 4.32.0.
+        [InlineData(ScriptConstants.LatestPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.32.0")]
+        [InlineData("latest", "[4.*, 5.0.0)", null, "4.32.0")]
+        [InlineData(ScriptConstants.StandardPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.23.0")]
+        [InlineData("standard", "[4.*, 5.0.0)", null, "4.23.0")]
+        [InlineData(ScriptConstants.ExtendedPlatformChannelNameUpper, "[4.*, 5.0.0)", null, "4.23.0")]
+        [InlineData("extended", "[4.*, 5.0.0)", null, "4.23.0")]
 
         // Host-config max at 4.22.0 (caps selection to <= 4.22.0)
         // Ordered (desc) after cap: 4.22.0, 4.3.0, 4.2.1, 4.2.0, 4.1.0, 4.0.2
@@ -898,7 +900,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
         private IList<string> GetLargeVersionsList()
         {
             return new List<string>()
-            { "3.7.0", "3.10.0", "3.11.0", "3.15.0", "3.14.0", "2.16.0", "3.13.0", "3.12.0", "3.9.1", "2.12.1", "2.18.0", "3.16.0", "2.19.0", "3.17.0", "4.0.2", "2.20.0", "3.18.0", "4.1.0", "4.2.0", "4.2.1", "2.21.0", "3.19.0", "3.19.2", "4.3.0", "3.20.0", "4.22.0", "4.22.1", "4.23.0" };
+            { "3.7.0", "3.10.0", "3.11.0", "3.15.0", "3.14.0", "2.16.0", "3.13.0", "3.12.0", "3.9.1", "2.12.1", "2.18.0", "3.16.0", "2.19.0", "3.17.0", "4.0.2", "2.20.0", "3.18.0", "4.1.0", "4.2.0", "4.2.1", "2.21.0", "3.19.0", "3.19.2", "4.3.0", "3.20.0", "4.22.0", "4.22.1", "4.23.0", "4.32.0", "4.33.0" };
         }
 
         private Mock<ILogger> GetVerifiableMockLogger(string stringToVerify, LogLevel logLevel)

--- a/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
+++ b/test/WebJobs.Script.Tests/ExtensionBundle/ExtensionBundleManagerTests.cs
@@ -383,7 +383,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ExtensionBundle
         [Theory]
         [InlineData("[3.*, 4.0.0)", "3.19.0", "3.19.0")]
         [InlineData("[4.*, 5.0.0)", "4.3.0", "4.3.0")]
-        [InlineData("[4.*, 4.3.0)", "4.30.0", "4.23.0")] // Existing behavior. We will override customers max range.
+        [InlineData("[4.*, 4.3.0)", "4.30.0", "4.23.0")] // Existing behavior. We will override the customer's max range.
 #if NET6_0
         [InlineData("[4.*, 5.0.0)", null, "4.3.0")]
         [InlineData("[4.*, 4.1.0)", null, "4.3.0")] // No overlap. Enforced net6 range will be used.


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md` -- TODO
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests) -- TODO

<!-- Optional: delete if not applicable  -->
### Additional information

This PR does two primary changes:

1. Adds a cap to net8 in-proc bundles of 4.32.0. This is in addition to the existing net6 cap.
2. ~Addresses a bug with hosting config bundle caps which will _always_ override any user configured max value. We only want to set a _lower_ max, not a higher max.~ -- reverted this change. We can separately discuss if this is desired behavior or not and address in another PR if so.

#### Additional Comments

I noticed an existing issue where if the user-defined version range and the allowed range has 0 overlap, then we will produce an invalid version range of `(HIGHER_VALUE, LOWER_VALUE)`, which will never download a bundle. This logic still will never download a bundle, but it gets the '(0.0.0, 0.0.0)` version range instead. Unsure if we want to address that issue. We could log a warning or error when it occurs.
