### PR TITLE
Exclude ACA Managed App Environment from IsLinuxConsumptionOnAtlas

### DIFF
--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -359,7 +359,8 @@ namespace Microsoft.Azure.WebJobs.Script
             return !environment.IsAppService() &&
                    (!string.IsNullOrEmpty(environment.GetEnvironmentVariable(ContainerName)) ||
                    !string.IsNullOrEmpty(environment.GetEnvironmentVariable(WebsitePodName))) &&
-                   !string.IsNullOrEmpty(environment.GetEnvironmentVariable(LegionServiceHost));
+                   !string.IsNullOrEmpty(environment.GetEnvironmentVariable(LegionServiceHost)) &&
+                   !environment.IsManagedAppEnvironment();
         }
 
         /// <summary>

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -350,7 +350,8 @@ namespace Microsoft.Azure.WebJobs.Script
         {
             return !environment.IsAppService() &&
                    !string.IsNullOrEmpty(environment.GetEnvironmentVariable(ContainerName)) &&
-                   string.IsNullOrEmpty(environment.GetEnvironmentVariable(LegionServiceHost));
+                   string.IsNullOrEmpty(environment.GetEnvironmentVariable(LegionServiceHost)) &&
+                   !environment.IsManagedAppEnvironment();
         }
 
         public static bool IsConsumptionOnLegion(this IEnvironment environment)

--- a/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
+++ b/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
@@ -264,6 +264,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
+        [Trait(TestTraits.Group, TestTraits.LinuxConsumptionMetricsTests)]
+        [InlineData("", true)]      // baseline Atlas detection
+        [InlineData(null, true)]
+        [InlineData("true", false)] // MANAGED_ENVIRONMENT set => not Atlas
+        [InlineData("1", false)]
+        public void IsLinuxConsumptionOnAtlas_ExcludesManagedAppEnvironment(string managedEnvironment, bool isLinuxConsumptionOnAtlas)
+        {
+            var testEnvironment = new TestEnvironment();
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "container-name");
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.ManagedEnvironment, managedEnvironment);
+
+            Assert.Equal(isLinuxConsumptionOnAtlas, testEnvironment.IsLinuxConsumptionOnAtlas());
+            Assert.Equal(isLinuxConsumptionOnAtlas, testEnvironment.IsLinuxMetricsPublishingEnabled());
+        }
+
+        [Theory]
         [InlineData(ScriptConstants.ElasticPremiumSku, true)]
         [InlineData("test", false)]
         [InlineData("", false)]

--- a/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
+++ b/test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs
@@ -246,11 +246,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Theory]
-        [InlineData(ScriptConstants.DynamicSku, "containerName", "", "", false)]
-        [InlineData(ScriptConstants.DynamicSku, "containerName", "podName", "", false)]
-        [InlineData(ScriptConstants.DynamicSku, "containerName", "podName", "legionServiceHost", true)]
-        [InlineData(ScriptConstants.DynamicSku, "containerName", "", "legionServiceHost", true)]
-        public void Returns_AtlasOrLegionConsumption(string sku, string containerName, string podName, string legionServiceHost, bool legion)
+        [Trait(TestTraits.Group, TestTraits.LinuxConsumptionMetricsTests)]
+        [InlineData(ScriptConstants.DynamicSku, "containerName", "", "", "", true, false)]
+        [InlineData(ScriptConstants.DynamicSku, "containerName", "podName", "", "", true, false)]
+        [InlineData(ScriptConstants.DynamicSku, "containerName", "podName", "legionServiceHost", "", false, true)]
+        [InlineData(ScriptConstants.DynamicSku, "containerName", "", "legionServiceHost", "", false, true)]
+        [InlineData(ScriptConstants.DynamicSku, "containerName", "", "", "true", false, false)] // MANAGED_ENVIRONMENT (ACA) => excluded from Atlas
+        [InlineData(ScriptConstants.DynamicSku, "containerName", "", "", "1", false, false)]
+        [InlineData(ScriptConstants.DynamicSku, "containerName", "", "legionServiceHost", "true", false, false)] // MANAGED_ENVIRONMENT (ACA) => excluded from Legion too
+        public void Returns_AtlasOrLegionConsumption(string sku, string containerName, string podName, string legionServiceHost, string managedEnvironment, bool atlas, bool legion)
         {
             var testEnvironment = new TestEnvironment();
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, string.Empty);
@@ -258,25 +262,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, containerName);
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.PodName, podName);
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.LegionServiceHost, legionServiceHost);
-
-            Assert.Equal(legion, testEnvironment.IsLinuxConsumptionOnLegion());
-            Assert.Equal(!legion, testEnvironment.IsLinuxConsumptionOnAtlas());
-        }
-
-        [Theory]
-        [Trait(TestTraits.Group, TestTraits.LinuxConsumptionMetricsTests)]
-        [InlineData("", true)]      // baseline Atlas detection
-        [InlineData(null, true)]
-        [InlineData("true", false)] // MANAGED_ENVIRONMENT set => not Atlas
-        [InlineData("1", false)]
-        public void IsLinuxConsumptionOnAtlas_ExcludesManagedAppEnvironment(string managedEnvironment, bool isLinuxConsumptionOnAtlas)
-        {
-            var testEnvironment = new TestEnvironment();
-            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "container-name");
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.ManagedEnvironment, managedEnvironment);
 
