### PR TITLE
[Compute Separation] Runtime stop endpoint and drain notification

### DIFF
--- a/src/Functions.WorkerProxy/FunctionRpcRelay.cs
+++ b/src/Functions.WorkerProxy/FunctionRpcRelay.cs
@@ -158,6 +158,17 @@ internal sealed class FunctionRpcRelay : FunctionRpc.FunctionRpcBase
                     }
                 }
 
+                // Intercept WorkerDrainRequest from runtime — update state machine.
+                // In runtime-initiated stop, the runtime sends this to notify
+                // the proxy to enter Draining state. Do NOT forward to the language worker.
+                if (string.Equals(side, "runtime", StringComparison.Ordinal)
+                    && message.ContentCase == StreamingMessage.ContentOneofCase.WorkerDrainRequest)
+                {
+                    _logger.LogInformation("Received WorkerDrainRequest from runtime.");
+                    _stateManager.UpdatePodStatus(WorkerPodStatus.Draining);
+                    continue;
+                }
+
                 // Intercept WorkerDrainComplete from runtime — update state machine.
                 // Do NOT forward drain messages to the language worker.
                 if (string.Equals(side, "runtime", StringComparison.Ordinal)

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/ConnectedWorkerChannel.cs
@@ -103,6 +103,15 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers
         }
 
         /// <inheritdoc/>
+        public void SendWorkerDrainRequest()
+        {
+            SendStreamingMessage(new Grpc.Messages.StreamingMessage
+            {
+                WorkerDrainRequest = new Grpc.Messages.WorkerDrainRequest()
+            });
+        }
+
+        /// <inheritdoc/>
         protected override void DisposeWorkerResources()
         {
         }

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/IConnectedWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/IConnectedWorkerChannel.cs
@@ -46,4 +46,12 @@ internal interface IConnectedWorkerChannel : IRpcWorkerChannel
     /// Sends a <c>WorkerDrainComplete</c> message to the worker proxy over gRPC.
     /// </summary>
     void SendWorkerDrainComplete();
+
+    /// <summary>
+    /// Sends a <c>WorkerDrainRequest</c> message to the worker proxy over gRPC.
+    /// Used in runtime-initiated stop to notify the proxy it should
+    /// enter the <c>Draining</c> state. Idempotent — safe to send even if the proxy
+    /// already initiated the drain.
+    /// </summary>
+    void SendWorkerDrainRequest();
 }

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/WorkerConnectionService.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/WorkerConnectionService.cs
@@ -38,7 +38,9 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
 
     private readonly ConcurrentDictionary<string, WorkerConnection> _workers = new();
     private readonly TaskCompletionSource _scriptHostStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly ReaderWriterLockSlim _lifecycleLock = new();
     private int _firstWorkerClaimed;
