### PR TITLE
Use minimal HostBuilder to reduce cold start allocation overhead

### DIFF
--- a/src/WebJobs.Script.WebHost/Program.cs
+++ b/src/WebJobs.Script.WebHost/Program.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using Microsoft.AspNetCore.Builder;
@@ -16,7 +17,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using DataProtectionConstants = Microsoft.Azure.Web.DataProtection.Constants;
-using ExtensionsHost = Microsoft.Extensions.Hosting.Host;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
 {
@@ -38,20 +38,32 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 .Build();
         }
 
+        /// <summary>
+        /// Creates an <see cref="IHostBuilder"/> with only the services the Functions host requires.
+        /// </summary>
+        /// <remarks>
+        /// A bare <see cref="HostBuilder"/> is used instead of <c>Host.CreateDefaultBuilder</c>
+        /// because the Functions host manages its own logging, configuration, and metrics.
+        /// </remarks>
         public static IHostBuilder CreateHostBuilder(string[] args = null)
         {
-            // Setting this env variable to test placeholder scenarios locally.
 #if PLACEHOLDER_SIMULATION
             SystemEnvironment.Instance.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
             SystemEnvironment.Instance.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady, "0");
 #endif
 
-            return ExtensionsHost.CreateDefaultBuilder(args ?? Array.Empty<string>())
-                // Scope and build validation are intentionally disabled. The host uses a two-level
-                // DI hierarchy with cross-boundary service resolution that would fail generic scope
-                // validation. The custom DependencyValidator provides tighter, bespoke validation.
-                // This preserves the behavior of WebHost.CreateDefaultBuilder(), which also disabled
-                // scope validation in Production by default.
+            return new HostBuilder()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .ConfigureHostConfiguration(config =>
+                {
+                    if (args is { Length: > 0 })
+                    {
+                        config.AddCommandLine(args);
+                    }
+                })
+                // Scope and build validation are disabled because the host uses a two-level
+                // DI hierarchy with cross-boundary service resolution. The custom
+                // DependencyValidator provides bespoke validation instead.
                 .UseDefaultServiceProvider((context, options) =>
                 {
                     options.ValidateScopes = false;
@@ -74,9 +86,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                         })
                         .ConfigureAppConfiguration((builderContext, config) =>
                         {
-                            // replace the default environment source with our own
+                            // Replace the default environment variables source with one
+                            // that is aware of Functions-specific settings.
                             IConfigurationSource envVarsSource = config.Sources.OfType<EnvironmentVariablesConfigurationSource>().FirstOrDefault();
-                            if (envVarsSource != null)
+                            if (envVarsSource is not null)
                             {
                                 config.Sources.Remove(envVarsSource);
                             }
@@ -91,14 +104,32 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                             });
                             config.Add(new FunctionsHostingConfigSource(SystemEnvironment.Instance));
 
+                            if (builderContext.HostingEnvironment.IsDevelopment())
+                            {
+                                config.AddUserSecrets<Program>(optional: true);
+                            }
+
                             var hostingEnvironmentConfigFilePath = SystemEnvironment.Instance.GetFunctionsHostingEnvironmentConfigFilePath();
                             if (!string.IsNullOrEmpty(hostingEnvironmentConfigFilePath))
                             {
                                 config.AddJsonFile(hostingEnvironmentConfigFilePath, optional: true, reloadOnChange: false);
                             }