-            Assert.Equal(isLinuxConsumptionOnAtlas, testEnvironment.IsLinuxConsumptionOnAtlas());
-            Assert.Equal(isLinuxConsumptionOnAtlas, testEnvironment.IsLinuxMetricsPublishingEnabled());
+            Assert.Equal(legion, testEnvironment.IsLinuxConsumptionOnLegion());
+            Assert.Equal(atlas, testEnvironment.IsLinuxConsumptionOnAtlas());
+            Assert.Equal(atlas, testEnvironment.IsLinuxMetricsPublishingEnabled());
         }
 
         [Theory]


### PR DESCRIPTION
## Summary

When the Functions host runs inside an Azure Container Apps (ACA) environment, the DI registration for `IMetricsPublisher` falls into the legacy `LinuxContainerMetricsPublisher` branch and tries to POST every 30s to a URL whose hostname is empty. Each attempt throws `System.UriFormatException: Invalid URI: The hostname could not be parsed` and is logged. This is high-volume log noise (one error per `_metricPublishInterval` per pod) on every ACA-hosted Linux FunctionApp.

Sample log seen in production:

```
Source            : Microsoft.Azure.WebJobs.Script.WebHost.Metrics.LinuxContainerMetricsPublisher
Summary           : Failed to publish status to /memoryactivity
ExceptionType     : System.UriFormatException
ExceptionMessage  : Invalid URI: The hostname could not be parsed.
   at System.Uri.CreateThis(...)
   at LinuxContainerMetricsPublisher.BuildRequest[TContent](...)        : LinuxContainerMetricsPublisher.cs:307
   at async LinuxContainerMetricsPublisher.SendRequest[T](...)          : LinuxContainerMetricsPublisher.cs:250
HostVersion       : 4.1039.500.6
```

## Root cause

`LinuxContainerMetricsPublisher` builds its URL from `Fabric_NodeIPOrFQDN`:

```csharp
private const string _requestUriFormat = "https://{0}:31002/api/metrics";
var nodeIpAddress = _environment.GetEnvironmentVariable(EnvironmentSettingNames.LinuxNodeIpAddress); // "Fabric_NodeIPOrFQDN"
_requestUri = string.Format(_requestUriFormat, nodeIpAddress);
```

`Fabric_NodeIPOrFQDN` is a Service Fabric / Antares Linux Consumption variable. ACA pods never set it, so `_requestUri` becomes `https://:31002/api/metrics` and the `HttpRequestMessage` ctor in `BuildRequest` throws.

### Why the publisher is even constructed on ACA

`WebHostServiceCollectionExtensions.cs`:

```csharp
services.AddSingleton<IMetricsPublisher>(s =>
{
    var environment = s.GetService<IEnvironment>();
    if (environment.IsLinuxConsumptionOnLegion())            { return new LinuxContainerLegionMetricsPublisher(...); }
    else if (environment.IsFlexConsumptionSku())             { return new FlexConsumptionMetricsPublisher(...); }
    else if (environment.IsLinuxMetricsPublishingEnabled())  { return new LinuxContainerMetricsPublisher(...); }  // <-- hit
    return NullMetricsPublisher.Instance;
});
```

And from `EnvironmentExtensions.cs`:

```csharp
public static bool IsLinuxMetricsPublishingEnabled(this IEnvironment environment) =>
    environment.IsLinuxConsumptionOnAtlas()
    && string.IsNullOrEmpty(environment.GetEnvironmentVariable(ContainerStartContext));

public static bool IsLinuxConsumptionOnAtlas(this IEnvironment environment) =>
    !environment.IsAppService()
    && !string.IsNullOrEmpty(environment.GetEnvironmentVariable(ContainerName))
    && string.IsNullOrEmpty(environment.GetEnvironmentVariable(LegionServiceHost));
```

On an ACA-hosted FunctionApp pod:

| Check | Value | Result |
|-------|-------|--------|
| `IsAppService()` | no `WEBSITE_INSTANCE_ID` | `false` |
| `CONTAINER_NAME` non-empty | set by ACA (pod name) | `true` |
| `LEGION_SERVICE_HOST` empty | not set | `true` |
| `CONTAINER_START_CONTEXT` empty | not set | `true` |
| `WEBSITE_SKU == "FlexConsumption"` | not set | `false` |

→ `IsLinuxConsumptionOnAtlas()` returns **true**, `IsLinuxMetricsPublishingEnabled()` returns **true**, host registers the wrong publisher.

### The gap

`IsAnyLinuxConsumption()` already excludes ACA:

```csharp
public static bool IsAnyLinuxConsumption(this IEnvironment environment) =>
    (environment.IsLinuxConsumptionOnAtlas()
        || environment.IsFlexConsumptionSku()
        || environment.IsLinuxConsumptionOnLegion())
    && !environment.IsManagedAppEnvironment();   // already guards composite check
```

But the **direct** callers of `IsLinuxConsumptionOnAtlas()` (and `IsLinuxMetricsPublishingEnabled()` which composes it) bypass this guard. The Atlas detection function itself needs to learn about ACA. ACA pods set `MANAGED_ENVIRONMENT=true` (which `IsManagedAppEnvironment()` already reads); adding that check to `IsLinuxConsumptionOnAtlas()` makes the publisher fall through to `NullMetricsPublisher.Instance` on ACA, which is the correct behavior.

## Change

```diff
 public static bool IsLinuxConsumptionOnAtlas(this IEnvironment environment)
 {
     return !environment.IsAppService() &&
            !string.IsNullOrEmpty(environment.GetEnvironmentVariable(ContainerName)) &&
-           string.IsNullOrEmpty(environment.GetEnvironmentVariable(LegionServiceHost));
+           string.IsNullOrEmpty(environment.GetEnvironmentVariable(LegionServiceHost)) &&
+           !environment.IsManagedAppEnvironment();
 }
```

Plus a theory in `test/WebJobs.Script.Tests/Environment/EnvironmentTests.cs` covering both `IsLinuxConsumptionOnAtlas` and `IsLinuxMetricsPublishingEnabled` with and without `MANAGED_ENVIRONMENT` set, and a `release_notes.md` entry.

## Blast-radius audit

All direct production callers of `IsLinuxConsumptionOnAtlas()` audited; each gates Atlas-specific behavior that should not run on ACA either:

| File | What `true` does | Safe to skip on ACA? |
|------|------------------|---------------------|
| `WebJobs.Script.WebHost/Program.cs` | Installs Linux-Consumption unhandled-exception handler | ✅ Yes |
| `WebJobs.Script/Config/TimerTriggerPlatformOptionsSetup.cs` | Sets `NonCronScheduleBehavior = Warn` (Atlas-only soft behavior) | ✅ Yes |
| `WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs` (`IHostedService`) | Registers `AtlasContainerInitializationHostedService` | ✅ Yes — ACA uses its own bootstrap |
| `WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs` (`IMetricsPublisher`) | Registers `LinuxContainerMetricsPublisher` (THE BUG) | ✅ Yes — fix target |
| `WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs` | Uses `CONTAINER_NAME` as JWT audience in placeholder mode | ✅ Yes — Atlas/Legion placeholder logic |

`IInstanceManager` registration doesn't call `IsLinuxConsumptionOnAtlas()` and is unaffected. Existing `Returns_IsLinuxConsumption` and `Returns_AtlasOrLegionConsumption` theories leave `MANAGED_ENVIRONMENT` unset and continue to pass unchanged.

## Repro

Any Functions app running on ACA (k8s-based Container Apps platform, not Flex Consumption) with `MANAGED_ENVIRONMENT=true`, `CONTAINER_NAME` set, `LEGION_SERVICE_HOST` unset, no `WEBSITE_SKU=FlexConsumption`. Affects production ACA-hosted Linux FunctionApps across regions on `HostVersion 4.1039.500.6` (and earlier).
