### PR TITLE
[Compute Separation] Enable Native AOT publishing for WorkerProxy

### DIFF
--- a/src/Functions.WorkerProxy/Dockerfile
+++ b/src/Functions.WorkerProxy/Dockerfile
@@ -1,13 +1,14 @@
-# Functions.WorkerProxy (gRPC relay + HTTP proxy)
+# Functions.WorkerProxy (gRPC relay + HTTP proxy) — Native AOT
 # Build context: repository root
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-noble-aot AS build
 WORKDIR /repo
+
 COPY . .
 RUN dotnet publish src/Functions.WorkerProxy/Functions.WorkerProxy.csproj \
-    -c Release -o /app/publish
+    -c Release -r linux-x64 -o /app/publish
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-noble-chiseled
 WORKDIR /app
 COPY --from=build /app/publish .
 EXPOSE 50051 50052 50053 50054
-ENTRYPOINT ["dotnet", "Microsoft.Azure.Functions.WorkerProxy.dll"]
+ENTRYPOINT ["./Microsoft.Azure.Functions.WorkerProxy"]

--- a/src/Functions.WorkerProxy/Functions.WorkerProxy.csproj
+++ b/src/Functions.WorkerProxy/Functions.WorkerProxy.csproj
@@ -8,6 +8,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DisableImplicitNamespaceImports>false</DisableImplicitNamespaceImports>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
     <!-- Standalone tool; opt out of repo-level code-analysis ruleset. -->
     <CodeAnalysisRuleSet />
   </PropertyGroup>
@@ -17,9 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.55.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.55.1" PrivateAssets="All" />
-    <PackageReference Include="Yarp.ReverseProxy" Version="2.0.1" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.76.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.76.0" PrivateAssets="All" />
+    <PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Functions.WorkerProxy/Program.cs
+++ b/src/Functions.WorkerProxy/Program.cs
@@ -1,11 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using Microsoft.Azure.Functions.WorkerProxy;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Azure.Functions.WorkerProxy;
 using Yarp.ReverseProxy.Forwarder;
 
-var builder = WebApplication.CreateBuilder(new WebApplicationOptions { Args = args });
+var builder = WebApplication.CreateSlimBuilder(new WebApplicationOptions { Args = args });
 
 // Prevent Aspire (or other orchestrators) from overriding our Kestrel configuration
 // via ASPNETCORE_URLS. The worker proxy manages its own ports explicitly.
@@ -24,6 +24,11 @@ builder.Services.AddSingleton<WorkerPodStateManager>();
 builder.Services.AddSingleton<FunctionRpcRelay>();
 builder.Services.AddGrpc();
 builder.Services.AddHttpForwarder();
