### PR TITLE
improving several flaky tests

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/HostDisposedExceptionTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/HostDisposedExceptionTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Serialization.Formatters.Binary;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Description;
@@ -46,11 +47,77 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration
             host.WebHost.Dispose();
             host.Dispose();
 
-            // In this scenario, the logger throws an exception before we enter the try/catch for the function invocation.
-            var ex = await Assert.ThrowsAsync<HostDisposedException>(() => CustomListener.RunAsync("two"));
+            // Capture log state after dispose so we have diagnostic context if the expected
+            // HostDisposedException does not surface (the test has historically been flaky here).
+            string logsAfterDispose = SafeGetLog(host);
 
-            Assert.Equal($"The host is disposed and cannot be used. Disposed object: '{typeof(ScriptLoggerFactory).FullName}'; Found IListener in stack trace: '{typeof(CustomListener).AssemblyQualifiedName}'", ex.Message);
-            Assert.Contains("CustomListener.RunAsync", ex.StackTrace);
+            // In this scenario, the logger throws an exception before we enter the try/catch for the function invocation.
+            Exception capturedException = null;
+            FunctionResult capturedResult = null;
+            try
+            {
+                capturedResult = await CustomListener.RunAsync("two");
+            }
+            catch (Exception runEx)
+            {
+                capturedException = runEx;
+            }
+
+            if (capturedException is not HostDisposedException hostDisposedException)
+            {
+                string logsAfterRun = SafeGetLog(host);
+                Assert.True(false, BuildDisposedAssertionFailureMessage(capturedException, capturedResult, logsAfterDispose, logsAfterRun));
+                return;
+            }
+
+            Assert.Equal($"The host is disposed and cannot be used. Disposed object: '{typeof(ScriptLoggerFactory).FullName}'; Found IListener in stack trace: '{typeof(CustomListener).AssemblyQualifiedName}'", hostDisposedException.Message);
+            Assert.Contains("CustomListener.RunAsync", hostDisposedException.StackTrace);
+        }
+
+        private static string SafeGetLog(TestFunctionHost host)
+        {
+            try
+            {
+                return host.GetLog();
+            }
+            catch (Exception ex)
+            {
+                return $"<<unable to read host log: {ex.GetType().Name}: {ex.Message}>>";
+            }
+        }
+
+        private static string BuildDisposedAssertionFailureMessage(Exception capturedException, FunctionResult capturedResult, string logsAfterDispose, string logsAfterRun)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"Expected '{nameof(HostDisposedException)}' from {nameof(CustomListener)}.{nameof(CustomListener.RunAsync)}(\"two\") after host dispose, but it was not observed.");
+
+            if (capturedException is null)
+            {
+                sb.AppendLine("Captured exception: <none>");
+            }
+            else
+            {
+                sb.AppendLine($"Captured exception: {capturedException.GetType().FullName}: {capturedException.Message}");
+                sb.AppendLine("Captured exception stack:");
+                sb.AppendLine(capturedException.StackTrace ?? "<no stack trace>");
+            }
+
+            if (capturedResult is not null)
+            {
+                sb.AppendLine($"Captured FunctionResult.Succeeded: {capturedResult.Succeeded}");
+                if (capturedResult.Exception is not null)
+                {
+                    sb.AppendLine($"Captured FunctionResult.Exception: {capturedResult.Exception.GetType().FullName}: {capturedResult.Exception.Message}");
+                    sb.AppendLine(capturedResult.Exception.StackTrace ?? "<no stack trace>");
+                }
+            }
+
+            sb.AppendLine("=== Host log captured immediately after dispose ===");
+            sb.AppendLine(logsAfterDispose);
+            sb.AppendLine("=== Host log captured after second RunAsync ===");
+            sb.AppendLine(logsAfterRun);
+
+            return sb.ToString();
         }
 
         // TODO: Need to review this

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebJobsStartupEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebJobsStartupEndToEndTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
@@ -15,6 +16,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
     public class WebJobsStartupEndToEndTests
     {
         private const string _projectName = "WebJobsStartupTests";
+        private const int _httpReadyTimeoutMs = 30_000;
+        private const int _httpReadyPollMs = 250;
         private readonly IDictionary<string, string> _envVars;
 
         public WebJobsStartupEndToEndTests()
@@ -36,12 +39,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
             try
             {
                 await fixture.InitializeAsync();
-                var client = fixture.Host.HttpClient;
 
-                var response = await client.GetAsync($"api/Function1");
+                var response = await GetWithRetryAsync(fixture, "api/Function1");
 
                 // The function does all the validation internally.
-                Assert.True(HttpStatusCode.OK == response.StatusCode, $"{response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+                Assert.True(HttpStatusCode.OK == response.StatusCode, await BuildHttpFailureMessageAsync(response, fixture));
             }
             finally
             {
@@ -57,12 +59,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
             try
             {
                 await fixture.InitializeAsync();
-                var client = fixture.Host.HttpClient;
 
-                var response = await client.GetAsync($"api/Function1");
+                var response = await GetWithRetryAsync(fixture, "api/Function1");
 
                 // The function does all the validation internally.
-                Assert.True(HttpStatusCode.OK == response.StatusCode, $"{response.StatusCode}: {await response.Content.ReadAsStringAsync()}");
+                Assert.True(HttpStatusCode.OK == response.StatusCode, await BuildHttpFailureMessageAsync(response, fixture));
 
                 const string expectedLogEntry =
                     "The 'FUNCTIONS_WORKER_RUNTIME' is set to 'dotnet-isolated', " +
@@ -160,6 +161,44 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
             {
                 await fixture.DisposeAsync();
             }
+        }
+
+        // The host may still be transitioning through warmup/restart when InitializeAsync returns
+        // (TestFunctionHost.IsHostStarted returns true for both Running and Error states). Retry the
+        // request briefly so a transient ServiceUnavailable/InternalServerError doesn't fail the test
+        // on its first call. If we still don't get a 2xx, the assertion downstream produces a rich
+        // failure message including host state, last error, and full host log.
+        private static async Task<HttpResponseMessage> GetWithRetryAsync(CSharpPrecompiledEndToEndTestFixture fixture, string requestUri)
+        {
+            var client = fixture.Host.HttpClient;
+            HttpResponseMessage response = null;
+            var deadline = DateTime.UtcNow.AddMilliseconds(_httpReadyTimeoutMs);
+            while (DateTime.UtcNow < deadline)
+            {
+                response?.Dispose();
+                response = await client.GetAsync(requestUri);
+                if ((int)response.StatusCode < 500)
+                {
+                    return response;
+                }
+
+                await Task.Delay(_httpReadyPollMs);
+            }
+
+            return response;
+        }
+
+        private static async Task<string> BuildHttpFailureMessageAsync(HttpResponseMessage response, CSharpPrecompiledEndToEndTestFixture fixture)
+        {
+            string body = response.Content is null ? "(null)" : await response.Content.ReadAsStringAsync();
+            var manager = fixture.Host.WebHostServices.GetService<IScriptHostManager>();
+            string state = manager?.State.ToString() ?? "(no manager)";
+            string lastError = manager?.LastError?.ToString() ?? "(none)";
+            return $"Expected 200 OK from {response.RequestMessage?.RequestUri}, got {(int)response.StatusCode} {response.StatusCode}.{Environment.NewLine}"
+                + $"Body: {body}{Environment.NewLine}"
+                + $"IScriptHostManager.State: {state}{Environment.NewLine}"
+                + $"IScriptHostManager.LastError: {lastError}{Environment.NewLine}"
+                + $"Host log:{Environment.NewLine}{fixture.Host.GetLog()}";
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebJobsStartupEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebJobsStartupEndToEndTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
@@ -40,10 +41,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
             {
                 await fixture.InitializeAsync();
 
-                var response = await GetWithRetryAsync(fixture, "api/Function1");
+                var (response, lastException) = await GetWithRetryAsync(fixture, "api/Function1");
 
                 // The function does all the validation internally.
-                Assert.True(HttpStatusCode.OK == response.StatusCode, await BuildHttpFailureMessageAsync(response, fixture));
+                Assert.True(response is not null && response.StatusCode == HttpStatusCode.OK, await BuildHttpFailureMessageAsync(response, lastException, fixture));
             }
             finally
             {
@@ -60,10 +61,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
             {
                 await fixture.InitializeAsync();
 
-                var response = await GetWithRetryAsync(fixture, "api/Function1");
+                var (response, lastException) = await GetWithRetryAsync(fixture, "api/Function1");
 
                 // The function does all the validation internally.
-                Assert.True(HttpStatusCode.OK == response.StatusCode, await BuildHttpFailureMessageAsync(response, fixture));
+                Assert.True(response is not null && response.StatusCode == HttpStatusCode.OK, await BuildHttpFailureMessageAsync(response, lastException, fixture));
 
                 const string expectedLogEntry =
                     "The 'FUNCTIONS_WORKER_RUNTIME' is set to 'dotnet-isolated', " +
@@ -164,41 +165,72 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
         }
 
         // The host may still be transitioning through warmup/restart when InitializeAsync returns
-        // (TestFunctionHost.IsHostStarted returns true for both Running and Error states). Retry the
-        // request briefly so a transient ServiceUnavailable/InternalServerError doesn't fail the test
-        // on its first call. If we still don't get a 2xx, the assertion downstream produces a rich
-        // failure message including host state, last error, and full host log.
-        private static async Task<HttpResponseMessage> GetWithRetryAsync(CSharpPrecompiledEndToEndTestFixture fixture, string requestUri)
+        // (TestFunctionHost.IsHostStarted returns true for both Running and Error states), and the
+        // HTTP listener may not be accepting connections yet. Retry the request briefly, swallowing
+        // transient 5xx responses and HttpRequestException/TaskCanceledException, so a warmup blip
+        // doesn't fail the test on its first call. The last response (if any) and last transient
+        // exception (if any) are both returned so the failure-message helper can include whichever
+        // signal is more informative.
+        private static async Task<(HttpResponseMessage Response, Exception LastException)> GetWithRetryAsync(CSharpPrecompiledEndToEndTestFixture fixture, string requestUri)
         {
             var client = fixture.Host.HttpClient;
             HttpResponseMessage response = null;
+            Exception lastException = null;
             var deadline = DateTime.UtcNow.AddMilliseconds(_httpReadyTimeoutMs);
             while (DateTime.UtcNow < deadline)
             {
                 response?.Dispose();
-                response = await client.GetAsync(requestUri);
-                if ((int)response.StatusCode < 500)
+                response = null;
+                try
                 {
-                    return response;
+                    response = await client.GetAsync(requestUri);
+                    if ((int)response.StatusCode < 500)
+                    {
+                        return (response, null);
+                    }
+                }
+                catch (HttpRequestException ex)
+                {
+                    lastException = ex;
+                }
+                catch (TaskCanceledException ex)
+                {
+                    lastException = ex;
                 }
 
                 await Task.Delay(_httpReadyPollMs);
             }
 
-            return response;
+            return (response, lastException);
         }
 
-        private static async Task<string> BuildHttpFailureMessageAsync(HttpResponseMessage response, CSharpPrecompiledEndToEndTestFixture fixture)
+        private static async Task<string> BuildHttpFailureMessageAsync(HttpResponseMessage response, Exception lastException, CSharpPrecompiledEndToEndTestFixture fixture)
         {
-            string body = response.Content is null ? "(null)" : await response.Content.ReadAsStringAsync();
             var manager = fixture.Host.WebHostServices.GetService<IScriptHostManager>();
             string state = manager?.State.ToString() ?? "(no manager)";
             string lastError = manager?.LastError?.ToString() ?? "(none)";
-            return $"Expected 200 OK from {response.RequestMessage?.RequestUri}, got {(int)response.StatusCode} {response.StatusCode}.{Environment.NewLine}"
-                + $"Body: {body}{Environment.NewLine}"
-                + $"IScriptHostManager.State: {state}{Environment.NewLine}"
-                + $"IScriptHostManager.LastError: {lastError}{Environment.NewLine}"
-                + $"Host log:{Environment.NewLine}{fixture.Host.GetLog()}";
+
+            var sb = new StringBuilder();
+            if (response is not null)
+            {
+                string body = response.Content is null ? "(null)" : await response.Content.ReadAsStringAsync();
+                sb.AppendLine($"Expected 200 OK from {response.RequestMessage?.RequestUri}, got {(int)response.StatusCode} {response.StatusCode}.");
+                sb.AppendLine($"Body: {body}");
+            }
+            else
+            {
+                sb.AppendLine("Expected 200 OK but no HttpResponseMessage was ever received during the retry window.");
+            }
+
+            if (lastException is not null)
+            {
+                sb.AppendLine($"Last transient exception: {lastException.GetType().FullName}: {lastException.Message}");
+            }
+
+            sb.AppendLine($"IScriptHostManager.State: {state}");
+            sb.AppendLine($"IScriptHostManager.LastError: {lastError}");
+            sb.Append($"Host log:{Environment.NewLine}{fixture.Host.GetLog()}");
+            return sb.ToString();
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -171,6 +171,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             }
         }
 
+        private static string FormatLogMessages(IEnumerable<LogMessage> messages)
+            => string.Join(Environment.NewLine, messages);
+
         public void Dispose()
         {
             _sharedMemoryManager.Dispose();
@@ -701,16 +704,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             await TestHelpers.Await(
                 () => _logger.GetLogMessages().Any(m => string.Equals(m.FormattedMessage, expectedCancellationLog)),
                 timeout: 3000,
-                pollingInterval: 50);
+                pollingInterval: 50,
+                userMessageCallback: () => $"Expected log message '{expectedCancellationLog}' was not written. Logs:{Environment.NewLine}{FormatLogMessages(_logger.GetLogMessages())}");
 
+            // The outbound log should happen twice: once for worker init request and once for the invocation cancel request.
+            // Wait for both messages instead of waiting for one and asserting on the count, which is a race.
             await TestHelpers.Await(
-                () => _logger.GetLogMessages().Any(m => string.Equals(m.FormattedMessage, _expectedLogMsg)),
+                () => _logger.GetLogMessages().Count(m => string.Equals(m.FormattedMessage, _expectedLogMsg)) >= 2,
                 timeout: 3000,
-                pollingInterval: 50);
+                pollingInterval: 50,
+                userMessageCallback: () => $"Expected 2 '{_expectedLogMsg}' messages. Logs:{Environment.NewLine}{FormatLogMessages(_logger.GetLogMessages())}");
 
             var traces = _logger.GetLogMessages();
-            // The outbound log should happen twice: once for worker init request and once for the invocation cancel request
-            Assert.Equal(traces.Where(m => m.FormattedMessage.Equals(_expectedLogMsg)).Count(), 2);
+            Assert.Equal(2, traces.Count(m => string.Equals(m.FormattedMessage, _expectedLogMsg)));
         }
 
         [Fact]
@@ -760,15 +766,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _workerChannel.SetupFunctionInvocationBuffers(GetTestFunctionsList("node"));
             _workerChannel.SendFunctionLoadRequests(null, TimeSpan.FromMinutes(5));
 
+            // Wait for all 3 outbound messages (one WorkerInitRequest, two FunctionLoadRequests)
+            // rather than waiting for the first to appear and racing the assertion.
             await TestHelpers.Await(
-                () => _logger.GetLogMessages().Any(m => string.Equals(m.FormattedMessage, _expectedLogMsg)),
+                () => _logger.GetLogMessages().Count(m => string.Equals(m.FormattedMessage, _expectedLogMsg)) >= 3,
                 timeout: 3000,
-                pollingInterval: 50);
+                pollingInterval: 50,
+                userMessageCallback: () => $"Expected 3 '{_expectedLogMsg}' messages. Logs:{Environment.NewLine}{FormatLogMessages(_logger.GetLogMessages())}");
 
             var traces = _logger.GetLogMessages();
-            var functionLoadLogs = traces.Where(m => string.Equals(m.FormattedMessage, _expectedLogMsg));
             AreExpectedMetricsGenerated();
-            Assert.Equal(3, functionLoadLogs.Count()); // one WorkInitRequest, two FunctionLoadRequest
+            Assert.Equal(3, traces.Count(m => string.Equals(m.FormattedMessage, _expectedLogMsg))); // one WorkInitRequest, two FunctionLoadRequest
         }
 
         [Fact]
