### PR TITLE
Add task to WebJobs.Script.Abstractions release to update build number

### DIFF
--- a/eng/ci/templates/official/pipelines/release.yml
+++ b/eng/ci/templates/official/pipelines/release.yml
@@ -3,7 +3,7 @@ parameters:
   type: stepList
 - name: folder
   type: string
-- name: package_name
+- name: packageName
   type: string
 - name: public
   type: boolean
@@ -52,7 +52,7 @@ stages:
     - pwsh: |
         $ErrorActionPreference = 'Stop'
 
-        $name = "${{ parameters.package_name }}".Trim()
+        $name = "${{ parameters.packageName }}".Trim()
         Write-Host "Getting version for $name"
         $package = Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/packages" -Recurse -Filter "$name.*.nupkg"
 
@@ -69,7 +69,7 @@ stages:
         $version = $package.Name.Trim("$name.").Trim('.nupkg')
         Write-Host "Package version: $version"
         Write-Host "##vso[build.updatebuildnumber]$version"
-        Write-Host "##vso[build.addbuildtag]${{ parameters.package_name }}"
+        Write-Host "##vso[build.addbuildtag]${{ parameters.packageName }}"
         Write-Host "##vso[build.addbuildtag]$version"
       displayName: Get package version
 

--- a/eng/ci/templates/official/pipelines/release.yml
+++ b/eng/ci/templates/official/pipelines/release.yml
@@ -3,6 +3,8 @@ parameters:
   type: stepList
 - name: folder
   type: string
+- name: package_name
+  type: string
 - name: public
   type: boolean
   default: false
@@ -46,6 +48,30 @@ stages:
     steps:
     - ${{ each step in parameters.downloadSteps }}:
       - ${{ step }}
+
+    - pwsh: |
+        $ErrorActionPreference = 'Stop'
+
+        $name = "${{ parameters.package_name }}".Trim()
+        Write-Host "Getting version for $name"
+        $package = Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/packages" -Recurse -Filter "$name.?.*.nupkg"
+
+        if ($package.Count -eq 0) {
+          Write-Host "##vso[task.LogIssue type=error;]Could not find package $name."
+          exit 1
+        }
+
+        if ($package.Count -gt 1) {
+          Write-Host "##vso[task.LogIssue type=error;]Too many packages matched $name."
+          exit 1
+        }
+
+        $version = $package.Name.Trim("$name.").Trim('.nupkg')
+        Write-Host "Package version: $version"
+        Write-Host "##vso[build.updatebuildnumber]$version"
+        Write-Host "##vso[build.addbuildtag]${{ parameters.package_name }}"
+        Write-Host "##vso[build.addbuildtag]$version"
+      displayName: Get package version
 
 - stage: Release
   dependsOn: Download

--- a/eng/ci/templates/official/pipelines/release.yml
+++ b/eng/ci/templates/official/pipelines/release.yml
@@ -54,15 +54,15 @@ stages:
 
         $name = "${{ parameters.package_name }}".Trim()
         Write-Host "Getting version for $name"
-        $package = Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/packages" -Recurse -Filter "$name.?.*.nupkg"
+        $package = Get-ChildItem -Path "$(Build.ArtifactStagingDirectory)/packages" -Recurse -Filter "$name.*.nupkg"
 
         if ($package.Count -eq 0) {
-          Write-Host "##vso[task.LogIssue type=error;]Could not find package $name."
+          Write-Host "##vso[task.logissue type=error;]Could not find package $name."
           exit 1
         }
 
         if ($package.Count -gt 1) {
-          Write-Host "##vso[task.LogIssue type=error;]Too many packages matched $name."
+          Write-Host "##vso[task.logissue type=error;]Too many packages matched $name."
           exit 1
         }
 

--- a/eng/ci/webjobs-script-abstractions-release.yml
+++ b/eng/ci/webjobs-script-abstractions-release.yml
@@ -38,6 +38,7 @@ extends:
       parameters:
         public: ${{ parameters.public }}
         folder: azure-webjobs-script-abstractions
+        package_name: Microsoft.Azure.WebJobs.Script.Abstractions
         packages: |
           **/*Abstractions*.nupkg
           !**/*.symbols.nupkg

--- a/src/WebJobs.Script.Abstractions/Directory.Version.props
+++ b/src/WebJobs.Script.Abstractions/Directory.Version.props
@@ -1,6 +1,5 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>1.0.4</VersionPrefix>
-    <UpdateBuildNumber Condition="'$(IsReleaseCI)' == 'true'">true</UpdateBuildNumber>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Add task to update build number (which is used in partner drop target folder path). Uses the same logic from [dotnet-worker](https://github.com/Azure/azure-functions-dotnet-worker/blob/main/eng/ci/official-release.yml#L113).

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
