### PR TITLE
Updating runtime assemblies manifest.

### DIFF
--- a/src/WebJobs.Script/runtimeassemblies-relaxed.json
+++ b/src/WebJobs.Script/runtimeassemblies-relaxed.json
@@ -620,6 +620,10 @@
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
+      "name": "Microsoft.VisualBasic.Core",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
       "name": "Microsoft.Win32.Primitives",
       "resolutionPolicy": "minorMatchOrLower"
     },
@@ -780,11 +784,19 @@
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
+      "name": "System.Data.DataSetExtensions",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
       "name": "System.Diagnostics.Contracts",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
       "name": "System.Diagnostics.Debug",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
+      "name": "System.Diagnostics.DiagnosticSource",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
@@ -829,6 +841,14 @@
     },
     {
       "name": "System.Dynamic.Runtime",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
+      "name": "System.Formats.Asn1",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
+      "name": "System.Formats.Tar",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
@@ -920,6 +940,10 @@
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
+      "name": "System.Linq.AsyncEnumerable",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
       "name": "System.Linq.Expressions",
       "resolutionPolicy": "minorMatchOrLower"
     },
@@ -948,6 +972,10 @@
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
+      "name": "System.Net.Http.Json",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
       "name": "System.Net.HttpListener",
       "resolutionPolicy": "minorMatchOrLower"
     },
@@ -972,11 +1000,19 @@
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
+      "name": "System.Net.Quic",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
       "name": "System.Net.Requests",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
       "name": "System.Net.Security",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
+      "name": "System.Net.ServerSentEvents",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
@@ -1017,6 +1053,10 @@
     },
     {
       "name": "System.ObjectModel",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
+      "name": "System.Private.CoreLib",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
@@ -1104,6 +1144,10 @@
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
+      "name": "System.Runtime.CompilerServices.Unsafe",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
       "name": "System.Runtime.CompilerServices.VisualC",
       "resolutionPolicy": "minorMatchOrLower"
     },
@@ -1120,11 +1164,19 @@
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
+      "name": "System.Runtime.InteropServices.JavaScript",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
       "name": "System.Runtime.InteropServices.RuntimeInformation",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
       "name": "System.Runtime.InteropServices.WindowsRuntime",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
+      "name": "System.Runtime.Intrinsics",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
@@ -1165,6 +1217,10 @@
     },
     {
       "name": "System.Security.Claims",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
+      "name": "System.Security.Cryptography",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
@@ -1244,11 +1300,23 @@
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
+      "name": "System.Text.Encodings.Web",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
+      "name": "System.Text.Json",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
       "name": "System.Text.RegularExpressions",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
       "name": "System.Threading",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
+      "name": "System.Threading.AccessControl",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {

--- a/src/WebJobs.Script/runtimeassemblies.json
+++ b/src/WebJobs.Script/runtimeassemblies.json
@@ -24,10 +24,6 @@
       "resolutionPolicy": "private"
     },
     {
-      "name": "Azure.Monitor.OpenTelemetry.LiveMetrics",
-      "resolutionPolicy": "private"
-    },
-    {
       "name": "Azure.Security.KeyVault.Secrets",
       "resolutionPolicy": "private"
     },
@@ -37,6 +33,10 @@
     },
     {
       "name": "Azure.Storage.Common",
+      "resolutionPolicy": "private"
+    },
+    {
+      "name": "Azure.Storage.Files.Shares",
       "resolutionPolicy": "private"
     },
     {
@@ -124,6 +124,10 @@
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
+      "name": "Microsoft.AspNetCore.Authentication.BearerToken",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
       "name": "Microsoft.AspNetCore.Authentication.Cookies",
       "resolutionPolicy": "minorMatchOrLower"
     },
@@ -153,6 +157,10 @@
     },
     {
       "name": "Microsoft.AspNetCore.Components.Authorization",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
+      "name": "Microsoft.AspNetCore.Components.Endpoints",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
@@ -344,10 +352,6 @@
       "resolutionPolicy": "private"
     },
     {
-      "name": "Microsoft.AspNetCore.Mvc.Razor.Language",
-      "resolutionPolicy": "private"
-    },
-    {
       "name": "Microsoft.AspNetCore.Mvc.TagHelpers",
       "resolutionPolicy": "minorMatchOrLower"
     },
@@ -360,11 +364,27 @@
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
+      "name": "Microsoft.AspNetCore.OutputCaching",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
+      "name": "Microsoft.AspNetCore.RateLimiting",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
       "name": "Microsoft.AspNetCore.Razor",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
       "name": "Microsoft.AspNetCore.Razor.Runtime",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
+      "name": "Microsoft.AspNetCore.Razor.Language",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
+      "name": "Microsoft.AspNetCore.RequestDecompression",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
@@ -412,6 +432,10 @@
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
+      "name": "Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
       "name": "Microsoft.AspNetCore.Server.Kestrel.Transport.Quic",
       "resolutionPolicy": "minorMatchOrLower"
     },