@@ -860,16 +868,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             _workerChannel.SetupFunctionInvocationBuffers(functionMetadata);
             _workerChannel.SendFunctionLoadRequests(null, TimeSpan.FromMinutes(5));
 
+            // Wait for all 3 outbound messages before asserting. The previous version only
+            // waited for the FunctionLoadRequestResponse metric, which races the outbound log writes.
             await TestHelpers.Await(
-                () => _metricsLogger.EventsBegan.Contains(MetricEventNames.FunctionLoadRequestResponse),
+                () => _logger.GetLogMessages().Count(m => string.Equals(m.FormattedMessage, _expectedLogMsg)) >= 3
+                      && _metricsLogger.EventsBegan.Contains(MetricEventNames.FunctionLoadRequestResponse),
                 timeout: 3000,
-                pollingInterval: 50);
+                pollingInterval: 50,
+                userMessageCallback: () => $"Expected 3 '{_expectedLogMsg}' messages and the FunctionLoadRequestResponse metric. Logs:{Environment.NewLine}{FormatLogMessages(_logger.GetLogMessages())}");
 
             var traces = _logger.GetLogMessages();
             ShowOutput(traces);
-            var functionLoadLogs = traces.Where(m => string.Equals(m.FormattedMessage, _expectedLogMsg));
             AreExpectedMetricsGenerated();
