### PR TITLE
fix(health-checks): skip WebJobsStorageHealthCheck when no active script host

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -8,3 +8,4 @@
 - Ensure wwwroot directory exists on new slot and app creation w/ networking restrictions (#11757)
 - Update Node.js Worker Version to [3.14.1](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.14.1) (#PR)
 - Update OpenTelemetry instrumentation and exporter packages (#11766)
+- Skip `WebJobsStorageHealthCheck` when no active script host is available (#11791)

--- a/src/WebJobs.Script/Diagnostics/HealthChecks/WebJobsStorageHealthCheck.cs
+++ b/src/WebJobs.Script/Diagnostics/HealthChecks/WebJobsStorageHealthCheck.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
         private readonly Lazy<Task> _initialized;
         private readonly IEnvironment _environment;
         private readonly IAzureBlobStorageProvider _provider;
+        private readonly IScriptHostManager _scriptHostManager;
 
         private HealthCheckResult _last;
         private HealthCheckContext _context;
@@ -43,13 +44,16 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
         /// </summary>
         /// <param name="provider">The blob storage provider.</param>
         /// <param name="environment">The environment.</param>
+        /// <param name="scriptHostManager">The script host manager.</param>
         public WebJobsStorageHealthCheck(
-            IAzureBlobStorageProvider provider, IEnvironment environment)
+            IAzureBlobStorageProvider provider, IEnvironment environment, IScriptHostManager scriptHostManager)
         {
             ArgumentNullException.ThrowIfNull(provider);
             ArgumentNullException.ThrowIfNull(environment);
+            ArgumentNullException.ThrowIfNull(scriptHostManager);
             _provider = provider;
             _environment = environment;
+            _scriptHostManager = scriptHostManager;
             _initialized = new(RunInBackgroundAsync);
         }
 
@@ -76,6 +80,13 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
                 // the ScriptHost from starting. So we want to ensure this check runs independent of ScriptHost
                 // starting. But we also want to avoid false negatives during placeholder mode.
                 return HealthCheckResult.Healthy("Placeholder mode. Check skipped.");
+            }
+
+            if (_scriptHostManager.Services is null)
+            {
+                // No active script host means storage configuration may not yet be available (or has been torn down).
+                // Skip the check rather than report a false negative.
+                return HealthCheckResult.Healthy("No active script host. Check skipped.");
             }
 
             _context = context;

--- a/test/WebJobs.Script.Tests/Diagnostics/HealthChecks/WebJobsStorageHealthCheckTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/HealthChecks/WebJobsStorageHealthCheckTests.cs
@@ -22,12 +22,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
         private readonly TestEnvironment _environment = new();
         private readonly Mock<BlobServiceClient> _mockBlobServiceClient = new();
         private readonly HealthCheckContext _healthCheckContext = new();
+        private readonly Mock<IScriptHostManager> _scriptHostManager = new();
+
+        public WebJobsStorageHealthCheckTests()
+        {
+            _scriptHostManager.SetupGet(m => m.Services).Returns(Mock.Of<IServiceProvider>());
+        }
 
         [Fact]
         public void Constructor_WithNullProvider_ThrowsArgumentNullException()
         {
             // Act & Assert
-            TestHelpers.Act(() => new WebJobsStorageHealthCheck(null, _environment))
+            TestHelpers.Act(() => new WebJobsStorageHealthCheck(null, _environment, _scriptHostManager.Object))
                 .Should().Throw<ArgumentNullException>()
                 .WithParameterName("provider");
         }
@@ -36,16 +42,25 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
         public void Constructor_WithNullEnvironment_ThrowsArgumentNullException()
         {
             // Act & Assert
-            TestHelpers.Act(() => new WebJobsStorageHealthCheck(_provider.Object, null))
+            TestHelpers.Act(() => new WebJobsStorageHealthCheck(_provider.Object, null, _scriptHostManager.Object))
                 .Should().Throw<ArgumentNullException>()
                 .WithParameterName("environment");
+        }
+
+        [Fact]
+        public void Constructor_WithNullScriptHostManager_ThrowsArgumentNullException()
+        {
+            // Act & Assert
+            TestHelpers.Act(() => new WebJobsStorageHealthCheck(_provider.Object, _environment, null))
+                .Should().Throw<ArgumentNullException>()
+                .WithParameterName("scriptHostManager");
         }
 
         [Fact]
         public async Task CheckHealthAsync_WithNullContext_ThrowsArgumentNullException()
         {
             // Arrange
-            WebJobsStorageHealthCheck healthCheck = new(_provider.Object, _environment);
+            WebJobsStorageHealthCheck healthCheck = new(_provider.Object, _environment, _scriptHostManager.Object);
 
             // Act & Assert
             await TestHelpers.Act(async () => await healthCheck.CheckHealthAsync(null, default))
@@ -58,7 +73,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
         {
             // Arrange
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
-            WebJobsStorageHealthCheck healthCheck = new(_provider.Object, _environment);
+            WebJobsStorageHealthCheck healthCheck = new(_provider.Object, _environment, _scriptHostManager.Object);
 
             // Act
             HealthCheckResult result = await healthCheck.CheckHealthAsync(_healthCheckContext, default);
@@ -66,6 +81,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
             // Assert
             result.Status.Should().Be(HealthStatus.Healthy);
             result.Description.Should().Be("Placeholder mode. Check skipped.");
+            result.Exception.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_WithNoActiveScriptHost_ReturnsHealthyWithSkippedMessage()
+        {
+            // Arrange
+            _scriptHostManager.SetupGet(m => m.Services).Returns((IServiceProvider)null);
+            WebJobsStorageHealthCheck healthCheck = new(_provider.Object, _environment, _scriptHostManager.Object);
+
+            // Act
+            HealthCheckResult result = await healthCheck.CheckHealthAsync(_healthCheckContext, default);
+
+            // Assert
+            VerifyGetContainersCalled(Times.Never());
+            result.Status.Should().Be(HealthStatus.Healthy);
+            result.Description.Should().Be("No active script host. Check skipped.");
             result.Exception.Should().BeNull();
         }
 
@@ -80,7 +112,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
             _provider.Setup(p => p.TryCreateBlobServiceClientFromConnection(
                 ConnectionStringNames.Storage, out client)).Returns(true);
 
-            WebJobsStorageHealthCheck healthCheck = new(_provider.Object, _environment);
+            WebJobsStorageHealthCheck healthCheck = new(_provider.Object, _environment, _scriptHostManager.Object);
 
             // Act
             HealthCheckResult result = await healthCheck.CheckHealthAsync(_healthCheckContext, default);
@@ -102,7 +134,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
             _provider.Setup(p => p.TryCreateBlobServiceClientFromConnection(
                 ConnectionStringNames.Storage, out client)).Returns(true);
 
-            WebJobsStorageHealthCheck healthCheck = new(_provider.Object, _environment);
+            WebJobsStorageHealthCheck healthCheck = new(_provider.Object, _environment, _scriptHostManager.Object);
 
             // Act
             HealthCheckContext context = new()
@@ -132,7 +164,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
             _provider.Setup(p => p.TryCreateBlobServiceClientFromConnection(
                 ConnectionStringNames.Storage, out client)).Throws(ex);
 
-            WebJobsStorageHealthCheck healthCheck = new(_provider.Object, _environment);
+            WebJobsStorageHealthCheck healthCheck = new(_provider.Object, _environment, _scriptHostManager.Object);
 
             // Act
             HealthCheckResult result = await healthCheck.CheckHealthAsync(_healthCheckContext, default);
@@ -155,7 +187,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
             _provider.Setup(p => p.TryCreateBlobServiceClientFromConnection(
                 ConnectionStringNames.Storage, out client)).Returns(true);
 
-            WebJobsStorageHealthCheck healthCheck = new(_provider.Object, _environment);
+            WebJobsStorageHealthCheck healthCheck = new(_provider.Object, _environment, _scriptHostManager.Object);
 
             // Act
             HealthCheckResult result = await healthCheck.CheckHealthAsync(_healthCheckContext, default);


### PR DESCRIPTION
When the script host has no active services (e.g., not yet started or torn down), the AzureWebJobsStorage configuration may be unavailable. Return a Healthy result with a skipped message instead of reporting a false negative, mirroring the existing placeholder-mode behavior.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information