### PR TITLE
[Compute Separation] Changes to WorkerProxy: inbound and outbound http ports

### DIFF
--- a/src/Functions.WorkerProxy/Dockerfile
+++ b/src/Functions.WorkerProxy/Dockerfile
@@ -10,5 +10,5 @@ RUN dotnet publish src/Functions.WorkerProxy/Functions.WorkerProxy.csproj \
 FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-noble-chiseled
 WORKDIR /app
 COPY --from=build /app/publish/Microsoft.Azure.Functions.WorkerProxy .
-EXPOSE 50051 50052 50053 50054
+EXPOSE 80 50051 50052 50053
 ENTRYPOINT ["./Microsoft.Azure.Functions.WorkerProxy"]

--- a/src/Functions.WorkerProxy/FunctionRpcRelay.cs
+++ b/src/Functions.WorkerProxy/FunctionRpcRelay.cs
@@ -75,7 +75,7 @@ internal sealed class FunctionRpcRelay : FunctionRpc.FunctionRpcBase
     // HTTP endpoint advertised by the worker in its WorkerInitResponse "HttpUri" capability.
     // Populated once per worker lifetime (during /assign); read by the HTTP forwarding
     // middleware to route invocations to the worker's dynamically-chosen port.
-    private volatile string? _workerHttpEndpoint;
+    internal volatile string? _workerHttpEndpoint;
 
     /// <summary>
     /// HTTP endpoint advertised by the worker via the <c>HttpUri</c> capability in
@@ -195,6 +195,13 @@ internal sealed class FunctionRpcRelay : FunctionRpc.FunctionRpcBase
             // Now that we know the function app directory, inject host.json and rewrite
             // the HttpUri capability so the runtime routes HTTP requests through this proxy.
             InjectHostJson(initResponse, functionAppDirectory);
+
+            // RewriteHttpUri MUST run AFTER the capability merge above. The merge produces
+            // the final, post-specialization capability set; rewriting before it would
+            // capture a stale or missing HttpUri (e.g. an init-only value that a Replace-
+            // strategy reload was supposed to drop). The
+            // SpecializeWorkerAsync_WorkerHttpEndpoint_* tests pin this ordering — if you
+            // reorder these calls and those tests still pass, the tests have rotted.
             RewriteHttpUri(initResponse);
 
             var capabilities = initResponse.WorkerInitResponse?.Capabilities;
@@ -375,8 +382,15 @@ internal sealed class FunctionRpcRelay : FunctionRpc.FunctionRpcBase
         }
         else
         {
+            // Defense-in-depth: explicitly clear any previously-captured value so the
+            // post-rewrite state always reflects the capabilities we just observed.
+            // Today there is only one call site (post-merge in SpecializeWorkerAsync),
+            // so _workerHttpEndpoint is null here in practice — but if anyone adds a
+            // pre-merge capture or re-enables re-specialization, this branch must not
+            // silently leave a stale destination in place.
+            _workerHttpEndpoint = null;
             _logger.LogWarning("Worker did not advertise an HttpUri capability in WorkerInitResponse. "
-                + "HTTP forwarding will rely on the --worker-http-endpoint override if provided.");
+                + "HTTP forwarding will require the --worker-http-endpoint override; otherwise requests will return 503.");
         }
 
         // Overwrite HttpUri with the proxy's endpoint so the runtime routes HTTP requests

--- a/src/Functions.WorkerProxy/FunctionRpcRelay.cs
+++ b/src/Functions.WorkerProxy/FunctionRpcRelay.cs
@@ -72,6 +72,17 @@ internal sealed class FunctionRpcRelay : FunctionRpc.FunctionRpcBase
     // TCS for correlating request/response pairs during /assign.
     internal TaskCompletionSource<StreamingMessage>? _pendingWorkerResponse;
 
