### PR TITLE
[Compute Separation]  Make worker link API return 200 after init handshake; defer ScriptHost startup to background

### DIFF
--- a/src/WebJobs.Script.Grpc/ExternalWorkers/WorkerConnectionService.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/WorkerConnectionService.cs
@@ -39,6 +39,7 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
 
     private readonly ConcurrentDictionary<string, WorkerConnection> _workers = new();
     private readonly ReaderWriterLockSlim _lifecycleLock = new();
+    private readonly CancellationTokenSource _shutdownCts = new();
     private TaskCompletionSource _scriptHostStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private int _firstWorkerClaimed;
     private volatile bool _stopping;
@@ -128,7 +129,7 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
             if (!_workers.TryAdd(workerId, worker))
             {
                 throw new InvalidOperationException(
-                    $"Worker '{workerId}' already exists. Disconnect it before reassigning.");
+                    $"Worker '{workerId}' is already linked.");
             }
 
             // The worker is now linked for the purposes of RuntimeState accounting.
@@ -141,150 +142,183 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
             _lifecycleLock.ExitReadLock();
         }
 
-        // The rest of connect runs outside the lock. The worker is in _workers,
-        // so DrainAndDisconnectAllAsync will find it and await ConnectCompleted
-        // before cleaning up.
-        await ConnectWorkerCoreAsync(workerId, endpoint, worker, cancellationToken);
+        // Start the full connect pipeline (Phase 1 + Phase 2) in the background.
+        // We await only InitCompleted (Phase 1: init handshake) so the API can
+        // return 200 after the worker is linked. Phase 2 (ScriptHost startup)
+        // continues in the background. ConnectCompleted signals after the full
+        // pipeline finishes, which DisconnectWorkerAsync awaits before cleanup.
+        _ = ConnectWorkerCoreAsync(workerId, endpoint, worker, cancellationToken);
+        await worker.InitCompleted.Task;
     }
 
     private async Task ConnectWorkerCoreAsync(string workerId, Uri endpoint, WorkerConnection worker, CancellationToken cancellationToken)
     {
         var info = worker.Info;
-        bool connected = false;
 
         try
         {
-            _logger.LogInformation("Connecting to external worker '{workerId}' at {endpoint}.", workerId, endpoint);
+            var channel = await EstablishChannelAsync(workerId, endpoint, worker, cancellationToken);
 
-            _eventManager.AddGrpcChannels(workerId);
+            // Phase 1 complete — signal InitCompleted so ConnectWorkerAsync
+            // (and the API caller) can return 200.
+            worker.InitCompleted.TrySetResult();
 
-            var client = _clientFactory.Create();
-            worker.Client = client;
+            _logger.LogInformation("Worker '{workerId}' linked. Starting host setup.", workerId);
 
-            await client.ConnectAsync(workerId, endpoint, cancellationToken);
-
-            var workerConfig = new RpcWorkerConfig
-            {
-                Description = new RpcWorkerDescription
-                {
-                    Language = "external",
-                    WorkerDirectory = string.Empty
-                },
-                CountOptions = new WorkerProcessCountOptions()
-            };
-
-            var channel = _channelFactory.Create(workerId, workerConfig);
-            await channel.StartWorkerProcessAsync(cancellationToken);
-
-            _logger.LogInformation("Waiting for worker '{workerId}' init handshake.", workerId);
-            await channel.WaitForInitAsync(InitTimeout, cancellationToken);
-
-            // Extract host.json from worker capabilities.
-            string hostJson = channel.GetCapabilityState("host_configuration_json");
-            if (hostJson is not null)
-            {
-                _logger.LogDebug("Received host.json configuration from worker '{workerId}'.", workerId);
-                _hostJsonContentProvider.SetContent(hostJson);
-            }
-            else
-            {
-                _logger.LogWarning("Worker '{workerId}' did not provide host_configuration_json capability.", workerId);
-            }
-
-            // Register the channel directly — no event needed.
-            _channelManager.AddChannel(workerId, channel);
-
-            // Subscribe to drain signals from the worker proxy.
-            channel.DrainRequested += OnWorkerDrainRequested;
-
-            _logger.LogInformation("Worker '{workerId}' connected and registered.", workerId);
-
-            // Start or update the ScriptHost based on whether this is the first worker.
-            // The first caller either starts or waits for the ScriptHost; concurrent
-            // callers block until startup completes, then call SetupChannel.
-            if (Interlocked.CompareExchange(ref _firstWorkerClaimed, 1, 0) == 0)
-            {
-                // First worker: start the ScriptHost. In external worker mode,
-                // WebJobsScriptHostService is not registered as an IHostedService,
-                // so the ScriptHost hasn't started yet. Now that a worker has delivered
-                // host.json and registered a channel, WaitForContent and WaitForChannelAsync
-                // will return immediately when the ScriptHost builds.
-                var tcs = _scriptHostStarted;
-                try
-                {
-                    _logger.LogInformation("First worker connected. Starting ScriptHost.");
-                    await _scriptHostManager.StartAsync(cancellationToken);
-                    tcs.TrySetResult();
-                }
-                catch (Exception ex)
-                {
-                    // Fault the current TCS so any concurrent waiters get the exception
-                    // (they'll propagate it and the platform can retry those workers too).
-                    // Replace the TCS BEFORE releasing the gate so the next winner sees
-                    // a fresh TCS, not the faulted one.
-                    tcs.TrySetException(ex);
-                    _scriptHostStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-                    Interlocked.Exchange(ref _firstWorkerClaimed, 0);
-                    throw;
-                }
-            }
-            else
-            {
-                // Wait for the first worker's StartAsync to complete before resolving the dispatcher.
-                await _scriptHostStarted.Task.WaitAsync(cancellationToken);
-
-                if (Utility.TryGetHostService(_scriptHostManager, out ConnectedWorkerInvocationDispatcher dispatcher))
-                {
-                    dispatcher.SetupChannel(channel);
-                    _logger.LogDebug("SetupChannel called for subsequent worker '{workerId}'.", workerId);
-                }
-            }
-
-            // [CS-TODO] Replace with value reported by the worker during the init
-            // handshake (expected as a "max_concurrency" capability on
-            // WorkerInitResponse, parsed via channel.GetCapabilityState(...) like
-            // "host_configuration_json" above). Until then, hard-code per the App
-            // Server contract.
-            const int workerSlotCapacity = 16;
-            _runtimeStateManager.OnWorkerCapacityAvailable(workerId, workerSlotCapacity);
-
-            info.State = WorkerConnectionState.Connected;
-            connected = true;
+            // Phase 2: ScriptHost startup and capacity advertisement.
+            // HTTP requests that arrive before Phase 2 completes will buffer
+            // in HostAvailabilityCheckMiddleware.DelayUntilHostReadyAsync().
+            //
+            // We await Phase 2 here (not fire-and-forget) so that
+            // ConnectCompleted signals only after the full pipeline finishes.
+            // This ensures DisconnectWorkerAsync won't tear down resources
+            // while Phase 2 is still running.
+            await CompleteWorkerSetupAsync(workerId, worker, channel, _shutdownCts.Token);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
         {
             _logger.LogError(ex, "Failed to connect worker '{workerId}'.", workerId);
 
             info.State = WorkerConnectionState.Error;
             info.ErrorMessage = ex.Message;
 
-            throw;
+            // If Phase 1 failed, fault InitCompleted so the API caller gets the exception.
+            // If Phase 1 already succeeded, TrySetException is a no-op.
+            worker.InitCompleted.TrySetException(ex);
+
+            try
+            {
+                await CleanupWorkerResourcesAsync(workerId, worker);
+            }
+            catch (Exception cleanupEx)
+            {
+                _logger.LogWarning(cleanupEx, "Cleanup after failed connect threw for worker '{workerId}'.", workerId);
+            }
+
+            _workers.TryRemove(workerId, out _);
+            _runtimeStateManager.OnWorkerUnlinked(workerId);
         }
         finally
         {
-            if (!connected)
-            {
-                // Clean up partially-created resources, drop the worker from
-                // tracking, and reverse the OnWorkerLinked accounting that
-                // ConnectWorkerAsync performed before invoking the core. Without
-                // this, a failed connect permanently inflates LinkedWorkerCount
-                // and can eventually block the platform from linking new workers
-                // once the configured maximum is reached.
-                try
-                {
-                    await CleanupWorkerResourcesAsync(workerId, worker);
-                }
-                catch (Exception cleanupEx)
-                {
-                    _logger.LogWarning(cleanupEx, "Cleanup after failed connect threw for worker '{workerId}'.", workerId);
-                }
-
-                _workers.TryRemove(workerId, out _);
-                _runtimeStateManager.OnWorkerUnlinked(workerId);
-            }
-
+            // Signal that the full pipeline (Phase 1 + Phase 2) has finished.
+            // DisconnectWorkerAsync awaits this before cleaning up.
             worker.ConnectCompleted.TrySetResult();
         }
+    }
+
+    /// <summary>
+    /// Phase 1: Establishes the gRPC connection, performs the init handshake
+    /// (WorkerInitRequest/WorkerInitResponse), extracts host.json from
+    /// capabilities, and registers the channel. Returns after the worker
+    /// is linked and the init handshake has succeeded.
+    /// </summary>
+    private async Task<IConnectedWorkerChannel> EstablishChannelAsync(string workerId, Uri endpoint, WorkerConnection worker, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Connecting to external worker '{workerId}' at {endpoint}.", workerId, endpoint);
+
+        _eventManager.AddGrpcChannels(workerId);
+
+        var client = _clientFactory.Create();
+        worker.Client = client;
+
+        await client.ConnectAsync(workerId, endpoint, cancellationToken);
+
+        var workerConfig = new RpcWorkerConfig
+        {
+            Description = new RpcWorkerDescription
+            {
+                Language = "external",
+                WorkerDirectory = string.Empty
+            },
+            CountOptions = new WorkerProcessCountOptions()
+        };
+
+        var channel = _channelFactory.Create(workerId, workerConfig);
+        await channel.StartWorkerProcessAsync(cancellationToken);
+
+        _logger.LogInformation("Waiting for worker '{workerId}' init handshake.", workerId);
+        await channel.WaitForInitAsync(InitTimeout, cancellationToken);
+
+        // Extract host.json from worker capabilities.
+        string hostJson = channel.GetCapabilityState("host_configuration_json");
+        if (hostJson is not null)
+        {
+            _logger.LogDebug("Received host.json configuration from worker '{workerId}'.", workerId);
+            _hostJsonContentProvider.SetContent(hostJson);
+        }
+        else
+        {
+            _logger.LogWarning("Worker '{workerId}' did not provide host_configuration_json capability.", workerId);
+        }
+
+        // Register the channel directly — no event needed.
+        _channelManager.AddChannel(workerId, channel);
+
+        // Subscribe to drain signals from the worker proxy.
+        channel.DrainRequested += OnWorkerDrainRequested;
+
+        _logger.LogInformation("Worker '{workerId}' connected and registered.", workerId);
+
+        return channel;
+    }
+
+    /// <summary>
+    /// Phase 2: Starts the ScriptHost (first worker) or sets up the channel
+    /// for dispatch (subsequent workers), then advertises capacity. Runs in
+    /// the background after the API returns 200.
+    /// </summary>
+    private async Task CompleteWorkerSetupAsync(string workerId, WorkerConnection worker, IConnectedWorkerChannel channel, CancellationToken cancellationToken)
+    {
+        // Start or update the ScriptHost based on whether this is the first worker.
+        // The first caller either starts or waits for the ScriptHost; concurrent
+        // callers block until startup completes, then call SetupChannel.
+        if (Interlocked.CompareExchange(ref _firstWorkerClaimed, 1, 0) == 0)
+        {
+            // First worker: start the ScriptHost. In external worker mode,
+            // WebJobsScriptHostService is not registered as an IHostedService,
+            // so the ScriptHost hasn't started yet. Now that a worker has delivered
+            // host.json and registered a channel, WaitForContent and WaitForChannelAsync
+            // will return immediately when the ScriptHost builds.
+            var tcs = _scriptHostStarted;
+            try
+            {
+                _logger.LogInformation("First worker connected. Starting ScriptHost.");
+                await _scriptHostManager.StartAsync(cancellationToken);
+                tcs.TrySetResult();
+            }
+            catch (Exception ex)
+            {
+                // Fault the current TCS so any concurrent waiters get the exception
+                // (they'll propagate it and the platform can retry those workers too).
+                // Replace the TCS BEFORE releasing the gate so the next winner sees
+                // a fresh TCS, not the faulted one.
+                tcs.TrySetException(ex);
+                _scriptHostStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                Interlocked.Exchange(ref _firstWorkerClaimed, 0);
+                throw;
+            }
+        }
+        else
+        {
+            // Wait for the first worker's StartAsync to complete before resolving the dispatcher.
+            await _scriptHostStarted.Task.WaitAsync(cancellationToken);
+
+            if (Utility.TryGetHostService(_scriptHostManager, out ConnectedWorkerInvocationDispatcher dispatcher))
+            {
+                dispatcher.SetupChannel(channel);
+                _logger.LogDebug("SetupChannel called for subsequent worker '{workerId}'.", workerId);
+            }
+        }
+
+        // [CS-TODO] Replace with value reported by the worker during the init
+        // handshake (expected as a "max_concurrency" capability on
+        // WorkerInitResponse, parsed via channel.GetCapabilityState(...) like
+        // "host_configuration_json" above). Until then, hard-code per the App
+        // Server contract.
+        const int workerSlotCapacity = 16;
+        _runtimeStateManager.OnWorkerCapacityAvailable(workerId, workerSlotCapacity);
+
+        worker.Info.State = WorkerConnectionState.Connected;
     }
 
     /// <inheritdoc/>
@@ -396,6 +430,14 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
     public WorkerConnectionInfo GetWorkerStatus(string workerId)
         => _workers.TryGetValue(workerId, out var worker) ? worker.Info : null;
 
+    /// <summary>
+    /// Waits for the full connect pipeline (Phase 1 + Phase 2) to complete for the
+    /// specified worker. Returns immediately if the worker is not tracked or has
+    /// already completed. Intended for test use only.
+    /// </summary>
+    internal Task WaitForWorkerConnectAsync(string workerId)
+        => _workers.TryGetValue(workerId, out var worker) ? worker.ConnectCompleted.Task : Task.CompletedTask;
+
     /// <inheritdoc/>
     public async Task DrainAndDisconnectAllAsync(CancellationToken cancellationToken)
     {
@@ -410,6 +452,7 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
         try
         {
             _stopping = true;
+            _shutdownCts.Cancel();
             workerIds = _workers.Keys.ToList();
         }
         finally
@@ -493,6 +536,7 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
 
         _workers.Clear();
         _lifecycleLock.Dispose();
+        _shutdownCts.Dispose();
     }
 
     /// <summary>
@@ -541,10 +585,18 @@ internal sealed class WorkerConnectionService : IHostedService, IWorkerConnectio
         public IOutboundGrpcClient Client { get; set; }
 
         /// <summary>
-        /// Gets a signal that indicates when <see cref="ConnectWorkerAsync"/> has
-        /// finished (success or failure).
-        /// <see cref="DisconnectWorkerAsync"/> awaits this before cleaning up to avoid
-        /// racing with an in-flight connection.
+        /// Gets a signal that completes when Phase 1 (gRPC connect + init handshake +
+        /// channel registration) has finished (success or failure). The outer
+        /// <c>ConnectWorkerAsync</c> awaits this so the API can return 200 after the
+        /// init handshake while Phase 2 continues in the background.
+        /// </summary>
+        public TaskCompletionSource InitCompleted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>
+        /// Gets a signal that completes when the full connect pipeline (Phase 1 +
+        /// Phase 2) has finished. The outer <c>DisconnectWorkerAsync</c> awaits this
+        /// before cleaning up to avoid racing with an in-flight connection or
+        /// background setup.
         /// </summary>
         public TaskCompletionSource ConnectCompleted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 

--- a/src/WebJobs.Script.WebHost/Controllers/WorkerController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/WorkerController.cs
@@ -2,8 +2,9 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies;
@@ -33,14 +34,14 @@ public sealed class WorkerController : Controller
     }
 
     /// <summary>
