### PR TITLE
Build coldstart artifacts once per OS and simplify the pipeline

### DIFF
--- a/eng/ci/host.coldstart.yml
+++ b/eng/ci/host.coldstart.yml
@@ -85,137 +85,111 @@ extends:
       os: windows
 
     stages:
-    - stage: RunWindows
-      displayName: Record latency(Windows)
-      jobs:
-      - ${{ each appId in split(variables.effectiveRunInstances, ',') }}:
+    # Build the host + apps ONCE per OS and publish them as artifacts; the run instances then
+    # download those artifacts instead of each restoring from the feed, which previously caused
+    # HTTP 429 throttling under high fan-out. Runs for every case (for JIT trace generation the
+    # apps are built with auth enabled). See publish-coldstart-artifacts.yml.
+    - ${{ each os in split('Windows,Linux', ',') }}:
+      - stage: Publish${{ os }}
+        displayName: Publish artifacts(${{ os }})
+        dependsOn: []
+        jobs:
+        - template: /eng/ci/templates/official/jobs/publish-coldstart-artifacts.yml@self
+          parameters:
+            os: ${{ os }}
+            createJitTrace: ${{ parameters.createJitTrace }}
+            apps:
+              - name: HelloHttpNet9
+                type: dotnet
+                include: ${{ parameters.includeHelloHttpNet9 }}
+              - name: HelloHttpNet9NoProxy
+                type: dotnet
+                include: ${{ parameters.includeHelloHttpNet9NoProxy }}
+              - name: HelloHttpNode
+                type: node
+                include: ${{ parameters.includeHelloHttpNode }}
+
+    # Run instances and result processing are identical per OS, so loop over both. The host/app
+    # binaries come from the matching Publish<OS> stage. PerfView profiling is Windows-only (the
+    # collect/stop steps run perfview.exe), so those parameters are passed only for Windows.
+    - ${{ each os in split('Windows,Linux', ',') }}:
+      - stage: Run${{ os }}
+        displayName: Record latency(${{ os }})
+        dependsOn: Publish${{ os }}
+        jobs:
+        - ${{ each appId in split(variables.effectiveRunInstances, ',') }}:
+          - ${{ if eq(parameters.includeHelloHttpNet9, true) }}:
+            - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
+              parameters:
+                description: .NET9 Web Application
+                functionAppName: HelloHttpNet9
+                instanceId: ${{ appId }}
+                os: ${{ os }}
+                appType: dotnet
+                netTraceCollectArguments: ${{ parameters.netTraceCollectArguments }}
+                collectNetTrace: ${{ parameters.collectNetTrace }}
+                createJitTrace: ${{ parameters.createJitTrace }}
+                ${{ if eq(os, 'Windows') }}:
+                  collectPerfViewProfileOnWindows: ${{ variables.shouldCollectPerfViewProfileOnWindows }}
+                  perfViewCollectArguments: ${{ parameters.perfViewCollectArguments }}
+          - ${{ if eq(parameters.includeHelloHttpNet9NoProxy, true) }}:
+            - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
+              parameters:
+                description: .NET9 Worker Application
+                functionAppName: HelloHttpNet9NoProxy
+                instanceId: ${{ appId }}
+                os: ${{ os }}
+                appType: dotnet
+                netTraceCollectArguments: ${{ parameters.netTraceCollectArguments }}
+                collectNetTrace: ${{ parameters.collectNetTrace }}
+                createJitTrace: ${{ parameters.createJitTrace }}
+                ${{ if eq(os, 'Windows') }}:
+                  collectPerfViewProfileOnWindows: ${{ variables.shouldCollectPerfViewProfileOnWindows }}
+                  perfViewCollectArguments: ${{ parameters.perfViewCollectArguments }}
+          - ${{ if eq(parameters.includeHelloHttpNode, true) }}:
+            - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
+              parameters:
+                description: Node Application
+                functionAppName: HelloHttpNode
+                instanceId: ${{ appId }}
+                os: ${{ os }}
+                appType: node
+                netTraceCollectArguments: ${{ parameters.netTraceCollectArguments }}
+                collectNetTrace: ${{ parameters.collectNetTrace }}
+                createJitTrace: ${{ parameters.createJitTrace }}
+                ${{ if eq(os, 'Windows') }}:
+                  collectPerfViewProfileOnWindows: ${{ variables.shouldCollectPerfViewProfileOnWindows }}
+                  perfViewCollectArguments: ${{ parameters.perfViewCollectArguments }}
+
+      - stage: Calculate${{ os }}
+        displayName: Process results(${{ os }})
+        dependsOn: Run${{ os }}
+        condition: always()
+        jobs:
         - ${{ if eq(parameters.includeHelloHttpNet9, true) }}:
