### PR TITLE
fix: fallback to cached env read for case insensitivity on linux

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,5 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+
+- fix: case sensitive config mismatch on linux (#11811)

--- a/src/WebJobs.Script/Config/ScriptEnvironmentVariablesConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/ScriptEnvironmentVariablesConfigurationSource.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.EnvironmentVariables;
 
@@ -12,19 +13,19 @@ namespace Microsoft.Azure.WebJobs.Script
     /// This source exists to replace the default <see cref="EnvironmentVariablesConfigurationSource"/> to allow
     /// us to override caching behavior.
     /// </summary>
-    /// <param name="liveEnvironmentLoading">
-    /// If true, the provider will use the live environment variables when fetching values.
+    /// <param name="liveEnvironmentRead">
+    /// If true, the provider will read the live environment variables when fetching values.
     /// If false, it will cache environment variables one time on load.
     /// </param>
     /// <remarks>
-    /// Live environment fetching is the existing behavior we use in the WebHost so that post-specialization
+    /// Live environment read is the existing behavior we use in the WebHost so that post-specialization
     /// changes to the environment are reflected in the configuration.
     /// </remarks>
-    public class ScriptEnvironmentVariablesConfigurationSource(bool liveEnvironmentLoading = true) : IConfigurationSource
+    public class ScriptEnvironmentVariablesConfigurationSource(bool liveEnvironmentRead = true) : IConfigurationSource
     {
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         {
-            return liveEnvironmentLoading
+            return liveEnvironmentRead
                 ? new WebHostEnvironmentVariablesProvider() : new CompatEnvironmentVariablesProvider();
         }
 
@@ -46,8 +47,6 @@ namespace Microsoft.Azure.WebJobs.Script
 
             public override void Load()
             {
-                base.Load();
-
                 static string Normalize(string key)
                 {
                     return key.Replace("__", ConfigurationPath.KeyDelimiter);
@@ -64,6 +63,13 @@ namespace Microsoft.Azure.WebJobs.Script
                            key.StartsWith(ServiceBusPrefix, StringComparison.OrdinalIgnoreCase);
                 }
 
+                // First load config from base class.
+                // Then add the prefixed string, but update a separate dictionary so we can atomically
+                // update the Data property with all new config at once, and not write to a dictionary
+                // being potentially accessed by other threads.
+                base.Load();
+                Dictionary<string, string> data = new(Data, StringComparer.OrdinalIgnoreCase);
+
                 // .NET 10 changed to special case some prefixes, inserting it into the "ConnectionStrings" section.
                 // For backwards compatibility, we still want to include these in the configuration.
                 foreach (DictionaryEntry kvp in Environment.GetEnvironmentVariables())
@@ -72,10 +78,13 @@ namespace Microsoft.Azure.WebJobs.Script
                     {
                         if (IsPrefixedString(key))
                         {
-                            Data[Normalize(key)] = value;
+                            data[Normalize(key)] = value;
                         }
                     }
                 }
+
+                // Atomic swap to publish all config at once.
+                Data = data;
             }
         }
 
@@ -87,13 +96,22 @@ namespace Microsoft.Azure.WebJobs.Script
 
             public override bool TryGet(string key, out string value)
             {
+                // First, try to get the value from the environment variables.
+                // If that fails, try to get the value from the normalized key.
+                // If that fails, try to get the value from the data (cached version).
+                // NOTE: falling back to Data introduces a stale read after delete issue.
+                // If an env variable is deleted, the cached value will still be returned.
+                // This is not a concern as of this comment, as we have no env var deletes.
+                // We will be moving away from directly using env vars in the future.
                 return
-                    (value = Environment.GetEnvironmentVariable(key)) != null ||
-                    (value = Environment.GetEnvironmentVariable(NormalizeKey(key))) != null;
+                    (value = Environment.GetEnvironmentVariable(key)) != null
+                    || (value = Environment.GetEnvironmentVariable(NormalizeKey(key))) != null
+                    || Data.TryGetValue(key, out value);
             }
 
             public override void Set(string key, string value)
             {
+                base.Set(key, value);
                 Environment.SetEnvironmentVariable(key, value);
             }
 

--- a/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
+++ b/src/WebJobs.Script/ScriptHostBuilderExtensions.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.WebJobs.Script
                 {
                     if (configBuilder.Sources[i] is EnvironmentVariablesConfigurationSource)
                     {
-                        configBuilder.Sources[i] = new ScriptEnvironmentVariablesConfigurationSource(liveEnvironmentLoading: false);
+                        configBuilder.Sources[i] = new ScriptEnvironmentVariablesConfigurationSource(liveEnvironmentRead: false);
                     }
                 }
 

