### PR TITLE
[Compute Separation] Specialization flow: StandbyManager skips host restart for external workers, /link triggers ScriptHost startup

### DIFF
--- a/src/WebJobs.Script.Grpc/ExternalWorkers/WorkerConnectionService.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/WorkerConnectionService.cs
@@ -37,8 +37,8 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
     private readonly ILogger _logger;
 
     private readonly ConcurrentDictionary<string, WorkerConnection> _workers = new();
-    private readonly TaskCompletionSource _scriptHostStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly ReaderWriterLockSlim _lifecycleLock = new();
+    private TaskCompletionSource _scriptHostStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private int _firstWorkerClaimed;
     private volatile bool _stopping;
 
@@ -191,8 +191,8 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
             _logger.LogInformation("Worker '{workerId}' connected and registered.", workerId);
 
             // Start or update the ScriptHost based on whether this is the first worker.
-            // The first caller starts the ScriptHost; concurrent callers block until
-            // startup completes, then call SetupChannel on the dispatcher.
+            // The first caller either starts or waits for the ScriptHost; concurrent
+            // callers block until startup completes, then call SetupChannel.
             if (Interlocked.CompareExchange(ref _firstWorkerClaimed, 1, 0) == 0)
             {
                 // First worker: start the ScriptHost. In external worker mode,
@@ -200,15 +200,22 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
                 // so the ScriptHost hasn't started yet. Now that a worker has delivered
                 // host.json and registered a channel, WaitForContent and WaitForChannelAsync
                 // will return immediately when the ScriptHost builds.
+                var tcs = _scriptHostStarted;
                 try
                 {
                     _logger.LogInformation("First worker connected. Starting ScriptHost.");
                     await _scriptHostManager.StartAsync(cancellationToken);
-                    _scriptHostStarted.TrySetResult();
+                    tcs.TrySetResult();
                 }
                 catch (Exception ex)
                 {
-                    _scriptHostStarted.TrySetException(ex);
+                    // Fault the current TCS so any concurrent waiters get the exception
+                    // (they'll propagate it and the platform can retry those workers too).
+                    // Replace the TCS BEFORE releasing the gate so the next winner sees
+                    // a fresh TCS, not the faulted one.
+                    tcs.TrySetException(ex);
+                    _scriptHostStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                    Interlocked.Exchange(ref _firstWorkerClaimed, 0);
                     throw;
                 }
             }
@@ -405,8 +412,6 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
     /// <inheritdoc/>
     public async ValueTask DisposeAsync()
     {
-        _lifecycleLock.Dispose();
-
         foreach (var kvp in _workers)
         {
             if (kvp.Value.Client is not null)
@@ -423,6 +428,7 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
         }
 
         _workers.Clear();
+        _lifecycleLock.Dispose();
     }
 
     /// <summary>

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/WorkerConnectionService.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/WorkerConnectionService.cs
@@ -222,7 +222,7 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
             else
             {
                 // Wait for the first worker's StartAsync to complete before resolving the dispatcher.
-                await _scriptHostStarted.Task;
+                await _scriptHostStarted.Task.WaitAsync(cancellationToken);
 
                 if (Utility.TryGetHostService(_scriptHostManager, out ConnectedWorkerInvocationDispatcher dispatcher))
                 {

--- a/src/WebJobs.Script.Grpc/Hosting/RpcServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.Grpc/Hosting/RpcServiceCollectionExtensions.cs
@@ -58,7 +58,7 @@ public static class RpcServiceCollectionExtensions
         return services;
     }
 
-    public static IServiceCollection AddCommonRpcServices(this IServiceCollection services)
+    public static IServiceCollection AddCommonRpcServices(this IServiceCollection services, bool skipInitializationService = false)
     {
         ArgumentNullException.ThrowIfNull(services);
 
@@ -72,7 +72,13 @@ public static class RpcServiceCollectionExtensions
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IConcurrencyThrottleProvider, WorkerChannelThrottleProvider>());
         services.AddSingleton<IWebHostWorkerManager, RpcWebHostWorkerManager>();
 
-        services.AddManagedHostedService<RpcInitializationService>();
+        // In external worker mode, there are no local worker channels or inbound gRPC
+        // server — workers connect outbound via the worker proxy. Skip the initialization
+        // service that starts the gRPC server and pre-warms local worker channels.
+        if (!skipInitializationService)
+        {
+            services.AddManagedHostedService<RpcInitializationService>();
+        }
 
         AddProcessRegistry(services);
 

--- a/src/WebJobs.Script.WebHost/Standby/StandbyManager.cs
+++ b/src/WebJobs.Script.WebHost/Standby/StandbyManager.cs
@@ -13,6 +13,7 @@ using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Properties;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -127,6 +128,17 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
             using (_metricsLogger.LatencyEvent(MetricEventNames.SpecializationLanguageWorkerChannelManagerSpecialize))
             {
+                // In external worker mode, there are no local language workers to specialize
+                // and no ScriptHost to restart. The platform will link workers via
+                // POST /admin/workers/link, which triggers ScriptHost startup via
+                // WorkerConnectionService. All we do here is apply environment settings
+                // so the ScriptHost starts with the right configuration when triggered.
+                if (_configuration.IsExternalWorkerEnabled())
+                {
+                    _logger.LogInformation("External worker mode enabled. Skipping local worker specialization and host restart.");
+                    return;
+                }
+
                 await _workerManager.SpecializeAsync();
             }
 

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 services.AddExternalWorkerServices(configuration);
             }
 