-          - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
+          - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
             parameters:
-              description: .NET9 Web Application
               functionAppName: HelloHttpNet9
-              instanceId: ${{ appId }} 
-              collectPerfViewProfileOnWindows: ${{ variables.shouldCollectPerfViewProfileOnWindows }}
-              perfViewCollectArguments: ${{ parameters.perfViewCollectArguments }}
-              netTraceCollectArguments: ${{ parameters.netTraceCollectArguments }}
-              collectNetTrace: ${{ parameters.collectNetTrace }}
-              createJitTrace: ${{ parameters.createJitTrace }}
-        - ${{ if eq(parameters.includeHelloHttpNet9NoProxy, true) }}:
-          - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
-            parameters:
-              description: .NET9 Worker Application
-              functionAppName: HelloHttpNet9NoProxy
-              instanceId: ${{ appId }}
-              collectPerfViewProfileOnWindows: ${{ variables.shouldCollectPerfViewProfileOnWindows }}
-              perfViewCollectArguments: ${{ parameters.perfViewCollectArguments }}
-              netTraceCollectArguments: ${{ parameters.netTraceCollectArguments }}
-              collectNetTrace: ${{ parameters.collectNetTrace }}
-              createJitTrace: ${{ parameters.createJitTrace }}
-        - ${{ if eq(parameters.includeHelloHttpNode, true) }}:
-          - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
-            parameters:
-              description: Node Application
-              functionAppName: HelloHttpNode
-              instanceId: ${{ appId }}
-              collectPerfViewProfileOnWindows: ${{ variables.shouldCollectPerfViewProfileOnWindows }}
-              perfViewCollectArguments: ${{ parameters.perfViewCollectArguments }}
-              netTraceCollectArguments: ${{ parameters.netTraceCollectArguments }}
-              collectNetTrace: ${{ parameters.collectNetTrace }}
-              createJitTrace: ${{ parameters.createJitTrace }}
-
-    - stage: CalculateWindows
-      displayName: Process results(Windows)
-      dependsOn: RunWindows
-      condition: always()
-      jobs:
-      - ${{ if eq(parameters.includeHelloHttpNet9, true) }}:
-        - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
-          parameters:
-            functionAppName: HelloHttpNet9
-            description: .NET9 Web Application
-            runInstances: 
-              items: ${{ split(variables.effectiveRunInstances, ',') }}
-      - ${{ if eq(parameters.includeHelloHttpNet9NoProxy, true) }}:
-        - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
-          parameters:
-            functionAppName: HelloHttpNet9NoProxy
-            description: .NET9 Worker Application
-            runInstances: 
-              items: ${{ split(variables.effectiveRunInstances, ',') }}
-      - ${{ if eq(parameters.includeHelloHttpNode, true) }}:
-        - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
-          parameters:
-            functionAppName: HelloHttpNode
-            description: Node Application
-            runInstances: 
-              items: ${{ split(variables.effectiveRunInstances, ',') }}
-
-# # LINUX
-    - stage: RunLinux
-      dependsOn: []
-      displayName:  Record latency(Linux)
-      jobs:
-      - ${{ each appId in split(variables.effectiveRunInstances, ',') }}:
-        - ${{ if eq(parameters.includeHelloHttpNet9, true) }}:
-          - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
-            parameters:
               description: .NET9 Web Application
