### PR TITLE
[Compute Separation] token auth on workerproxy /admin apis

### DIFF
--- a/aspire.config.json
+++ b/aspire.config.json
@@ -1,0 +1,5 @@
+{
+  "appHost": {
+    "path": "tools/ComputeSeparation/AppHost/AppHost.csproj"
+  }
+}

--- a/src/Functions.WorkerProxy/Authentication/ContainerJwtAuth.cs
+++ b/src/Functions.WorkerProxy/Authentication/ContainerJwtAuth.cs
@@ -1,0 +1,207 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication.Shared;
+using Microsoft.Extensions.Primitives;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Microsoft.Azure.Functions.WorkerProxy.Authentication;
+
+/// <summary>
+/// JWT bearer authentication that mirrors the Functions runtime's
+/// <c>x-ms-site-token</c> scheme so calls into the worker proxy's admin
+/// endpoints can be authenticated with the same tokens NNA already mints
+/// for the runtime's <c>/admin/host/assign</c> call.
+///
+/// Tokens are signed with the container's encryption key
+/// (<c>CONTAINER_ENCRYPTION_KEY</c>, falling back to
+/// <c>WEBSITE_AUTH_ENCRYPTION_KEY</c>); the audience is the pod or container
+/// identity (the proxy never takes on the customer's site identity); and the
+/// issuer is one of the platform issuers (Antares App Service core or Legion
+/// core). The token may be presented either via the standard
+/// <c>Authorization: Bearer ...</c> header or via the <c>x-ms-site-token</c>
+/// header, identical to the runtime.
+///
+/// Behavior matches the runtime when no encryption key is configured: the
+/// signing-key list is empty, validation parameters have no
+/// <c>IssuerSigningKeys</c>, and every token is rejected (fail closed).
+/// </summary>
+internal static class ContainerJwtAuth
+{
+    public const string SiteTokenHeaderName = "x-ms-site-token";
+
+    // Mirrors src/WebJobs.Script/ScriptConstants.cs.
+    public const string AppServiceCoreUri = "https://appservice.core.azurewebsites.net";
+    public const string LegionCoreUri = "https://legion.core.azurewebsites.net";
+
+    // Mirrors src/WebJobs.Script/Environment/EnvironmentSettingNames.cs.
+    public const string ContainerEncryptionKey = "CONTAINER_ENCRYPTION_KEY";
+    public const string WebSiteAuthEncryptionKey = "WEBSITE_AUTH_ENCRYPTION_KEY";
+    public const string WebsitePodName = "WEBSITE_POD_NAME";
+    public const string ContainerName = "CONTAINER_NAME";
+
+    /// <summary>
+    /// Registers JWT bearer authentication and authorization services so that
+    /// endpoints can be protected with <c>RequireAuthorization()</c>.
+    /// Reads environment variables via <see cref="Environment.GetEnvironmentVariable(string)"/>.
+    /// </summary>
+    public static IServiceCollection AddContainerJwtAuth(this IServiceCollection services)
+        => services.AddContainerJwtAuth(Environment.GetEnvironmentVariable);
+
+    /// <summary>
+    /// Test-friendly overload that takes an explicit environment-variable
+    /// lookup so tests don't need to mutate process environment.
+    /// </summary>
+    public static IServiceCollection AddContainerJwtAuth(this IServiceCollection services, Func<string, string?> getEnv)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(getEnv);
+
+        services
+            .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(options => ConfigureJwtBearer(options, getEnv));
+
+        services.AddAuthorization();
+
+        return services;
+    }
+
+    internal static void ConfigureJwtBearer(JwtBearerOptions options, Func<string, string?> getEnv)
+    {
+        options.TokenValidationParameters = CreateTokenValidationParameters(getEnv);
+
+        options.Events = new JwtBearerEvents
+        {
+            OnMessageReceived = c =>
+            {
+                // The proxy mirrors the runtime: tokens may arrive on the standard
+                // Authorization header OR on x-ms-site-token. When the latter is
+                // present, it takes precedence (the runtime makes the same choice).
+                if (c.Request.Headers.TryGetValue(SiteTokenHeaderName, out StringValues values))
+                {
+                    c.Token = values.FirstOrDefault();
+                }
+
+                return Task.CompletedTask;
+            },
+            OnTokenValidated = c =>
+            {
+                // Add a single Admin claim so RequireAuthorization() succeeds.
+                // The proxy doesn't have multi-tier auth like the runtime; any
+                // valid platform-issued token is sufficient to call admin endpoints.
+                var identity = new ClaimsIdentity(
+                [
+                    new Claim(ClaimTypes.Role, "Admin")
+                ]);
+                c.Principal?.AddIdentity(identity);
+                c.Success();
+
+                return Task.CompletedTask;
+            },
+            OnAuthenticationFailed = c =>
+            {
+                var loggerFactory = c.HttpContext.RequestServices.GetService<ILoggerFactory>();
+                var logger = loggerFactory?.CreateLogger("Microsoft.Azure.Functions.WorkerProxy.Authentication");
+                if (logger is null)
+                {
+                    return Task.CompletedTask;
+                }
+
+                string message = c.Exception switch
+                {
+                    SecurityTokenInvalidIssuerException iex => $"Token issuer validation failed for issuer '{iex.InvalidIssuer}'.",
+                    SecurityTokenInvalidAudienceException iaex => $"Token audience validation failed for audience '{iaex.InvalidAudience}'.",
+                    SecurityTokenExpiredException => "Token validation failed: token expired.",
+                    SecurityTokenSignatureKeyNotFoundException => "Token validation failed: signing key not found.",
+                    _ => "Token validation failed."
+                };
+
+                logger.LogDebug(c.Exception, "{Message}", message);
+                return Task.CompletedTask;
+            }
+        };
+    }
+
+    internal static TokenValidationParameters CreateTokenValidationParameters(Func<string, string?> getEnv)
+    {
+        var keys = GetSigningKeys(getEnv);
+        var audiences = GetValidAudiences(getEnv);
+
+        // Match the runtime exactly when no key is configured: leave
+        // IssuerSigningKeys unset so every token fails validation.
+        if (keys.Length == 0)
+        {
+            // CodeQL [SM04555] this handler does not verify AAD tokens. It verifies tokens issued by the platform. 
+            // CodeQL [SM04554] this handler does not verify AAD tokens. It verifies tokens issued by the platform.
+            return new TokenValidationParameters();
+        }
+
+        // CodeQL [SM04555] this handler does not verify AAD tokens. It verifies tokens issued by the platform. 
+        // CodeQL [SM04554] this handler does not verify AAD tokens. It verifies tokens issued by the platform.
+        return new TokenValidationParameters
+        {
+            IssuerSigningKeys = keys,
+            ValidIssuers = [AppServiceCoreUri, LegionCoreUri],
+            ValidAudiences = audiences,
+            IssuerValidator = SiteTokenValidators.IssuerValidator,
+            AudienceValidator = SiteTokenValidators.AudienceValidator,
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+        };
+    }
+
+    internal static SymmetricSecurityKey[] GetSigningKeys(Func<string, string?> getEnv)
+    {
+        // Order matches runtime's SecretsUtility: CONTAINER_ENCRYPTION_KEY first,
+        // then WEBSITE_AUTH_ENCRYPTION_KEY. The runtime additionally falls back
+        // to Microsoft.Azure.Web.DataProtection's default key, but that path is
+        // host-only (not AOT-safe and not present in container scenarios where
+        // the proxy is the entry point).
+        var keys = new List<SymmetricSecurityKey>(capacity: 2);
+
+        TryAddKey(getEnv(ContainerEncryptionKey), keys);
+        TryAddKey(getEnv(WebSiteAuthEncryptionKey), keys);
+
+        return keys.ToArray();
+    }
+
+    internal static string[] GetValidAudiences(Func<string, string?> getEnv)
+    {
+        // The proxy is always pod/container-identity (it never specializes to
+        // a customer site), so the only valid audiences are the pod name
+        // (Flex Consumption) or the container name (Atlas / Legion v1).
+        var audiences = new List<string>(capacity: 2);
+
+        AddIfPresent(getEnv(WebsitePodName), audiences);
+        AddIfPresent(getEnv(ContainerName), audiences);
+
+        return audiences.ToArray();
+    }
+
+    private static void TryAddKey(string? rawKey, List<SymmetricSecurityKey> keys)
+    {
+        if (string.IsNullOrEmpty(rawKey))
+        {
+            return;
+        }
+
+        // Mirrors the runtime: if a configured encryption key is malformed,
+        // SiteTokenKeyParser.ToKeyBytes throws FormatException and startup
+        // fails loudly. The runtime's SecretsUtility.GetTokenIssuerSigningKeys
+        // does the same — no try/catch around .ToKeyBytes(). Silent
+        // fall-through would leave operators chasing 401s with no signal.
+        keys.Add(new SymmetricSecurityKey(SiteTokenKeyParser.ToKeyBytes(rawKey)));
+    }
+
+    private static void AddIfPresent(string? value, List<string> target)
+    {
+        if (!string.IsNullOrEmpty(value))
+        {
+            target.Add(value);
+        }
+    }
+}

