### PR TITLE
Fix function-key prefix matching in Kubernetes secrets repository merge

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -13,3 +13,4 @@
 - Fix .NET10 breaking change with connection-string prefixed env vars. (#11793)
 - Only register the host-name-fixup middleware on hosting environments where requests are routed through the Antares front end
 - Resolve correct `IHostApplicationLifetime` instance within certain ScriptHost services (#11798)
+- Fix function-key prefix matching in the Kubernetes secrets repository merge step

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/KubernetesSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/KubernetesSecretsRepository.cs
@@ -109,8 +109,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
             else
             {
-                // A function key is changing. Add all host and other functions keys
-                foreach (var key in currentKeys.Where(k => !k.Key.StartsWith($"{FunctionKeyPrefix}.{functionName}")))
+                // A function key is changing. Add all host and other function keys.
+                // Filter out the existing entries for the target function so we don't
+                // re-persist keys that were intentionally removed. Storage shape is
+                // "functions.{functionName}.{keyName}" (see line below and ReadFunctionSecrets),
+                // so the prefix to exclude is "functions.{functionName}." with a trailing dot.
+                var functionKeyPrefixForTarget = $"{FunctionKeyPrefix}{functionName}.";
+                foreach (var key in currentKeys.Where(k => !k.Key.StartsWith(functionKeyPrefixForTarget, StringComparison.Ordinal)))
                 {
                     newKeys.Add(key.Key, key.Value);
                 }

--- a/test/WebJobs.Script.Tests/Security/KubernetesSecretsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests/Security/KubernetesSecretsRepositoryTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Moq;

--- a/test/WebJobs.Script.Tests/Security/KubernetesSecretsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests/Security/KubernetesSecretsRepositoryTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Moq;
@@ -61,6 +62,121 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.NotNull(result);
             Assert.Equal("value", result.GetFunctionKey("Key1", "function2").Value);
             Assert.Equal("value", result.GetFunctionKey("key2", "function2").Value);
+        }
+
+        // Verifies that a function key removed from the in-memory secrets is also
+        // removed from the merged data written to the Kubernetes Secret. The merge
+        // step previously used a filter prefix of "functions..{functionName}" (a
+        // stray dot from FunctionKeyPrefix already ending in "."), which never
+        // matched the storage key shape "functions.{functionName}.{keyName}".
+        [Fact]
+        public async Task WriteAsync_FunctionKeyRemoved_DoesNotRePersistDeletedKey()
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsKubernetesSecretName, "test");
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.KubernetesServiceHost, "127.0.0.1");
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.KubernetesServiceHttpsPort, "443");
+
+            IDictionary<string, string> configMapData = new Dictionary<string, string>();
+            var clientMock = new Mock<IKubernetesClient>(MockBehavior.Strict);
+            clientMock.Setup(c => c.GetSecrets()).ReturnsAsync(configMapData);
+            clientMock.SetupGet(c => c.IsWritable).Returns(true);
+            clientMock.Setup(c => c.OnSecretChange(It.IsAny<Action>()));
+            clientMock.Setup(c => c.UpdateSecrets(It.IsAny<IDictionary<string, string>>())).Returns<IDictionary<string, string>>(updated =>
+            {
+                configMapData.Clear();
+                foreach (var k in updated)
+                {
+                    configMapData[k.Key] = k.Value;
+                }
+                return Task.CompletedTask;
+            });
+
+            var repo = new KubernetesSecretsRepository(environment, clientMock.Object);
+
+            await repo.WriteAsync(ScriptSecretsType.Function, "myfunc", new FunctionSecrets
+            {
+                Keys = new List<Key>
+                {
+                    new Key { Name = "default", Value = "v1" },
+                    new Key { Name = "extra", Value = "v2" }
+                }
+            });
+            await repo.WriteAsync(ScriptSecretsType.Function, "otherfunc", new FunctionSecrets
+            {
+                Keys = new List<Key>
+                {
+                    new Key { Name = "default", Value = "v3" }
+                }
+            });
+
+            Assert.True(configMapData.ContainsKey("functions.myfunc.default"));
+            Assert.True(configMapData.ContainsKey("functions.myfunc.extra"));
+            Assert.True(configMapData.ContainsKey("functions.otherfunc.default"));
+
+            // Simulate revoking "default" by writing only the remaining "extra" key.
+            await repo.WriteAsync(ScriptSecretsType.Function, "myfunc", new FunctionSecrets
+            {
+                Keys = new List<Key>
+                {
+                    new Key { Name = "extra", Value = "v2" }
+                }
+            });
+
+            Assert.False(
+                configMapData.ContainsKey("functions.myfunc.default"),
+                "Deleted function key 'default' must not be re-persisted by Mergekeys.");
+            Assert.True(configMapData.ContainsKey("functions.myfunc.extra"));
+            Assert.True(
+                configMapData.ContainsKey("functions.otherfunc.default"),
+                "Keys belonging to other functions must be preserved when one function's keys change.");
+        }
+
+        // The Mergekeys filter must use the function name as a path segment so that
+        // siblings whose names share a prefix (e.g., "func" vs "funcOther") are not
+        // accidentally cleared when one is being updated.
+        [Fact]
+        public async Task WriteAsync_FunctionNamePrefixCollision_DoesNotAffectSiblingFunction()
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsKubernetesSecretName, "test");
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.KubernetesServiceHost, "127.0.0.1");
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.KubernetesServiceHttpsPort, "443");
+
+            IDictionary<string, string> configMapData = new Dictionary<string, string>();
+            var clientMock = new Mock<IKubernetesClient>(MockBehavior.Strict);
+            clientMock.Setup(c => c.GetSecrets()).ReturnsAsync(configMapData);
+            clientMock.SetupGet(c => c.IsWritable).Returns(true);
+            clientMock.Setup(c => c.OnSecretChange(It.IsAny<Action>()));
+            clientMock.Setup(c => c.UpdateSecrets(It.IsAny<IDictionary<string, string>>())).Returns<IDictionary<string, string>>(updated =>
+            {
+                configMapData.Clear();
+                foreach (var k in updated)
+                {
+                    configMapData[k.Key] = k.Value;
+                }
+                return Task.CompletedTask;
+            });
+
+            var repo = new KubernetesSecretsRepository(environment, clientMock.Object);
+
+            await repo.WriteAsync(ScriptSecretsType.Function, "func", new FunctionSecrets
+            {
+                Keys = new List<Key> { new Key { Name = "default", Value = "a" } }
+            });
+            await repo.WriteAsync(ScriptSecretsType.Function, "funcother", new FunctionSecrets
+            {
+                Keys = new List<Key> { new Key { Name = "default", Value = "b" } }
+            });
+
+            // Updating "func" must not touch "funcother".
+            await repo.WriteAsync(ScriptSecretsType.Function, "func", new FunctionSecrets
+            {
+                Keys = new List<Key> { new Key { Name = "default", Value = "a2" } }
+            });
+
+            Assert.Equal("a2", configMapData["functions.func.default"]);
+            Assert.Equal("b", configMapData["functions.funcother.default"]);
         }
     }
 }


### PR DESCRIPTION
The merge step in KubernetesSecretsRepository.Mergekeys filtered out existing entries for the target function with a prefix of "functions..{functionName}" (a double dot, because FunctionKeyPrefix already ends with "."). The storage key shape is
"functions.{functionName}.{keyName}", so the filter never matched and removed keys were carried over into the merged data on subsequent writes.

Build the prefix as "functions.{functionName}." with a single trailing separator. The trailing dot also avoids prefix collisions between sibling function names that share a prefix (e.g. "func" vs "funcOther"). Add unit tests covering both behaviors.
