### PR TITLE
test improvements: stop and dispose WebHost on flaky tests

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpPrecompiledTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpPrecompiledTestFixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -24,10 +24,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
             return Task.CompletedTask;
         }
 
-        public override Task DisposeAsync()
+        public override async Task DisposeAsync()
         {
             _dispose?.Dispose();
-            return base.DisposeAsync();
+
+            if (Host.WebHost is not null)
+            {
+                await Host.WebHost.StopAsync();
+                Host.WebHost.Dispose();
+            }
+
+            await base.DisposeAsync();
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpPrecompiledTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpPrecompiledTestFixture.cs
@@ -28,13 +28,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
         {
             _dispose?.Dispose();
 
-            if (Host.WebHost is not null)
+            try
             {
-                await Host.WebHost.StopAsync();
-                Host.WebHost.Dispose();
+                if (Host.WebHost is not null)
+                {
+                    await Host.WebHost.StopAsync();
+                    Host.WebHost.Dispose();
+                }
             }
-
-            await base.DisposeAsync();
+            finally
+            {
+                await base.DisposeAsync();
+            }
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/ProxyEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/ProxyEndToEndTests.cs
@@ -452,18 +452,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             public async Task DisposeAsync()
             {
-                if (TestHost.WebHost is not null)
+                try
                 {
-                    await TestHost.WebHost.StopAsync();
-                    TestHost.WebHost.Dispose();
+                    if (TestHost.WebHost is not null)
+                    {
+                        await TestHost.WebHost.StopAsync();
+                        TestHost.WebHost.Dispose();
+                    }
                 }
+                finally
+                {
+                    TestHost?.Dispose();
+                    HttpServer?.Dispose();
+                    HttpClient?.Dispose();
 
-                TestHost?.Dispose();
-                HttpServer?.Dispose();
-                HttpClient?.Dispose();
-
-                TestHelpers.ClearHostLogs();
-                await FileUtility.DeleteDirectoryAsync(_testHome, recursive: true);
+                    TestHelpers.ClearHostLogs();
+                    await FileUtility.DeleteDirectoryAsync(_testHome, recursive: true);
+                }
             }
         }
     }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/ProxyEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/ProxyEndToEndTests.cs
@@ -383,7 +383,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
         }
 
-        public class TestFixture : IDisposable
+        public class TestFixture : IAsyncLifetime
         {
             private readonly string _testHome;
 
@@ -448,14 +448,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             public HttpServer HttpServer { get; set; }
 
-            public void Dispose()
+            public Task InitializeAsync() => Task.CompletedTask;
+
+            public async Task DisposeAsync()
             {
+                if (TestHost.WebHost is not null)
+                {
+                    await TestHost.WebHost.StopAsync();
+                    TestHost.WebHost.Dispose();
+                }
+
                 TestHost?.Dispose();
                 HttpServer?.Dispose();
                 HttpClient?.Dispose();
 
                 TestHelpers.ClearHostLogs();
-                FileUtility.DeleteDirectoryAsync(_testHome, recursive: true);
+                await FileUtility.DeleteDirectoryAsync(_testHome, recursive: true);
             }
         }
     }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebHostStartupEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebHostStartupEndToEndTests.cs
@@ -50,7 +50,7 @@ public class WebHostStartupEndToEndTests
             // This should recover as the second call to BuildHost should succeed
             await TestHelpers.Await(async () =>
             {
-                var result = await fixture.Host.HttpClient.GetAsync("/api/HttpRequestDataFunction");
+                using var result = await fixture.Host.HttpClient.GetAsync("/api/HttpRequestDataFunction");
                 return result.IsSuccessStatusCode && await result.Content.ReadAsStringAsync() == "Welcome to Azure Functions!";
 
             }, timeout: 30000, userMessageCallback: fixture.Host.GetLog);

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebHostStartupEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebHostStartupEndToEndTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
@@ -54,7 +53,7 @@ public class WebHostStartupEndToEndTests
                 var result = await fixture.Host.HttpClient.GetAsync("/api/HttpRequestDataFunction");
                 return result.IsSuccessStatusCode && await result.Content.ReadAsStringAsync() == "Welcome to Azure Functions!";
 
-            }, 10000, userMessageCallback: fixture.Host.GetLog);
+            }, timeout: 30000, userMessageCallback: fixture.Host.GetLog);
 
             var debugMsg = fixture.Host.GetWebHostLogMessages("Microsoft.Azure.WebJobs.Script.WorkerFunctionMetadataProvider")
                 .Where(m => m.Level == Microsoft.Extensions.Logging.LogLevel.Debug)

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebJobsStartupEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WebJobsStartupEndToEndTests.cs
@@ -150,13 +150,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                 Assert.IsType<ExternalStartupException>(manager.LastError);
                 Assert.Equal(expectedErrorMessage, manager.LastError.InnerException.Message);
 
-                // Check that we continuously retry this (it will backoff).
-                var logMessages = fixture.Host.GetWebHostLogMessages();
-                var buildingMessageCount = logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Building host: version spec: ~4, startup suppressed: 'False'"));
-                Assert.True(buildingMessageCount > 1, $"Expected more than one host restart. Actual: {buildingMessageCount}.{Environment.NewLine}{fixture.Host.GetLog()}");
-
-                var diagnosticEventCount = logMessages.Count(p => p.Category == LogCategories.Startup && p.State?.Any(k => k.Key == ScriptConstants.DiagnosticEventKey) == true);
-                Assert.True(diagnosticEventCount > 1, $"Expected more than one diagnostic event. Actual: {diagnosticEventCount}.{Environment.NewLine}{fixture.Host.GetLog()}");
+                // Check that we continuously retry this (it will backoff). The retry/backoff loop
+                // emits these log entries asynchronously, so poll until both counts exceed 1 rather
+                // than taking a one-shot snapshot that can race with the second retry.
+                int buildingMessageCount = 0;
+                int diagnosticEventCount = 0;
+                await TestHelpers.Await(
+                    () =>
+                    {
+                        var logMessages = fixture.Host.GetWebHostLogMessages();
+                        buildingMessageCount = logMessages.Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains("Building host: version spec: ~4, startup suppressed: 'False'"));
+                        diagnosticEventCount = logMessages.Count(p => p.Category == LogCategories.Startup && p.State?.Any(k => k.Key == ScriptConstants.DiagnosticEventKey) == true);
+                        return buildingMessageCount > 1 && diagnosticEventCount > 1;
+                    },
+                    userMessageCallback: () => $"Expected more than one host restart and more than one diagnostic event. Actual building: {buildingMessageCount}, diagnostic: {diagnosticEventCount}.{Environment.NewLine}{fixture.Host.GetLog()}");
             }
             finally
             {


### PR DESCRIPTION
The underlying issue here is that `TestFunctionHost` does not properly stop or dispose its internal `WebHost` when disposing itself. This has been causing a handful of tests to run into issues either due to races with static values (like our custom AssemblyLoadContext) or with a FileSystemWatcher running when it should not be.

Ideally we'd have `TestFunctionHost` actually properly shut down and dispose everything internally, but after a while of trying to debug this, I decided to get some good improvements out first while I continue trying to capture and fix deadlock issues there in another PR.

Also fixed one issue in `TransientError_DuringHostBuild_DoesNotDeadlock` with a timeout on cold (first-run) CI machines where a test would fail because it simply hadn't had long enough to trigger the scenario.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)