### PR TITLE
Update Java Worker to 2.19.4

### DIFF
--- a/eng/build/Workers.Java.props
+++ b/eng/build/Workers.Java.props
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.19.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" Version="2.19.4" />
   </ItemGroup>
 
 </Project>

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Updated Java Worker to [2.19.4](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.4) (bumps `commons-lang3` from 3.9 to 3.18.0, addresses GHSA-j288-q9x7-2f5v)

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,4 +3,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-- Updated Java Worker to [2.19.4](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.4) (bumps `commons-lang3` from 3.9 to 3.18.0, addresses GHSA-j288-q9x7-2f5v)
+- Updated Java Worker to [2.19.4](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.4)

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,4 +3,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-- Updated Java Worker to [2.19.4](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.4)
+- Updated Java Worker to [2.19.4](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.4) (#11772)


### PR DESCRIPTION
Bumps `Microsoft.Azure.Functions.JavaWorker` from 2.19.1 to [2.19.4](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.4), which updates `commons-lang3` from 3.9 to 3.18.0 and addresses [GHSA-j288-q9x7-2f5v](https://github.com/advisories/GHSA-j288-q9x7-2f5v).

This matches the Java Worker version already in use on `dev` (see #11533).