### PR TITLE
fix: address missed active invocation count metric

### DIFF
--- a/src/WebJobs.Script.WebHost/Metrics/HostMetricsProvider.cs
+++ b/src/WebJobs.Script.WebHost/Metrics/HostMetricsProvider.cs
@@ -11,13 +11,12 @@ using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Script.Diagnostics.OpenTelemetry;
 using Microsoft.Azure.WebJobs.Script.Metrics;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
 {
-    public class HostMetricsProvider : IHostMetricsProvider, IDisposable
+    public sealed class HostMetricsProvider : IHostMetricsProvider, IDisposable
     {
         private readonly MeterListener _meterListener;
         private readonly IServiceProvider _serviceProvider;
@@ -100,11 +99,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
                 return;
             }
 
-            if (instrument == null)
-            {
-                throw new ArgumentNullException(nameof(instrument));
-            }
-
+            ArgumentNullException.ThrowIfNull(instrument);
             AddOrUpdateMetricsCache(instrument.Name, measurement);
         }
 
@@ -117,20 +112,23 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Metrics
 
         public IReadOnlyDictionary<string, long> GetHostMetricsOrNull()
         {
+            var functionActivityStatusProvider = _serviceProvider.GetScriptHostServiceOrNull<IFunctionActivityStatusProvider>();
+            if (functionActivityStatusProvider is not null)
+            {
+                var functionActivityStatus = functionActivityStatusProvider.GetStatus();
+
+                if (functionActivityStatus.OutstandingInvocations > 0)
+                {
+                    AddOrUpdateMetricsCache(HostMetrics.ActiveInvocationCount, functionActivityStatus.OutstandingInvocations);
+                }
+            }
+
             if (!HasMetrics())
             {
                 return null;
             }
 
-            var functionActivityStatusProvider = _serviceProvider.GetScriptHostServiceOrNull<IFunctionActivityStatusProvider>();
-            if (functionActivityStatusProvider is not null)
-            {
-                var functionActivityStatus = functionActivityStatusProvider.GetStatus();
-                AddOrUpdateMetricsCache(HostMetrics.ActiveInvocationCount, functionActivityStatus.OutstandingInvocations);
-            }
-
             var metrics = Interlocked.Exchange(ref _metricsCache, new ConcurrentDictionary<string, long>());
-
             return metrics;
         }
 

--- a/src/WebJobs.Script/Metrics/HostMetrics.cs
+++ b/src/WebJobs.Script/Metrics/HostMetrics.cs
@@ -27,9 +27,9 @@ namespace Microsoft.Azure.WebJobs.Script.Metrics
 
         public static readonly string FaasMeterVersion = typeof(HostMetrics).Assembly.GetName().Version?.ToString();
 
-        private Counter<long> _appFailureCount;
-        private Counter<long> _startedInvocationCount;
-        private Histogram<double> _faasInvokeDuration;
+        private readonly Counter<long> _appFailureCount;
+        private readonly Counter<long> _startedInvocationCount;
+        private readonly Histogram<double> _faasInvokeDuration;
 
         private KeyValuePair<string, object>? _cachedFunctionGroupTag = null;
 

--- a/test/WebJobs.Script.Tests/Metrics/HostMetricsProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Metrics/HostMetricsProviderTests.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
         private StandbyOptions _standbyOptions;
         private TestOptionsMonitor<StandbyOptions> _standbyOptionsMonitor;
         private TestLogger<HostMetricsProvider> _logger;
+        private FunctionActivityStatus _activityStatus;
 
         public HostMetricsProviderTests()
         {
@@ -31,10 +32,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             serviceCollection.AddSingleton<IEnvironment>(new TestEnvironment());
             serviceCollection.AddSingleton<IHostMetrics, HostMetrics>();
 
-            // Mock the function activity status provider to return a single outstanding invocation
+            // Mock the function activity status provider; tests can mutate _activityStatus to change outstanding invocations.
+            _activityStatus = new FunctionActivityStatus() { OutstandingInvocations = 0 };
             var mockStatusProvider = new Mock<IFunctionActivityStatusProvider>();
-            var activityStatus = new FunctionActivityStatus() { OutstandingInvocations = 1 };
-            mockStatusProvider.Setup(p => p.GetStatus()).Returns(activityStatus);
+            mockStatusProvider.Setup(p => p.GetStatus()).Returns(() => _activityStatus);
             serviceCollection.AddSingleton<IFunctionActivityStatusProvider>(mockStatusProvider.Object);
 
             // Mock the script host manager to return the mock status provider
@@ -136,6 +137,38 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Metrics
             // Assert
             var result = hostMetricsProvider.GetHostMetricsOrNull();
             Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetHostMetricsOrNull_OnlyOutstandingInvocations_ReturnsActiveInvocationCount()
+        {
+            // Regression test: previously, when no metrics were recorded via the meter listener,
+            // GetHostMetricsOrNull would early-return null and miss reporting ActiveInvocationCount
+            // sourced from IFunctionActivityStatusProvider.
+            var hostMetricsProvider = CreateProvider();
+            _activityStatus.OutstandingInvocations = 3;
+
+            var result = hostMetricsProvider.GetHostMetricsOrNull();
+
+            Assert.NotNull(result);
+            Assert.True(result.TryGetValue(HostMetrics.ActiveInvocationCount, out var activeInvocationCount));
+            Assert.Equal(3, activeInvocationCount);
+            Assert.Single(result);
+        }
+
+        [Fact]
+        public void GetHostMetricsOrNull_NoOutstandingInvocations_OmitsActiveInvocationCount()
+        {
+            var metrics = _serviceProvider.GetRequiredService<IHostMetrics>();
+            var hostMetricsProvider = CreateProvider();
+            _activityStatus.OutstandingInvocations = 0;
+
+            metrics.IncrementStartedInvocationCount();
+
+            var result = hostMetricsProvider.GetHostMetricsOrNull();
+
+            Assert.NotNull(result);
+            Assert.False(result.ContainsKey(HostMetrics.ActiveInvocationCount));
         }
 
         [Fact]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

Addresses an issue where there is a window in which we can mistakenly short-circuit the host metric collections and incorrectly repo 0 ActiveFunctionInvocations.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