--- a/src/Functions.WorkerProxy/Functions.WorkerProxy.csproj
+++ b/src/Functions.WorkerProxy/Functions.WorkerProxy.csproj
@@ -18,9 +18,29 @@
     <InternalsVisibleTo Include="Microsoft.Azure.Functions.WorkerProxy.Tests" />
   </ItemGroup>
 
+  <!--
+    Linked source: pull the parity-critical JWT helpers (key parser, OrdinalIgnoreCase
+    validators) from the runtime's own source tree so both assemblies validate
+    NNA-minted x-ms-site-tokens identically. The files live in
+    src/WebJobs.Script.WebHost so the runtime's own ScriptJwtBearerExtensions and
+    SecretsUtility consume them too — drift between the two implementations is
+    structurally impossible for the shared bits.
+
+    Files are listed explicitly (not globbed) so adding a new shared file is a
+    deliberate two-project change. The proxy publishes AOT; anything compiled
+    in here must be AOT-safe (no reflection, no dynamic codegen).
+  -->
+  <ItemGroup>
+    <Compile Include="..\WebJobs.Script.WebHost\Security\Authentication\Shared\SiteTokenKeyParser.cs"
+             LinkBase="Authentication\Shared" />
+    <Compile Include="..\WebJobs.Script.WebHost\Security\Authentication\Shared\SiteTokenValidators.cs"
+             LinkBase="Authentication\Shared" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.76.0" />
     <PackageReference Include="Grpc.Tools" Version="2.76.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
     <PackageReference Include="Yarp.ReverseProxy" Version="2.3.0" />
   </ItemGroup>
 

--- a/src/Functions.WorkerProxy/Program.cs
+++ b/src/Functions.WorkerProxy/Program.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Net;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Azure.Functions.WorkerProxy;
+using Microsoft.Azure.Functions.WorkerProxy.Authentication;
 using Yarp.ReverseProxy.Forwarder;
 
 var builder = WebApplication.CreateSlimBuilder(new WebApplicationOptions { Args = args });
@@ -21,13 +23,14 @@ string httpProxyEndpoint = GetStringArg(args, "--http-proxy-endpoint", $"http://
 string podName = GetStringArg(args, "--pod-name",
     Environment.GetEnvironmentVariable("COMPUTERNAME")
     ?? Environment.GetEnvironmentVariable("POD_NAME")
-    ?? System.Net.Dns.GetHostName());
+    ?? Dns.GetHostName());
 
 builder.Services.AddSingleton(new RelayOptions(runtimeGrpcPort, workerGrpcPort, httpProxyPort, hostJsonPath, httpProxyEndpoint, podName));
 builder.Services.AddSingleton<WorkerPodStateManager>();
 builder.Services.AddSingleton<FunctionRpcRelay>();
 builder.Services.AddGrpc();
 builder.Services.AddHttpForwarder();
+builder.Services.AddContainerJwtAuth();
 
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
@@ -63,23 +66,38 @@ app.Use(async (ctx, next) =>
     await next();
 });
 
+app.UseAuthentication();
+app.UseAuthorization();
+
 app.MapGrpcService<FunctionRpcRelay>();
 
 // ---------------------------------------------------------------------------
 // Management API endpoints (minimal APIs for AOT compatibility).
 // Called by NNA on the management port.
+//
+// /admin/worker/ready is anonymous — NNA polls it before specialization,
+// before any encryption key has been delivered, so it cannot present a
+// container-issued JWT. All other /admin endpoints require a valid
+// container-issued JWT (presented via either the standard Authorization:
+// Bearer header or the x-ms-site-token header), matching the runtime's
+// /admin/host/assign authentication.
 // ---------------------------------------------------------------------------
 
 var stateManager = app.Services.GetRequiredService<WorkerPodStateManager>();
 var relay = app.Services.GetRequiredService<FunctionRpcRelay>();
 
-app.MapGet("/admin/worker/ready", () => ManagementApiHandlers.HandleReady(stateManager));
+var admin = app.MapGroup("/admin");
+
+admin.MapGet("/worker/ready", () => ManagementApiHandlers.HandleReady(stateManager))
+    .AllowAnonymous();
+
+var adminAuthed = admin.MapGroup(string.Empty).RequireAuthorization();
 
 // Worker specialization. NNA calls this after /admin/worker/ready succeeds with the
 // app settings payload. The worker proxy drives the full init + specialization +
 // metadata prefetch sequence with the worker, caching all responses for later replay
 // to the runtime.