-            services.AddCommonRpcServices();
+            services.AddCommonRpcServices(skipInitializationService: configuration.IsExternalWorkerEnabled());
 
             services.AddSingleton<IHostFunctionMetadataProvider, HostFunctionMetadataProvider>();
             services.AddSingleton<IFunctionMetadataProvider, FunctionMetadataProvider>();

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/ComputeSeparationTestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/ComputeSeparationTestHelpers.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
 using Xunit.Abstractions;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ComputeSeparation;
@@ -194,5 +196,37 @@ internal static class ComputeSeparationTestHelpers
                 // Best-effort cleanup.
             }
         }
+    }
+
+    /// <summary>
+    /// Polls <c>GET /ready</c> on the worker proxy management endpoint until it returns 200,
+    /// replacing fixed <c>Task.Delay</c> waits after process startup.
+    /// </summary>
+    public static async Task WaitForWorkerProxyReadyAsync(int managementPort, ITestOutputHelper output, TimeSpan? timeout = null)
+    {
+        timeout ??= TimeSpan.FromSeconds(30);
+        using var client = new HttpClient { BaseAddress = new Uri($"http://localhost:{managementPort}") };
+        var sw = Stopwatch.StartNew();
+
+        while (sw.Elapsed < timeout)
+        {
+            try
+            {
+                var response = await client.GetAsync("/ready");
+                if (response.StatusCode == System.Net.HttpStatusCode.OK)
+                {
+                    output.WriteLine($"Worker proxy ready after {sw.Elapsed.TotalSeconds:F1}s.");
+                    return;
+                }
+            }
+            catch (HttpRequestException)
+            {
+                // Not listening yet.
+            }
+
+            await Task.Delay(250);
+        }
+
+        throw new TimeoutException($"Worker proxy did not become ready within {timeout.Value.TotalSeconds}s.");
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/SpecializationEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/SpecializationEndToEndTests.cs
@@ -1,0 +1,320 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.Tests.Integration.Fixtures;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
+using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.WebJobs.Script.Tests;
+using Newtonsoft.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ComputeSeparation;
+
+/// <summary>
+/// End-to-end test for the specialization flow in external worker mode.
+/// Starts the runtime in Flex Consumption placeholder mode, specializes via
+/// <c>/admin/instance/assign</c>, links a worker via <c>/admin/workers/link</c>,
+/// and invokes a function through the mock worker.
+/// </summary>
+[Trait(TestTraits.Category, TestTraits.EndToEnd)]
+[Trait(TestTraits.Group, nameof(SpecializationEndToEndTests))]
+public class SpecializationEndToEndTests : IAsyncLifetime, IDisposable, IClassFixture<AzuriteFixture>
+{
+    private const int RuntimeGrpcPort = 60071;
+    private const int WorkerGrpcPort = 60072;
+    private const int HttpProxyPort = 60073;
+    private const int ManagementPort = 60074;
+
+    private readonly ITestOutputHelper _output;
+    private readonly AzuriteFixture _azurite;
+    private readonly string _encryptionKey = Convert.ToBase64String(TestHelpers.GenerateKeyBytes());
+    private readonly string _testRootPath = Path.Combine(Path.GetTempPath(), $"FunctionsSpecE2E_{Guid.NewGuid():N}");
+
+    private Process _workerProxyProcess;
+    private Process _mockWorkerProcess;
+    private TestEnvironment _environment;
+    private TestLoggerProvider _loggerProvider;
+    private IHost _webHost;
+    private HttpClient _httpClient;
+
+    // Process-level env vars that must be set for DI registration (SystemEnvironment.Instance checks).
+    // Cleaned up in Dispose.
+    private static readonly string[] ProcessEnvVars =
+    [
+        EnvironmentSettingNames.AzureWebsitePlaceholderMode,
+        EnvironmentSettingNames.AzureWebsiteSku,
+        EnvironmentSettingNames.FunctionsWorkerExternalEnabled,
+        "AzureWebJobsStorage",
+    ];
+
+    public SpecializationEndToEndTests(ITestOutputHelper output, AzuriteFixture azurite)
+    {
+        _output = output;
+        _azurite = azurite;
+        StandbyManager.ResetChangeToken();
+    }
+
+    public async Task InitializeAsync()
+    {
+        string repoRoot = ComputeSeparationTestHelpers.FindRepoRoot();
+
+        // 1. Start worker proxy + mock worker child processes.
+        string workerProxyDll = ComputeSeparationTestHelpers.FindBuiltDll(repoRoot, "src", "Functions.WorkerProxy");
+        string mockWorkerDll = ComputeSeparationTestHelpers.FindBuiltDll(repoRoot, "tools", "ComputeSeparation", "MockWorker");
+
+        _workerProxyProcess = ComputeSeparationTestHelpers.StartManagedProcess(
+            _output, "dotnet",
+            $"\"{workerProxyDll}\" --runtime-grpc-port {RuntimeGrpcPort} --worker-grpc-port {WorkerGrpcPort} --http-proxy-port {HttpProxyPort} --management-port {ManagementPort}",
+            new(), "WorkerProxy");
+
+        await Task.Delay(2000);
+        ComputeSeparationTestHelpers.EnsureProcessRunning(_workerProxyProcess, "WorkerProxy", new());
+
+        _mockWorkerProcess = ComputeSeparationTestHelpers.StartManagedProcess(
+            _output, "dotnet",
+            $"\"{mockWorkerDll}\" --grpc-endpoint http://localhost:{WorkerGrpcPort}",
+            new(), "MockWorker");
+
+        await ComputeSeparationTestHelpers.WaitForWorkerProxyReadyAsync(ManagementPort, _output);
+
+        // 2. Configure environment.
+        //    Process-level vars are needed for SystemEnvironment.Instance checks during DI.
+        //    TestEnvironment is injected as IEnvironment for runtime behavior.
+        //    InMemoryCollection in IConfiguration ensures config reads also see these values.
+        string storageConnection = _azurite.GetConnectionString();
+
+        Environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
+        Environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, ScriptConstants.FlexConsumptionSku);
+        Environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionsWorkerExternalEnabled, "true");
+        Environment.SetEnvironmentVariable("AzureWebJobsStorage", storageConnection);
+
+        _environment = new TestEnvironment(new Dictionary<string, string>
+        {
+            { EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1" },
+            { EnvironmentSettingNames.AzureWebsiteContainerReady, null },
+            { EnvironmentSettingNames.AzureWebsiteSku, ScriptConstants.FlexConsumptionSku },
+            { EnvironmentSettingNames.ContainerEncryptionKey, _encryptionKey },
+            { EnvironmentSettingNames.AzureWebsiteName, "test-compute-sep-app" },
+            { EnvironmentSettingNames.AzureWebsiteInstanceId, Guid.NewGuid().ToString() },
+            { EnvironmentSettingNames.FunctionsWorkerExternalEnabled, "true" },
+            { EnvironmentSettingNames.FunctionWorkerRuntime, "node" },
+            { "AzureWebEncryptionKey", "0F75CA46E7EBDD39E4CA6B074D1F9A5972B849A55F91A248" },
+            { "AzureWebJobsStorage", storageConnection },
+        });
+
+        // 3. Build and start the host via TestServer.
+        var uniqueTestPath = Path.Combine(_testRootPath, Guid.NewGuid().ToString());
+        var scriptRootPath = Path.Combine(uniqueTestPath, "wwwroot");
+        FileUtility.EnsureDirectoryExists(scriptRootPath);
+
+        _loggerProvider = new TestLoggerProvider();
+
+        _webHost = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder.UseTestServer();
+
+                webHostBuilder.ConfigureServices(services =>
+                {
+                    services.ConfigureAll<ScriptApplicationHostOptions>(o =>
+                    {
+                        o.IsSelfHost = true;
+                        o.LogPath = Path.Combine(uniqueTestPath, "logs");
+                        o.SecretsPath = Path.Combine(uniqueTestPath, "secrets");
+                        o.ScriptPath = scriptRootPath;
+                    });
+
+                    services.AddSingleton<IEnvironment>(_ => _environment);
+                    services.AddSingleton<IMetricsLogger>(_ => new TestMetricsLogger());
+                    services.AddSingleton<ILinuxConsumptionMetricsTracker>(_ => new TestMetricsTracker());
+                });
+
+                webHostBuilder.UseStartup<Startup>();
+                webHostBuilder.ConfigureAppConfiguration((_, c) =>
+                {
+                    var source = c.Sources.OfType<WebScriptHostConfigurationSource>().SingleOrDefault();
+                    if (source is not null)
+                    {
+                        c.Sources.Remove(source);
+                    }
+
+                    c.AddTestSettings();
+                    c.AddInMemoryCollection([
+                        KeyValuePair.Create("AzureWebJobsStorage", storageConnection),
+                        KeyValuePair.Create(EnvironmentSettingNames.FunctionsWorkerExternalEnabled, "true"),
+                    ]);
+                });
+            })
+            .ConfigureLogging(c =>
+            {
+                c.AddProvider(_loggerProvider);
+                c.AddFilter((cat, lev) => true);
+            })
+            .ConfigureScriptHostLogging(b => b.AddProvider(_loggerProvider))
+            .ConfigureScriptHostServices(s => s.PostConfigure<HttpOptions>(o => o.DynamicThrottlesEnabled = false))
+            .ConfigureScriptHostAppConfiguration(c =>
+            {
+                c.AddInMemoryCollection([KeyValuePair.Create("AzureWebJobsStorage", storageConnection)]);
+            })
+            .Build();
+
+        await _webHost.StartAsync();
+
+        _httpClient = _webHost.GetTestClient();
+        _httpClient.BaseAddress = new Uri("https://localhost/");
+
+        Assert.True(_environment.IsPlaceholderModeEnabled(), "Host should be in placeholder mode.");
+        _output.WriteLine("Runtime started in placeholder mode.");
+    }
+
+    [Fact]
+    public async Task SpecializationFlow_AssignThenLinkThenInvoke()
+    {
+        var secretManager = _webHost.Services.GetService<ISecretManagerProvider>().Current;
+        string masterKey = (await secretManager.GetHostSecretsAsync()).MasterKey;
+
+        // 1. Specialize via /admin/instance/assign with encrypted context.
+        var assignmentContext = new HostAssignmentContext
+        {
+            SiteId = 1234,
+            SiteName = "test-compute-sep-app",
+            Environment = new Dictionary<string, string>
+            {
+                { EnvironmentSettingNames.FunctionsWorkerExternalEnabled, "true" },
+                { EnvironmentSettingNames.FunctionWorkerRuntime, "node" },
+                { EnvironmentSettingNames.AzureWebsiteName, "test-compute-sep-app" },
+            }
+        };
+
+        string encryptedContext = EncryptionHelper.Encrypt(
+            JsonConvert.SerializeObject(assignmentContext),
+            Convert.FromBase64String(_encryptionKey));
+
+        var assignResponse = await SendAdminRequest(
+            masterKey, HttpMethod.Post, "admin/instance/assign",
+            new { encryptedContext });
+
+        _output.WriteLine($"Assign response: {assignResponse.StatusCode}");
+        Assert.Equal(HttpStatusCode.Accepted, assignResponse.StatusCode);
+
+        // 2. Link a worker.
+        var sw = Stopwatch.StartNew();
+        HttpResponseMessage linkResponse = null;
+
+        while (sw.Elapsed < TimeSpan.FromMinutes(2))
+        {
+            linkResponse = await SendAdminRequest(
+                masterKey, HttpMethod.Post, "admin/workers/link",
+                new
+                {
+                    workerId = "w_spec_e2e01",
+                    podName = "worker-pod-spec-e2e",
+                    grpcEndpoint = $"http://localhost:{RuntimeGrpcPort}",
+                    podKey = "test-key"
+                });
+
+            if (linkResponse.StatusCode == HttpStatusCode.Accepted)
+            {
+                break;
+            }
+
+            _output.WriteLine($"Link returned {linkResponse.StatusCode} at {sw.Elapsed.TotalSeconds:F1}s, retrying...");
+            await Task.Delay(1000);
+        }
+
+        _output.WriteLine($"Link response: {linkResponse?.StatusCode}");
+        Assert.Equal(HttpStatusCode.Accepted, linkResponse?.StatusCode);
+
+        // 3. Wait for host to reach Running state.
+        await TestHelpers.Await(
+            () =>
+            {
+                var manager = _webHost.Services.GetService<IScriptHostManager>();
+                _output.WriteLine($"Host state: {manager.State} ({sw.Elapsed.TotalSeconds:F1}s)");
+                return manager.State == ScriptHostState.Running;
+            },
+            timeout: 120_000,
+            pollingInterval: 1000,
+            userMessageCallback: () => string.Join(Environment.NewLine,
+                _loggerProvider.GetAllLogMessages()
+                    .Where(m => m.FormattedMessage is not null)
+                    .TakeLast(50)
+                    .Select(m => $"[{m.Timestamp:HH:mm:ss.fff}] {m.FormattedMessage}")));
+
+        _output.WriteLine("Host is running.");
+
+        // 4. Invoke a function.
+        var invokeResponse = await _httpClient.GetAsync("/api/HttpTrigger");
+        string invokeBody = await invokeResponse.Content.ReadAsStringAsync();
+        _output.WriteLine($"Invoke: {invokeResponse.StatusCode} — {invokeBody}");
+
+        Assert.Equal(HttpStatusCode.OK, invokeResponse.StatusCode);
+        Assert.Contains("Hello from mock worker!", invokeBody);
+    }
+
+    public Task DisposeAsync()
+    {
+        Dispose();
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _httpClient?.Dispose();
+
+        if (_webHost is not null)
+        {
+            try { _webHost.StopAsync().GetAwaiter().GetResult(); } catch { }
+            _webHost.Dispose();
+        }
+
+        _loggerProvider?.Dispose();
+        ComputeSeparationTestHelpers.KillProcess(_output, _mockWorkerProcess, "MockWorker");
+        ComputeSeparationTestHelpers.KillProcess(_output, _workerProxyProcess, "WorkerProxy");
+        ComputeSeparationTestHelpers.TryDeleteDirectory(_testRootPath);
+
+        foreach (string key in ProcessEnvVars)
+        {
+            Environment.SetEnvironmentVariable(key, null);
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    private async Task<HttpResponseMessage> SendAdminRequest(
+        string masterKey, HttpMethod method, string path, object body = null)
+    {
+        var request = new HttpRequestMessage(method, path);
+        request.Headers.Add(AuthenticationLevelHandler.FunctionsKeyHeaderName, masterKey);
+
+        if (body is not null)
+        {
+            request.Content = new StringContent(
+                JsonConvert.SerializeObject(body), Encoding.UTF8, "application/json");
+        }
+
+        return await _httpClient.SendAsync(request);
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAllocationEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAllocationEndToEndTests.cs
@@ -77,7 +77,7 @@ public class WorkerAllocationEndToEndTests : IAsyncLifetime, IDisposable
             _workerProxyLogs,
             "WorkerProxy");
 
-        await Task.Delay(3000);
+        await Task.Delay(2000);
         ComputeSeparationTestHelpers.EnsureProcessRunning(_workerProxyProcess, "WorkerProxy", _workerProxyLogs);
 
         // 2. Start the mock worker.
@@ -88,7 +88,7 @@ public class WorkerAllocationEndToEndTests : IAsyncLifetime, IDisposable
             _mockWorkerLogs,
             "MockWorker");
 
-        await Task.Delay(3000);
+        await ComputeSeparationTestHelpers.WaitForWorkerProxyReadyAsync(ManagementPort, _output);
         ComputeSeparationTestHelpers.EnsureProcessRunning(_mockWorkerProcess, "MockWorker", _mockWorkerLogs);
 
         // 3. Start the runtime via TestFunctionHost.

--- a/test/WebJobs.Script.Tests/StandbyManagerTests.cs
+++ b/test/WebJobs.Script.Tests/StandbyManagerTests.cs
@@ -138,6 +138,66 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Equal(bool.TrueString, _testEnvironment.GetEnvironmentVariable(EnvironmentSettingNames.InitializedFromPlaceholder));
         }
 