+
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.TypeInfoResolverChain.Insert(0, WorkerProxyJsonContext.Default);
+});
 
 builder.WebHost.ConfigureKestrel(options =>
 {
@@ -91,7 +96,7 @@ app.MapPost("/instanceState", async (HttpContext ctx, CancellationToken cancella
     // Always attempt to read — ContentLength may be null for chunked requests.
     try
     {
-        var clientState = await ctx.Request.ReadFromJsonAsync<WorkerPodState>(cancellationToken);
+        var clientState = await ctx.Request.ReadFromJsonAsync(WorkerProxyJsonContext.Default.WorkerPodState, cancellationToken);
         clientRevisionId = clientState?.RevisionId ?? 0;
     }
     catch

--- a/src/Functions.WorkerProxy/WorkerPodState.cs
+++ b/src/Functions.WorkerProxy/WorkerPodState.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Functions.WorkerProxy;
 /// Pod status values for the worker proxy state machine.
 /// Matches the Go Proxy's <c>FunctionAppPodStatus</c> pattern.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter<WorkerPodStatus>))]
 internal enum WorkerPodStatus
 {
     None,
@@ -22,7 +22,7 @@ internal enum WorkerPodStatus
 /// <summary>
 /// Health status values for the worker proxy.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter<WorkerPodHealthStatus>))]
 internal enum WorkerPodHealthStatus
 {
     None,

--- a/src/Functions.WorkerProxy/WorkerProxyJsonContext.cs
+++ b/src/Functions.WorkerProxy/WorkerProxyJsonContext.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Azure.Functions.WorkerProxy;
+
+[JsonSerializable(typeof(WorkerPodState))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+internal partial class WorkerProxyJsonContext : JsonSerializerContext
+{
+}

--- a/tools/ComputeSeparation/AppHost/Program.cs
+++ b/tools/ComputeSeparation/AppHost/Program.cs
@@ -108,6 +108,7 @@ static void AddProjectResources(
         .WaitFor(storage);
 
     var workerProxy = builder.AddProject<Projects.Functions_WorkerProxy>("worker-proxy")
+        .WithHttpEndpoint(managementPort, managementPort, name: "management", isProxied: false)
         .WithArgs(
             "--runtime-grpc-port", runtimeGrpcPort.ToString(),
             "--worker-grpc-port", workerGrpcPort.ToString(),
@@ -137,7 +138,7 @@ static void AddContainerResources(
         .WithEndpoint(targetPort: runtimeGrpcPort, name: "proxy-runtime-grpc", scheme: "http")
         .WithEndpoint(targetPort: workerGrpcPort, name: "proxy-worker-grpc", scheme: "http")
         .WithEndpoint(targetPort: httpProxyPort, name: "http-proxy", scheme: "http")
-        .WithEndpoint(targetPort: managementPort, name: "management", scheme: "http")
+        .WithHttpEndpoint(managementPort, managementPort, name: "proxy-management")
         .WithArgs(
             "--runtime-grpc-port", runtimeGrpcPort.ToString(),
             "--worker-grpc-port", workerGrpcPort.ToString(),
@@ -189,7 +190,6 @@ static void AddContainerResources(
         })
         .WaitFor(storage);
 
-    workerProxy.WaitFor(runtime);
     mockWorker.WaitFor(workerProxy);
 }
 

--- a/tools/ComputeSeparation/compute-separation.http
+++ b/tools/ComputeSeparation/compute-separation.http
@@ -5,14 +5,14 @@
 ###
 ### Prerequisites:
 ###   1. Start the Aspire harness (or start the runtime manually)
-###   2. Get the master key from the runtime's admin API
+###   2. Select either the 'project' (default) or 'container' environment, based on how you started Aspire.
 ###
 ### Variables — update these for your environment:
+### Select "project" or "container" environment to toggle workerGrpcEndpoint.
 
 @runtimeHost = http://localhost:7071
 @workerProxyHost = http://localhost:50054
 @masterKey = dev-master-key
-@workerGrpcEndpoint = http://localhost:50051
 
 ### ============================================================
 ### Runtime Admin APIs

--- a/tools/ComputeSeparation/http-client.env.json
+++ b/tools/ComputeSeparation/http-client.env.json
@@ -1,0 +1,8 @@
+{
+  "project": {
+    "workerGrpcEndpoint": "http://localhost:50051"
+  },
+  "container": {
+    "workerGrpcEndpoint": "http://worker-proxy.dev.internal:50051"
+  }
+}


### PR DESCRIPTION
 Publishes the WorkerProxy as a Native AOT binary, reducing the container image from ~250 MB to ~50 MB.

  Changes

   - AOT enablement — PublishAot=true, InvariantGlobalization=true, CreateSlimBuilder
   - Package upgrades — Grpc.AspNetCore
    2.76.0, Grpc.Tools 2.76.0, Yarp.ReverseProxy 2.3.0 (AOT-compatible versions)
   - JSON source generator — WorkerProxyJsonContext for reflection-free serialization; switched to generic JsonStringEnumConverter<T>
   - Dockerfile — sdk:10.0-noble-aot build image, runtime-deps:10.0-noble-chiseled runtime image, native binary entrypoint
   - Aspire AppHost — pinned management API to port 50054 in both project and container modes
   - Dev tooling — added http-client.env.json for project/container environment switching