-              functionAppName: HelloHttpNet9
-              instanceId: ${{ appId }}
-              os: Linux
-              collectNetTrace: ${{ parameters.collectNetTrace }}
-              netTraceCollectArguments: ${{ parameters.netTraceCollectArguments }}
-              createJitTrace: ${{ parameters.createJitTrace }}
+              os: ${{ os }}
+              runInstances:
+                items: ${{ split(variables.effectiveRunInstances, ',') }}
         - ${{ if eq(parameters.includeHelloHttpNet9NoProxy, true) }}:
-          - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
+          - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
             parameters:
-              description: .NET9 Worker Application
               functionAppName: HelloHttpNet9NoProxy
-              instanceId: ${{ appId }}
-              os: Linux
-              collectNetTrace: ${{ parameters.collectNetTrace }}
-              netTraceCollectArguments: ${{ parameters.netTraceCollectArguments }}
-              createJitTrace: ${{ parameters.createJitTrace }}
+              description: .NET9 Worker Application
+              os: ${{ os }}
+              runInstances:
+                items: ${{ split(variables.effectiveRunInstances, ',') }}
         - ${{ if eq(parameters.includeHelloHttpNode, true) }}:
-          - template: /eng/ci/templates/official/jobs/run-coldstart.yml@self
+          - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
             parameters:
-              description: Node Application
               functionAppName: HelloHttpNode
-              instanceId: ${{ appId }}
-              os: Linux
-              collectNetTrace: ${{ parameters.collectNetTrace }}
-              netTraceCollectArguments: ${{ parameters.netTraceCollectArguments }}
-              createJitTrace: ${{ parameters.createJitTrace }}  
-
-    - stage: CalculateLinux
-      displayName:  Process results(Linux)
-      dependsOn: RunLinux
-      condition: always()
-      jobs:
-      - ${{ if eq(parameters.includeHelloHttpNet9, true) }}:
-        - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
-          parameters:
-            functionAppName: HelloHttpNet9
-            description: .NET9 Web Application
-            os: Linux
-            runInstances: 
-              items: ${{ split(variables.effectiveRunInstances, ',') }}
-      - ${{ if eq(parameters.includeHelloHttpNet9NoProxy, true) }}:
-        - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
-          parameters:
-            functionAppName: HelloHttpNet9NoProxy
-            description: .NET9 Worker Application
-            os: Linux
-            runInstances: 
-              items: ${{ split(variables.effectiveRunInstances, ',') }}
-      - ${{ if eq(parameters.includeHelloHttpNode, true) }}:
-        - template: /eng/ci/templates/official/jobs/process-coldstart.yml@self
-          parameters:
-            functionAppName: HelloHttpNode
-            description: Node Application
-            os: Linux
-            runInstances: 
-              items: ${{ split(variables.effectiveRunInstances, ',') }}
+              description: Node Application
+              os: ${{ os }}
+              runInstances:
+                items: ${{ split(variables.effectiveRunInstances, ',') }}
 
 # Merge JIT traces from different function apps and dedupe.
     - stage: MergeWindowsJitTraceFiles

