### PR TITLE
[Compute Separation] adding startup log for workerproxy

### DIFF
--- a/src/Functions.WorkerProxy/Program.cs
+++ b/src/Functions.WorkerProxy/Program.cs
@@ -190,6 +190,12 @@ adminAuthed.MapPost("/infra/instanceState", async (HttpContext ctx, Cancellation
     return await ManagementApiHandlers.HandleInstanceStateAsync(clientRevision, stateManager, cancellationToken);
 });
 
+app.Lifetime.ApplicationStarted.Register(() =>
+{
+    app.Logger.LogInformation("WorkerProxy listening. runtimeGrpcPort={RuntimeGrpcPort}, workerGrpcPort={WorkerGrpcPort}, httpProxyPort={HttpProxyPort}, managementPort={ManagementPort}, httpProxyEndpoint={HttpProxyEndpoint}, podName={PodName}",
+         runtimeGrpcPort, workerGrpcPort, httpProxyPort, managementPort, httpProxyEndpoint, podName);
+});
+
 app.Run();
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
With default logging enabled, it was impossible to tell if the WorkerProxy had actually started up successfully as it's  mostly silent until something connects to it. Adding a log to show some life.