-app.MapPost("/admin/worker/assign", async (HttpContext ctx, CancellationToken cancellationToken) =>
+adminAuthed.MapPost("/worker/assign", async (HttpContext ctx, CancellationToken cancellationToken) =>
 {
     WorkerAssignRequest? assignRequest;
     try
@@ -94,7 +112,7 @@ app.MapPost("/admin/worker/assign", async (HttpContext ctx, CancellationToken ca
     return await ManagementApiHandlers.HandleAssignAsync(assignRequest, stateManager, relay, cancellationToken);
 });
 
-app.MapPost("/admin/worker/drain", async (HttpContext ctx, CancellationToken cancellationToken) =>
+adminAuthed.MapPost("/worker/drain", async (HttpContext ctx, CancellationToken cancellationToken) =>
 {
     WorkerDrainRequest? drainRequest;
     try
@@ -110,7 +128,7 @@ app.MapPost("/admin/worker/drain", async (HttpContext ctx, CancellationToken can
     return await ManagementApiHandlers.HandleDrainAsync(drainRequest, stateManager, relay, logger);
 });
 
-app.MapPost("/admin/infra/instanceState", async (HttpContext ctx, CancellationToken cancellationToken) =>
+adminAuthed.MapPost("/infra/instanceState", async (HttpContext ctx, CancellationToken cancellationToken) =>
 {
     int clientRevision = 0;
 

--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -16,6 +16,7 @@ using Microsoft.Azure.WebJobs.Script.Extensions;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication.Jwt;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication.Shared;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -148,8 +149,8 @@ namespace Microsoft.Extensions.DependencyInjection
             if (signingKeys.Length > 0)
             {
                 result.IssuerSigningKeys = signingKeys;
-                result.AudienceValidator = AudienceValidator;
-                result.IssuerValidator = IssuerValidator;
+                result.AudienceValidator = SiteTokenValidators.AudienceValidator;
+                result.IssuerValidator = SiteTokenValidators.IssuerValidator;
                 result.ValidAudiences = GetValidAudiences();
                 result.ValidIssuers =
                 [
@@ -161,32 +162,6 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             return result;
-        }
-
-        private static string IssuerValidator(string issuer, SecurityToken securityToken, TokenValidationParameters validationParameters)
-        {
-            if (!validationParameters.ValidIssuers.Any(p => string.Equals(issuer, p, StringComparison.OrdinalIgnoreCase)))
-            {
-                throw new SecurityTokenInvalidIssuerException("IDX10205: Issuer validation failed.")
-                {
-                    InvalidIssuer = issuer,
-                };
-            }
-
-            return issuer;
-        }
-
-        private static bool AudienceValidator(IEnumerable<string> audiences, SecurityToken securityToken, TokenValidationParameters validationParameters)
-        {
-            foreach (string audience in audiences)
-            {
-                if (validationParameters.ValidAudiences.Any(p => string.Equals(audience, p, StringComparison.OrdinalIgnoreCase)))
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         private static void LogAuthenticationFailure(AuthenticationFailedContext context)

--- a/src/WebJobs.Script.WebHost/Security/Authentication/Shared/SiteTokenKeyParser.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Shared/SiteTokenKeyParser.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication.Shared
+{
+    /// <summary>
+    /// Parses container/site encryption keys from their environment-variable form.
+    /// A 64-character string is interpreted as hex (32 bytes); anything else as
+    /// Base64. This file is shared (via linked source) between
+    /// <c>WebJobs.Script.WebHost</c> and <c>Functions.WorkerProxy</c> so both
+    /// projects decode identically.
+    /// </summary>
+    internal static class SiteTokenKeyParser
+    {
+        /// <summary>
+        /// Parses the key, throwing on malformed input.
+        /// </summary>
+        public static byte[] ToKeyBytes(string hexOrBase64)
+        {
+            if (hexOrBase64.Length == 64)
+            {
+                return ParseHex(hexOrBase64);
+            }
+
+            return Convert.FromBase64String(hexOrBase64);
+        }
+
+        private static byte[] ParseHex(string hex)
+        {
+            byte[] bytes = new byte[32];
+            for (int i = 0; i < 32; i++)
+            {
+                bytes[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+            }
+
+            return bytes;
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Security/Authentication/Shared/SiteTokenValidators.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Shared/SiteTokenValidators.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication.Shared
+{
+    /// <summary>
+    /// JWT issuer/audience validators that compare against
+    /// <see cref="TokenValidationParameters.ValidIssuers"/> /
+    /// <see cref="TokenValidationParameters.ValidAudiences"/> using
+    /// <see cref="StringComparison.OrdinalIgnoreCase"/>.
+    ///
+    /// Shared (via linked source) between <c>WebJobs.Script.WebHost</c> and
+    /// <c>Functions.WorkerProxy</c> so both projects accept the same
+    /// NNA-minted tokens regardless of casing differences.
+    /// </summary>
+    internal static class SiteTokenValidators
+    {
+        public static string IssuerValidator(string issuer, SecurityToken securityToken, TokenValidationParameters validationParameters)
+        {
+            if (validationParameters.ValidIssuers is null ||
+                !validationParameters.ValidIssuers.Any(p => string.Equals(issuer, p, StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new SecurityTokenInvalidIssuerException("IDX10205: Issuer validation failed.")
+                {
+                    InvalidIssuer = issuer,
+                };
+            }
+
+            return issuer;
+        }
+
+        public static bool AudienceValidator(IEnumerable<string> audiences, SecurityToken securityToken, TokenValidationParameters validationParameters)
+        {
+            if (audiences is null || validationParameters.ValidAudiences is null)
+            {
+                return false;
+            }
+
+            foreach (string audience in audiences)
+            {
+                if (validationParameters.ValidAudiences.Any(p => string.Equals(audience, p, StringComparison.OrdinalIgnoreCase)))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Security/SecretsUtility.cs
+++ b/src/WebJobs.Script.WebHost/Security/SecretsUtility.cs
@@ -3,9 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using Microsoft.Azure.Web.DataProtection;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication.Shared;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost
@@ -73,16 +73,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         public static byte[] ToKeyBytes(this string hexOrBase64)
         {
-            // only support 32 bytes (256 bits) key length
-            if (hexOrBase64.Length == 64)
-            {
-                return Enumerable.Range(0, hexOrBase64.Length)
-                    .Where(x => x % 2 == 0)
-                    .Select(x => Convert.ToByte(hexOrBase64.Substring(x, 2), 16))
-                    .ToArray();
-            }
-
-            return Convert.FromBase64String(hexOrBase64);
+            // Shared with Functions.WorkerProxy via linked source so both
+            // assemblies decode encryption keys identically.
+            return SiteTokenKeyParser.ToKeyBytes(hexOrBase64);
         }
 
         public static SymmetricSecurityKey[] GetTokenIssuerSigningKeys()

--- a/test/Functions.WorkerProxy.Tests/ContainerJwtAuthTests.cs
+++ b/test/Functions.WorkerProxy.Tests/ContainerJwtAuthTests.cs
@@ -1,0 +1,372 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Azure.Functions.WorkerProxy.Authentication;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication.Shared;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Microsoft.Azure.Functions.WorkerProxy.Tests;
+
+public class ContainerJwtAuthTests
+{
+    private const string TestPodName = "test-pod-12345";
+    private const string TestContainerName = "test-container-67890";
+
+    // 32 random bytes, base64-encoded — same shape as a real container key.
+    private const string TestKeyBase64 = "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=";
+
+    private static readonly byte[] TestKeyBytes = Convert.FromBase64String(TestKeyBase64);
+
+    // --- Helper ---
+
+    private static Func<string, string?> EnvWith(string? containerKey, string? podName, string? containerName = null, string? siteAuthKey = null)
+    {
+        return name => name switch
+        {
+            ContainerJwtAuth.ContainerEncryptionKey => containerKey,
+            ContainerJwtAuth.WebSiteAuthEncryptionKey => siteAuthKey,
+            ContainerJwtAuth.WebsitePodName => podName,
+            ContainerJwtAuth.ContainerName => containerName,
+            _ => null
+        };
+    }
+
+    private static string CreateToken(string audience, string issuer, byte[]? signingKey = null, DateTime? expires = null)
+    {
+        var key = new SymmetricSecurityKey(signingKey ?? TestKeyBytes);
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var handler = new JsonWebTokenHandler();
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = issuer,
+            Audience = audience,
+            Expires = expires ?? DateTime.UtcNow.AddMinutes(10),
+            SigningCredentials = creds,
+            Subject = new ClaimsIdentity([new Claim("sub", "test-subject")])
+        };
+        return handler.CreateToken(descriptor);
+    }
+
+    // --- GetSigningKeys ---
+
+    [Fact]
+    public void GetSigningKeys_NoEnvKeys_ReturnsEmpty()
+    {
+        var keys = ContainerJwtAuth.GetSigningKeys(EnvWith(null, TestPodName));
+        Assert.Empty(keys);
+    }
+
+    [Fact]
+    public void GetSigningKeys_ContainerEncryptionKeyBase64_AddsKey()
+    {
+        var keys = ContainerJwtAuth.GetSigningKeys(EnvWith(TestKeyBase64, TestPodName));
+        var key = Assert.Single(keys);
+        Assert.Equal(TestKeyBytes, key.Key);
+    }
+
+    [Fact]
+    public void GetSigningKeys_ContainerEncryptionKeyHex_AddsKey()
+    {
+        // 64-char hex form — alternative encoding accepted by the runtime.
+        string hex = Convert.ToHexString(TestKeyBytes);
+        Assert.Equal(64, hex.Length);
+        var keys = ContainerJwtAuth.GetSigningKeys(EnvWith(hex, TestPodName));
+        var key = Assert.Single(keys);
+        Assert.Equal(TestKeyBytes, key.Key);
+    }
+
+    [Fact]
+    public void GetSigningKeys_BothKeys_AddsBoth()
+    {
+        // Two different valid keys → both registered as candidate signing keys.
+        var second = Convert.ToBase64String(new byte[32]);
+        var keys = ContainerJwtAuth.GetSigningKeys(EnvWith(TestKeyBase64, TestPodName, siteAuthKey: second));
+        Assert.Equal(2, keys.Length);
+    }
+
+    [Fact]
+    public void GetSigningKeys_MalformedKey_Throws()
+    {
+        // Not valid base64 and not 64-char hex → FormatException bubbles out
+        // of the parser. Mirrors runtime: SecretsUtility.GetTokenIssuerSigningKeys
+        // does not catch, so a misconfigured CONTAINER_ENCRYPTION_KEY fails
+        // startup loudly instead of silently rejecting every admin call.
+        Assert.Throws<FormatException>(() => ContainerJwtAuth.GetSigningKeys(EnvWith("not-a-real-key", TestPodName)));
+    }
+
+    // --- GetValidAudiences ---
+
+    [Fact]
+    public void GetValidAudiences_PodName_Included()
+    {
+        var audiences = ContainerJwtAuth.GetValidAudiences(EnvWith(TestKeyBase64, TestPodName));
+        Assert.Contains(TestPodName, audiences);
+    }
+
+    [Fact]
+    public void GetValidAudiences_ContainerName_Included()
+    {
+        var audiences = ContainerJwtAuth.GetValidAudiences(EnvWith(TestKeyBase64, podName: null, containerName: TestContainerName));
+        Assert.Contains(TestContainerName, audiences);
+    }
+
+    [Fact]
+    public void GetValidAudiences_NeitherSet_Empty()
+    {
+        var audiences = ContainerJwtAuth.GetValidAudiences(EnvWith(TestKeyBase64, podName: null, containerName: null));
+        Assert.Empty(audiences);
+    }
+
+    // --- CreateTokenValidationParameters ---
+
+    [Fact]
+    public void CreateValidationParameters_NoKey_LeavesIssuerSigningKeysNull()
+    {
+        // Mirrors the runtime: with no key, the validation parameters carry no
+        // signing keys, so every token presented at runtime fails validation.
+        var p = ContainerJwtAuth.CreateTokenValidationParameters(EnvWith(null, TestPodName));
+        Assert.Null(p.IssuerSigningKeys);
+    }
+
+    [Fact]
+    public void CreateValidationParameters_WithKey_PopulatesAllFields()
+    {
+        var p = ContainerJwtAuth.CreateTokenValidationParameters(EnvWith(TestKeyBase64, TestPodName));
+        Assert.NotNull(p.IssuerSigningKeys);
+        Assert.Single(p.IssuerSigningKeys);
+        Assert.Contains(ContainerJwtAuth.AppServiceCoreUri, p.ValidIssuers);
+        Assert.Contains(ContainerJwtAuth.LegionCoreUri, p.ValidIssuers);
+        Assert.Contains(TestPodName, p.ValidAudiences);
+    }
+
+    // --- End-to-end through the JwtBearer middleware ---
+
+    private static async Task<TestServer> CreateServerAsync(Func<string, string?> getEnv)
+    {
+        var builder = new HostBuilder().ConfigureWebHost(web =>
+        {
+            web.UseTestServer();
+            web.ConfigureServices(s =>
+            {
+                s.AddRouting();
+                s.AddContainerJwtAuth(getEnv);
+            });
+            web.Configure(app =>
+            {
+                app.UseRouting();
+                app.UseAuthentication();
+                app.UseAuthorization();
+                app.UseEndpoints(e =>
+                {
+                    var admin = e.MapGroup("/admin");
+                    admin.MapGet("/worker/ready", () => Results.Ok()).AllowAnonymous();
+
+                    var adminAuthed = admin.MapGroup(string.Empty).RequireAuthorization();
+                    adminAuthed.MapPost("/worker/assign", () => Results.Ok());
+                    adminAuthed.MapPost("/worker/drain", () => Results.Ok());
+                    adminAuthed.MapPost("/infra/instanceState", () => Results.Ok());
+                });
+            });
+        });
+
+        var host = await builder.StartAsync();
+        return host.GetTestServer();
+    }
+
+    private static HttpRequestMessage Get(string path, string? bearer = null, string? siteToken = null)
+        => BuildRequest(HttpMethod.Get, path, bearer, siteToken);
+
+    private static HttpRequestMessage Post(string path, string? bearer = null, string? siteToken = null)
+        => BuildRequest(HttpMethod.Post, path, bearer, siteToken);
+
+    private static HttpRequestMessage BuildRequest(HttpMethod method, string path, string? bearer = null, string? siteToken = null)
+    {
+        var req = new HttpRequestMessage(method, path);
+        if (bearer is not null)
+        {
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearer);
+        }
+
+        if (siteToken is not null)
+        {
+            req.Headers.Add(ContainerJwtAuth.SiteTokenHeaderName, siteToken);
+        }
+
+        return req;
+    }
+
+    [Fact]
+    public async Task ReadyEndpoint_Anonymous_Returns200()
+    {
+        // /admin/worker/ready is anonymous: NNA polls it before specialization,
+        // before any encryption key has been delivered, so it cannot present a
+        // container-issued JWT.
+        using var server = await CreateServerAsync(EnvWith(TestKeyBase64, TestPodName));
+        var resp = await server.CreateClient().SendAsync(Get("/admin/worker/ready"));
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GuardedEndpoint_NoToken_Returns401()
+    {
+        using var server = await CreateServerAsync(EnvWith(TestKeyBase64, TestPodName));
+        var resp = await server.CreateClient().SendAsync(Post("/admin/worker/assign"));
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Endpoint_ValidBearerToken_Returns200()
+    {
+        using var server = await CreateServerAsync(EnvWith(TestKeyBase64, TestPodName));
+        var token = CreateToken(audience: TestPodName, issuer: ContainerJwtAuth.LegionCoreUri);
+        var resp = await server.CreateClient().SendAsync(Post("/admin/worker/assign", bearer: token));
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Endpoint_ValidSiteTokenHeader_Returns200()
+    {
+        using var server = await CreateServerAsync(EnvWith(TestKeyBase64, TestPodName));
+        var token = CreateToken(audience: TestPodName, issuer: ContainerJwtAuth.LegionCoreUri);
+        var resp = await server.CreateClient().SendAsync(Post("/admin/worker/assign", siteToken: token));
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Endpoint_AppServiceCoreIssuer_Returns200()
+    {
+        using var server = await CreateServerAsync(EnvWith(TestKeyBase64, TestPodName));
+        var token = CreateToken(audience: TestPodName, issuer: ContainerJwtAuth.AppServiceCoreUri);
+        var resp = await server.CreateClient().SendAsync(Post("/admin/worker/assign", bearer: token));
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Endpoint_AudienceFromContainerName_Returns200()
+    {
+        using var server = await CreateServerAsync(EnvWith(TestKeyBase64, podName: null, containerName: TestContainerName));
+        var token = CreateToken(audience: TestContainerName, issuer: ContainerJwtAuth.LegionCoreUri);
+        var resp = await server.CreateClient().SendAsync(Post("/admin/worker/assign", bearer: token));
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Endpoint_WrongSigningKey_Returns401()
+    {
+        using var server = await CreateServerAsync(EnvWith(TestKeyBase64, TestPodName));
+        var wrongKey = new byte[32];
+        wrongKey[0] = 0xFF;
+        var token = CreateToken(audience: TestPodName, issuer: ContainerJwtAuth.LegionCoreUri, signingKey: wrongKey);
+        var resp = await server.CreateClient().SendAsync(Post("/admin/worker/assign", bearer: token));
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Endpoint_WrongIssuer_Returns401()
+    {
+        using var server = await CreateServerAsync(EnvWith(TestKeyBase64, TestPodName));
+        var token = CreateToken(audience: TestPodName, issuer: "https://attacker.example.com");
+        var resp = await server.CreateClient().SendAsync(Post("/admin/worker/assign", bearer: token));
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Endpoint_WrongAudience_Returns401()
+    {
+        using var server = await CreateServerAsync(EnvWith(TestKeyBase64, TestPodName));
+        var token = CreateToken(audience: "some-other-pod", issuer: ContainerJwtAuth.LegionCoreUri);
+        var resp = await server.CreateClient().SendAsync(Post("/admin/worker/assign", bearer: token));
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Endpoint_ExpiredToken_Returns401()
+    {
+        using var server = await CreateServerAsync(EnvWith(TestKeyBase64, TestPodName));
+        var token = CreateToken(audience: TestPodName, issuer: ContainerJwtAuth.LegionCoreUri, expires: DateTime.UtcNow.AddMinutes(-10));
+        var resp = await server.CreateClient().SendAsync(Post("/admin/worker/assign", bearer: token));
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Endpoint_NoEncryptionKeyConfigured_AllTokensRejected()
+    {
+        // Fail-closed parity with the runtime: when no key is configured,
+        // even a token signed with what we *think* is the right key is
+        // rejected because the validation parameters carry no signing keys.
+        using var server = await CreateServerAsync(EnvWith(null, TestPodName));
+        var token = CreateToken(audience: TestPodName, issuer: ContainerJwtAuth.LegionCoreUri);
+        var resp = await server.CreateClient().SendAsync(Post("/admin/worker/assign", bearer: token));
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("/admin/worker/assign", "POST")]
+    [InlineData("/admin/worker/drain", "POST")]
+    [InlineData("/admin/infra/instanceState", "POST")]
+    public async Task GuardedAdminEndpoints_RequireAuth(string path, string method)
+    {
+        // Regression: every guarded admin endpoint inherits auth via the nested
+        // MapGroup. Asserts that an unauthenticated request to each one returns
+        // 401, not 200. /admin/worker/ready is intentionally NOT in this list —
+        // it is anonymous (covered by ReadyEndpoint_Anonymous_Returns200).
+        using var server = await CreateServerAsync(EnvWith(TestKeyBase64, TestPodName));
+        var req = new HttpRequestMessage(new HttpMethod(method), path);
+        var resp = await server.CreateClient().SendAsync(req);
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task SiteTokenHeader_TakesPrecedenceOverAuthorizationHeader()
+    {
+        // Matches runtime behavior: when both headers are present, x-ms-site-token wins.
+        using var server = await CreateServerAsync(EnvWith(TestKeyBase64, TestPodName));
+        var validToken = CreateToken(audience: TestPodName, issuer: ContainerJwtAuth.LegionCoreUri);
+        var bogusBearer = "this.is.not-a-valid-jwt";
+
+        var resp = await server.CreateClient().SendAsync(Post("/admin/worker/assign", bearer: bogusBearer, siteToken: validToken));
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    // --- Parity with runtime: case-insensitive issuer / audience ---
+
+    [Fact]
+    public async Task Endpoint_IssuerCasingDiffers_IsAccepted()
+    {
+        using var server = await CreateServerAsync(EnvWith(TestKeyBase64, TestPodName));
+        var token = CreateToken(TestPodName, "https://Legion.Core.AzureWebsites.NET");
+        var resp = await server.CreateClient().SendAsync(Post("/admin/worker/assign", bearer: token));
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Endpoint_AudienceCasingDiffers_IsAccepted()
+    {
+        using var server = await CreateServerAsync(EnvWith(TestKeyBase64, TestPodName));
+        var token = CreateToken(TestPodName.ToUpperInvariant(), ContainerJwtAuth.LegionCoreUri);
+        var resp = await server.CreateClient().SendAsync(Post("/admin/worker/assign", bearer: token));
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public void KeyParser_ToKeyBytes_MalformedHex_Throws()
+    {
+        // 64 chars but not valid hex (contains 'Z'). Both the runtime and the
+        // proxy let the FormatException bubble so a misconfigured encryption
+        // key fails loudly at startup rather than silently dropping the key
+        // and 401-ing every admin request with no diagnostic.
+        const string MalformedHex = "ZZ75CA46E7EBDD39E4CA6B074D1F9A5972B849A55F91A248F6B038A61BACE9D7";
+        Assert.Throws<FormatException>(() => SiteTokenKeyParser.ToKeyBytes(MalformedHex));
+    }
+}

--- a/test/Functions.WorkerProxy.Tests/Functions.WorkerProxy.Tests.csproj
+++ b/test/Functions.WorkerProxy.Tests/Functions.WorkerProxy.Tests.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/ComputeSeparationTestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/ComputeSeparationTestHelpers.cs
@@ -6,9 +6,11 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.IdentityModel.Tokens;
 using Xunit.Abstractions;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ComputeSeparation;
@@ -19,6 +21,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ComputeSeparation;
 /// </summary>
 internal static class ComputeSeparationTestHelpers
 {
+    private const string WorkerProxyAudience = "worker-proxy-compute-separation";
+    private static readonly byte[] WorkerProxySigningKeyBytes = TestHelpers.GenerateKeyBytes();
+    private static readonly string WorkerProxySigningKey = Convert.ToBase64String(WorkerProxySigningKeyBytes);
+
     public static string FindRepoRoot()
     {
         string dir = Path.GetDirectoryName(typeof(ComputeSeparationTestHelpers).Assembly.Location);
@@ -147,6 +153,24 @@ internal static class ComputeSeparationTestHelpers
         return process;
     }
 
+    public static IDictionary<string, string> GetWorkerProxyAuthEnvironment()
+        => new Dictionary<string, string>
+        {
+            [EnvironmentSettingNames.ContainerEncryptionKey] = WorkerProxySigningKey,
+            [EnvironmentSettingNames.WebsitePodName] = WorkerProxyAudience
+        };
+
+    public static HttpClient CreateAuthenticatedWorkerProxyClient(int managementPort)
+    {
+        var client = new HttpClient
+        {
+            BaseAddress = new Uri($"http://localhost:{managementPort}")
+        };
+
+        client.DefaultRequestHeaders.Add(ScriptConstants.SiteTokenHeaderName, CreateWorkerProxySiteToken());
+        return client;
+    }
+
     public static void EnsureProcessRunning(Process process, string label, ConcurrentBag<string> logSink)
     {
         if (process.HasExited)
@@ -228,5 +252,22 @@ internal static class ComputeSeparationTestHelpers
         }
 
         throw new TimeoutException($"Worker proxy did not become ready within {timeout.Value.TotalSeconds}s.");
+    }
+
+    private static string CreateWorkerProxySiteToken()
+    {
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var tokenDescriptor = new SecurityTokenDescriptor
+        {
+            Audience = WorkerProxyAudience,
+            Issuer = ScriptConstants.LegionCoreUri,
+            Expires = DateTime.UtcNow.AddHours(1),
+            SigningCredentials = new SigningCredentials(
+                new SymmetricSecurityKey(WorkerProxySigningKeyBytes),
+                SecurityAlgorithms.HmacSha256Signature)
+        };
+
+        var token = tokenHandler.CreateToken(tokenDescriptor);
+        return tokenHandler.WriteToken(token);
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/ExternalWorkerEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/ExternalWorkerEndToEndTests.cs
@@ -67,7 +67,8 @@ public class ExternalWorkerEndToEndTests : IAsyncLifetime, IDisposable
             "dotnet",
             $"\"{workerProxyDll}\" --runtime-grpc-port {RuntimeGrpcPort} --worker-grpc-port {WorkerGrpcPort} --http-proxy-port {HttpProxyPort} --management-port {ManagementPort}",
             _workerProxyLogs,
-            "WorkerProxy");
+            "WorkerProxy",
+            environmentVariables: ComputeSeparationTestHelpers.GetWorkerProxyAuthEnvironment());
 
         await Task.Delay(3000);
         ComputeSeparationTestHelpers.EnsureProcessRunning(_workerProxyProcess, "WorkerProxy", _workerProxyLogs);
@@ -87,7 +88,7 @@ public class ExternalWorkerEndToEndTests : IAsyncLifetime, IDisposable
 
         // 2b. Assign the worker — drives init + specialize + metadata prefetch
         //     so cached responses are ready when the runtime connects.
-        using var proxyClient = new HttpClient { BaseAddress = new Uri($"http://localhost:{ManagementPort}") };
+        using var proxyClient = ComputeSeparationTestHelpers.CreateAuthenticatedWorkerProxyClient(ManagementPort);
         var assignResponse = await proxyClient.PostAsync("/admin/worker/assign",
             new StringContent(
                 JsonConvert.SerializeObject(new { environment = new { FUNCTIONS_WORKER_RUNTIME = "node" }, functionAppDirectory = "/home/site/wwwroot" }),

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/SpecializationEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/SpecializationEndToEndTests.cs
@@ -87,7 +87,8 @@ public class SpecializationEndToEndTests : IAsyncLifetime, IDisposable, IClassFi
         _workerProxyProcess = ComputeSeparationTestHelpers.StartManagedProcess(
             _output, "dotnet",
             $"\"{workerProxyDll}\" --runtime-grpc-port {RuntimeGrpcPort} --worker-grpc-port {WorkerGrpcPort} --http-proxy-port {HttpProxyPort} --management-port {ManagementPort}",
-            new(), "WorkerProxy");
+            new(), "WorkerProxy",
+            environmentVariables: ComputeSeparationTestHelpers.GetWorkerProxyAuthEnvironment());
 
         await Task.Delay(2000);
         ComputeSeparationTestHelpers.EnsureProcessRunning(_workerProxyProcess, "WorkerProxy", new());
@@ -197,7 +198,7 @@ public class SpecializationEndToEndTests : IAsyncLifetime, IDisposable, IClassFi
 
         // 2. Assign the worker — drives init + specialize + metadata prefetch
         //    so cached responses are ready when the runtime links.
-        using var proxyClient = new HttpClient { BaseAddress = new Uri($"http://localhost:{ManagementPort}") };
+        using var proxyClient = ComputeSeparationTestHelpers.CreateAuthenticatedWorkerProxyClient(ManagementPort);
         var workerAssignResponse = await proxyClient.PostAsync("/admin/worker/assign",
             new StringContent(
                 JsonConvert.SerializeObject(new { environment = new { FUNCTIONS_WORKER_RUNTIME = "node" }, functionAppDirectory = "/home/site/wwwroot" }),

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAllocationEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAllocationEndToEndTests.cs
@@ -75,7 +75,8 @@ public class WorkerAllocationEndToEndTests : IAsyncLifetime, IDisposable
             "dotnet",
             $"\"{workerProxyDll}\" --runtime-grpc-port {RuntimeGrpcPort} --worker-grpc-port {WorkerGrpcPort} --http-proxy-port {HttpProxyPort} --management-port {ManagementPort}",
             _workerProxyLogs,
-            "WorkerProxy");
+            "WorkerProxy",
+            environmentVariables: ComputeSeparationTestHelpers.GetWorkerProxyAuthEnvironment());
 
         await Task.Delay(2000);
         ComputeSeparationTestHelpers.EnsureProcessRunning(_workerProxyProcess, "WorkerProxy", _workerProxyLogs);
@@ -114,7 +115,7 @@ public class WorkerAllocationEndToEndTests : IAsyncLifetime, IDisposable
         _output.WriteLine("Got master key for admin API calls.");
 
         // 1. Assign the worker — drives init + specialize + metadata prefetch.
-        using var proxyClient = new HttpClient { BaseAddress = new Uri($"http://localhost:{ManagementPort}") };
+        using var proxyClient = ComputeSeparationTestHelpers.CreateAuthenticatedWorkerProxyClient(ManagementPort);
         var assignResponse = await CallWorkerAssignAsync(proxyClient);
         _output.WriteLine($"Assign response: {assignResponse.StatusCode}");
         Assert.Equal(HttpStatusCode.OK, assignResponse.StatusCode);
@@ -152,7 +153,7 @@ public class WorkerAllocationEndToEndTests : IAsyncLifetime, IDisposable
         string masterKey = await _host.GetMasterKeyAsync();
 
         // 1. Assign the worker — drives init + specialize + metadata prefetch.
-        using var proxyClient = new HttpClient { BaseAddress = new Uri($"http://localhost:{ManagementPort}") };
+        using var proxyClient = ComputeSeparationTestHelpers.CreateAuthenticatedWorkerProxyClient(ManagementPort);
         var assignResponse = await CallWorkerAssignAsync(proxyClient);
         _output.WriteLine($"Assign response: {assignResponse.StatusCode}");
         Assert.Equal(HttpStatusCode.OK, assignResponse.StatusCode);

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAssignAndLinkEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAssignAndLinkEndToEndTests.cs
@@ -66,7 +66,8 @@ public class WorkerAssignAndLinkEndToEndTests : IAsyncLifetime, IDisposable
         _workerProxyProcess = ComputeSeparationTestHelpers.StartManagedProcess(
             _output, "dotnet",
             $"\"{workerProxyDll}\" --runtime-grpc-port {RuntimeGrpcPort} --worker-grpc-port {WorkerGrpcPort} --http-proxy-port {HttpProxyPort} --management-port {ManagementPort}",
-            _workerProxyLogs, "WorkerProxy");
+            _workerProxyLogs, "WorkerProxy",
+            environmentVariables: ComputeSeparationTestHelpers.GetWorkerProxyAuthEnvironment());
 
         await Task.Delay(2000);
         ComputeSeparationTestHelpers.EnsureProcessRunning(_workerProxyProcess, "WorkerProxy", _workerProxyLogs);
@@ -100,7 +101,7 @@ public class WorkerAssignAndLinkEndToEndTests : IAsyncLifetime, IDisposable
     [Fact]
     public async Task AssignFirst_ThenLink_FullFlow()
     {
-        using var proxyClient = new HttpClient { BaseAddress = new Uri($"http://localhost:{ManagementPort}") };
+        using var proxyClient = ComputeSeparationTestHelpers.CreateAuthenticatedWorkerProxyClient(ManagementPort);
 
         // 1. Assign first — drives init + specialize + metadata prefetch.
         _output.WriteLine("Step 1: Calling /admin/worker/assign on worker proxy.");
@@ -126,7 +127,7 @@ public class WorkerAssignAndLinkEndToEndTests : IAsyncLifetime, IDisposable
     [Fact]
     public async Task LinkFirst_ThenAssign_FullFlow()
     {
-        using var proxyClient = new HttpClient { BaseAddress = new Uri($"http://localhost:{ManagementPort}") };
+        using var proxyClient = ComputeSeparationTestHelpers.CreateAuthenticatedWorkerProxyClient(ManagementPort);
         string masterKey = await _host.GetMasterKeyAsync();
 
         // 1. Link first — runtime connects and sends WorkerInitRequest.

--- a/test/WebJobs.Script.Tests/Helpers/SecretsUtilityTest.cs
+++ b/test/WebJobs.Script.Tests/Helpers/SecretsUtilityTest.cs
@@ -21,5 +21,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Helpers
             Assert.Equal(keyBytes, SecretsUtility.ToKeyBytes(base64Key));
             Assert.Equal(keyBytes, Convert.FromBase64String(base64Key));
         }
+
+        [Fact]
+        public void ToKeyBytes_MalformedInput_Throws()
+        {
+            // Guards the runtime contract: SecretsUtility.ToKeyBytes (and the
+            // shared SiteTokenKeyParser it delegates to) must throw on malformed
+            // input. SecretsUtility.GetTokenIssuerSigningKeys relies on this to
+            // surface configuration errors at startup; silently swallowing would
+            // leave operators chasing 401s with no signal.
+            const string MalformedHex = "ZZ75CA46E7EBDD39E4CA6B074D1F9A5972B849A55F91A248F6B038A61BACE9D7";
+            Assert.Throws<FormatException>(() => SecretsUtility.ToKeyBytes(MalformedHex));
+            Assert.Throws<FormatException>(() => SecretsUtility.ToKeyBytes("not-base64-or-hex"));
+        }
     }
 }

--- a/tools/ComputeSeparation/AppHost/AppHost.csproj
+++ b/tools/ComputeSeparation/AppHost/AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.2.1">
+<Project Sdk="Aspire.AppHost.Sdk/13.2.3">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting" Version="13.2.1" />
-    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.2.1" />
-    <PackageReference Include="Aspire.Hosting.Docker" Version="13.2.1" />
+    <PackageReference Include="Aspire.Hosting" Version="13.2.3" />
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.2.3" />
+    <PackageReference Include="Aspire.Hosting.Docker" Version="13.2.3" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.26.0" />
   </ItemGroup>
 

--- a/tools/ComputeSeparation/AppHost/Program.cs
+++ b/tools/ComputeSeparation/AppHost/Program.cs
@@ -32,6 +32,11 @@ const string MasterKey = "dev-master-key";
 // 64 hex chars = 32 bytes (256-bit AES key). Must match the pre-encrypted payload in compute-separation.http.
 const string ContainerEncryptionKey = "0F75CA46E7EBDD39E4CA6B074D1F9A5972B849A55F91A248F6B038A61BACE9D7";
 
+// Well-known pod identity for the worker proxy in local dev. Used as the JWT
+// audience when minting tokens for /admin/worker/* and /admin/infra/* calls.
+// Must match the @workerProxyToken value in compute-separation.http.
+const string DevPodName = "devhost-pod";
+
 // Well-known Azurite storage emulator account key.
 // https://learn.microsoft.com/azure/storage/common/storage-use-azurite#well-known-storage-account-and-key
 const string AzuriteAccountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
@@ -120,6 +125,11 @@ static void AddProjectResources(
 
     var workerProxy = builder.AddProject<Projects.Functions_WorkerProxy>("worker-proxy")
         .WithHttpEndpoint(managementPort, managementPort, name: "management", isProxied: false)
+        // Match the runtime's container identity so the proxy validates the
+        // same JWT tokens NNA mints for /admin/host/assign — see the
+        // ContainerJwtAuth helper. Audience for proxy tokens is WEBSITE_POD_NAME.
+        .WithEnvironment("CONTAINER_ENCRYPTION_KEY", ContainerEncryptionKey)
+        .WithEnvironment("WEBSITE_POD_NAME", DevPodName)
         .WithArgs(
             "--runtime-grpc-port", runtimeGrpcPort.ToString(),
             "--worker-grpc-port", workerGrpcPort.ToString(),
@@ -157,6 +167,9 @@ static void AddContainerResources(
         .WithHttpEndpoint(managementPort, managementPort, name: "proxy-management")
         .WithBindMount(hostJsonSource, "/home/site/wwwroot/host.json", isReadOnly: true)
         .WithEnvironment("Logging__LogLevel__Default", "Debug")
+        // See AddProjectResources for context — same JWT auth seeds in container mode.
+        .WithEnvironment("CONTAINER_ENCRYPTION_KEY", ContainerEncryptionKey)
+        .WithEnvironment("WEBSITE_POD_NAME", DevPodName)
         .WithArgs(
             "--runtime-grpc-port", runtimeGrpcPort.ToString(),
             "--worker-grpc-port", workerGrpcPort.ToString(),

--- a/tools/ComputeSeparation/SampleIsolatedApp/local.settings.json
+++ b/tools/ComputeSeparation/SampleIsolatedApp/local.settings.json
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
+  }
+}

--- a/tools/ComputeSeparation/compute-separation.http
+++ b/tools/ComputeSeparation/compute-separation.http
@@ -15,6 +15,12 @@
 @workerProxyHost = http://localhost:50054
 @masterKey = dev-master-key
 
+### Long-lived JWT for worker proxy /admin/* calls.
+### Signed with the dev CONTAINER_ENCRYPTION_KEY from AppHost/Program.cs.
+### Audience = WEBSITE_POD_NAME ("devhost-pod"), issuer = LegionCoreUri,
+### expires 2050-01-01.
+@workerProxyToken= eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJkZXZob3N0LXBvZCIsImlzcyI6Imh0dHBzOi8vbGVnaW9uLmNvcmUuYXp1cmV3ZWJzaXRlcy5uZXQiLCJleHAiOjI1MjQ2MDgwMDAsInN1YiI6ImRldiIsImlhdCI6MTc3Njg5MzY3NSwibmJmIjoxNzc2ODkzNjc1fQ.djEdgPlEeKeG3FBEDK1D-oMWvuppG7H9WAv-0kJQn-U
+
 ### ============================================================
 ### Full Orchestration Flow
 ### ============================================================
@@ -38,6 +44,7 @@
 ### Step 1: Check worker proxy readiness
 ### NNA polls this until the worker has connected to the proxy via gRPC.
 GET {{workerProxyHost}}/admin/worker/ready
+x-ms-site-token: {{workerProxyToken}}
 
 ###
 
@@ -47,6 +54,7 @@ GET {{workerProxyHost}}/admin/worker/ready
 ### caching all responses for later replay to the runtime.
 POST {{workerProxyHost}}/admin/worker/assign
 Content-Type: application/json
+x-ms-site-token: {{workerProxyToken}}
 
 {
   "environment": {
@@ -120,6 +128,7 @@ GET {{runtimeHost}}/admin/host/ping
 ###   { functionsContainerType, podName, revision, state: { podStatus, runtimePodName, ... } }
 POST {{workerProxyHost}}/admin/infra/instanceState
 Content-Type: application/json
+x-ms-site-token: {{workerProxyToken}}
 
 {
   "revision": 0
@@ -137,6 +146,7 @@ Content-Type: application/json
 ### Runtime drains in-flight invocations and sends WorkerDrainComplete back.
 POST {{workerProxyHost}}/admin/worker/drain
 Content-Type: application/json
+x-ms-site-token: {{workerProxyToken}}
 
 {
   "reason": "IdleScaleIn"


### PR DESCRIPTION
## Summary

This aligns worker proxy admin authentication with the runtime so both components honor the same container-issued site token behavior.

## Key changes

- Share the site-token validation behavior used by the runtime and worker proxy.
- Keep the worker readiness probe anonymous before specialization, while requiring site-token auth for the remaining worker admin APIs.
- Fail loudly on malformed container signing keys to match runtime behavior.