-    /// Links an external worker to this runtime. Initiates an outbound gRPC connection
-    /// to the worker proxy and returns immediately. The connection and handshake
-    /// complete in the background.
+    /// Links an external worker to this runtime. Establishes an outbound gRPC
+    /// connection to the worker proxy, performs the init handshake, and returns
+    /// only after the worker is fully linked.
     /// </summary>
     [HttpPut]
     [Route("admin/workers/{workerId}")]
     [Authorize(Policy = PolicyNames.AdminAuthLevel)]
-    public IActionResult LinkWorker([FromRoute] string workerId, [FromBody] ExternalWorkerInfo request)
+    public async Task<IActionResult> LinkWorker([FromRoute] string workerId, [FromBody] ExternalWorkerInfo request)
     {
         if (string.IsNullOrWhiteSpace(workerId))
         {
@@ -83,27 +84,26 @@ public sealed class WorkerController : Controller
             return Conflict($"Worker '{workerId}' is already linked.");
         }
 
-        // Build the response before starting async work. ConnectWorkerAsync sets
-        // _workerStates on a background thread, so reading it immediately after
-        // fire-and-forget would race and likely return null.
-        var info = new WorkerConnectionInfo
+        try
         {
-            WorkerId = workerId,
-            State = WorkerConnectionState.Connecting
-        };
-
-        // Fire-and-forget: kick off the connection in the background,
-        // matching the pattern used by HostController.Drain and InstanceController.Assign.
-        _ = _connectionManager.ConnectWorkerAsync(workerId, endpoint, CancellationToken.None)
-            .ContinueWith(
-                t =>
-                {
-                    if (t.IsFaulted)
-                    {
-                        _logger.LogError(t.Exception, "Worker '{workerId}' connection failed.", workerId);
-                    }
-                });
-
-        return Accepted(info);
+            await _connectionManager.ConnectWorkerAsync(workerId, endpoint, HttpContext.RequestAborted);
+            return Ok();
+        }
+        catch (InvalidOperationException ex)
+        {
+            var message = $"Worker '{workerId}' link rejected.";
+            _logger.LogWarning(ex, message);
+            return Conflict(message);
+        }
+        catch (OperationCanceledException) when (HttpContext.RequestAborted.IsCancellationRequested)
+        {
+            throw; // Let the framework handle client disconnection.
+        }
+        catch (Exception ex)
+        {
+            var message = $"Worker '{workerId}' connection failed.";
+            _logger.LogError(ex, message);
+            return StatusCode(StatusCodes.Status503ServiceUnavailable, message);
+        }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/SpecializationEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/SpecializationEndToEndTests.cs
@@ -245,7 +245,7 @@ public class SpecializationEndToEndTests : IAsyncLifetime, IDisposable, IClassFi
                     podKey = "test-key"
                 });
 
