### PR TITLE
Port updates for compute separation testing in private stamp and docker files with sample app for WSL tests

### DIFF
--- a/src/Functions.WorkerProxy/Dockerfile
+++ b/src/Functions.WorkerProxy/Dockerfile
@@ -11,5 +11,5 @@ RUN dotnet publish src/Functions.WorkerProxy/Functions.WorkerProxy.csproj \
 FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-noble
 WORKDIR /app
 COPY --from=build /app/publish/ ./
-EXPOSE 80 50051 50052 50053
+EXPOSE 80 28080 50053 50054
 ENTRYPOINT ["./Microsoft.Azure.Functions.WorkerProxy"]

--- a/src/Functions.WorkerProxy/Dockerfile.with-sample
+++ b/src/Functions.WorkerProxy/Dockerfile.with-sample
@@ -1,0 +1,51 @@
+# Functions.WorkerProxy (gRPC relay + HTTP proxy) — with sample function app baked in.
+#
+# Variant of ./Dockerfile that also layers the SampleIsolatedApp publish output into
+# /home/site/wwwroot/. This is used by WSL compute-separation tests so the worker-proxy
+# can read host.json from {functionAppDirectory}/host.json (see
+# FunctionRpcRelay.InjectHostJson) without needing a shared volume mount to the
+# worker-net-host container's wwwroot.
+#
+# Build context: repository root (same as ./Dockerfile).
+#
+# Usage (from azure-functions-host repo root):
+#   docker build -f src/Functions.WorkerProxy/Dockerfile.with-sample \
+#                -t <registry>/functions-worker-proxy-with-sample:latest .
+
+# --- Stage 1: AOT-publish Functions.WorkerProxy ---
+FROM mcr.microsoft.com/dotnet/sdk:10.0-noble-aot AS build
+WORKDIR /repo
+
+COPY . .
+RUN dotnet publish src/Functions.WorkerProxy/Functions.WorkerProxy.csproj \
+    -c Release -r linux-x64 -o /app/publish \
+    && find /app/publish -maxdepth 1 \( -name '*.pdb' -o -name '*.dbg' \) -delete
+
+# --- Stage 2: Publish SampleIsolatedApp (for /home/site/wwwroot contents) ---
+# Only the published output (including host.json) is needed; FunctionsNetHost executes
+# the app inside the worker-net-host container, not here.
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS publish-sample
+WORKDIR /repo
+COPY tools/ComputeSeparation/SampleIsolatedApp/ ./SampleIsolatedApp/
+RUN dotnet publish SampleIsolatedApp/SampleIsolatedApp.csproj \
+    -c Release -o /app/wwwroot
+
+# --- Stage 3: Final image ---
+# NOTE: base is runtime-deps:10.0-noble (NOT -chiseled). The production worker-proxy
+# uses the chiseled variant for minimal size, but the chiseled image has no /bin/sh
+# or /bin/tee which blocks our ENTRYPOINT-based log capture. Since Dockerfile.with-sample
+# is a test-only variant already, accepting a larger base here is a worthwhile tradeoff
+# for reliable log capture. The product binary itself is identical.
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-noble
+WORKDIR /app
+COPY --from=build /app/publish/ ./
+COPY --from=publish-sample /app/wwwroot/ /home/site/wwwroot/
+EXPOSE 80 28080 50053 50054
+
+# Tee stdout+stderr to /tmp/container-stdout.log so the Legion WSL integration test can
+# recover the full process log via `ctr tasks exec cat /tmp/container-stdout.log` even
+# when the `ctr tasks attach` host-side capture misses the startup window.
+# Using bash + `exec` + process substitution so the worker-proxy PROCESS replaces the
+# shell as PID 1 (proper SIGTERM handling on pod shutdown) while its stdout/stderr are
+# simultaneously piped to the capture file and the container's real stdout.
+ENTRYPOINT ["/bin/bash", "-c", "exec ./Microsoft.Azure.Functions.WorkerProxy > >(tee /tmp/container-stdout.log) 2>&1"]

--- a/src/Functions.WorkerProxy/Program.cs
+++ b/src/Functions.WorkerProxy/Program.cs
@@ -31,10 +31,15 @@ builder.Services.AddSingleton<IConfigureOptions<WorkerProxyEnvironmentOptions>>(
     builder.Logging.Services.AddSingleton<ILoggerProvider, WorkerProxyFileLoggerProvider>();
 }
 
