### PR TITLE
[Compute Separation] Adding runtime state tracking and publishing

### DIFF
--- a/src/WebJobs.Script.Grpc/ExternalWorkers/ExternalWorkerServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/ExternalWorkerServiceCollectionExtensions.cs
@@ -41,6 +41,7 @@ internal static class ExternalWorkerServiceCollectionExtensions
         services.AddSingleton<IConnectedWorkerChannelFactory, ConnectedWorkerChannelFactory>();
         services.AddSingleton<IConnectedWorkerChannelManager, ConnectedWorkerChannelManager>();
         services.AddSingleton<IOutboundGrpcClientFactory, OutboundGrpcClientFactory>();
+        services.AddSingleton<IRuntimeStateManager, RuntimeStateManager>();
 
         // WorkerConnectionService must start (and block until worker handshake completes)
         // before WebJobsScriptHostService builds the ScriptHost.

--- a/src/WebJobs.Script.Grpc/ExternalWorkers/WorkerConnectionService.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/WorkerConnectionService.cs
@@ -34,6 +34,7 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
     private readonly IOutboundGrpcClientFactory _clientFactory;
     private readonly ExternalWorkerOptions _options;
     private readonly HostJsonContentProvider _hostJsonContentProvider;
+    private readonly IRuntimeStateManager _runtimeStateManager;
     private readonly ILogger _logger;
 
     private readonly ConcurrentDictionary<string, WorkerConnection> _workers = new();
@@ -53,6 +54,7 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
         IOutboundGrpcClientFactory clientFactory,
         IOptions<ExternalWorkerOptions> options,
         HostJsonContentProvider hostJsonContentProvider,
+        IRuntimeStateManager runtimeStateManager,
         ILoggerFactory loggerFactory)
     {
         _channelFactory = channelFactory ?? throw new ArgumentNullException(nameof(channelFactory));
@@ -62,6 +64,7 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
         _clientFactory = clientFactory ?? throw new ArgumentNullException(nameof(clientFactory));
         _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
         _hostJsonContentProvider = hostJsonContentProvider ?? throw new ArgumentNullException(nameof(hostJsonContentProvider));
+        _runtimeStateManager = runtimeStateManager ?? throw new ArgumentNullException(nameof(runtimeStateManager));
         _logger = loggerFactory.CreateLogger<WorkerConnectionService>();
     }
 
@@ -87,7 +90,7 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
         {
             // API-driven path: no worker is connected at startup.
             // The ScriptHost will block at WaitForContent / WaitForChannelAsync
-            // until a worker is linked via POST /admin/workers/link.
+            // until a worker is linked via PUT /admin/workers/{workerId}.
             // The WebHost layer (admin APIs) remains responsive during this time.
             _logger.LogInformation("No gRPC endpoint configured. Host will wait for worker assignment via admin API.");
         }
@@ -127,6 +130,11 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
                 throw new InvalidOperationException(
                     $"Worker '{workerId}' already exists. Disconnect it before reassigning.");
             }
+
+            // The worker is now linked for the purposes of RuntimeState accounting.
+            // It remains linked through any state transitions (Connecting, Connected,
+            // Draining, Error) until DisconnectWorkerAsync removes it from _workers.
+            _runtimeStateManager.OnWorkerLinked(workerId);
         }
         finally
         {
@@ -142,6 +150,7 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
     private async Task ConnectWorkerCoreAsync(string workerId, Uri endpoint, WorkerConnection worker, CancellationToken cancellationToken)
     {
         var info = worker.Info;
+        bool connected = false;
 
         try
         {
@@ -231,15 +240,20 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
                 }
             }
 
+            // [CS-TODO] Replace with value reported by the worker during the init
+            // handshake (expected as a "max_concurrency" capability on
+            // WorkerInitResponse, parsed via channel.GetCapabilityState(...) like
+            // "host_configuration_json" above). Until then, hard-code per the App
+            // Server contract.
+            const int workerSlotCapacity = 16;
+            _runtimeStateManager.OnWorkerCapacityAvailable(workerId, workerSlotCapacity);
+
             info.State = WorkerConnectionState.Connected;
+            connected = true;
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to connect worker '{workerId}'.", workerId);
-
-            // Clean up partially-created resources so the platform can retry
-            // after calling DELETE to clear the Error state.
-            await CleanupWorkerResourcesAsync(workerId, worker);
 
             info.State = WorkerConnectionState.Error;
             info.ErrorMessage = ex.Message;
@@ -248,6 +262,27 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
         }
         finally
         {
+            if (!connected)
+            {
+                // Clean up partially-created resources, drop the worker from
+                // tracking, and reverse the OnWorkerLinked accounting that
+                // ConnectWorkerAsync performed before invoking the core. Without
+                // this, a failed connect permanently inflates LinkedWorkerCount
+                // and can eventually block the platform from linking new workers
+                // once the configured maximum is reached.
+                try
+                {
+                    await CleanupWorkerResourcesAsync(workerId, worker);
+                }
+                catch (Exception cleanupEx)
+                {
+                    _logger.LogWarning(cleanupEx, "Cleanup after failed connect threw for worker '{workerId}'.", workerId);
+                }
+
+                _workers.TryRemove(workerId, out _);
+                _runtimeStateManager.OnWorkerUnlinked(workerId);
+            }
+
             worker.ConnectCompleted.TrySetResult();
         }
     }
@@ -270,6 +305,15 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
 
         // Wait for any in-flight ConnectWorkerAsync to finish before cleaning up.
         await worker.ConnectCompleted.Task;
+
+        // Withdraw this worker's capacity from the shared slot pool up front,
+        // before we start the (potentially long) drain. From this point on
+        // the worker won't serve new invocations, so its capacity must not be
+        // advertised to the App Server. The worker stays linked (visible in
+        // LinkedWorkerCount) until it is removed from _workers below.
+        // OnWorkerCapacityUnavailable is idempotent and a no-op if the worker
+        // never contributed capacity (e.g. connect failed before handshake).
+        _runtimeStateManager.OnWorkerCapacityUnavailable(workerId);
 
         // Mark channel as draining so no new invocations are routed.
         var channel = _channelManager.GetChannel(workerId);
@@ -312,10 +356,6 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
             // [CS-TODO] When the last worker is drained (scale-in), should the runtime
             // pause trigger listeners or enter a degraded state? For now we just disconnect.
 
-            await CleanupWorkerResourcesAsync(workerId, worker);
-
-            // Remove from tracking only after cleanup succeeds.
-            _workers.TryRemove(workerId, out _);
             _logger.LogInformation("Worker '{workerId}' disconnected.", workerId);
         }
         catch (Exception ex)
@@ -326,6 +366,25 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
             worker.Info.ErrorMessage = ex.Message;
 
             throw;
+        }
+        finally
+        {
+            // Always release resources and drop the worker from tracking, even
+            // when drain throws. Slot-pool capacity was already returned at the
+            // start of the drain; here we reverse the OnWorkerLinked accounting
+            // so a failed disconnect can't permanently inflate LinkedWorkerCount
+            // and eventually block the platform from linking new workers.
+            try
+            {
+                await CleanupWorkerResourcesAsync(workerId, worker);
+            }
+            catch (Exception cleanupEx)
+            {
+                _logger.LogWarning(cleanupEx, "Cleanup after disconnect threw for worker '{workerId}'.", workerId);
+            }
+
+            _workers.TryRemove(workerId, out _);
+            _runtimeStateManager.OnWorkerUnlinked(workerId);
         }
     }
 
@@ -357,6 +416,11 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
         {
             _lifecycleLock.ExitWriteLock();
         }
