### PR TITLE
[Compute Separation] grpc keep-alive; fix tests; fix .http env wiring

### DIFF
--- a/src/WebJobs.Script.Grpc/ExternalWorkers/OutboundGrpcClient.cs
+++ b/src/WebJobs.Script.Grpc/ExternalWorkers/OutboundGrpcClient.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -25,8 +26,12 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc.ExternalWorkers;
 /// </summary>
 internal class OutboundGrpcClient : IOutboundGrpcClient
 {
+    internal static readonly TimeSpan DefaultKeepAlivePingDelay = TimeSpan.FromSeconds(30);
+    internal static readonly TimeSpan DefaultKeepAlivePingTimeout = TimeSpan.FromSeconds(10);
+
     private readonly IScriptEventManager _eventManager;
     private readonly ILogger _logger;
+    private readonly Func<Uri, GrpcChannel> _channelFactory;
 
     private GrpcChannel? _channel;
     private AsyncDuplexStreamingCall<StreamingMessage, StreamingMessage>? _call;
@@ -38,9 +43,18 @@ internal class OutboundGrpcClient : IOutboundGrpcClient
     /// <param name="eventManager">The event manager that holds per-worker gRPC channels.</param>
     /// <param name="logger">Logger instance.</param>
     public OutboundGrpcClient(IScriptEventManager eventManager, ILogger<OutboundGrpcClient> logger)
+        : this(eventManager, logger, CreateGrpcChannel)
+    {
+    }
+
+    internal OutboundGrpcClient(
+        IScriptEventManager eventManager,
+        ILogger<OutboundGrpcClient> logger,
+        Func<Uri, GrpcChannel> channelFactory)
     {
         _eventManager = eventManager ?? throw new ArgumentNullException(nameof(eventManager));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _channelFactory = channelFactory ?? throw new ArgumentNullException(nameof(channelFactory));
     }
 
     /// <summary>
@@ -57,7 +71,7 @@ internal class OutboundGrpcClient : IOutboundGrpcClient
 
         try
         {
-            _channel = GrpcChannel.ForAddress(endpoint);
+            _channel = _channelFactory(endpoint);
             var client = new FunctionRpc.FunctionRpcClient(_channel);
             _call = client.EventStream(cancellationToken: _cts.Token);
 
@@ -85,6 +99,29 @@ internal class OutboundGrpcClient : IOutboundGrpcClient
             _cts?.Dispose();
             throw;
         }
+    }
+
+    internal static GrpcChannel CreateGrpcChannel(Uri endpoint)
+    {
+        return GrpcChannel.ForAddress(endpoint, CreateGrpcChannelOptions());
+    }
+
+    internal static GrpcChannelOptions CreateGrpcChannelOptions()
+    {
+        return new GrpcChannelOptions
+        {
+            HttpHandler = CreateHttpHandler()
+        };
+    }
+
+    private static SocketsHttpHandler CreateHttpHandler()
+    {
+        return new SocketsHttpHandler
+        {
+            KeepAlivePingDelay = DefaultKeepAlivePingDelay,
+            KeepAlivePingTimeout = DefaultKeepAlivePingTimeout,
+            KeepAlivePingPolicy = HttpKeepAlivePingPolicy.Always
+        };
     }
 
     private async Task PushOutbound(

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/ComputeSeparationTestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/ComputeSeparationTestHelpers.cs
@@ -9,6 +9,8 @@ using System.IO;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Tokens;
 using Xunit.Abstractions;
@@ -169,6 +171,50 @@ internal static class ComputeSeparationTestHelpers
 
         client.DefaultRequestHeaders.Add(ScriptConstants.SiteTokenHeaderName, CreateWorkerProxySiteToken());
         return client;
+    }
+
+    public static HttpContent CreateJsonContent(object payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        return new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+    }
+
+    public static HttpContent CreateWorkerAssignRequestContent(
+        string workerRuntime = "node",
+        string functionAppName = "test-compute-sep-app",
+        int functionAppId = 1234,
+        string functionGroupName = "http",
+        bool isAlwaysReady = false,
+        string functionAppDirectory = "/home/site/wwwroot")
+    {
+        var assignPayload = new
+        {
+            FunctionAppName = functionAppName,
+            FunctionAppId = functionAppId,
+            FunctionGroupName = functionGroupName,
+            IsAlwaysReady = isAlwaysReady,
+            Environment = new Dictionary<string, string>
+            {
+                ["FUNCTIONS_WORKER_RUNTIME"] = workerRuntime
+            },
+            FunctionAppDirectory = functionAppDirectory
+        };
+
+        return CreateJsonContent(assignPayload);
+    }
+
+    public static object CreateWorkerLinkRequest(string workerId, int runtimeGrpcPort, int httpProxyPort)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workerId);
+
+        return new
+        {
+            WorkerPodName = workerId,
+            WorkerHttpEndpoint = $"http://localhost:{httpProxyPort}",
+            WorkerGrpcEndpoint = $"http://localhost:{runtimeGrpcPort}",
+            WorkerContainerEncryptionKey = WorkerProxySigningKey
+        };
     }
 
     public static void EnsureProcessRunning(Process process, string label, ConcurrentBag<string> logSink)

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/ComputeSeparationTestHelpers.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/ComputeSeparationTestHelpers.cs
@@ -190,15 +190,15 @@ internal static class ComputeSeparationTestHelpers
     {
         var assignPayload = new
         {
-            FunctionAppName = functionAppName,
-            FunctionAppId = functionAppId,
-            FunctionGroupName = functionGroupName,
-            IsAlwaysReady = isAlwaysReady,
-            Environment = new Dictionary<string, string>
+            functionAppName,
+            functionAppId,
+            functionGroupName,
+            isAlwaysReady,
+            environment = new Dictionary<string, string>
             {
                 ["FUNCTIONS_WORKER_RUNTIME"] = workerRuntime
             },
-            FunctionAppDirectory = functionAppDirectory
+            functionAppDirectory
         };
 
         return CreateJsonContent(assignPayload);

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/ExternalWorkerEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/ExternalWorkerEndToEndTests.cs
@@ -10,7 +10,6 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.WebJobs.Script.Tests;
-using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -89,10 +88,9 @@ public class ExternalWorkerEndToEndTests : IAsyncLifetime, IDisposable
         // 2b. Assign the worker — drives init + specialize + metadata prefetch
         //     so cached responses are ready when the runtime connects.
         using var proxyClient = ComputeSeparationTestHelpers.CreateAuthenticatedWorkerProxyClient(ManagementPort);
-        var assignResponse = await proxyClient.PostAsync("/admin/worker/assign",
-            new StringContent(
-                JsonConvert.SerializeObject(new { environment = new { FUNCTIONS_WORKER_RUNTIME = "node" }, functionAppDirectory = "/home/site/wwwroot" }),
-                Encoding.UTF8, "application/json"));
+        var assignResponse = await proxyClient.PostAsync(
+            "/admin/worker/assign",
+            ComputeSeparationTestHelpers.CreateWorkerAssignRequestContent());
         _output.WriteLine($"Worker assign response: {assignResponse.StatusCode}");
         Assert.Equal(HttpStatusCode.OK, assignResponse.StatusCode);
 

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/SpecializationEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/SpecializationEndToEndTests.cs
@@ -8,7 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
@@ -27,7 +27,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.WebJobs.Script.Tests;
-using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -208,10 +207,9 @@ public class SpecializationEndToEndTests : IAsyncLifetime, IDisposable, IClassFi
         // 2. Assign the worker — drives init + specialize + metadata prefetch
         //    so cached responses are ready when the runtime links.
         using var proxyClient = ComputeSeparationTestHelpers.CreateAuthenticatedWorkerProxyClient(ManagementPort);
-        var workerAssignResponse = await proxyClient.PostAsync("/admin/worker/assign",
-            new StringContent(
-                JsonConvert.SerializeObject(new { environment = new { FUNCTIONS_WORKER_RUNTIME = "node" }, functionAppDirectory = "/home/site/wwwroot" }),
-                Encoding.UTF8, "application/json"));
+        var workerAssignResponse = await proxyClient.PostAsync(
+            "/admin/worker/assign",
+            ComputeSeparationTestHelpers.CreateWorkerAssignRequestContent());
         _output.WriteLine($"Worker assign response: {workerAssignResponse.StatusCode}");
         Assert.Equal(HttpStatusCode.OK, workerAssignResponse.StatusCode);
 
@@ -229,7 +227,7 @@ public class SpecializationEndToEndTests : IAsyncLifetime, IDisposable, IClassFi
         };
 
         string encryptedContext = EncryptionHelper.Encrypt(
-            JsonConvert.SerializeObject(assignmentContext),
+            JsonSerializer.Serialize(assignmentContext),
             Convert.FromBase64String(_encryptionKey));
 
         var assignResponse = await SendAdminRequest(
@@ -247,13 +245,7 @@ public class SpecializationEndToEndTests : IAsyncLifetime, IDisposable, IClassFi
         {
             linkResponse = await SendAdminRequest(
                 masterKey, HttpMethod.Put, "admin/workers/w_spec_e2e01",
-                new
-                {
-                    workerId = "w_spec_e2e01",
-                    podName = "worker-pod-spec-e2e",
-                    grpcEndpoint = $"http://localhost:{RuntimeGrpcPort}",
-                    podKey = "test-key"
-                });
+                ComputeSeparationTestHelpers.CreateWorkerLinkRequest("w_spec_e2e01", RuntimeGrpcPort, HttpProxyPort));
 
             if (linkResponse.StatusCode == HttpStatusCode.OK)
             {
@@ -331,8 +323,7 @@ public class SpecializationEndToEndTests : IAsyncLifetime, IDisposable, IClassFi
 
         if (body is not null)
         {
-            request.Content = new StringContent(
-                JsonConvert.SerializeObject(body), Encoding.UTF8, "application/json");
+            request.Content = ComputeSeparationTestHelpers.CreateJsonContent(body);
         }
 
         return await _httpClient.SendAsync(request);

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAllocationApiTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAllocationApiTests.cs
@@ -5,14 +5,11 @@ using System;
 using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.ComputeSeparation;
@@ -96,7 +93,7 @@ public class WorkerAllocationApiTests : IAsyncLifetime
     [Fact]
     public async Task LinkWorker_MissingEndpoint_Returns400()
     {
-        var request = new { workerId = "w_test1234" };
+        var request = new { WorkerPodName = "w_test1234" };
         var response = await SendAdminRequest(HttpMethod.Put, "admin/workers/w_test1234", request);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -106,10 +103,7 @@ public class WorkerAllocationApiTests : IAsyncLifetime
     public async Task AdminEndpoint_WithoutAuth_Returns401()
     {
         var request = new HttpRequestMessage(HttpMethod.Put, "admin/workers/w_test1234");
-        request.Content = new StringContent(
-            JsonConvert.SerializeObject(new { grpcEndpoint = "http://10.0.1.42:50051" }),
-            Encoding.UTF8,
-            "application/json");
+        request.Content = ComputeSeparationTestHelpers.CreateJsonContent(new { WorkerGrpcEndpoint = "http://10.0.1.42:50051" });
         var response = await _host.HttpClient.SendAsync(request);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -174,10 +168,7 @@ public class WorkerAllocationApiTests : IAsyncLifetime
 
         if (body is not null)
         {
-            request.Content = new StringContent(
-                JsonConvert.SerializeObject(body),
-                Encoding.UTF8,
-                "application/json");
+            request.Content = ComputeSeparationTestHelpers.CreateJsonContent(body);
         }
 
         return await _host.HttpClient.SendAsync(request);

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAllocationEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAllocationEndToEndTests.cs
@@ -7,12 +7,10 @@ using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.WebJobs.Script.Tests;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -121,16 +119,10 @@ public class WorkerAllocationEndToEndTests : IAsyncLifetime, IDisposable
         Assert.Equal(HttpStatusCode.OK, assignResponse.StatusCode);
 
         // 2. Link the worker via the admin API.
-        var linkRequest = new
-        {
-            workerId = "w_e2etest01",
-            podName = "worker-pod-e2e",
-            grpcEndpoint = $"http://localhost:{RuntimeGrpcPort}",
-            podKey = "test-key"
-        };
+        var linkRequest = ComputeSeparationTestHelpers.CreateWorkerLinkRequest("w_e2etest01", RuntimeGrpcPort, HttpProxyPort);
 
         var linkResponse = await SendAdminRequest(
-            masterKey, HttpMethod.Put, $"admin/workers/{linkRequest.workerId}", linkRequest);
+            masterKey, HttpMethod.Put, "admin/workers/w_e2etest01", linkRequest);
 
         string linkBody = await linkResponse.Content.ReadAsStringAsync();
         _output.WriteLine($"Link response: {linkResponse.StatusCode} — {linkBody}");
@@ -159,16 +151,10 @@ public class WorkerAllocationEndToEndTests : IAsyncLifetime, IDisposable
         Assert.Equal(HttpStatusCode.OK, assignResponse.StatusCode);
 
         // 2. Link the worker.
-        var linkRequest = new
-        {
-            workerId = "w_e2estop01",
-            podName = "worker-pod-stop",
-            grpcEndpoint = $"http://localhost:{RuntimeGrpcPort}",
-            podKey = "test-key"
-        };
+        var linkRequest = ComputeSeparationTestHelpers.CreateWorkerLinkRequest("w_e2estop01", RuntimeGrpcPort, HttpProxyPort);
 
         var linkResponse = await SendAdminRequest(
-            masterKey, HttpMethod.Put, $"admin/workers/{linkRequest.workerId}", linkRequest);
+            masterKey, HttpMethod.Put, "admin/workers/w_e2estop01", linkRequest);
         Assert.Equal(HttpStatusCode.OK, linkResponse.StatusCode);
 
         // 3. Wait for host ready (ScriptHost startup runs in background after link).
@@ -177,10 +163,10 @@ public class WorkerAllocationEndToEndTests : IAsyncLifetime, IDisposable
 
         // 4. Verify worker proxy is in ReadyForRequest state.
         var stateResponse = await proxyClient.PostAsync("/admin/infra/instanceState",
-            new StringContent("{\"revision\": 0}", Encoding.UTF8, "application/json"));
-        var state = JObject.Parse(await stateResponse.Content.ReadAsStringAsync());
-        _output.WriteLine($"Worker proxy state before stop: {state}");
-        Assert.Equal("ReadyForRequest", state["state"]?["podStatus"]?.ToString());
+            ComputeSeparationTestHelpers.CreateJsonContent(new { revision = 0 }));
+        using var state = JsonDocument.Parse(await stateResponse.Content.ReadAsStringAsync());
+        _output.WriteLine($"Worker proxy state before stop: {state.RootElement}");
+        Assert.Equal("ReadyForRequest", state.RootElement.GetProperty("state").GetProperty("podStatus").GetString());
 
         // 4. Call /admin/host/stop.
         var stopResponse = await SendAdminRequest(masterKey, HttpMethod.Post, "admin/host/stop");
@@ -192,7 +178,7 @@ public class WorkerAllocationEndToEndTests : IAsyncLifetime, IDisposable
         // but the proxy process may exit at any point during this sequence. Any of these
         // outcomes is valid: observing Draining, observing MarkedForDeletion, or the proxy
         // process exiting (connection lost).
-        int lastRevision = state["revision"]?.Value<int>() ?? 0;
+        int lastRevision = state.RootElement.GetProperty("revision").GetInt32();
         var sw = Stopwatch.StartNew();
         string finalStatus = null;
         bool proxyExited = false;
@@ -202,13 +188,13 @@ public class WorkerAllocationEndToEndTests : IAsyncLifetime, IDisposable
             try
             {
                 var pollResponse = await proxyClient.PostAsync("/admin/infra/instanceState",
-                    new StringContent($"{{\"revision\": {lastRevision}}}", Encoding.UTF8, "application/json"));
+                    ComputeSeparationTestHelpers.CreateJsonContent(new { revision = lastRevision }));
 
                 if (pollResponse.StatusCode == HttpStatusCode.OK)
                 {
-                    var pollState = JObject.Parse(await pollResponse.Content.ReadAsStringAsync());
-                    finalStatus = pollState["state"]?["podStatus"]?.ToString();
-                    lastRevision = pollState["revision"]?.Value<int>() ?? lastRevision;
+                    using var pollState = JsonDocument.Parse(await pollResponse.Content.ReadAsStringAsync());
+                    finalStatus = pollState.RootElement.GetProperty("state").GetProperty("podStatus").GetString();
+                    lastRevision = pollState.RootElement.GetProperty("revision").GetInt32();
                     _output.WriteLine($"Worker proxy state: {finalStatus} (revision {lastRevision}, {sw.Elapsed.TotalSeconds:F1}s)");
 
                     if (string.Equals(finalStatus, "MarkedForDeletion", StringComparison.OrdinalIgnoreCase)
@@ -268,10 +254,7 @@ public class WorkerAllocationEndToEndTests : IAsyncLifetime, IDisposable
 
         if (body is not null)
         {
-            request.Content = new StringContent(
-                JsonConvert.SerializeObject(body),
-                Encoding.UTF8,
-                "application/json");
+            request.Content = ComputeSeparationTestHelpers.CreateJsonContent(body);
         }
 
         return await _host.HttpClient.SendAsync(request);
@@ -279,14 +262,9 @@ public class WorkerAllocationEndToEndTests : IAsyncLifetime, IDisposable
 
     private static async Task<HttpResponseMessage> CallWorkerAssignAsync(HttpClient proxyClient)
     {
-        var assignPayload = new
-        {
-            environment = new { FUNCTIONS_WORKER_RUNTIME = "node" },
-            functionAppDirectory = "/home/site/wwwroot"
-        };
-
-        return await proxyClient.PostAsync("/admin/worker/assign",
-            new StringContent(JsonConvert.SerializeObject(assignPayload), Encoding.UTF8, "application/json"));
+        return await proxyClient.PostAsync(
+            "/admin/worker/assign",
+            ComputeSeparationTestHelpers.CreateWorkerAssignRequestContent());
     }
 
     private async Task WaitForHostReadyAsync(string masterKey, TimeSpan timeout)
@@ -300,8 +278,8 @@ public class WorkerAllocationEndToEndTests : IAsyncLifetime, IDisposable
                 var response = await SendAdminRequest(masterKey, HttpMethod.Get, "admin/host/status");
                 if (response.StatusCode == HttpStatusCode.OK)
                 {
-                    var status = JObject.Parse(await response.Content.ReadAsStringAsync());
-                    string state = status["state"]?.ToString();
+                    using var status = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+                    string state = status.RootElement.GetProperty("state").GetString();
                     _output.WriteLine($"Host state: {state} ({sw.Elapsed.TotalSeconds:F1}s)");
 
                     if (string.Equals(state, "Running", StringComparison.OrdinalIgnoreCase))

--- a/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAssignAndLinkEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ComputeSeparation/WorkerAssignAndLinkEndToEndTests.cs
@@ -7,12 +7,10 @@ using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.WebJobs.Script.Tests;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -159,27 +157,16 @@ public class WorkerAssignAndLinkEndToEndTests : IAsyncLifetime, IDisposable
 
     private static async Task<HttpResponseMessage> CallWorkerAssignAsync(HttpClient proxyClient)
     {
-        var assignPayload = new
-        {
-            environment = new { FUNCTIONS_WORKER_RUNTIME = "node" },
-            functionAppDirectory = "/home/site/wwwroot"
-        };
-
-        return await proxyClient.PostAsync("/admin/worker/assign",
-            new StringContent(JsonConvert.SerializeObject(assignPayload), Encoding.UTF8, "application/json"));
+        return await proxyClient.PostAsync(
+            "/admin/worker/assign",
+            ComputeSeparationTestHelpers.CreateWorkerAssignRequestContent());
     }
 
     private async Task<HttpResponseMessage> CallWorkerLinkAsync(string masterKey)
     {
-        var linkRequest = new
-        {
-            workerId = "w_assign_e2e",
-            podName = "worker-pod-assign-e2e",
-            grpcEndpoint = $"http://localhost:{RuntimeGrpcPort}",
-            podKey = "test-key"
-        };
+        var linkRequest = ComputeSeparationTestHelpers.CreateWorkerLinkRequest("w_assign_e2e", RuntimeGrpcPort, HttpProxyPort);
 
-        return await SendAdminRequest(masterKey, HttpMethod.Put, $"admin/workers/{linkRequest.workerId}", linkRequest);
+        return await SendAdminRequest(masterKey, HttpMethod.Put, "admin/workers/w_assign_e2e", linkRequest);
     }
 
     private async Task AssertHttpTriggerInvocationAsync()
@@ -219,8 +206,7 @@ public class WorkerAssignAndLinkEndToEndTests : IAsyncLifetime, IDisposable
 
         if (body is not null)
         {
-            request.Content = new StringContent(
-                JsonConvert.SerializeObject(body), Encoding.UTF8, "application/json");
+            request.Content = ComputeSeparationTestHelpers.CreateJsonContent(body);
         }
 
         return await _host.HttpClient.SendAsync(request);
@@ -237,8 +223,8 @@ public class WorkerAssignAndLinkEndToEndTests : IAsyncLifetime, IDisposable
                 var response = await SendAdminRequest(masterKey, HttpMethod.Get, "admin/host/status");
                 if (response.StatusCode == HttpStatusCode.OK)
                 {
-                    var status = JObject.Parse(await response.Content.ReadAsStringAsync());
-                    string state = status["state"]?.ToString();
+                    using var status = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+                    string state = status.RootElement.GetProperty("state").GetString();
                     _output.WriteLine($"Host state: {state} ({sw.Elapsed.TotalSeconds:F1}s)");
 
                     if (string.Equals(state, "Running", StringComparison.OrdinalIgnoreCase))

--- a/test/WebJobs.Script.Tests/Extensions/ScriptJwtBearerExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Extensions/ScriptJwtBearerExtensionsTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Extensions
         [InlineData(true, "FlexConsumption", null, "1", "RandomPodName", "", "RandomPodName")] // Placeholder mode Flex Consumption
         [InlineData(true, "Dynamic", null, "1", null, "RandomContainerName", "RandomContainerName")] // Placeholder mode Linux Consumption on Legion
         [InlineData(true, "Dynamic", null, null, null, "RandomContainerName", "RandomContainerName")] // Placeholder mode Linux Consumption on Atlas
-        [InlineData(false, "FlexConsumption", null, "1", "RandomPodName", null, "https://RandomSiteName.azurewebsites.net/azurefunctions,https://RandomSiteName.azurewebsites.net")]
+        [InlineData(false, "FlexConsumption", null, "1", "RandomPodName", null, "https://RandomSiteName.azurewebsites.net/azurefunctions,https://RandomSiteName.azurewebsites.net,RandomPodName")]
         [InlineData(false, "Dynamic", null, null, null, "RandomContainerName", "https://RandomSiteName.azurewebsites.net/azurefunctions,https://RandomSiteName.azurewebsites.net")]
         [InlineData(false, "Dynamic", "123", null, null, null, "https://RandomSiteName.azurewebsites.net/azurefunctions,https://RandomSiteName.azurewebsites.net")]
         public void CreateTokenValidationParameters_HasExpectedAudiences(bool isPlaceholderModeEnabled, string sku,

--- a/test/WebJobs.Script.Tests/Workers/ExternalWorkers/HostJsonContentProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/ExternalWorkers/HostJsonContentProviderTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Description;
@@ -207,6 +208,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.ExternalWorkers
 
     public class OutboundGrpcClientTests
     {
+        [Fact]
+        public void CreateGrpcChannelOptions_UsesSocketsHttpHandlerWithKeepAliveSettings()
+        {
+            var options = OutboundGrpcClient.CreateGrpcChannelOptions();
+
+            using var handler = Assert.IsType<SocketsHttpHandler>(options.HttpHandler);
+            Assert.Equal(OutboundGrpcClient.DefaultKeepAlivePingDelay, handler.KeepAlivePingDelay);
+            Assert.Equal(OutboundGrpcClient.DefaultKeepAlivePingTimeout, handler.KeepAlivePingTimeout);
+            Assert.Equal(HttpKeepAlivePingPolicy.Always, handler.KeepAlivePingPolicy);
+        }
+
         [Fact]
         public async Task DisposeAsync_CalledMultipleTimes_DoesNotThrow()
         {

--- a/tools/ComputeSeparation/compute-separation.http
+++ b/tools/ComputeSeparation/compute-separation.http
@@ -14,6 +14,14 @@
 @runtimeHost = http://localhost:7071
 @workerProxyHost = http://localhost:50054
 @masterKey = dev-master-key
+@containerEncryptionKey = 0F75CA46E7EBDD39E4CA6B074D1F9A5972B849A55F91A248F6B038A61BACE9D7
+@functionAppName = devhost
+@functionAppId = 1234
+@functionGroupName = http
+@workerId = w_test01
+
+### Select the "project" or "container" environment from http-client.env.json
+### so Step 4 uses the correct proxy endpoints for the current run mode.
 
 ### Long-lived JWT for worker proxy /admin/* calls.
 ### Signed with the dev CONTAINER_ENCRYPTION_KEY from AppHost/Program.cs.
@@ -51,15 +59,22 @@ x-ms-site-token: {{workerProxyToken}}
 ### Step 2: Specialize the worker
 ### NNA calls this after /admin/worker/ready succeeds. The proxy drives the full
 ### init + specialization + metadata prefetch sequence with the worker,
-### caching all responses for later replay to the runtime.
+### caching all responses for later replay to the runtime. The assign payload
+### now includes function identity / inventory metadata in addition to env vars.
+### This endpoint is source-generated with a camelCase JSON contract, so keep
+### these property names camelCase.
 POST {{workerProxyHost}}/admin/worker/assign
 Content-Type: application/json
 x-ms-site-token: {{workerProxyToken}}
 
 {
+  "functionAppName": "{{functionAppName}}",
+  "functionAppId": {{functionAppId}},
+  "functionGroupName": "{{functionGroupName}}",
+  "isAlwaysReady": false,
   "environment": {
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-    "WEBSITE_SITE_NAME": "devhost"
+    "WEBSITE_SITE_NAME": "{{functionAppName}}"
   },
   "functionAppDirectory": "/home/site/wwwroot"
 }
@@ -86,15 +101,17 @@ Content-Type: application/json
 ### FunctionMetadataResponse. This triggers ScriptHost startup and function loading.
 ### Returns 200 OK after gRPC connection and init handshake succeed (capabilities
 ### including host.json received). ScriptHost startup and function loading complete
-### in the background.
-PUT {{runtimeHost}}/admin/workers/w_test01?code={{masterKey}}
+### in the background. In project mode the proxy endpoints are localhost ports;
+### in container mode override them to container-reachable values such as
+### http://worker-proxy:50051 and http://worker-proxy:50053.
+PUT {{runtimeHost}}/admin/workers/{{workerId}}?code={{masterKey}}
 Content-Type: application/json
 
 {
-  "workerId": "w_test01",
-  "podName": "worker-pod-test01",
-  "grpcEndpoint": "{{workerGrpcEndpoint}}",
-  "podKey": "test-key"
+  "WorkerPodName": "{{workerId}}",
+  "WorkerHttpEndpoint": "{{workerProxyHttpEndpoint}}",
+  "WorkerGrpcEndpoint": "{{workerProxyGrpcEndpoint}}",
+  "WorkerContainerEncryptionKey": "{{containerEncryptionKey}}"
 }
 
 ###

--- a/tools/ComputeSeparation/http-client.env.json
+++ b/tools/ComputeSeparation/http-client.env.json
@@ -1,8 +1,10 @@
 {
   "project": {
-    "workerGrpcEndpoint": "http://localhost:50051"
+    "workerProxyGrpcEndpoint": "http://localhost:50051",
+    "workerProxyHttpEndpoint": "http://localhost:50053"
   },
   "container": {
-    "workerGrpcEndpoint": "http://worker-proxy.dev.internal:50051"
+    "workerProxyGrpcEndpoint": "http://worker-proxy.dev.internal:50051",
+    "workerProxyHttpEndpoint": "http://worker-proxy.dev.internal:50053"
   }
 }


### PR DESCRIPTION
- Adds client-side gRPC keep-alives for the runtime's outbound external-worker connection to make idle links more resilient.
- Aligns the compute-separation specialization and worker-link flow with the current runtime and worker-proxy contract.
- Fixes the local HTTP workflow so project and container mode requests target the correct worker-proxy endpoints.