### PR TITLE
fix: improve connection string check for blob client

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -9,3 +9,4 @@
 - Update Node.js Worker Version to [3.14.1](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.14.1) (#PR)
 - Update OpenTelemetry instrumentation and exporter packages (#11766)
 - Skip `WebJobsStorageHealthCheck` when no active script host is available (#11791)
+- Avoid false-positive connection string checks when constructing `BlobServiceClient` (#11794)

--- a/src/WebJobs.Script/StorageProvider/StorageClientProvider.cs
+++ b/src/WebJobs.Script/StorageProvider/StorageClientProvider.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <returns>true if this <see cref="IConfiguration"/> object is a connection string; false otherwise.</returns>
         protected bool IsConnectionStringPresent(IConfiguration configuration)
         {
-            return configuration is IConfigurationSection section && section.Value != null;
+            return configuration is IConfigurationSection section && !string.IsNullOrWhiteSpace(section.Value);
         }
 
         private TClientOptions CreateClientOptions(IConfiguration configuration)

--- a/test/WebJobs.Script.Tests.Integration/Storage/AzureBlobStorageProviderTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Storage/AzureBlobStorageProviderTests.cs
@@ -78,6 +78,36 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Storage
             Assert.False(azureBlobStorageProvider.TryCreateBlobServiceClientFromConnection(ConnectionStringNames.Storage, out BlobServiceClient blobServiceClient));
         }
 
+        [Fact]
+        public void TryCreateBlobServiceClient_EmptyConnectionStringWithManagedIdentity_ReflectsCurrentBehavior()
+        {
+            var webHostValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "AzureWebJobsStorage", string.Empty },
+            };
+
+            var scriptHostValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "AzureWebJobsStorage:credential", "managedidentity" },
+                { "AzureWebJobsStorage:blobServiceUri", "https://teststorage.blob.core.windows.net" }
+            };
+
+            var webHostConfiguration = new ConfigurationBuilder()
+                .AddInMemoryCollection(webHostValues)
+                .Build();
+            var activeHostConfiguration = new ConfigurationBuilder()
+                .AddInMemoryCollection(scriptHostValues)
+                .Build();
+
+            var provider = TestHelpers.GetAzureBlobStorageProvider(webHostConfiguration, activeHostConfiguration);
+
+            bool result = provider.TryCreateBlobServiceClientFromConnection(StorageConnection, out var client);
+
+            Assert.True(result, "Expected BlobServiceClient creation to succeed when __blobServiceUri and __credential are configured, even when the connection-string value is empty.");
+            Assert.NotNull(client);
+            Assert.Equal("teststorage", client.AccountName);
+        }
+
         [Theory]
         [InlineData("ConnectionStrings:AzureWebJobsStorage1")]
         [InlineData("AzureWebJobsStorage1")]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #11787

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

This addresses a regression in .net10 which we moved to in the latest release. Previously empty env variables where ignored when bootstrapping config, but with .NET10 they are now mapped in. This means we can end up with config of:

``` CSharp
{ "AzureWebJobsStorage", string.Empty },
{ "AzureWebJobsStorage:credential", "managedidentity" },
{ "AzureWebJobsStorage:blobServiceUri", "https://teststorage.blob.core.windows.net" }
```

Our connection string check will then return a false-positive and subsequently ignore all of the managed identity values. The fix is to also check for empty string and whitespace.