### PR TITLE
 Fix benchmark pipeline artifact naming and align with .NET 10 TFM upgrade

### DIFF
--- a/eng/ci/templates/official/jobs/run-benchmarks.yml
+++ b/eng/ci/templates/official/jobs/run-benchmarks.yml
@@ -30,10 +30,10 @@ jobs:
     agentId: ${{ parameters.functionAppName }}${{ parameters.os }}
     runDescription: ${{ parameters.description }}
     functionApp: ${{ parameters.functionAppName }}
-    benchmarkArtifactName: benchmark_results_$(Agent.OS)_$(functionApp)
+    benchmarkArtifactName: AzFunc_${{ parameters.os }}_${{ parameters.functionAppName }}
     functionAppOutputPath: $(Build.ArtifactStagingDirectory)/FunctionApps/$(functionApp)
     traceDirectory: $(Build.ArtifactStagingDirectory)/out
-    benchmarkResultsJsonPath: $(traceDirectory)/BenchmarkResults/$(Build.BuildNumber)_$(functionApp).json
+    benchmarkResultsJsonPath: $(traceDirectory)/BenchmarkResults/$(originalBuildNumber)_$(functionApp).json
     functionsWorkerRuntime: 'dotnet-isolated'
     configFilePath: "./eng/perf/http.benchmarks.yml"
     hostLocation: "./../../"
@@ -54,12 +54,24 @@ jobs:
       - output: pipelineArtifact
         displayName: Publish artifacts
         path: $(traceDirectory)
-        artifact: AzFunc_$(Build.BuildNumber)_${{ parameters.os }}_${{ parameters.functionAppName }}
+        artifact: $(benchmarkArtifactName)
         condition: always()
 
   steps:
 
+  # Capture the original build number before any parallel stage's dotnet build
+  # updates it via UpdateAzDoBuildNumber in eng/build/Version.targets.
+  - pwsh: |
+      Write-Host "##vso[task.setvariable variable=originalBuildNumber]$(Build.BuildNumber)"
+    displayName: Capture original build number
+
   - template: /eng/ci/templates/install-dotnet.yml@self
+
+  - task: UseDotNet@2 # Needed by crank
+    displayName: Install .NET 8
+    inputs:
+      packageType: sdk
+      version: 8.x
 
   - script: dotnet tool install -g Microsoft.Crank.Agent --version "0.2.0-*"
     displayName: Install Microsoft.Crank.Agent tool
@@ -121,7 +133,7 @@ jobs:
       scriptLocation: inlineScript
       inlineScript: |
         $crankArgs = "--config $(configFilePath) --scenario hellohttp --profile win2022 --load.options.reuseBuild true --description `"$(runDescription)`" --command-line-property --no-measurements --json $(benchmarkResultsJsonPath) --property sourceVersion=$(Build.SourceVersion) --property buildNumber=$(Build.BuildNumber) --property buildId=$(Build.BuildId) --property sourceBranch=$(Build.SourceBranch) --variable FunctionsWorkerRuntime=$(functionsWorkerRuntime) --variable HostLocation=$(hostLocation) --variable FunctionAppPath=$(functionAppOutputPath)"
-        $crankArgs += " --hostruntime.options.traceOutput $(traceDirectory)/$(Build.BuildNumber)_$(functionApp)_$(Agent.OS)"
+        $crankArgs += " --hostruntime.options.traceOutput $(traceDirectory)/$(originalBuildNumber)_$(functionApp)_$(Agent.OS)"
         $crankArgs += " --variable CrankAgentAppVm=$(appAgentHostName) --variable CrankAgentLoadVm=localhost --variable AspNetUrls=http://$(appAgentHostName):5000"
         $crankArgs += " $(crankExtraArguments)"
         $command = "crank $crankArgs"
@@ -154,7 +166,7 @@ jobs:
       $fileNamePattern = "*_$(functionApp).json"
 
       if (Test-Path $baselineDir -PathType Container) {
-          $baselineFile = Get-ChildItem -Path $baselineDir -Filter $fileNamePattern | Select-Object -First 1
+          $baselineFile = Get-ChildItem -Path $baselineDir -Filter $fileNamePattern -Recurse | Select-Object -First 1
 
           if ($baselineFile) {
               Write-Host "Found baseline benchmark result file: $($baselineFile.FullName)"

--- a/eng/ci/templates/official/jobs/setup-benchmark-agents.yml
+++ b/eng/ci/templates/official/jobs/setup-benchmark-agents.yml
@@ -34,6 +34,12 @@ jobs:
 
   - template: /eng/ci/templates/install-dotnet.yml@self
 
+  - task: UseDotNet@2 # Needed by crank
+    displayName: Install .NET 8
+    inputs:
+      packageType: sdk
+      version: 8.x
+
   - script: dotnet tool install -g Microsoft.Crank.Agent --version "0.2.0-*"
     displayName: Install Microsoft.Crank.Agent tool
 

--- a/eng/perf/http.benchmarks.yml
+++ b/eng/perf/http.benchmarks.yml
@@ -8,7 +8,10 @@ jobs:
       functionshost:
         localFolder: '{{HostLocation}}'
     project: functionshost/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj
-    readyStateText: 'Application started.'
+    framework: net10.0
+    sdkVersion: '10.0.103'
+    runtimeVersion: '10.0.5'
+    aspNetCoreVersion: '10.0.5'
     environmentVariables:
       FUNCTIONS_WORKER_RUNTIME: '{{FunctionsWorkerRuntime}}'
       AzureWebJobsScriptRoot: '{{FunctionAppPath}}'


### PR DESCRIPTION
 PR #11532 (Dec 2025) changed the published benchmark artifact naming format from `benchmark_results_{OS}_{App}` to `AzFunc_{BuildNumber}_{OS}_{App}`, and changed the publish target from just the benchmark
JSON file to the entire trace directory. This didn't immediately break the pipeline because the existing baseline build (from Jan 23) still used the old naming. When a new baseline was tagged on April 2 with
 the new artifact format, subsequent runs could no longer download the baseline artifacts since the download step still expected the old naming convention, causing failures starting April 3.

 ## Changes

 **Artifact naming fixes (`run-benchmarks.yml`):**
 - Updated `benchmarkArtifactName` to `AzFunc_{OS}_{App}` — removes `$(Build.BuildNumber)` to make it deterministic so download and publish names match across runs.
 - Publish artifact now uses the shared `$(benchmarkArtifactName)` variable.
 - Added a step to capture the original `$(Build.BuildNumber)` into `$(originalBuildNumber)` before parallel stages can change it via `UpdateAzDoBuildNumber`, ensuring consistent JSON file paths between the
crank run and comparison steps.
 - Added `-Recurse` to `Get-ChildItem` when locating the baseline JSON within the downloaded artifact (now nested in `BenchmarkResults/` subfolder).

 **Alignment with TFM upgrade (net8 → net10):**
 - Added explicit .NET 8 SDK install in `run-benchmarks.yml` and `setup-benchmark-agents.yml`. The benchmark agents now ship with .NET 10 as the default SDK, but the crank tools require .NET 8 to run.
 - Updated crank config (`http.benchmarks.yml`) to target .NET 10.
 - Pinned `sdkVersion`, `runtimeVersion`, and `aspNetCoreVersion` in the crank benchmark config for deterministic results, ensuring crank uses specific SDK/runtime versions.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x]  My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