--- a/test/WebJobs.Script.Tests/Config/ScriptEnvironmentVariablesConfigurationSourceTests.cs
+++ b/test/WebJobs.Script.Tests/Config/ScriptEnvironmentVariablesConfigurationSourceTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.Script.Config.Tests
             string prefixed = $"{prefix}{_key}";
             using (new EnvironmentVariableScope(prefixed, _value))
             {
-                IConfigurationRoot config = BuildConfiguration(liveEnvironmentLoading: true);
+                IConfigurationRoot config = BuildConfiguration(liveEnvironmentRead: true);
 
                 // AsEnumerable surfaces entries from the provider's Data dictionary.
                 config.AsEnumerable()
@@ -110,11 +110,175 @@ namespace Microsoft.Azure.WebJobs.Script.Config.Tests
             }
         }
 
-        private static IConfigurationRoot BuildConfiguration(bool liveEnvironmentLoading = false)
+        [Fact]
+        public void LiveRead_TryGet_LiveValuePresent_PrecedesData()
+        {
+            // Live read should always win over Data when the env var is present with the exact key.
+            string key = $"TEST_LIVE_{Guid.NewGuid():N}";
+            using (new EnvironmentVariableScope(key, "from-env"))
+            {
+                IConfigurationProvider provider = BuildProvider(liveEnvironmentRead: true);
+
+                // Mutate Data to a different value via Set to prove live read wins.
+                provider.Set(key, "from-data");
+                Environment.SetEnvironmentVariable(key, "from-env-after-set");
+
+                provider.TryGet(key, out string value).Should().BeTrue();
+                value.Should().Be("from-env-after-set");
+            }
+        }
+
+        [Fact]
+        public void LiveRead_TryGet_ColonKey_FallsBackToNormalizedUnderscoreEnv()
+        {
+            // Caller asks via "Section:Key"; env var is set as "Section__Key".
+            string suffix = Guid.NewGuid().ToString("N");
+            string envKey = $"TEST_SECTION__{suffix}";
+            string colonKey = $"TEST_SECTION:{suffix}";
+
+            using (new EnvironmentVariableScope(envKey, _value))
+            {
+                IConfigurationProvider provider = BuildProvider(liveEnvironmentRead: true);
+
+                provider.TryGet(colonKey, out string value).Should().BeTrue();
+                value.Should().Be(_value);
+            }
+        }
+
+        [Fact]
+        public void LiveRead_TryGet_AbsentEverywhere_ReturnsFalse()
+        {
+            IConfigurationProvider provider = BuildProvider(liveEnvironmentRead: true);
+
+            string key = $"TEST_MISSING_{Guid.NewGuid():N}";
+            provider.TryGet(key, out string value).Should().BeFalse();
+            value.Should().BeNull();
+        }
+
+        [Fact]
+        public void LiveRead_TryGet_CaseMismatchLiveMisses_FallsBackToData()
+        {
+            // Regression for the Linux case-sensitivity bug. Env vars set with one case may not
+            // be resolvable via a live read with different case (Linux env is case-sensitive at
+            // the OS layer). The cached Data dictionary uses OrdinalIgnoreCase, so the fallback
+            // should resolve the value regardless of OS.
+            string suffix = Guid.NewGuid().ToString("N");
+            string envKey = $"TEST_SECTION__lower_{suffix}";
+
+            using (new EnvironmentVariableScope(envKey, _value))
+            {
+                IConfigurationProvider provider = BuildProvider(liveEnvironmentRead: true);
+
+                // Request the key with mismatched casing using the colon form. On Linux this
+                // simulates the production failure mode (AzureWebJobsStorage:AccountName vs
+                // AzureWebJobsStorage__accountName). On Windows the live read may already hit
+                // due to OS case-insensitivity; either way the value must resolve.
+                string requestedKey = $"TEST_SECTION:LOWER_{suffix}";
+                provider.TryGet(requestedKey, out string value).Should().BeTrue();
+                value.Should().Be(_value);
+            }
+        }
+
+        [Fact]
+        public void LiveRead_TryGet_EnvDeletedAfterLoad_FallsBackToCachedData()
+        {
+            // Documents intentional staleness: once Load snapshots the env var into Data,
+            // deleting the env var leaves the cached value visible via the fallback path
+            // until the next Reload. Acceptable trade-off because specialization adds
+            // env vars rather than removing them.
+            string key = $"TEST_DELETE_{Guid.NewGuid():N}";
+            Environment.SetEnvironmentVariable(key, _value);
+            try
+            {
+                IConfigurationProvider provider = BuildProvider(liveEnvironmentRead: true);
+                Environment.SetEnvironmentVariable(key, null);
+
+                provider.TryGet(key, out string value).Should().BeTrue();
+                value.Should().Be(_value);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(key, null);
+            }
+        }
+
+        [Fact]
+        public void LiveRead_Set_WritesBothEnvironmentAndData()
+        {
+            string key = $"TEST_SET_{Guid.NewGuid():N}";
+            try
+            {
+                IConfigurationProvider provider = BuildProvider(liveEnvironmentRead: true);
+                provider.Set(key, _value);
+
+                Environment.GetEnvironmentVariable(key).Should().Be(_value);
+
+                // Clear env and confirm Data still has the value (proves Data write happened).
+                Environment.SetEnvironmentVariable(key, null);
+                provider.TryGet(key, out string value).Should().BeTrue();
+                value.Should().Be(_value);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(key, null);
+            }
+        }
+
+        [Fact]
+        public void Cached_Load_DoesNotSeeEnvChangesUntilReload()
+        {
+            string key = $"TEST_CACHED_{Guid.NewGuid():N}";
+            Environment.SetEnvironmentVariable(key, "initial");
+            try
+            {
+                IConfigurationRoot config = BuildConfiguration(liveEnvironmentRead: false);
+                config[key].Should().Be("initial");
+
+                Environment.SetEnvironmentVariable(key, "updated");
+                config[key].Should().Be("initial", "cached provider should not see env changes without Reload");
+
+                config.Reload();
+                config[key].Should().Be("updated");
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(key, null);
+            }
+        }
+
+        [Fact]
+        public void Cached_Reload_RemovesDeletedEnvVarsFromSnapshot()
+        {
+            string key = $"TEST_REMOVE_{Guid.NewGuid():N}";
+            Environment.SetEnvironmentVariable(key, _value);
+            try
+            {
+                IConfigurationRoot config = BuildConfiguration(liveEnvironmentRead: false);
+                config[key].Should().Be(_value);
+
+                Environment.SetEnvironmentVariable(key, null);
+                config.Reload();
+                config[key].Should().BeNull();
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(key, null);
+            }
+        }
+
+        private static IConfigurationRoot BuildConfiguration(bool liveEnvironmentRead = false)
         {
             var builder = new ConfigurationBuilder();
-            builder.Add(new ScriptEnvironmentVariablesConfigurationSource(liveEnvironmentLoading));
+            builder.Add(new ScriptEnvironmentVariablesConfigurationSource(liveEnvironmentRead));
             return builder.Build();
+        }
+
+        private static IConfigurationProvider BuildProvider(bool liveEnvironmentRead)
+        {
+            var source = new ScriptEnvironmentVariablesConfigurationSource(liveEnvironmentRead);
+            var provider = source.Build(new ConfigurationBuilder());
+            provider.Load();
+            return provider;
         }
 
         private sealed class EnvironmentVariableScope : IDisposable


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #11787