+    // HTTP endpoint advertised by the worker in its WorkerInitResponse "HttpUri" capability.
+    // Populated once per worker lifetime (during /assign); read by the HTTP forwarding
+    // middleware to route invocations to the worker's dynamically-chosen port.
+    private volatile string? _workerHttpEndpoint;
+
+    /// <summary>
+    /// HTTP endpoint advertised by the worker via the <c>HttpUri</c> capability in
+    /// <c>WorkerInitResponse</c>. Null until the worker has completed init.
+    /// </summary>
+    public string? WorkerHttpEndpoint => _workerHttpEndpoint;
+
     // Guard against concurrent or repeated /assign calls.
     private int _specializationStarted;
 
@@ -353,9 +364,23 @@ internal sealed class FunctionRpcRelay : FunctionRpc.FunctionRpcBase
             return;
         }
 
-        // Always set HttpUri to the proxy's endpoint. The worker may or may not have
-        // reported its own HttpUri — in container mode it often doesn't because
-        // its HTTP listener address isn't known at init time.
+        // Capture the worker's advertised HttpUri (dynamically-chosen port reported by
+        // the isolated worker SDK's HttpUriProvider) before we overwrite it. This is what
+        // the HTTP forwarding middleware will use as the YARP destination for invocations.
+        if (message.WorkerInitResponse.Capabilities.TryGetValue("HttpUri", out var advertisedUri)
+            && !string.IsNullOrWhiteSpace(advertisedUri))
+        {
+            _workerHttpEndpoint = advertisedUri;
+            _logger.LogInformation("Captured worker HttpUri '{Uri}' for HTTP invocation forwarding.", advertisedUri);
+        }
+        else
+        {
+            _logger.LogWarning("Worker did not advertise an HttpUri capability in WorkerInitResponse. "
+                + "HTTP forwarding will rely on the --worker-http-endpoint override if provided.");
+        }
+
+        // Overwrite HttpUri with the proxy's endpoint so the runtime routes HTTP requests
+        // through this proxy (and we can then forward to the worker's real endpoint).
         message.WorkerInitResponse.Capabilities["HttpUri"] = _options.HttpProxyEndpoint;
         _logger.LogInformation("Set HttpUri capability to {Uri}.", _options.HttpProxyEndpoint);
     }

--- a/src/Functions.WorkerProxy/Program.cs
+++ b/src/Functions.WorkerProxy/Program.cs
@@ -15,10 +15,11 @@ int runtimeGrpcPort = GetIntArg(args, "--runtime-grpc-port", 50051);
 int workerGrpcPort = GetIntArg(args, "--worker-grpc-port", 50052);
 int httpProxyPort = GetIntArg(args, "--http-proxy-port", 50053);
 int managementPort = GetIntArg(args, "--management-port", 80);
-// Optional override for the worker's HTTP endpoint. When null, the proxy uses the
-// HttpUri advertised by the worker in its WorkerInitResponse capabilities (dynamic
-// port chosen by the .NET isolated worker SDK). Override is primarily for the
-// Aspire dev harness and tests where the worker's port is known ahead of time.
+// Explicit override for the worker's HTTP endpoint. When set (via CLI arg or env var),
+// this takes precedence over the HttpUri the worker advertises in its WorkerInitResponse
+// capabilities. When null, the proxy falls back to the worker-advertised HttpUri
+// (dynamic port chosen by the worker SDK). The override exists for the Aspire dev
+// harness, tests, and any deployment where the operator wants to pin the worker port.
 string? workerHttpEndpointOverride = GetStringArgOrNull(args, "--worker-http-endpoint");
 string? hostJsonPath = GetStringArgOrNull(args, "--host-json-path");
 string httpProxyEndpoint = GetStringArg(args, "--http-proxy-endpoint", $"http://localhost:{httpProxyPort}");
