### PR TITLE
Update Node.js Worker Version to 3.14.1

### DIFF
--- a/eng/build/Workers.Node.props
+++ b/eng/build/Workers.Node.props
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" VersionOverride="3.13.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" VersionOverride="3.14.0" />
   </ItemGroup>
 
 </Project>

--- a/eng/build/Workers.Node.props
+++ b/eng/build/Workers.Node.props
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" VersionOverride="3.14.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.NodeJsWorker" VersionOverride="3.14.1" />
   </ItemGroup>
 
 </Project>

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,4 +6,4 @@
 
 - Restore Workflows-bundle worker discovery on Logic App (#11759)
 - Ensure wwwroot directory exists on new slot and app creation w/ networking restrictions (#11757)
-- Update NodeJS Worker Version to [3.14.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.14.0)
+- Update Node.js Worker Version to [3.14.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.14.0) (#PR)

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,3 +6,4 @@
 
 - Restore Workflows-bundle worker discovery on Logic App (#11759)
 - Ensure wwwroot directory exists on new slot and app creation w/ networking restrictions (#11757)
+- Update NodeJS Worker Version to [3.14.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.14.0)

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,4 +6,4 @@
 
 - Restore Workflows-bundle worker discovery on Logic App (#11759)
 - Ensure wwwroot directory exists on new slot and app creation w/ networking restrictions (#11757)
-- Update Node.js Worker Version to [3.14.0](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.14.0) (#PR)
+- Update Node.js Worker Version to [3.14.1](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.14.1) (#PR)


### PR DESCRIPTION
### Issue describing the changes in this PR

Updates the Azure Functions Host Node.js worker package reference to consume `Microsoft.Azure.Functions.NodeJsWorker` `3.14.1` for Node.js 26 support.

Related release work:
- Node.js Worker PR: https://github.com/Azure/azure-functions-nodejs-worker/pull/809
- Node.js Worker release pipeline: https://dev.azure.com/azfunc/Azure%20Functions/_releaseProgress?releaseId=11087&_a=release-pipeline-progress
- Node 26 image work item: https://msazure.visualstudio.com/Antares/_workitems/edit/37774023

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the in-proc branch is not required
    * [ ] Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

- Updates `eng/build/Workers.Node.props` from `3.13.0` to `3.14.1`.
- Adds release note entry for the Node.js Worker `3.14.1` package update.
- Focused validation: `git -c core.whitespace=cr-at-eol diff --check`.

Update: retargeted to Node.js Worker 3.14.1, which includes the bundled protobuf inquire fix from Azure/azure-functions-nodejs-worker#815.