### PR TITLE
fix(config): load connstrings directly into config

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -10,3 +10,4 @@
 - Update OpenTelemetry instrumentation and exporter packages (#11766)
 - Skip `WebJobsStorageHealthCheck` when no active script host is available (#11791)
 - Avoid false-positive connection string checks when constructing `BlobServiceClient` (#11794)
+- Fix .NET10 breaking change with connection-string prefixed env vars. (#11793)

--- a/src/WebJobs.Script/Config/ScriptEnvironmentVariablesConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/ScriptEnvironmentVariablesConfigurationSource.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.EnvironmentVariables;
 
@@ -11,14 +12,74 @@ namespace Microsoft.Azure.WebJobs.Script
     /// This source exists to replace the default <see cref="EnvironmentVariablesConfigurationSource"/> to allow
     /// us to override caching behavior.
     /// </summary>
-    public class ScriptEnvironmentVariablesConfigurationSource : IConfigurationSource
+    /// <param name="liveEnvironmentLoading">
+    /// If true, the provider will use the live environment variables when fetching values.
+    /// If false, it will cache environment variables one time on load.
+    /// </param>
+    /// <remarks>
+    /// Live environment fetching is the existing behavior we use in the WebHost so that post-specialization
+    /// changes to the environment are reflected in the configuration.
+    /// </remarks>
+    public class ScriptEnvironmentVariablesConfigurationSource(bool liveEnvironmentLoading = true) : IConfigurationSource
     {
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         {
-            return new WebHostEnvironmentVariablesProvider();
+            return liveEnvironmentLoading
+                ? new WebHostEnvironmentVariablesProvider() : new CompatEnvironmentVariablesProvider();
         }
 
-        private class WebHostEnvironmentVariablesProvider : EnvironmentVariablesConfigurationProvider
+        private class CompatEnvironmentVariablesProvider : EnvironmentVariablesConfigurationProvider
+        {
+            // Values taken from https://github.com/dotnet/runtime/blob/46e21499a8f230988fac59b694af407a86e0f46c/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs#L18
+            // These should be kept in sync with any values added AFTER .NET8
+            private const string PostgreSqlServerPrefix = "POSTGRESQLCONNSTR_";
+            private const string ApiHubPrefix = "APIHUBCONNSTR_";
+            private const string DocDbPrefix = "DOCDBCONNSTR_";
+            private const string EventHubPrefix = "EVENTHUBCONNSTR_";
+            private const string NotificationHubPrefix = "NOTIFICATIONHUBCONNSTR_";
+            private const string RedisCachePrefix = "REDISCACHECONNSTR_";
+            private const string ServiceBusPrefix = "SERVICEBUSCONNSTR_";
+
+            public CompatEnvironmentVariablesProvider() : base()
+            {
+            }
+
+            public override void Load()
+            {
+                base.Load();
+
+                static string Normalize(string key)
+                {
+                    return key.Replace("__", ConfigurationPath.KeyDelimiter);
+                }
+
+                static bool IsPrefixedString(string key)
+                {
+                    return key.StartsWith(PostgreSqlServerPrefix, StringComparison.OrdinalIgnoreCase) ||
+                           key.StartsWith(ApiHubPrefix, StringComparison.OrdinalIgnoreCase) ||
+                           key.StartsWith(DocDbPrefix, StringComparison.OrdinalIgnoreCase) ||
+                           key.StartsWith(EventHubPrefix, StringComparison.OrdinalIgnoreCase) ||
+                           key.StartsWith(NotificationHubPrefix, StringComparison.OrdinalIgnoreCase) ||
+                           key.StartsWith(RedisCachePrefix, StringComparison.OrdinalIgnoreCase) ||
+                           key.StartsWith(ServiceBusPrefix, StringComparison.OrdinalIgnoreCase);
+                }
+
+                // .NET 10 changed to special case some prefixes, inserting it into the "ConnectionStrings" section.
+                // For backwards compatibility, we still want to include these in the configuration.
+                foreach (DictionaryEntry kvp in Environment.GetEnvironmentVariables())
+                {
+                    if (kvp.Key is string key && kvp.Value is string value)
+                    {
+                        if (IsPrefixedString(key))
+                        {
+                            Data[Normalize(key)] = value;
+                        }
+                    }
+                }
+            }
+        }
+
+        private class WebHostEnvironmentVariablesProvider : CompatEnvironmentVariablesProvider
         {
             public WebHostEnvironmentVariablesProvider() : base()
             {

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.Tracing;
+using System.Linq;
 using System.Net.Http;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
@@ -37,6 +38,7 @@ using Microsoft.Azure.WebJobs.Script.Workers.Profiles;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc.Configuration;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -142,6 +144,15 @@ namespace Microsoft.Azure.WebJobs.Script
             // Allow FunctionsStartup to add configuration after all other configuration is registered.
             builder.ConfigureAppConfiguration((context, configBuilder) =>
             {
+                // Replace the default environment variables source with a .NET8 back-compat version.
+                for (int i = 0; i < configBuilder.Sources.Count; i++)
+                {
+                    if (configBuilder.Sources[i] is EnvironmentVariablesConfigurationSource)
+                    {
+                        configBuilder.Sources[i] = new ScriptEnvironmentVariablesConfigurationSource(liveEnvironmentLoading: false);
+                    }
+                }
+
                 // Pre-build configuration here to load bundles and to store for later validation.
                 IConfigurationRoot config = configBuilder.Build();
                 var environment = applicationOptions.RootServiceProvider.GetService<IEnvironment>();

--- a/test/Resources/TestProjects/WebJobsStartupTests/Function1.cs
+++ b/test/Resources/TestProjects/WebJobsStartupTests/Function1.cs
@@ -119,7 +119,7 @@ namespace WebJobsStartupTests
                     root.Providers.ElementAt(i++) is ChainedConfigurationProvider &&
                     root.Providers.ElementAt(i++) is MemoryConfigurationProvider && // FUNCTIONS_WORKER_RUNTIME surfaced from environment.
                     root.Providers.ElementAt(i++) is JsonConfigurationProvider &&
-                    root.Providers.ElementAt(i++) is EnvironmentVariablesConfigurationProvider &&
+                    root.Providers.ElementAt(i++).GetType().Name.StartsWith("CompatEnvironmentVariablesProvider") &&
                     root.Providers.ElementAt(i++) is MemoryConfigurationProvider && // From Startup.cs.
                     root.Providers.ElementAt(i++) is JsonConfigurationProvider && // From test settings.
                     root.Providers.ElementAt(i++) is MemoryConfigurationProvider; // From fixture injecting emulator settings.

--- a/test/WebJobs.Script.Tests/Config/ScriptEnvironmentVariablesConfigurationSourceTests.cs
+++ b/test/WebJobs.Script.Tests/Config/ScriptEnvironmentVariablesConfigurationSourceTests.cs
@@ -1,0 +1,136 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AwesomeAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Config.Tests
+{
+    /// <summary>
+    /// Tests for the ScriptEnvironmentVariablesConfigurationSource.
+    /// </summary>
+    /// <remarks>
+    /// Not ideal this uses live environment variables, but unavoidable due to the nature of the system under test.
+    /// </remarks>
+    public class ScriptEnvironmentVariablesConfigurationSourceTests
+    {
+        private readonly string _key = $"TEST_KEY_{Guid.NewGuid():N}";
+        private readonly string _value = $"SOME_TEST_VALUE_{Guid.NewGuid():N}";
+
+        public static TheoryData<string> SpecialCasedPrefixes => new()
+        {
+            "POSTGRESQLCONNSTR_",
+            "APIHUBCONNSTR_",
+            "DOCDBCONNSTR_",
+            "EVENTHUBCONNSTR_",
+            "NOTIFICATIONHUBCONNSTR_",
+            "REDISCACHECONNSTR_",
+            "SERVICEBUSCONNSTR_",
+        };
+
+        [Theory]
+        [MemberData(nameof(SpecialCasedPrefixes))]
+        public void Load_PrefixedValue_IsAvailableInDataAsIs(string prefix)
+        {
+            string prefixed = $"{prefix}{_key}";
+            using (new EnvironmentVariableScope(prefixed, _value))
+            {
+                IConfiguration config = BuildConfiguration();
+                config[prefixed].Should().Be(_value);
+                config.GetConnectionString(_key).Should().Be(_value);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(SpecialCasedPrefixes))]
+        public void Load_PrefixedValue_IsEnumeratedInDataAsIs(string prefix)
+        {
+            string prefixed = $"{prefix}{_key}";
+            using (new EnvironmentVariableScope(prefixed, _value))
+            {
+                IConfigurationRoot config = BuildConfiguration();
+
+                // AsEnumerable surfaces entries from the provider's Data dictionary.
+                config.AsEnumerable()
+                    .Should()
+                    .Contain(kvp => kvp.Key == prefixed && kvp.Value == _value);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(SpecialCasedPrefixes))]
+        public void Load_PrefixedValue_IsEnumeratedInDataAsIs_LiveLoading(string prefix)
+        {
+            string prefixed = $"{prefix}{_key}";
+            using (new EnvironmentVariableScope(prefixed, _value))
+            {
+                IConfigurationRoot config = BuildConfiguration(liveEnvironmentLoading: true);
+
+                // AsEnumerable surfaces entries from the provider's Data dictionary.
+                config.AsEnumerable()
+                    .Should()
+                    .Contain(kvp => kvp.Key == prefixed && kvp.Value == _value);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(SpecialCasedPrefixes))]
+        public void Load_PrefixIsCaseInsensitive_KeyPreservedAsIs(string prefix)
+        {
+            string prefixed = $"{prefix.ToLowerInvariant()}Test_{Guid.NewGuid():N}";
+            using (new EnvironmentVariableScope(prefixed, _value))
+            {
+                IConfigurationRoot config = BuildConfiguration();
+
+                KeyValuePair<string, string> entry = config.AsEnumerable()
+                    .FirstOrDefault(kvp => string.Equals(kvp.Key, prefixed, StringComparison.OrdinalIgnoreCase));
+
+                entry.Key.Should().BeEquivalentTo(prefixed);
+                entry.Value.Should().Be(_value);
+            }
+        }
+
+        [Fact]
+        public void Load_NonSpecialCasedPrefixedValue_NotAddedByOverride()
+        {
+            // Sanity check: variables without one of the special-cased prefixes are not added
+            // by the override's logic (they may still be added by the base provider).
+            string prefixed = $"NOT_SPECIAL_{Guid.NewGuid():N}";
+            using (new EnvironmentVariableScope(prefixed, _value))
+            {
+                IConfigurationRoot config = BuildConfiguration();
+
+                // The base provider still surfaces arbitrary env vars, so the value should be
+                // resolvable through TryGet; the assertion confirms our override doesn't break that.
+                config[prefixed].Should().Be(_value);
+            }
+        }
+
+        private static IConfigurationRoot BuildConfiguration(bool liveEnvironmentLoading = false)
+        {
+            var builder = new ConfigurationBuilder();
+            builder.Add(new ScriptEnvironmentVariablesConfigurationSource(liveEnvironmentLoading: false));
+            return builder.Build();
+        }
+
+        private sealed class EnvironmentVariableScope : IDisposable
+        {
+            private readonly string _key;
+
+            public EnvironmentVariableScope(string key, string value)
+            {
+                _key = key;
+                Environment.SetEnvironmentVariable(key, value);
+            }
+
+            public void Dispose()
+            {
+                Environment.SetEnvironmentVariable(_key, null);
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Config/ScriptEnvironmentVariablesConfigurationSourceTests.cs
+++ b/test/WebJobs.Script.Tests/Config/ScriptEnvironmentVariablesConfigurationSourceTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config.Tests
         private static IConfigurationRoot BuildConfiguration(bool liveEnvironmentLoading = false)
         {
             var builder = new ConfigurationBuilder();
-            builder.Add(new ScriptEnvironmentVariablesConfigurationSource(liveEnvironmentLoading: false));
+            builder.Add(new ScriptEnvironmentVariablesConfigurationSource(liveEnvironmentLoading));
             return builder.Build();
         }
 


### PR DESCRIPTION
.NET10 has a breaking change where they started to check for more connection string formats and loading them into 'ConnectionStrings:' section. This PR loads them directly into the configuration on-top of the .NET10 ConnectionStrings section behavior.

<!-- Please provide all the information below.  -->

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