@@ -59,13 +60,18 @@ app.Use(async (ctx, next) =>
         var logger = ctx.RequestServices.GetRequiredService<ILogger<FunctionRpcRelay>>();
         var relayInstance = ctx.RequestServices.GetRequiredService<FunctionRpcRelay>();
 
-        // Prefer the HttpUri the worker advertised via gRPC WorkerInitResponse
-        // (dynamic port). Fall back to the CLI/env override when provided (dev harness).
-        string? destination = relayInstance.WorkerHttpEndpoint ?? workerHttpEndpointOverride;
-        if (string.IsNullOrWhiteSpace(destination))
+        // Resolve destination using the documented precedence:
+        //   1. --worker-http-endpoint override (CLI/env), if non-blank.
+        //   2. The HttpUri the worker advertised via gRPC WorkerInitResponse (dynamic port).
+        //   3. Null → 503.
+        // See WorkerHttpDestinationResolver for the full contract and tests.
+        string? destination = WorkerHttpDestinationResolver.Resolve(
+            workerHttpEndpointOverride,
+            relayInstance.WorkerHttpEndpoint);
+        if (destination is null)
         {
             logger.LogWarning("[HTTP Proxy] No worker HTTP endpoint available yet "
-                + "(worker has not reported HttpUri and no --worker-http-endpoint override). Returning 503.");
+                + "(no --worker-http-endpoint override and worker has not reported HttpUri). Returning 503.");
             ctx.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
             return;
         }

--- a/src/Functions.WorkerProxy/Program.cs
+++ b/src/Functions.WorkerProxy/Program.cs
@@ -14,8 +14,12 @@ builder.WebHost.UseUrls();
 int runtimeGrpcPort = GetIntArg(args, "--runtime-grpc-port", 50051);
 int workerGrpcPort = GetIntArg(args, "--worker-grpc-port", 50052);
 int httpProxyPort = GetIntArg(args, "--http-proxy-port", 50053);