-int runtimeGrpcPort = GetIntArg(args, builder.Configuration, "--runtime-grpc-port", 50051);
-int workerGrpcPort = GetIntArg(args, builder.Configuration, "--worker-grpc-port", 50052);
-int httpProxyPort = GetIntArg(args, builder.Configuration, "--http-proxy-port", 50053);
-int managementPort = GetIntArg(args, builder.Configuration, "--management-port", 50054);
+int runtimeGrpcPort = GetIntArg(args, builder.Configuration, "--runtime-grpc-port", 50053);
+int workerGrpcPort = GetIntArg(args, builder.Configuration, "--worker-grpc-port", 50054);
+int httpProxyPort = GetIntArg(args, builder.Configuration, "--http-proxy-port", 28080);
+int managementPort = GetIntArg(args, builder.Configuration, "--management-port", 80);
+// Explicit override for the worker's HTTP endpoint. When set (via CLI arg or env var),
+// this takes precedence over the HttpUri the worker advertises in its WorkerInitResponse
+// capabilities. When null, the proxy falls back to the worker-advertised HttpUri
+// (dynamic port chosen by the worker SDK). The override exists for the Aspire dev
+// harness, tests, and any deployment where the operator wants to pin the worker port.
 string? workerHttpEndpointOverride = GetStringArgOrNull(args, builder.Configuration, "--worker-http-endpoint");
 string? hostJsonPath = GetStringArgOrNull(args, builder.Configuration, "--host-json-path");
 string httpProxyEndpoint = GetStringArg(args, builder.Configuration, "--http-proxy-endpoint", $"http://localhost:{httpProxyPort}");

--- a/tools/ComputeSeparation/FunctionsNetHost/Dockerfile
+++ b/tools/ComputeSeparation/FunctionsNetHost/Dockerfile
@@ -10,7 +10,7 @@
 #   docker build -f tools/ComputeSeparation/FunctionsNetHost/Dockerfile -t functions-nethost .
 #   docker run -v /path/to/app:/home/site/wwwroot \
 #              -e FUNCTIONS_GRPC_HOST=<proxy-host> \
-#              -e FUNCTIONS_GRPC_PORT=50052 \
+#              -e FUNCTIONS_GRPC_PORT=50054 \
 #              functions-nethost
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS extract-nethost
@@ -44,9 +44,9 @@ RUN mkdir -p /home/site/wwwroot
 
 ENV HOME=/home
 ENV FUNCTIONS_GRPC_HOST=localhost
-# Worker-proxy's worker-facing gRPC listener defaults to 50052 (WORKER_GRPC_PORT).
+# Worker-proxy's worker-facing gRPC listener defaults to 50054 (WORKER_GRPC_PORT).
 # FunctionsNetHost dials this endpoint to register as the language worker.
-ENV FUNCTIONS_GRPC_PORT=50052
+ENV FUNCTIONS_GRPC_PORT=50054
 
 ENTRYPOINT ["/bin/sh", "-c", \
     "exec /app/FunctionsNetHost FunctionsNetHost --functions-uri http://${FUNCTIONS_GRPC_HOST}:${FUNCTIONS_GRPC_PORT} --functions-request-id dev-request-id --functions-worker-id w_nethost01 --functions-grpc-max-message-length 134217728"]

--- a/tools/ComputeSeparation/FunctionsNetHost/Dockerfile
+++ b/tools/ComputeSeparation/FunctionsNetHost/Dockerfile
@@ -44,6 +44,8 @@ RUN mkdir -p /home/site/wwwroot
 
 ENV HOME=/home
 ENV FUNCTIONS_GRPC_HOST=localhost