+    private volatile bool _stopping;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="WorkerConnectionService"/> class.
@@ -94,6 +96,11 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
     /// <inheritdoc/>
     public async Task ConnectWorkerAsync(string workerId, Uri endpoint, CancellationToken cancellationToken)
     {
+        if (_stopping)
+        {
+            throw new InvalidOperationException("Cannot connect new workers while the runtime is stopping.");
+        }
+
         var info = new WorkerConnectionInfo
         {
             WorkerId = workerId,
@@ -102,11 +109,39 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
 
         var worker = new WorkerConnection { Info = info };
 
-        if (!_workers.TryAdd(workerId, worker))
+        // Hold the read lock only for the _stopping re-check and TryAdd.
+        // This guarantees the worker is visible in _workers before
+        // DrainAndDisconnectAllAsync can snapshot the dictionary.
+        // IMPORTANT: No await allowed inside this lock — ReaderWriterLockSlim is thread-affine.
+        _lifecycleLock.EnterReadLock();
+
+        try
         {
-            throw new InvalidOperationException(
-                $"Worker '{workerId}' already exists. Disconnect it before reassigning.");
+            if (_stopping)
+            {
+                throw new InvalidOperationException("Cannot connect new workers while the runtime is stopping.");
+            }
+
+            if (!_workers.TryAdd(workerId, worker))
+            {
+                throw new InvalidOperationException(
+                    $"Worker '{workerId}' already exists. Disconnect it before reassigning.");
+            }
         }
+        finally
+        {
+            _lifecycleLock.ExitReadLock();
+        }
+
+        // The rest of connect runs outside the lock. The worker is in _workers,
+        // so DrainAndDisconnectAllAsync will find it and await ConnectCompleted
+        // before cleaning up.
+        await ConnectWorkerCoreAsync(workerId, endpoint, worker, cancellationToken);
+    }
+
+    private async Task ConnectWorkerCoreAsync(string workerId, Uri endpoint, WorkerConnection worker, CancellationToken cancellationToken)
+    {
+        var info = worker.Info;
 
         try
         {
@@ -234,6 +269,11 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
         if (channel is IConnectedWorkerChannel connectedChannel)
         {
             connectedChannel.BeginDrain();
+
+            // Notify the worker proxy it should enter the Draining state.
+            // In worker-initiated drain the proxy already knows,
+            // but sending this is idempotent and keeps the code path simple.
+            connectedChannel.SendWorkerDrainRequest();
         }
 
         worker.Info.State = WorkerConnectionState.Draining;
@@ -290,6 +330,41 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
     public WorkerConnectionInfo GetWorkerStatus(string workerId)
         => _workers.TryGetValue(workerId, out var worker) ? worker.Info : null;
 
+    /// <inheritdoc/>
+    public async Task DrainAndDisconnectAllAsync(CancellationToken cancellationToken)
+    {
+        IList<string> workerIds;
+
+        // Hold the write lock to atomically set _stopping and snapshot _workers.
+        // This guarantees no in-flight ConnectWorkerAsync can TryAdd between
+        // setting the flag and taking the snapshot.
+        // IMPORTANT: No await allowed inside this lock — ReaderWriterLockSlim is thread-affine.
+        _lifecycleLock.EnterWriteLock();
+
+        try
+        {
+            _stopping = true;
+            workerIds = _workers.Keys.ToList();
+        }
+        finally
+        {
+            _lifecycleLock.ExitWriteLock();
+        }
+
+        if (workerIds.Count == 0)
+        {
+            _logger.LogInformation("No workers connected. Nothing to drain.");
+            return;
+        }
+
+        _logger.LogInformation("Draining and disconnecting {count} worker(s).", workerIds.Count);
+
+        var tasks = workerIds.Select(id => DisconnectWorkerAsync(id, cancellationToken));
+        await Task.WhenAll(tasks);
+
+        _logger.LogInformation("All workers drained and disconnected.");
+    }
+
     /// <summary>
     /// Event handler for <see cref="IConnectedWorkerChannel.DrainRequested"/>.
     /// Fired when the worker proxy sends a <c>WorkerDrainRequest</c> over gRPC.
@@ -313,25 +388,25 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
     /// <inheritdoc/>
     public async Task StopAsync(CancellationToken cancellationToken)
     {
-        foreach (string workerId in _workers.Keys)
+        // Reuse the same drain path as /admin/instance/stop so workers get
+        // the full graceful shutdown (BeginDrain → DrainInvocations →
+        // SendWorkerDrainComplete) and the _stopping flag + lifecycle lock
+        // prevent races with in-flight connects.
+        try
         {
-            if (_workers.TryGetValue(workerId, out var worker))
-            {
-                try
-                {
-                    await RemoveWorkerAsync(workerId, worker);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Error during graceful shutdown of worker '{workerId}'.", workerId);
-                }
-            }
+            await DrainAndDisconnectAllAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error during graceful shutdown of workers.");
         }
     }
 
     /// <inheritdoc/>
     public async ValueTask DisposeAsync()
     {
+        _lifecycleLock.Dispose();
+
         foreach (var kvp in _workers)
         {
             if (kvp.Value.Client is not null)
@@ -381,16 +456,6 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
         }
 
         _eventManager.RemoveGrpcChannels(workerId);
-    }
-
-    /// <summary>
-    /// Full cleanup: disposes resources and removes the worker from tracking.
-    /// Used by disconnect and stop, where the worker entry should not persist.
-    /// </summary>
-    private async Task RemoveWorkerAsync(string workerId, WorkerConnection worker)
-    {
-        await CleanupWorkerResourcesAsync(workerId, worker);
-        _workers.TryRemove(workerId, out _);
     }
 
     /// <summary>

--- a/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
@@ -1,36 +1,41 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 {
     /// <summary>
-    /// Controller responsible for instance operations that are orthogonal to the script host.
-    /// An instance is an unassigned generic container running with the runtime in standby mode.
-    /// These APIs are used by the AppService Controller to validate standby instance status and info.
+    /// Controller responsible for instance operations such as specialization,
+    /// lifecycle management, and health checks.
     /// </summary>
     public class InstanceController : Controller
     {
         private readonly IEnvironment _environment;
         private readonly IInstanceManager _instanceManager;
+        private readonly IScriptHostManager _scriptHostManager;
         private readonly IMetricsLogger _metricsLogger;
         private readonly ILogger _logger;
         private readonly StartupContextProvider _startupContextProvider;
 
-        public InstanceController(IEnvironment environment, IInstanceManager instanceManager, ILoggerFactory loggerFactory, StartupContextProvider startupContextProvider, IMetricsLogger metricsLogger)
+        public InstanceController(IEnvironment environment, IInstanceManager instanceManager, IScriptHostManager scriptHostManager, ILoggerFactory loggerFactory, StartupContextProvider startupContextProvider, IMetricsLogger metricsLogger)
         {
             _environment = environment;
             _instanceManager = instanceManager;
+            _scriptHostManager = scriptHostManager;
             _logger = loggerFactory.CreateLogger<InstanceController>();
             _startupContextProvider = startupContextProvider;
             _metricsLogger = metricsLogger;
@@ -114,6 +119,67 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         {
             // Reaching here implies that http health of the container is ok.
             return Ok();
+        }
+
+        /// <summary>
+        /// Stops the runtime pod. Enables drain mode to stop trigger listeners
+        /// and stop accepting new invocations, then drains and disconnects all
+        /// connected external workers in parallel.
+        /// Called by the Go Proxy when the platform decides to stop the entire runtime pod.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// POST /admin/instance/stop
+        /// </code>
+        /// </example>
+        [HttpPost]
+        [Route("admin/instance/stop")]
+        [Authorize(Policy = PolicyNames.AdminAuthLevel)]
+        public IActionResult Stop()
+        {
+            _logger.LogInformation("Received request to stop the runtime instance.");
+
+            if (!Utility.TryGetHostService(_scriptHostManager, out IDrainModeManager drainModeManager))
+            {
+                _logger.LogWarning("Stop requested but ScriptHost is not ready (IDrainModeManager unavailable).");
+                return StatusCode(StatusCodes.Status503ServiceUnavailable);
+            }
+
+            // IWorkerConnectionManager is only registered when external workers are enabled.
+            // In non-compute-separation scenarios, /stop still drains the host but has no workers to disconnect.
+            var connectionManager = HttpContext.RequestServices.GetService<IWorkerConnectionManager>();
+
+            // Fire-and-forget: drain host listeners, then disconnect all workers.
+            _ = StopCoreAsync(drainModeManager, connectionManager)
+                .ContinueWith(
+                    t =>
+                    {
+                        if (t.IsFaulted)
+                        {
+                            _logger.LogError(t.Exception, "Error during runtime stop.");
+                        }
+                        else
+                        {
+                            _logger.LogInformation("Runtime stop completed.");
+                        }
+                    },
+                    TaskScheduler.Default);
+
+            return Accepted();
+        }
+
+        private async Task StopCoreAsync(IDrainModeManager drainModeManager, IWorkerConnectionManager connectionManager)
+        {
+            // Step 1: Stop trigger listeners and stop accepting new invocations.
+            _logger.LogInformation("Enabling drain mode.");
+            await drainModeManager.EnableDrainModeAsync(CancellationToken.None);
+
+            // Step 2: Drain in-flight invocations and disconnect all workers (if any).
+            if (connectionManager is not null)
+            {
+                _logger.LogInformation("Draining and disconnecting all workers.");
+                await connectionManager.DrainAndDisconnectAllAsync(CancellationToken.None);
+            }
         }
     }
 }

--- a/src/WebJobs.Script/Workers/IWorkerConnectionManager.cs
+++ b/src/WebJobs.Script/Workers/IWorkerConnectionManager.cs
@@ -48,4 +48,13 @@ public interface IWorkerConnectionManager
     /// </summary>
     /// <param name="workerId">The worker identifier.</param>
     WorkerConnectionInfo GetWorkerStatus(string workerId);
+
+    /// <summary>
+    /// Drains and disconnects all connected workers in parallel.
+    /// Each worker is drained (in-flight invocations complete with timeout),
+    /// sent a <c>WorkerDrainComplete</c> message, and then the gRPC connection is closed.
+    /// Used by the <c>/admin/instance/stop</c> endpoint for runtime-initiated stop.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task DrainAndDisconnectAllAsync(CancellationToken cancellationToken);
 }

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAllocationApiTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAllocationApiTests.cs
@@ -45,6 +45,8 @@ public class WorkerAllocationApiTests : IAsyncLifetime
                 services.AddSingleton(_mockConnectionManager.Object);
             });
 
+        // TestFunctionHost.StartAsync() already polls IsHostStarted() before
+        // the constructor returns, so the host is ready at this point.
         return Task.CompletedTask;
     }
 