-int managementPort = GetIntArg(args, "--management-port", 50054);
-string workerHttpEndpoint = GetStringArg(args, "--worker-http-endpoint", "http://localhost:8080");
+int managementPort = GetIntArg(args, "--management-port", 80);
+// Optional override for the worker's HTTP endpoint. When null, the proxy uses the
+// HttpUri advertised by the worker in its WorkerInitResponse capabilities (dynamic
+// port chosen by the .NET isolated worker SDK). Override is primarily for the
+// Aspire dev harness and tests where the worker's port is known ahead of time.
+string? workerHttpEndpointOverride = GetStringArgOrNull(args, "--worker-http-endpoint");
 string? hostJsonPath = GetStringArgOrNull(args, "--host-json-path");
 string httpProxyEndpoint = GetStringArg(args, "--http-proxy-endpoint", $"http://localhost:{httpProxyPort}");
 string podName = GetStringArg(args, "--pod-name",
@@ -53,9 +57,22 @@ app.Use(async (ctx, next) =>
     if (ctx.Connection.LocalPort == httpProxyPort)
     {
         var logger = ctx.RequestServices.GetRequiredService<ILogger<FunctionRpcRelay>>();
+        var relayInstance = ctx.RequestServices.GetRequiredService<FunctionRpcRelay>();
+
+        // Prefer the HttpUri the worker advertised via gRPC WorkerInitResponse
+        // (dynamic port). Fall back to the CLI/env override when provided (dev harness).
+        string? destination = relayInstance.WorkerHttpEndpoint ?? workerHttpEndpointOverride;
+        if (string.IsNullOrWhiteSpace(destination))
+        {
+            logger.LogWarning("[HTTP Proxy] No worker HTTP endpoint available yet "
+                + "(worker has not reported HttpUri and no --worker-http-endpoint override). Returning 503.");
+            ctx.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            return;
+        }
+
         logger.LogDebug("[HTTP Proxy] Received {Method} {Path} on port {Port}, forwarding to {Destination}",
-            ctx.Request.Method, ctx.Request.Path, httpProxyPort, workerHttpEndpoint);
-        await forwarder.SendAsync(ctx, workerHttpEndpoint, httpClient);
+            ctx.Request.Method, ctx.Request.Path, httpProxyPort, destination);
+        await forwarder.SendAsync(ctx, destination, httpClient);
         logger.LogDebug("[HTTP Proxy] Forwarded request completed with status {StatusCode}", ctx.Response.StatusCode);
         return;
     }

--- a/src/Functions.WorkerProxy/WorkerHttpDestinationResolver.cs
+++ b/src/Functions.WorkerProxy/WorkerHttpDestinationResolver.cs
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.Functions.WorkerProxy;
+
+/// <summary>
+/// Resolves the destination URI the HTTP forwarding middleware should target for an
+/// incoming worker request, applying the precedence contract:
+///
+/// <list type="number">
+///   <item>The explicit <c>--worker-http-endpoint</c> override (CLI arg or environment
+///   variable) wins when supplied. This exists for the Aspire dev harness, integration
+///   tests, and any deployment where the operator wants to pin the destination
+///   regardless of what the worker reports.</item>
+///   <item>Otherwise, the dynamic <c>HttpUri</c> the worker advertised in its
+///   <c>WorkerInitResponse</c> (or <c>FunctionEnvironmentReloadResponse</c>) capabilities
+///   is used. Real .NET-isolated, Python, and Node v4 workers all bind to a
+///   kernel-assigned loopback port at startup and advertise it this way.</item>
+///   <item>If neither is available — or both are blank — the resolver returns
+///   <see langword="null"/> and the middleware should respond with HTTP 503.</item>
+/// </list>
+///
+/// Whitespace-only values in either source are treated as "not provided" so that an
+/// empty environment variable does not silently shadow a valid worker-advertised URI.
+/// Returned values are trimmed so leading/trailing whitespace from env vars (a
+/// real-world hazard with Helm chart and docker-compose templating) does not feed
+/// YARP a malformed URI and surface as 500s instead of the intended 503.
+/// </summary>
+// CS-TODO: This static resolver covers the only two destination sources we have today
+// (explicit override and worker-advertised HttpUri). If/when a third source appears
+// (e.g., per-request routing, sidecar discovery, multi-worker fan-out), refactor into
+// a composable provider chain registered in DI so precedence is expressed by
+// registration order rather than hard-coded if/else here. Defer until there is a third
+// source — the interface shape (per-request HttpContext? startup-only string? both?)
+// will fall out naturally from what that third source needs, and pre-committing to one
+// here would lock in a guess.
+internal static class WorkerHttpDestinationResolver
+{
+    /// <summary>
+    /// Picks the destination URI according to the precedence rules described on the
+    /// type. Returns <see langword="null"/> when no usable destination is available.
+    /// </summary>
+    /// <param name="overrideEndpoint">The value of <c>--worker-http-endpoint</c>, or
+    /// <see langword="null"/> when no override was supplied.</param>
+    /// <param name="advertisedEndpoint">The HttpUri the worker advertised via gRPC, or
+    /// <see langword="null"/> when the worker has not (yet) reported one.</param>
+    public static string? Resolve(string? overrideEndpoint, string? advertisedEndpoint)
+    {
+        if (!string.IsNullOrWhiteSpace(overrideEndpoint))
+        {
+            return overrideEndpoint.Trim();
+        }
+
+        if (!string.IsNullOrWhiteSpace(advertisedEndpoint))
+        {
+            return advertisedEndpoint.Trim();
+        }
+
+        return null;
+    }
+}

--- a/test/Functions.WorkerProxy.Tests/FunctionRpcRelayTests.cs
+++ b/test/Functions.WorkerProxy.Tests/FunctionRpcRelayTests.cs
@@ -448,6 +448,183 @@ public class FunctionRpcRelayTests : IDisposable
         Assert.Equal("http://localhost:50053", cached["HttpUri"]);
     }
 
