### PR TITLE
[Compute Separation] adding readiness probe

### DIFF
--- a/src/Functions.WorkerProxy/Program.cs
+++ b/src/Functions.WorkerProxy/Program.cs
@@ -50,6 +50,16 @@ string? workerHttpEndpointOverride = GetStringArgOrNull(args, builder.Configurat
 string? hostJsonPath = GetStringArgOrNull(args, builder.Configuration, "--host-json-path");
 string httpProxyEndpoint = GetStringArg(args, builder.Configuration, "--http-proxy-endpoint", $"http://localhost:{httpProxyPort}");
 string? configuredPodName = GetStringArgOrNull(args, builder.Configuration, "--pod-name");
+
+// Readiness-probe knobs. These close a race between the worker advertising its
+// HttpUri capability and Kestrel actually calling BindAsync on the chosen port.
+// See WorkerEndpointReadinessProbe for the full rationale. Defaults err on the
+// side of forwarding as quickly as possible: a 1 ms retry cadence with a 5 s
+// total budget (well under the worker coordinator's 15 s
+// FunctionStartTimeoutInSeconds). The total timeout also bounds each individual
+// ConnectAsync, so a single hung attempt can't blow the budget.
+int probeRetryDelayMs = GetIntArg(args, builder.Configuration, "--worker-http-probe-retry-delay-ms", 1);
+int probeTotalTimeoutMs = GetIntArg(args, builder.Configuration, "--worker-http-probe-timeout-ms", 5000);
 string podName = !string.IsNullOrWhiteSpace(configuredPodName)
     ? configuredPodName
     : !string.IsNullOrWhiteSpace(workerProxyEnvironmentOptions.ComputerName)
@@ -59,6 +69,10 @@ string podName = !string.IsNullOrWhiteSpace(configuredPodName)
 builder.Services.AddSingleton(new RelayOptions(runtimeGrpcPort, workerGrpcPort, httpProxyPort, hostJsonPath, httpProxyEndpoint, podName));
 builder.Services.AddSingleton<WorkerPodStateManager>();
 builder.Services.AddSingleton<FunctionRpcRelay>();
+builder.Services.AddSingleton(sp => new WorkerEndpointReadinessProbe(
+    sp.GetRequiredService<ILogger<WorkerEndpointReadinessProbe>>(),
+    retryDelay: TimeSpan.FromMilliseconds(probeRetryDelayMs),
+    totalTimeout: TimeSpan.FromMilliseconds(probeTotalTimeoutMs)));
 builder.Services.AddGrpc();
 builder.Services.AddHttpForwarder();
 builder.Services.AddContainerJwtAuth();
@@ -88,6 +102,7 @@ app.Use(async (ctx, next) =>
     {
         var logger = ctx.RequestServices.GetRequiredService<ILogger<FunctionRpcRelay>>();
         var relayInstance = ctx.RequestServices.GetRequiredService<FunctionRpcRelay>();
+        var readinessProbe = ctx.RequestServices.GetRequiredService<WorkerEndpointReadinessProbe>();
 
         // Resolve destination using the documented precedence:
         //   1. --worker-http-endpoint override (CLI/env), if non-blank.
@@ -103,6 +118,18 @@ app.Use(async (ctx, next) =>
                 + "(no --worker-http-endpoint override and worker has not reported HttpUri). Returning 503.");
             ctx.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
             return;
+        }
+
+        // Closes the Kestrel-bind race in the worker: the worker advertises its
+        // HttpUri capability before Kestrel actually binds the chosen port, so
+        // the runtime can dispatch an invocation in that gap and YARP returns a
+        // 502 (which the worker coordinator then waits 15 s for before timing
+        // out). The probe is a no-op once a destination is observed ready, so
+        // it only adds latency on the very first forward after the worker comes
+        // online.
+        if (!readinessProbe.IsKnownReady(destination))
+        {
+            await readinessProbe.WaitForReadyAsync(destination, ctx.RequestAborted);
         }
 
         var requestLogContext = WorkerProxyHttpRequestLogContext.Create(ctx.Request, destination);
@@ -214,8 +241,8 @@ adminAuthed.MapPost("/infra/instanceState", async (HttpContext ctx, Cancellation
 
 app.Lifetime.ApplicationStarted.Register(() =>
 {
-    app.Logger.LogInformation("WorkerProxy listening. runtimeGrpcPort={RuntimeGrpcPort}, workerGrpcPort={WorkerGrpcPort}, httpProxyPort={HttpProxyPort}, managementPort={ManagementPort}, httpProxyEndpoint={HttpProxyEndpoint}, podName={PodName}",
-         runtimeGrpcPort, workerGrpcPort, httpProxyPort, managementPort, httpProxyEndpoint, podName);
+    app.Logger.LogInformation("WorkerProxy listening. runtimeGrpcPort={RuntimeGrpcPort}, workerGrpcPort={WorkerGrpcPort}, httpProxyPort={HttpProxyPort}, managementPort={ManagementPort}, httpProxyEndpoint={HttpProxyEndpoint}, podName={PodName}, probeRetryDelayMs={ProbeRetryDelayMs}, probeTimeoutMs={ProbeTimeoutMs}",
+         runtimeGrpcPort, workerGrpcPort, httpProxyPort, managementPort, httpProxyEndpoint, podName, probeRetryDelayMs, probeTotalTimeoutMs);
 });
 
 app.Run();

--- a/src/Functions.WorkerProxy/WorkerEndpointReadinessProbe.cs
+++ b/src/Functions.WorkerProxy/WorkerEndpointReadinessProbe.cs
@@ -1,0 +1,226 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Microsoft.Azure.Functions.WorkerProxy;
+
+/// <summary>
+/// Probes a destination's TCP port for readiness before the HTTP forwarding
+/// middleware sends a request to it.
+///
+/// <para>
+/// The .NET-isolated worker's <c>HttpUri</c> capability is registered eagerly:
+/// the dynamic loopback port is picked (via a temp socket that is then released),
+/// and the capability is announced via gRPC before Kestrel has actually called
+/// <c>BindAsync</c> on that port. With the async pre-launcher and fast cold-start
+/// path, the runtime can dispatch an invocation in the brief window between the
+/// capability being announced and Kestrel binding, which surfaces as a
+/// connection-refused (502) from YARP and a downstream 15 s
+/// <c>FunctionStartTimeoutInSeconds</c> in the worker's coordinator (because the
+/// matching HTTP context never arrives).
+/// </para>
+/// <para>
+/// This probe closes the race by attempting a fast TCP connect (with a tight
+/// retry loop) before each forward. Once a destination is observed ready it is
+/// cached, so steady-state traffic incurs no extra syscalls.
+/// </para>
+/// <para>
+/// AOT-safe: uses only <see cref="Socket"/>, <see cref="IPEndPoint"/>,
+/// <see cref="Dns"/>, and <see cref="ConcurrentDictionary{TKey, TValue}"/>.
+/// </para>
+/// </summary>
+internal sealed class WorkerEndpointReadinessProbe
+{
+    private readonly ConcurrentDictionary<string, byte> _readyDestinations = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, IPEndPoint> _endpointCache = new(StringComparer.Ordinal);
+    private readonly ILogger<WorkerEndpointReadinessProbe> _logger;
+    private readonly TimeSpan _retryDelay;
+    private readonly TimeSpan _totalTimeout;
+
+    public WorkerEndpointReadinessProbe(
+        ILogger<WorkerEndpointReadinessProbe> logger,
+        TimeSpan retryDelay,
+        TimeSpan totalTimeout)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        _logger = logger;
+        _retryDelay = retryDelay;
+        _totalTimeout = totalTimeout;
+    }
+
+    /// <summary>
+    /// Gets the number of milliseconds between probe attempts.
+    /// </summary>
+    public double RetryDelayMs => _retryDelay.TotalMilliseconds;
+
+    /// <summary>
+    /// Gets the total time the probe will keep retrying before giving up.
+    /// </summary>
+    public double TotalTimeoutMs => _totalTimeout.TotalMilliseconds;
+
+    /// <summary>
+    /// Returns <see langword="true"/> if <paramref name="destination"/> has been
+    /// observed accepting TCP connections at least once in this process. Used by
+    /// the middleware to skip the await on the steady-state hot path entirely.
+    /// </summary>
+    public bool IsKnownReady(string destination) => _readyDestinations.ContainsKey(destination);
+
+    /// <summary>
+    /// Awaits until the destination's TCP port accepts a connection, or until
+    /// the configured total timeout elapses (or the supplied
+    /// <paramref name="cancellationToken"/> fires). Returns <see langword="true"/>
+    /// on success and caches the result so future calls return immediately.
+    ///
+    /// <para>
+    /// The hot path (port already listening on the very first attempt) does
+    /// exactly one <see cref="Socket"/> allocation and one
+    /// <see cref="Socket.ConnectAsync(EndPoint, CancellationToken)"/> call: on
+    /// loopback that completes in tens of microseconds. The single deadline
+    /// <see cref="CancellationTokenSource"/> is allocated once outside the loop
+    /// so retries don't pay a per-attempt allocation either.
+    /// </para>
+    ///
+    /// <para>
+    /// Returns <see langword="false"/> when the timeout elapses without a
+    /// successful connect, or when the destination URI can't be parsed/resolved.
+    /// Callers may still attempt to forward — they will get a 502 from YARP —
+    /// but the warning we log here is the diagnostic signal that the worker
+    /// never came online.
+    /// </para>
+    /// </summary>
+    public async ValueTask<bool> WaitForReadyAsync(string destination, CancellationToken cancellationToken)
+    {
+        if (_readyDestinations.ContainsKey(destination))
+        {
+            return true;
+        }
+
+        if (!TryResolveEndpoint(destination, out var endpoint))
+        {
+            _logger.LogWarning(
+                "[Readiness Probe] Destination could not be resolved; skipping probe. Destination={Destination}",
+                destination);
+            return false;
+        }
+
+        // A single deadline CTS bounds the whole loop AND every individual
+        // ConnectAsync — so a hung connect (e.g., firewalled destination) still
+        // unwinds in _totalTimeout. Allocated once outside the loop so the hot
+        // path (port already listening) pays exactly one CTS allocation.
+        using var deadlineCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        deadlineCts.CancelAfter(_totalTimeout);
+        var deadlineToken = deadlineCts.Token;
+
+        var sw = Stopwatch.StartNew();
+        int attempts = 0;
+        Exception? lastError = null;
+
+        while (true)
+        {
+            attempts++;
+
+            try
+            {
+                using var socket = new Socket(endpoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+                await socket.ConnectAsync(endpoint, deadlineToken);
+
+                _readyDestinations.TryAdd(destination, 0);
+                _logger.LogInformation(
+                    "[Readiness Probe] Destination ready. Destination={Destination}, ElapsedMs={ElapsedMs}, Attempts={Attempts}",
+                    destination, sw.Elapsed.TotalMilliseconds, attempts);
+
+                return true;
+            }
+            catch (SocketException ex)
+            {
+                // Expected during the race window: connection refused, host unreachable, etc.
+                lastError = ex;
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
+                // Total-deadline elapsed during a connect attempt.
+                break;
+            }
+
+            try
+            {
+                await Task.Delay(_retryDelay, deadlineToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+
+        _logger.LogWarning(
+            lastError,
+            "[Readiness Probe] Destination not ready after {ElapsedMs} ms ({Attempts} attempts). Destination={Destination}. Forwarding will likely fail with 502.",
+            sw.Elapsed.TotalMilliseconds, attempts, destination);
+
+        return false;
+    }
+
+    private bool TryResolveEndpoint(string destination, out IPEndPoint endpoint)
+    {
+        if (_endpointCache.TryGetValue(destination, out var cached))
+        {
+            endpoint = cached;
+            return true;
+        }
+
+        if (!Uri.TryCreate(destination, UriKind.Absolute, out var uri))
+        {
+            endpoint = null!;
+            return false;
+        }
+
+        IPAddress? address;
+        if (IPAddress.TryParse(uri.Host, out var parsedIp))
+        {
+            address = parsedIp;
+        }
+        else if (string.Equals(uri.Host, "localhost", StringComparison.OrdinalIgnoreCase))
+        {
+            address = IPAddress.Loopback;
+        }
+        else
+        {
+            // Synchronous DNS — runs once per distinct destination. Real production
+            // destinations are loopback, so this branch is exercised only by the
+            // --worker-http-endpoint override (Aspire harness, integration tests).
+            try
+            {
+                var addresses = Dns.GetHostAddresses(uri.Host);
+                address = addresses.Length > 0 ? addresses[0] : null;
+            }
+            catch (SocketException)
+            {
+                endpoint = null!;
+                return false;
+            }
+        }
+
+        if (address is null)
+        {
+            endpoint = null!;
+            return false;
+        }
+
+        endpoint = new IPEndPoint(address, uri.Port);
+        _endpointCache.TryAdd(destination, endpoint);
+
+        return true;
+    }
+}

--- a/test/Functions.WorkerProxy.Tests/WorkerEndpointReadinessProbeTests.cs
+++ b/test/Functions.WorkerProxy.Tests/WorkerEndpointReadinessProbeTests.cs
@@ -1,0 +1,192 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.Azure.Functions.WorkerProxy;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Microsoft.Azure.Functions.WorkerProxy.Tests;
+
+public class WorkerEndpointReadinessProbeTests
+{
+    // Pre-bound listener: the probe must succeed on the first attempt and cache the
+    // result so subsequent calls are a no-op fast-path.
+    [Fact]
+    public async Task WaitForReadyAsync_PortAlreadyListening_ReturnsTrueImmediately()
+    {
+        using var listener = StartLoopbackListener(out int port);
+        var probe = CreateProbe();
+        string destination = $"http://127.0.0.1:{port}";
+
+        bool ready = await probe.WaitForReadyAsync(destination, CancellationToken.None);
+
+        Assert.True(ready);
+        Assert.True(probe.IsKnownReady(destination));
+    }
+
+    // The whole point of the probe: a destination that comes online after the probe
+    // starts must be picked up by the retry loop. We deliberately delay binding so
+    // the first attempt fails (connection refused) but a subsequent one succeeds.
+    [Fact]
+    public async Task WaitForReadyAsync_PortBoundAfterShortDelay_Succeeds()
+    {
+        int port = GetUnusedTcpPort();
+        var probe = CreateProbe(totalTimeoutMs: 5_000);
+        var destination = $"http://127.0.0.1:{port}";
+
+        TcpListener? listener = null;
+        try
+        {
+            var bindTask = Task.Run(async () =>
+            {
+                await Task.Delay(100);
+                listener = new TcpListener(IPAddress.Loopback, port);
+                listener.Start();
+            });
+
+            var sw = Stopwatch.StartNew();
+            bool ready = await probe.WaitForReadyAsync(destination, CancellationToken.None);
+            sw.Stop();
+
+            await bindTask;
+
+            Assert.True(ready);
+            Assert.True(probe.IsKnownReady(destination));
+            // The probe should have spent meaningfully less than the full budget.
+            Assert.True(sw.Elapsed < TimeSpan.FromSeconds(2),
+                $"Probe took {sw.ElapsedMilliseconds} ms; expected fast pick-up after bind.");
+        }
+        finally
+        {
+            listener?.Stop();
+        }
+    }
+
+    // Timeout path: when the destination never accepts connections, the probe must
+    // give up and return false within (approximately) the configured budget — and
+    // crucially must NOT cache the destination as ready.
+    [Fact]
+    public async Task WaitForReadyAsync_NeverListening_ReturnsFalseWithinBudget()
+    {
+        int port = GetUnusedTcpPort();
+        var probe = CreateProbe(totalTimeoutMs: 200);
+        var destination = $"http://127.0.0.1:{port}";
+
+        var sw = Stopwatch.StartNew();
+        bool ready = await probe.WaitForReadyAsync(destination, CancellationToken.None);
+        sw.Stop();
+
+        Assert.False(ready);
+        Assert.False(probe.IsKnownReady(destination));
+        // Generous upper bound: 200 ms budget + retry-delay slop + scheduler jitter.
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(2),
+            $"Probe took {sw.ElapsedMilliseconds} ms; expected ~200 ms.");
+    }
+
+    // After a successful probe, subsequent calls must be a true fast-path (no
+    // socket syscalls, instant return) even if the destination later disappears.
+    [Fact]
+    public async Task WaitForReadyAsync_CachedDestination_ShortCircuits()
+    {
+        int port;
+        using (var listener = StartLoopbackListener(out port))
+        {
+            var probe = CreateProbe();
+            string destination = $"http://127.0.0.1:{port}";
+
+            Assert.True(await probe.WaitForReadyAsync(destination, CancellationToken.None));
+
+            // Stop the listener — proves the second call did NOT touch the network.
+            listener.Stop();
+
+            var sw = Stopwatch.StartNew();
+            bool ready = await probe.WaitForReadyAsync(destination, CancellationToken.None);
+            sw.Stop();
+
+            Assert.True(ready);
+            Assert.True(sw.Elapsed < TimeSpan.FromMilliseconds(50),
+                $"Cached lookup took {sw.ElapsedMilliseconds} ms; expected near-zero.");
+        }
+    }
+
+    // Cancellation: in production the request's cancellation token plumbs through.
+    // An already-cancelled token must abort the probe immediately with OCE rather
+    // than burning the full timeout budget.
+    [Fact]
+    public async Task WaitForReadyAsync_CancelledToken_Throws()
+    {
+        int port = GetUnusedTcpPort();
+        var probe = CreateProbe(totalTimeoutMs: 5_000);
+        var destination = $"http://127.0.0.1:{port}";
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await probe.WaitForReadyAsync(destination, cts.Token));
+    }
+
+    // A worker that hasn't advertised an HttpUri yet would be filtered by the
+    // resolver, but we still defend the probe against unparseable inputs so a
+    // misconfigured override never crashes the proxy.
+    [Fact]
+    public async Task WaitForReadyAsync_InvalidDestination_ReturnsFalse()
+    {
+        var probe = CreateProbe();
+
+        bool ready = await probe.WaitForReadyAsync("not-a-url", CancellationToken.None);
+
+        Assert.False(ready);
+    }
+
+    // Hostname resolution: localhost must be treated as loopback even when no
+    // listener is bound to the IPv6 form. The probe should reach the IPv4 listener.
+    [Fact]
+    public async Task WaitForReadyAsync_LocalhostHostname_Resolves()
+    {
+        using var listener = StartLoopbackListener(out int port);
+        var probe = CreateProbe();
+        string destination = $"http://localhost:{port}";
+
+        bool ready = await probe.WaitForReadyAsync(destination, CancellationToken.None);
+
+        Assert.True(ready);
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new WorkerEndpointReadinessProbe(
+            null!,
+            retryDelay: TimeSpan.FromMilliseconds(1),
+            totalTimeout: TimeSpan.FromMilliseconds(100)));
+    }
+
+    private static WorkerEndpointReadinessProbe CreateProbe(int totalTimeoutMs = 1_000) =>
+        new(
+            NullLogger<WorkerEndpointReadinessProbe>.Instance,
+            retryDelay: TimeSpan.FromMilliseconds(1),
+            totalTimeout: TimeSpan.FromMilliseconds(totalTimeoutMs));
+
+    private static TcpListener StartLoopbackListener(out int port)
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        return listener;
+    }
+
+    private static int GetUnusedTcpPort()
+    {
+        using var temp = new TcpListener(IPAddress.Loopback, 0);
+        temp.Start();
+        int port = ((IPEndPoint)temp.LocalEndpoint).Port;
+        temp.Stop();
+
+        return port;
+    }
+}


### PR DESCRIPTION
workerproxy was forwarding requests before functionsnethost was listening properly... probe first to make sure it's up