--- a/eng/ci/templates/official/jobs/publish-coldstart-artifacts.yml
+++ b/eng/ci/templates/official/jobs/publish-coldstart-artifacts.yml
@@ -1,0 +1,129 @@
+# Builds the coldstart output (host + benchmark apps) ONCE per OS and publishes it as
+# pipeline artifacts, so the fan-out instances download instead of each running 'dotnet
+# publish' (which caused occasional throttling of the Azure Artifacts feed with HTTP 429).
+# Output is tar.gz'd because pipeline artifacts drop the Unix execute bit the host/worker
+# executables need on Linux (tar ships on the Windows runner image too, so the archive/extract
+# steps are identical on both OSes).
+
+parameters:
+- name: os
+  type: string
+  default: Windows
+  values:
+    - Windows
+    - Linux
+- name: apps
+  type: object
+  default: []
+- name: createJitTrace
+  type: boolean
+  default: false
+
+jobs:
+- job: PublishColdStartArtifacts_${{ parameters.os }}
+  displayName: Publish coldstart artifacts (${{ parameters.os }})
+
+  pool:
+    name: 1es-pool-azfunc-benchmarking
+    ${{ if eq(parameters.os, 'Linux') }}:
+      image: 1es-ubuntu-22.04-benchmark-runner-vanilla
+      os: linux
+    ${{ else }}:
+      image: 1es-windows-2022-benchmark-runner-vanilla
+      os: windows
+
+  variables:
+    ${{ if eq(parameters.os, 'Linux') }}:
+      publishRid: linux-x64
+    ${{ else }}:
+      publishRid: win-x64
+    hostOutputPath: $(Build.BinariesDirectory)/Published/HostRuntime
+    artifactsStagingPath: $(Build.ArtifactStagingDirectory)/coldstart
+    perfAppsStagingPath: $(Agent.TempDirectory)/perfapps
+    # JIT trace generation collects from an auth-enabled app (as the SLA site does), so the
+    # .NET apps must be built with the AUTH_FUNCTION constant in that case.
+    ${{ if eq(parameters.createJitTrace, true) }}:
+      benchmarkAppBuildConstants: -p:DefineConstants=AUTH_FUNCTION
+    ${{ else }}:
+      benchmarkAppBuildConstants: ''
+    # Restore pulls every worker's packages (python/node/java/...), a large NuGet cache; keep it
+    # off the OS disk by pointing NUGET_PACKAGES at the Agent.TempDirectory work/resource disk.
+    NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages
+
+  templateContext:
+    outputParentDirectory: $(artifactsStagingPath)
+    outputs:
+    - output: pipelineArtifact
+      displayName: Publish host artifact
+      path: $(artifactsStagingPath)/host
+      artifact: coldstart_host_${{ parameters.os }}
+    - ${{ each app in parameters.apps }}:
+      - ${{ if eq(app.include, true) }}:
+        - output: pipelineArtifact
+          displayName: Publish ${{ app.name }} app artifact
+          path: $(artifactsStagingPath)/app_${{ app.name }}
+          artifact: coldstart_app_${{ parameters.os }}_${{ app.name }}
+
+  steps:
+  - template: /eng/ci/templates/install-dotnet.yml@self
+
+  - task: DotNetCoreCLI@2
+    displayName: Publish host
+    inputs:
+      command: publish
+      publishWebProjects: false
+      zipAfterPublish: false
+      modifyOutputPath: false
+      projects: '$(Build.SourcesDirectory)/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj'
+      arguments: -c Release -o $(hostOutputPath) -r $(publishRid) -p:PlaceholderSimulation=true
+      workingDirectory: $(Build.SourcesDirectory)/src/WebJobs.Script.WebHost
+
+  - pwsh: |
+      New-Item -ItemType Directory -Force -Path "$(artifactsStagingPath)/host" | Out-Null
+      tar -czf "$(artifactsStagingPath)/host/host.tar.gz" -C "$(hostOutputPath)" .
+    displayName: Archive host
+
+  # Build each benchmark app from a copy of the whole perf/Apps tree OUTSIDE the repo, so
+  # none of the repo-root MSBuild props/targets (central package management, signing,
+  # StyleCop, Release.props, ...) apply while perf/Apps/global.json still pins the SDK.
+  # This mirrors the per-instance (JIT) path and keeps the prebuilt apps identical to it
+  # (publishing a .NET app in-place would otherwise fail with NU1008).
+  - task: CopyFiles@2
+    displayName: Copy benchmark apps out of repo
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)/perf/Apps'
+      Contents: '**/*'
+      TargetFolder: '$(perfAppsStagingPath)'
+      CleanTargetFolder: true
+
+  - ${{ each app in parameters.apps }}:
+    - ${{ if eq(app.include, true) }}:
+      # .NET isolated app: publish to a dedicated output dir, then archive that dir.
+      - ${{ if eq(app.type, 'dotnet') }}:
+        - task: DotNetCoreCLI@2
+          displayName: Publish ${{ app.name }}
+          inputs:
+            command: publish
+            publishWebProjects: false
+            zipAfterPublish: false
+            modifyOutputPath: false
+            projects: '$(perfAppsStagingPath)/${{ app.name }}/HelloHttp.csproj'
+            arguments: -c Release -o $(Build.BinariesDirectory)/Published/${{ app.name }} -f net9.0 -r $(publishRid) $(benchmarkAppBuildConstants)
+            workingDirectory: $(perfAppsStagingPath)/${{ app.name }}
+        - pwsh: |
+            New-Item -ItemType Directory -Force -Path "$(artifactsStagingPath)/app_${{ app.name }}" | Out-Null
+            tar -czf "$(artifactsStagingPath)/app_${{ app.name }}/app.tar.gz" -C "$(Build.BinariesDirectory)/Published/${{ app.name }}" .
+          displayName: Archive ${{ app.name }}
+      # Node app: 'npm install' in place, then archive the app folder (incl. node_modules).
+      - ${{ if eq(app.type, 'node') }}:
+        - task: UseNode@1
+          displayName: Install Node.js for ${{ app.name }}
+          inputs:
+            version: '18.x'
+        - script: npm install
+          displayName: npm install ${{ app.name }}
+          workingDirectory: $(perfAppsStagingPath)/${{ app.name }}
+        - pwsh: |
+            New-Item -ItemType Directory -Force -Path "$(artifactsStagingPath)/app_${{ app.name }}" | Out-Null
+            tar -czf "$(artifactsStagingPath)/app_${{ app.name }}/app.tar.gz" -C "$(perfAppsStagingPath)/${{ app.name }}" .
+          displayName: Archive ${{ app.name }}

