### PR TITLE
[Compute Separation] improving workerproxy logging

### DIFF
--- a/src/Functions.WorkerProxy/CapabilityLogFormatter.cs
+++ b/src/Functions.WorkerProxy/CapabilityLogFormatter.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Text;
+using System.Text.Json;
+
+namespace Microsoft.Azure.Functions.WorkerProxy;
+
+internal static class CapabilityLogFormatter
+{
+    private const string HostConfigurationJsonCapability = "host_configuration_json";
+
+    public static string Format(IEnumerable<KeyValuePair<string, string>>? capabilities)
+    {
+        List<KeyValuePair<string, string>> orderedCapabilities = capabilities?
+            .OrderBy(static capability => capability.Key, StringComparer.Ordinal)
+            .ToList() ?? [];
+
+        if (orderedCapabilities.Count == 0)
+        {
+            return "{}";
+        }
+
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
+
+        writer.WriteStartObject();
+
+        foreach (KeyValuePair<string, string> capability in orderedCapabilities)
+        {
+            writer.WriteString(capability.Key, GetFormattedValue(capability));
+        }
+
+        writer.WriteEndObject();
+        writer.Flush();
+
+        return Encoding.UTF8.GetString(stream.GetBuffer(), 0, checked((int)stream.Length));
+    }
+
+    private static string GetFormattedValue(KeyValuePair<string, string> capability)
+    {
+        if (string.Equals(capability.Key, HostConfigurationJsonCapability, StringComparison.Ordinal))
+        {
+            return $"<omitted; length={capability.Value.Length}>";
+        }
+
+        return capability.Value;
+    }
+}