@@ -437,6 +461,10 @@
     },
     {
       "name": "Microsoft.AspNetCore.SignalR.Protocols.Json",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
+      "name": "Microsoft.AspNetCore.StaticAssets",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
@@ -480,27 +508,7 @@
       "resolutionPolicy": "private"
     },
     {
-      "name": "Microsoft.Azure.Cosmos.Client",
-      "resolutionPolicy": "private"
-    },
-    {
-      "name": "Microsoft.Azure.Cosmos.Core",
-      "resolutionPolicy": "private"
-    },
-    {
-      "name": "Microsoft.Azure.Cosmos.Direct",
-      "resolutionPolicy": "private"
-    },
-    {
       "name": "Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption",
-      "resolutionPolicy": "private"
-    },
-    {
-      "name": "Microsoft.Azure.Cosmos.Table",
-      "resolutionPolicy": "private"
-    },
-    {
-      "name": "Microsoft.Azure.DocumentDB.Core",
       "resolutionPolicy": "private"
     },
     {
@@ -576,14 +584,6 @@
       "resolutionPolicy": "private"
     },
     {
-      "name": "Microsoft.Build",
-      "resolutionPolicy": "private"
-    },
-    {
-      "name": "Microsoft.Build.Framework",
-      "resolutionPolicy": "private"
-    },
-    {
       "name": "Microsoft.CodeAnalysis",
       "resolutionPolicy": "private"
     },
@@ -605,10 +605,6 @@
     },
     {
       "name": "Microsoft.CSharp",
-      "resolutionPolicy": "minorMatchOrLower"
-    },
-    {
-      "name": "Microsoft.DotNet.PlatformAbstractions",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
@@ -686,6 +682,10 @@
     {
       "name": "Microsoft.Extensions.Diagnostics",
       "resolutionPolicy": "private"
+    },
+    {
+      "name": "Microsoft.Extensions.Diagnostics.Abstractions",
+      "resolutionPolicy": "minorMatchOrLower"
     },
     {
       "name": "Microsoft.Extensions.Diagnostics.HealthChecks",
@@ -812,6 +812,10 @@
       "resolutionPolicy": "private"
     },
     {
+      "name": "Microsoft.Extensions.Validation",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
       "name": "Microsoft.Extensions.WebEncoders",
       "resolutionPolicy": "minorMatchOrLower"
     },
@@ -822,6 +826,10 @@
     {
       "name": "Microsoft.Identity.Client.Extensions.Msal",
       "resolutionPolicy": "private"
+    },
+    {
+      "name": "Microsoft.IdentityModel.Abstractions",
+      "resolutionPolicy": "minorMatchOrLower"
     },
     {
       "name": "Microsoft.IdentityModel.JsonWebTokens",
@@ -856,15 +864,7 @@
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
-      "name": "Microsoft.OData.Core",
-      "resolutionPolicy": "private"
-    },
-    {
-      "name": "Microsoft.OData.Edm",
-      "resolutionPolicy": "private"
-    },
-    {
-      "name": "Microsoft.Spatial",
+      "name": "Microsoft.Security.Utilities.Core",
       "resolutionPolicy": "private"
     },
     {
@@ -1152,6 +1152,14 @@
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
+      "name": "System.Formats.Cbor",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
+      "name": "System.Formats.Tar",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
       "name": "System.Globalization",
       "resolutionPolicy": "minorMatchOrLower"
     },
@@ -1244,6 +1252,10 @@
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
+      "name": "System.Linq.AsyncEnumerable",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
       "name": "System.Linq.Expressions",
       "resolutionPolicy": "minorMatchOrLower"
     },
@@ -1313,6 +1325,10 @@
     },
     {
       "name": "System.Net.Security",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
+      "name": "System.Net.ServerSentEvents",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
@@ -1460,6 +1476,10 @@
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
+      "name": "System.Runtime.InteropServices.JavaScript",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
       "name": "System.Runtime.InteropServices.RuntimeInformation",
       "resolutionPolicy": "minorMatchOrLower"
     },
@@ -1505,6 +1525,10 @@
     },
     {
       "name": "System.Security.Claims",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
+      "name": "System.Security.Cryptography",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
@@ -1600,11 +1624,19 @@
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
+      "name": "System.Threading.AccessControl",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
       "name": "System.Threading.Channels",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
       "name": "System.Threading.Overlapped",
+      "resolutionPolicy": "minorMatchOrLower"
+    },
+    {
+      "name": "System.Threading.RateLimiting",
       "resolutionPolicy": "minorMatchOrLower"
     },
     {
@@ -1642,10 +1674,6 @@
     {
       "name": "System.Transactions.Local",
       "resolutionPolicy": "minorMatchOrLower"
-    },
-    {
-      "name": "Microsoft.Security.Utilities",
-      "resolutionPolicy": "private"
     },
     {
       "name": "protobuf-net",


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

This pull request updates the runtime assembly lists in `runtimeassemblies.json` and `runtimeassemblies-relaxed.json` to better align with current dependencies and requirements. The main changes include adding support for new assemblies, removing obsolete or unused assemblies, and updating the resolution policies for some components.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