--- a/eng/ci/templates/official/jobs/publish-coldstart-artifacts.yml
+++ b/eng/ci/templates/official/jobs/publish-coldstart-artifacts.yml
@@ -46,9 +46,6 @@ jobs:
       benchmarkAppBuildConstants: -p:DefineConstants=AUTH_FUNCTION
     ${{ else }}:
       benchmarkAppBuildConstants: ''
-    # Restore pulls every worker's packages (python/node/java/...), a large NuGet cache; keep it
-    # off the OS disk by pointing NUGET_PACKAGES at the Agent.TempDirectory work/resource disk.
-    NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages
 
   templateContext:
     outputParentDirectory: $(artifactsStagingPath)
@@ -119,7 +116,7 @@ jobs:
         - task: UseNode@1
           displayName: Install Node.js for ${{ app.name }}
           inputs:
-            version: '18.x'
+            version: '24.x'
         - script: npm install
           displayName: npm install ${{ app.name }}
           workingDirectory: $(perfAppsStagingPath)/${{ app.name }}

--- a/eng/ci/templates/official/jobs/run-coldstart.yml
+++ b/eng/ci/templates/official/jobs/run-coldstart.yml
@@ -11,6 +11,9 @@ parameters:
   values:
     - Windows
     - Linux
+- name: appType
+  type: string
+  default: dotnet
 - name: collectPerfViewProfileOnWindows
   type: boolean
   default: false
@@ -50,10 +53,10 @@ jobs:
     logsDirectory: $(Build.ArtifactStagingDirectory)/Logs
     stdOutLogsFilePath: $(logsDirectory)/std_out_logs.txt
     stdErrorLogsFilePath: $(logsDirectory)/std_error_logs.txt
-    ${{ if or(eq(parameters.functionAppName, 'HelloHttpNet9'), eq(parameters.functionAppName, 'HelloHttpNet9NoProxy')) }}:
+    ${{ if eq(parameters.appType, 'dotnet') }}:
       FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
       FUNCTIONS_WORKER_RUNTIME_VERSION: '9.0'