+
+                            if (args is { Length: > 0 })
+                            {
+                                config.AddCommandLine(args);
+                            }
                         })
                         .ConfigureLogging((context, loggingBuilder) =>
                         {
+                            loggingBuilder.Configure(options =>
+                            {
+                                options.ActivityTrackingOptions =
+                                    ActivityTrackingOptions.SpanId |
+                                    ActivityTrackingOptions.TraceId |
+                                    ActivityTrackingOptions.ParentId;
+                            });
+
                             loggingBuilder.ClearProviders();
 
                             loggingBuilder.AddDefaultWebJobsFilters();

--- a/src/WebJobs.Script.WebHost/Program.cs
+++ b/src/WebJobs.Script.WebHost/Program.cs
@@ -114,11 +114,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                             {
                                 config.AddJsonFile(hostingEnvironmentConfigFilePath, optional: true, reloadOnChange: false);
                             }
-
-                            if (args is { Length: > 0 })
-                            {
-                                config.AddCommandLine(args);
-                            }
                         })
                         .ConfigureLogging((context, loggingBuilder) =>
                         {

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebHostStartupEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebHostStartupEndToEndTests.cs
@@ -104,6 +104,17 @@ public class WebHostStartupEndToEndTests
         TestHelpers.AssertOptionLogged(allOptionsLogs, nameof(LanguageWorkerOptions));
     }
 
+    [Fact]
+    public void CreateHostBuilder_ConfiguresActivityTrackingOptions()
+    {
+        using var host = Program.CreateHostBuilder(args: null).Build();
+        var options = host.Services.GetRequiredService<IOptions<LoggerFactoryOptions>>().Value;
+
+        Assert.Equal(
+            ActivityTrackingOptions.SpanId | ActivityTrackingOptions.TraceId | ActivityTrackingOptions.ParentId,
+            options.ActivityTrackingOptions);
+    }
+
     private static IHostBuilder CreateHostBuilder(TestLoggerProvider loggerProvider, params string[] functions)
     {
         var environment = new TestEnvironment(new Dictionary<string, string>


### PR DESCRIPTION
#### Problem

The migration from `WebHost.CreateDefaultBuilder` to `Host.CreateDefaultBuilder` (done as part of the .NET 10 TFM upgrade) introduced a **11–21% P50 cold start latency regression** across all scenarios, observed in perflab nightly CI runs against the `dev` branch. `Host.CreateDefaultBuilder` registers default logging providers, metrics config binding, and additional configuration sources that the Functions host does not need. These defaults add `IConfigureOptions<T>` and `IOptionsChangeTokenSource<T>` registrations that cause additional `GetChildKeys` calls during specialization, increasing host allocation from ~21 MB to ~32 MB and exceeding the 24 MB `NoGCRegion` budget — triggering ~16 ms of GC pauses.

##### How the extra registrations cause the regression

1. During specialization, the inner script host (222 services) is rebuilt by the DI container.
2. Many of those services depend on `ILogger<T>` or `IOptions<T>`.
3. When DI resolves `ILogger<T>`, it resolves `ILoggerFactory` → `IOptions<LoggerFilterOptions>`.
4. The `OptionsFactory<T>` iterates **all** `IConfigureOptions<LoggerFilterOptions>` registrations — including orphaned ones from `Host.CreateDefaultBuilder`'s `logging.AddConfiguration("Logging")` and `AddEventSourceLogger()` that were not removed by `ClearProviders()`.
5. Each orphaned registration calls `config.GetSection(...).GetChildren()` → `GetChildKeys()` across all 9 configuration providers × 81 keys.
6. The same cascading happens for `IOptions<MetricsOptions>` via the orphaned `MetricsConfigureOptions` from `AddMetrics(config.GetSection("Metrics"))`.
7. The result is thousands of extra `GetChildKeys` calls producing ~11 MB of additional transient allocations (`List<String>`, Dictionary enumerators, `DistinctIterator`, `ConfigurationSection`), pushing total host allocation past the 24 MB `NoGCRegion` budget and triggering GC pauses during the critical specialization path.

#### Fix

Replace `Host.CreateDefaultBuilder` with a bare `new HostBuilder()` that registers only the services the Functions host actually needs. `HostBuilder.Build()` internally provides base infrastructure (`AddLogging()`, `AddMetrics()`, `IHostEnvironment`, `IHostApplicationLifetime`), and `ConfigureWebHostDefaults` provides the web server infrastructure (Kestrel, IIS, routing, host filtering). Content root, command line args, user secrets, and `ActivityTrackingOptions` are explicitly configured to maintain parity with the .NET 8 `WebHost.CreateDefaultBuilder` behavior (tag [`v4.1048.100`](https://github.com/Azure/azure-functions-host/releases/tag/v4.1048.100)).

#### CI Validation Results

Validated across two perflab CI runs.

##### P50 Latency

| Scenario | Pre-upgrade (net8, [`v4.1048.100`](https://github.com/Azure/azure-functions-host/releases/tag/v4.1048.100)) | Post-upgrade (net10 dev) | This PR (net10 minimal HostBuilder) |
|----------|-------------------|-------------------------|--------------------------------------|
| Windows Web App | 719 ms | 754 ms (+5%) | **703–721 ms (−0.3% to −2%)** ✅ |
| Windows Worker | 422 ms | 501 ms (+19%) | **388–394 ms (−7% to −8%)** 🎉 |
| Linux Web App | 523 ms | 597 ms (+14%) | **509 ms (−3%)** 🎉 |
| Linux Worker | 361 ms | 435 ms (+21%) | **337–341 ms (−6% to −7%)** 🎉 |

##### Host Allocation & GC (Windows Worker)

| Metric | Pre-upgrade (net8, [`v4.1048.100`](https://github.com/Azure/azure-functions-host/releases/tag/v4.1048.100)) | Post-upgrade (net10 dev) | This PR |
|--------|-------------------|-------------------------|---------|
| Host Allocation | 21.1 MB | 32.1 MB (+52%) | **14.9 MB (−29% vs net8)** 🎉 |
| Host GC Time | 0 ms | 17.4 ms | **0 ms** ✅ |
| Host JIT Count | 154 | 195 (+27%) | **179 (+16%)** |

##### Host Allocation & GC (Windows Web App)

| Metric | Pre-upgrade (net8, [`v4.1048.100`](https://github.com/Azure/azure-functions-host/releases/tag/v4.1048.100)) | Post-upgrade (net10 dev) | This PR |
|--------|-------------------|-------------------------|---------|
| Host Allocation | 21.3 MB | 32.3 MB (+52%) | **15.2–15.3 MB (−28% vs net8)** 🎉 |
| Host GC Time | 0 ms | 18.0 ms | **0 ms** ✅ |
| Host JIT Count | 188 | 218 (+16%) | **221–222 (+18%)** |

The fix eliminates the regression and improves over the net8 baseline by removing defaults that were redundant for the Functions host.

#### What changed

`Host.CreateDefaultBuilder(args)` → `new HostBuilder()` in `Program.cs`, with explicit registration of:
- `UseContentRoot(Directory.GetCurrentDirectory())`
- `ConfigureHostConfiguration` with `AddCommandLine(args)` for host-level settings
- `AddCommandLine(args)` in app config
- `AddUserSecrets<Program>` in Development
- `ActivityTrackingOptions` (SpanId, TraceId, ParentId)

#### What is intentionally not registered

These were registered by `Host.CreateDefaultBuilder` but are redundant for the Functions host. The "In .NET 8?" column indicates whether the item was also present in the .NET 8 `WebHost.CreateDefaultBuilder` ([`v4.1048.100`](https://github.com/Azure/azure-functions-host/blob/a390074a394510ee76391452f621380cb46c9337/src/WebJobs.Script.WebHost/Program.cs#L47)):

| Default | In .NET 8? | Why it's not needed |
|---------|:---:|-------------------|
| `appsettings.json` / `appsettings.{env}.json` with `reloadOnChange: true` | ✅ Yes | Functions host has its own config sources; no appsettings.json in published output |
| `AddEnvironmentVariables()` | ✅ Yes | Replaced by `ScriptEnvironmentVariablesConfigurationSource` |
| `AddEnvironmentVariables(prefix: "DOTNET_")` in host config | ❌ No | Functions sets the environment explicitly via `UseSetting(EnvironmentKey, ...)` with `AZURE_FUNCTIONS_ENVIRONMENT`; `DOTNET_ENVIRONMENT` / `DOTNET_URLS` are not used |
| `logging.AddConfiguration("Logging")` | ✅ Yes | Customer logging config flows through the inner script host via `AddConfiguration("AzureFunctionsJobHost:Logging")` in [`ScriptHostBuilderExtensions.cs`](https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script/ScriptHostBuilderExtensions.cs#L92) |
| `logging.AddConsole/Debug/EventSource` | ✅ Yes | Functions host manages its own logging providers; cleared by `ClearProviders()` |
| `logging.AddEventLog` (Windows) | ❌ No | New in Generic Host; cleared by `ClearProviders()` |
| `services.AddMetrics(config.GetSection("Metrics"))` | ❌ No | Base `AddMetrics()` is provided by `HostBuilder.Build()` internally |

**Note on `ClearProviders()`:** The Functions host calls `loggingBuilder.ClearProviders()` in its `ConfigureLogging` to remove all default `ILoggerProvider` registrations and replace them with its own (WebJobs filters, forwarding logger, etc.). However, `ClearProviders()` only removes `ILoggerProvider` entries — it does **not** remove the associated `IConfigureOptions<T>` and `IOptionsChangeTokenSource<T>` registrations (e.g., from `AddConfiguration("Logging")`, `AddConsole()` formatters, `AddEventSourceLogger()` filters). These orphaned registrations remain in the DI container and fire during options resolution, causing cascading `GetChildKeys` calls that drive the allocation regression. By not registering these providers in the first place, the `new HostBuilder()` approach eliminates both the providers and their orphaned options bindings.

#### Testing

- Perflab CI cold start benchmarks (2 runs) — results above
- Existing unit and integration test suites pass (no test changes required)
- `--urls` command-line binding verified (used by integration test `HostProcessLauncher`)

<details>
<summary><strong>Appendix: Full 3-way registration comparison</strong></summary>

Compares what each builder registers, independent of what the Functions host adds on top. 🔴 = wasted/redundant for Functions host.

##### Configuration — Host Level

| Source | .NET 8 `WebHost` ([`v4.1048.100`](https://github.com/Azure/azure-functions-host/releases/tag/v4.1048.100)) | .NET 10 `Host.CreateDefaultBuilder` | This PR (`new HostBuilder()`) |
|--------|:---:|:---:|:---:|
| ContentRoot = CWD | ✅ | ✅ | ✅ (explicit) |
| `ASPNETCORE_` env vars | ✅ (WebHostBuilder ctor) | ❌ | ❌ |
| `DOTNET_` env vars | ❌ | ✅ | ❌ |
| CLI args in host config | ✅ | ✅ | ✅ (explicit) |

##### Configuration — App Level

| Source | .NET 8 `WebHost` | .NET 10 `Host.CreateDefaultBuilder` | This PR |
|--------|:---:|:---:|:---:|
| `appsettings.json` (reloadOnChange) | ✅ 🔴 | ✅ 🔴 | ❌ |
| `appsettings.{env}.json` (reloadOnChange) | ✅ 🔴 | ✅ 🔴 | ❌ |
| User Secrets (Dev) | ✅ (Assembly.Load, no reload) | ✅ (Assembly.Load, reload) | ✅ (generic `<Program>`, no reload) |
| `AddEnvironmentVariables()` (all) | ✅ 🔴 | ✅ 🔴 | ❌ |
| CLI args in app config | ✅ | ✅ | ✅ (explicit) |

##### Logging Providers

| Provider | .NET 8 `WebHost` | .NET 10 `Host.CreateDefaultBuilder` | This PR | Orphaned after `ClearProviders()` |
|----------|:---:|:---:|:---:|---|
| `AddConfiguration("Logging")` | ✅ 🔴 | ✅ 🔴 | ❌ | `IConfigureOptions<LoggerFilterOptions>` + change token |
| `AddConsole()` (builder default) | ✅ 🔴 | ✅ 🔴 | ❌ | 9 orphaned (options binders + formatter change tokens) |
| `AddDebug()` | ✅ 🔴 | ✅ 🔴 | ❌ | None |
| `AddEventSourceLogger()` | ✅ 🔴 | ✅ 🔴 | ❌ | `IConfigureOptions<LoggerFilterOptions>` + change token |
| `AddEventLog()` (Windows) | ❌ | ✅ 🔴 | ❌ | Orphaned filter rule |
| `ActivityTrackingOptions` | ✅ | ✅ | ✅ (explicit) | N/A — needed |

##### Services & Metrics

| Service | .NET 8 `WebHost` | .NET 10 `Host.CreateDefaultBuilder` | This PR |
|---------|:---:|:---:|:---:|
| `AddMetrics()` (bare) | ✅ | ✅ (HostBuilder.Build) | ✅ (HostBuilder.Build) |
| `AddMetrics(config.GetSection("Metrics"))` | ❌ | ✅ 🔴 | ❌ |
| `AddLogging()` | ✅ | ✅ (HostBuilder.Build) | ✅ (HostBuilder.Build) |
| `HostOptions` config binding | ❌ | ✅ (HostBuilder.Build) | ✅ (HostBuilder.Build) |
| `IHostApplicationLifetime` | ✅ | ✅ (HostBuilder.Build) | ✅ (HostBuilder.Build) |

##### Service Provider Validation

| Option | .NET 8 `WebHost` | .NET 10 `Host.CreateDefaultBuilder` | This PR |
|--------|:---:|:---:|:---:|
| `ValidateScopes` | Dev only | Dev only → overridden `false` | `false` |
| `ValidateOnBuild` | ❌ | Dev only → overridden `false` | `false` |

##### File Watchers (wasted)

| Watcher | .NET 8 `WebHost` | .NET 10 `Host.CreateDefaultBuilder` | This PR |
|---------|:---:|:---:|:---:|
| `appsettings.json` FileSystemWatcher | ✅ 🔴 | ✅ 🔴 | ❌ |
| `appsettings.{env}.json` FileSystemWatcher | ✅ 🔴 | ✅ 🔴 | ❌ |
| User Secrets FileSystemWatcher (Dev) | ❌ | ✅ 🔴 | ❌ |

##### Web Defaults (identical across all three via `ConfigureWebHostDefaults`)

Kestrel, IIS/IISIntegration, AddRouting, HostFiltering, ForwardedHeaders, StaticWebAssets (Dev) — all present and unchanged.

##### Net Impact

| Metric | .NET 8 `WebHost` | .NET 10 `Host.CreateDefaultBuilder` | This PR |
|--------|:---:|:---:|:---:|
| Config providers | 8 | 9 (+1) | 7 (−1) |
| Orphaned logging registrations | ~19 | ~23 (+4) | **0** |
| Wasted file watchers | 2 | 3 (+1) | **0** |
| Host allocation (specialization) | 21 MB | 32 MB | **15 MB** |
| GC time (specialization) | 0 ms | 16–18 ms | **0 ms** |

</details>

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