+# Worker-proxy's worker-facing gRPC listener defaults to 50052 (WORKER_GRPC_PORT).
+# FunctionsNetHost dials this endpoint to register as the language worker.
 ENV FUNCTIONS_GRPC_PORT=50052
 
 ENTRYPOINT ["/bin/sh", "-c", \

--- a/tools/ComputeSeparation/FunctionsNetHost/Dockerfile.with-sample
+++ b/tools/ComputeSeparation/FunctionsNetHost/Dockerfile.with-sample
@@ -49,10 +49,10 @@ COPY --from=publish-sample /app/wwwroot/ /home/site/wwwroot/
 
 ENV HOME=/home
 ENV FUNCTIONS_GRPC_HOST=localhost
-# Worker-proxy's worker-facing gRPC listener defaults to 50052 (WorkerProxyGrpcWorkerPort
+# Worker-proxy's worker-facing gRPC listener defaults to 50054 (WorkerProxyGrpcWorkerPort
 # in the Legion WSL test; see FunctionsComputeSeparationTests.cs). FunctionsNetHost dials
 # this endpoint to register as the language worker.
-ENV FUNCTIONS_GRPC_PORT=50052
+ENV FUNCTIONS_GRPC_PORT=50054
 
 # Entrypoint tees all stdout+stderr to /tmp/container-stdout.log so integration tests can
 # recover the full process log via `ctr tasks exec cat` even when the `ctr tasks attach`

--- a/tools/ComputeSeparation/FunctionsNetHost/Dockerfile.with-sample
+++ b/tools/ComputeSeparation/FunctionsNetHost/Dockerfile.with-sample
@@ -1,0 +1,63 @@
+# FunctionsNetHost — with sample function app baked in.
+#
+# Variant of ./Dockerfile that additionally publishes
+# tools/ComputeSeparation/SampleIsolatedApp and bakes its output into
+# /home/site/wwwroot/, so the image is self-sufficient without a customer
+# code mount. Used by the WSL real-images compute-separation test.
+#
+# Build context: repository root (same as ./Dockerfile).
+#
+# Usage (from azure-functions-host repo root):
+#   docker build -f tools/ComputeSeparation/FunctionsNetHost/Dockerfile.with-sample \
+#                -t <registry>/functions-worker-net-host-with-sample:latest .
+
+# --- Stage 1: Extract FunctionsNetHost from NuGet (matches ./Dockerfile) ---
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS extract-nethost
+
+WORKDIR /extract
+COPY NuGet.config .
+
+# Use dotnet restore with a minimal project to pull the NuGet package.
+RUN echo '<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup><ItemGroup><PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" Version="1.0.14" /></ItemGroup></Project>' > /extract/Extract.csproj \
+    && dotnet restore Extract.csproj --configfile NuGet.config
+
+RUN CONTENT_DIR=$(find /root/.nuget/packages/microsoft.azure.functions.dotnetisolatednativehost/1.0.14/contentFiles/any/any/workers/dotnet-isolated -maxdepth 0) \
+    && cp "${CONTENT_DIR}/bin/FunctionsNetHost" /extract/ \
+    && cp "${CONTENT_DIR}/bin/libnethost.so" /extract/ \
+    && cp "${CONTENT_DIR}/worker.config.json" /extract/ \
+    && cp -r "${CONTENT_DIR}/bin/prelaunchapps" /extract/
+
+# --- Stage 2: Publish SampleIsolatedApp ---
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS publish-sample
+WORKDIR /repo
+COPY tools/ComputeSeparation/SampleIsolatedApp/ ./SampleIsolatedApp/
+RUN dotnet publish SampleIsolatedApp/SampleIsolatedApp.csproj \
+    -c Release -o /app/wwwroot
+
+# --- Stage 3: Final image ---
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble
+
+WORKDIR /app
+
+COPY --from=extract-nethost /extract/FunctionsNetHost ./
+COPY --from=extract-nethost /extract/libnethost.so ./
+COPY --from=extract-nethost /extract/worker.config.json ./
+COPY --from=extract-nethost /extract/prelaunchapps/ ./prelaunchapps/
+
+# Sample app pre-baked at the standard customer code path — no external mount needed.
+COPY --from=publish-sample /app/wwwroot/ /home/site/wwwroot/
+
+ENV HOME=/home
+ENV FUNCTIONS_GRPC_HOST=localhost
+# Worker-proxy's worker-facing gRPC listener defaults to 50052 (WorkerProxyGrpcWorkerPort
+# in the Legion WSL test; see FunctionsComputeSeparationTests.cs). FunctionsNetHost dials
+# this endpoint to register as the language worker.
+ENV FUNCTIONS_GRPC_PORT=50052
+
+# Entrypoint tees all stdout+stderr to /tmp/container-stdout.log so integration tests can
+# recover the full process log via `ctr tasks exec cat` even when the `ctr tasks attach`
+# log-capture approach misses the startup window. FunctionsNetHost's output isn't
+# interactive, so the tee has no side-effects; PID 1 is /bin/sh, which matches the base
+# ./Dockerfile (that already uses a wrapper shell).
+ENTRYPOINT ["/bin/sh", "-c", \
+    "/app/FunctionsNetHost FunctionsNetHost --functions-uri http://${FUNCTIONS_GRPC_HOST}:${FUNCTIONS_GRPC_PORT} --functions-request-id dev-request-id --functions-worker-id w_nethost01 --functions-grpc-max-message-length 134217728 2>&1 | tee /tmp/container-stdout.log"]


### PR DESCRIPTION
### Issue describing the changes in this PR
Port updates for compute separation testing in private stamp and docker files with sample app for WSL tests


### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