-    ${{ if eq(parameters.functionAppName, 'HelloHttpNode') }}:
+    ${{ if eq(parameters.appType, 'node') }}:
       FUNCTIONS_WORKER_RUNTIME: 'node'
       WEBSITE_RUN_FROM_PACKAGE: '1' # Node app needs this to use placeholder channel.
     AzureWebJobsScriptRoot: '$(functionAppOutputPath)'
@@ -67,10 +70,6 @@ jobs:
     traceZipFilePath: $(traceDirectory)/$(traceFileZipName)
     traceAnalysisResultMarkdownFilePath: $(traceDirectory)/results/$(traceFileNameWithoutExtension).md
     traceLogPath: $(logsDirectory)/logs.log
-    ${{ if eq(parameters.os, 'Linux') }}:
-      publishRid: linux-x64
-    ${{ if eq(parameters.os, 'Windows') }}:
-      publishRid: win-x64
     ${{ if and(eq(parameters.collectNetTrace, true), eq(parameters.instanceId, '1')) }}:
       netTraceFileNameWithoutExtension: azfunc_${{ parameters.functionAppName }}_${{ parameters.os }}_${{ parameters.instanceId }}
       netTraceFileName: $(netTraceFileNameWithoutExtension).nettrace
@@ -80,12 +79,10 @@ jobs:
     ${{ if and(eq(parameters.createJitTrace, true), eq(parameters.instanceId, '1')) }}:
       warmupApiUrl: http://localhost:5000  # For JIT trace generation case, we call the home page instead of the api/warmup endpoint to ensure the host is up and running.
       WEBSITE_SITE_NAME: PGO_${{ parameters.functionAppName }}_${{ parameters.os }}
-      benchmarkAppBuildConstants: "-p:DefineConstants=AUTH_FUNCTION" # To publish the function app with authentication enabled.
       functionInvocationUrl: http://localhost:5000/api/HelloAuth?forcespecialization=1&code=test
     ${{ else }}:
       warmupApiUrl: http://localhost:5000/api/warmup?restart=1
       functionInvocationUrl: http://localhost:5000/api/Hello?forcespecialization=1
-      benchmarkAppBuildConstants: ""
 
   ${{ if and(or(eq(parameters.collectPerfViewProfileOnWindows, true), eq(parameters.collectNetTrace, true)), eq(parameters.instanceId, '1')) }}:
     templateContext:
@@ -113,54 +110,16 @@ jobs:
   - script: dotnet --info
     displayName: "Print .NET Environment Info"
 
-  - ${{ if eq(parameters.functionAppName, 'HelloHttpNode') }}:
-    - task: CopyFiles@2
-      displayName: Copy node js app content to script root dir
-      inputs:
-        SourceFolder: '$(Build.SourcesDirectory)/perf/Apps/HelloHttpNode'
-        Contents: '**/*'
-        TargetFolder: '$(functionAppOutputPath)'
-        CleanTargetFolder: true
-
+  - ${{ if eq(parameters.appType, 'node') }}:
     - task: UseNode@1
       displayName: Install Node.js
       inputs:
         version: '18.x'
 
