### PR TITLE
Add skipPlaceholderInit support for native runtime

### DIFF
--- a/src/WebJobs.Script.Grpc/Rpc/RpcInitializationService.cs
+++ b/src/WebJobs.Script.Grpc/Rpc/RpcInitializationService.cs
@@ -125,8 +125,25 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
                 if (_placeholderLanguageWorkersList.Count() != 0)
                 {
-                    return Task.WhenAll(_placeholderLanguageWorkersList.Select(runtime =>
-                    _webHostRpcWorkerChannelManager.InitializeChannelAsync(_languageWorkerOptions.CurrentValue.WorkerConfigs, runtime)));
+                    var workerConfigs = _languageWorkerOptions.CurrentValue.WorkerConfigs;
+                    var runtimesToInit = _placeholderLanguageWorkersList
+                        .Where(runtime =>
+                        {
+                            var config = workerConfigs?.FirstOrDefault(c =>
+                                string.Equals(c.Description?.Language, runtime, StringComparison.OrdinalIgnoreCase));
+                            if (config?.Description?.SkipPlaceholderInit == true)
+                            {
+                                _logger.LogDebug("Skipping placeholder channel initialization for runtime: {runtime} (skipPlaceholderInit=true)", runtime);
+                                return false;
+                            }
+                            return true;
+                        });
+
+                    if (runtimesToInit.Any())
+                    {
+                        return Task.WhenAll(runtimesToInit.Select(runtime =>
+                            _webHostRpcWorkerChannelManager.InitializeChannelAsync(workerConfigs, runtime)));
+                    }
                 }
             }
             return Task.CompletedTask;

--- a/src/WebJobs.Script.Grpc/WorkerFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script.Grpc/WorkerFunctionMetadataProvider.cs
@@ -62,6 +62,19 @@ namespace Microsoft.Azure.WebJobs.Script
 
             _logger.LogInformation("Fetching metadata for workerRuntime: {workerRuntime}", _workerRuntime);
 
+            // Skip worker init in placeholder mode if the runtime opts out (e.g., native/compiled runtimes
+            // where the worker binary doesn't exist until deployment).
+            if (_environment.IsPlaceholderModeEnabled())
+            {
+                var config = workerConfigs?.FirstOrDefault(c =>
+                    string.Equals(c.Description?.Language, _workerRuntime, StringComparison.OrdinalIgnoreCase));
+                if (config?.Description?.SkipPlaceholderInit == true)
+                {
+                    _logger.LogInformation("Skipping worker initialization in placeholder mode for runtime: {workerRuntime} (skipPlaceholderInit=true)", _workerRuntime);
+                    return new FunctionMetadataResult(false, ImmutableArray<FunctionMetadata>.Empty);
+                }
+            }
+
             IEnumerable<FunctionMetadata> functions = new List<FunctionMetadata>();
             _logger.ReadingFunctionMetadataFromProvider(_metadataProviderName);
 

--- a/src/WebJobs.Script/Workers/WorkerDescription.cs
+++ b/src/WebJobs.Script/Workers/WorkerDescription.cs
@@ -26,6 +26,13 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         public string ExecutableWorkingDirectory { get; set; }
 
         /// <summary>
+        /// Gets or sets whether to skip initializing this worker during placeholder mode.
+        /// When true, the host will not attempt to start the worker process in placeholder mode.
+        /// Used by runtimes where the worker binary is deployed at specialization time (e.g., native/compiled runtimes).
+        /// </summary>
+        public bool SkipPlaceholderInit { get; set; }
+
+        /// <summary>
         /// Gets or sets the default path to the worker.
         /// </summary>
         public string DefaultWorkerPath { get; set; }


### PR DESCRIPTION
Adds a `skipPlaceholderInit` property to worker.config.json that tells the host to skip starting the worker process during placeholder mode. This enables the native runtime Docker image where the worker binary is deployed at specialization time and doesn't exist during placeholder.

Changes:
- `WorkerDescription.cs`: Add `SkipPlaceholderInit` property
- `WorkerFunctionMetadataProvider.cs`: Return empty metadata in placeholder mode when `skipPlaceholderInit=true`  
- `RpcInitializationService.cs`: Skip placeholder channel creation for runtimes with `skipPlaceholderInit=true`