-            if (linkResponse.StatusCode == HttpStatusCode.Accepted)
+            if (linkResponse.StatusCode == HttpStatusCode.OK)
             {
                 break;
             }
@@ -255,7 +255,7 @@ public class SpecializationEndToEndTests : IAsyncLifetime, IDisposable, IClassFi
         }
 
         _output.WriteLine($"Link response: {linkResponse?.StatusCode}");
-        Assert.Equal(HttpStatusCode.Accepted, linkResponse?.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, linkResponse?.StatusCode);
 
         // 5. Wait for host to reach Running state.
         await TestHelpers.Await(

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAllocationApiTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAllocationApiTests.cs
@@ -75,7 +75,7 @@ public class WorkerAllocationApiTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task LinkWorker_Returns202_WithWorkerConnectionInfo()
+    public async Task LinkWorker_Returns200()
     {
         _mockConnectionManager
             .Setup(m => m.ConnectWorkerAsync(It.IsAny<string>(), It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
@@ -84,11 +84,7 @@ public class WorkerAllocationApiTests : IAsyncLifetime
         var request = new { workerId = "w_test1234", podName = "worker-pod-abc123", grpcEndpoint = "http://10.0.1.42:50051", podKey = "test-key" };
         var response = await SendAdminRequest(HttpMethod.Put, "admin/workers/w_test1234", request);
 
-        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
-
-        var body = JObject.Parse(await response.Content.ReadAsStringAsync());
-        Assert.Equal("w_test1234", body["workerId"]?.ToString());
-        Assert.Equal("Connecting", body["state"]?.ToString());
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAllocationEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAllocationEndToEndTests.cs
@@ -133,13 +133,11 @@ public class WorkerAllocationEndToEndTests : IAsyncLifetime, IDisposable
 
         string linkBody = await linkResponse.Content.ReadAsStringAsync();
         _output.WriteLine($"Link response: {linkResponse.StatusCode} — {linkBody}");
-        Assert.Equal(HttpStatusCode.Accepted, linkResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, linkResponse.StatusCode);
 
-        // 3. Wait until the host is running (worker connected and ScriptHost started).
+        // 3. Wait until the host is running (ScriptHost startup runs in background after link).
         await WaitForHostReadyAsync(masterKey, TimeSpan.FromMinutes(2));
         _output.WriteLine("Host is ready.");
-
-        // 4. Invoke a function through the mock worker.
         var invokeResponse = await _host.HttpClient.GetAsync("/api/HttpTrigger");
         string invokeBody = await invokeResponse.Content.ReadAsStringAsync();
         _output.WriteLine($"Invoke response: {invokeResponse.StatusCode} — {invokeBody}");
@@ -170,9 +168,9 @@ public class WorkerAllocationEndToEndTests : IAsyncLifetime, IDisposable
 
         var linkResponse = await SendAdminRequest(
             masterKey, HttpMethod.Put, $"admin/workers/{linkRequest.workerId}", linkRequest);
-        Assert.Equal(HttpStatusCode.Accepted, linkResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, linkResponse.StatusCode);
 
-        // 3. Wait for host ready.
+        // 3. Wait for host ready (ScriptHost startup runs in background after link).
         await WaitForHostReadyAsync(masterKey, TimeSpan.FromMinutes(2));
         _output.WriteLine("Host is ready.");
 

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAssignAndLinkEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAssignAndLinkEndToEndTests.cs
@@ -111,9 +111,9 @@ public class WorkerAssignAndLinkEndToEndTests : IAsyncLifetime, IDisposable
         _output.WriteLine("Step 2: Calling PUT /admin/workers/{workerId} on runtime.");
         string masterKey = await _host.GetMasterKeyAsync();
         var linkResponse = await CallWorkerLinkAsync(masterKey);
-        Assert.Equal(HttpStatusCode.Accepted, linkResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, linkResponse.StatusCode);
 
-        // 3. Wait for host to be running and invoke a function.
+        // 3. Wait for host to be running (ScriptHost startup runs in background after link).
         await WaitForHostReadyAsync(masterKey, TimeSpan.FromMinutes(2));
         await AssertHttpTriggerInvocationAsync();
     }
@@ -131,9 +131,10 @@ public class WorkerAssignAndLinkEndToEndTests : IAsyncLifetime, IDisposable
 
         // 1. Link first — runtime connects and sends WorkerInitRequest.
         //    The proxy blocks because specialization hasn't completed yet.
+        //    With synchronous linking, the link call blocks until the handshake
+        //    completes, so we start it concurrently and assign afterward.
         _output.WriteLine("Step 1: Calling PUT /admin/workers/{workerId} on runtime (before assign).");
-        var linkResponse = await CallWorkerLinkAsync(masterKey);
-        Assert.Equal(HttpStatusCode.Accepted, linkResponse.StatusCode);
+        var linkTask = CallWorkerLinkAsync(masterKey);
 
         // Give the runtime a moment to connect and send WorkerInitRequest to the proxy.
         await Task.Delay(2000);
@@ -144,7 +145,11 @@ public class WorkerAssignAndLinkEndToEndTests : IAsyncLifetime, IDisposable
         var assignResponse = await CallWorkerAssignAsync(proxyClient);
         Assert.Equal(HttpStatusCode.OK, assignResponse.StatusCode);
 
-        // 3. Wait for host to be running and invoke a function.
+        // 3. Wait for the link to complete (now unblocked by assign).
+        var linkResponse = await linkTask;
+        Assert.Equal(HttpStatusCode.OK, linkResponse.StatusCode);
+
+        // 4. Wait for host to be running (ScriptHost startup runs in background after link).
         await WaitForHostReadyAsync(masterKey, TimeSpan.FromMinutes(2));
         await AssertHttpTriggerInvocationAsync();
     }

--- a/test/WebJobs.Script.Tests/Workers/ExternalWorkers/WorkerConnectionServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ExternalWorkers/WorkerConnectionServiceTests.cs
@@ -95,6 +95,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
 
             await service.ConnectWorkerAsync("w_1", new Uri("http://localhost:50051"), CancellationToken.None);
 
+            // Wait for the full connect pipeline (Phase 1 + Phase 2) to complete.
+            await service.WaitForWorkerConnectAsync("w_1");
+
             var info = service.GetWorkerStatus("w_1");
             Assert.Equal(WorkerConnectionState.Connected, info.State);
             Assert.Equal(1, service.ActiveWorkerCount);
@@ -135,6 +138,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
 
             await service.ConnectWorkerAsync("w_1", new Uri("http://localhost:50051"), CancellationToken.None);
 
+            // ScriptHost startup runs in the background after the link returns.
+            await service.WaitForWorkerConnectAsync("w_1");
+
             _mockHostManager.Verify(m => m.StartAsync(It.IsAny<CancellationToken>()), Times.Once);
         }
 
@@ -159,16 +165,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
 
             var service = CreateService();
 
-            // First worker fails. Failed connects are removed from tracking so
-            // the platform can immediately retry the same workerId without an
-            // explicit DELETE; the failure surfaces only via the thrown exception.
-            await Assert.ThrowsAsync<InvalidOperationException>(
-                () => service.ConnectWorkerAsync("w_fail", new Uri("http://localhost:50051"), CancellationToken.None));
+            // First worker: Phase 1 (init handshake) succeeds so ConnectWorkerAsync
+            // returns without throwing. Phase 2 (ScriptHost startup) fails in the
+            // background and triggers full cleanup — the worker is removed from tracking.
+            await service.ConnectWorkerAsync("w_fail", new Uri("http://localhost:50051"), CancellationToken.None);
 
+            // Wait for the background Phase 2 to run, fail, and clean up.
+            await service.WaitForWorkerConnectAsync("w_fail");
+
+            // Worker is removed from tracking after Phase 2 failure (same as old behavior).
             Assert.Null(service.GetWorkerStatus("w_fail"));
 
             // Second worker succeeds — the recovery path reset _firstWorkerClaimed.
             await service.ConnectWorkerAsync("w_retry", new Uri("http://localhost:50052"), CancellationToken.None);
+
+            // Wait for the background Phase 2 to complete.
+            await service.WaitForWorkerConnectAsync("w_retry");
 
             var retryInfo = service.GetWorkerStatus("w_retry");
             Assert.Equal(WorkerConnectionState.Connected, retryInfo.State);
@@ -182,6 +194,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
             var service = CreateService();
 
             await service.ConnectWorkerAsync("w_dup", new Uri("http://localhost:50051"), CancellationToken.None);
+
+            // Wait for the full connect pipeline (Phase 1 + Phase 2) to complete.
+            await service.WaitForWorkerConnectAsync("w_dup");
 
             var originalInfo = service.GetWorkerStatus("w_dup");
             Assert.Equal(WorkerConnectionState.Connected, originalInfo.State);

--- a/test/WebJobs.Script.Tests/Workers/ExternalWorkers/WorkerControllerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ExternalWorkers/WorkerControllerTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Controllers;
@@ -27,10 +28,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
             _mockWebHostEnvironment = new Mock<IScriptWebHostEnvironment>();
             _mockWebHostEnvironment.Setup(e => e.InStandbyMode).Returns(false);
             _controller = new WorkerController(_mockConnectionManager.Object, _mockWebHostEnvironment.Object, NullLoggerFactory.Instance);
+            _controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            };
         }
 
         [Fact]
