### PR TITLE
[Compute Separation] improving docker images

### DIFF
--- a/eng/build/Workers.props
+++ b/eng/build/Workers.props
@@ -1,7 +1,7 @@
 <Project>
 
   <!-- Individual workers are in their own props file. -->
-  <Import Project="$(MSBuildThisFileDirectory)Workers.*.props" />
+  <Import Project="$(MSBuildThisFileDirectory)Workers.*.props" Condition="'$(ExcludeWorkers)' != 'true'" />
 
   <!-- Remove all worker items from the ReadyToRun publish list -->
   <Target Name="ExcludeWorkers" AfterTargets="ComputeFilesToPublish" BeforeTargets="ResolveReadyToRunCompilers" Condition="'$(PublishReadyToRun)' == 'true'">

--- a/eng/build/Workers.props
+++ b/eng/build/Workers.props
@@ -1,7 +1,7 @@
 <Project>
 
-  <!-- Individual workers are in their own props file. -->
-  <Import Project="$(MSBuildThisFileDirectory)Workers.*.props" Condition="'$(ExcludeWorkers)' != 'true'" />
+  <!-- Individual workers are in their own props file. Skip restore entirely when SkipWorkerPackages is set. -->
+  <Import Project="$(MSBuildThisFileDirectory)Workers.*.props" Condition="'$(SkipWorkerPackages)' != 'true'" />
 
   <!-- Remove all worker items from the ReadyToRun publish list -->
   <Target Name="ExcludeWorkers" AfterTargets="ComputeFilesToPublish" BeforeTargets="ResolveReadyToRunCompilers" Condition="'$(PublishReadyToRun)' == 'true'">
@@ -12,7 +12,7 @@
   </Target>
 
   <!-- Add all worker items back to the publish list -->
-  <Target Name="ReAddWorkersToPublish" AfterTargets="CreateReadyToRunImages" BeforeTargets="CopyFilesToPublishDirectory" Condition="'$(PublishWorkers)' != 'false'">
+  <Target Name="ReAddWorkersToPublish" AfterTargets="CreateReadyToRunImages" BeforeTargets="CopyFilesToPublishDirectory" Condition="'$(PublishWorkers)' != 'false' and '$(SkipWorkerPackages)' != 'true'">
     <ItemGroup>
       <ResolvedFileToPublish Include="@(_WorkerPublishFiles)" />
     </ItemGroup>

--- a/src/Functions.WorkerProxy/Dockerfile
+++ b/src/Functions.WorkerProxy/Dockerfile
@@ -9,6 +9,6 @@ RUN dotnet publish src/Functions.WorkerProxy/Functions.WorkerProxy.csproj \
 
 FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-noble-chiseled
 WORKDIR /app
-COPY --from=build /app/publish .
+COPY --from=build /app/publish/Microsoft.Azure.Functions.WorkerProxy .
 EXPOSE 50051 50052 50053 50054
 ENTRYPOINT ["./Microsoft.Azure.Functions.WorkerProxy"]

--- a/src/WebJobs.Script.WebHost/Dockerfile
+++ b/src/WebJobs.Script.WebHost/Dockerfile
@@ -5,10 +5,10 @@ WORKDIR /repo
 COPY . .
 RUN dotnet publish src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj \
     -c Release -o /app/publish \
-    -p:ExcludeWorkers=true -p:PublishWorkers=false \
+    -p:SkipWorkerPackages=true -p:PublishWorkers=false \
     && mkdir -p /app/publish/workers
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled-extra
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble
 WORKDIR /app
 
 # Workers are excluded at build time via ExcludeWorkers + PublishWorkers=false.

--- a/src/WebJobs.Script.WebHost/Dockerfile
+++ b/src/WebJobs.Script.WebHost/Dockerfile
@@ -4,17 +4,16 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /repo
 COPY . .
 RUN dotnet publish src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj \
-    -c Release -o /app/publish
+    -c Release -o /app/publish \
+    -p:ExcludeWorkers=true -p:PublishWorkers=false \
+    && mkdir -p /app/publish/workers
 
-FROM mcr.microsoft.com/dotnet/aspnet:10.0
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled-extra
 WORKDIR /app
-COPY --from=build /app/publish .
 
-# In compute separation mode the runtime has no local workers — all function
-# execution happens on remote worker pods. Remove bundled worker binaries to
-# shrink the image. The empty directory must remain because the host probes it
-# at startup.
-RUN rm -rf /app/workers/* && mkdir -p /app/workers
+# Workers are excluded at build time via ExcludeWorkers + PublishWorkers=false.
+# In compute separation mode all execution happens on remote worker pods.
+COPY --from=build /app/publish .
 
 EXPOSE 7071
 ENTRYPOINT ["dotnet", "Microsoft.Azure.WebJobs.Script.WebHost.dll"]


### PR DESCRIPTION
## Shrink compute separation Docker images

### Runtime image (`WebJobs.Script.WebHost/Dockerfile`)
- **2.48 GB → ~317 MB**
- Added `ExcludeWorkers` MSBuild property to skip restoring bundled language workers (Python 960 MB, PowerShell 348 MB, dotnet-isolated 98 MB, Java 60 MB) — they're unused in compute separation mode where all execution happens on remote worker pods
- Also uses `PublishWorkers=false` to exclude workers from publish output
- Switched base from `aspnet:10.0` (full Ubuntu) to `aspnet:10.0-noble-chiseled-extra` (distroless), saving ~120 MB on the base layer
- Empty `workers/` directory preserved for host startup probe

### WorkerProxy image (`Functions.WorkerProxy/Dockerfile`)
- **93.9 MB → ~46 MB**
- Copy only the native AOT binary into the final image, excluding the 36 MB `.dbg` debug symbols file that was inadvertently included via `COPY /app/publish .`

### Build infrastructure (`Workers.props`)
- New `ExcludeWorkers` property gates the `Import` of per-language worker `.props` files, skipping NuGet restore of all worker packages when set to `true`
- Existing `PublishWorkers` property continues to control publish-time inclusion
