### PR TITLE
[Compute Separation] new FunctionsNetHost; file logging in workerproxy; diagnostic logs

### DIFF
--- a/src/Functions.WorkerProxy/Diagnostics/WorkerProxyFileLogger.cs
+++ b/src/Functions.WorkerProxy/Diagnostics/WorkerProxyFileLogger.cs
@@ -1,0 +1,107 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Globalization;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.Functions.WorkerProxy.Diagnostics;
+
+internal sealed class WorkerProxyFileLogger : ILogger
+{
+    private const string TimestampFormat = "O";
+
+    private readonly string _categoryName;
+    private readonly Action<string> _writeLine;
+
+    internal WorkerProxyFileLogger(string categoryName, Action<string> writeLine)
+    {
+        ArgumentNullException.ThrowIfNull(categoryName);
+        ArgumentNullException.ThrowIfNull(writeLine);
+
+        _categoryName = categoryName;
+        _writeLine = writeLine;
+    }
+
+    public IDisposable BeginScope<TState>(TState state)
+        where TState : notnull
+    {
+        return NullScope.Instance;
+    }
+
+    public bool IsEnabled(LogLevel logLevel)
+    {
+        return logLevel != LogLevel.None;
+    }
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        ArgumentNullException.ThrowIfNull(formatter);
+
+        if (!IsEnabled(logLevel))
+        {
+            return;
+        }
+
+        string message = formatter(state, exception);
+        if (string.IsNullOrWhiteSpace(message) && exception is null)
+        {
+            return;
+        }
+
+        _writeLine(FormatLogEntry(_categoryName, logLevel, eventId, message, exception));
+    }
+
+    internal static string FormatLogEntry(string categoryName, LogLevel logLevel, EventId eventId, string? message, Exception? exception)
+    {
+        ArgumentNullException.ThrowIfNull(categoryName);
+
+        var builder = new StringBuilder();
+        builder.Append(DateTime.UtcNow.ToString(TimestampFormat, CultureInfo.InvariantCulture));
+        builder.Append(" [");
+        builder.Append(logLevel.ToString());
+        builder.Append("] ");
+        builder.Append(categoryName);
+
+        if (eventId.Id != 0 || !string.IsNullOrWhiteSpace(eventId.Name))
+        {
+            builder.Append(" {EventId=");
+            builder.Append(eventId.Id.ToString(CultureInfo.InvariantCulture));
+
+            if (!string.IsNullOrWhiteSpace(eventId.Name))
+            {
+                builder.Append(", Name=");
+                builder.Append(eventId.Name);
+            }
+
+            builder.Append('}');
+        }
+
+        if (!string.IsNullOrWhiteSpace(message))
+        {
+            builder.Append(": ");
+            builder.Append(message.Trim());
+        }
+
+        if (exception is not null)
+        {
+            builder.AppendLine();
+            builder.Append(exception);
+        }
+
+        return builder.ToString();
+    }
+
+    private sealed class NullScope : IDisposable
+    {
+        public static NullScope Instance { get; } = new();
+
+        private NullScope()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Functions.WorkerProxy/Diagnostics/WorkerProxyFileLoggerProvider.cs
+++ b/src/Functions.WorkerProxy/Diagnostics/WorkerProxyFileLoggerProvider.cs
@@ -1,0 +1,90 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.Functions.WorkerProxy.Diagnostics;
+
+internal sealed class WorkerProxyFileLoggerProvider : ILoggerProvider
+{
+    internal const string DefaultLogFilePath = "/home/logs.log";
+
+    private readonly Action<string> _writeLine;
+    private readonly IDisposable? _disposable;
+
+    public WorkerProxyFileLoggerProvider()
+        : this(new FileLineWriter(DefaultLogFilePath))
+    {
+    }
+
+    internal WorkerProxyFileLoggerProvider(string logFilePath)
+        : this(new FileLineWriter(logFilePath))
+    {
+    }
+
+    internal WorkerProxyFileLoggerProvider(Action<string> writeLine)
+    {
+        ArgumentNullException.ThrowIfNull(writeLine);
+
+        _writeLine = writeLine;
+    }
+
+    private WorkerProxyFileLoggerProvider(FileLineWriter lineWriter)
+        : this(lineWriter.WriteLine)
+    {
+        _disposable = lineWriter;
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        ArgumentNullException.ThrowIfNull(categoryName);
+
+        return new WorkerProxyFileLogger(categoryName, _writeLine);
+    }
+
+    public void Dispose()
+    {
+        _disposable?.Dispose();
+    }
+
+    private sealed class FileLineWriter : IDisposable
+    {
+        private readonly object _syncRoot = new();
+        private readonly StreamWriter _writer;
+
+        public FileLineWriter(string logFilePath)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(logFilePath);
+
+            string? directory = Path.GetDirectoryName(logFilePath);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var stream = new FileStream(logFilePath, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
+            _writer = new StreamWriter(stream)
+            {
+                AutoFlush = true
+            };
+        }
+
+        public void WriteLine(string message)
+        {
+            ArgumentNullException.ThrowIfNull(message);
+
+            lock (_syncRoot)
+            {
+                _writer.WriteLine(message);
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_syncRoot)
+            {
+                _writer.Dispose();
+            }
+        }
+    }
+}

--- a/src/Functions.WorkerProxy/Dockerfile
+++ b/src/Functions.WorkerProxy/Dockerfile
@@ -8,7 +8,7 @@ RUN dotnet publish src/Functions.WorkerProxy/Functions.WorkerProxy.csproj \
     -c Release -r linux-x64 -o /app/publish \
     && find /app/publish -maxdepth 1 \( -name '*.pdb' -o -name '*.dbg' \) -delete
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-noble-chiseled
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-noble
 WORKDIR /app
 COPY --from=build /app/publish/ ./
 EXPOSE 80 50051 50052 50053

--- a/src/Functions.WorkerProxy/Program.cs
+++ b/src/Functions.WorkerProxy/Program.cs
@@ -23,10 +23,12 @@ builder.WebHost.UseUrls();
 builder.Services.AddOptions<WorkerProxyEnvironmentOptions>();
 builder.Services.AddSingleton<IConfigureOptions<WorkerProxyEnvironmentOptions>>(workerProxyEnvironmentOptionsSetup);
 
-if (workerProxyEnvironmentOptions.IsFlexOrLegion)
+// [CS-TODO] Temporarily removing this gate; need to ensure it's the proper check
+// if (workerProxyEnvironmentOptions.IsFlexOrLegion)
 {
     builder.Logging.ClearProviders();
     builder.Logging.Services.AddSingleton<ILoggerProvider, MsFunctionLogsLoggerProvider>();
+    builder.Logging.Services.AddSingleton<ILoggerProvider, WorkerProxyFileLoggerProvider>();
 }
 
 int runtimeGrpcPort = GetIntArg(args, builder.Configuration, "--runtime-grpc-port", 50051);

--- a/src/WebJobs.Script.WebHost/Startup.cs
+++ b/src/WebJobs.Script.WebHost/Startup.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -30,6 +31,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
         {
+            if (Configuration.IsExternalWorkerEnabled())
+            {
+                var startupLogger = loggerFactory.CreateLogger(LogCategories.Startup);
+
+                startupLogger.LogInformation(
+                    "External worker mode enabled at startup. '{settingName}' is set, so the root host registered external worker services.",
+                    EnvironmentSettingNames.FunctionsWorkerExternalEnabled);
+            }
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/test/Functions.WorkerProxy.Tests/WorkerProxyFileLoggerTests.cs
+++ b/test/Functions.WorkerProxy.Tests/WorkerProxyFileLoggerTests.cs
@@ -1,0 +1,97 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Microsoft.Azure.Functions.WorkerProxy.Configuration;
+using Microsoft.Azure.Functions.WorkerProxy.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Microsoft.Azure.Functions.WorkerProxy.Tests;
+
+public class WorkerProxyFileLoggerTests
+{
+    private static readonly Regex FileLogRegex = new(
+        "^(?<Timestamp>[^ ]+) \\[(?<Level>[^\\]]+)\\] (?<Category>[^:]+): (?<Message>.+)$",
+        RegexOptions.Compiled);
+
+    [Fact]
+    public void Log_WritesHumanReadableEntry()
+    {
+        var lines = new List<string>();
+        using var provider = new WorkerProxyFileLoggerProvider(lines.Add);
+        ILogger logger = provider.CreateLogger("Microsoft.Azure.Functions.WorkerProxy.FunctionRpcRelay");
+        var exception = new InvalidOperationException("bad details");
+
+        logger.LogError(exception, "summary {Value}", 123);
+
+        string entry = Assert.Single(lines);
+        string[] segments = entry.Split(Environment.NewLine, count: 2, StringSplitOptions.None);
+        Match match = FileLogRegex.Match(segments[0]);
+
+        Assert.True(match.Success);
+        Assert.Equal("Error", match.Groups["Level"].Value);
+        Assert.Equal("Microsoft.Azure.Functions.WorkerProxy.FunctionRpcRelay", match.Groups["Category"].Value);
+        Assert.Equal("summary 123", match.Groups["Message"].Value);
+        Assert.True(DateTime.TryParse(match.Groups["Timestamp"].Value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out _));
+        Assert.Contains(nameof(InvalidOperationException), entry);
+        Assert.Contains("bad details", entry);
+    }
+
+    [Fact]
+    public void Provider_AppendsToConfiguredFile()
+    {
+        string logFilePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.log");
+
+        try
+        {
+            using (var provider = new WorkerProxyFileLoggerProvider(logFilePath))
+            {
+                ILogger logger = provider.CreateLogger("Category");
+
+                logger.LogInformation("hello");
+                logger.LogWarning("again");
+            }
+
+            string[] lines = File.ReadAllLines(logFilePath);
+
+            Assert.Equal(2, lines.Length);
+            Assert.Contains("[Information] Category: hello", lines[0], StringComparison.Ordinal);
+            Assert.Contains("[Warning] Category: again", lines[1], StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (File.Exists(logFilePath))
+            {
+                File.Delete(logFilePath);
+            }
+        }
+    }
+
+    [Fact]
+    public void LoggerFactory_FansOutToBothProviders()
+    {
+        var runtimeLines = new List<string>();
+        var fileLines = new List<string>();
+
+        using var runtimeProvider = new MsFunctionLogsLoggerProvider(runtimeLines.Add, Options.Create(new WorkerProxyEnvironmentOptions()));
+        using var fileProvider = new WorkerProxyFileLoggerProvider(fileLines.Add);
+        using var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.ClearProviders();
+            builder.AddProvider(runtimeProvider);
+            builder.AddProvider(fileProvider);
+        });
+
+        ILogger logger = loggerFactory.CreateLogger("Category");
+
+        logger.LogInformation("hello from factory");
+
+        Assert.Single(runtimeLines);
+        Assert.Single(fileLines);
+        Assert.Contains("hello from factory", fileLines[0], StringComparison.Ordinal);
+        Assert.Contains("MS_FUNCTION_LOGS", runtimeLines[0], StringComparison.Ordinal);
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/SpecializationEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/SpecializationEndToEndTests.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption;
 using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Tests.Integration.Fixtures;
 using Microsoft.Azure.WebJobs.Script.WebHost;
@@ -193,6 +194,14 @@ public class SpecializationEndToEndTests : IAsyncLifetime, IDisposable, IClassFi
     [Fact]
     public async Task SpecializationFlow_AssignThenLinkThenInvoke()
     {
+        Assert.Contains(
+            _loggerProvider.GetAllLogMessages(),
+            m => string.Equals(m.Category, LogCategories.Startup, StringComparison.Ordinal)
+                && string.Equals(
+                    m.FormattedMessage,
+                    $"External worker mode enabled at startup. '{EnvironmentSettingNames.FunctionsWorkerExternalEnabled}' is set, so the root host registered external worker services.",
+                    StringComparison.Ordinal));
+
         var secretManager = _webHost.Services.GetService<ISecretManagerProvider>().Current;
         string masterKey = (await secretManager.GetHostSecretsAsync()).MasterKey;
 

--- a/tools/ComputeSeparation/AppHost/Program.cs
+++ b/tools/ComputeSeparation/AppHost/Program.cs
@@ -198,8 +198,7 @@ static void AddContainerResources(
         // Add a second HTTP listener on all interfaces (0.0.0.0) at the known port so the
         // proxy can reach it across Docker container boundaries. The SDK's default listener
         // binds to localhost only, which is unreachable from other containers.
-        .WithEnvironment("FUNCTIONS_HTTP_PORT", mockWorkerHttpPort.ToString())
-        .WaitFor(workerProxy);
+        .WithEnvironment("FUNCTIONS_HTTP_PORT", mockWorkerHttpPort.ToString());
 
     // Wire proxy env vars that depend on the worker being defined.
     // Use the Docker container name + fixed port directly (not Aspire's *.dev.internal proxy)
@@ -236,8 +235,6 @@ static void AddContainerResources(
             ConfigureStorageConnectionString(context, storage);
         })
         .WaitFor(storage);
-
-    isolatedWorker.WaitFor(workerProxy);
 }
 
 static void ConfigureStorageConnectionString(

--- a/tools/ComputeSeparation/FunctionsNetHost/Dockerfile
+++ b/tools/ComputeSeparation/FunctionsNetHost/Dockerfile
@@ -16,17 +16,19 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS extract-nethost
 
 WORKDIR /extract
-COPY NuGet.config .
 
-# Use dotnet restore with a minimal project to pull the NuGet package.
-RUN echo '<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup><ItemGroup><PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.14" /></ItemGroup></Project>' > /extract/Extract.csproj \
-    && dotnet restore Extract.csproj --configfile NuGet.config
-
-RUN CONTENT_DIR=$(find /root/.nuget/packages/microsoft.azure.functions.dotnetisolatednativehost/1.0.14/contentFiles/any/any/workers/dotnet-isolated -maxdepth 0) \
-    && cp "${CONTENT_DIR}/bin/FunctionsNetHost" /extract/ \
-    && cp "${CONTENT_DIR}/bin/libnethost.so" /extract/ \
-    && cp "${CONTENT_DIR}/worker.config.json" /extract/ \
-    && cp -r "${CONTENT_DIR}/bin/prelaunchapps" /extract/
+# Build Linux FunctionsNetHost from source and stage the same files that the packaged native host provides.
+RUN apt-get update \
+    && apt-get install -y git clang zlib1g-dev \
+    && git clone --depth 1 --single-branch --branch brettsam/nethost_retry https://github.com/Azure/azure-functions-dotnet-worker.git /tmp/azure-functions-dotnet-worker \
+    && for tfm in net10.0 net9.0 net8.0; do \
+        version="${tfm#net}"; \
+        dotnet publish /tmp/azure-functions-dotnet-worker/host/src/PrelaunchApp/App.csproj -c Release -f "${tfm}" -p:UseAppHost=false -o "/extract/prelaunchapps/${version}"; \
+    done \
+    && dotnet publish /tmp/azure-functions-dotnet-worker/host/src/FunctionsNetHost/FunctionsNetHost.csproj -c Release -r linux-x64 -o /tmp/functionsnethost-linux \
+    && cp /tmp/functionsnethost-linux/FunctionsNetHost /extract/ \
+    && cp /tmp/functionsnethost-linux/libnethost.so /extract/ \
+    && cp /tmp/azure-functions-dotnet-worker/host/tools/build/worker.config.json /extract/
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble
 

--- a/tools/ComputeSeparation/SampleIsolatedApp/Dockerfile
+++ b/tools/ComputeSeparation/SampleIsolatedApp/Dockerfile
@@ -12,25 +12,23 @@
 #              -e FUNCTIONS_GRPC_PORT=50052 \
 #              sample-isolated-worker
 
-# --- Stage 1: Extract FunctionsNetHost from NuGet ---
+# --- Stage 1: Build FunctionsNetHost from source ---
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS extract-nethost
 
 WORKDIR /extract
 
-# Download the .nupkg directly from the NuGet feed (it's just a zip file) and extract.
-COPY NuGet.config .
-RUN dotnet nuget list source --configfile NuGet.config --format short \
-    | grep -oP 'https://\S+' | head -1 > /tmp/feed-url.txt
-
-# Use dotnet restore with a minimal project to pull the package.
-RUN echo '<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup><ItemGroup><PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.14" /></ItemGroup></Project>' > /extract/Extract.csproj \
-    && dotnet restore Extract.csproj --configfile NuGet.config
-
-RUN CONTENT_DIR=$(find /root/.nuget/packages/microsoft.azure.functions.dotnetisolatednativehost/1.0.14/contentFiles/any/any/workers/dotnet-isolated -maxdepth 0) \
-    && cp "${CONTENT_DIR}/bin/FunctionsNetHost" /extract/ \
-    && cp "${CONTENT_DIR}/bin/libnethost.so" /extract/ \
-    && cp "${CONTENT_DIR}/worker.config.json" /extract/ \
-    && cp -r "${CONTENT_DIR}/bin/prelaunchapps" /extract/
+# Build Linux FunctionsNetHost from source and stage the same files that the packaged native host provides.
+RUN apt-get update \
+    && apt-get install -y git clang zlib1g-dev \
+    && git clone --depth 1 --single-branch --branch brettsam/nethost_retry https://github.com/Azure/azure-functions-dotnet-worker.git /tmp/azure-functions-dotnet-worker \
+    && for tfm in net10.0 net9.0 net8.0; do \
+        version="${tfm#net}"; \
+        dotnet publish /tmp/azure-functions-dotnet-worker/host/src/PrelaunchApp/App.csproj -c Release -f "${tfm}" -p:UseAppHost=false -o "/extract/prelaunchapps/${version}"; \
+    done \
+    && dotnet publish /tmp/azure-functions-dotnet-worker/host/src/FunctionsNetHost/FunctionsNetHost.csproj -c Release -r linux-x64 -o /tmp/functionsnethost-linux \
+    && cp /tmp/functionsnethost-linux/FunctionsNetHost /extract/ \
+    && cp /tmp/functionsnethost-linux/libnethost.so /extract/ \
+    && cp /tmp/azure-functions-dotnet-worker/host/tools/build/worker.config.json /extract/
 
 # --- Stage 2: Publish sample isolated app ---
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS publish-app


### PR DESCRIPTION
- Improves compute-separation diagnostics by adding a human-readable WorkerProxy log sink at `/home/logs.log` while preserving the existing runtime-compatible logging stream.
- Updates the local compute-separation container setup to use the current FunctionsNetHost source and a more debugging-friendly runtime environment for native-host startup investigation.
- Adds clearer startup diagnostics for external worker mode and relaxes the local worker/proxy startup dependency so debugging can observe the connection sequence more directly.