-        public void LinkWorker_ValidRequest_Returns202Accepted()
+        public async Task LinkWorker_ValidRequest_Returns200Ok()
         {
             var request = new ExternalWorkerInfo
             {
@@ -44,34 +49,31 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
                 .Setup(m => m.ConnectWorkerAsync(It.IsAny<string>(), It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            var result = _controller.LinkWorker("w_test1234", request);
+            var result = await _controller.LinkWorker("w_test1234", request);
 
-            var accepted = Assert.IsType<AcceptedResult>(result);
-            var info = Assert.IsType<WorkerConnectionInfo>(accepted.Value);
-            Assert.Equal("w_test1234", info.WorkerId);
-            Assert.Equal(WorkerConnectionState.Connecting, info.State);
+            Assert.IsType<OkResult>(result);
         }
 
         [Fact]
-        public void LinkWorker_NullRequest_Returns400()
+        public async Task LinkWorker_NullRequest_Returns400()
         {
-            var result = _controller.LinkWorker("w_test1234", null);
+            var result = await _controller.LinkWorker("w_test1234", null);
 
             Assert.IsType<BadRequestObjectResult>(result);
         }
 
         [Fact]
-        public void LinkWorker_MissingEndpoint_Returns400()
+        public async Task LinkWorker_MissingEndpoint_Returns400()
         {
             var request = new ExternalWorkerInfo { WorkerId = "w_test1234" };
 
-            var result = _controller.LinkWorker("w_test1234", request);
+            var result = await _controller.LinkWorker("w_test1234", request);
 
             Assert.IsType<BadRequestObjectResult>(result);
         }
 
         [Fact]
-        public void LinkWorker_InvalidEndpoint_Returns400()
+        public async Task LinkWorker_InvalidEndpoint_Returns400()
         {
             var request = new ExternalWorkerInfo
             {
@@ -79,7 +81,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
                 GrpcEndpoint = "not-a-valid-uri"
             };
 
-            var result = _controller.LinkWorker("w_test1234", request);
+            var result = await _controller.LinkWorker("w_test1234", request);
 
             Assert.IsType<BadRequestObjectResult>(result);
         }
@@ -88,21 +90,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
         [InlineData(null)]
         [InlineData("")]
         [InlineData("   ")]
-        public void LinkWorker_MissingRouteWorkerId_Returns400(string routeWorkerId)
+        public async Task LinkWorker_MissingRouteWorkerId_Returns400(string routeWorkerId)
         {
             var request = new ExternalWorkerInfo
             {
                 GrpcEndpoint = "http://10.0.1.42:50051"
             };
 
-            var result = _controller.LinkWorker(routeWorkerId, request);
+            var result = await _controller.LinkWorker(routeWorkerId, request);
 
             var badRequest = Assert.IsType<BadRequestObjectResult>(result);
             Assert.Contains("route", badRequest.Value.ToString(), StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
-        public void LinkWorker_BodyIdMismatchesRouteId_Returns400()
+        public async Task LinkWorker_BodyIdMismatchesRouteId_Returns400()
         {
             var request = new ExternalWorkerInfo
             {
@@ -110,14 +112,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
                 GrpcEndpoint = "http://10.0.1.42:50051"
             };
 
-            var result = _controller.LinkWorker("w_routeid1", request);
+            var result = await _controller.LinkWorker("w_routeid1", request);
 
             var badRequest = Assert.IsType<BadRequestObjectResult>(result);
             Assert.Contains("does not match", badRequest.Value.ToString());
         }
 
         [Fact]
-        public void LinkWorker_NullBodyWorkerId_UsesRouteId()
+        public async Task LinkWorker_NullBodyWorkerId_UsesRouteId()
         {
             var request = new ExternalWorkerInfo
             {
@@ -128,16 +130,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
                 .Setup(m => m.ConnectWorkerAsync("w_routeid1", It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.CompletedTask);
 
-            var result = _controller.LinkWorker("w_routeid1", request);
+            var result = await _controller.LinkWorker("w_routeid1", request);
 
-            var accepted = Assert.IsType<AcceptedResult>(result);
-            var info = Assert.IsType<WorkerConnectionInfo>(accepted.Value);
-            Assert.Equal("w_routeid1", info.WorkerId);
-            Assert.Equal(WorkerConnectionState.Connecting, info.State);
+            Assert.IsType<OkResult>(result);
         }
 
         [Fact]
-        public void LinkWorker_BeforeSpecialization_Returns400()
+        public async Task LinkWorker_BeforeSpecialization_Returns400()
         {
             _mockWebHostEnvironment.Setup(e => e.InStandbyMode).Returns(true);
 
@@ -147,14 +146,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
                 GrpcEndpoint = "http://10.0.1.42:50051"
             };
 
-            var result = _controller.LinkWorker("w_test1234", request);
+            var result = await _controller.LinkWorker("w_test1234", request);
 
             var badRequest = Assert.IsType<BadRequestObjectResult>(result);
             Assert.Contains("specialized", badRequest.Value.ToString());
         }
 
         [Fact]
-        public void LinkWorker_DuplicateWorkerId_Returns409Conflict()
+        public async Task LinkWorker_DuplicateWorkerId_Returns409Conflict()
         {
             _mockConnectionManager
                 .Setup(m => m.GetWorkerStatus("w_test1234"))
@@ -166,10 +165,49 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
                 GrpcEndpoint = "http://10.0.1.42:50051"
             };
 
-            var result = _controller.LinkWorker("w_test1234", request);
+            var result = await _controller.LinkWorker("w_test1234", request);
 
             var conflict = Assert.IsType<ConflictObjectResult>(result);
             Assert.Contains("already linked", conflict.Value.ToString());
+        }
+
+        [Fact]
+        public async Task LinkWorker_ConnectionFails_Returns503()
+        {
+            var request = new ExternalWorkerInfo
+            {
+                WorkerId = "w_test1234",
+                GrpcEndpoint = "http://10.0.1.42:50051"
+            };
+
+            _mockConnectionManager
+                .Setup(m => m.ConnectWorkerAsync(It.IsAny<string>(), It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("gRPC connection failed"));
+
+            var result = await _controller.LinkWorker("w_test1234", request);
+
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(StatusCodes.Status503ServiceUnavailable, objectResult.StatusCode);
+            Assert.Contains("connection failed", objectResult.Value.ToString());
+        }
+
+        [Fact]
+        public async Task LinkWorker_RuntimeStopping_Returns409()
+        {
+            var request = new ExternalWorkerInfo
+            {
+                WorkerId = "w_test1234",
+                GrpcEndpoint = "http://10.0.1.42:50051"
+            };
+
+            _mockConnectionManager
+                .Setup(m => m.ConnectWorkerAsync(It.IsAny<string>(), It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("Cannot connect new workers while the runtime is stopping."));
+
+            var result = await _controller.LinkWorker("w_test1234", request);
+
+            var conflict = Assert.IsType<ConflictObjectResult>(result);
+            Assert.Contains("link rejected", conflict.Value.ToString());
         }
     }
 }

--- a/tools/ComputeSeparation/compute-separation.http
+++ b/tools/ComputeSeparation/compute-separation.http
@@ -76,6 +76,9 @@ Content-Type: application/json
 ### an outbound gRPC connection to the worker proxy. The proxy replays cached
 ### StartStream, WorkerInitResponse (with host.json + capabilities), and
 ### FunctionMetadataResponse. This triggers ScriptHost startup and function loading.
+### Returns 200 OK after gRPC connection and init handshake succeed (capabilities
+### including host.json received). ScriptHost startup and function loading complete
+### in the background.
 PUT {{runtimeHost}}/admin/workers/w_test01?code={{masterKey}}
 Content-Type: application/json
 


### PR DESCRIPTION
## Make worker link API synchronous with Phase 1/Phase 2 split

Changes `PUT /admin/workers/{workerId}` from fire-and-forget (202 Accepted) to synchronous (200 OK), aligning with the platform-control-apis spec.

### Behavior

The API now returns **200 OK** after the gRPC connection and init handshake succeed (Phase 1). ScriptHost startup, function loading, and capacity advertisement continue in the background (Phase 2), matching the `IHostedService.StartAsync` pattern. HTTP requests arriving before Phase 2 completes buffer in `HostAvailabilityCheckMiddleware`.

**Phase 1 (synchronous — API blocks until complete):**
- gRPC transport connection
- `WorkerInitRequest` / `WorkerInitResponse` handshake (includes capabilities + `host.json`)
- Channel registration + drain signal subscription

**Phase 2 (background — after 200 returns):**
- ScriptHost startup (first worker) / `SetupChannel` (subsequent workers)
- `OnWorkerCapacityAvailable` (slot capacity advertisement)

### Error handling

- Validation failures → 400
- State conflicts (stopping, duplicate) → 409
- gRPC/handshake failures → 503
- Phase 2 failures → logged, full cleanup (same as pre-change behavior)
- Client disconnect → `OperationCanceledException` re-thrown to framework
- Shutdown → `_shutdownCts` cancels in-flight Phase 2 work

### Design notes

- `ConnectWorkerAsync` returns after Phase 1 via `InitCompleted` TCS; `ConnectCompleted` TCS signals after Phase 2, ensuring `DisconnectWorkerAsync` waits for the full pipeline before cleanup (no race)
- Error response bodies use log-style messages, not `ex.Message`