-            Assert.Equal(3, functionLoadLogs.Count());
+            Assert.Equal(3, traces.Count(m => string.Equals(m.FormattedMessage, _expectedLogMsg)));
             Assert.True(traces.Any(m => string.Equals(m.FormattedMessage, string.Format("Sending FunctionLoadRequestCollection with number of functions: '{0}'", functionMetadata.ToList().Count))));
         }
 


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

## Reduce flake / improve diagnostics for top 3 CI flaky tests

Targets the three highest-volume flaky tests on `dev` over the last week (ADO `host.public`, `host.official`, `host.integration-tests`).

### 1. `GrpcWorkerChannelTests` — deterministic fix (await-vs-assert race)

Affected tests: `SendInvocationCancelRequest_PublishesOutboundEvent`, `SendLoadRequests_PublishesOutboundEvents`, `SendLoadRequestCollection_PublishesOutboundEvents`.

- **Failure seen in CI:** `Assert.Equal() Failure — Expected: 3, Actual: 2`.
- **Cause:** each test calls `TestHelpers.Await` to wait for *any* matching log to appear, then immediately asserts the expected total count. The remaining message(s) can still be in flight at the time of the assertion.
- **Fix:** move the count check **inside** the `Await` predicate (e.g. `Count(... ) >= 2/3`) and pass a `userMessageCallback` that dumps every captured log on timeout so we still get good signal if the count never reaches the expected value.