+    // --- WorkerHttpEndpoint capture tests ---
+    // These verify the dynamic port advertised by the worker via its WorkerInitResponse
+    // (or FunctionEnvironmentReloadResponse) "HttpUri" capability is correctly captured
+    // into FunctionRpcRelay.WorkerHttpEndpoint, which the HTTP forwarding middleware uses
+    // as the YARP destination. Real .NET-isolated, Python, and Node v4 workers all bind
+    // to a kernel-assigned loopback port at startup and advertise it here, so losing this
+    // value silently breaks HTTP invocation routing entirely.
+
+    [Fact]
+    public async Task SpecializeWorkerAsync_WorkerHttpEndpoint_CapturedFromInitResponse_MergeStrategy()
+    {
+        var relay = CreateRelay();
+        relay._workerConnected.TrySetResult();
+
+        var initCaps = new Dictionary<string, string>
+        {
+            ["HttpUri"] = "http://localhost:5001"
+        };
+
+        var workerTask = SimulateWorkerAsync(relay, initCapabilities: initCaps);
+        await Task.WhenAll(
+            relay.SpecializeWorkerAsync(new Dictionary<string, string>(), "/app", CancellationToken.None),
+            workerTask);
+
+        Assert.Equal("http://localhost:5001", relay.WorkerHttpEndpoint);
+    }
+
+    [Fact]
+    public async Task SpecializeWorkerAsync_WorkerHttpEndpoint_ReplaceStrategyWithoutHttpUri_DropsCapture()
+    {
+        // CapabilitiesUpdateStrategy.Replace means the reload-time set IS the new
+        // capability set — anything not in it is intentionally gone. If the worker
+        // advertised HttpUri at init time but omits it from a Replace reload, that's
+        // the worker explicitly signalling "I no longer expose an HTTP endpoint" (e.g.,
+        // a worker that dropped its in-process HTTP listener after specialization).
+        // The proxy must respect that and leave WorkerHttpEndpoint null so requests
+        // fall through to the override or 503, rather than continuing to route to a
+        // listener that no longer exists.
+        var relay = CreateRelay();
+        relay._workerConnected.TrySetResult();
+
+        var initCaps = new Dictionary<string, string>
+        {
+            ["HttpUri"] = "http://localhost:5001",
+            ["RawHttpBodyBytes"] = "true"
+        };
+
+        var reloadCaps = new Dictionary<string, string>
+        {
+            ["RpcHttpBodyOnly"] = "True"
+        };
+
+        var workerTask = SimulateWorkerAsync(relay,
+            initCapabilities: initCaps,
+            reloadCapabilities: reloadCaps,
+            reloadStrategy: FunctionEnvironmentReloadResponse.Types.CapabilitiesUpdateStrategy.Replace);
+
+        await Task.WhenAll(
+            relay.SpecializeWorkerAsync(new Dictionary<string, string>(), "/app", CancellationToken.None),
+            workerTask);
+
+        Assert.Null(relay.WorkerHttpEndpoint);
+    }
+
+    [Fact]
+    public async Task SpecializeWorkerAsync_WorkerHttpEndpoint_CapturedFromReloadCapabilities()
+    {
+        // Some workers (e.g., the Python HTTP v2 streaming path) advertise HttpUri
+        // only after specialization, in the FunctionEnvironmentReloadResponse rather
+        // than the initial WorkerInitResponse. The capture must work in that case too.
+        var relay = CreateRelay();
+        relay._workerConnected.TrySetResult();
+
+        var reloadCaps = new Dictionary<string, string>
+        {
+            ["HttpUri"] = "http://localhost:5002"
+        };
+
+        var workerTask = SimulateWorkerAsync(relay, reloadCapabilities: reloadCaps);
+        await Task.WhenAll(
+            relay.SpecializeWorkerAsync(new Dictionary<string, string>(), "/app", CancellationToken.None),
+            workerTask);
+
+        Assert.Equal("http://localhost:5002", relay.WorkerHttpEndpoint);
+    }
+
+    [Fact]
+    public async Task SpecializeWorkerAsync_WorkerHttpEndpoint_ReloadValueWinsOverInit()
+    {
+        // If the worker advertises HttpUri at both init and reload time, the reload
+        // value is more recent and therefore authoritative. This mirrors the merge
+        // semantics applied to every other capability.
+        var relay = CreateRelay();
+        relay._workerConnected.TrySetResult();
+
+        var initCaps = new Dictionary<string, string>
+        {
+            ["HttpUri"] = "http://localhost:5001"
+        };
+
+        var reloadCaps = new Dictionary<string, string>
+        {
+            ["HttpUri"] = "http://localhost:5099"
+        };
+
+        var workerTask = SimulateWorkerAsync(relay, initCapabilities: initCaps, reloadCapabilities: reloadCaps);
+        await Task.WhenAll(
+            relay.SpecializeWorkerAsync(new Dictionary<string, string>(), "/app", CancellationToken.None),
+            workerTask);
+
+        Assert.Equal("http://localhost:5099", relay.WorkerHttpEndpoint);
+    }
+
+    [Fact]
+    public async Task SpecializeWorkerAsync_WorkerHttpEndpoint_NullWhenWorkerNeverAdvertisesIt()
+    {
+        // Workers that don't support HttpUri at all (Java, PowerShell, Node v3, .NET
+        // isolated without the AspNetCore extension) should leave WorkerHttpEndpoint
+        // null. The middleware then falls back to the --worker-http-endpoint override
+        // or returns 503 if no override was provided.
+        var relay = CreateRelay();
+        relay._workerConnected.TrySetResult();
+
+        var workerTask = SimulateWorkerAsync(relay);
+        await Task.WhenAll(
+            relay.SpecializeWorkerAsync(new Dictionary<string, string>(), "/app", CancellationToken.None),
+            workerTask);
+
+        Assert.Null(relay.WorkerHttpEndpoint);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task SpecializeWorkerAsync_WorkerHttpEndpoint_NullWhenWorkerAdvertisesBlankValue(string blankValue)
+    {
+        // Defensive: a worker that advertises an empty/whitespace HttpUri is treated
+        // as if it advertised nothing, rather than producing a routing destination of
+        // "" that would later cause forwarder.SendAsync to throw.
+        var relay = CreateRelay();
+        relay._workerConnected.TrySetResult();
+
+        var initCaps = new Dictionary<string, string>
+        {
+            ["HttpUri"] = blankValue
+        };
+
+        var workerTask = SimulateWorkerAsync(relay, initCapabilities: initCaps);
+        await Task.WhenAll(
+            relay.SpecializeWorkerAsync(new Dictionary<string, string>(), "/app", CancellationToken.None),
+            workerTask);
+
+        Assert.Null(relay.WorkerHttpEndpoint);
+    }
+
+    [Fact]
+    public async Task SpecializeWorkerAsync_WorkerHttpEndpoint_RewriteWithoutHttpUri_ClearsPreviouslyCapturedValue()
+    {
+        // Defense-in-depth regression for the capture-clear contract: the rewrite path
+        // must reset _workerHttpEndpoint when the post-merge capabilities don't include
+        // HttpUri, even if a previous run had captured a value. Today there's only one
+        // call site so this can't happen via SpecializeWorkerAsync alone, but pre-seeding
+        // the field simulates the "second specialization" / "pre-merge capture added by
+        // a future refactor" scenarios. Without the explicit `_workerHttpEndpoint = null`
+        // in RewriteHttpUri's else branch, this test would silently retain "http://stale".
+        var relay = CreateRelay();
+        relay._workerConnected.TrySetResult();
+        relay._workerHttpEndpoint = "http://stale-from-previous-run:9999";
+
+        var workerTask = SimulateWorkerAsync(relay);
+        await Task.WhenAll(
+            relay.SpecializeWorkerAsync(new Dictionary<string, string>(), "/app", CancellationToken.None),
+            workerTask);
+
+        Assert.Null(relay.WorkerHttpEndpoint);
+    }
+
     // --- Env var forwarding tests ---
 
     [Fact]

--- a/test/Functions.WorkerProxy.Tests/WorkerHttpDestinationResolverTests.cs
+++ b/test/Functions.WorkerProxy.Tests/WorkerHttpDestinationResolverTests.cs
@@ -1,0 +1,129 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.WorkerProxy;
+using Xunit;
+
+namespace Microsoft.Azure.Functions.WorkerProxy.Tests;
+
+public class WorkerHttpDestinationResolverTests
+{
+    // The override (--worker-http-endpoint, CLI or env var) is the operator's explicit
+    // pin. When supplied it must win regardless of what the worker advertises — that's
+    // the whole point of the override (Aspire dev harness, integration tests pointing
+    // at a stub, deployments where the operator wants a fixed destination).
+    [Fact]
+    public void Resolve_OverrideAndAdvertisedBothSet_ReturnsOverride()
+    {
+        var result = WorkerHttpDestinationResolver.Resolve(
+            overrideEndpoint: "http://override:1234",
+            advertisedEndpoint: "http://localhost:5001");
+
+        Assert.Equal("http://override:1234", result);
+    }
+
+    [Fact]
+    public void Resolve_OnlyOverrideSet_ReturnsOverride()
+    {
+        var result = WorkerHttpDestinationResolver.Resolve(
+            overrideEndpoint: "http://override:1234",
+            advertisedEndpoint: null);
+
+        Assert.Equal("http://override:1234", result);
+    }
+
+    // The common production path: no override is supplied, so the worker-advertised
+    // dynamic port (captured from WorkerInitResponse / FunctionEnvironmentReloadResponse
+    // capabilities) is the destination.
+    [Fact]
+    public void Resolve_OnlyAdvertisedSet_ReturnsAdvertised()
+    {
+        var result = WorkerHttpDestinationResolver.Resolve(
+            overrideEndpoint: null,
+            advertisedEndpoint: "http://localhost:5001");
+
+        Assert.Equal("http://localhost:5001", result);
+    }
+
+    [Fact]
+    public void Resolve_NeitherSet_ReturnsNull()
+    {
+        var result = WorkerHttpDestinationResolver.Resolve(
+            overrideEndpoint: null,
+            advertisedEndpoint: null);
+
+        Assert.Null(result);
+    }
+
+    // Defensive: an environment variable that's been set to an empty/whitespace string
+    // (a real-world scenario in container orchestrators that always inject the variable
+    // even when empty) must NOT shadow a perfectly good worker-advertised URI. Treating
+    // a blank override as "no override supplied" lets the proxy fall through to the
+    // worker's dynamic port instead of 503ing.
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void Resolve_BlankOverride_FallsThroughToAdvertised(string blankOverride)
+    {
+        var result = WorkerHttpDestinationResolver.Resolve(
+            overrideEndpoint: blankOverride,
+            advertisedEndpoint: "http://localhost:5001");
+
+        Assert.Equal("http://localhost:5001", result);
+    }
+
+    // Defensive: a worker that advertised a blank HttpUri (or the field never being set)
+    // is treated as "no advertised destination" so we don't try to forward to "".
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Resolve_BlankAdvertised_NotUsed(string blankAdvertised)
+    {
+        var result = WorkerHttpDestinationResolver.Resolve(
+            overrideEndpoint: null,
+            advertisedEndpoint: blankAdvertised);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Resolve_BothBlank_ReturnsNull()
+    {
+        var result = WorkerHttpDestinationResolver.Resolve(
+            overrideEndpoint: "  ",
+            advertisedEndpoint: "");
+
+        Assert.Null(result);
+    }
+
+    // Whitespace-padded values from env-var templating (Helm, docker-compose, k8s
+    // ConfigMap) must be trimmed before being handed to YARP — otherwise the forwarder
+    // throws UriFormatException at request time and the operator sees 500s instead of
+    // either the 503 they'd get from a missing destination or the successful forwarding
+    // they intended.
+    [Theory]
+    [InlineData("  http://override:1234", "http://override:1234")]
+    [InlineData("http://override:1234  ", "http://override:1234")]
+    [InlineData("\thttp://override:1234\n", "http://override:1234")]
+    public void Resolve_PaddedOverride_IsTrimmed(string paddedOverride, string expected)
+    {
+        var result = WorkerHttpDestinationResolver.Resolve(
+            overrideEndpoint: paddedOverride,
+            advertisedEndpoint: null);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("  http://localhost:5001", "http://localhost:5001")]
+    [InlineData("http://localhost:5001\r\n", "http://localhost:5001")]
+    public void Resolve_PaddedAdvertised_IsTrimmed(string paddedAdvertised, string expected)
+    {
+        var result = WorkerHttpDestinationResolver.Resolve(
+            overrideEndpoint: null,
+            advertisedEndpoint: paddedAdvertised);
+
+        Assert.Equal(expected, result);
+    }
+}

--- a/tools/ComputeSeparation/MockWorker/Program.cs
+++ b/tools/ComputeSeparation/MockWorker/Program.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Net;
+using System.Net.Sockets;
 using Grpc.Core;
 using Grpc.Net.Client;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
@@ -10,13 +11,20 @@ const string WorkerId = "w_mock0001";
 const string FunctionName = "HttpTrigger";
 string functionId = Guid.NewGuid().ToString();
 
-// Start a simple HTTP server for HTTP proxying (the worker proxy forwards HTTP here).
-// Use "+" to listen on all interfaces (required for container networking).
-int httpPort = ResolveHttpPort(args);
+// Pick a free TCP port the same way the .NET isolated worker SDK's HttpUriProvider
+// does (see Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.Utilities):
+// bind a socket to loopback:0, read the kernel-assigned port, then release it before
+// the real listener binds. This mirrors how a production worker advertises HttpUri,
+// so the worker proxy exercises the same dynamic-port discovery path it will hit
+// in deployed scenarios. There is intentionally no override.
+int httpPort = GetUnusedTcpPort();
+
+// Listen on loopback only (localhost) — same as the isolated worker SDK in production.
+// Cross-container scenarios are not supported by this mock; use SampleIsolatedApp for those.
 var httpListener = new HttpListener();
-httpListener.Prefixes.Add($"http://+:{httpPort}/");
+httpListener.Prefixes.Add($"http://localhost:{httpPort}/");
 httpListener.Start();
-Console.WriteLine($"[MockWorker] HTTP server listening on http://+:{httpPort}/");
+Console.WriteLine($"[MockWorker] HTTP server listening on http://localhost:{httpPort}/");
 
 // Handle HTTP requests on a background task.
 _ = Task.Run(async () =>
@@ -265,18 +273,14 @@ static string ResolveGrpcEndpoint(string[] args)
     return "http://localhost:50052";
 }
 
-static int ResolveHttpPort(string[] args)
+// Mirrors Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.Utilities.GetUnusedTcpPort
+// from the .NET isolated worker SDK: bind a TCP socket to loopback with port 0, let the
+// kernel assign a free port, capture it via LocalEndPoint, then dispose the socket so the
+// real HttpListener can bind to that port. There is a brief TOCTOU window between dispose
+// and rebind, identical to the production code path.
+static int GetUnusedTcpPort()
 {
-    // 1. --http-port <port> from command-line args
-    for (int i = 0; i < args.Length - 1; i++)
-    {
-        if (string.Equals(args[i], "--http-port", StringComparison.OrdinalIgnoreCase)
-            && int.TryParse(args[i + 1], out int port))
-        {
-            return port;
-        }
-    }
-
-    // 2. Default — matches the worker proxy's default --worker-http-endpoint (http://localhost:8080)
-    return 8080;
+    using Socket tcpSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+    tcpSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+    return ((IPEndPoint)tcpSocket.LocalEndPoint!).Port;
 }


### PR DESCRIPTION
### Issue describing the changes in this PR
Changes the WorkerProxy component
- Changed the default management http port to 80 to align with platform and existing functions worker
- Language worker picks a port dynamically on startup to receive http function executions and communicates this over GRPC but WorkerProxy was using a configure port.  Updated WorkerProxy to use the port specified over GRPC.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)