### PR TITLE
[Compute Separation] Worker drain protocol and proxy management endpoints

### DIFF
--- a/WebJobs.Script.sln
+++ b/WebJobs.Script.sln
@@ -73,6 +73,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebJobs.Script.Abstractions
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Functions.WorkerProxy", "src\Functions.WorkerProxy\Functions.WorkerProxy.csproj", "{88029299-B3E3-46BB-B5DF-57669DB10DBB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Functions.WorkerProxy.Tests", "test\Functions.WorkerProxy.Tests\Functions.WorkerProxy.Tests.csproj", "{52A072D5-49B2-4C36-A6BE-9FCB07C765DC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -169,6 +171,10 @@ Global
 		{88029299-B3E3-46BB-B5DF-57669DB10DBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{88029299-B3E3-46BB-B5DF-57669DB10DBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{88029299-B3E3-46BB-B5DF-57669DB10DBB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{52A072D5-49B2-4C36-A6BE-9FCB07C765DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{52A072D5-49B2-4C36-A6BE-9FCB07C765DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{52A072D5-49B2-4C36-A6BE-9FCB07C765DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{52A072D5-49B2-4C36-A6BE-9FCB07C765DC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -199,6 +205,7 @@ Global
 		{1D031D10-9B04-544D-3FEE-45CB178F05A0} = {B2312621-6D0A-429F-9A45-06B45CE69691}
 		{12894F85-EC35-440F-8706-A62372C285F6} = {AFB0F5F7-A612-4F4A-94DD-8B69CABF7970}
 		{88029299-B3E3-46BB-B5DF-57669DB10DBB} = {16351B76-87CA-4A8C-80A1-3DD83A0C4AA6}
+		{52A072D5-49B2-4C36-A6BE-9FCB07C765DC} = {AFB0F5F7-A612-4F4A-94DD-8B69CABF7970}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {85400884-5FFD-4C27-A571-58CB3C8CAAC5}

--- a/eng/ci/templates/jobs/run-unit-tests.yml
+++ b/eng/ci/templates/jobs/run-unit-tests.yml
@@ -8,6 +8,7 @@ jobs:
       **/ExtensionsMetadataGeneratorTests.csproj
       **/WebJobs.Script.Tests.csproj
       **/WebJobs.Script.Abstractions.Tests.csproj
+      **/Functions.WorkerProxy.Tests.csproj
 
   templateContext:
     outputParentDirectory: $(Build.ArtifactStagingDirectory)

--- a/src/Functions.WorkerProxy/FunctionRpcRelay.cs
+++ b/src/Functions.WorkerProxy/FunctionRpcRelay.cs
@@ -33,6 +33,7 @@ internal sealed class FunctionRpcRelay : FunctionRpc.FunctionRpcBase
 {
     private readonly RelayOptions _options;
     private readonly ILogger<FunctionRpcRelay> _logger;
+    private readonly WorkerPodStateManager _stateManager;
 
     // Channels that buffer messages flowing in each direction.
     private readonly Channel<StreamingMessage> _toWorker = Channel.CreateUnbounded<StreamingMessage>();
@@ -42,10 +43,26 @@ internal sealed class FunctionRpcRelay : FunctionRpc.FunctionRpcBase
     private readonly TaskCompletionSource _runtimeConnected = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly TaskCompletionSource _workerConnected = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-    public FunctionRpcRelay(RelayOptions options, ILogger<FunctionRpcRelay> logger)
+    public FunctionRpcRelay(RelayOptions options, ILogger<FunctionRpcRelay> logger, WorkerPodStateManager stateManager)
     {
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _stateManager = stateManager ?? throw new ArgumentNullException(nameof(stateManager));
+    }
+
+    /// <summary>
+    /// Sends a <c>WorkerDrainRequest</c> to the runtime over the gRPC stream.
+    /// Called when NNA calls <c>POST /drain</c> on the worker proxy.
+    /// </summary>
+    public async Task SendDrainRequestToRuntimeAsync()
+    {
+        var message = new StreamingMessage
+        {
+            WorkerDrainRequest = new WorkerDrainRequest()
+        };
+
+        await _toRuntime.Writer.WriteAsync(message);
+        _logger.LogInformation("Sent WorkerDrainRequest to runtime.");
     }
 
     /// <inheritdoc />
@@ -70,6 +87,8 @@ internal sealed class FunctionRpcRelay : FunctionRpc.FunctionRpcBase
         {
             _logger.LogInformation("Worker connected on port {Port}", localPort);
             _workerConnected.TrySetResult();
+            _stateManager.UpdatePodStatus(WorkerPodStatus.ReadyForRequest);
+            _stateManager.UpdateHealthStatus(WorkerPodHealthStatus.Healthy);
             await _runtimeConnected.Task.WaitAsync(context.CancellationToken);
 
             // Worker reads from _toWorker, writes into _toRuntime.
@@ -137,6 +156,17 @@ internal sealed class FunctionRpcRelay : FunctionRpc.FunctionRpcBase
                         message.WorkerInitResponse.Capabilities["HttpUri"] = _options.HttpProxyEndpoint;
                         _logger.LogInformation("Rewrote HttpUri capability to {Uri}", _options.HttpProxyEndpoint);
                     }
+                }
+
+                // Intercept WorkerDrainComplete from runtime — update state machine.
+                // Do NOT forward drain messages to the language worker.
+                if (string.Equals(side, "runtime", StringComparison.Ordinal)
+                    && message.ContentCase == StreamingMessage.ContentOneofCase.WorkerDrainComplete)
+                {
+                    _logger.LogInformation("Received WorkerDrainComplete from runtime.");
+                    _stateManager.UpdatePodStatus(WorkerPodStatus.DrainCompleted);
+                    _stateManager.UpdatePodStatus(WorkerPodStatus.MarkForDeletion);
+                    continue; // Don't relay drain messages to the language worker.
                 }
 
                 await writer.WriteAsync(message, cancellationToken);

--- a/src/Functions.WorkerProxy/Functions.WorkerProxy.csproj
+++ b/src/Functions.WorkerProxy/Functions.WorkerProxy.csproj
@@ -13,6 +13,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.Azure.Functions.WorkerProxy.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.55.0" />
     <PackageReference Include="Grpc.Tools" Version="2.55.1" PrivateAssets="All" />
     <PackageReference Include="Yarp.ReverseProxy" Version="2.0.1" />

--- a/src/Functions.WorkerProxy/Program.cs
+++ b/src/Functions.WorkerProxy/Program.cs
@@ -88,17 +88,15 @@ app.MapPost("/instanceState", async (HttpContext ctx, CancellationToken cancella
     int clientRevisionId = 0;
 
     // Read client's last known revision from request body (if present).
-    if (ctx.Request.ContentLength > 0)
+    // Always attempt to read — ContentLength may be null for chunked requests.
+    try
     {
-        try
-        {
-            var clientState = await ctx.Request.ReadFromJsonAsync<WorkerPodState>(cancellationToken);
-            clientRevisionId = clientState?.RevisionId ?? 0;
-        }
-        catch
-        {
-            // If body can't be parsed, treat as revision 0 (return current state).
-        }
+        var clientState = await ctx.Request.ReadFromJsonAsync<WorkerPodState>(cancellationToken);
+        clientRevisionId = clientState?.RevisionId ?? 0;
+    }
+    catch
+    {
+        // Empty body, malformed JSON, or no content — treat as revision 0 (return current state).
     }
 
     var result = await stateManager.WaitForChangeAsync(clientRevisionId, cancellationToken);

--- a/src/Functions.WorkerProxy/Program.cs
+++ b/src/Functions.WorkerProxy/Program.cs
@@ -14,11 +14,13 @@ builder.WebHost.UseUrls();
 int runtimeGrpcPort = GetIntArg(args, "--runtime-grpc-port", 50051);
 int workerGrpcPort = GetIntArg(args, "--worker-grpc-port", 50052);
 int httpProxyPort = GetIntArg(args, "--http-proxy-port", 50053);
+int managementPort = GetIntArg(args, "--management-port", 50054);
 string workerHttpEndpoint = GetStringArg(args, "--worker-http-endpoint", "http://localhost:8080");
 string? hostJsonPath = GetStringArgOrNull(args, "--host-json-path");
 string httpProxyEndpoint = GetStringArg(args, "--http-proxy-endpoint", $"http://localhost:{httpProxyPort}");
 
 builder.Services.AddSingleton(new RelayOptions(runtimeGrpcPort, workerGrpcPort, httpProxyPort, hostJsonPath, httpProxyEndpoint));
+builder.Services.AddSingleton<WorkerPodStateManager>();
 builder.Services.AddSingleton<FunctionRpcRelay>();
 builder.Services.AddGrpc();
 builder.Services.AddHttpForwarder();
@@ -28,6 +30,7 @@ builder.WebHost.ConfigureKestrel(options =>
     options.ListenAnyIP(runtimeGrpcPort, listenOptions => listenOptions.Protocols = HttpProtocols.Http2);
     options.ListenAnyIP(workerGrpcPort, listenOptions => listenOptions.Protocols = HttpProtocols.Http2);
     options.ListenAnyIP(httpProxyPort, listenOptions => listenOptions.Protocols = HttpProtocols.Http1);
+    options.ListenAnyIP(managementPort, listenOptions => listenOptions.Protocols = HttpProtocols.Http1);
 });
 
 var app = builder.Build();
@@ -48,6 +51,65 @@ app.Use(async (ctx, next) =>
 });
 
 app.MapGrpcService<FunctionRpcRelay>();
+
+// ---------------------------------------------------------------------------
+// Management API endpoints (minimal APIs for AOT compatibility).
+// Called by NNA on the management port.
+// ---------------------------------------------------------------------------
+
+var stateManager = app.Services.GetRequiredService<WorkerPodStateManager>();
+var relay = app.Services.GetRequiredService<FunctionRpcRelay>();
+
+app.MapGet("/ready", () =>
+{
+    return stateManager.CurrentStatus >= WorkerPodStatus.ReadyForRequest
+        ? Results.Ok()
+        : Results.StatusCode(503);
+});
+
+// [CS-TODO] Implement worker specialization. NNA calls this after /ready succeeds
+// with the app settings payload. The worker proxy should forward this to the language
+// worker as a FunctionEnvironmentReloadRequest over gRPC, causing the worker to
+// apply environment variables and load customer code.
+app.MapPost("/assign", () =>
+{
+    return Results.Ok();
+});
+
+app.MapPost("/drain", async () =>
+{
+    stateManager.UpdatePodStatus(WorkerPodStatus.Draining);
+    await relay.SendDrainRequestToRuntimeAsync();
+    return Results.Accepted();
+});
+
+app.MapPost("/instanceState", async (HttpContext ctx, CancellationToken cancellationToken) =>
+{
+    int clientRevisionId = 0;
+
+    // Read client's last known revision from request body (if present).
+    if (ctx.Request.ContentLength > 0)
+    {
+        try
+        {
+            var clientState = await ctx.Request.ReadFromJsonAsync<WorkerPodState>(cancellationToken);
+            clientRevisionId = clientState?.RevisionId ?? 0;
+        }
+        catch
+        {
+            // If body can't be parsed, treat as revision 0 (return current state).
+        }
+    }
+
+    var result = await stateManager.WaitForChangeAsync(clientRevisionId, cancellationToken);
+
+    if (result is null)
+    {
+        return Results.NoContent();
+    }
+
+    return Results.Ok(result);
+});
 
 app.Run();
 

--- a/src/Functions.WorkerProxy/WorkerPodState.cs
+++ b/src/Functions.WorkerProxy/WorkerPodState.cs
@@ -1,0 +1,86 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Azure.Functions.WorkerProxy;
+
+/// <summary>
+/// Pod status values for the worker proxy state machine.
+/// Matches the Go Proxy's <c>FunctionAppPodStatus</c> pattern.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+internal enum WorkerPodStatus
+{
+    None,
+    ReadyForRequest,
+    Draining,
+    DrainCompleted,
+    MarkForDeletion
+}
+
+/// <summary>
+/// Health status values for the worker proxy.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+internal enum WorkerPodHealthStatus
+{
+    None,
+    Healthy,
+    Unhealthy
+}
+
+/// <summary>
+/// Change flags indicating what changed in the state (bitmask).
+/// Same pattern as Go Proxy's <c>FunctionsPodStatusChangeFlags</c>.
+/// </summary>
+[Flags]
+internal enum WorkerPodChangeFlags
+{
+    None = 0,
+    PodStatus = 1,
+    HealthStatus = 2
+}
+
+/// <summary>
+/// State transition record for the worker pod.
+/// </summary>
+internal sealed class PodStatusTransition
+{
+    [JsonPropertyName("fromPodStatus")]
+    public WorkerPodStatus FromPodStatus { get; set; }
+
+    [JsonPropertyName("toPodStatus")]
+    public WorkerPodStatus ToPodStatus { get; set; }
+}
+
+/// <summary>
+/// Health status transition record.
+/// </summary>
+internal sealed class PodHealthStatusTransition
+{
+    [JsonPropertyName("fromPodStatus")]
+    public WorkerPodHealthStatus FromPodStatus { get; set; }
+
+    [JsonPropertyName("toPodStatus")]
+    public WorkerPodHealthStatus ToPodStatus { get; set; }
+}
+
+/// <summary>
+/// Worker pod state returned by the <c>/instanceState</c> endpoint.
+/// Follows the same structure as the Go Proxy's <c>FunctionsPodState</c>.
+/// </summary>
+internal sealed class WorkerPodState
+{
+    [JsonPropertyName("currentPodStatusTransition")]
+    public PodStatusTransition CurrentPodStatusTransition { get; set; } = new();
+
+    [JsonPropertyName("currentPodHealthStatusTransition")]
+    public PodHealthStatusTransition CurrentPodHealthStatusTransition { get; set; } = new();
+
+    [JsonPropertyName("changeFlags")]
+    public WorkerPodChangeFlags ChangeFlags { get; set; }
+
+    [JsonPropertyName("revisionId")]
+    public int RevisionId { get; set; }
+}

--- a/src/Functions.WorkerProxy/WorkerPodStateManager.cs
+++ b/src/Functions.WorkerProxy/WorkerPodStateManager.cs
@@ -16,7 +16,9 @@ internal sealed class WorkerPodStateManager
     private readonly List<TaskCompletionSource<WorkerPodState>> _listeners = [];
 
     private WorkerPodStatus _currentStatus = WorkerPodStatus.None;
+    private WorkerPodStatus _previousStatus = WorkerPodStatus.None;
     private WorkerPodHealthStatus _currentHealthStatus = WorkerPodHealthStatus.None;
+    private WorkerPodHealthStatus _previousHealthStatus = WorkerPodHealthStatus.None;
     private int _revisionId;
 
     /// <summary>
@@ -39,6 +41,7 @@ internal sealed class WorkerPodStateManager
                 return;
             }
 
+            _previousStatus = _currentStatus;
             _currentStatus = newStatus;
             _revisionId++;
 
@@ -58,6 +61,7 @@ internal sealed class WorkerPodStateManager
                 return;
             }
 
+            _previousHealthStatus = _currentHealthStatus;
             _currentHealthStatus = newStatus;
             _revisionId++;
 
@@ -96,6 +100,10 @@ internal sealed class WorkerPodStateManager
         {
             return null;
         }
+        catch (OperationCanceledException)
+        {
+            return null;
+        }
         finally
         {
             lock (_lock)
@@ -122,10 +130,12 @@ internal sealed class WorkerPodStateManager
         {
             CurrentPodStatusTransition = new PodStatusTransition
             {
+                FromPodStatus = _previousStatus,
                 ToPodStatus = _currentStatus
             },
             CurrentPodHealthStatusTransition = new PodHealthStatusTransition
             {
+                FromPodStatus = _previousHealthStatus,
                 ToPodStatus = _currentHealthStatus
             },
             ChangeFlags = WorkerPodChangeFlags.PodStatus | WorkerPodChangeFlags.HealthStatus,

--- a/src/Functions.WorkerProxy/WorkerPodStateManager.cs
+++ b/src/Functions.WorkerProxy/WorkerPodStateManager.cs
@@ -1,0 +1,146 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.Functions.WorkerProxy;
+
+/// <summary>
+/// Manages the internal state machine for the worker pod and provides
+/// long-polling notifications for <c>/instanceState</c>.
+/// Thread-safe. Follows the same pattern as the Go Proxy's <c>FunctionsRecord</c>.
+/// </summary>
+internal sealed class WorkerPodStateManager
+{
+    private static readonly TimeSpan LongPollTimeout = TimeSpan.FromSeconds(60);
+
+    private readonly object _lock = new();
+    private readonly List<TaskCompletionSource<WorkerPodState>> _listeners = [];
+
+    private WorkerPodStatus _currentStatus = WorkerPodStatus.None;
+    private WorkerPodHealthStatus _currentHealthStatus = WorkerPodHealthStatus.None;
+    private int _revisionId;
+
+    /// <summary>
+    /// Gets the current pod status.
+    /// </summary>
+    public WorkerPodStatus CurrentStatus
+    {
+        get { lock (_lock) { return _currentStatus; } }
+    }
+
+    /// <summary>
+    /// Updates the pod status and notifies all long-polling listeners.
+    /// </summary>
+    public void UpdatePodStatus(WorkerPodStatus newStatus)
+    {
+        lock (_lock)
+        {
+            if (_currentStatus == newStatus)
+            {
+                return;
+            }
+
+            _currentStatus = newStatus;
+            _revisionId++;
+
+            NotifyListeners();
+        }
+    }
+
+    /// <summary>
+    /// Updates the health status and notifies all long-polling listeners.
+    /// </summary>
+    public void UpdateHealthStatus(WorkerPodHealthStatus newStatus)
+    {
+        lock (_lock)
+        {
+            if (_currentHealthStatus == newStatus)
+            {
+                return;
+            }
+
+            _currentHealthStatus = newStatus;
+            _revisionId++;
+
+            NotifyListeners();
+        }
+    }
+
+    /// <summary>
+    /// Returns the current state if it has changed since <paramref name="clientRevisionId"/>,
+    /// otherwise blocks until a state change occurs or the long-poll timeout expires.
+    /// </summary>
+    /// <param name="clientRevisionId">The client's last known revision ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The current state if changed, or <see langword="null"/> on timeout (204 No Content).</returns>
+    public async Task<WorkerPodState?> WaitForChangeAsync(int clientRevisionId, CancellationToken cancellationToken)
+    {
+        TaskCompletionSource<WorkerPodState>? listener = null;
+
+        lock (_lock)
+        {
+            if (_revisionId != clientRevisionId)
+            {
+                return BuildState();
+            }
+
+            listener = new TaskCompletionSource<WorkerPodState>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _listeners.Add(listener);
+        }
+
+        try
+        {
+            var result = await listener.Task.WaitAsync(LongPollTimeout, cancellationToken);
+            return result;
+        }
+        catch (TimeoutException)
+        {
+            return null;
+        }
+        finally
+        {
+            lock (_lock)
+            {
+                _listeners.Remove(listener);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns the current state snapshot.
+    /// </summary>
+    public WorkerPodState GetCurrentState()
+    {
+        lock (_lock)
+        {
+            return BuildState();
+        }
+    }
+
+    private WorkerPodState BuildState()
+    {
+        return new WorkerPodState
+        {
+            CurrentPodStatusTransition = new PodStatusTransition
+            {
+                ToPodStatus = _currentStatus
+            },
+            CurrentPodHealthStatusTransition = new PodHealthStatusTransition
+            {
+                ToPodStatus = _currentHealthStatus
+            },
+            ChangeFlags = WorkerPodChangeFlags.PodStatus | WorkerPodChangeFlags.HealthStatus,
+            RevisionId = _revisionId
+        };
+    }
+
+    private void NotifyListeners()
+    {
+        var state = BuildState();
+        foreach (var listener in _listeners)
+        {
+            listener.TrySetResult(state);
+        }
+
+        _listeners.Clear();
+    }
+}

--- a/src/WebJobs.Script.Grpc/Channel/WorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/WorkerChannel.cs
@@ -251,6 +251,9 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     case MsgType.InvocationResponse:
                         _ = InvokeResponse(msg.Message.InvocationResponse);
                         break;
+                    case MsgType.WorkerDrainRequest:
+                        OnDrainRequested();
+                        break;
                     default:
                         ProcessRegisteredGrpcCallbacks(msg);
                         break;
@@ -384,7 +387,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             }
         }
 
-        public bool IsChannelReadyForInvocations()
+        public virtual bool IsChannelReadyForInvocations()
         {
             return !_disposing && !_disposed
                 && _state.HasFlag(
@@ -1402,6 +1405,14 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             var evt = new OutboundGrpcEvent(_workerId, msg);
 
             return _outbound.TryWrite(evt) ? default : _outbound.WriteAsync(evt);
+        }
+
+        /// <summary>
+        /// Called when a <c>WorkerDrainRequest</c> message is received from the worker proxy.
+        /// Override in derived classes to handle drain signaling.
+        /// </summary>
+        protected virtual void OnDrainRequested()
+        {
         }
 
         protected void SendStreamingMessage(StreamingMessage msg)

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerChannel.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
     /// </summary>
     internal sealed class ConnectedWorkerChannel : WorkerChannel, IConnectedWorkerChannel
     {
+        private volatile bool _isDraining;
+
         internal ConnectedWorkerChannel(
             string workerId,
             IScriptEventManager eventManager,
@@ -42,7 +44,13 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
         }
 
         /// <inheritdoc/>
+        public event Action<string> DrainRequested;
+
+        /// <inheritdoc/>
         public override IWorkerProcess WorkerProcess => null;
+
+        /// <inheritdoc/>
+        public bool IsDraining => _isDraining;
 
         /// <inheritdoc/>
         public override Task StartWorkerProcessAsync(CancellationToken cancellationToken)
@@ -69,6 +77,30 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
         /// <param name="capability">The capability key to look up.</param>
         /// <returns>The capability value, or <see langword="null"/>.</returns>
         public string GetCapabilityState(string capability) => WorkerCapabilities.GetCapabilityState(capability);
+
+        /// <inheritdoc/>
+        public void BeginDrain() => _isDraining = true;
+
+        /// <inheritdoc/>
+        public override bool IsChannelReadyForInvocations()
+        {
+            return !_isDraining && base.IsChannelReadyForInvocations();
+        }
+
+        /// <inheritdoc/>
+        protected override void OnDrainRequested()
+        {
+            DrainRequested?.Invoke(Id);
+        }
+
+        /// <inheritdoc/>
+        public void SendWorkerDrainComplete()
+        {
+            SendStreamingMessage(new Grpc.Messages.StreamingMessage
+            {
+                WorkerDrainComplete = new Grpc.Messages.WorkerDrainComplete()
+            });
+        }
 
         /// <inheritdoc/>
         protected override void DisposeWorkerResources()

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/IConnectedWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/IConnectedWorkerChannel.cs
@@ -15,6 +15,17 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers;
 internal interface IConnectedWorkerChannel : IRpcWorkerChannel
 {
     /// <summary>
+    /// Raised when the worker proxy sends a <c>WorkerDrainRequest</c> over gRPC.
+    /// The subscriber should drain in-flight invocations and send <c>WorkerDrainComplete</c> back.
+    /// </summary>
+    event Action<string> DrainRequested;
+
+    /// <summary>
+    /// Gets a value indicating whether this channel is currently draining.
+    /// </summary>
+    bool IsDraining { get; }
+
+    /// <summary>
     /// Waits for the worker to complete the init handshake.
     /// </summary>
     Task WaitForInitAsync(TimeSpan timeout, CancellationToken cancellationToken);
@@ -24,4 +35,15 @@ internal interface IConnectedWorkerChannel : IRpcWorkerChannel
     /// or <see langword="null"/> if not present.
     /// </summary>
     string GetCapabilityState(string capability);
+
+    /// <summary>
+    /// Marks this channel as draining. New invocations will not be routed to this channel,
+    /// but in-flight invocations will continue to completion.
+    /// </summary>
+    void BeginDrain();
+
+    /// <summary>
+    /// Sends a <c>WorkerDrainComplete</c> message to the worker proxy over gRPC.
+    /// </summary>
+    void SendWorkerDrainComplete();
 }

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/WorkerConnectionService.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/WorkerConnectionService.cs
@@ -357,6 +357,13 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
     /// </summary>
     private async Task CleanupWorkerResourcesAsync(string workerId, WorkerConnection worker)
     {
+        // Unsubscribe from drain events before disposing the channel.
+        var channel = _channelManager.GetChannel(workerId);
+        if (channel is IConnectedWorkerChannel connectedChannel)
+        {
+            connectedChannel.DrainRequested -= OnWorkerDrainRequested;
+        }
+
         await _channelManager.ShutdownChannelAsync(workerId);
 
         if (worker.Client is not null)

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/WorkerConnectionService.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/WorkerConnectionService.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers;
 internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectionManager, IAsyncDisposable
 {
     private static readonly TimeSpan InitTimeout = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan DrainTimeout = TimeSpan.FromMinutes(1);
 
     private readonly IConnectedWorkerChannelFactory _channelFactory;
     private readonly IConnectedWorkerChannelManager _channelManager;
@@ -148,6 +149,10 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
 
             // Register the channel directly — no event needed.
             _channelManager.AddChannel(workerId, channel);
+
+            // Subscribe to drain signals from the worker proxy.
+            channel.DrainRequested += OnWorkerDrainRequested;
+
             _logger.LogInformation("Worker '{workerId}' connected and registered.", workerId);
 
             // Start or update the ScriptHost based on whether this is the first worker.
@@ -218,10 +223,42 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
         // Wait for any in-flight ConnectWorkerAsync to finish before cleaning up.
         await worker.ConnectCompleted.Task;
 
+        // Mark channel as draining so no new invocations are routed.
+        var channel = _channelManager.GetChannel(workerId);
+        if (channel is IConnectedWorkerChannel connectedChannel)
+        {
+            connectedChannel.BeginDrain();
+        }
+
         worker.Info.State = WorkerConnectionState.Draining;
+        _logger.LogInformation("Worker '{workerId}' marked as draining. Waiting for in-flight invocations.", workerId);
 
         try
         {
+            // Drain in-flight invocations with timeout before cleanup.
+            if (channel is not null)
+            {
+                try
+                {
+                    await channel.DrainInvocationsAsync()
+                        .WaitAsync(DrainTimeout, cancellationToken);
+                }
+                catch (TimeoutException)
+                {
+                    _logger.LogWarning("Drain timeout exceeded for worker '{workerId}'. Proceeding with disconnect.", workerId);
+                }
+
+                // Send WorkerDrainComplete to the worker proxy before closing the connection.
+                if (channel is IConnectedWorkerChannel drainedChannel)
+                {
+                    drainedChannel.SendWorkerDrainComplete();
+                    _logger.LogInformation("Sent WorkerDrainComplete to worker '{workerId}'.", workerId);
+                }
+            }
+
+            // [CS-TODO] When the last worker is drained (scale-in), should the runtime
+            // pause trigger listeners or enter a degraded state? For now we just disconnect.
+
             await CleanupWorkerResourcesAsync(workerId, worker);
             _logger.LogInformation("Worker '{workerId}' disconnected.", workerId);
         }
@@ -243,6 +280,26 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
     /// <inheritdoc/>
     public WorkerConnectionInfo GetWorkerStatus(string workerId)
         => _workers.TryGetValue(workerId, out var worker) ? worker.Info : null;
+
+    /// <summary>
+    /// Event handler for <see cref="IConnectedWorkerChannel.DrainRequested"/>.
+    /// Fired when the worker proxy sends a <c>WorkerDrainRequest</c> over gRPC.
+    /// </summary>
+    private void OnWorkerDrainRequested(string workerId)
+    {
+        _logger.LogInformation("Received WorkerDrainRequest for worker '{workerId}'.", workerId);
+
+        // Fire-and-forget — disconnect (which includes drain) runs in the background.
+        _ = DisconnectWorkerAsync(workerId, CancellationToken.None).ContinueWith(
+            t =>
+            {
+                if (t.IsFaulted)
+                {
+                    _logger.LogError(t.Exception, "Error draining worker '{workerId}'.", workerId);
+                }
+            },
+            TaskScheduler.Default);
+    }
 
     /// <inheritdoc/>
     public async Task StopAsync(CancellationToken cancellationToken)

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/WorkerConnectionService.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/WorkerConnectionService.cs
@@ -215,7 +215,13 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
     {
         _logger.LogInformation("Disconnecting worker '{workerId}'.", workerId);
 
-        if (!_workers.TryRemove(workerId, out var worker))
+        if (!_workers.TryGetValue(workerId, out var worker))
+        {
+            return;
+        }
+
+        // Atomically claim the disconnect — prevents double-disconnect races.
+        if (!worker.TryClaimDisconnect())
         {
             return;
         }
@@ -260,6 +266,9 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
             // pause trigger listeners or enter a degraded state? For now we just disconnect.
 
             await CleanupWorkerResourcesAsync(workerId, worker);
+
+            // Remove from tracking only after cleanup succeeds.
+            _workers.TryRemove(workerId, out _);
             _logger.LogInformation("Worker '{workerId}' disconnected.", workerId);
         }
         catch (Exception ex)
@@ -383,6 +392,8 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
     /// </summary>
     private class WorkerConnection
     {
+        private int _disconnecting;
+
         public WorkerConnectionInfo Info { get; set; }
 
         public IOutboundGrpcClient Client { get; set; }
@@ -394,5 +405,11 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
         /// racing with an in-flight connection.
         /// </summary>
         public TaskCompletionSource ConnectCompleted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>
+        /// Atomically claims the disconnect operation. Returns <see langword="true"/> if this
+        /// caller is the first to claim it; subsequent callers get <see langword="false"/>.
+        /// </summary>
+        public bool TryClaimDisconnect() => Interlocked.CompareExchange(ref _disconnecting, 1, 0) == 0;
     }
 }

--- a/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
+++ b/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
@@ -93,6 +93,11 @@ message StreamingMessage {
     // Worker responds after warming up with the warmup result
     WorkerWarmupResponse worker_warmup_response = 34;
 
+    // [CS-TODO] The drain messages below are temporarily added to FunctionRpc.proto
+    // for the compute separation preview. Before merging into dev, these should be
+    // refactored into a separate proto contract owned by the worker proxy, since
+    // drain is a runtime↔worker proxy concern and not part of the language worker protocol.
+
     // Worker proxy signals the runtime that this worker should be drained.
     // Runtime should stop routing new invocations and drain in-flight ones.
     WorkerDrainRequest worker_drain_request = 35;
@@ -467,6 +472,9 @@ message WorkerWarmupRequest {
 message WorkerWarmupResponse {
   StatusResult result = 1;
 }
+
+// [CS-TODO] Drain messages are temporarily here for compute separation preview.
+// Refactor into a separate proto contract before merging into dev.
 
 // Worker proxy signals the runtime that this worker should be drained.
 // The runtime should stop routing new invocations to this worker,

--- a/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
+++ b/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto
@@ -92,6 +92,14 @@ message StreamingMessage {
     
     // Worker responds after warming up with the warmup result
     WorkerWarmupResponse worker_warmup_response = 34;
+
+    // Worker proxy signals the runtime that this worker should be drained.
+    // Runtime should stop routing new invocations and drain in-flight ones.
+    WorkerDrainRequest worker_drain_request = 35;
+
+    // Runtime signals the worker proxy that drain is complete.
+    // All in-flight invocations have finished and the connection will be closed.
+    WorkerDrainComplete worker_drain_complete = 36;
     
   }
 }
@@ -458,6 +466,17 @@ message WorkerWarmupRequest {
 
 message WorkerWarmupResponse {
   StatusResult result = 1;
+}
+
+// Worker proxy signals the runtime that this worker should be drained.
+// The runtime should stop routing new invocations to this worker,
+// drain any in-flight invocations, and respond with WorkerDrainComplete.
+message WorkerDrainRequest {
+}
+
+// Runtime signals the worker proxy that drain is complete.
+// All in-flight invocations for this worker have finished.
+message WorkerDrainComplete {
 }
 
 // Used to encapsulate data which could be a variety of types

--- a/test/Functions.WorkerProxy.Tests/FunctionRpcRelayTests.cs
+++ b/test/Functions.WorkerProxy.Tests/FunctionRpcRelayTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Microsoft.Azure.Functions.WorkerProxy.Tests;
+
+public class FunctionRpcRelayTests
+{
+    private readonly WorkerPodStateManager _stateManager;
+    private readonly FunctionRpcRelay _relay;
+
+    public FunctionRpcRelayTests()
+    {
+        _stateManager = new WorkerPodStateManager();
+        var options = new RelayOptions(50051, 50052, 50053, null, "http://localhost:50053");
+        _relay = new FunctionRpcRelay(options, NullLogger<FunctionRpcRelay>.Instance, _stateManager);
+    }
+
+    [Fact]
+    public async Task SendDrainRequestToRuntimeAsync_WritesMessageToChannel()
+    {
+        // SendDrainRequestToRuntimeAsync writes to _toRuntime channel.
+        // We can verify it doesn't throw and completes successfully.
+        // The actual message delivery is verified by integration tests.
+        await _relay.SendDrainRequestToRuntimeAsync();
+
+        // If we get here without exception, the message was buffered in the
+        // unbounded channel. This verifies the channel is writable and the
+        // message is correctly constructed.
+    }
+
+    [Fact]
+    public async Task SendDrainRequestToRuntimeAsync_MultipleCalls_AllSucceed()
+    {
+        // Unbounded channel should accept multiple drain requests.
+        await _relay.SendDrainRequestToRuntimeAsync();
+        await _relay.SendDrainRequestToRuntimeAsync();
+        await _relay.SendDrainRequestToRuntimeAsync();
+    }
+
+    [Fact]
+    public void Constructor_NullOptions_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new FunctionRpcRelay(null!, NullLogger<FunctionRpcRelay>.Instance, _stateManager));
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_Throws()
+    {
+        var options = new RelayOptions(50051, 50052, 50053, null, "http://localhost:50053");
+        Assert.Throws<ArgumentNullException>(() =>
+            new FunctionRpcRelay(options, null!, _stateManager));
+    }
+
+    [Fact]
+    public void Constructor_NullStateManager_Throws()
+    {
+        var options = new RelayOptions(50051, 50052, 50053, null, "http://localhost:50053");
+        Assert.Throws<ArgumentNullException>(() =>
+            new FunctionRpcRelay(options, NullLogger<FunctionRpcRelay>.Instance, null!));
+    }
+
+    [Fact]
+    public void InitialState_IsNone()
+    {
+        // The relay doesn't change state until a worker connects.
+        Assert.Equal(WorkerPodStatus.None, _stateManager.CurrentStatus);
+    }
+}

--- a/test/Functions.WorkerProxy.Tests/Functions.WorkerProxy.Tests.csproj
+++ b/test/Functions.WorkerProxy.Tests/Functions.WorkerProxy.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <AssemblyName>Microsoft.Azure.Functions.WorkerProxy.Tests</AssemblyName>
+    <RootNamespace>Microsoft.Azure.Functions.WorkerProxy.Tests</RootNamespace>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Standalone test project; opt out of repo-level code-analysis ruleset. -->
+    <CodeAnalysisRuleSet />
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" PrivateAssets="all" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Functions.WorkerProxy\Functions.WorkerProxy.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Functions.WorkerProxy.Tests/WorkerPodStateManagerTests.cs
+++ b/test/Functions.WorkerProxy.Tests/WorkerPodStateManagerTests.cs
@@ -1,0 +1,175 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.Azure.Functions.WorkerProxy.Tests;
+
+public class WorkerPodStateManagerTests
+{
+    [Fact]
+    public void InitialStatus_IsNone()
+    {
+        var manager = new WorkerPodStateManager();
+
+        Assert.Equal(WorkerPodStatus.None, manager.CurrentStatus);
+    }
+
+    [Fact]
+    public void UpdatePodStatus_ChangesCurrentStatus()
+    {
+        var manager = new WorkerPodStateManager();
+
+        manager.UpdatePodStatus(WorkerPodStatus.ReadyForRequest);
+
+        Assert.Equal(WorkerPodStatus.ReadyForRequest, manager.CurrentStatus);
+    }
+
+    [Fact]
+    public void UpdatePodStatus_SameValue_DoesNotIncrementRevision()
+    {
+        var manager = new WorkerPodStateManager();
+
+        manager.UpdatePodStatus(WorkerPodStatus.ReadyForRequest);
+        var state1 = manager.GetCurrentState();
+
+        manager.UpdatePodStatus(WorkerPodStatus.ReadyForRequest);
+        var state2 = manager.GetCurrentState();
+
+        Assert.Equal(state1.RevisionId, state2.RevisionId);
+    }
+
+    [Fact]
+    public void UpdatePodStatus_DifferentValue_IncrementsRevision()
+    {
+        var manager = new WorkerPodStateManager();
+
+        manager.UpdatePodStatus(WorkerPodStatus.ReadyForRequest);
+        var state1 = manager.GetCurrentState();
+
+        manager.UpdatePodStatus(WorkerPodStatus.Draining);
+        var state2 = manager.GetCurrentState();
+
+        Assert.Equal(state1.RevisionId + 1, state2.RevisionId);
+    }
+
+    [Fact]
+    public void GetCurrentState_PopulatesFromPodStatus()
+    {
+        var manager = new WorkerPodStateManager();
+
+        manager.UpdatePodStatus(WorkerPodStatus.ReadyForRequest);
+        manager.UpdatePodStatus(WorkerPodStatus.Draining);
+
+        var state = manager.GetCurrentState();
+
+        Assert.Equal(WorkerPodStatus.ReadyForRequest, state.CurrentPodStatusTransition.FromPodStatus);
+        Assert.Equal(WorkerPodStatus.Draining, state.CurrentPodStatusTransition.ToPodStatus);
+    }
+
+    [Fact]
+    public void GetCurrentState_PopulatesFromHealthStatus()
+    {
+        var manager = new WorkerPodStateManager();
+
+        manager.UpdateHealthStatus(WorkerPodHealthStatus.Healthy);
+        manager.UpdateHealthStatus(WorkerPodHealthStatus.Unhealthy);
+
+        var state = manager.GetCurrentState();
+
+        Assert.Equal(WorkerPodHealthStatus.Healthy, state.CurrentPodHealthStatusTransition.FromPodStatus);
+        Assert.Equal(WorkerPodHealthStatus.Unhealthy, state.CurrentPodHealthStatusTransition.ToPodStatus);
+    }
+
+    [Fact]
+    public async Task WaitForChangeAsync_ReturnsImmediately_WhenRevisionDiffers()
+    {
+        var manager = new WorkerPodStateManager();
+        manager.UpdatePodStatus(WorkerPodStatus.ReadyForRequest);
+
+        // Client has revision 0, current is 1 — should return immediately.
+        var result = await manager.WaitForChangeAsync(0, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(WorkerPodStatus.ReadyForRequest, result!.CurrentPodStatusTransition.ToPodStatus);
+    }
+
+    [Fact]
+    public async Task WaitForChangeAsync_BlocksUntilStateChanges()
+    {
+        var manager = new WorkerPodStateManager();
+        manager.UpdatePodStatus(WorkerPodStatus.ReadyForRequest);
+
+        var currentRevision = manager.GetCurrentState().RevisionId;
+
+        // Start waiting — client is up to date.
+        var waitTask = manager.WaitForChangeAsync(currentRevision, CancellationToken.None);
+
+        // Should not complete yet.
+        await Task.Delay(50);
+        Assert.False(waitTask.IsCompleted);
+
+        // Trigger a state change.
+        manager.UpdatePodStatus(WorkerPodStatus.Draining);
+
+        var result = await waitTask;
+
+        Assert.NotNull(result);
+        Assert.Equal(WorkerPodStatus.Draining, result!.CurrentPodStatusTransition.ToPodStatus);
+    }
+
+    [Fact]
+    public async Task WaitForChangeAsync_ReturnsNull_OnTimeout()
+    {
+        var manager = new WorkerPodStateManager();
+        var currentRevision = manager.GetCurrentState().RevisionId;
+
+        // Use a short cancellation to avoid waiting the full 60s.
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+        var result = await manager.WaitForChangeAsync(currentRevision, cts.Token);
+
+        // Should return null (timeout / cancellation) without throwing.
+        // The implementation catches TimeoutException and returns null.
+        // Cancellation may also trigger — either way, no state change occurred.
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task WaitForChangeAsync_MultipleListeners_AllNotified()
+    {
+        var manager = new WorkerPodStateManager();
+        var currentRevision = manager.GetCurrentState().RevisionId;
+
+        var wait1 = manager.WaitForChangeAsync(currentRevision, CancellationToken.None);
+        var wait2 = manager.WaitForChangeAsync(currentRevision, CancellationToken.None);
+        var wait3 = manager.WaitForChangeAsync(currentRevision, CancellationToken.None);
+
+        manager.UpdatePodStatus(WorkerPodStatus.ReadyForRequest);
+
+        var results = await Task.WhenAll(wait1, wait2, wait3);
+
+        Assert.All(results, r =>
+        {
+            Assert.NotNull(r);
+            Assert.Equal(WorkerPodStatus.ReadyForRequest, r!.CurrentPodStatusTransition.ToPodStatus);
+        });
+    }
+
+    [Fact]
+    public void FullLifecycle_TracksAllTransitions()
+    {
+        var manager = new WorkerPodStateManager();
+
+        manager.UpdatePodStatus(WorkerPodStatus.ReadyForRequest);
+        manager.UpdatePodStatus(WorkerPodStatus.Draining);
+        manager.UpdatePodStatus(WorkerPodStatus.DrainCompleted);
+        manager.UpdatePodStatus(WorkerPodStatus.MarkForDeletion);
+
+        var state = manager.GetCurrentState();
+
+        Assert.Equal(WorkerPodStatus.DrainCompleted, state.CurrentPodStatusTransition.FromPodStatus);
+        Assert.Equal(WorkerPodStatus.MarkForDeletion, state.CurrentPodStatusTransition.ToPodStatus);
+        Assert.Equal(4, state.RevisionId);
+    }
+}

--- a/test/WebJobs.Script.Tests/Workers/ExternalWorkers/WorkerConnectionServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ExternalWorkers/WorkerConnectionServiceTests.cs
@@ -333,11 +333,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
             var service = CreateService();
             await service.ConnectWorkerAsync("w_1", new Uri("http://localhost:50051"), CancellationToken.None);
 
-            // Simulate drain request from worker proxy by raising the event.
-            _mockChannel.Raise(c => c.DrainRequested += null, "w_1");
-
-            // Give the fire-and-forget a moment to execute.
-            await Task.Delay(200);
+            // DisconnectWorkerAsync is what OnWorkerDrainRequested calls (fire-and-forget).
+            // Calling it directly avoids flaky Task.Delay waits.
+            await service.DisconnectWorkerAsync("w_1", CancellationToken.None);
 
             _mockChannel.Verify(c => c.BeginDrain(), Times.Once);
         }
@@ -353,9 +351,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
             var service = CreateService();
             await service.ConnectWorkerAsync("w_1", new Uri("http://localhost:50051"), CancellationToken.None);
 
-            _mockChannel.Raise(c => c.DrainRequested += null, "w_1");
-
-            await Task.Delay(200);
+            await service.DisconnectWorkerAsync("w_1", CancellationToken.None);
 
             _mockChannel.Verify(c => c.SendWorkerDrainComplete(), Times.Once);
         }

--- a/test/WebJobs.Script.Tests/Workers/ExternalWorkers/WorkerConnectionServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ExternalWorkers/WorkerConnectionServiceTests.cs
@@ -310,5 +310,54 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
                 _hostJsonContentProvider,
                 NullLoggerFactory.Instance);
         }
+
+        [Fact]
+        public async Task ConnectWorkerAsync_SubscribesToDrainRequestedEvent()
+        {
+            SetupFullConnectMocks();
+            var service = CreateService();
+
+            await service.ConnectWorkerAsync("w_1", new Uri("http://localhost:50051"), CancellationToken.None);
+
+            _mockChannel.VerifyAdd(c => c.DrainRequested += It.IsAny<Action<string>>(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DrainWorker_MarksChannelAsDraining()
+        {
+            SetupFullConnectMocks();
+            _mockChannelManager
+                .Setup(m => m.GetChannel("w_1"))
+                .Returns(_mockChannel.Object);
+
+            var service = CreateService();
+            await service.ConnectWorkerAsync("w_1", new Uri("http://localhost:50051"), CancellationToken.None);
+
+            // Simulate drain request from worker proxy by raising the event.
+            _mockChannel.Raise(c => c.DrainRequested += null, "w_1");
+
+            // Give the fire-and-forget a moment to execute.
+            await Task.Delay(200);
+
+            _mockChannel.Verify(c => c.BeginDrain(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DrainWorker_SendsDrainComplete()
+        {
+            SetupFullConnectMocks();
+            _mockChannelManager
+                .Setup(m => m.GetChannel("w_1"))
+                .Returns(_mockChannel.Object);
+
+            var service = CreateService();
+            await service.ConnectWorkerAsync("w_1", new Uri("http://localhost:50051"), CancellationToken.None);
+
+            _mockChannel.Raise(c => c.DrainRequested += null, "w_1");
+
+            await Task.Delay(200);
+
+            _mockChannel.Verify(c => c.SendWorkerDrainComplete(), Times.Once);
+        }
     }
 }

--- a/tools/ComputeSeparation/AppHost/AppHost.csproj
+++ b/tools/ComputeSeparation/AppHost/AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.2.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.2.1">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -12,9 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting" Version="13.2.0" />
-    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.2.0" />
-    <PackageReference Include="Aspire.Hosting.Docker" Version="13.2.0" />
+    <PackageReference Include="Aspire.Hosting" Version="13.2.1" />
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.2.1" />
+    <PackageReference Include="Aspire.Hosting.Docker" Version="13.2.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.26.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/ComputeSeparation/AppHost/Program.cs
+++ b/tools/ComputeSeparation/AppHost/Program.cs
@@ -7,7 +7,9 @@
 // Set the "UseContainers" configuration key (or USE_CONTAINERS env var) to "true"
 // to run all components as Docker containers instead of local projects.
 
+using System.Text;
 using Aspire.Hosting.Azure;
+using Azure.Storage.Blobs;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -20,6 +22,10 @@ const int workerGrpcPort = 50052;
 const int httpProxyPort = 50053;
 const int runtimePort = 7071;
 const int mockWorkerHttpPort = 8080;
+
+// --- Well-known values for local development ---
+const string HostId = "devhost";
+const string MasterKey = "dev-master-key";
 
 // Well-known Azurite storage emulator account key.
 // https://learn.microsoft.com/azure/storage/common/storage-use-azurite#well-known-storage-account-and-key
@@ -36,6 +42,41 @@ else
 {
     AddProjectResources(builder, storage);
 }
+
+// --- Seed well-known master key into Azurite ---
+// The runtime uses BlobStorageSecretsRepository, which reads from
+// azure-webjobs-secrets/{hostId}/host.json. We pre-seed this blob
+// so admin APIs can be called with a known key during development.
+builder.Eventing.Subscribe<ResourceReadyEvent>(storage.Resource, async (@event, ct) =>
+{
+    var blobEndpoint = storage.GetEndpoint("blob");
+
+    string scheme = await blobEndpoint.Property(EndpointProperty.Scheme).GetValueAsync(ct) ?? "http";
+    string host = await blobEndpoint.Property(EndpointProperty.IPV4Host).GetValueAsync(ct) ?? "127.0.0.1";
+    string port = await blobEndpoint.Property(EndpointProperty.Port).GetValueAsync(ct) ?? "10000";
+    string blobUrl = $"{scheme}://{host}:{port}/devstoreaccount1;";
+
+    string connectionString = $"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey={AzuriteAccountKey};BlobEndpoint={blobUrl}";
+
+    var blobServiceClient = new BlobServiceClient(connectionString);
+    var containerClient = blobServiceClient.GetBlobContainerClient("azure-webjobs-secrets");
+    await containerClient.CreateIfNotExistsAsync(cancellationToken: ct);
+
+    string hostSecretsJson = $$"""
+        {
+          "masterKey": {
+            "name": "master",
+            "value": "{{MasterKey}}",
+            "encrypted": false
+          },
+          "functionKeys": [],
+          "systemKeys": []
+        }
+        """;
+
+    await containerClient.UploadBlobAsync($"{HostId}/host.json",
+        new BinaryData(Encoding.UTF8.GetBytes(hostSecretsJson)), ct);
+});
 
 builder.Build().Run();
 
@@ -54,9 +95,10 @@ static void AddProjectResources(
     var runtime = builder.AddProject<Projects.WebJobs_Script_WebHost>("runtime")
         .WithHttpEndpoint(runtimePort, runtimePort, name: "functions-http", isProxied: false)
         .WithEnvironment("FUNCTIONS_WORKER_EXTERNAL_ENABLED", "true")
-        .WithEnvironment("FUNCTIONS_WORKER_EXTERNAL_GRPC_ENDPOINT", runtimeGrpcEndpoint)
+        // .WithEnvironment("FUNCTIONS_WORKER_EXTERNAL_GRPC_ENDPOINT", runtimeGrpcEndpoint)
         .WithEnvironment("FUNCTIONS_WORKER_RUNTIME", "node")
         .WithEnvironment("AZURE_FUNCTIONS_ENVIRONMENT", "Development")
+        .WithEnvironment("AzureFunctionsWebHost__hostid", HostId)
         .WithEnvironment("ASPNETCORE_URLS", runtimeUrl)
         .WithEnvironment(context =>
         {
@@ -133,6 +175,7 @@ static void AddContainerResources(
         })
         .WithEnvironment("FUNCTIONS_WORKER_RUNTIME", "node")
         .WithEnvironment("AZURE_FUNCTIONS_ENVIRONMENT", "Development")
+        .WithEnvironment("AzureFunctionsWebHost__hostid", HostId)
         .WithEnvironment("ASPNETCORE_URLS", $"http://+:{runtimePort.ToString()}")
         .WithEnvironment(context =>
         {
@@ -151,7 +194,15 @@ static void ConfigureStorageConnectionString(
     var blob = storage.GetEndpoint("blob");
     var queue = storage.GetEndpoint("queue");
     var table = storage.GetEndpoint("table");
+
+    // Use IPV4Host (127.0.0.1) instead of Host/Url (localhost) to avoid IPv6 resolution
+    // issues with Azurite. This matches how Aspire's AzureStorageEmulatorConnectionString
+    // builds the connection string internally.
     context.EnvironmentVariables["AzureWebJobsStorage"] =
         ReferenceExpression.Create(
-            $"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey={AzuriteAccountKey};BlobEndpoint={blob.Property(EndpointProperty.Url)}/devstoreaccount1;QueueEndpoint={queue.Property(EndpointProperty.Url)}/devstoreaccount1;TableEndpoint={table.Property(EndpointProperty.Url)}/devstoreaccount1;");
+            $"DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey={AzuriteAccountKey};{EmulatorEndpoint("BlobEndpoint", blob)}{EmulatorEndpoint("QueueEndpoint", queue)}{EmulatorEndpoint("TableEndpoint", table)}");
+
+    static ReferenceExpression EmulatorEndpoint(string key, EndpointReference endpoint)
+        => ReferenceExpression.Create(
+            $"{key}={endpoint.Property(EndpointProperty.Scheme)}://{endpoint.Property(EndpointProperty.IPV4Host)}:{endpoint.Property(EndpointProperty.Port)}/devstoreaccount1;");
 }

--- a/tools/ComputeSeparation/ComputeSeparation.sln
+++ b/tools/ComputeSeparation/ComputeSeparation.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
 VisualStudioVersion = 18.3.11520.95 d18.3
@@ -18,6 +18,16 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AppHost", "AppHost\AppHost.csproj", "{E07A9874-7159-4079-B1D3-40DC787B0CF6}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MockWorker", "MockWorker\MockWorker.csproj", "{4D9D96A9-609F-4737-9D3C-40D68D19E6D2}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{8879BC11-7F71-421D-AC0A-D8320E41E08E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Functions.WorkerProxy.Tests", "..\..\test\Functions.WorkerProxy.Tests\Functions.WorkerProxy.Tests.csproj", "{3268F41E-5EB5-4AD6-935D-B33FC8AF1803}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebJobs.Script.Tests", "..\..\test\WebJobs.Script.Tests\WebJobs.Script.Tests.csproj", "{4ACB3CF8-D73C-4DFA-B854-DAEBB4052998}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebJobs.Script.Tests.Integration", "..\..\test\WebJobs.Script.Tests.Integration\WebJobs.Script.Tests.Integration.csproj", "{1070B9E9-DD48-4580-957E-96F65E3EB3FF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebJobs.Script.Tests.Shared", "..\..\test\WebJobs.Script.Tests.Shared\WebJobs.Script.Tests.Shared.csproj", "{C6632E20-394A-4306-AE5F-78AEBC016565}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -49,6 +59,22 @@ Global
 		{4D9D96A9-609F-4737-9D3C-40D68D19E6D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4D9D96A9-609F-4737-9D3C-40D68D19E6D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4D9D96A9-609F-4737-9D3C-40D68D19E6D2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3268F41E-5EB5-4AD6-935D-B33FC8AF1803}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3268F41E-5EB5-4AD6-935D-B33FC8AF1803}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3268F41E-5EB5-4AD6-935D-B33FC8AF1803}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3268F41E-5EB5-4AD6-935D-B33FC8AF1803}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4ACB3CF8-D73C-4DFA-B854-DAEBB4052998}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4ACB3CF8-D73C-4DFA-B854-DAEBB4052998}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4ACB3CF8-D73C-4DFA-B854-DAEBB4052998}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4ACB3CF8-D73C-4DFA-B854-DAEBB4052998}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1070B9E9-DD48-4580-957E-96F65E3EB3FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1070B9E9-DD48-4580-957E-96F65E3EB3FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1070B9E9-DD48-4580-957E-96F65E3EB3FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1070B9E9-DD48-4580-957E-96F65E3EB3FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C6632E20-394A-4306-AE5F-78AEBC016565}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C6632E20-394A-4306-AE5F-78AEBC016565}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C6632E20-394A-4306-AE5F-78AEBC016565}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C6632E20-394A-4306-AE5F-78AEBC016565}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -60,6 +86,10 @@ Global
 		{49B11084-9350-4E3C-B69A-2C6DEBBCB489} = {84CB62F0-D4BA-4A5F-B0A2-3732932BFE82}
 		{E07A9874-7159-4079-B1D3-40DC787B0CF6} = {110948B0-49A1-43AF-92E2-E365440C82F8}
 		{4D9D96A9-609F-4737-9D3C-40D68D19E6D2} = {110948B0-49A1-43AF-92E2-E365440C82F8}
+		{3268F41E-5EB5-4AD6-935D-B33FC8AF1803} = {8879BC11-7F71-421D-AC0A-D8320E41E08E}
+		{4ACB3CF8-D73C-4DFA-B854-DAEBB4052998} = {8879BC11-7F71-421D-AC0A-D8320E41E08E}
+		{1070B9E9-DD48-4580-957E-96F65E3EB3FF} = {8879BC11-7F71-421D-AC0A-D8320E41E08E}
+		{C6632E20-394A-4306-AE5F-78AEBC016565} = {8879BC11-7F71-421D-AC0A-D8320E41E08E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B3516E8F-8A8F-450B-96BB-ED1720699710}

--- a/tools/ComputeSeparation/compute-separation.http
+++ b/tools/ComputeSeparation/compute-separation.http
@@ -1,0 +1,73 @@
+### Compute Separation — E2E HTTP Testing
+###
+### These .http files are used with VS Code REST Client or Visual Studio
+### to test the compute separation admin APIs end-to-end.
+###
+### Prerequisites:
+###   1. Start the Aspire harness (or start the runtime manually)
+###   2. Get the master key from the runtime's admin API
+###
+### Variables — update these for your environment:
+
+@runtimeHost = http://localhost:7071
+@workerProxyHost = http://localhost:50054
+@masterKey = dev-master-key
+@workerGrpcEndpoint = http://localhost:50051
+
+### ============================================================
+### Runtime Admin APIs
+### ============================================================
+
+### Get host status
+GET {{runtimeHost}}/admin/host/status?code={{masterKey}}
+
+###
+
+### Link a worker to the runtime
+POST {{runtimeHost}}/admin/workers/link?code={{masterKey}}
+Content-Type: application/json
+
+{
+  "workerId": "w_test01",
+  "podName": "worker-pod-test01",
+  "grpcEndpoint": "{{workerGrpcEndpoint}}",
+  "podKey": "test-key"
+}
+
+###
+
+### Ping the host
+GET {{runtimeHost}}/admin/host/ping
+
+###
+
+### Invoke an HTTP trigger function (after worker is linked)
+GET {{runtimeHost}}/api/HttpTrigger
+
+### ============================================================
+### Worker Proxy Management APIs
+### ============================================================
+
+###
+
+### Check worker proxy readiness
+GET {{workerProxyHost}}/ready
+
+###
+
+### Trigger worker drain (scale-in scenario)
+### Worker proxy sends WorkerDrainRequest to runtime over gRPC,
+### runtime drains in-flight invocations and sends WorkerDrainComplete back.
+POST {{workerProxyHost}}/drain
+
+###
+
+### Poll worker pod state (long-polling)
+### Send with revisionId 0 to get current state immediately.
+### Send with the last known revisionId to block until state changes.
+POST {{workerProxyHost}}/instanceState
+Content-Type: application/json
+
+{
+  "revisionId": 0
+}


### PR DESCRIPTION
Implements the single-worker scale-in drain flow for compute separation. When the platform (NNA) decides to remove a worker, the worker proxy signals the runtime over gRPC, 
the runtime drains in-flight invocations, and sends a completion signal back. Also adds management HTTP endpoints to the worker proxy and improves the Aspire dev harness. 

#### Deferred
 
 - `POST /admin/instance/stop` (Scenario 2: full runtime stop) — future PR
 - `/assign` implementation (worker specialization via `FunctionEnvironmentReloadRequest`) — `[CS-TODO]`
 - Last-worker-drained behavior (pause triggers / degraded state) — `[CS-TODO]`