### PR TITLE
fix: atomic load for ActiveHostConfigurationProvider

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,5 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+
+- fix: address config reload concurrent read/write race (#11815)

--- a/src/WebJobs.Script/Config/ActiveHostConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/ActiveHostConfigurationSource.cs
@@ -7,14 +7,9 @@ using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.WebJobs.Script.Configuration
 {
-    public class ActiveHostConfigurationSource : IConfigurationSource
+    public class ActiveHostConfigurationSource(IScriptHostManager scriptHostManager) : IConfigurationSource
     {
-        private readonly IScriptHostManager _scriptHostManager;
-
-        public ActiveHostConfigurationSource(IScriptHostManager scriptHostManager)
-        {
-            _scriptHostManager = scriptHostManager;
-        }
+        private readonly IScriptHostManager _scriptHostManager = scriptHostManager;
 
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         {
@@ -28,27 +23,32 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
 
             public ActiveHostConfigurationProvider(IScriptHostManager scriptHostManager)
             {
-                _scriptHostManager = scriptHostManager ?? throw new ArgumentNullException(nameof(scriptHostManager));
+                ArgumentNullException.ThrowIfNull(scriptHostManager);
+                _scriptHostManager = scriptHostManager;
                 scriptHostManager.ActiveHostChanged += HandleActiveHostChange;
             }
 
             public override void Load()
             {
-                if ((_scriptHostManager as IServiceProvider)?.GetService(typeof(IConfiguration)) is IConfigurationRoot activeHostConfiguration)
+                if ((_scriptHostManager as IServiceProvider)?.GetService(typeof(IConfiguration))
+                    is not IConfigurationRoot activeHostConfiguration)
                 {
-                    Data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                    foreach (var kvp in activeHostConfiguration.AsEnumerable())
-                    {
-                        if (!Data.ContainsKey(kvp.Key))
-                        {
-                            Data[kvp.Key] = kvp.Value;
-                        }
-                    }
-
-                    _changeTokenRegistration?.Dispose();
-                    _changeTokenRegistration = activeHostConfiguration.GetReloadToken().RegisterChangeCallback(_ => Load(), null);
-                    OnReload();
+                    return;
                 }
+
+                Dictionary<string, string> data = new(StringComparer.OrdinalIgnoreCase);
+                foreach (var kvp in activeHostConfiguration.AsEnumerable())
+                {
+                    if (!data.ContainsKey(kvp.Key))
+                    {
+                        data[kvp.Key] = kvp.Value;
+                    }
+                }
+
+                Data = data;
+                _changeTokenRegistration?.Dispose();
+                _changeTokenRegistration = activeHostConfiguration.GetReloadToken().RegisterChangeCallback(_ => Load(), null);
+                OnReload();
             }
 
             private void HandleActiveHostChange(object sender, ActiveHostChangedEventArgs e)
@@ -59,6 +59,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             public void Dispose()
             {
                 _changeTokenRegistration?.Dispose();
+                _changeTokenRegistration = null;
                 _scriptHostManager.ActiveHostChanged -= HandleActiveHostChange;
             }
         }

--- a/src/WebJobs.Script/Config/ScriptEnvironmentVariablesConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/ScriptEnvironmentVariablesConfigurationSource.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.EnvironmentVariables;
 
@@ -46,8 +47,6 @@ namespace Microsoft.Azure.WebJobs.Script
 
             public override void Load()
             {
-                base.Load();
-
                 static string Normalize(string key)
                 {
                     return key.Replace("__", ConfigurationPath.KeyDelimiter);
@@ -64,6 +63,13 @@ namespace Microsoft.Azure.WebJobs.Script
                            key.StartsWith(ServiceBusPrefix, StringComparison.OrdinalIgnoreCase);
                 }
 
+                // First load config from base class.
+                // Then add the prefixed string, but update a separate dictionary so we can atomically
+                // update the Data property with all new config at once, and not write to a dictionary
+                // being potentially accessed by other threads.
+                base.Load();
+                Dictionary<string, string> data = new(Data, StringComparer.OrdinalIgnoreCase);
+
                 // .NET 10 changed to special case some prefixes, inserting it into the "ConnectionStrings" section.
                 // For backwards compatibility, we still want to include these in the configuration.
                 foreach (DictionaryEntry kvp in Environment.GetEnvironmentVariables())
@@ -72,10 +78,13 @@ namespace Microsoft.Azure.WebJobs.Script
                     {
                         if (IsPrefixedString(key))
                         {
-                            Data[Normalize(key)] = value;
+                            data[Normalize(key)] = value;
                         }
                     }
                 }
+
+                // Atomic swap to publish all config at once.
+                Data = data;
             }
         }
 

--- a/src/WebJobs.Script/StorageProvider/BlobServiceClientProvider.cs
+++ b/src/WebJobs.Script/StorageProvider/BlobServiceClientProvider.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <summary>
         /// Initializes a new instance of the <see cref="BlobServiceClientProvider"/> class that uses the registered Azure services to create a BlobServiceClient.
         /// </summary>
-        /// <param name="componentFactory">The Azure factory responsible for creating clients. <see cref="AzureComponentFactory"/></param>
-        /// <param name="logForwarder">Log forwarder that forwards events to ILogger. <see cref="AzureEventSourceLogForwarder"/></param>
+        /// <param name="componentFactory">The Azure factory responsible for creating clients. <see cref="AzureComponentFactory"/>.</param>
+        /// <param name="logForwarder">Log forwarder that forwards events to ILogger. <see cref="AzureEventSourceLogForwarder"/>.</param>
         public BlobServiceClientProvider(AzureComponentFactory componentFactory, AzureEventSourceLogForwarder logForwarder)
             : base(componentFactory, logForwarder) { }
 
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <param name="configuration">Configuration to retrieve settings from.</param>
         /// <param name="tokenCredential">Credential for the client.</param>
         /// <param name="options">Options to configure the client.</param>
-        /// <returns>An instance of <see cref="BlobServiceClient"/></returns>
+        /// <returns>An instance of <see cref="BlobServiceClient"/>.</returns>
         protected override BlobServiceClient CreateClient(IConfiguration configuration, TokenCredential tokenCredential, BlobClientOptions options)
         {
             // If connection string is present, it will be honored first; bypass creating a serviceUri


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

part of #11787

While investigating the blob client issue above, I also identified a potential enumerable read/write conflict. We do not atomically swap the `Data`, but instead update it in place. Any config consumers enumerating that `Data` dictionary at the same time will lead to exceptions. I have verified this exception can be seen occasionally in our logs.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

