### PR TITLE
[INVESTIGATION - DO NOT MERGE] Capture deadlock dump from TestFunctionHost.Dispose

### DIFF
--- a/eng/ci/templates/official/jobs/run-integration-tests.yml
+++ b/eng/ci/templates/official/jobs/run-integration-tests.yml
@@ -154,14 +154,82 @@ jobs:
       arguments: '--filter "Group=RawAssemblyEndToEndTests" $(test_args)'
       projects: $(test_projects)
 
-  - task: DotNetCoreCLI@2
+  - task: PowerShell@2
     displayName: Samples end to end tests
     condition: succeededOrFailed()
     inputs:
-      command: test
+      targetType: inline
+      pwsh: true
+      script: |
+        $dumpDir = Join-Path $env:BUILD_ARTIFACTSTAGINGDIRECTORY "SamplesHangDumps"
+        New-Item -ItemType Directory -Path $dumpDir -Force | Out-Null
+
+        # Install dotnet-dump globally for hang diagnostics
+        dotnet tool install --global dotnet-dump 2>$null
+        $env:PATH = [System.Environment]::GetEnvironmentVariable("PATH","User") + ";" + $env:PATH
+
+        # Start the test run in the background
+        $testProc = Start-Process -FilePath "dotnet" `
+          -ArgumentList "test","test/WebJobs.Script.Tests.Integration/WebJobs.Script.Tests.Integration.csproj",`
+            "--filter","Group=SamplesEndToEndTests","-c","release","--no-build",`
+            "--logger","trx;LogFileName=SamplesE2E.trx",`
+            "--results-directory",$dumpDir `
+          -PassThru -NoNewWindow
+
+        $timeoutMin = 10
+        $deadline = (Get-Date).AddMinutes($timeoutMin)
+
+        while (-not $testProc.HasExited -and (Get-Date) -lt $deadline) {
+          Start-Sleep -Seconds 10
+        }
+
+        if (-not $testProc.HasExited) {
+          Write-Host "##[warning]Samples E2E tests exceeded $timeoutMin minutes — capturing hang dumps."
+
+          # Dump the testhost process (the one actually running tests)
+          $testhosts = Get-Process -Name "testhost" -ErrorAction SilentlyContinue |
+            Where-Object { $_.StartTime -gt $testProc.StartTime.AddSeconds(-5) }
+          foreach ($th in $testhosts) {
+            $dumpFile = Join-Path $dumpDir "testhost_$($th.Id)_hangdump.dmp"
+            Write-Host "Collecting dump for testhost PID $($th.Id) -> $dumpFile"
+            dotnet-dump collect -p $th.Id -o $dumpFile --type Full 2>&1 | Write-Host
+          }
+
+          # Also dump any dotnet worker processes started by the tests
+          $workers = Get-Process -Name "dotnet" -ErrorAction SilentlyContinue |
+            Where-Object { $_.StartTime -gt $testProc.StartTime.AddSeconds(-5) -and $_.Id -ne $testProc.Id }
+          foreach ($w in $workers | Select-Object -First 5) {
+            $dumpFile = Join-Path $dumpDir "dotnet_$($w.Id)_hangdump.dmp"
+            Write-Host "Collecting dump for dotnet PID $($w.Id) -> $dumpFile"
+            dotnet-dump collect -p $w.Id -o $dumpFile --type Full 2>&1 | Write-Host
+          }
+
+          # Kill the test process tree
+          Stop-Process -Id $testProc.Id -Force -ErrorAction SilentlyContinue
+          Write-Host "##vso[task.logissue type=error]Samples E2E tests timed out after $timeoutMin minutes."
+          exit 1
+        }
+        else {
+          Write-Host "Samples E2E tests completed with exit code $($testProc.ExitCode)."
+          exit $testProc.ExitCode
+        }
+
+  - task: PublishPipelineArtifact@1
+    displayName: Publish Samples hang dumps
+    condition: failed()
+    inputs:
+      targetPath: $(Build.ArtifactStagingDirectory)/SamplesHangDumps
+      artifactName: SamplesHangDumps
+
+  - task: PublishTestResults@2
+    displayName: Publish Samples test results
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFormat: VSTest
+      testResultsFiles: '$(Build.ArtifactStagingDirectory)/SamplesHangDumps/**/*.trx'
       testRunTitle: Samples end to end tests
-      arguments: '--filter "Group=SamplesEndToEndTests" $(test_args)'
-      projects: $(test_projects)
+      failTaskOnFailedTests: true
+      failTaskOnMissingResultsFile: false
 
   - task: DotNetCoreCLI@2
     displayName: Drain mode end to end tests

--- a/eng/ci/templates/official/jobs/run-integration-tests.yml
+++ b/eng/ci/templates/official/jobs/run-integration-tests.yml
@@ -12,6 +12,14 @@ jobs:
     is_release: $[contains(variables['Build.SourceBranch'], 'release/')]
     test_args: -c release --no-build
 
+  templateContext:
+    outputs:
+    - output: pipelineArtifact
+      displayName: Publish Samples hang dumps
+      path: $(Build.ArtifactStagingDirectory)/SamplesHangDumps
+      artifact: SamplesHangDumps
+      condition: failed()
+
   steps:
   - template: /eng/ci/templates/install-dotnet.yml@self
 
@@ -213,13 +221,6 @@ jobs:
           Write-Host "Samples E2E tests completed with exit code $($testProc.ExitCode)."
           exit $testProc.ExitCode
         }
-
-  - task: PublishPipelineArtifact@1
-    displayName: Publish Samples hang dumps
-    condition: failed()
-    inputs:
-      targetPath: $(Build.ArtifactStagingDirectory)/SamplesHangDumps
-      artifactName: SamplesHangDumps
 
   - task: PublishTestResults@2
     displayName: Publish Samples test results

--- a/src/WebJobs.Script.Grpc/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -125,6 +125,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         internal IWebHostRpcWorkerChannelManager WebHostLanguageWorkerChannelManager => _webHostLanguageWorkerChannelManager;
 
+        private bool IsShuttingDown =>
+            _disposing
+            || _disposed
+            || (_applicationLifetime?.ApplicationStopping.IsCancellationRequested ?? false);
+
         private async Task<int> GetMaxProcessCount()
         {
             if (_environment.IsMultiLanguageRuntimeEnvironment())
@@ -471,11 +476,6 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         private async void WorkerError(WorkerErrorEvent workerError)
         {
-            if (_disposing || _disposed)
-            {
-                return;
-            }
-
             try
             {
                 if (string.Equals(_workerRuntime, workerError.Language))
@@ -490,33 +490,38 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     _logger.LogDebug("WorkerErrorEvent runtime:{runtime} does not match current runtime:{currentRuntime}. Failed with: {exception}", workerError.Language, _workerRuntime, workerError.Exception);
                 }
             }
-            catch (TaskCanceledException)
+            catch (OperationCanceledException)
             {
-                // Specifically in the "we were torn down while trying to restart" case, we want to catch here and ignore
-                // If we don't catch the exception from an async void method, we'll end up tearing down the entire runtime instead
-                // It's possible we want to catch *all* exceptions and log or ignore here, but taking the minimal change first
-                // For example if we capture and log, we're left in a worker-less state with a working Host runtime - is that desired? Will it self recover elsewhere?
+                // Specifically in the "we were torn down while trying to restart" case, we want to catch here and ignore.
+                // If we don't catch the exception from an async void method, we'll end up tearing down the entire runtime instead.
+                // Covers both TaskCanceledException (derived) and direct OperationCanceledException from cancellation tokens.
+            }
+            catch (Exception ex) when (IsShuttingDown)
+            {
+                // Late-arriving WorkerErrorEvents can fire after IsShuttingDown becomes true mid-handler
+                // (e.g. ScriptHost.StopAsync tears the workers down). Swallow + log so the unhandled
+                // async-void exception doesn't kill the host process during normal shutdown.
+                _logger.LogDebug(ex, "Suppressed exception in WorkerError for runtime:{runtime}, workerId:{workerId} because the host is shutting down.", workerError.Language, workerError.WorkerId);
             }
         }
 
         private async void WorkerRestart(WorkerRestartEvent workerRestart)
         {
-            if (_disposing || _disposed)
-            {
-                return;
-            }
-
             try
             {
                 _logger.LogDebug("Handling WorkerRestartEvent for runtime:{runtime}, workerId:{workerId}", workerRestart.Language, workerRestart.WorkerId);
                 await DisposeAndRestartWorkerChannel(workerRestart.Language, workerRestart.WorkerId);
             }
-            catch (TaskCanceledException)
+            catch (OperationCanceledException)
             {
-                // Specifically in the "we were torn down while trying to restart" case, we want to catch here and ignore
-                // If we don't catch the exception from an async void method, we'll end up tearing down the entire runtime instead
-                // It's possible we want to catch *all* exceptions and log or ignore here, but taking the minimal change first
-                // For example if we capture and log, we're left in a worker-less state with a working Host runtime - is that desired? Will it self recover elsewhere?
+                // Specifically in the "we were torn down while trying to restart" case, we want to catch here and ignore.
+                // If we don't catch the exception from an async void method, we'll end up tearing down the entire runtime instead.
+                // Covers both TaskCanceledException (derived) and direct OperationCanceledException from cancellation tokens.
+            }
+            catch (Exception ex) when (IsShuttingDown)
+            {
+                // See note in WorkerError. Late shutdown races would otherwise crash the process via async void.
+                _logger.LogDebug(ex, "Suppressed exception in WorkerRestart for runtime:{runtime}, workerId:{workerId} because the host is shutting down.", workerRestart.Language, workerRestart.WorkerId);
             }
         }
 
@@ -527,10 +532,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         private async Task DisposeAndRestartWorkerChannel(string runtime, string workerId, Exception workerException = null)
         {
-            if (_disposing || _disposed)
-            {
-                return;
-            }
+            // Capture IsShuttingDown up front so the dispose half and the restart-gating
+            // half see a consistent view even if shutdown begins mid-method.
+            bool isShuttingDown = IsShuttingDown;
 
             _logger.LogDebug("Attempting to dispose webhost or jobhost channel for workerId: '{channelId}', runtime: '{language}'", workerId, runtime);
 
@@ -539,6 +543,10 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
             try
             {
+                // Always dispose the channel — even during shutdown. If we skip this, the channel (and
+                // its WorkerProcess) stays in the channel manager's dictionary and never gets disposed,
+                // which leaks WorkerProcess instances and can deadlock JobObjectRegistry disposal later
+                // because its sync wait on WorkerProcess.ProcessWaitingForTermination never completes.
                 isWebHostChannelDisposed = await _webHostLanguageWorkerChannelManager.ShutdownChannelIfExistsAsync(runtime, workerId, workerException);
                 if (!isWebHostChannelDisposed)
                 {
@@ -550,12 +558,27 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     _logger.LogDebug("Did not find WebHost or JobHost channel to dispose for workerId: '{channelId}', runtime: '{language}'", workerId, runtime);
                 }
             }
+            catch (Exception ex) when (isShuttingDown)
+            {
+                // Already shutting down — log and swallow. Calling StopApplication() would be a no-op
+                // and the noise isn't helpful.
+                _logger.LogDebug(ex, "Suppressed exception while shutting down channel for workerId '{channelId}' because the host is already shutting down.", workerId);
+            }
             catch (Exception ex)
             {
                 // If an exception was thrown while trying to shut down a channel, we're left in an undetermined state. The safest thing to do is
                 // to restart the entire host and let everything come back up from scratch.
                 _logger.LogError(ex, "Error while shutting down channel for workerId '{channelId}'. Shutting down and proactively recycling the Functions Host to recover.", workerId);
                 _applicationLifetime.StopApplication();
+            }
+
+            // Skip the restart half if we're shutting down — spinning up a fresh worker during
+            // teardown is what created the original async-void crashes that motivated the IsShuttingDown
+            // guard in the first place.
+            if (isShuttingDown)
+            {
+                _logger.LogDebug("Skipping worker channel restart for runtime '{runtime}' because the host is shutting down. workerId: '{channelId}'", runtime, workerId);
+                return;
             }
 
             if (ShouldRestartWorkerChannel(runtime, isWebHostChannelDisposed, isJobHostChannelDisposed))
@@ -586,7 +609,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         private async Task StartWorkerChannel(string runtime)
         {
-            if (_disposing || _disposed)
+            if (IsShuttingDown)
             {
                 return;
             }
@@ -602,8 +625,8 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 {
                     // Issue only one restart at a time.
                     await _startWorkerProcessLock.WaitAsync();
-                    // After waiting on the lock (which could take some time), make sure we're not in a disposed state trying to start things up
-                    if (_disposing || _disposed)
+                    // After waiting on the lock (which could take some time), make sure we're not in a disposed/shutting-down state trying to start things up
+                    if (IsShuttingDown)
                     {
                         return;
                     }

--- a/src/WebJobs.Script.Grpc/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script.Grpc/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -352,6 +352,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     {
                         if (standbyChannels.TryGetValue(workerId, out TaskCompletionSource<IRpcWorkerChannel> channelTask))
                         {
+                            // Signal any in-flight initialization that we are shutting down.
+                            // If the ContinueWith in InitializeLanguageWorkerChannel hasn't run yet,
+                            // TrySetCanceled completes the TCS immediately so we don't block forever.
+                            // If it already ran (SetResult or SetException), TrySetCanceled is a no-op.
+                            channelTask.TrySetCanceled();
+
                             IRpcWorkerChannel workerChannel = null;
 
                             try

--- a/src/WebJobs.Script.Grpc/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script.Grpc/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -414,6 +414,22 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     value.SetException(exception);
                 }
             }
+
+            // The worker process may have already started and been registered with the process registry
+            // before StartWorkerProcessAsync ultimately faulted (e.g. the init RPC didn't complete in time
+            // or the worker exited before initializing). Dispose the channel here so the underlying
+            // WorkerProcess is properly cleaned up; otherwise the channel reference falls out of scope
+            // (only the faulted TCS remains in the dict), and the worker process leaks until the
+            // WebHost shuts down -- at which point JobObjectRegistry.Close blocks forever waiting on a
+            // TCS that no one will ever signal.
+            try
+            {
+                (initializedLanguageWorkerChannel as IDisposable)?.Dispose();
+            }
+            catch (Exception disposeEx)
+            {
+                _logger.LogDebug(disposeEx, "Error disposing worker channel after start failure for workerId:{id}", initializedLanguageWorkerChannel.Id);
+            }
         }
     }
 }

--- a/src/WebJobs.Script.Grpc/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script.Grpc/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -411,7 +411,21 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 if (channel.TryGetValue(initializedLanguageWorkerChannel.Id, out TaskCompletionSource<IRpcWorkerChannel> value))
                 {
                     value.SetResult(initializedLanguageWorkerChannel);
+                    return;
                 }
+            }
+
+            // The runtime was already removed from _workerChannels by ShutdownChannelsAsync (which
+            // raced with this initialization). The TCS was canceled, so ShutdownChannelsAsync won't
+            // dispose this channel. We must dispose it here to avoid leaking the worker process.
+            _logger.LogDebug("Channel for workerId:{id} was initialized after shutdown removed it from the dictionary. Disposing.", initializedLanguageWorkerChannel.Id);
+            try
+            {
+                (initializedLanguageWorkerChannel as IDisposable)?.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Error disposing late-initialized worker channel for workerId:{id}", initializedLanguageWorkerChannel.Id);
             }
         }
 

--- a/src/WebJobs.Script.Grpc/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script.Grpc/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -86,6 +86,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                         _logger.LogError("Failed to start language worker process for runtime: {language}. workerId:{id}", runtime, rpcWorkerChannel.Id);
                         SetExceptionOnInitializedWorkerChannel(runtime, rpcWorkerChannel, processStartTask.Exception);
                     }
+                    else if (processStartTask.Status == TaskStatus.Canceled)
+                    {
+                        _logger.LogDebug("Language worker process start was canceled for runtime: {language}. workerId:{id}", runtime, rpcWorkerChannel.Id);
+                        SetExceptionOnInitializedWorkerChannel(runtime, rpcWorkerChannel, new TaskCanceledException(processStartTask));
+                    }
                 });
             }
             catch (Exception ex)

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -40,7 +40,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
-    public class TestFunctionHost : IDisposable
+    public class TestFunctionHost : IAsyncDisposable, IDisposable
     {
         private readonly ScriptApplicationHostOptions _hostOptions;
         private readonly IHost _webHost;
@@ -507,22 +507,66 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             return JwtTokenHelper.CreateToken(validUntil, audience, issuer, key, notBefore);
         }
 
-        public void Dispose()
+        public void Dispose() => DisposeAsync().AsTask().GetAwaiter().GetResult();
+
+        public async ValueTask DisposeAsync()
         {
-            if (!_isDisposed)
+            if (_isDisposed)
             {
-                HttpClient.Dispose();
-                
-                _stillRunningTimer?.Change(-1, -1);
-                _stillRunningTimer?.Dispose();
-
-                if (_timerFired)
-                {
-                    Console.WriteLine($"The test host with id {_id} is now disposed.");
-                }
-
-                _isDisposed = true;
+                return;
             }
+
+            try
+            {
+                if (_webHost is not null)
+                {
+                    try
+                    {
+                        await _webHost.StopAsync();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // IHost.StopAsync is not idempotent once IHost.Dispose has run -- the
+                        // HostApplicationLifetime CTS and the hosted services' CTSes get
+                        // disposed by the ServiceProvider, so a second StopAsync throws.
+                        // Some test fixtures still explicitly stop+dispose the WebHost in
+                        // their own DisposeAsync before this runs; swallow the expected
+                        // ObjectDisposedException so the rest of teardown (HttpClient,
+                        // watchdog timer) completes normally.
+                    }
+                    catch (AggregateException ex) when (ex.InnerExceptions.Count > 0 && ex.InnerExceptions.All(e => e is ObjectDisposedException))
+                    {
+                        // Same scenario as above, but IHost packs per-service stop failures
+                        // into an AggregateException.
+                    }
+                }
+            }
+            finally
+            {
+                if (_webHost is IAsyncDisposable asyncDisposable)
+                {
+                    // Microsoft.Extensions.Hosting.Internal.Host implements IAsyncDisposable;
+                    // prefer it so the ServiceProvider disposes services (e.g. AspNetCoreGrpcServer)
+                    // via their IAsyncDisposable path rather than sync-over-async.
+                    await asyncDisposable.DisposeAsync();
+                }
+                else
+                {
+                    _webHost?.Dispose();
+                }
+            }
+
+            HttpClient.Dispose();
+
+            _stillRunningTimer?.Change(-1, -1);
+            _stillRunningTimer?.Dispose();
+
+            if (_timerFired)
+            {
+                Console.WriteLine($"The test host with id {_id} is now disposed.");
+            }
+
+            _isDisposed = true;
         }
 
         public async Task<bool> IsHostStarted()

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
@@ -310,7 +310,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                     await fileMonitoringService.StopAsync(default);
                 }
 
-                Host.Dispose();
+                await Host.DisposeAsync();
             }
 
             _scriptRoot?.Dispose();

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
@@ -605,6 +605,43 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.Equal(expectedProcessCount, functionDispatcher.JobHostLanguageWorkerChannelManager.GetChannels().Count());
         }
 
+        [Fact]
+        public async Task FunctionDispatcher_DisposesButDoesNotRestart_When_ApplicationStopping()
+        {
+            int expectedProcessCount = 1;
+            using var applicationStopping = new CancellationTokenSource();
+            var mockApplicationLifetime = new Mock<IHostApplicationLifetime>();
+            mockApplicationLifetime.SetupGet(m => m.ApplicationStopping).Returns(applicationStopping.Token);
+
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(
+                expectedProcessCount,
+                runtime: RpcWorkerConstants.NodeLanguageWorkerName,
+                applicationLifetime: mockApplicationLifetime.Object);
+
+            await functionDispatcher.InitializeAsync(GetTestFunctionsList(RpcWorkerConstants.NodeLanguageWorkerName));
+            await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount);
+
+            applicationStopping.Cancel();
+            _testLoggerProvider.ClearAllLogMessages();
+
+            var testWorkerChannel = (TestRpcWorkerChannel)functionDispatcher.JobHostLanguageWorkerChannelManager.GetChannels().First();
+            string workerId = testWorkerChannel.Id;
+            testWorkerChannel.RaiseWorkerError();
+            testWorkerChannel.RaiseWorkerRestart();
+
+            await Task.Delay(500);
+
+            var logs = _testLoggerProvider.GetAllLogMessages();
+
+            // The channel should be torn down so its WorkerProcess.Dispose runs (prevents
+            // JobObjectRegistry deadlock during IHost disposal), but no new worker should be spawned.
+            Assert.DoesNotContain(logs, m => m.FormattedMessage.Contains("Restarting worker channel"));
+            Assert.Contains(logs, m => m.FormattedMessage.Contains($"Skipping worker channel restart for runtime '{RpcWorkerConstants.NodeLanguageWorkerName}' because the host is shutting down. workerId: '{workerId}'"));
+            Assert.DoesNotContain(
+                functionDispatcher.JobHostLanguageWorkerChannelManager.GetChannels(),
+                c => string.Equals(c.Id, workerId, StringComparison.Ordinal));
+        }
+
         [Theory]
         [InlineData("node", "node", false, true, true)]
         [InlineData("node", "node", true, false, true)]
@@ -720,7 +757,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             string runtime = null,
             bool workerIndexing = false,
             bool placeholder = false,
-            IRpcWorkerChannelFactory channelFactory = null)
+            IRpcWorkerChannelFactory channelFactory = null,
+            IHostApplicationLifetime applicationLifetime = null)
         {
             var eventManager = new ScriptEventManager();
             var metricsLogger = new Mock<IMetricsLogger>();
@@ -781,7 +819,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             return new RpcFunctionInvocationDispatcher(scriptOptions,
                 metricsLogger.Object,
                 testEnv,
-                mockApplicationLifetime.Object,
+                applicationLifetime ?? mockApplicationLifetime.Object,
                 eventManager,
                 _testLoggerFactory,
                 channelFactory,


### PR DESCRIPTION
**This PR is for diagnostic investigation only - DO NOT MERGE.**

## Goal

Reproduce the sync-over-async deadlock that occurs when `TestFunctionHost.Dispose()` stops the underlying `IHost`, and capture a full process dump in CI so we can identify the actual blocking primitive.

Prior sessions narrowed the workaround to `CSharpPrecompiledTestFixture.DisposeAsync()` (PR #11795 base branch), which avoids the deadlock by stopping the WebHost from an async path before `TestFunctionHost.Dispose()` runs. That ships, but it leaves the underlying production bug unidentified - other fixtures hit the same shape (e.g. the `ProxyEndToEndTests.TestFixture` `FileMonitoringService` crash uncovered last build).

## Changes in this PR

1. **`TestFunctionHost.Dispose()`** - call `_webHost.StopAsync().GetAwaiter().GetResult(); _webHost.Dispose();` before the existing `HttpClient` / timer cleanup. This is the sync-over-async path that has historically deadlocked.
2. **`CSharpPrecompiledTestFixture.DisposeAsync()`** - removed the narrower workaround so we don't double-stop. The base `EndToEndTestFixture.DisposeAsync` calls `Host?.Dispose()` which now stops the WebHost itself.
3. **`eng/ci/templates/official/jobs/run-non-e2e-tests.yml`** -
   - Added `--blame-hang-dump-type full --blame-hang-timeout 5m` to the per-iteration `dotnet test` invocation. When the testhost goes silent for 5 minutes (which a sync-over-async deadlock will cause), VSTest captures a full dump.
   - Added `templateContext.outputs.pipelineArtifact` so `$(Agent.TempDirectory)\flake-repro` (containing both the per-iter trx/log AND the testhost dumps) is uploaded as a build artifact even on failure (`condition: succeededOrFailed()`).

## How to use

1. Wait for the CI run on this PR. With `parallel: 4` x `iterations: 5` = 20 testhost invocations per build, the deadlock is expected to land at least once.
2. From the failed build's **Artifacts** page, download the `flake-repro-*` zip(s). Each contains:
   - `iteration-N.log` / `iteration-N.trx` - the per-iter VSTest output
   - `<machine>_<random>\<testhost>.dmp` (only present when the hang fired)
   - `Sequence_*.xml` - which test was running when the hang was detected
3. Open the `.dmp` in Visual Studio (`File > Open > File...` then **Debug Managed Memory**), or analyze with `dotnet-dump analyze` / WinDbg + SOS.
4. Inspect the thread stuck in `IHost.StopAsync` -> hosted-service `StopAsync` -> the actual blocker. Prior hypothesis: `Microsoft.Azure.WebJobs.Script.Grpc.JobObjectRegistry.Close()` awaiting `ProcessWaitingForTermination.Task.Wait()` unbounded.

## Companion PR

Investigation parent: #11795 (`brettsam/repro-externalstartup-flake`) - that PR contains the narrower fix that will actually ship. This PR is the diagnostic harness only.
