### PR TITLE
Removing unnecessary service registrations for Flex.

### DIFF
--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -296,9 +296,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             });
         }
 
-        private static void AddLinuxContainerServices(this IServiceCollection services)
+        internal static void AddLinuxContainerServices(this IServiceCollection services, IEnvironment environment = null)
         {
-            if (SystemEnvironment.Instance.IsLinuxConsumptionOnLegion())
+            environment ??= SystemEnvironment.Instance;
+
+            if (environment.IsLinuxConsumptionOnLegion())
             {
                 services.AddLinuxConsumptionMetricsServices();
             }
@@ -373,7 +375,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddSingleton<LinuxContainerActivityPublisher>(s =>
             {
                 var environment = s.GetService<IEnvironment>();
-                if (environment.IsAnyLinuxConsumption())
+                if (environment.IsLinuxConsumptionOnAtlas() || environment.IsLinuxConsumptionOnLegion())
                 {
                     var logger = s.GetService<ILogger<LinuxContainerActivityPublisher>>();
                     var meshInitServiceClient = s.GetService<IMeshServiceClient>();
@@ -387,7 +389,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddSingleton<IHostedService>(s =>
             {
                 var environment = s.GetService<IEnvironment>();
-                if (environment.IsAnyLinuxConsumption())
+                if (environment.IsLinuxConsumptionOnAtlas() || environment.IsLinuxConsumptionOnLegion())
                 {
                     return s.GetRequiredService<LinuxContainerActivityPublisher>();
                 }
@@ -398,7 +400,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddSingleton<ILinuxContainerActivityPublisher>(s =>
             {
                 var environment = s.GetService<IEnvironment>();
-                if (environment.IsAnyLinuxConsumption())
+                if (environment.IsLinuxConsumptionOnAtlas() || environment.IsLinuxConsumptionOnLegion())
                 {
                     return s.GetRequiredService<LinuxContainerActivityPublisher>();
                 }

--- a/test/WebJobs.Script.Tests/WebHost/WebHostServiceCollectionExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/WebHost/WebHostServiceCollectionExtensionsTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests
+{
+    public class WebHostServiceCollectionExtensionsTests
+    {
+        [Fact]
+        public void AddLinuxContainerServices_LinuxConsumptionOnAtlas_RegistersExpectedServices()
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "TestContainer");
+
+            using var provider = BuildServiceProvider(environment);
+
+            Assert.IsType<LinuxContainerActivityPublisher>(provider.GetRequiredService<ILinuxContainerActivityPublisher>());
+            Assert.Null(provider.GetService<ILinuxConsumptionMetricsTracker>());
+        }
+
+        [Fact]
+        public void AddLinuxContainerServices_FlexConsumption_RegistersExpectedServices()
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "TestContainer");
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.LegionServiceHost, "TestLegionHost");
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, ScriptConstants.FlexConsumptionSku);
+
+            using var provider = BuildServiceProvider(environment);
+
+            Assert.Same(NullLinuxContainerActivityPublisher.Instance, provider.GetRequiredService<ILinuxContainerActivityPublisher>());
+            Assert.Null(provider.GetService<ILinuxConsumptionMetricsTracker>());
+        }
+
+        [Fact]
+        public void AddLinuxContainerServices_LinuxConsumptionOnLegion_RegistersExpectedServices()
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.ContainerName, "TestContainer");
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.LegionServiceHost, "TestLegionHost");
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, ScriptConstants.DynamicSku);
+
+            using var provider = BuildServiceProvider(environment);
+
+            Assert.IsType<LinuxContainerActivityPublisher>(provider.GetRequiredService<ILinuxContainerActivityPublisher>());
+            Assert.NotNull(provider.GetService<ILinuxConsumptionMetricsTracker>());
+        }
+
+        private static ServiceProvider BuildServiceProvider(IEnvironment environment)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(environment);
+            services.AddLogging();
+            services.AddOptions();
+            services.AddHttpClient();
+            services.AddLinuxContainerServices(environment);
+
+            return services.BuildServiceProvider();
+        }
+    }
+}


### PR DESCRIPTION
We've identified that the events LinuxContainerActivityPublisher is publishing to the platform currently are only needed for Linux Consumption CV1 (ACI and Legion), not Flex. So removing this service registration as an optimization.