-    - script: npm install
-      displayName: Run npm install for HelloHttpNode
-      workingDirectory: '$(functionAppOutputPath)'
-
-  - ${{ if or(eq(parameters.functionAppName, 'HelloHttpNet9'), eq(parameters.functionAppName, 'HelloHttpNet9NoProxy')) }}:
-    - task: CopyFiles@2
-      displayName: Copy benchmark apps to temp location
-      inputs:
-        SourceFolder: '$(Build.SourcesDirectory)/perf/Apps'
-        Contents: '**/*'
-        TargetFolder: '$(Build.ArtifactStagingDirectory)/PerformanceTestApps'
-        CleanTargetFolder: true
-
-    - task: DotNetCoreCLI@2
-      displayName: Publish benchmark app
-      inputs:
-        command: publish
-        publishWebProjects: false
-        zipAfterPublish: false
-        modifyOutputPath: false
-        projects: '$(Build.ArtifactStagingDirectory)/PerformanceTestApps/${{ parameters.functionAppName }}/HelloHttp.csproj'
-        arguments: -c Release -o $(functionAppOutputPath) -f net9.0 -r $(publishRid) $(benchmarkAppBuildConstants)
-        workingDirectory: $(Build.ArtifactStagingDirectory)/PerformanceTestApps/${{ parameters.functionAppName }}
-
-  - task: DotNetCoreCLI@2
-    displayName: Publish host
-    inputs:
-      command: publish
-      publishWebProjects: false
-      zipAfterPublish: false
-      modifyOutputPath: false
-      projects: '$(Build.SourcesDirectory)/src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj'
-      arguments: -c Release -o $(hostOutputPath) -r $(publishRid) -p:PlaceholderSimulation=true 
-      workingDirectory: $(Build.SourcesDirectory)/src/WebJobs.Script.WebHost
+  - template: /eng/ci/templates/steps/acquire-coldstart-binaries.yml@self
+    parameters:
+      functionAppName: ${{ parameters.functionAppName }}
+      os: ${{ parameters.os }}
 
   - pwsh: |
       New-Item -ItemType Directory -Path $(logsDirectory)

--- a/eng/ci/templates/official/jobs/run-coldstart.yml
+++ b/eng/ci/templates/official/jobs/run-coldstart.yml
@@ -14,6 +14,9 @@ parameters:
 - name: appType
   type: string
   default: dotnet
+  values:
+    - dotnet
+    - node
 - name: collectPerfViewProfileOnWindows
   type: boolean
   default: false

--- a/eng/ci/templates/official/jobs/run-coldstart.yml
+++ b/eng/ci/templates/official/jobs/run-coldstart.yml
@@ -117,7 +117,7 @@ jobs:
     - task: UseNode@1
       displayName: Install Node.js
       inputs:
-        version: '18.x'
+        version: '24.x'
 
   - template: /eng/ci/templates/steps/acquire-coldstart-binaries.yml@self
     parameters:

--- a/eng/ci/templates/steps/acquire-coldstart-binaries.yml
+++ b/eng/ci/templates/steps/acquire-coldstart-binaries.yml
@@ -1,0 +1,35 @@
+# Downloads the host + benchmark app binaries built once per OS (publish-coldstart-artifacts.yml)
+# so each run instance avoids a per-instance feed restore (which throttled the feed: HTTP 429).
+# Artifacts are tar.gz'd to preserve the Linux execute bit. Applies to every run, including JIT
+# (the app is prebuilt with auth constants in the build stage).
+# Note: Node also needs the Node runtime installed on the run agent (see run-coldstart.yml);
+# this template only places the binaries.
+
+parameters:
+- name: functionAppName
+  type: string
+- name: os
+  type: string
+
+steps:
+# Benchmark app content -> $(functionAppOutputPath).
+- task: DownloadPipelineArtifact@2
+  displayName: Download prebuilt benchmark app
+  inputs:
+    artifact: coldstart_app_${{ parameters.os }}_${{ parameters.functionAppName }}
+    path: $(Pipeline.Workspace)/coldstart_app
+- pwsh: |
+    New-Item -ItemType Directory -Force -Path "$(functionAppOutputPath)" | Out-Null
+    tar -xzf "$(Pipeline.Workspace)/coldstart_app/app.tar.gz" -C "$(functionAppOutputPath)"
+  displayName: Extract prebuilt benchmark app
+
+# Host binaries -> $(hostOutputPath).
+- task: DownloadPipelineArtifact@2
+  displayName: Download prebuilt host
+  inputs:
+    artifact: coldstart_host_${{ parameters.os }}
+    path: $(Pipeline.Workspace)/coldstart_host
+- pwsh: |
+    New-Item -ItemType Directory -Force -Path "$(hostOutputPath)" | Out-Null
+    tar -xzf "$(Pipeline.Workspace)/coldstart_host/host.tar.gz" -C "$(hostOutputPath)"
+  displayName: Extract prebuilt host