Issue: the live environment variable reading in `ScriptEnvironmentVariablesConfigurationSource` creates a case-sensitivity inconsistency on linux platforms. Any configuration APIs that read from the cache on that type will be case _insensitive_, but getting the actual value is case _sensitive_. This introduces a subtle issue when reading configuration between the webhost and scripthost. ScriptHost will be entirely case insensitive, and WebHost will be partially case sensitive. 

This is the root cause of the blob client creation issues. If secret manager initializes before the active host is ready (and config for it reloaded), we will get into a state where `AzureWebJobsStorage` section exists, but config binding fails because we try to fetch `AzureWebJobsStorage__AccountName`, but only `AzureWebJobsStorage__accountName` exists (casing difference).

This PR takes as targeted of a fix possible. While we eventually want to remove the live reads entirely it may be too risky/large to do for this specific fix. Additionally, we are already performing a full configuration reload on specialization: https://github.com/Azure/azure-functions-host/blob/c376f3f89008ddfa67e007ff58b83d394e9f08a7/src/WebJobs.Script.WebHost/Standby/StandbyManager.cs#L116, so the delta between live and config should _only_ be casing.

### Risks

This does introduce a stale-config risk when it comes to environment variable deletion. If we were to set an env variable to null or empty mid lifecycle (without a config reload -- specialization will reload the config, so not an issue there), reads that would previously pick up the null or empty will now fallback to the cache and get the stale value. I went over our code and I don't see any cases where we do that. I only found that we write env variables when specialization completes, but those are written with non-null values, so it won't be an issue.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
