### PR TITLE
[Compute Separation] improving timing logs for startup

### DIFF
--- a/src/Functions.WorkerProxy.Supervisor/FunctionLogWriter.cs
+++ b/src/Functions.WorkerProxy.Supervisor/FunctionLogWriter.cs
@@ -48,7 +48,7 @@ internal sealed class FunctionLogWriter
 
         if (line.Length > 0)
         {
-            WriteSupervisorMessage(2, $"workerproxy-process: {line}");
+            WriteSupervisorMessage(4, $"workerproxy-process: {line}");
         }
     }
 

--- a/src/Functions.WorkerProxy/FunctionRpcRelay.cs
+++ b/src/Functions.WorkerProxy/FunctionRpcRelay.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using System.Threading.Channels;
 using Grpc.Core;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
@@ -47,6 +48,16 @@ internal record RelayOptions(int RuntimeGrpcPort, int WorkerGrpcPort, int HttpPr
 /// </summary>
 internal sealed class FunctionRpcRelay : FunctionRpc.FunctionRpcBase
 {
+    private const string FunctionsNetHostRpcLogPrefix = "FunctionsNetHost:";
+
+    private enum HostJsonSource
+    {
+        FunctionAppDirectory,
+        ExplicitPath
+    }
+
+    private sealed record HostJsonReadResult(string Path, string Content, HostJsonSource Source);
+
     private readonly RelayOptions _options;
     private readonly ILogger<FunctionRpcRelay> _logger;
     private readonly WorkerPodStateManager _stateManager;
@@ -153,13 +164,22 @@ internal sealed class FunctionRpcRelay : FunctionRpc.FunctionRpcBase
             // The worker SDK expects this env var to be set during FunctionLoad.
             reloadRequest.EnvironmentVariables.TryAdd("FUNCTIONS_APPLICATION_DIRECTORY", functionAppDirectory);
 
+            var hostJsonReadTask = ReadHostJsonAsync(functionAppDirectory, token);
+
             _logger.LogInformation("Sending FunctionEnvironmentReloadRequest (functionAppDirectory={dir}).", functionAppDirectory);
+            var reloadStart = Stopwatch.GetTimestamp();
             var reloadResponse = await SendAndWaitAsync(
                 new StreamingMessage { FunctionEnvironmentReloadRequest = reloadRequest },
                 StreamingMessage.ContentOneofCase.FunctionEnvironmentReloadResponse,
                 token);
 
             var status = reloadResponse.FunctionEnvironmentReloadResponse?.Result?.Status;
+            var capabilitiesCount = reloadResponse.FunctionEnvironmentReloadResponse?.Capabilities.Count ?? 0;
+            _logger.LogInformation("Received FunctionEnvironmentReloadResponse. Status: {Status}, CapabilitiesCount: {CapabilitiesCount}, ElapsedMilliseconds: {ElapsedMilliseconds}.",
+                status,
+                capabilitiesCount,
+                Stopwatch.GetElapsedTime(reloadStart).TotalMilliseconds);
+
             if (status == StatusResult.Types.Status.Failure)
             {
                 var errorMsg = reloadResponse.FunctionEnvironmentReloadResponse?.Result?.Exception?.Message
@@ -198,7 +218,7 @@ internal sealed class FunctionRpcRelay : FunctionRpc.FunctionRpcBase
 
             // Now that we know the function app directory, inject host.json and rewrite
             // the HttpUri capability so the runtime routes HTTP requests through this proxy.
-            InjectHostJson(initResponse, functionAppDirectory);
+            InjectHostJson(initResponse, await hostJsonReadTask);
 
             // RewriteHttpUri MUST run AFTER the capability merge above. The merge produces
             // the final, post-specialization capability set; rewriting before it would
@@ -331,6 +351,9 @@ internal sealed class FunctionRpcRelay : FunctionRpc.FunctionRpcBase
     /// 2. Try the explicit <see cref="RelayOptions.HostJsonPath"/> override.
     /// </summary>
     internal void InjectHostJson(StreamingMessage message, string functionAppDirectory)
+        => InjectHostJson(message, ReadHostJson(functionAppDirectory));
+
+    private void InjectHostJson(StreamingMessage message, HostJsonReadResult? hostJson)
     {
         if (message.ContentCase != StreamingMessage.ContentOneofCase.WorkerInitResponse)
         {
@@ -339,27 +362,74 @@ internal sealed class FunctionRpcRelay : FunctionRpc.FunctionRpcBase
 
         var capabilities = message.WorkerInitResponse.Capabilities;
 
+        if (hostJson is null)
+        {
+            _logger.LogWarning("No host.json found. The runtime will use a default configuration.");
+            return;
+        }
+
+        capabilities["host_configuration_json"] = hostJson.Content;
+        if (hostJson.Source == HostJsonSource.FunctionAppDirectory)
+        {
+            _logger.LogInformation("Injected host.json from function app directory '{path}'.", hostJson.Path);
+            return;
+        }
+
+        _logger.LogInformation("Injected host.json from explicit path '{path}'.", hostJson.Path);
+    }
+
+    private HostJsonReadResult? ReadHostJson(string? functionAppDirectory)
+    {
         // 1. Try reading from the function app directory.
         if (!string.IsNullOrEmpty(functionAppDirectory))
         {
             string appDirHostJson = Path.Combine(functionAppDirectory, "host.json");
             if (File.Exists(appDirHostJson))
             {
-                capabilities["host_configuration_json"] = File.ReadAllText(appDirHostJson);
-                _logger.LogInformation("Injected host.json from function app directory '{path}'.", appDirHostJson);
-                return;
+                return new HostJsonReadResult(
+                    appDirHostJson,
+                    File.ReadAllText(appDirHostJson),
+                    HostJsonSource.FunctionAppDirectory);
             }
         }
 
         // 2. Explicit HostJsonPath option.
         if (!string.IsNullOrEmpty(_options.HostJsonPath) && File.Exists(_options.HostJsonPath))
         {
-            capabilities["host_configuration_json"] = File.ReadAllText(_options.HostJsonPath);
-            _logger.LogInformation("Injected host.json from explicit path '{path}'.", _options.HostJsonPath);
-            return;
+            return new HostJsonReadResult(
+                _options.HostJsonPath,
+                File.ReadAllText(_options.HostJsonPath),
+                HostJsonSource.ExplicitPath);
         }
 
-        _logger.LogWarning("No host.json found. The runtime will use a default configuration.");
+        return null;
+    }
+
+    private async Task<HostJsonReadResult?> ReadHostJsonAsync(string? functionAppDirectory, CancellationToken cancellationToken)
+    {
+        // 1. Try reading from the function app directory.
+        if (!string.IsNullOrEmpty(functionAppDirectory))
+        {
+            string appDirHostJson = Path.Combine(functionAppDirectory, "host.json");
+            if (File.Exists(appDirHostJson))
+            {
+                return new HostJsonReadResult(
+                    appDirHostJson,
+                    await File.ReadAllTextAsync(appDirHostJson, cancellationToken),
+                    HostJsonSource.FunctionAppDirectory);
+            }
+        }
+
+        // 2. Explicit HostJsonPath option.
+        if (!string.IsNullOrEmpty(_options.HostJsonPath) && File.Exists(_options.HostJsonPath))
+        {
+            return new HostJsonReadResult(
+                _options.HostJsonPath,
+                await File.ReadAllTextAsync(_options.HostJsonPath, cancellationToken),
+                HostJsonSource.ExplicitPath);
+        }
+
+        return null;
     }
 
     private void RewriteHttpUri(StreamingMessage message)
@@ -451,6 +521,11 @@ internal sealed class FunctionRpcRelay : FunctionRpc.FunctionRpcBase
                 if (side == RelaySide.Worker)
                 {
                     // --- Worker-side interception ---
+
+                    if (message.ContentCase == StreamingMessage.ContentOneofCase.RpcLog)
+                    {
+                        WriteFunctionsNetHostLogToConsole(message.RpcLog);
+                    }
 
                     // Cache StartStream and signal worker connected. Do NOT relay.
                     if (message.ContentCase == StreamingMessage.ContentOneofCase.StartStream)
@@ -569,6 +644,17 @@ internal sealed class FunctionRpcRelay : FunctionRpc.FunctionRpcBase
         {
             forwardWriter.TryComplete();
         }
+    }
+
+    private static void WriteFunctionsNetHostLogToConsole(RpcLog? rpcLog)
+    {
+        var message = rpcLog?.Message;
+        if (message is null || !message.StartsWith(FunctionsNetHostRpcLogPrefix, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        Console.WriteLine(message);
     }
 
     private static async Task WriteOutboundAsync(

--- a/test/Functions.WorkerProxy.Tests/FunctionRpcRelayTests.cs
+++ b/test/Functions.WorkerProxy.Tests/FunctionRpcRelayTests.cs
@@ -737,6 +737,23 @@ public class FunctionRpcRelayTests : IDisposable
         Assert.Equal(hostJsonContent, cached["host_configuration_json"]);
     }
 
+    [Fact]
+    public async Task SpecializeWorkerAsync_HostJsonRead_StartsBeforeEnvironmentReloadCompletes()
+    {
+        string hostJsonPath = Path.Combine(_tempDir, "host.json");
+        string hostJsonContent = """{"version":"2.0","source":"prefetched"}""";
+        File.WriteAllText(hostJsonPath, hostJsonContent);
+
+        var relay = CreateRelay();
+        relay._workerConnected.TrySetResult();
+
+        var workerTask = SimulateWorkerAsync(relay, onEnvReload: _ => File.Delete(hostJsonPath));
+        await relay.SpecializeWorkerAsync(new Dictionary<string, string>(), _tempDir, CancellationToken.None);
+
+        var cached = relay._cachedWorkerInitResponse!.WorkerInitResponse.Capabilities;
+        Assert.Equal(hostJsonContent, cached["host_configuration_json"]);
+    }
+
     // --- Helper methods ---
 
     /// <summary>

--- a/test/Functions.WorkerProxy.Tests/Supervisor/FunctionLogWriterTests.cs
+++ b/test/Functions.WorkerProxy.Tests/Supervisor/FunctionLogWriterTests.cs
@@ -30,7 +30,7 @@ public class FunctionLogWriterTests
         writer.WriteProcessLine("fatal \"boom\"");
 
         string line = output.ToString();
-        Assert.StartsWith("MS_FUNCTION_LOGS 2,,,,workerproxy.process,workerproxy.supervisor", line);
+        Assert.StartsWith("MS_FUNCTION_LOGS 4,,,,workerproxy.process,workerproxy.supervisor", line);
         Assert.Contains("\"workerproxy-process: fatal 'boom'\"", line);
         Assert.Contains(",4.1050.100,2026-04-25T12:34:56.0000000Z,", line);
         Assert.Contains(",CONTAINER-01,stamp-01,tenant-01,", line);

--- a/tools/ComputeSeparation/FunctionsNetHost/Dockerfile
+++ b/tools/ComputeSeparation/FunctionsNetHost/Dockerfile
@@ -19,8 +19,10 @@ WORKDIR /extract
 
 # Build Linux FunctionsNetHost from source and stage the same files that the packaged native host provides.
 RUN apt-get update \
-    && apt-get install -y git clang zlib1g-dev \
-    && git clone --depth 1 --single-branch --branch brettsam/nethost_retry https://github.com/Azure/azure-functions-dotnet-worker.git /tmp/azure-functions-dotnet-worker \
+    && apt-get install -y curl clang zlib1g-dev \
+    && mkdir -p /tmp/azure-functions-dotnet-worker \
+    && curl -fsSL "https://github.com/Azure/azure-functions-dotnet-worker/archive/409466bfbcd9a7c3c6a9c47fbda30248e6afaf68.tar.gz" \
+        | tar -xz --strip-components=1 -C /tmp/azure-functions-dotnet-worker \
     && for tfm in net10.0 net9.0 net8.0; do \
         version="${tfm#net}"; \
         dotnet publish /tmp/azure-functions-dotnet-worker/host/src/PrelaunchApp/App.csproj -c Release -f "${tfm}" -p:UseAppHost=false -o "/extract/prelaunchapps/${version}"; \
@@ -43,6 +45,7 @@ COPY --from=extract-nethost /extract/prelaunchapps/ ./prelaunchapps/
 RUN mkdir -p /home/site/wwwroot
 
 ENV HOME=/home
+ENV FUNCTIONS_WORKER_RUNTIME_VERSION=10.0
 ENV FUNCTIONS_GRPC_HOST=localhost
 # Worker-proxy's worker-facing gRPC listener defaults to 50054 (WORKER_GRPC_PORT).
 # FunctionsNetHost dials this endpoint to register as the language worker.

--- a/tools/ComputeSeparation/SampleIsolatedApp/Dockerfile
+++ b/tools/ComputeSeparation/SampleIsolatedApp/Dockerfile
@@ -19,8 +19,10 @@ WORKDIR /extract
 
 # Build Linux FunctionsNetHost from source and stage the same files that the packaged native host provides.
 RUN apt-get update \
-    && apt-get install -y git clang zlib1g-dev \
-    && git clone --depth 1 --single-branch --branch brettsam/nethost_retry https://github.com/Azure/azure-functions-dotnet-worker.git /tmp/azure-functions-dotnet-worker \
+    && apt-get install -y curl clang zlib1g-dev \
+    && mkdir -p /tmp/azure-functions-dotnet-worker \
+    && curl -fsSL "https://github.com/Azure/azure-functions-dotnet-worker/archive/409466bfbcd9a7c3c6a9c47fbda30248e6afaf68.tar.gz" \
+        | tar -xz --strip-components=1 -C /tmp/azure-functions-dotnet-worker \
     && for tfm in net10.0 net9.0 net8.0; do \
         version="${tfm#net}"; \
         dotnet publish /tmp/azure-functions-dotnet-worker/host/src/PrelaunchApp/App.csproj -c Release -f "${tfm}" -p:UseAppHost=false -o "/extract/prelaunchapps/${version}"; \
@@ -53,6 +55,7 @@ COPY --from=extract-nethost /extract/prelaunchapps/ ./prelaunchapps/
 COPY --from=publish-app /app/publish/ /home/site/wwwroot/
 
 ENV HOME=/home
+ENV FUNCTIONS_WORKER_RUNTIME_VERSION=10.0
 ENV FUNCTIONS_GRPC_HOST=localhost
 ENV FUNCTIONS_GRPC_PORT=50052
 


### PR DESCRIPTION
- Added WorkerProxy timing logs around `FunctionEnvironmentReloadRequest`/`FunctionEnvironmentReloadResponse`, including elapsed time, status, and capability count.
- Echo prefixed `FunctionsNetHost:` `RpcLog` messages from the worker through WorkerProxy console output so FunctionsNetHost startup instrumentation is captured.
- Start reading `host.json` asynchronously before env reload and inject the prefetched content after specialization to avoid post-reload file I/O.
- Changed WorkerProxy supervisor passthrough process logs to default to event level 4 instead of level 2.
- Pinned FunctionsNetHost Docker builds to exact dotnet-worker commit `409466bfbcd9a7c3c6a9c47fbda30248e6afaf68` instead of a moving branch.
- Set `FUNCTIONS_WORKER_RUNTIME_VERSION=10.0` in the compute-separation Dockerfiles for FunctionsNetHost prelaunch optimization.
- Added/updated WorkerProxy tests for host.json prefetch behavior and supervisor log level output.
