### PR TITLE
improving CI secrets checkout behavior

### DIFF
--- a/eng/ci/templates/official/jobs/run-integration-tests.yml
+++ b/eng/ci/templates/official/jobs/run-integration-tests.yml
@@ -46,6 +46,21 @@ jobs:
       command: ci
       workingDir: sample/CustomHandlerRetry
 
+  - task: DotNetCoreCLI@2
+    displayName: Restore
+    inputs:
+      command: custom
+      custom: restore
+      arguments: -v m
+      projects: $(test_projects)
+
+  - task: DotNetCoreCLI@2
+    displayName: Build
+    inputs:
+      command: build
+      arguments: -v m -c release --no-restore
+      projects: $(test_projects)
+
   - task: AzurePowerShell@5
     displayName: Checkout secrets
     inputs:
@@ -76,21 +91,6 @@ jobs:
       CosmosDbSecretMap: $(CosmosDb)
       AzureWebJobsEventHubSenderSecretMap: $(EventHub)
       AzureWebJobsEventHubReceiverSecretMap: $(EventHub)
-
-  - task: DotNetCoreCLI@2
-    displayName: Restore
-    inputs:
-      command: custom
-      custom: restore
-      arguments: -v m
-      projects: $(test_projects)
-
-  - task: DotNetCoreCLI@2
-    displayName: Build
-    inputs:
-      command: build
-      arguments: -v m -c release --no-restore
-      projects: $(test_projects)
 
   - task: DotNetCoreCLI@2
     displayName: C# end to end tests

--- a/eng/ci/templates/official/jobs/run-integration-tests.yml
+++ b/eng/ci/templates/official/jobs/run-integration-tests.yml
@@ -210,7 +210,7 @@ jobs:
       projects: $(test_projects)
 
   - task: AzurePowerShell@5
-    condition: always()
+    condition: and(always(), ne(variables['LeaseBlob'], ''))
     displayName: Checkin secrets
     inputs:
       azureSubscription: Azure-Functions-Host-CI-internal

--- a/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
+++ b/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
@@ -33,6 +33,21 @@ jobs:
       targetType: inline
       script: 'Install-Module -Name Az.Storage -RequiredVersion 1.11.0 -Scope CurrentUser -Force -AllowClobber'
 
+  - task: DotNetCoreCLI@2
+    displayName: Restore
+    inputs:
+      command: custom
+      custom: restore
+      arguments: -v m
+      projects: $(test_projects)
+
+  - task: DotNetCoreCLI@2
+    displayName: Build
+    inputs:
+      command: build
+      arguments: -v m -c release --no-restore
+      projects: $(test_projects)
+
   - task: AzurePowerShell@5
     displayName: Checkout secrets
     inputs:
@@ -76,21 +91,6 @@ jobs:
   - bash: |
       az login --service-principal -u $(ARM_CLIENT_ID) --tenant $(ARM_TENANT_ID) --allow-no-subscriptions --federated-token $(ARM_ID_TOKEN)
     displayName: 'Login to Azure'
-
-  - task: DotNetCoreCLI@2
-    displayName: Restore
-    inputs:
-      command: custom
-      custom: restore
-      arguments: -v m
-      projects: $(test_projects)
-
-  - task: DotNetCoreCLI@2
-    displayName: Build
-    inputs:
-      command: build
-      arguments: -v m -c release --no-restore
-      projects: $(test_projects)
 
   - task: DotNetCoreCLI@2
     displayName: 'Specialization tests'

--- a/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
+++ b/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
@@ -164,7 +164,7 @@ jobs:
       AzureWebJobsSecretStorageKeyVaultClientSecret: $(AzureClientSecret)
 
   - task: AzurePowerShell@5
-    condition: always()
+    condition: and(always(), ne(variables['LeaseBlob'], ''))
     displayName: Checkin secrets
     inputs:
       azureSubscription: Azure-Functions-Host-CI-internal

--- a/eng/script/checkout-secrets.ps1
+++ b/eng/script/checkout-secrets.ps1
@@ -31,6 +31,21 @@ While($true) {
     Write-Host "  ${name}: $leaseStatus"
     
     if ($leaseStatus -eq "Locked") {
+      try {
+        $blob.ICloudBlob.FetchAttributes()
+        $lastModified = $blob.ICloudBlob.Properties.LastModified
+        if ($lastModified -ne $null -and $lastModified.UtcDateTime -lt (Get-Date).AddHours(-6).ToUniversalTime()) {
+          $age = [math]::Round(((Get-Date).ToUniversalTime() - $lastModified.UtcDateTime).TotalHours, 1)
+          $build = $blob.ICloudBlob.Metadata["Build"]
+          $url = $blob.ICloudBlob.Metadata["BuildUrl"]
+          Write-Host "##vso[task.logissue type=warning]Stale lease detected on '${name}' (locked for ${age}h). Build: ${build} | URL: ${url}"
+          Write-Host "  Breaking stale lease on ${name}."
+          $blob.ICloudBlob.BreakLease([TimeSpan]::Zero, $null, $null, $null)
+          Write-Host "  Lease broken. Will attempt to acquire on next pass."
+        }
+      } catch {
+        # best effort
+      }
       continue
     }
 

--- a/eng/script/checkout-secrets.ps1
+++ b/eng/script/checkout-secrets.ps1
@@ -8,7 +8,8 @@ function AcquireLease($blob) {
 }
 
 # use this for tracking metadata in lease blobs
-$buildName = "3.0." + $env:buildNumber + "_" + $env:SYSTEM_JOBDISPLAYNAME
+$buildName = "$env:BUILD_BUILDID - $env:BUILD_BUILDNUMBER ($env:SYSTEM_JOBDISPLAYNAME)"
+$buildUrl = "$env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI$env:SYSTEM_TEAMPROJECT/_build/results?buildId=$env:BUILD_BUILDID"
 
 Import-Module Az.Storage
 
@@ -42,6 +43,7 @@ While($true) {
       try {
         $blob.ICloudBlob.FetchAttributes()
         $blob.ICloudBlob.Metadata["Build"] = $buildName
+        $blob.ICloudBlob.Metadata["BuildUrl"] = $buildUrl
         $accessCondition = New-Object -TypeName Microsoft.Azure.Storage.AccessCondition
         $accessCondition.LeaseId = $token
         $blob.ICloudBlob.SetMetadata($accessCondition)

--- a/eng/script/checkout-secrets.ps1
+++ b/eng/script/checkout-secrets.ps1
@@ -44,7 +44,7 @@ While($true) {
           Write-Host "  Lease broken. Will attempt to acquire on next pass."
         }
       } catch {
-        # best effort
+        Write-Host "##vso[task.logissue type=warning]Unable to inspect or break stale lease on '${name}'. Continuing. $($_.Exception.Message)"
       }
       continue
     }


### PR DESCRIPTION
We had a series of broken ci locks (held for eternity) that reduced our ci secret pool down to 3 locks (from 6). We are meant to be writing useful metadata into these blobs as we lock them, but they were all hardcoded to "3.0" from years ago and it was hard to track down what had actually happened.

I manually released the locks so the pool is back to full now, but this change:
- updates the metadata to be more useful
- checks for stale locks (6 hours old), emits warning in CI and auto-breaks the lease
- Restores and Builds before checking out secrets to reduce the time we hold each lock by ~7 minutes

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)