+
+        // Tell the runtime-state manager immediately so GetState/AcquireSlots
+        // report zero slots for the entire drain window, rather than leaking
+        // capacity per-worker as each disconnect completes.
+        _runtimeStateManager.SetStopping();
 
         if (workerIds.Count == 0)
         {

--- a/src/WebJobs.Script.WebHost/ContainerManagement/RuntimeStatePublisher.cs
+++ b/src/WebJobs.Script.WebHost/ContainerManagement/RuntimeStatePublisher.cs
@@ -1,0 +1,147 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost.Management;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement
+{
+    /// <summary>
+    /// Hosted service that forwards <see cref="IRuntimeStateManager"/> state
+    /// changes to the mesh service via <see cref="IMeshServiceClient.PublishRuntimeState"/>.
+    /// </summary>
+    /// <remarks>
+    /// Change notifications are debounced over a short window so bursts (e.g.
+    /// several <c>OnWorkerAdded</c> calls during initial link, or many
+    /// acquire/release operations in quick succession) coalesce into a single
+    /// mesh publish carrying the latest snapshot. Only registered when
+    /// compute separation is enabled.
+    /// </remarks>
+    internal sealed class RuntimeStatePublisher : IHostedService, IDisposable
+    {
+        private const int PublishDebounceMs = 500;
+
+        private readonly IRuntimeStateManager _stateManager;
+        private readonly IMeshServiceClient _meshServiceClient;
+        private readonly ILogger<RuntimeStatePublisher> _logger;
+        private readonly Timer _timer;
+
+        private int _publishPending;
+        private int _publishInFlight;
+        private bool _disposed;
+
+        public RuntimeStatePublisher(
+            IRuntimeStateManager stateManager,
+            IMeshServiceClient meshServiceClient,
+            ILogger<RuntimeStatePublisher> logger)
+        {
+            _stateManager = stateManager ?? throw new ArgumentNullException(nameof(stateManager));
+            _meshServiceClient = meshServiceClient ?? throw new ArgumentNullException(nameof(meshServiceClient));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            _timer = new Timer(OnPublishTimer, null, Timeout.Infinite, Timeout.Infinite);
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Starting {name}.", nameof(RuntimeStatePublisher));
+            _stateManager.StateChanged += OnStateChanged;
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Stopping {name}.", nameof(RuntimeStatePublisher));
+            _stateManager.StateChanged -= OnStateChanged;
+            _timer.Change(Timeout.Infinite, Timeout.Infinite);
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _stateManager.StateChanged -= OnStateChanged;
+            _timer.Dispose();
+        }
+
+        private void OnStateChanged()
+        {
+            // First change in a quiet window arms the timer; subsequent changes
+            // within the debounce window piggyback on the pending publish and
+            // will see the latest snapshot when the timer fires.
+            if (Interlocked.CompareExchange(ref _publishPending, 1, 0) == 0)
+            {
+                try
+                {
+                    _timer.Change(PublishDebounceMs, Timeout.Infinite);
+                }
+                catch (ObjectDisposedException)
+                {
+                    // Raced with Dispose — drop the publish.
+                    Interlocked.Exchange(ref _publishPending, 0);
+                }
+            }
+        }
+
+        private async void OnPublishTimer(object state)
+        {
+            // Serialize publishes: if a previous invocation is still running
+            // (publish slower than the debounce window), let it absorb any
+            // newly-pending change via the drain loop below. This prevents
+            // concurrent calls into IMeshServiceClient.PublishRuntimeState
+            // and avoids out-of-order snapshot delivery.
+            if (Interlocked.CompareExchange(ref _publishInFlight, 1, 0) != 0)
+            {
+                return;
+            }
+
+            try
+            {
+                // Drain the pending flag so changes raised while we were
+                // publishing are coalesced into another iteration on this
+                // loop rather than racing as a concurrent invocation.
+                while (Interlocked.Exchange(ref _publishPending, 0) == 1)
+                {
+                    try
+                    {
+                        var snapshot = _stateManager.GetState();
+                        await _meshServiceClient.PublishRuntimeState(snapshot);
+                    }
+                    catch (Exception ex) when (!ex.IsFatal())
+                    {
+                        _logger.LogError(ex, "Failed to publish runtime state.");
+                    }
+                }
+            }
+            finally
+            {
+                Volatile.Write(ref _publishInFlight, 0);
+            }
+
+            // Close the window where a state change armed the timer between
+            // our last drain and releasing the gate: that timer callback
+            // would have returned early because the gate was held.
+            if (Volatile.Read(ref _publishPending) == 1)
+            {
+                try
+                {
+                    _timer.Change(0, Timeout.Infinite);
+                }
+                catch (ObjectDisposedException)
+                {
+                    Interlocked.Exchange(ref _publishPending, 0);
+                }
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -536,5 +536,66 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                 return StatusCode(StatusCodes.Status503ServiceUnavailable);
             }
         }
+
+        /// <summary>
+        /// Stops the runtime pod. Enables drain mode to stop trigger listeners
+        /// and stop accepting new invocations, then drains and disconnects all
+        /// connected external workers in parallel.
+        /// Called by the Go Proxy when the platform decides to stop the entire runtime pod.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// POST /admin/host/stop
+        /// </code>
+        /// </example>
+        [HttpPost]
+        [Route("admin/host/stop")]
+        [Authorize(Policy = PolicyNames.AdminAuthLevel)]
+        public IActionResult Stop()
+        {
+            _logger.LogInformation("Received request to stop the runtime instance.");
+
+            if (!Utility.TryGetHostService(_scriptHostManager, out IDrainModeManager drainModeManager))
+            {
+                _logger.LogWarning("Stop requested but ScriptHost is not ready (IDrainModeManager unavailable).");
+                return StatusCode(StatusCodes.Status503ServiceUnavailable);
+            }
+
+            // IWorkerConnectionManager is only registered when external workers are enabled.
+            // In non-compute-separation scenarios, /stop still drains the host but has no workers to disconnect.
+            var connectionManager = HttpContext.RequestServices.GetService<IWorkerConnectionManager>();
+
+            // Fire-and-forget: drain host listeners, then disconnect all workers.
+            _ = StopCoreAsync(drainModeManager, connectionManager)
+                .ContinueWith(
+                    t =>
+                    {
+                        if (t.IsFaulted)
+                        {
+                            _logger.LogError(t.Exception, "Error during runtime stop.");
+                        }
+                        else
+                        {
+                            _logger.LogInformation("Runtime stop completed.");
+                        }
+                    },
+                    TaskScheduler.Default);
+
+            return Accepted();
+        }
+
+        private async Task StopCoreAsync(IDrainModeManager drainModeManager, IWorkerConnectionManager connectionManager)
+        {
+            // Step 1: Stop trigger listeners and stop accepting new invocations.
+            _logger.LogInformation("Enabling drain mode.");
+            await drainModeManager.EnableDrainModeAsync(CancellationToken.None);
+
+            // Step 2: Drain in-flight invocations and disconnect all workers (if any).
+            if (connectionManager is not null)
+            {
+                _logger.LogInformation("Draining and disconnecting all workers.");
+                await connectionManager.DrainAndDisconnectAllAsync(CancellationToken.None);
+            }
+        }
     }
 }

--- a/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
@@ -1,12 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
@@ -20,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 {
     /// <summary>
     /// Controller responsible for instance operations such as specialization,
-    /// lifecycle management, and health checks.
+    /// health checks, and runtime state reporting.
     /// </summary>
     public class InstanceController : Controller
     {
@@ -122,64 +120,32 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         }
 
         /// <summary>
-        /// Stops the runtime pod. Enables drain mode to stop trigger listeners
-        /// and stop accepting new invocations, then drains and disconnects all
-        /// connected external workers in parallel.
-        /// Called by the Go Proxy when the platform decides to stop the entire runtime pod.
+        /// Returns a snapshot of this runtime instance's state: linked worker
+        /// count and request-slot accounting. This is the same payload that is
+        /// published to the mesh service as <c>publish-runtime-state</c>.
         /// </summary>
+        /// <remarks>
+        /// Returns <c>503 Service Unavailable</c> when compute separation is not
+        /// enabled (no <see cref="IRuntimeStateManager"/> is registered).
+        /// </remarks>
         /// <example>
         /// <code>
-        /// POST /admin/instance/stop
+        /// GET /admin/instance/state
         /// </code>
         /// </example>
-        [HttpPost]
-        [Route("admin/instance/stop")]
+        [HttpGet]
+        [Route("admin/instance/state")]
         [Authorize(Policy = PolicyNames.AdminAuthLevel)]
-        public IActionResult Stop()
+        public IActionResult GetState()
         {
-            _logger.LogInformation("Received request to stop the runtime instance.");
-
-            if (!Utility.TryGetHostService(_scriptHostManager, out IDrainModeManager drainModeManager))
+            var runtimeStateManager = HttpContext.RequestServices.GetService<IRuntimeStateManager>();
+            if (runtimeStateManager is null)
             {
-                _logger.LogWarning("Stop requested but ScriptHost is not ready (IDrainModeManager unavailable).");
+                _logger.LogWarning("GetState called but the external workers feature is not enabled.");
                 return StatusCode(StatusCodes.Status503ServiceUnavailable);
             }
 
-            // IWorkerConnectionManager is only registered when external workers are enabled.
-            // In non-compute-separation scenarios, /stop still drains the host but has no workers to disconnect.
-            var connectionManager = HttpContext.RequestServices.GetService<IWorkerConnectionManager>();
-
-            // Fire-and-forget: drain host listeners, then disconnect all workers.
-            _ = StopCoreAsync(drainModeManager, connectionManager)
-                .ContinueWith(
-                    t =>
-                    {
-                        if (t.IsFaulted)
-                        {
-                            _logger.LogError(t.Exception, "Error during runtime stop.");
-                        }
-                        else
-                        {
-                            _logger.LogInformation("Runtime stop completed.");
-                        }
-                    },
-                    TaskScheduler.Default);
-
-            return Accepted();
-        }
-
-        private async Task StopCoreAsync(IDrainModeManager drainModeManager, IWorkerConnectionManager connectionManager)
-        {
-            // Step 1: Stop trigger listeners and stop accepting new invocations.
-            _logger.LogInformation("Enabling drain mode.");
-            await drainModeManager.EnableDrainModeAsync(CancellationToken.None);
-
-            // Step 2: Drain in-flight invocations and disconnect all workers (if any).
-            if (connectionManager is not null)
-            {
-                _logger.LogInformation("Draining and disconnecting all workers.");
-                await connectionManager.DrainAndDisconnectAllAsync(CancellationToken.None);
-            }
+            return Ok(runtimeStateManager.GetState());
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Controllers/RequestSlotsController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/RequestSlotsController.cs
@@ -1,0 +1,106 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
+{
+    /// <summary>
+    /// Controller responsible for request-slot lease management.
+    /// </summary>
+    [Authorize(Policy = PolicyNames.AdminAuthLevel)]
+    public class RequestSlotsController : Controller
+    {
+        private readonly ILogger _logger;
+
+        public RequestSlotsController(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory.CreateLogger<RequestSlotsController>();
+        }
+
+        /// <summary>
+        /// Reserves request slots against the runtime's shared pool.
+        /// </summary>
+        /// <remarks>
+        /// Grants may be partial: the response's <see cref="RequestSlotsLeaseResponse.AcquiredSlotCount"/>
+        /// indicates the number of slots actually reserved, which can be anywhere
+        /// from zero to <see cref="RequestSlotsLeaseRequest.Count"/>.
+        /// The caller is responsible for releasing whatever was granted.
+        /// </remarks>
+        [HttpPost]
+        [Route("admin/request-slots/leases")]
+        public IActionResult AcquireLeases([FromBody] RequestSlotsLeaseRequest request)
+        {
+            if (request is null)
+            {
+                return BadRequest("Request body is required.");
+            }
+
+            if (request.Count <= 0)
+            {
+                return BadRequest($"'{nameof(request.Count)}' must be greater than zero.");
+            }
+
+            var runtimeStateManager = HttpContext.RequestServices.GetService<IRuntimeStateManager>();
+            if (runtimeStateManager is null)
+            {
+                _logger.LogWarning("AcquireLeases called but external workers feature is not enabled.");
+                return StatusCode(StatusCodes.Status503ServiceUnavailable);
+            }
+
+            int granted = runtimeStateManager.AcquireSlots(request.Count);
+            if (granted < request.Count)
+            {
+                _logger.LogInformation(
+                    "Partial slot grant: requested {requested}, granted {granted}.",
+                    request.Count,
+                    granted);
+            }
+
+            return Ok(new RequestSlotsLeaseResponse { AcquiredSlotCount = granted });
+        }
+
+        /// <summary>
+        /// Releases previously-acquired request slots back to the runtime's pool.
+        /// </summary>
+        /// <remarks>
+        /// Release is best-effort: if <see cref="RequestSlotsLeaseRequest.Count"/>
+        /// exceeds the runtime's current lease count, the runtime clamps at the
+        /// actual leased amount and returns success. The caller (App Server) is
+        /// expected to treat transport failures as non-fatal and continue to
+        /// update its local accounting regardless.
+        /// </remarks>
+        [HttpDelete]
+        [Route("admin/request-slots/leases")]
+        public IActionResult ReleaseLeases([FromBody] RequestSlotsLeaseRequest request)
+        {
+            if (request is null)
+            {
+                return BadRequest("Request body is required.");
+            }
+
+            if (request.Count <= 0)
+            {
+                return BadRequest($"'{nameof(request.Count)}' must be greater than zero.");
+            }
+
+            var runtimeStateManager = HttpContext.RequestServices.GetService<IRuntimeStateManager>();
+            if (runtimeStateManager is null)
+            {
+                _logger.LogWarning("ReleaseLeases called but external workers feature is not enabled.");
+                return StatusCode(StatusCodes.Status503ServiceUnavailable);
+            }
+
+            runtimeStateManager.ReleaseSlots(request.Count);
+
+            return Ok();
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Controllers/WorkerController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/WorkerController.cs
@@ -33,15 +33,20 @@ public sealed class WorkerController : Controller
     }
 
     /// <summary>
-    /// Links a worker pod to this runtime. Initiates an outbound gRPC connection
+    /// Links an external worker to this runtime. Initiates an outbound gRPC connection
     /// to the worker proxy and returns immediately. The connection and handshake
     /// complete in the background.
     /// </summary>
-    [HttpPost]
-    [Route("admin/workers/link")]
+    [HttpPut]
+    [Route("admin/workers/{workerId}")]
     [Authorize(Policy = PolicyNames.AdminAuthLevel)]
-    public IActionResult Link([FromBody] WorkerLinkRequest request)
+    public IActionResult LinkWorker([FromRoute] string workerId, [FromBody] ExternalWorkerInfo request)
     {
+        if (string.IsNullOrWhiteSpace(workerId))
+        {
+            return BadRequest("Worker id is required in the route.");
+        }
+
         if (request is null)
         {
             return BadRequest("Request body is required.");
@@ -50,6 +55,12 @@ public sealed class WorkerController : Controller
         if (_webHostEnvironment.InStandbyMode)
         {
             return BadRequest("Cannot link workers before the host has been specialized.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.WorkerId) &&
+            !string.Equals(request.WorkerId, workerId, StringComparison.Ordinal))
+        {
+            return BadRequest($"Body '{nameof(request.WorkerId)}' '{request.WorkerId}' does not match route worker id '{workerId}'.");
         }
 
         if (string.IsNullOrWhiteSpace(request.GrpcEndpoint))
@@ -62,19 +73,11 @@ public sealed class WorkerController : Controller
             return BadRequest($"'{request.GrpcEndpoint}' is not a valid URI.");
         }
 
-        string workerId = request.WorkerId;
-        if (string.IsNullOrWhiteSpace(workerId))
-        {
-            workerId = $"w_{Guid.NewGuid():N}"[..10];
-        }
-
         _logger.LogInformation("Received worker link request for '{workerId}' at {endpoint}.", workerId, endpoint);
 
         // Check for duplicate before starting async work — return 409 Conflict.
-        // [CS-TODO] If a worker connection fails (Error state), the entry remains in _workers
-        // and a retry with the same workerId will be rejected with 409. There is currently no
-        // API to clear this state (DELETE was removed). May need a platform-side solution
-        // (e.g., always use a new workerId on retry) or a host-side cleanup mechanism.
+        // Failed connections are auto-removed by WorkerConnectionService so the
+        // platform can retry the same workerId without an explicit DELETE.
         if (_connectionManager.GetWorkerStatus(workerId) is not null)
         {
             return Conflict($"Worker '{workerId}' is already linked.");

--- a/src/WebJobs.Script.WebHost/Management/IMeshServiceClient.cs
+++ b/src/WebJobs.Script.WebHost/Management/IMeshServiceClient.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Azure.WebJobs.Script.Workers;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 {
@@ -21,5 +22,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         Task NotifyHealthEvent(ContainerHealthEventType healthEventType, Type source, string details);
 
         Task CreateBindMount(string sourcePath, string targetPath);
+
+        /// <summary>
+        /// Publishes the current <see cref="RuntimeState"/> snapshot to the mesh service
+        /// so the App Server can observe linked-worker and request-slot accounting.
+        /// </summary>
+        Task PublishRuntimeState(RuntimeState state);
     }
 }

--- a/src/WebJobs.Script.WebHost/Management/MeshServiceClient.cs
+++ b/src/WebJobs.Script.WebHost/Management/MeshServiceClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
@@ -20,6 +21,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         public const string SquashFsOperation = "squashfs";
         public const string ZipOperation = "zip";
         public const string AddFES = "add-fes";
+        public const string PublishRuntimeStateOperation = "publish-runtime-state";
         private readonly HttpClient _client;
         private readonly ILogger _logger;
         private readonly IEnvironment _environment;
@@ -112,6 +114,29 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
             });
 
             _logger.LogInformation($"Posted health event status: {responseMessage.StatusCode}");
+        }
+
+        public async Task PublishRuntimeState(RuntimeState state)
+        {
+            if (state is null)
+            {
+                throw new ArgumentNullException(nameof(state));
+            }
+
+            _logger.LogDebug(
+                "Publishing runtime state: linkedWorkers={linkedWorkers}/{maxLinkedWorkers}, availableSlots={availableSlots}/{totalSlots}.",
+                state.LinkedWorkerCount,
+                state.MaxLinkedWorkers,
+                state.TotalAvailableRequestSlots,
+                state.TotalRequestSlots);
+
+            var response = await SendAsync(new[]
+            {
+                new KeyValuePair<string, string>(Operation, PublishRuntimeStateOperation),
+                new KeyValuePair<string, string>("content", Serialize(state)),
+            });
+
+            response.EnsureSuccessStatusCode();
         }
 
         public async Task CreateBindMount(string sourcePath, string targetPath)

--- a/src/WebJobs.Script.WebHost/Management/NullMeshServiceClient.cs
+++ b/src/WebJobs.Script.WebHost/Management/NullMeshServiceClient.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Azure.WebJobs.Script.Workers;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
 {
@@ -49,6 +50,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
         }
 
         public Task CreateBindMount(string sourcePath, string targetPath)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task PublishRuntimeState(RuntimeState state)
         {
             return Task.CompletedTask;
         }

--- a/src/WebJobs.Script.WebHost/Models/ExternalWorkerInfo.cs
+++ b/src/WebJobs.Script.WebHost/Models/ExternalWorkerInfo.cs
@@ -6,13 +6,13 @@ using Newtonsoft.Json;
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Models;
 
 /// <summary>
-/// Request body for <c>POST /admin/workers/link</c>.
+/// Request body for <c>PUT /admin/workers/{workerId}</c>.
 /// </summary>
-public sealed class WorkerLinkRequest
+public sealed class ExternalWorkerInfo
 {
     /// <summary>
     /// Gets or sets the platform-assigned worker identifier.
-    /// If null, the host generates one.
+    /// Optional in the body; when provided it must match the worker id specified in the route.
     /// </summary>
     [JsonProperty("workerId")]
     public string WorkerId { get; set; }
@@ -26,7 +26,7 @@ public sealed class WorkerLinkRequest
     /// <summary>
     /// Gets or sets the gRPC endpoint URI of the worker proxy (required).
     /// </summary>
-    /// <example>http://10.0.1.42:50051</example>
+    /// <example>http://10.0.1.42:50051.</example>
     [JsonProperty("grpcEndpoint")]
     public string GrpcEndpoint { get; set; }
 

--- a/src/WebJobs.Script.WebHost/Models/RequestSlotsLeaseRequest.cs
+++ b/src/WebJobs.Script.WebHost/Models/RequestSlotsLeaseRequest.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
+{
+    /// <summary>
+    /// Represents a request to modify the number of leased request slots for the current instance.
+    /// </summary>
+    public sealed class RequestSlotsLeaseRequest
+    {
+        /// <summary>
+        /// Gets or sets the number of request slots to acquire or release.
+        /// Must be greater than zero.
+        /// </summary>
+        [JsonProperty("count")]
+        public int Count { get; set; }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Models/RequestSlotsLeaseResponse.cs
+++ b/src/WebJobs.Script.WebHost/Models/RequestSlotsLeaseResponse.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Models
+{
+    /// <summary>
+    /// Response payload for the <c>POST /admin/request-slots/leases</c> admin API.
+    /// </summary>
+    public sealed class RequestSlotsLeaseResponse
+    {
+        /// <summary>
+        /// Gets or sets the number of request slots actually reserved by the runtime.
+        /// May be less than <see cref="RequestSlotsLeaseRequest.Count"/> if
+        /// insufficient slots were available at the time of the call. The caller is
+        /// responsible for releasing whatever was granted via
+        /// <c>DELETE /admin/request-slots/leases</c>.
+        /// </summary>
+        [JsonProperty("acquiredSlotCount")]
+        public int AcquiredSlotCount { get; set; }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Standby/StandbyManager.cs
+++ b/src/WebJobs.Script.WebHost/Standby/StandbyManager.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             {
                 // In external worker mode, there are no local language workers to specialize
                 // and no ScriptHost to restart. The platform will link workers via
-                // POST /admin/workers/link, which triggers ScriptHost startup via
+                // PUT /admin/workers/{workerId}, which triggers ScriptHost startup via
                 // WorkerConnectionService. All we do here is apply environment settings
                 // so the ScriptHost starts with the right configuration when triggered.
                 if (_configuration.IsExternalWorkerEnabled())

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -205,6 +205,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             if (configuration.IsExternalWorkerEnabled())
             {
                 services.AddExternalWorkerServices(configuration);
+
+                // Forwards runtime state changes (linked workers, request slot
+                // accounting) to the mesh service. Only relevant when compute
+                // separation is active.
+                services.AddSingleton<RuntimeStatePublisher>();
+                services.AddSingleton<IHostedService>(s => s.GetRequiredService<RuntimeStatePublisher>());
             }
 
             services.AddCommonRpcServices(skipInitializationService: configuration.IsExternalWorkerEnabled());
@@ -218,7 +224,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             // In external worker mode, the ScriptHost cannot start until a worker
             // connects and delivers host.json + function metadata. WorkerConnectionService
             // calls WebJobsScriptHostService.StartAsync() after the first worker connects
-            // (whether config-driven on startup or API-driven via POST /admin/workers/link).
+            // (whether config-driven on startup or API-driven via PUT /admin/workers/{workerId}).
             if (!configuration.IsExternalWorkerEnabled())
             {
                 services.AddSingleton<IHostedService>(s => s.GetRequiredService<WebJobsScriptHostService>());

--- a/src/WebJobs.Script/Workers/IRuntimeStateManager.cs
+++ b/src/WebJobs.Script/Workers/IRuntimeStateManager.cs
@@ -1,0 +1,102 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Script.Workers;
+
+/// <summary>
+/// Tracks runtime-wide state relevant to the App Server: the set of linked
+/// workers and the pool of request slots they contribute. State changes are
+/// signalled via <see cref="StateChanged"/> so a publisher can forward
+/// snapshots to the mesh service.
+/// </summary>
+/// <remarks>
+/// Only registered when compute separation is active
+/// (<c>FUNCTIONS_WORKER_EXTERNAL_ENABLED=true</c>). Callers outside the
+/// compute-separation code path should not take a dependency on this type.
+/// </remarks>
+public interface IRuntimeStateManager
+{
+    /// <summary>
+    /// Raised on every state-producing mutation (worker link/unlink,
+    /// capacity change, slot acquire/release). Handlers should be cheap and
+    /// non-blocking - the event is raised from the mutating thread.
+    /// </summary>
+    event Action StateChanged;
+
+    /// <summary>
+    /// Returns an immutable snapshot of the current runtime state.
+    /// Safe to call from any thread.
+    /// </summary>
+    RuntimeState GetState();
+
+    /// <summary>
+    /// Records a newly-linked worker. Counted in
+    /// <see cref="RuntimeState.LinkedWorkerCount"/> for its entire tracking
+    /// lifetime, regardless of health. Idempotent on duplicate id.
+    /// </summary>
+    /// <param name="workerId">Platform-assigned worker id.</param>
+    void OnWorkerLinked(string workerId);
+
+    /// <summary>
+    /// Removes a previously-linked worker from tracking. No-op if the worker
+    /// was never linked. Does not alter capacity - callers should call
+    /// <see cref="OnWorkerCapacityUnavailable"/> first if capacity is still
+    /// being advertised for this worker.
+    /// </summary>
+    /// <param name="workerId">Platform-assigned worker id.</param>
+    void OnWorkerUnlinked(string workerId);
+
+    /// <summary>
+    /// Declares that a linked worker is now healthy and contributing the
+    /// specified slot capacity to the shared pool. Called after the init
+    /// handshake succeeds. Idempotent: if capacity is already tracked for
+    /// the worker the call is ignored.
+    /// </summary>
+    /// <param name="workerId">Platform-assigned worker id.</param>
+    /// <param name="slotCapacity">
+    /// The worker's max invocation concurrency. Must be positive.
+    /// </param>
+    void OnWorkerCapacityAvailable(string workerId, int slotCapacity);
+
+    /// <summary>
+    /// Declares that a linked worker can no longer serve new invocations
+    /// (e.g. drain has begun). Subtracts the capacity that was added for it.
+    /// No-op if the worker never contributed capacity. The worker remains
+    /// linked until <see cref="OnWorkerUnlinked"/> is called.
+    /// </summary>
+    /// <param name="workerId">Platform-assigned worker id.</param>
+    void OnWorkerCapacityUnavailable(string workerId);
+
+    /// <summary>
+    /// Reserves up to <paramref name="requestedSlotCount"/> request slots,
+    /// granting a partial amount if fewer are available.
+    /// </summary>
+    /// <param name="requestedSlotCount">
+    /// Number of slots the caller would like to acquire. Must be positive.
+    /// </param>
+    /// <returns>
+    /// The number of slots actually reserved. Zero when no slots are available;
+    /// less than <paramref name="requestedSlotCount"/> when only a partial grant
+    /// was possible; equal to <paramref name="requestedSlotCount"/> on a full grant.
+    /// </returns>
+    int AcquireSlots(int requestedSlotCount);
+
+    /// <summary>
+    /// Releases previously-acquired request slots. The leased count is clamped
+    /// at zero so over-releases cannot produce negative values.
+    /// </summary>
+    /// <param name="count">Number of slots to release. Must be positive.</param>
+    void ReleaseSlots(int count);
+
+    /// <summary>
+    /// Marks the runtime as stopping. From this point on <see cref="GetState"/>
+    /// reports zero for <see cref="RuntimeState.TotalRequestSlots"/> and
+    /// <see cref="RuntimeState.TotalAvailableRequestSlots"/>, and
+    /// <see cref="AcquireSlots"/> grants nothing. Intended to be called once,
+    /// by the worker connection manager, at the start of host shutdown. The
+    /// transition is a one-way latch; subsequent calls are no-ops.
+    /// </summary>
+    void SetStopping();
+}

--- a/src/WebJobs.Script/Workers/RuntimeState.cs
+++ b/src/WebJobs.Script/Workers/RuntimeState.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.WebJobs.Script.Workers;
+
+/// <summary>
+/// Immutable snapshot of runtime-wide state relevant to the App Server:
+/// the cap on linked workers and request-slot accounting.
+/// Published to the mesh service as <c>publish-runtime-state</c> and
+/// returned by the <c>GET /admin/instance/state</c> admin API.
+/// </summary>
+public sealed class RuntimeState
+{
+    /// <summary>
+    /// Gets the maximum number of workers that may be linked to this runtime.
+    /// The platform will ensure this limit is not exceeded when linking workers.
+    /// </summary>
+    [JsonProperty("maxLinkedWorkers")]
+    public int MaxLinkedWorkers { get; init; }
+
+    /// <summary>
+    /// Gets the total number of linked workers, including unhealthy or draining workers.
+    /// </summary>
+    [JsonProperty("linkedWorkerCount")]
+    public int LinkedWorkerCount { get; init; }
+
+    /// <summary>
+    /// Gets the total request-slot capacity contributed by all linked workers
+    /// (sum of each worker's reported max concurrency). This will only include
+    /// capacity from workers that have completed their init handshake and are
+    /// considered healthy.
+    /// </summary>
+    [JsonProperty("totalRequestSlots")]
+    public int TotalRequestSlots { get; init; }
+
+    /// <summary>
+    /// Gets the number of request slots currently available (total minus leased).
+    /// Clamped at zero; will not report negative values when outstanding leases
+    /// exceed the current total (e.g. after workers drain). Returns zero if no
+    /// healthy workers are linked or the runtime is stopping.
+    /// </summary>
+    [JsonProperty("totalAvailableRequestSlots")]
+    public int TotalAvailableRequestSlots { get; init; }
+}

--- a/src/WebJobs.Script/Workers/RuntimeStateManager.cs
+++ b/src/WebJobs.Script/Workers/RuntimeStateManager.cs
@@ -1,0 +1,290 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.Workers;
+
+/// <summary>
+/// Default <see cref="IRuntimeStateManager"/> implementation. Thread-safe.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two independent lifecycles are tracked:
+/// </para>
+/// <list type="bullet">
+///   <item><description>
+///   <b>Linked set</b> — drives <see cref="RuntimeState.LinkedWorkerCount"/>.
+///   A worker is linked from <see cref="OnWorkerLinked"/> until
+///   <see cref="OnWorkerUnlinked"/>, regardless of health.
+///   </description></item>
+///   <item><description>
+///   <b>Capacity contributions</b> — drive <see cref="RuntimeState.TotalRequestSlots"/>.
+///   Only counted from <see cref="OnWorkerCapacityAvailable"/> until
+///   <see cref="OnWorkerCapacityUnavailable"/>, which is normally a strict subset
+///   of the linked window.
+///   </description></item>
+/// </list>
+/// <para>
+/// Slot accounting uses a single mutex to keep <c>_totalRequestSlots</c> and
+/// <c>_leasedSlots</c> mutually consistent for <see cref="AcquireSlots"/>
+/// (compare-then-set). <see cref="GetState"/> reads under the same mutex so
+/// snapshots are internally consistent.
+/// </para>
+/// </remarks>
+internal sealed class RuntimeStateManager : IRuntimeStateManager
+{
+    // [CS-TODO] Make configurable. Hard-coded to match the current App Server contract.
+    private const int MaxLinkedWorkersValue = 20;
+
+    private readonly ConcurrentDictionary<string, byte> _linkedWorkers = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, int> _workerCapacities = new(StringComparer.Ordinal);
+    private readonly object _slotLock = new();
+    private readonly ILogger<RuntimeStateManager> _logger;
+
+    private int _totalRequestSlots;
+    private int _leasedSlots;
+    private int _stoppingFlag;
+
+    public RuntimeStateManager(ILogger<RuntimeStateManager> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc/>
+    public event Action StateChanged;
+
+    private bool IsStopping => Volatile.Read(ref _stoppingFlag) != 0;
+
+    /// <inheritdoc/>
+    public RuntimeState GetState()
+    {
+        // While stopping, the runtime refuses to advertise any slots: total and
+        // available are both clamped to zero so the App Server stops routing
+        // new work here immediately, without waiting for every worker's
+        // OnWorkerCapacityUnavailable to be called during parallel drain.
+        // LinkedWorkerCount is intentionally not clamped — operators still
+        // want visibility into how many workers are draining.
+        if (IsStopping)
+        {
+            return new RuntimeState
+            {
+                MaxLinkedWorkers = MaxLinkedWorkersValue,
+                LinkedWorkerCount = _linkedWorkers.Count,
+                TotalRequestSlots = 0,
+                TotalAvailableRequestSlots = 0
+            };
+        }
+
+        int total;
+        int leased;
+
+        lock (_slotLock)
+        {
+            total = _totalRequestSlots;
+            leased = _leasedSlots;
+        }
+
+        return new RuntimeState
+        {
+            MaxLinkedWorkers = MaxLinkedWorkersValue,
+            LinkedWorkerCount = _linkedWorkers.Count,
+            TotalRequestSlots = total,
+            TotalAvailableRequestSlots = Math.Max(0, total - leased)
+        };
+    }
+
+    /// <inheritdoc/>
+    public void OnWorkerLinked(string workerId)
+    {
+        if (string.IsNullOrEmpty(workerId))
+        {
+            throw new ArgumentException("Worker id is required.", nameof(workerId));
+        }
+
+        if (!_linkedWorkers.TryAdd(workerId, 0))
+        {
+            _logger.LogDebug("Worker '{workerId}' is already linked; ignoring duplicate.", workerId);
+            return;
+        }
+
+        _logger.LogInformation("Worker '{workerId}' linked. Linked worker count: {count}.", workerId, _linkedWorkers.Count);
+        RaiseStateChanged();
+    }
+
+    /// <inheritdoc/>
+    public void OnWorkerUnlinked(string workerId)
+    {
+        if (string.IsNullOrEmpty(workerId))
+        {
+            throw new ArgumentException("Worker id is required.", nameof(workerId));
+        }
+
+        if (!_linkedWorkers.TryRemove(workerId, out _))
+        {
+            return;
+        }
+
+        _logger.LogInformation("Worker '{workerId}' unlinked. Linked worker count: {count}.", workerId, _linkedWorkers.Count);
+        RaiseStateChanged();
+    }
+
+    /// <inheritdoc/>
+    public void OnWorkerCapacityAvailable(string workerId, int slotCapacity)
+    {
+        if (string.IsNullOrEmpty(workerId))
+        {
+            throw new ArgumentException("Worker id is required.", nameof(workerId));
+        }
+
+        if (slotCapacity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(slotCapacity), "Slot capacity must be positive.");
+        }
+
+        if (!_workerCapacities.TryAdd(workerId, slotCapacity))
+        {
+            _logger.LogDebug("Worker '{workerId}' already has capacity tracked; ignoring duplicate.", workerId);
+            return;
+        }
+
+        lock (_slotLock)
+        {
+            _totalRequestSlots += slotCapacity;
+        }
+
+        _logger.LogInformation(
+            "Worker '{workerId}' contributed slot capacity {slotCapacity}. Total slots: {totalSlots}.",
+            workerId,
+            slotCapacity,
+            _totalRequestSlots);
+
+        RaiseStateChanged();
+    }
+
+    /// <inheritdoc/>
+    public void OnWorkerCapacityUnavailable(string workerId)
+    {
+        if (string.IsNullOrEmpty(workerId))
+        {
+            throw new ArgumentException("Worker id is required.", nameof(workerId));
+        }
+
+        if (!_workerCapacities.TryRemove(workerId, out int capacity))
+        {
+            return;
+        }
+
+        lock (_slotLock)
+        {
+            _totalRequestSlots -= capacity;
+        }
+
+        _logger.LogInformation(
+            "Worker '{workerId}' capacity withdrawn; reclaimed {slotCapacity} slot(s). Total slots: {totalSlots}.",
+            workerId,
+            capacity,
+            _totalRequestSlots);
+
+        RaiseStateChanged();
+    }
+
+    /// <inheritdoc/>
+    public int AcquireSlots(int requestedSlotCount)
+    {
+        if (requestedSlotCount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(requestedSlotCount), "Requested slot count must be positive.");
+        }
+
+        // No new leases once the runtime is stopping. Matches the GetState()
+        // promise that available slots are zero from the moment SetStopping
+        // is called.
+        if (IsStopping)
+        {
+            return 0;
+        }
+
+        int granted;
+        lock (_slotLock)
+        {
+            int available = Math.Max(0, _totalRequestSlots - _leasedSlots);
+            granted = Math.Min(requestedSlotCount, available);
+            _leasedSlots += granted;
+        }
+
+        if (granted > 0)
+        {
+            RaiseStateChanged();
+        }
+
+        return granted;
+    }
+
+    /// <inheritdoc/>
+    public void ReleaseSlots(int count)
+    {
+        if (count <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count), "Slot count must be positive.");
+        }
+
+        int over;
+        int released;
+
+        lock (_slotLock)
+        {
+            over = Math.Max(0, count - _leasedSlots);
+            _leasedSlots = Math.Max(0, _leasedSlots - count);
+        }
+
+        released = count - over;
+
+        if (over > 0)
+        {
+            _logger.LogWarning(
+                "Attempted to release {count} slot(s) but only {available} were leased; clamped at zero.",
+                count,
+                released);
+        }
+
+        // Mirror AcquireSlots: only notify when state actually changed. A fully
+        // over-released call (e.g. release after the lease count has already
+        // been reset to zero by SetStopping) is a no-op and should not trigger
+        // a debounced publish to the mesh service.
+        if (released > 0)
+        {
+            RaiseStateChanged();
+        }
+    }
+
+    /// <inheritdoc/>
+    public void SetStopping()
+    {
+        // One-way latch. Interlocked ensures the StateChanged event is raised
+        // exactly once for this transition, even under concurrent callers.
+        if (Interlocked.Exchange(ref _stoppingFlag, 1) != 0)
+        {
+            return;
+        }
+
+        _logger.LogInformation("Runtime marked as stopping; request slots are no longer advertised.");
+        RaiseStateChanged();
+    }
+
+    private void RaiseStateChanged()
+    {
+        try
+        {
+            StateChanged?.Invoke();
+        }
+        catch (Exception ex)
+        {
+            // A faulty subscriber must not break the mutating path.
+            _logger.LogError(ex, "Error invoking {eventName} handler.", nameof(StateChanged));
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/SpecializationEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/SpecializationEndToEndTests.cs
@@ -226,7 +226,7 @@ public class SpecializationEndToEndTests : IAsyncLifetime, IDisposable, IClassFi
         while (sw.Elapsed < TimeSpan.FromMinutes(2))
         {
             linkResponse = await SendAdminRequest(
-                masterKey, HttpMethod.Post, "admin/workers/link",
+                masterKey, HttpMethod.Put, "admin/workers/w_spec_e2e01",
                 new
                 {
                     workerId = "w_spec_e2e01",

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAllocationApiTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAllocationApiTests.cs
@@ -82,7 +82,7 @@ public class WorkerAllocationApiTests : IAsyncLifetime
             .Returns(Task.CompletedTask);
 
         var request = new { workerId = "w_test1234", podName = "worker-pod-abc123", grpcEndpoint = "http://10.0.1.42:50051", podKey = "test-key" };
-        var response = await SendAdminRequest(HttpMethod.Post, "admin/workers/link", request);
+        var response = await SendAdminRequest(HttpMethod.Put, "admin/workers/w_test1234", request);
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
@@ -95,7 +95,7 @@ public class WorkerAllocationApiTests : IAsyncLifetime
     public async Task LinkWorker_MissingEndpoint_Returns400()
     {
         var request = new { workerId = "w_test1234" };
-        var response = await SendAdminRequest(HttpMethod.Post, "admin/workers/link", request);
+        var response = await SendAdminRequest(HttpMethod.Put, "admin/workers/w_test1234", request);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -103,7 +103,7 @@ public class WorkerAllocationApiTests : IAsyncLifetime
     [Fact]
     public async Task AdminEndpoint_WithoutAuth_Returns401()
     {
-        var request = new HttpRequestMessage(HttpMethod.Post, "admin/workers/link");
+        var request = new HttpRequestMessage(HttpMethod.Put, "admin/workers/w_test1234");
         request.Content = new StringContent(
             JsonConvert.SerializeObject(new { grpcEndpoint = "http://10.0.1.42:50051" }),
             Encoding.UTF8,
@@ -116,7 +116,7 @@ public class WorkerAllocationApiTests : IAsyncLifetime
     [Fact]
     public async Task Stop_Returns202()
     {
-        var response = await SendAdminRequest(HttpMethod.Post, "admin/instance/stop");
+        var response = await SendAdminRequest(HttpMethod.Post, "admin/host/stop");
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
     }
@@ -141,12 +141,12 @@ public class WorkerAllocationApiTests : IAsyncLifetime
                 return Task.CompletedTask;
             });
 
-        await SendAdminRequest(HttpMethod.Post, "admin/workers/link",
+        await SendAdminRequest(HttpMethod.Put, "admin/workers/w1",
             new { workerId = "w1", grpcEndpoint = "http://10.0.1.1:50051" });
-        await SendAdminRequest(HttpMethod.Post, "admin/workers/link",
+        await SendAdminRequest(HttpMethod.Put, "admin/workers/w2",
             new { workerId = "w2", grpcEndpoint = "http://10.0.1.2:50051" });
 
-        var response = await SendAdminRequest(HttpMethod.Post, "admin/instance/stop");
+        var response = await SendAdminRequest(HttpMethod.Post, "admin/host/stop");
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
         // Wait for the fire-and-forget to invoke DrainAndDisconnectAllAsync.

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAllocationEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAllocationEndToEndTests.cs
@@ -22,12 +22,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ComputeSeparation;
 /// End-to-end integration test that verifies the API-driven worker linking flow.
 /// Unlike <see cref="ExternalWorkerEndToEndTests"/> which auto-connects via an environment
 /// variable, this test starts the runtime with no pre-configured worker endpoint and uses
-/// the <c>POST /admin/workers/link</c> API to link a worker at runtime.
+/// the <c>PUT /admin/workers/{workerId}</c> API to link a worker at runtime.
 ///
 /// Flow:
 /// 1. Worker proxy + mock worker start as child processes
 /// 2. Runtime starts via TestFunctionHost (external worker enabled, no gRPC endpoint)
-/// 3. <c>POST /admin/workers/link</c> connects the worker
+/// 3. <c>PUT /admin/workers/{workerId}</c> connects the worker
 /// 4. <c>GET /api/HttpTrigger</c> invokes a function through the mock worker
 /// </summary>
 [Trait(TestTraits.Category, TestTraits.EndToEnd)]
@@ -123,7 +123,7 @@ public class WorkerAllocationEndToEndTests : IAsyncLifetime, IDisposable
         };
 
         var linkResponse = await SendAdminRequest(
-            masterKey, HttpMethod.Post, "admin/workers/link", linkRequest);
+            masterKey, HttpMethod.Put, $"admin/workers/{linkRequest.workerId}", linkRequest);
 
         string linkBody = await linkResponse.Content.ReadAsStringAsync();
         _output.WriteLine($"Link response: {linkResponse.StatusCode} — {linkBody}");
@@ -157,7 +157,7 @@ public class WorkerAllocationEndToEndTests : IAsyncLifetime, IDisposable
         };
 
         var linkResponse = await SendAdminRequest(
-            masterKey, HttpMethod.Post, "admin/workers/link", linkRequest);
+            masterKey, HttpMethod.Put, $"admin/workers/{linkRequest.workerId}", linkRequest);
         Assert.Equal(HttpStatusCode.Accepted, linkResponse.StatusCode);
 
         // 2. Wait for host ready.
@@ -172,8 +172,8 @@ public class WorkerAllocationEndToEndTests : IAsyncLifetime, IDisposable
         _output.WriteLine($"Worker proxy state before stop: {state}");
         Assert.Equal("ReadyForRequest", state["currentPodStatusTransition"]?["toPodStatus"]?.ToString());
 
-        // 4. Call /admin/instance/stop.
-        var stopResponse = await SendAdminRequest(masterKey, HttpMethod.Post, "admin/instance/stop");
+        // 4. Call /admin/host/stop.
+        var stopResponse = await SendAdminRequest(masterKey, HttpMethod.Post, "admin/host/stop");
         _output.WriteLine($"Stop response: {stopResponse.StatusCode}");
         Assert.Equal(HttpStatusCode.Accepted, stopResponse.StatusCode);
 

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAssignAndLinkEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAssignAndLinkEndToEndTests.cs
@@ -108,7 +108,7 @@ public class WorkerAssignAndLinkEndToEndTests : IAsyncLifetime, IDisposable
         Assert.Equal(HttpStatusCode.OK, assignResponse.StatusCode);
 
         // 2. Link the runtime to the worker proxy.
-        _output.WriteLine("Step 2: Calling /admin/workers/link on runtime.");
+        _output.WriteLine("Step 2: Calling PUT /admin/workers/{workerId} on runtime.");
         string masterKey = await _host.GetMasterKeyAsync();
         var linkResponse = await CallWorkerLinkAsync(masterKey);
         Assert.Equal(HttpStatusCode.Accepted, linkResponse.StatusCode);
@@ -131,7 +131,7 @@ public class WorkerAssignAndLinkEndToEndTests : IAsyncLifetime, IDisposable
 
         // 1. Link first — runtime connects and sends WorkerInitRequest.
         //    The proxy blocks because specialization hasn't completed yet.
-        _output.WriteLine("Step 1: Calling /admin/workers/link on runtime (before assign).");
+        _output.WriteLine("Step 1: Calling PUT /admin/workers/{workerId} on runtime (before assign).");
         var linkResponse = await CallWorkerLinkAsync(masterKey);
         Assert.Equal(HttpStatusCode.Accepted, linkResponse.StatusCode);
 
@@ -173,7 +173,7 @@ public class WorkerAssignAndLinkEndToEndTests : IAsyncLifetime, IDisposable
             podKey = "test-key"
         };
 
-        return await SendAdminRequest(masterKey, HttpMethod.Post, "admin/workers/link", linkRequest);
+        return await SendAdminRequest(masterKey, HttpMethod.Put, $"admin/workers/{linkRequest.workerId}", linkRequest);
     }
 
     private async Task AssertHttpTriggerInvocationAsync()

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
@@ -381,5 +381,60 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 testmetricslogger.EventsBegan.Contains(eventName) && 
                 testmetricslogger.EventsEnded.Contains(eventName));
         }
+
+        private static InstanceController CreateInstanceController(IRuntimeStateManager runtimeStateManager)
+        {
+            var loggerFactory = new LoggerFactory();
+            var environment = new TestEnvironment();
+            var metricsLogger = new TestMetricsLogger();
+            var startupContextProvider = new StartupContextProvider(environment, loggerFactory.CreateLogger<StartupContextProvider>());
+
+            var controller = new InstanceController(environment, null, null, loggerFactory, startupContextProvider, metricsLogger);
+
+            var services = new Mock<IServiceProvider>();
+            services.Setup(s => s.GetService(typeof(IRuntimeStateManager))).Returns(runtimeStateManager);
+
+            controller.ControllerContext = new Microsoft.AspNetCore.Mvc.ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { RequestServices = services.Object }
+            };
+
+            return controller;
+        }
+        [Fact]
+        public void GetState_WhenExternalWorkersDisabled_Returns503()
+        {
+            var controller = CreateInstanceController(runtimeStateManager: null);
+
+            var result = controller.GetState();
+
+            var statusResult = Assert.IsType<StatusCodeResult>(result);
+            Assert.Equal(StatusCodes.Status503ServiceUnavailable, statusResult.StatusCode);
+        }
+
+        [Fact]
+        public void GetState_ReturnsSnapshot()
+        {
+            var state = new RuntimeState
+            {
+                MaxLinkedWorkers = 20,
+                LinkedWorkerCount = 3,
+                TotalRequestSlots = 48,
+                TotalAvailableRequestSlots = 40
+            };
+            var mock = new Mock<IRuntimeStateManager>();
+            mock.Setup(m => m.GetState()).Returns(state);
+
+            var controller = CreateInstanceController(mock.Object);
+
+            var result = controller.GetState();
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var payload = Assert.IsType<RuntimeState>(ok.Value);
+            Assert.Equal(20, payload.MaxLinkedWorkers);
+            Assert.Equal(3, payload.LinkedWorkerCount);
+            Assert.Equal(48, payload.TotalRequestSlots);
+            Assert.Equal(40, payload.TotalAvailableRequestSlots);
+        }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/Management/MeshServiceClientTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/MeshServiceClientTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -210,6 +210,69 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             _handlerMock.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Once(),
                 ItExpr.Is<HttpRequestMessage>(r => IsCreateBindMountRequest(r, sourcePath, targetPath)),
                 ItExpr.IsAny<CancellationToken>());
+        }
+
+        private static bool IsPublishRuntimeStateRequest(HttpRequestMessage request, Microsoft.Azure.WebJobs.Script.Workers.RuntimeState expected)
+        {
+            var formData = request.Content.ReadAsFormDataAsync().Result;
+            if (!string.Equals(MeshInitUri, request.RequestUri.AbsoluteUri) ||
+                !string.Equals(MeshServiceClient.PublishRuntimeStateOperation, formData["operation"]) ||
+                !string.Equals(ContainerName, request.Headers.GetValues(ScriptConstants.ContainerInstanceHeader).FirstOrDefault()))
+            {
+                return false;
+            }
+
+            var payload = JsonConvert.DeserializeObject<Microsoft.Azure.WebJobs.Script.Workers.RuntimeState>(formData["content"]);
+            return payload.MaxLinkedWorkers == expected.MaxLinkedWorkers
+                && payload.LinkedWorkerCount == expected.LinkedWorkerCount
+                && payload.TotalRequestSlots == expected.TotalRequestSlots
+                && payload.TotalAvailableRequestSlots == expected.TotalAvailableRequestSlots;
+        }
+
+        [Fact]
+        public async Task PublishRuntimeState_SendsExpectedOperationAndPayload()
+        {
+            _handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK
+                });
+
+            var state = new Microsoft.Azure.WebJobs.Script.Workers.RuntimeState
+            {
+                MaxLinkedWorkers = 20,
+                LinkedWorkerCount = 3,
+                TotalRequestSlots = 48,
+                TotalAvailableRequestSlots = 40
+            };
+
+            await _meshServiceClient.PublishRuntimeState(state);
+
+            _handlerMock.Protected().Verify<Task<HttpResponseMessage>>("SendAsync", Times.Once(),
+                ItExpr.Is<HttpRequestMessage>(r => IsPublishRuntimeStateRequest(r, state)),
+                ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task PublishRuntimeState_NullState_Throws()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(() => _meshServiceClient.PublishRuntimeState(null));
+        }
+
+        [Fact]
+        public async Task PublishRuntimeState_NonSuccessResponse_Throws()
+        {
+            _handlerMock.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()).ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.InternalServerError
+                });
+
+            var state = new Microsoft.Azure.WebJobs.Script.Workers.RuntimeState();
+
+            await Assert.ThrowsAsync<HttpRequestException>(() => _meshServiceClient.PublishRuntimeState(state));
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests.Integration/Management/RequestSlotsControllerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/RequestSlotsControllerTests.cs
@@ -1,0 +1,153 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs.Script.WebHost.Controllers;
+using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Extensions.Logging;
+using Microsoft.WebJobs.Script.Tests;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
+{
+    [Trait(TestTraits.Category, TestTraits.EndToEnd)]
+    [Trait(TestTraits.Group, TestTraits.ContainerInstanceTests)]
+    public class RequestSlotsControllerTests
+    {
+        private static RequestSlotsController CreateController(IRuntimeStateManager runtimeStateManager)
+        {
+            var loggerFactory = new LoggerFactory();
+
+            var controller = new RequestSlotsController(loggerFactory);
+
+            var services = new Mock<IServiceProvider>();
+            services.Setup(s => s.GetService(typeof(IRuntimeStateManager))).Returns(runtimeStateManager);
+
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { RequestServices = services.Object }
+            };
+
+            return controller;
+        }
+
+        [Fact]
+        public void AcquireLeases_WhenExternalWorkersDisabled_Returns503()
+        {
+            var controller = CreateController(runtimeStateManager: null);
+
+            var result = controller.AcquireLeases(new RequestSlotsLeaseRequest { Count = 5 });
+
+            var statusResult = Assert.IsType<StatusCodeResult>(result);
+            Assert.Equal(StatusCodes.Status503ServiceUnavailable, statusResult.StatusCode);
+        }
+
+        [Fact]
+        public void AcquireLeases_NullBody_ReturnsBadRequest()
+        {
+            var mock = new Mock<IRuntimeStateManager>(MockBehavior.Strict);
+            var controller = CreateController(mock.Object);
+
+            var result = controller.AcquireLeases(null);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+            mock.VerifyNoOtherCalls();
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void AcquireLeases_NonPositiveCount_ReturnsBadRequest(int count)
+        {
+            var mock = new Mock<IRuntimeStateManager>(MockBehavior.Strict);
+            var controller = CreateController(mock.Object);
+
+            var result = controller.AcquireLeases(new RequestSlotsLeaseRequest { Count = count });
+
+            Assert.IsType<BadRequestObjectResult>(result);
+            mock.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void AcquireLeases_ReturnsGrantedCount()
+        {
+            var mock = new Mock<IRuntimeStateManager>();
+            mock.Setup(m => m.AcquireSlots(5)).Returns(3);
+            var controller = CreateController(mock.Object);
+
+            var result = controller.AcquireLeases(new RequestSlotsLeaseRequest { Count = 5 });
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var payload = Assert.IsType<RequestSlotsLeaseResponse>(ok.Value);
+            Assert.Equal(3, payload.AcquiredSlotCount);
+            mock.Verify(m => m.AcquireSlots(5), Times.Once);
+        }
+
+        [Fact]
+        public void AcquireLeases_FullGrant_ReturnsRequestedCount()
+        {
+            var mock = new Mock<IRuntimeStateManager>();
+            mock.Setup(m => m.AcquireSlots(4)).Returns(4);
+            var controller = CreateController(mock.Object);
+
+            var result = controller.AcquireLeases(new RequestSlotsLeaseRequest { Count = 4 });
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var payload = Assert.IsType<RequestSlotsLeaseResponse>(ok.Value);
+            Assert.Equal(4, payload.AcquiredSlotCount);
+        }
+
+        [Fact]
+        public void ReleaseLeases_WhenExternalWorkersDisabled_Returns503()
+        {
+            var controller = CreateController(runtimeStateManager: null);
+
+            var result = controller.ReleaseLeases(new RequestSlotsLeaseRequest { Count = 2 });
+
+            var statusResult = Assert.IsType<StatusCodeResult>(result);
+            Assert.Equal(StatusCodes.Status503ServiceUnavailable, statusResult.StatusCode);
+        }
+
+        [Fact]
+        public void ReleaseLeases_NullBody_ReturnsBadRequest()
+        {
+            var mock = new Mock<IRuntimeStateManager>(MockBehavior.Strict);
+            var controller = CreateController(mock.Object);
+
+            var result = controller.ReleaseLeases(null);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+            mock.VerifyNoOtherCalls();
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-5)]
+        public void ReleaseLeases_NonPositiveCount_ReturnsBadRequest(int count)
+        {
+            var mock = new Mock<IRuntimeStateManager>(MockBehavior.Strict);
+            var controller = CreateController(mock.Object);
+
+            var result = controller.ReleaseLeases(new RequestSlotsLeaseRequest { Count = count });
+
+            Assert.IsType<BadRequestObjectResult>(result);
+            mock.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void ReleaseLeases_DelegatesToManagerAndReturnsOk()
+        {
+            var mock = new Mock<IRuntimeStateManager>();
+            var controller = CreateController(mock.Object);
+
+            var result = controller.ReleaseLeases(new RequestSlotsLeaseRequest { Count = 7 });
+
+            Assert.IsType<OkResult>(result);
+            mock.Verify(m => m.ReleaseSlots(7), Times.Once);
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/ContainerManagement/RuntimeStatePublisherTests.cs
+++ b/test/WebJobs.Script.Tests/ContainerManagement/RuntimeStatePublisherTests.cs
@@ -1,0 +1,276 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement;
+using Microsoft.Azure.WebJobs.Script.WebHost.Management;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.ContainerManagement
+{
+    public class RuntimeStatePublisherTests
+    {
+        private static readonly TimeSpan ObservationWindow = TimeSpan.FromSeconds(3);
+
+        private readonly TestRuntimeStateManager _stateManager = new();
+        private readonly Mock<IMeshServiceClient> _mockMeshClient = new();
+
+        [Fact]
+        public async Task StateChange_AfterStart_PublishesSnapshot()
+        {
+            var published = new TaskCompletionSource<RuntimeState>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _mockMeshClient
+                .Setup(c => c.PublishRuntimeState(It.IsAny<RuntimeState>()))
+                .Callback<RuntimeState>(s => published.TrySetResult(s))
+                .Returns(Task.CompletedTask);
+
+            _stateManager.NextSnapshot = new RuntimeState { LinkedWorkerCount = 1, TotalRequestSlots = 16, TotalAvailableRequestSlots = 16 };
+
+            using var publisher = CreatePublisher();
+            await publisher.StartAsync(CancellationToken.None);
+
+            _stateManager.RaiseStateChanged();
+
+            var completed = await Task.WhenAny(published.Task, Task.Delay(ObservationWindow));
+            Assert.Same(published.Task, completed);
+            var snapshot = published.Task.Result;
+            Assert.Equal(1, snapshot.LinkedWorkerCount);
+            Assert.Equal(16, snapshot.TotalRequestSlots);
+        }
+
+        [Fact]
+        public async Task StateChange_BeforeStart_DoesNotPublish()
+        {
+            _mockMeshClient
+                .Setup(c => c.PublishRuntimeState(It.IsAny<RuntimeState>()))
+                .Returns(Task.CompletedTask);
+
+            using var publisher = CreatePublisher();
+
+            _stateManager.RaiseStateChanged();
+
+            await Task.Delay(TimeSpan.FromSeconds(1));
+
+            _mockMeshClient.Verify(c => c.PublishRuntimeState(It.IsAny<RuntimeState>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task StateChange_AfterStop_DoesNotPublish()
+        {
+            _mockMeshClient
+                .Setup(c => c.PublishRuntimeState(It.IsAny<RuntimeState>()))
+                .Returns(Task.CompletedTask);
+
+            using var publisher = CreatePublisher();
+            await publisher.StartAsync(CancellationToken.None);
+            await publisher.StopAsync(CancellationToken.None);
+
+            _stateManager.RaiseStateChanged();
+
+            await Task.Delay(TimeSpan.FromSeconds(1));
+
+            _mockMeshClient.Verify(c => c.PublishRuntimeState(It.IsAny<RuntimeState>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task RapidStateChanges_CoalesceIntoSinglePublish()
+        {
+            int publishCount = 0;
+            _mockMeshClient
+                .Setup(c => c.PublishRuntimeState(It.IsAny<RuntimeState>()))
+                .Callback(() => Interlocked.Increment(ref publishCount))
+                .Returns(Task.CompletedTask);
+
+            using var publisher = CreatePublisher();
+            await publisher.StartAsync(CancellationToken.None);
+
+            for (int i = 0; i < 20; i++)
+            {
+                _stateManager.RaiseStateChanged();
+            }
+
+            // The debounce window is ~500ms; allow some headroom.
+            await Task.Delay(TimeSpan.FromSeconds(2));
+
+            Assert.Equal(1, Volatile.Read(ref publishCount));
+        }
+
+        [Fact]
+        public async Task PublishFailure_DoesNotThrowToStateManager()
+        {
+            _mockMeshClient
+                .Setup(c => c.PublishRuntimeState(It.IsAny<RuntimeState>()))
+                .ThrowsAsync(new InvalidOperationException("mesh down"));
+
+            using var publisher = CreatePublisher();
+            await publisher.StartAsync(CancellationToken.None);
+
+            _stateManager.RaiseStateChanged();
+
+            // Give the timer time to fire and the exception time to surface.
+            await Task.Delay(TimeSpan.FromSeconds(2));
+
+            // If the publisher propagated the exception out of the async void timer,
+            // the process would have crashed. Reaching this line means it was swallowed.
+            _mockMeshClient.Verify(c => c.PublishRuntimeState(It.IsAny<RuntimeState>()), Times.AtLeastOnce);
+        }
+
+        [Fact]
+        public async Task StateChange_DuringSlowPublish_DoesNotCauseConcurrentPublish()
+        {
+            var firstEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseFirst = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            int inFlight = 0;
+            int maxInFlight = 0;
+
+            _mockMeshClient
+                .Setup(c => c.PublishRuntimeState(It.IsAny<RuntimeState>()))
+                .Returns<RuntimeState>(async _ =>
+                {
+                    int now = Interlocked.Increment(ref inFlight);
+                    InterlockedExtensions.Max(ref maxInFlight, now);
+                    if (firstEntered.TrySetResult(true))
+                    {
+                        await releaseFirst.Task;
+                    }
+                    Interlocked.Decrement(ref inFlight);
+                });
+
+            using var publisher = CreatePublisher();
+            await publisher.StartAsync(CancellationToken.None);
+
+            _stateManager.RaiseStateChanged();
+
+            // Wait for the first publish to enter (timer ~500ms + jitter).
+            var entered = await Task.WhenAny(firstEntered.Task, Task.Delay(ObservationWindow));
+            Assert.Same(firstEntered.Task, entered);
+
+            // Raise a second change while the first publish is parked. The
+            // gate must prevent a concurrent call; the drain loop must
+            // schedule one follow-up publish after we release.
+            _stateManager.RaiseStateChanged();
+
+            // Give the debounce timer ample time to fire — without the gate
+            // this would invoke PublishRuntimeState concurrently.
+            await Task.Delay(TimeSpan.FromSeconds(1));
+
+            Assert.Equal(1, Volatile.Read(ref inFlight));
+
+            releaseFirst.TrySetResult(true);
+
+            // Allow the drain loop to publish the second snapshot.
+            await Task.Delay(TimeSpan.FromSeconds(1));
+
+            Assert.Equal(1, Volatile.Read(ref maxInFlight));
+            _mockMeshClient.Verify(c => c.PublishRuntimeState(It.IsAny<RuntimeState>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task StateChange_DuringSlowPublish_FollowUpPublishUsesLatestSnapshot()
+        {
+            var firstEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseFirst = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var snapshots = new System.Collections.Concurrent.ConcurrentQueue<RuntimeState>();
+
+            _mockMeshClient
+                .Setup(c => c.PublishRuntimeState(It.IsAny<RuntimeState>()))
+                .Returns<RuntimeState>(async snapshot =>
+                {
+                    snapshots.Enqueue(snapshot);
+                    if (firstEntered.TrySetResult(true))
+                    {
+                        await releaseFirst.Task;
+                    }
+                });
+
+            _stateManager.NextSnapshot = new RuntimeState { LinkedWorkerCount = 1, TotalRequestSlots = 16, TotalAvailableRequestSlots = 16 };
+
+            using var publisher = CreatePublisher();
+            await publisher.StartAsync(CancellationToken.None);
+
+            _stateManager.RaiseStateChanged();
+
+            var entered = await Task.WhenAny(firstEntered.Task, Task.Delay(ObservationWindow));
+            Assert.Same(firstEntered.Task, entered);
+
+            // Update the snapshot, then raise — the drain loop must call
+            // GetState() again and publish the *new* snapshot.
+            _stateManager.NextSnapshot = new RuntimeState { LinkedWorkerCount = 2, TotalRequestSlots = 32, TotalAvailableRequestSlots = 30 };
+            _stateManager.RaiseStateChanged();
+
+            await Task.Delay(TimeSpan.FromMilliseconds(750));
+            releaseFirst.TrySetResult(true);
+
+            await Task.Delay(TimeSpan.FromSeconds(1));
+
+            Assert.Equal(2, snapshots.Count);
+            Assert.True(snapshots.TryDequeue(out var first));
+            Assert.True(snapshots.TryDequeue(out var second));
+            Assert.Equal(1, first.LinkedWorkerCount);
+            Assert.Equal(2, second.LinkedWorkerCount);
+            Assert.Equal(32, second.TotalRequestSlots);
+        }
+
+        private RuntimeStatePublisher CreatePublisher() =>
+            new(_stateManager, _mockMeshClient.Object, NullLogger<RuntimeStatePublisher>.Instance);
+
+        private sealed class TestRuntimeStateManager : IRuntimeStateManager
+        {
+            public event Action StateChanged;
+
+            public RuntimeState NextSnapshot { get; set; } = new RuntimeState();
+
+            public void RaiseStateChanged() => StateChanged?.Invoke();
+
+            public RuntimeState GetState() => NextSnapshot;
+
+            public void OnWorkerLinked(string workerId)
+            {
+            }
+
+            public void OnWorkerUnlinked(string workerId)
+            {
+            }
+
+            public void OnWorkerCapacityAvailable(string workerId, int slotCapacity)
+            {
+            }
+
+            public void OnWorkerCapacityUnavailable(string workerId)
+            {
+            }
+
+            public int AcquireSlots(int requestedSlotCount) => 0;
+
+            public void ReleaseSlots(int count)
+            {
+            }
+
+            public void SetStopping()
+            {
+            }
+        }
+
+        private static class InterlockedExtensions
+        {
+            public static void Max(ref int location, int value)
+            {
+                int initial;
+                do
+                {
+                    initial = Volatile.Read(ref location);
+                    if (value <= initial)
+                    {
+                        return;
+                    }
+                }
+                while (Interlocked.CompareExchange(ref location, value, initial) != initial);
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/StaticAnalysisTests.cs
+++ b/test/WebJobs.Script.Tests/StaticAnalysisTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -46,7 +46,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 "HostController.GetWorkerProcesses",
                 "HostController.Ping",
                 "InstanceController.GetHttpHealthStatus",
-                "InstanceController.GetInstanceInfo"
+                "InstanceController.GetInstanceInfo",
+                "InstanceController.GetState"
             };
 
             // looking for all GET actions that aren't marked with the ResourceContainsSecretsAttribute

--- a/test/WebJobs.Script.Tests/Workers/ExternalWorkers/RuntimeStateManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ExternalWorkers/RuntimeStateManagerTests.cs
@@ -1,0 +1,337 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
+{
+    public class RuntimeStateManagerTests
+    {
+        private readonly RuntimeStateManager _manager = new(NullLogger<RuntimeStateManager>.Instance);
+
+        [Fact]
+        public void GetState_Initially_ReportsZeroWorkersAndSlots()
+        {
+            var state = _manager.GetState();
+
+            Assert.Equal(20, state.MaxLinkedWorkers);
+            Assert.Equal(0, state.LinkedWorkerCount);
+            Assert.Equal(0, state.TotalRequestSlots);
+            Assert.Equal(0, state.TotalAvailableRequestSlots);
+        }
+
+        [Fact]
+        public void OnWorkerLinked_IncrementsLinkedCountWithoutCapacity()
+        {
+            int changes = 0;
+            _manager.StateChanged += () => changes++;
+
+            _manager.OnWorkerLinked("w1");
+
+            var state = _manager.GetState();
+            Assert.Equal(1, state.LinkedWorkerCount);
+            Assert.Equal(0, state.TotalRequestSlots);
+            Assert.Equal(0, state.TotalAvailableRequestSlots);
+            Assert.Equal(1, changes);
+        }
+
+        [Fact]
+        public void OnWorkerLinked_Duplicate_IsIdempotent()
+        {
+            _manager.OnWorkerLinked("w1");
+
+            int changes = 0;
+            _manager.StateChanged += () => changes++;
+
+            _manager.OnWorkerLinked("w1");
+
+            var state = _manager.GetState();
+            Assert.Equal(1, state.LinkedWorkerCount);
+            Assert.Equal(0, changes);
+        }
+
+        [Fact]
+        public void OnWorkerLinked_NullOrEmptyId_Throws()
+        {
+            Assert.Throws<ArgumentException>(() => _manager.OnWorkerLinked(null));
+            Assert.Throws<ArgumentException>(() => _manager.OnWorkerLinked(string.Empty));
+        }
+
+        [Fact]
+        public void OnWorkerUnlinked_DecrementsLinkedCount()
+        {
+            _manager.OnWorkerLinked("w1");
+            _manager.OnWorkerLinked("w2");
+
+            _manager.OnWorkerUnlinked("w1");
+
+            var state = _manager.GetState();
+            Assert.Equal(1, state.LinkedWorkerCount);
+        }
+
+        [Fact]
+        public void OnWorkerUnlinked_UnknownWorker_IsNoOp()
+        {
+            _manager.OnWorkerLinked("w1");
+
+            int changes = 0;
+            _manager.StateChanged += () => changes++;
+
+            _manager.OnWorkerUnlinked("does-not-exist");
+
+            var state = _manager.GetState();
+            Assert.Equal(1, state.LinkedWorkerCount);
+            Assert.Equal(0, changes);
+        }
+
+        [Fact]
+        public void OnWorkerCapacityAvailable_AddsToTotalSlots()
+        {
+            _manager.OnWorkerLinked("w1");
+
+            _manager.OnWorkerCapacityAvailable("w1", 16);
+
+            var state = _manager.GetState();
+            Assert.Equal(1, state.LinkedWorkerCount);
+            Assert.Equal(16, state.TotalRequestSlots);
+            Assert.Equal(16, state.TotalAvailableRequestSlots);
+        }
+
+        [Fact]
+        public void OnWorkerCapacityAvailable_Duplicate_IsIdempotent()
+        {
+            _manager.OnWorkerCapacityAvailable("w1", 16);
+
+            int changes = 0;
+            _manager.StateChanged += () => changes++;
+
+            _manager.OnWorkerCapacityAvailable("w1", 99);
+
+            var state = _manager.GetState();
+            Assert.Equal(16, state.TotalRequestSlots);
+            Assert.Equal(0, changes);
+        }
+
+        [Fact]
+        public void OnWorkerCapacityAvailable_HeterogeneousCapacities_Sum()
+        {
+            _manager.OnWorkerCapacityAvailable("w1", 16);
+            _manager.OnWorkerCapacityAvailable("w2", 4);
+
+            var state = _manager.GetState();
+            Assert.Equal(20, state.TotalRequestSlots);
+        }
+
+        [Fact]
+        public void OnWorkerCapacityAvailable_NonPositiveCapacity_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => _manager.OnWorkerCapacityAvailable("w1", 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => _manager.OnWorkerCapacityAvailable("w1", -1));
+        }
+
+        [Fact]
+        public void OnWorkerCapacityUnavailable_SubtractsOriginalCapacity()
+        {
+            _manager.OnWorkerCapacityAvailable("w1", 16);
+            _manager.OnWorkerCapacityAvailable("w2", 4);
+
+            _manager.OnWorkerCapacityUnavailable("w1");
+
+            var state = _manager.GetState();
+            Assert.Equal(4, state.TotalRequestSlots);
+        }
+
+        [Fact]
+        public void OnWorkerCapacityUnavailable_UnknownWorker_IsNoOp()
+        {
+            _manager.OnWorkerCapacityAvailable("w1", 16);
+
+            int changes = 0;
+            _manager.StateChanged += () => changes++;
+
+            _manager.OnWorkerCapacityUnavailable("does-not-exist");
+
+            var state = _manager.GetState();
+            Assert.Equal(16, state.TotalRequestSlots);
+            Assert.Equal(0, changes);
+        }
+
+        [Fact]
+        public void DrainingWorker_StaysLinkedButSurrendersCapacity()
+        {
+            _manager.OnWorkerLinked("w1");
+            _manager.OnWorkerCapacityAvailable("w1", 16);
+
+            _manager.OnWorkerCapacityUnavailable("w1");
+
+            var state = _manager.GetState();
+            Assert.Equal(1, state.LinkedWorkerCount);
+            Assert.Equal(0, state.TotalRequestSlots);
+            Assert.Equal(0, state.TotalAvailableRequestSlots);
+        }
+
+        [Fact]
+        public void AcquireSlots_WhenSufficient_GrantsFullRequest()
+        {
+            _manager.OnWorkerCapacityAvailable("w1", 16);
+
+            int granted = _manager.AcquireSlots(5);
+
+            var state = _manager.GetState();
+            Assert.Equal(5, granted);
+            Assert.Equal(16, state.TotalRequestSlots);
+            Assert.Equal(11, state.TotalAvailableRequestSlots);
+        }
+
+        [Fact]
+        public void AcquireSlots_WhenInsufficient_GrantsPartial()
+        {
+            _manager.OnWorkerCapacityAvailable("w1", 4);
+
+            int granted = _manager.AcquireSlots(10);
+
+            var state = _manager.GetState();
+            Assert.Equal(4, granted);
+            Assert.Equal(0, state.TotalAvailableRequestSlots);
+        }
+
+        [Fact]
+        public void AcquireSlots_WhenNoneAvailable_GrantsZeroWithoutStateChange()
+        {
+            int changes = 0;
+            _manager.StateChanged += () => changes++;
+
+            int granted = _manager.AcquireSlots(5);
+
+            Assert.Equal(0, granted);
+            Assert.Equal(0, changes);
+        }
+
+        [Fact]
+        public void AcquireSlots_NonPositiveCount_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => _manager.AcquireSlots(0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => _manager.AcquireSlots(-1));
+        }
+
+        [Fact]
+        public void ReleaseSlots_ReturnsSlotsToPool()
+        {
+            _manager.OnWorkerCapacityAvailable("w1", 16);
+            _manager.AcquireSlots(5);
+
+            _manager.ReleaseSlots(3);
+
+            var state = _manager.GetState();
+            Assert.Equal(14, state.TotalAvailableRequestSlots);
+        }
+
+        [Fact]
+        public void ReleaseSlots_OverRelease_ClampsAtZero()
+        {
+            _manager.OnWorkerCapacityAvailable("w1", 16);
+            _manager.AcquireSlots(2);
+
+            _manager.ReleaseSlots(10);
+
+            var state = _manager.GetState();
+            Assert.Equal(16, state.TotalAvailableRequestSlots);
+        }
+
+        [Fact]
+        public void ReleaseSlots_NonPositiveCount_Throws()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => _manager.ReleaseSlots(0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => _manager.ReleaseSlots(-1));
+        }
+
+        [Fact]
+        public void ReleaseSlots_NothingLeased_DoesNotRaiseStateChanged()
+        {
+            // Mirrors AcquireSlots: a no-op release (over-released to zero) must
+            // not trigger a debounced publish to the mesh service.
+            _manager.OnWorkerCapacityAvailable("w1", 16);
+
+            int changes = 0;
+            _manager.StateChanged += () => changes++;
+
+            _manager.ReleaseSlots(5);
+
+            Assert.Equal(0, changes);
+        }
+
+        [Fact]
+        public void GetState_WhenLeasedExceedsTotal_ClampsAvailableAtZero()
+        {
+            _manager.OnWorkerCapacityAvailable("w1", 16);
+            _manager.AcquireSlots(10);
+            _manager.OnWorkerCapacityUnavailable("w1");
+
+            var state = _manager.GetState();
+            Assert.Equal(0, state.TotalRequestSlots);
+            Assert.Equal(0, state.TotalAvailableRequestSlots);
+        }
+
+        [Fact]
+        public void StateChanged_FiresOnEveryMutation()
+        {
+            int changes = 0;
+            _manager.StateChanged += () => changes++;
+
+            _manager.OnWorkerLinked("w1");
+            _manager.OnWorkerCapacityAvailable("w1", 16);
+            _manager.AcquireSlots(2);
+            _manager.ReleaseSlots(1);
+            _manager.OnWorkerCapacityUnavailable("w1");
+            _manager.OnWorkerUnlinked("w1");
+
+            Assert.Equal(6, changes);
+        }
+
+        [Fact]
+        public void SetStopping_ClampsTotalAndAvailableSlotsToZero()
+        {
+            _manager.OnWorkerLinked("w1");
+            _manager.OnWorkerCapacityAvailable("w1", 16);
+            _manager.AcquireSlots(4);
+
+            _manager.SetStopping();
+
+            var state = _manager.GetState();
+            Assert.Equal(1, state.LinkedWorkerCount);
+            Assert.Equal(0, state.TotalRequestSlots);
+            Assert.Equal(0, state.TotalAvailableRequestSlots);
+        }
+
+        [Fact]
+        public void SetStopping_AcquireSlots_GrantsZeroWithoutStateChange()
+        {
+            _manager.OnWorkerCapacityAvailable("w1", 16);
+            _manager.SetStopping();
+
+            int changes = 0;
+            _manager.StateChanged += () => changes++;
+
+            int granted = _manager.AcquireSlots(5);
+
+            Assert.Equal(0, granted);
+            Assert.Equal(0, changes);
+        }
+
+        [Fact]
+        public void SetStopping_RaisesStateChangedOnce()
+        {
+            int changes = 0;
+            _manager.StateChanged += () => changes++;
+
+            _manager.SetStopping();
+            _manager.SetStopping();
+            _manager.SetStopping();
+
+            Assert.Equal(1, changes);
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Workers/ExternalWorkers/WorkerConnectionServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ExternalWorkers/WorkerConnectionServiceTests.cs
@@ -159,12 +159,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
 
             var service = CreateService();
 
-            // First worker fails.
+            // First worker fails. Failed connects are removed from tracking so
+            // the platform can immediately retry the same workerId without an
+            // explicit DELETE; the failure surfaces only via the thrown exception.
             await Assert.ThrowsAsync<InvalidOperationException>(
                 () => service.ConnectWorkerAsync("w_fail", new Uri("http://localhost:50051"), CancellationToken.None));
 
-            var failInfo = service.GetWorkerStatus("w_fail");
-            Assert.Equal(WorkerConnectionState.Error, failInfo.State);
+            Assert.Null(service.GetWorkerStatus("w_fail"));
 
             // Second worker succeeds — the recovery path reset _firstWorkerClaimed.
             await service.ConnectWorkerAsync("w_retry", new Uri("http://localhost:50052"), CancellationToken.None);
@@ -194,7 +195,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
         }
 
         [Fact]
-        public async Task ConnectWorkerAsync_Failure_SetsErrorState()
+        public async Task ConnectWorkerAsync_Failure_RemovesWorkerAndPropagatesException()
         {
             SetupFullConnectMocks();
             _mockGrpcClient
@@ -203,12 +204,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
 
             var service = CreateService();
 
-            await Assert.ThrowsAsync<InvalidOperationException>(
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
                 () => service.ConnectWorkerAsync("w_fail", new Uri("http://localhost:50051"), CancellationToken.None));
 
-            var info = service.GetWorkerStatus("w_fail");
-            Assert.Equal(WorkerConnectionState.Error, info.State);
-            Assert.Equal("connection refused", info.ErrorMessage);
+            Assert.Equal("connection refused", ex.Message);
+            Assert.Null(service.GetWorkerStatus("w_fail"));
+            Assert.DoesNotContain(service.GetWorkerStatuses(), w => w.WorkerId == "w_fail");
         }
 
         [Fact]
@@ -334,6 +335,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
         }
 
         private WorkerConnectionService CreateService(IOptions<ExternalWorkerOptions> options = null)
+            => CreateService(options, null);
+
+        private WorkerConnectionService CreateService(IOptions<ExternalWorkerOptions> options, IRuntimeStateManager runtimeStateManager)
         {
             options ??= Options.Create(new ExternalWorkerOptions { IsEnabled = true });
 
@@ -345,6 +349,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
                 _mockClientFactory.Object,
                 options,
                 _hostJsonContentProvider,
+                runtimeStateManager ?? Mock.Of<IRuntimeStateManager>(),
                 NullLoggerFactory.Instance);
         }
 
@@ -442,6 +447,218 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
                 () => service.ConnectWorkerAsync("w_late", new Uri("http://localhost:50053"), CancellationToken.None));
 
             Assert.Contains("stopping", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public async Task ConnectWorkerAsync_CallsOnWorkerLinkedAndOnWorkerCapacityAvailable()
+        {
+            SetupFullConnectMocks();
+            var mockRuntimeState = new Mock<IRuntimeStateManager>(MockBehavior.Strict);
+            mockRuntimeState.Setup(m => m.OnWorkerLinked("w_1"));
+            mockRuntimeState.Setup(m => m.OnWorkerCapacityAvailable("w_1", It.IsAny<int>()));
+
+            var service = CreateService(null, mockRuntimeState.Object);
+
+            await service.ConnectWorkerAsync("w_1", new Uri("http://localhost:50051"), CancellationToken.None);
+
+            mockRuntimeState.Verify(m => m.OnWorkerLinked("w_1"), Times.Once);
+            mockRuntimeState.Verify(m => m.OnWorkerCapacityAvailable("w_1", It.Is<int>(n => n > 0)), Times.Once);
+        }
+
+        [Fact]
+        public async Task ConnectWorkerAsync_CallsOnWorkerLinkedBeforeOnWorkerCapacityAvailable()
+        {
+            SetupFullConnectMocks();
+            var sequence = new System.Collections.Generic.List<string>();
+            var mockRuntimeState = new Mock<IRuntimeStateManager>();
+            mockRuntimeState
+                .Setup(m => m.OnWorkerLinked(It.IsAny<string>()))
+                .Callback<string>(id => sequence.Add($"linked:{id}"));
+            mockRuntimeState
+                .Setup(m => m.OnWorkerCapacityAvailable(It.IsAny<string>(), It.IsAny<int>()))
+                .Callback<string, int>((id, _) => sequence.Add($"capacity:{id}"));
+
+            var service = CreateService(null, mockRuntimeState.Object);
+
+            await service.ConnectWorkerAsync("w_1", new Uri("http://localhost:50051"), CancellationToken.None);
+
+            Assert.Equal(new[] { "linked:w_1", "capacity:w_1" }, sequence);
+        }
+
+        [Fact]
+        public async Task ConnectWorkerAsync_Failure_LinkedButNoCapacityPublished()
+        {
+            SetupFullConnectMocks();
+            _mockGrpcClient
+                .Setup(c => c.ConnectAsync(It.IsAny<string>(), It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("connection refused"));
+
+            var mockRuntimeState = new Mock<IRuntimeStateManager>();
+            var service = CreateService(null, mockRuntimeState.Object);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => service.ConnectWorkerAsync("w_fail", new Uri("http://localhost:50051"), CancellationToken.None));
+
+            mockRuntimeState.Verify(m => m.OnWorkerLinked("w_fail"), Times.Once);
+            mockRuntimeState.Verify(m => m.OnWorkerCapacityAvailable(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+
+            // OnWorkerLinked must be reversed by OnWorkerUnlinked, otherwise a failed
+            // connect permanently inflates LinkedWorkerCount and can eventually block
+            // the platform from linking new workers.
+            mockRuntimeState.Verify(m => m.OnWorkerUnlinked("w_fail"), Times.Once);
+
+            // The worker must also be removed from the service's tracking so the
+            // platform can retry the same workerId after clearing the Error state.
+            Assert.Null(service.GetWorkerStatus("w_fail"));
+            Assert.DoesNotContain(service.GetWorkerStatuses(), w => w.WorkerId == "w_fail");
+        }
+
+        [Fact]
+        public async Task DisconnectWorkerAsync_Failure_RemovesWorkerAndUnlinks()
+        {
+            SetupFullConnectMocks();
+            _mockChannelManager
+                .Setup(m => m.GetChannel("w_fail"))
+                .Returns(_mockChannel.Object);
+
+            // Make the drain throw a non-timeout exception so we hit the catch block.
+            _mockChannel
+                .Setup(c => c.DrainInvocationsAsync())
+                .ThrowsAsync(new InvalidOperationException("drain failed"));
+
+            var mockRuntimeState = new Mock<IRuntimeStateManager>();
+            var service = CreateService(null, mockRuntimeState.Object);
+
+            await service.ConnectWorkerAsync("w_fail", new Uri("http://localhost:50051"), CancellationToken.None);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => service.DisconnectWorkerAsync("w_fail", CancellationToken.None));
+
+            // Even on a failed disconnect the worker must not linger as "linked",
+            // otherwise LinkedWorkerCount drifts upward across retries.
+            mockRuntimeState.Verify(m => m.OnWorkerUnlinked("w_fail"), Times.Once);
+            Assert.Null(service.GetWorkerStatus("w_fail"));
+            Assert.DoesNotContain(service.GetWorkerStatuses(), w => w.WorkerId == "w_fail");
+        }
+
+        [Fact]
+        public async Task DisconnectWorkerAsync_CallsCapacityUnavailableThenUnlinked()
+        {
+            SetupFullConnectMocks();
+            _mockChannelManager
+                .Setup(m => m.GetChannel("w_1"))
+                .Returns(_mockChannel.Object);
+
+            var sequence = new System.Collections.Generic.List<string>();
+            var mockRuntimeState = new Mock<IRuntimeStateManager>();
+            mockRuntimeState
+                .Setup(m => m.OnWorkerLinked(It.IsAny<string>()))
+                .Callback<string>(id => sequence.Add($"linked:{id}"));
+            mockRuntimeState
+                .Setup(m => m.OnWorkerCapacityAvailable(It.IsAny<string>(), It.IsAny<int>()))
+                .Callback<string, int>((id, _) => sequence.Add($"capacity:{id}"));
+            mockRuntimeState
+                .Setup(m => m.OnWorkerCapacityUnavailable(It.IsAny<string>()))
+                .Callback<string>(id => sequence.Add($"capacity-unavailable:{id}"));
+            mockRuntimeState
+                .Setup(m => m.OnWorkerUnlinked(It.IsAny<string>()))
+                .Callback<string>(id => sequence.Add($"unlinked:{id}"));
+
+            var service = CreateService(null, mockRuntimeState.Object);
+
+            await service.ConnectWorkerAsync("w_1", new Uri("http://localhost:50051"), CancellationToken.None);
+            await service.DisconnectWorkerAsync("w_1", CancellationToken.None);
+
+            Assert.Equal(
+                new[] { "linked:w_1", "capacity:w_1", "capacity-unavailable:w_1", "unlinked:w_1" },
+                sequence);
+        }
+
+        [Fact]
+        public async Task DisconnectWorkerAsync_CapacityUnavailableHappensBeforeChannelBeginDrain()
+        {
+            SetupFullConnectMocks();
+            _mockChannelManager
+                .Setup(m => m.GetChannel("w_1"))
+                .Returns(_mockChannel.Object);
+
+            var sequence = new System.Collections.Generic.List<string>();
+            var mockRuntimeState = new Mock<IRuntimeStateManager>();
+            mockRuntimeState
+                .Setup(m => m.OnWorkerCapacityUnavailable(It.IsAny<string>()))
+                .Callback<string>(id => sequence.Add($"capacity-unavailable:{id}"));
+            _mockChannel
+                .Setup(c => c.BeginDrain())
+                .Callback(() => sequence.Add("begin-drain"));
+
+            var service = CreateService(null, mockRuntimeState.Object);
+
+            await service.ConnectWorkerAsync("w_1", new Uri("http://localhost:50051"), CancellationToken.None);
+            sequence.Clear();
+            await service.DisconnectWorkerAsync("w_1", CancellationToken.None);
+
+            int capacityIdx = sequence.IndexOf("capacity-unavailable:w_1");
+            int drainIdx = sequence.IndexOf("begin-drain");
+            Assert.True(capacityIdx >= 0);
+            Assert.True(drainIdx >= 0);
+            Assert.True(capacityIdx < drainIdx, $"Expected capacity withdraw before BeginDrain, got sequence: {string.Join(",", sequence)}");
+        }
+
+        [Fact]
+        public async Task DrainAndDisconnectAllAsync_CallsSetStoppingOnce()
+        {
+            SetupFullConnectMocks();
+
+            var mockClient1 = new Mock<IOutboundGrpcClient>();
+            var mockClient2 = new Mock<IOutboundGrpcClient>();
+            int createCount = 0;
+            _mockClientFactory
+                .Setup(f => f.Create())
+                .Returns(() => ++createCount == 1 ? mockClient1.Object : mockClient2.Object);
+
+            var mockRuntimeState = new Mock<IRuntimeStateManager>();
+            var service = CreateService(null, mockRuntimeState.Object);
+
+            await service.ConnectWorkerAsync("w_1", new Uri("http://localhost:50051"), CancellationToken.None);
+            await service.ConnectWorkerAsync("w_2", new Uri("http://localhost:50052"), CancellationToken.None);
+
+            await service.DrainAndDisconnectAllAsync(CancellationToken.None);
+
+            mockRuntimeState.Verify(m => m.SetStopping(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DrainAndDisconnectAllAsync_CallsSetStoppingBeforeAnyWorkerUnlinked()
+        {
+            SetupFullConnectMocks();
+
+            var mockClient1 = new Mock<IOutboundGrpcClient>();
+            var mockClient2 = new Mock<IOutboundGrpcClient>();
+            int createCount = 0;
+            _mockClientFactory
+                .Setup(f => f.Create())
+                .Returns(() => ++createCount == 1 ? mockClient1.Object : mockClient2.Object);
+
+            var sequence = new System.Collections.Generic.List<string>();
+            var mockRuntimeState = new Mock<IRuntimeStateManager>();
+            mockRuntimeState
+                .Setup(m => m.SetStopping())
+                .Callback(() => sequence.Add("stopping"));
+            mockRuntimeState
+                .Setup(m => m.OnWorkerUnlinked(It.IsAny<string>()))
+                .Callback<string>(id => sequence.Add($"unlinked:{id}"));
+
+            var service = CreateService(null, mockRuntimeState.Object);
+            await service.ConnectWorkerAsync("w_1", new Uri("http://localhost:50051"), CancellationToken.None);
+            await service.ConnectWorkerAsync("w_2", new Uri("http://localhost:50052"), CancellationToken.None);
+
+            await service.DrainAndDisconnectAllAsync(CancellationToken.None);
+
+            int stoppingIdx = sequence.IndexOf("stopping");
+            Assert.True(stoppingIdx >= 0);
+            Assert.All(
+                sequence.Where(s => s.StartsWith("unlinked:", StringComparison.Ordinal)),
+                unlinked => Assert.True(sequence.IndexOf(unlinked) > stoppingIdx));
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/ExternalWorkers/WorkerControllerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ExternalWorkers/WorkerControllerTests.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
         }
 
         [Fact]
-        public void Link_ValidRequest_Returns202Accepted()
+        public void LinkWorker_ValidRequest_Returns202Accepted()
         {
-            var request = new WorkerLinkRequest
+            var request = new ExternalWorkerInfo
             {
                 WorkerId = "w_test1234",
                 PodName = "worker-pod-abc123",
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
                 .Setup(m => m.ConnectWorkerAsync(It.IsAny<string>(), It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            var result = _controller.Link(request);
+            var result = _controller.LinkWorker("w_test1234", request);
 
             var accepted = Assert.IsType<AcceptedResult>(result);
             var info = Assert.IsType<WorkerConnectionInfo>(accepted.Value);
@@ -53,88 +53,120 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
         }
 
         [Fact]
-        public void Link_NullRequest_Returns400()
+        public void LinkWorker_NullRequest_Returns400()
         {
-            var result = _controller.Link(null);
+            var result = _controller.LinkWorker("w_test1234", null);
 
             Assert.IsType<BadRequestObjectResult>(result);
         }
 
         [Fact]
-        public void Link_MissingEndpoint_Returns400()
+        public void LinkWorker_MissingEndpoint_Returns400()
         {
-            var request = new WorkerLinkRequest { WorkerId = "w_test1234" };
+            var request = new ExternalWorkerInfo { WorkerId = "w_test1234" };
 
-            var result = _controller.Link(request);
+            var result = _controller.LinkWorker("w_test1234", request);
 
             Assert.IsType<BadRequestObjectResult>(result);
         }
 
         [Fact]
-        public void Link_InvalidEndpoint_Returns400()
+        public void LinkWorker_InvalidEndpoint_Returns400()
         {
-            var request = new WorkerLinkRequest
+            var request = new ExternalWorkerInfo
             {
                 WorkerId = "w_test1234",
                 GrpcEndpoint = "not-a-valid-uri"
             };
 
-            var result = _controller.Link(request);
+            var result = _controller.LinkWorker("w_test1234", request);
 
             Assert.IsType<BadRequestObjectResult>(result);
         }
 
-        [Fact]
-        public void Link_NullWorkerId_GeneratesId()
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void LinkWorker_MissingRouteWorkerId_Returns400(string routeWorkerId)
         {
-            var request = new WorkerLinkRequest
+            var request = new ExternalWorkerInfo
+            {
+                GrpcEndpoint = "http://10.0.1.42:50051"
+            };
+
+            var result = _controller.LinkWorker(routeWorkerId, request);
+
+            var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Contains("route", badRequest.Value.ToString(), StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void LinkWorker_BodyIdMismatchesRouteId_Returns400()
+        {
+            var request = new ExternalWorkerInfo
+            {
+                WorkerId = "w_bodyid01",
+                GrpcEndpoint = "http://10.0.1.42:50051"
+            };
+
+            var result = _controller.LinkWorker("w_routeid1", request);
+
+            var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Contains("does not match", badRequest.Value.ToString());
+        }
+
+        [Fact]
+        public void LinkWorker_NullBodyWorkerId_UsesRouteId()
+        {
+            var request = new ExternalWorkerInfo
             {
                 GrpcEndpoint = "http://10.0.1.42:50051"
             };
 
             _mockConnectionManager
-                .Setup(m => m.ConnectWorkerAsync(It.IsAny<string>(), It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
+                .Setup(m => m.ConnectWorkerAsync("w_routeid1", It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            var result = _controller.Link(request);
+            var result = _controller.LinkWorker("w_routeid1", request);
 
             var accepted = Assert.IsType<AcceptedResult>(result);
             var info = Assert.IsType<WorkerConnectionInfo>(accepted.Value);
-            Assert.StartsWith("w_", info.WorkerId);
+            Assert.Equal("w_routeid1", info.WorkerId);
             Assert.Equal(WorkerConnectionState.Connecting, info.State);
         }
 
         [Fact]
-        public void Link_BeforeSpecialization_Returns400()
+        public void LinkWorker_BeforeSpecialization_Returns400()
         {
             _mockWebHostEnvironment.Setup(e => e.InStandbyMode).Returns(true);
 
-            var request = new WorkerLinkRequest
+            var request = new ExternalWorkerInfo
             {
                 WorkerId = "w_test1234",
                 GrpcEndpoint = "http://10.0.1.42:50051"
             };
 
-            var result = _controller.Link(request);
+            var result = _controller.LinkWorker("w_test1234", request);
 
             var badRequest = Assert.IsType<BadRequestObjectResult>(result);
             Assert.Contains("specialized", badRequest.Value.ToString());
         }
 
         [Fact]
-        public void Link_DuplicateWorkerId_Returns409Conflict()
+        public void LinkWorker_DuplicateWorkerId_Returns409Conflict()
         {
             _mockConnectionManager
                 .Setup(m => m.GetWorkerStatus("w_test1234"))
                 .Returns(new WorkerConnectionInfo { WorkerId = "w_test1234", State = WorkerConnectionState.Connected });
 
-            var request = new WorkerLinkRequest
+            var request = new ExternalWorkerInfo
             {
                 WorkerId = "w_test1234",
                 GrpcEndpoint = "http://10.0.1.42:50051"
             };
 
-            var result = _controller.Link(request);
+            var result = _controller.LinkWorker("w_test1234", request);
 
             var conflict = Assert.IsType<ConflictObjectResult>(result);
             Assert.Contains("already linked", conflict.Value.ToString());

--- a/tools/ComputeSeparation/compute-separation.http
+++ b/tools/ComputeSeparation/compute-separation.http
@@ -27,7 +27,7 @@
 ###      → Proxy caches all responses for later replay
 ###   3. Specialize the runtime (/admin/instance/assign on runtime)
 ###      → Runtime exits placeholder mode, applies app settings
-###   4. Link the worker to the runtime (/admin/workers/link on runtime)
+###   4. Link a worker to the runtime (PUT /admin/workers/{workerId} on runtime)
 ###      → Runtime connects to proxy gRPC, receives cached init + metadata
 ###      → ScriptHost starts, functions loaded, host becomes Running
 ###   5. Invoke a function (GET /api/HttpTrigger)
@@ -71,12 +71,12 @@ Content-Type: application/json
 
 ###
 
-### Step 4: Link the worker to the runtime
+### Step 4: Link a worker to the runtime
 ### RCP calls this after both sides are specialized. The runtime establishes
 ### an outbound gRPC connection to the worker proxy. The proxy replays cached
 ### StartStream, WorkerInitResponse (with host.json + capabilities), and
 ### FunctionMetadataResponse. This triggers ScriptHost startup and function loading.
-POST {{runtimeHost}}/admin/workers/link?code={{masterKey}}
+PUT {{runtimeHost}}/admin/workers/w_test01?code={{masterKey}}
 Content-Type: application/json
 
 {
@@ -135,4 +135,40 @@ POST {{workerProxyHost}}/drain
 
 ### Stop the runtime instance (full runtime stop)
 ### Drains host listeners, disconnects all workers, sends WorkerDrainComplete to each.
-POST {{runtimeHost}}/admin/instance/stop?code={{masterKey}}
+POST {{runtimeHost}}/admin/host/stop?code={{masterKey}}
+
+### ============================================================
+### Runtime State APIs (compute separation)
+### ============================================================
+
+### Get this runtime instance's state snapshot.
+### Returns the same payload that is published to the mesh service as
+### 'publish-runtime-state': maxLinkedWorkers, linkedWorkerCount,
+### totalRequestSlots, totalAvailableRequestSlots.
+### Returns 503 if compute separation is not enabled.
+GET {{runtimeHost}}/admin/instance/state?code={{masterKey}}
+
+###
+
+### Reserve request slots from the runtime's pool.
+### Returns 200 + granted count on success,
+### 503 if compute separation is not enabled.
+POST {{runtimeHost}}/admin/request-slots/leases?code={{masterKey}}
+Content-Type: application/json
+
+{
+  "count": 5
+}
+
+###
+
+### Release previously-acquired request slots back to the pool.
+### Over-releases are clamped at the current leased count (never goes negative).
+### Returns 200 with no body on success; the caller should treat transport
+### failures as non-fatal and continue local accounting.
+DELETE {{runtimeHost}}/admin/request-slots/leases?code={{masterKey}}
+Content-Type: application/json
+
+{
+  "count": 5
+}


### PR DESCRIPTION
Adding runtime worker/slot tracking and publishing as per agreed upon platform contracts.