--- a/src/Functions.WorkerProxy/Diagnostics/MsFunctionLogsLogger.cs
+++ b/src/Functions.WorkerProxy/Diagnostics/MsFunctionLogsLogger.cs
@@ -91,7 +91,9 @@ internal sealed class MsFunctionLogsLogger : ILogger
     internal static string NormalizeString(string? value, bool addEnclosingQuotes = true)
     {
         string normalized = value ?? string.Empty;
-        normalized = normalized.Replace(Environment.NewLine, " ", StringComparison.Ordinal);
+        normalized = normalized.Replace("\r\n", " ", StringComparison.Ordinal);
+        normalized = normalized.Replace("\r", " ", StringComparison.Ordinal);
+        normalized = normalized.Replace("\n", " ", StringComparison.Ordinal);
         normalized = normalized.Replace("\"", "'", StringComparison.Ordinal);
 
         return addEnclosingQuotes ? $"\"{normalized}\"" : normalized;

--- a/src/Functions.WorkerProxy/FunctionRpcRelay.cs
+++ b/src/Functions.WorkerProxy/FunctionRpcRelay.cs
@@ -178,8 +178,12 @@ internal sealed class FunctionRpcRelay : FunctionRpc.FunctionRpcBase
             if (reloadCapabilities is not null)
             {
                 var envReloadResponse = reloadResponse.FunctionEnvironmentReloadResponse!;
-                var initCapabilities = initResponse.WorkerInitResponse!.Capabilities;
                 var strategy = envReloadResponse.CapabilitiesUpdateStrategy;
+                var initCapabilities = initResponse.WorkerInitResponse!.Capabilities;
+
+                _logger.LogInformation("Worker capabilities received by proxy ({Strategy}): {Capabilities}",
+                    strategy,
+                    CapabilityLogFormatter.Format(reloadCapabilities));
 
                 if (strategy == FunctionEnvironmentReloadResponse.Types.CapabilitiesUpdateStrategy.Replace)
                 {
@@ -204,14 +208,8 @@ internal sealed class FunctionRpcRelay : FunctionRpc.FunctionRpcBase
             // reorder these calls and those tests still pass, the tests have rotted.
             RewriteHttpUri(initResponse);
 
-            var capabilities = initResponse.WorkerInitResponse?.Capabilities;
-            if (capabilities is not null)
-            {
-                foreach (var cap in capabilities)
-                {
-                    _logger.LogInformation("WorkerInitResponse capability: {Key} = {Value}", cap.Key, cap.Value);
-                }
-            }
+            _logger.LogInformation("WorkerProxy capabilities to runtime: {Capabilities}",
+                CapabilityLogFormatter.Format(initResponse.WorkerInitResponse!.Capabilities));
 
             // 3. FunctionsMetadataRequest → FunctionMetadataResponse (prefetch)
             _logger.LogInformation("Prefetching function metadata.");

--- a/test/Functions.WorkerProxy.Tests/CapabilityLogFormatterTests.cs
+++ b/test/Functions.WorkerProxy.Tests/CapabilityLogFormatterTests.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.Azure.Functions.WorkerProxy.Tests;
+
+public class CapabilityLogFormatterTests
+{
+    [Fact]
+    public void Format_ReturnsEmptyObject_WhenCapabilitiesAreMissing()
+    {
+        Assert.Equal("{}", CapabilityLogFormatter.Format(null));
+        Assert.Equal("{}", CapabilityLogFormatter.Format(Array.Empty<KeyValuePair<string, string>>()));
+    }
+
+    [Fact]
+    public void Format_OrdersKeysAndSummarizesHostConfigurationJson()
+    {
+        Dictionary<string, string> capabilities = new()
+        {
+            ["z-key"] = "last",
+            ["host_configuration_json"] = """{"version":"2.0"}""",
+            ["a-key"] = "first"
+        };
+
+        string result = CapabilityLogFormatter.Format(capabilities);
+
+        Assert.Equal("""{"a-key":"first","host_configuration_json":"\u003Comitted; length=17\u003E","z-key":"last"}""", result);
+    }
+}

--- a/test/Functions.WorkerProxy.Tests/FunctionRpcRelayTests.cs
+++ b/test/Functions.WorkerProxy.Tests/FunctionRpcRelayTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -29,6 +30,12 @@ public class FunctionRpcRelayTests : IDisposable
     {
         var options = new RelayOptions(50051, 50052, 50053, hostJsonPath, "http://localhost:50053", "test-pod");
         return new FunctionRpcRelay(options, NullLogger<FunctionRpcRelay>.Instance, _stateManager);
+    }
+
+    private FunctionRpcRelay CreateRelay(ILogger<FunctionRpcRelay> logger, string? hostJsonPath = null)
+    {
+        var options = new RelayOptions(50051, 50052, 50053, hostJsonPath, "http://localhost:50053", "test-pod");
+        return new FunctionRpcRelay(options, logger, _stateManager);
     }
 
     private static StreamingMessage CreateWorkerInitResponse(Dictionary<string, string>? capabilities = null)
@@ -413,6 +420,53 @@ public class FunctionRpcRelayTests : IDisposable
         Assert.True(cached.ContainsKey("HttpUri"));
     }
 
+    [Fact]
+    public async Task SpecializeWorkerAsync_LogsIncomingAndFinalCapabilitiesAsSingleLineDictionaries()
+    {
+        string hostJsonContent = """{"version":"2.0","extensions":{"http":{"routePrefix":""}}}""";
+        File.WriteAllText(Path.Combine(_tempDir, "host.json"), hostJsonContent);
+
+        var logger = new TestLogger<FunctionRpcRelay>();
+        var relay = CreateRelay(logger);
+        relay._workerConnected.TrySetResult();
+
+        var initCaps = new Dictionary<string, string>
+        {
+            ["EnableUserCodeException"] = "True"
+        };
+
+        var reloadCaps = new Dictionary<string, string>
+        {
+            ["HttpUri"] = "http://localhost:9999",
+            ["RpcHttpBodyOnly"] = "True"
+        };
+
+        var expectedFinalCapabilities = new Dictionary<string, string>
+        {
+            ["EnableUserCodeException"] = "True",
+            ["HttpUri"] = "http://localhost:50053",
+            ["RpcHttpBodyOnly"] = "True",
+            ["host_configuration_json"] = hostJsonContent
+        };
+
+        var workerTask = SimulateWorkerAsync(relay, initCapabilities: initCaps, reloadCapabilities: reloadCaps);
+        await Task.WhenAll(
+            relay.SpecializeWorkerAsync(new Dictionary<string, string>(), _tempDir, CancellationToken.None),
+            workerTask);
+
+        Assert.Contains(logger.Messages, message => string.Equals(
+            message,
+            $"Worker capabilities received by proxy (Merge): {CapabilityLogFormatter.Format(reloadCaps)}",
+            StringComparison.Ordinal));
+
+        Assert.Contains(logger.Messages, message => string.Equals(
+            message,
+            $"WorkerProxy capabilities to runtime: {CapabilityLogFormatter.Format(expectedFinalCapabilities)}",
+            StringComparison.Ordinal));
+
+        Assert.DoesNotContain(logger.Messages, message => message.Contains("WorkerInitResponse capability:", StringComparison.Ordinal));
+    }
+
     // --- RewriteHttpUri tests ---
 
     [Fact]
@@ -765,6 +819,38 @@ public class FunctionRpcRelayTests : IDisposable
                 Result = new StatusResult { Status = StatusResult.Types.Status.Success }
             }
         });