@@ -52,6 +54,9 @@ public class WorkerAllocationApiTests : IAsyncLifetime
     {
         if (_host is not null)
         {
+            // Gracefully stop the host before deleting the temp directory. This stops
+            // hosted services (including FileMonitoringService) so file watchers won't
+            // fire after the directory is deleted, avoiding DirectoryNotFoundException.
             await _host.WebHost.StopAsync();
             _host.Dispose();
         }
@@ -106,6 +111,50 @@ public class WorkerAllocationApiTests : IAsyncLifetime
         var response = await _host.HttpClient.SendAsync(request);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Stop_Returns202()
+    {
+        var response = await SendAdminRequest(HttpMethod.Post, "admin/instance/stop");
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Stop_WithMockedWorkers_CallsDisconnect()
+    {
+        var drainCalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Link two workers first
+        _mockConnectionManager
+            .Setup(m => m.ConnectWorkerAsync(It.IsAny<string>(), It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _mockConnectionManager
+            .Setup(m => m.GetWorkerStatus(It.IsAny<string>()))
+            .Returns((WorkerConnectionInfo)null);
+        _mockConnectionManager
+            .Setup(m => m.DrainAndDisconnectAllAsync(It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                drainCalled.TrySetResult();
+                return Task.CompletedTask;
+            });
+
+        await SendAdminRequest(HttpMethod.Post, "admin/workers/link",
+            new { workerId = "w1", grpcEndpoint = "http://10.0.1.1:50051" });
+        await SendAdminRequest(HttpMethod.Post, "admin/workers/link",
+            new { workerId = "w2", grpcEndpoint = "http://10.0.1.2:50051" });
+
+        var response = await SendAdminRequest(HttpMethod.Post, "admin/instance/stop");
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        // Wait for the fire-and-forget to invoke DrainAndDisconnectAllAsync.
+        await drainCalled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        _mockConnectionManager.Verify(
+            m => m.DrainAndDisconnectAllAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     private async Task<HttpResponseMessage> SendAdminRequest(HttpMethod method, string path, object body = null)

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAllocationEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAllocationEndToEndTests.cs
@@ -38,6 +38,7 @@ public class WorkerAllocationEndToEndTests : IAsyncLifetime, IDisposable
     private const int RuntimeGrpcPort = 60061;
     private const int WorkerGrpcPort = 60062;
     private const int HttpProxyPort = 60063;
+    private const int ManagementPort = 60064;
 
     private readonly ITestOutputHelper _output;
     private readonly ConcurrentBag<string> _workerProxyLogs = new();
@@ -72,7 +73,7 @@ public class WorkerAllocationEndToEndTests : IAsyncLifetime, IDisposable
         _workerProxyProcess = ComputeSeparationTestHelpers.StartManagedProcess(
             _output,
             "dotnet",
-            $"\"{workerProxyDll}\" --runtime-grpc-port {RuntimeGrpcPort} --worker-grpc-port {WorkerGrpcPort} --http-proxy-port {HttpProxyPort}",
+            $"\"{workerProxyDll}\" --runtime-grpc-port {RuntimeGrpcPort} --worker-grpc-port {WorkerGrpcPort} --http-proxy-port {HttpProxyPort} --management-port {ManagementPort}",
             _workerProxyLogs,
             "WorkerProxy");
 
@@ -139,6 +140,80 @@ public class WorkerAllocationEndToEndTests : IAsyncLifetime, IDisposable
 
         Assert.Equal(HttpStatusCode.OK, invokeResponse.StatusCode);
         Assert.Contains("Hello from mock worker!", invokeBody);
+    }
+
+    [Fact]
+    public async Task WorkerLinkFlow_StopDrainsAndDisconnects()
+    {
+        string masterKey = await _host.GetMasterKeyAsync();
+
+        // 1. Link a worker.
+        var linkRequest = new
+        {
+            workerId = "w_e2estop01",
+            podName = "worker-pod-stop",
+            grpcEndpoint = $"http://localhost:{RuntimeGrpcPort}",
+            podKey = "test-key"
+        };
+
+        var linkResponse = await SendAdminRequest(
+            masterKey, HttpMethod.Post, "admin/workers/link", linkRequest);
+        Assert.Equal(HttpStatusCode.Accepted, linkResponse.StatusCode);
+
+        // 2. Wait for host ready.
+        await WaitForHostReadyAsync(masterKey, TimeSpan.FromMinutes(2));
+        _output.WriteLine("Host is ready.");
+
+        // 3. Verify worker proxy is in ReadyForRequest state.
+        using var proxyClient = new HttpClient { BaseAddress = new Uri($"http://localhost:{ManagementPort}") };
+        var stateResponse = await proxyClient.PostAsync("/instanceState",
+            new StringContent("{\"revisionId\": 0}", Encoding.UTF8, "application/json"));
+        var state = JObject.Parse(await stateResponse.Content.ReadAsStringAsync());
+        _output.WriteLine($"Worker proxy state before stop: {state}");
+        Assert.Equal("ReadyForRequest", state["currentPodStatusTransition"]?["toPodStatus"]?.ToString());
+
+        // 4. Call /admin/instance/stop.
+        var stopResponse = await SendAdminRequest(masterKey, HttpMethod.Post, "admin/instance/stop");
+        _output.WriteLine($"Stop response: {stopResponse.StatusCode}");
+        Assert.Equal(HttpStatusCode.Accepted, stopResponse.StatusCode);
+
+        // 5. Poll worker proxy /instanceState until it reaches MarkForDeletion.
+        int lastRevision = state["revisionId"]?.Value<int>() ?? 0;
+        var sw = Stopwatch.StartNew();
+        string finalStatus = null;
+
+        while (sw.Elapsed < TimeSpan.FromMinutes(2))
+        {
+            try
+            {
+                var pollResponse = await proxyClient.PostAsync("/instanceState",
+                    new StringContent($"{{\"revisionId\": {lastRevision}}}", Encoding.UTF8, "application/json"));
+
+                if (pollResponse.StatusCode == HttpStatusCode.OK)
+                {
+                    var pollState = JObject.Parse(await pollResponse.Content.ReadAsStringAsync());
+                    finalStatus = pollState["currentPodStatusTransition"]?["toPodStatus"]?.ToString();
+                    lastRevision = pollState["revisionId"]?.Value<int>() ?? lastRevision;
+                    _output.WriteLine($"Worker proxy state: {finalStatus} (revision {lastRevision}, {sw.Elapsed.TotalSeconds:F1}s)");
+
+                    if (string.Equals(finalStatus, "MarkForDeletion", StringComparison.OrdinalIgnoreCase))
+                    {
+                        break;
+                    }
+                }
+            }
+            catch (HttpRequestException)
+            {
+                // Proxy may have shut down — that's also an acceptable outcome.
+                _output.WriteLine("Worker proxy connection lost — process may have exited.");
+                break;
+            }
+
+            await Task.Delay(500);
+        }
+
+        Assert.Equal("MarkForDeletion", finalStatus);
+        _output.WriteLine("Worker proxy reached MarkForDeletion — stop completed successfully.");
     }
 
     public Task DisposeAsync()

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             instanceManager.Reset();
 
-            var instanceController = new InstanceController(environment, instanceManager, loggerFactory, startupContextProvider, testmetricslogger);
+            var instanceController = new InstanceController(environment, instanceManager, null, loggerFactory, startupContextProvider, testmetricslogger);
 
             var hostAssignmentContext = new HostAssignmentContext
             {
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             var loggerProvider = new TestLoggerProvider();
             loggerFactory.AddProvider(loggerProvider);
 
-            var instanceController = new InstanceController(null, null, loggerFactory, null, new TestMetricsLogger());
+            var instanceController = new InstanceController(null, null, null, loggerFactory, null, new TestMetricsLogger());
         
             var actionResult = instanceController.GetHttpHealthStatus();
             var okResult = actionResult as OkResult;
@@ -155,7 +155,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             instanceManager.Reset();
 
-            var instanceController = new InstanceController(environment, instanceManager, loggerFactory, startupContextProvider, testmetricslogger);
+            var instanceController = new InstanceController(environment, instanceManager, null, loggerFactory, startupContextProvider, testmetricslogger);
 
             var hostAssignmentContext = new HostAssignmentContext
             {
@@ -212,7 +212,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             instanceManager.Reset();
 
-            var instanceController = new InstanceController(environment, instanceManager, loggerFactory, startupContextProvider, testmetricslogger);
+            var instanceController = new InstanceController(environment, instanceManager, null, loggerFactory, startupContextProvider, testmetricslogger);
 
             var hostAssignmentContext = new HostAssignmentContext
             {
@@ -258,7 +258,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
 
             instanceManager.Reset();
 
-            var instanceController = new InstanceController(environment, instanceManager.Object, loggerFactory,
+            var instanceController = new InstanceController(environment, instanceManager.Object, null, loggerFactory,
                 startupContextProvider, testmetricslogger);
             DefaultHttpContext context = new() { User = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
             {
@@ -307,7 +307,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             var loggerFactory = new LoggerFactory();
             var loggerProvider = new TestLoggerProvider();
             loggerFactory.AddProvider(loggerProvider);
-            var instanceController = new InstanceController(environment, null, loggerFactory, null, testmetricslogger);
+            var instanceController = new InstanceController(environment, null, null, loggerFactory, null, testmetricslogger);
 
             // HostAssignmentRequest is null
             var result = await instanceController.Assign(null);
@@ -352,7 +352,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             var loggerProvider = new TestLoggerProvider();
             loggerFactory.AddProvider(loggerProvider);
 
-            var instanceController = new InstanceController(environment, null, loggerFactory, null, testmetricslogger);
+            var instanceController = new InstanceController(environment, null, null, loggerFactory, null, testmetricslogger);
             DefaultHttpContext context = new()
             {
                 User = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]{}))

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -489,6 +489,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
 
             HttpResponseMessage response = await HttpClient.SendAsync(request);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                string body = await response.Content.ReadAsStringAsync();
+                Console.WriteLine($"[TestFunctionHost] GetHostStatusAsync returned {(int)response.StatusCode}: {body}");
+            }
+
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadAsAsync<HostStatus>();
         }
@@ -506,7 +513,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             if (!_isDisposed)
             {
                 HttpClient.Dispose();
-                
+
                 _stillRunningTimer?.Change(-1, -1);
                 _stillRunningTimer?.Dispose();
 
@@ -521,8 +528,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public async Task<bool> IsHostStarted()
         {
-            HostStatus status = await GetHostStatusAsync();
-            return status.State == $"{ScriptHostState.Running}" || status.State == $"{ScriptHostState.Error}";
+            try
+            {
+                HostStatus status = await GetHostStatusAsync();
+                return status.State == $"{ScriptHostState.Running}" || status.State == $"{ScriptHostState.Error}";
+            }
+            catch (HttpRequestException ex)
+            {
+                // Host may return non-success status codes transiently during startup.
+                // Log details to help diagnose flaky test failures.
+                Console.WriteLine($"[TestFunctionHost] IsHostStarted check failed: {ex.Message}");
+                Console.WriteLine($"[TestFunctionHost] Host logs at time of failure:");
+                Console.WriteLine(GetLog());
+                throw;
+            }
         }
 
         private class TestStartup

--- a/test/WebJobs.Script.Tests/Workers/ExternalWorkers/WorkerConnectionServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ExternalWorkers/WorkerConnectionServiceTests.cs
@@ -355,5 +355,56 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
 
             _mockChannel.Verify(c => c.SendWorkerDrainComplete(), Times.Once);
         }
+
+        [Fact]
+        public async Task DrainAndDisconnectAllAsync_DisconnectsAllWorkers()
+        {
+            SetupFullConnectMocks();
+
+            var mockClient1 = new Mock<IOutboundGrpcClient>();
+            var mockClient2 = new Mock<IOutboundGrpcClient>();
+            int createCount = 0;
+            _mockClientFactory
+                .Setup(f => f.Create())
+                .Returns(() => ++createCount == 1 ? mockClient1.Object : mockClient2.Object);
+
+            _mockEventManager
+                .Setup(m => m.TryAddWorkerState(It.IsAny<string>(), It.IsAny<object>()))
+                .Returns(true);
+
+            var service = CreateService();
+            await service.ConnectWorkerAsync("w_1", new Uri("http://localhost:50051"), CancellationToken.None);
+            await service.ConnectWorkerAsync("w_2", new Uri("http://localhost:50052"), CancellationToken.None);
+
+            Assert.Equal(2, service.ActiveWorkerCount);
+
+            await service.DrainAndDisconnectAllAsync(CancellationToken.None);
+
+            Assert.Equal(0, service.ActiveWorkerCount);
+            Assert.Empty(service.GetWorkerStatuses());
+        }
+
+        [Fact]
+        public async Task ConnectWorkerAsync_WhileStopping_Throws()
+        {
+            SetupFullConnectMocks();
+
+            var mockClient1 = new Mock<IOutboundGrpcClient>();
+            _mockClientFactory
+                .Setup(f => f.Create())
+                .Returns(mockClient1.Object);
+
+            var service = CreateService();
+            await service.ConnectWorkerAsync("w_1", new Uri("http://localhost:50051"), CancellationToken.None);
+
+            // Initiate stop — this sets the _stopping flag
+            await service.DrainAndDisconnectAllAsync(CancellationToken.None);
+
+            // Attempting to connect a new worker after stop should fail
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => service.ConnectWorkerAsync("w_late", new Uri("http://localhost:50053"), CancellationToken.None));
+
+            Assert.Contains("stopping", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
     }
 }

--- a/tools/ComputeSeparation/compute-separation.http
+++ b/tools/ComputeSeparation/compute-separation.http
@@ -44,6 +44,12 @@ GET {{runtimeHost}}/admin/host/ping
 ### Invoke an HTTP trigger function (after worker is linked)
 GET {{runtimeHost}}/api/HttpTrigger
 
+###
+
+### Stop the runtime instance (full runtime stop)
+### Drains host listeners, disconnects all workers, sends WorkerDrainComplete to each.
+POST {{runtimeHost}}/admin/instance/stop?code={{masterKey}}
+
 ### ============================================================
 ### Worker Proxy Management APIs
 ### ============================================================


### PR DESCRIPTION
## `POST /admin/instance/stop` — Runtime Stop Endpoint

Adds the runtime-initiated stop endpoint for compute separation. When the platform decides to stop a runtime pod, the Go Proxy calls `POST /admin/instance/stop`. The runtime:

1. Enables drain mode (stops trigger listeners)
2. Sends `WorkerDrainRequest` to each worker proxy over gRPC → proxy enters `Draining` state
3. Waits for in-flight invocations to complete (1-min timeout per worker)
4. Sends `WorkerDrainComplete` to each proxy → proxy transitions to `MarkForDeletion`
5. Closes all gRPC connections

Returns `202 Accepted` immediately — the drain runs asynchronously. The platform polls `/instanceState` on each worker proxy for completion.

### Race prevention

A `ReaderWriterLockSlim` prevents the race where `POST /admin/workers/link` and `/stop` overlap:

- `ConnectWorkerAsync` holds a **read lock** around the `_stopping` check + `TryAdd` (multiple connects can proceed concurrently)
- `DrainAndDisconnectAllAsync` holds a **write lock** to atomically set `_stopping` and snapshot all worker IDs — guarantees no stragglers escape the drain

A `volatile bool _stopping` fast-rejects new connects after stop without touching the lock.

### Other changes

- **`StopAsync` (IHostedService)** now delegates to `DrainAndDisconnectAllAsync` for a unified shutdown path with the same race-prevention guarantees (previously bypassed `TryClaimDisconnect`)
- **`SendWorkerDrainRequest`** is sent in all disconnect paths (idempotent via `WorkerPodStateManager`), keeping a single code path for both runtime-initiated and worker-initiated drain
- **`FunctionRpcRelay`** intercepts `WorkerDrainRequest` from the runtime side → updates state machine, does not forward to language worker
- **Non-external-worker mode**: `IWorkerConnectionManager` is resolved via `GetService<T>()` — when not registered, `/stop` gracefully drains only the host with no DI failure