--- a/eng/ci/templates/variables/coldstart.yml
+++ b/eng/ci/templates/variables/coldstart.yml
@@ -2,6 +2,5 @@ variables:
 # This controls how many cold start samples are collected for each app+OS combination.
 - name: runInstances
   value: "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20"
-# Reduced instance count for JIT trace generation to minimize YAML size
 - name: jitReleaseInstances
-  value: "1,2,3"
+  value: "1"


### PR DESCRIPTION
 ## Summary
 The coldstart benchmark pipeline fans out to many run instances (20 per app, across 2 OSes). Previously **every** instance restored from the Azure Artifacts feed and ran its own `dotnet publish` of the host and the benchmark app, which caused **occasional HTTP 429 throttling** of the feed.
 
 This PR builds the host + benchmark apps **once per OS**, publishes them as pipeline artifacts, and has the run instances download those artifacts instead of restoring. This both fixes the feed throttling and **reduces overall pipeline run time**, since each run instance no longer repeats the build/restore - it just downloads prebuilt binaries. It also de-duplicates the pipeline YAML.
 
 ## Changes
 
 ### Build once, fan out (fixes feed throttling, cuts run time)
 - **New `eng/ci/templates/official/jobs/publish-coldstart-artifacts.yml`** - builds the host and each included benchmark app a single time per OS and publishes them as `coldstart_host_<OS>` / `coldstart_app_<OS>_<App>` artifacts.
   - .NET apps are built from a copy of `perf/Apps` **outside the repo** so repo-root MSBuild props/targets (central package management, signing, StyleCop, ...) don't apply, mirroring the existing per-instance JIT path (avoids `NU1008`).
   - For JIT trace generation, the .NET apps are built with the `AUTH_FUNCTION` constant, matching the SLA site.
   - Output is `tar.gz`'d so the Linux execute bit survives pipeline-artifact upload/download.
 - **New `eng/ci/templates/steps/acquire-coldstart-binaries.yml`** - downloads and extracts the prebuilt host + app for a run instance.
 - **`run-coldstart.yml`** - removed the per-instance host/app `dotnet publish` and `npm install`/copy steps; it now consumes the prebuilt artifacts via the new step template. This removes redundant build work from every run instance, shortening the `Run` stages. Added an `appType` parameter (`dotnet`/`node`) so the job branches on app type instead of hard-coded app names.
 
 ### Readability / de-duplication
 - `host.coldstart.yml` - collapsed the near-identical `Publish`, `Run`, and `Calculate` stages for Windows and Linux into `${{ each os in split('Windows,Linux', ',') }}` loops. PerfView parameters are injected only for Windows (its profiling steps run `perfview.exe`).
 - `coldstart.yml` variables - reduced `jitReleaseInstances` from `1,2,3` to `1` (one instance is sufficient for JIT trace generation and keeps generated YAML smaller).
 
 ## Behavior
 No intended change to the benchmark methodology or collected results - apps and host are built with the same configuration, just once per OS instead of per instance. Stage names (`PublishWindows`, `RunWindows`, `CalculateWindows`, and their Linux counterparts) are preserved, so cross-stage `dependsOn` wiring (including the `Merge*JitTraceFiles` stages) is unchanged.
 
 ## Testing
 - Validated by running the `host.coldstart` pipeline in ADO. <!-- link the run(s) here -->
 - Confirmed the publish stages produce the host/app artifacts and run instances consume them without per-instance feed restores.
 
 ## Risk / rollback
 - Pipeline-only change (`eng/ci/**`); no product code affected.
 - The publish job runs on `1es-pool-azfunc-benchmarking`, sharing the benchmarking pool with run jobs; watch pool capacity on large fan-outs.
 - Revert is a straight revert of this commit