+    }
+
+    private sealed class TestLogger<T> : ILogger<T>
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            return NullScope.Instance;
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Messages.Add(formatter(state, exception));
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+
+            public void Dispose()
+            {
+            }
+        }
     }
 
     private static async Task<Exception?> CaptureOutcomeAsync(Task task)

--- a/test/Functions.WorkerProxy.Tests/MsFunctionLogsLoggerTests.cs
+++ b/test/Functions.WorkerProxy.Tests/MsFunctionLogsLoggerTests.cs
@@ -24,12 +24,16 @@ public class MsFunctionLogsLoggerTests
         var lines = new List<string>();
         using var provider = new MsFunctionLogsLoggerProvider(lines.Add, CreateOptions("container-01", "Stamp-01", "TENANT-01"));
         ILogger logger = provider.CreateLogger("Microsoft.Azure.Functions.WorkerProxy.FunctionRpcRelay");
-        string summaryValue = $"line1{Environment.NewLine}\"summary\"";
-        var exception = new InvalidOperationException($"bad{Environment.NewLine}\"details\"");
+        string summaryValue = "line1\r\"cr\"\n\"lf\"\r\n\"crlf\"";
+        var exception = new InvalidOperationException("bad\r\"cr\"\n\"lf\"\r\n\"crlf\"");
 
         logger.LogError(exception, "summary {Value}", summaryValue);
 
-        Match match = TraceEventRegex.Match(Assert.Single(lines));
+        string line = Assert.Single(lines);
+        Assert.DoesNotContain('\r', line);
+        Assert.DoesNotContain('\n', line);
+
+        Match match = TraceEventRegex.Match(line);
 
         Assert.True(match.Success);
         Assert.Equal("2", match.Groups["Level"].Value);
@@ -88,10 +92,10 @@ public class MsFunctionLogsLoggerTests
     [Fact]
     public void NormalizeString_ReplacesNewLinesAndDoubleQuotes()
     {
-        string value = $"line1{Environment.NewLine}\"line2\"";
+        string value = "line1\r\"line2\"\n\"line3\"\r\n\"line4\"";
 
-        Assert.Equal("\"line1 'line2'\"", MsFunctionLogsLogger.NormalizeString(value));
-        Assert.Equal("line1 'line2'", MsFunctionLogsLogger.NormalizeString(value, addEnclosingQuotes: false));
+        Assert.Equal("\"line1 'line2' 'line3' 'line4'\"", MsFunctionLogsLogger.NormalizeString(value));
+        Assert.Equal("line1 'line2' 'line3' 'line4'", MsFunctionLogsLogger.NormalizeString(value, addEnclosingQuotes: false));
     }
 
     [Fact]


### PR DESCRIPTION
- Looking at logs in kusto and there were issues with newline parsing. Fixing this.
- We shouldn't log host.json contents. 
- Summarizing capabilities to one line rather than one-per-capabiliity