+        [Fact]
+        public async Task Specialize_ExternalWorkerMode_SkipsWorkerSpecialization()
+        {
+            TestMetricsLogger metricsLogger = new TestMetricsLogger();
+            var hostNameProvider = new HostNameProvider(_testEnvironment);
+
+            // Simulate external worker mode by configuring the mock configuration to return "true"
+            _mockConfiguration
+                .Setup(c => c[EnvironmentSettingNames.FunctionsWorkerExternalEnabled])
+                .Returns("true");
+
+            var manager = new StandbyManager(
+                _mockHostManager.Object,
+                _mockLanguageWorkerChannelManager.Object,
+                _mockConfiguration.Object,
+                _mockWebHostEnvironment.Object,
+                _testEnvironment,
+                _mockOptionsMonitor.Object,
+                NullLogger<StandbyManager>.Instance,
+                hostNameProvider,
+                _mockApplicationLifetime.Object,
+                metricsLogger);
+
+            await manager.SpecializeHostAsync();
+
+            // SpecializeAsync, RestartHostAsync, and DelayUntilHostReadyAsync should NOT
+            // be called in external worker mode. The /link call triggers ScriptHost startup.
+            _mockLanguageWorkerChannelManager.Verify(
+                m => m.SpecializeAsync(), Times.Never);
+            _mockHostManager.Verify(
+                m => m.RestartHostAsync(It.IsAny<string>(), It.IsAny<System.Threading.CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task Specialize_StandardMode_CallsWorkerSpecialization()
+        {
+            TestMetricsLogger metricsLogger = new TestMetricsLogger();
+            var hostNameProvider = new HostNameProvider(_testEnvironment);
+
+            // No external worker setting → standard mode
+            var manager = new StandbyManager(
+                _mockHostManager.Object,
+                _mockLanguageWorkerChannelManager.Object,
+                _mockConfiguration.Object,
+                _mockWebHostEnvironment.Object,
+                _testEnvironment,
+                _mockOptionsMonitor.Object,
+                NullLogger<StandbyManager>.Instance,
+                hostNameProvider,
+                _mockApplicationLifetime.Object,
+                metricsLogger);
+
+            await manager.SpecializeHostAsync();
+
+            // SpecializeAsync SHOULD be called in standard mode
+            _mockLanguageWorkerChannelManager.Verify(
+                m => m.SpecializeAsync(), Times.Once);
+        }
+
         private bool AreExpectedMetricsGenerated(TestMetricsLogger metricsLogger)
         {
             return metricsLogger.EventsBegan.Contains(MetricEventNames.SpecializationSpecializeHost) && metricsLogger.EventsEnded.Contains(MetricEventNames.SpecializationSpecializeHost)

--- a/test/WebJobs.Script.Tests/Workers/ExternalWorkers/WorkerConnectionServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ExternalWorkers/WorkerConnectionServiceTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Eventing;
@@ -135,6 +136,42 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
             await service.ConnectWorkerAsync("w_1", new Uri("http://localhost:50051"), CancellationToken.None);
 
             _mockHostManager.Verify(m => m.StartAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ConnectWorkerAsync_FirstWorkerFails_SecondWorkerCanRetryAndSucceed()
+        {
+            SetupFullConnectMocks();
+
+            // First call to StartAsync fails, second succeeds.
+            int startAttempt = 0;
+            _mockHostManager
+                .Setup(m => m.StartAsync(It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    if (++startAttempt == 1)
+                    {
+                        return Task.FromException(new InvalidOperationException("transient failure"));
+                    }
+
+                    return Task.CompletedTask;
+                });
+
+            var service = CreateService();
+
+            // First worker fails.
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => service.ConnectWorkerAsync("w_fail", new Uri("http://localhost:50051"), CancellationToken.None));
+
+            var failInfo = service.GetWorkerStatus("w_fail");
+            Assert.Equal(WorkerConnectionState.Error, failInfo.State);
+
+            // Second worker succeeds — the recovery path reset _firstWorkerClaimed.
+            await service.ConnectWorkerAsync("w_retry", new Uri("http://localhost:50052"), CancellationToken.None);
+
+            var retryInfo = service.GetWorkerStatus("w_retry");
+            Assert.Equal(WorkerConnectionState.Connected, retryInfo.State);
+            Assert.Equal(2, _mockHostManager.Invocations.Count(i => i.Method.Name == nameof(IScriptHostManager.StartAsync)));
         }
 
         [Fact]

--- a/tools/ComputeSeparation/AppHost/Program.cs
+++ b/tools/ComputeSeparation/AppHost/Program.cs
@@ -28,6 +28,10 @@ const int mockWorkerHttpPort = 8080;
 const string HostId = "devhost";
 const string MasterKey = "dev-master-key";
 
+// Well-known encryption key for local dev specialization (/admin/instance/assign).
+// 64 hex chars = 32 bytes (256-bit AES key). Must match the pre-encrypted payload in compute-separation.http.
+const string ContainerEncryptionKey = "0F75CA46E7EBDD39E4CA6B074D1F9A5972B849A55F91A248F6B038A61BACE9D7";
+
 // Well-known Azurite storage emulator account key.
 // https://learn.microsoft.com/azure/storage/common/storage-use-azurite#well-known-storage-account-and-key
 const string AzuriteAccountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
@@ -101,6 +105,10 @@ static void AddProjectResources(
         .WithEnvironment("AZURE_FUNCTIONS_ENVIRONMENT", "Development")
         .WithEnvironment("AzureFunctionsWebHost__hostid", HostId)
         .WithEnvironment("ASPNETCORE_URLS", runtimeUrl)
+        .WithEnvironment("WEBSITE_PLACEHOLDER_MODE", "1")
+        .WithEnvironment("WEBSITE_SKU", "FlexConsumption")
+        .WithEnvironment("CONTAINER_ENCRYPTION_KEY", ContainerEncryptionKey)
+        .WithEnvironment("MESH_INIT_URI", "http://localhost:6060")
         .WithEnvironment(context =>
         {
             ConfigureStorageConnectionString(context, storage);
@@ -184,8 +192,11 @@ static void AddContainerResources(
         .WithEnvironment("AZURE_FUNCTIONS_ENVIRONMENT", "Development")
         .WithEnvironment("AzureFunctionsWebHost__hostid", HostId)
         .WithEnvironment("ASPNETCORE_URLS", $"http://+:{runtimePort.ToString()}")
-        .WithEnvironment(context =>
-        {
+        .WithEnvironment("WEBSITE_PLACEHOLDER_MODE", "1")
+        .WithEnvironment("WEBSITE_SKU", "FlexConsumption")
+        .WithEnvironment("CONTAINER_ENCRYPTION_KEY", ContainerEncryptionKey)
+        .WithEnvironment("MESH_INIT_URI", "http://localhost:6060")
+        .WithEnvironment(context =>        {
             ConfigureStorageConnectionString(context, storage);
         })
         .WaitFor(storage);

--- a/tools/ComputeSeparation/compute-separation.http
+++ b/tools/ComputeSeparation/compute-separation.http
@@ -50,7 +50,38 @@ GET {{runtimeHost}}/api/HttpTrigger
 ### Drains host listeners, disconnects all workers, sends WorkerDrainComplete to each.
 POST {{runtimeHost}}/admin/instance/stop?code={{masterKey}}
 
+###
+
 ### ============================================================
+### Specialization Flow (Placeholder → Specialize → Link)
+### ============================================================
+
+### Specialize the runtime (simulate platform /assign call)
+### The payload is encrypted with the well-known CONTAINER_ENCRYPTION_KEY from
+### the Aspire harness (0F75CA46E7EBDD39E4CA6B074D1F9A5972B849A55F91A248F6B038A61BACE9D7).
+### Plaintext: {"SiteId":1234,"SiteName":"devhost","Environment":{"FUNCTIONS_WORKER_EXTERNAL_ENABLED":"true","FUNCTIONS_WORKER_RUNTIME":"node","WEBSITE_SITE_NAME":"devhost"}}
+POST {{runtimeHost}}/admin/instance/assign?code={{masterKey}}
+Content-Type: application/json
+
+{
+  "encryptedContext": "STOt1wkHpw6kqe5/g0bxkQ==.YhyWltLkQVJD0Q+z4nJQvZEjj+kMzBOFY0LzUwtk9ASao/7ZB8myX3rLO9JGGnGnoAn6zlQij2Vkt36Jpn6gl8vYGAol7E/cSDqvOTQyRclR1Xb7Ph227TIsJfc5x9M2312QxC+uUsuz/OLOfFcHjO25aZ2XWk4iI3lorGeXnLgYi97oIQd8jKNaa+qcGW0eG0t9Mi1a8DQ+EWt1pT5iKA==.l7sP0SVC5PPsmjsAf9df4iUs609Ck09VtyO6LEvhMVs="
+}
+
+###
+
+### After specialization, link the worker.
+### The /link call triggers ScriptHost startup and delivers host.json + function metadata.
+POST {{runtimeHost}}/admin/workers/link?code={{masterKey}}
+Content-Type: application/json
+
+{
+  "workerId": "w_test01",
+  "podName": "worker-pod-test01",
+  "grpcEndpoint": "{{workerGrpcEndpoint}}",
+  "podKey": "test-key"
+}
+
+###
 ### Worker Proxy Management APIs
 ### ============================================================
 


### PR DESCRIPTION
- **`StandbyManager` skips host lifecycle for external workers** — During `/assign`, env vars and config are applied but `SpecializeAsync`, `RestartHostAsync`, and `DelayUntilHostReady` are skipped. The `ScriptHost` is started later by the `/link` call.
- **`RpcInitializationService` not registered in external worker mode** — No inbound gRPC server or local worker channel pre-warming when workers are external.
- **First-worker failure recovery** — If the first worker's `StartAsync` fails, subsequent workers can retry instead of being permanently blocked by a faulted `TaskCompletionSource`.
- **`DisposeAsync` ordering fix** — `ReaderWriterLockSlim` is now disposed after worker cleanup to prevent `ObjectDisposedException` during shutdown races.
- **Aspire harness updated for placeholder mode** — Adds `WEBSITE_PLACEHOLDER_MODE`, `WEBSITE_SKU`, `CONTAINER_ENCRYPTION_KEY`, and `MESH_INIT_URI` env vars for local specialization testing.
- **`.http` file supports `/assign`** — Pre-encrypted specialization payload using a well-known dev encryption key for manual testing.