### 2. `WebJobsStartupEndToEndTests.ExternalStartup_Succeeds` (+ `InProcAppsWorkWithDotnetIsolatedAsFunctionWorkerRuntimeValue`) — fix + richer diagnostics

- **Failure seen in CI:** `ServiceUnavailable: Function host is not running` / `InternalServerError` on the first HTTP request.
- **Cause:** `TestFunctionHost.IsHostStarted` returns true for both `Running` **and** `Error` states, so `fixture.InitializeAsync()` can return while the host is still transitioning, and the very first `HttpClient.GetAsync` lands during warmup.
- **Fix:** new `GetWithRetryAsync` helper polls the endpoint until a non-5xx response or a ~30s deadline. If the deadline elapses, a new `BuildHttpFailureMessageAsync` helper produces a rich failure message including status code, response body, `IScriptHostManager.State`, `IScriptHostManager.LastError`, and the full host log — instead of a bare `ServiceUnavailable`.

### 3. `HostDisposedExceptionTests.DisposedScriptLoggerFactory_UsesFullStackTrace` — telemetry only

- **Failure seen in CI:** `Assert.Throws() Failure — Expected: HostDisposedException, Actual: (No exception was thrown)`.
- **Cause:** unclear — there's a race in the executor pipeline after dispose, but the current assertion gives us no information about what actually happened instead.
- **Change (telemetry-first):** replace `Assert.ThrowsAsync<HostDisposedException>` with a manual try/catch that captures the actual exception (type + stack) or, if none was thrown, the returned `FunctionResult.Succeeded` / `FunctionResult.Exception`, plus host log snapshots both immediately after dispose and after the second `RunAsync`. Existing assertions on `ex.Message` / `ex.StackTrace` are retained for the success path. Next CI flake will give us enough detail to write a deterministic fix.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)