### PR TITLE
Restrict GET admin/host/triggers to platform claim

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -6,9 +6,4 @@
 
 - fix: address config reload concurrent read/write race (#11815)
 - fix: avoid health checks triggering secret-manager too early (#11816)
-- Restore Workflows-bundle worker discovery on Logic App (#11759)
-- Ensure wwwroot directory exists on new slot and app creation w/ networking restrictions (#11757)
-- Update Node.js Worker Version to [3.14.1](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.14.1) (#PR)
-- Log enum names instead of integers in options formatting for `TimerTriggerPlatformOptions` (#11689)
-- Update WebHostWorkerRuntimeResolver to always read from IConfiguration variable value for FWR (#11720)
 - Restrict GET admin/host/triggers to platform claim (#11697)

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,3 +6,9 @@
 
 - fix: address config reload concurrent read/write race (#11815)
 - fix: avoid health checks triggering secret-manager too early (#11816)
+- Restore Workflows-bundle worker discovery on Logic App (#11759)
+- Ensure wwwroot directory exists on new slot and app creation w/ networking restrictions (#11757)
+- Update Node.js Worker Version to [3.14.1](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.14.1) (#PR)
+- Log enum names instead of integers in options formatting for `TimerTriggerPlatformOptions` (#11689)
+- Update WebHostWorkerRuntimeResolver to always read from IConfiguration variable value for FWR (#11720)
+- Restrict GET admin/host/triggers to platform claim (#11697)

--- a/src/WebJobs.Script.WebHost/Controllers/HostController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/HostController.cs
@@ -21,6 +21,7 @@ using Microsoft.Azure.WebJobs.Script.Scale;
 using Microsoft.Azure.WebJobs.Script.WebHost.Filters;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication;
 using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
@@ -414,20 +415,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
         {
             _metricsLogger.LogEvent(MetricEventNames.GetTriggersInvoked);
 
-            // This endpoint is only available in validation mode
-            if (_environment.IsInValidationMode())
+            if (!User.IsFuncPlatform())
             {
-                var result = await _functionsSyncManager.GetTriggersAsync();
-
-                // GetTriggersAsync() does not swallow exceptions, so any failures will still be a 500.
-                // The only result.Success == false we need to consider is when the environment
-                // does not support sync triggers.
-                return result.Success
-                    ? Ok(result)
-                    : StatusCode(StatusCodes.Status403Forbidden, new { status = result.Error });
+                return Forbid();
             }
 
-            return StatusCode(StatusCodes.Status403Forbidden, new { status = "GetTriggers operation is not supported in for this instance." });
+            var result = await _functionsSyncManager.GetTriggersAsync();
+            return result.Success
+                ? Ok(result)
+                : StatusCode(StatusCodes.Status500InternalServerError, new { status = result.Error });
         }
 
         [HttpPost]

--- a/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/InstanceController.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
                 }
                 else
                 {
-                    if (!User.HasClaim(SecurityConstants.AssignUnencryptedClaimType, "true"))
+                    if (!User.IsFuncPlatform())
                     {
                         _logger.LogWarning("Required claims missing for invoking unencrypted assignment");
                         return Forbid();

--- a/src/WebJobs.Script.WebHost/Security/Authentication/ClaimsPrincipalExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Security.Claims;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication
+{
+    public static class ClaimsPrincipalExtensions
+    {
+        public static bool IsFuncPlatform(this ClaimsPrincipal principal)
+        {
+            return principal.HasClaim(SecurityConstants.FuncPlatformClaimType, "true");
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
                     if (string.Equals(c.SecurityToken.Issuer, ScriptConstants.LegionCoreUri, StringComparison.OrdinalIgnoreCase))
                     {
-                        claims.Add(new Claim(SecurityConstants.AssignUnencryptedClaimType, "true"));
+                        claims.Add(new Claim(SecurityConstants.FuncPlatformClaimType, "true"));
                     }
 
                     c.Principal.AddIdentity(new ClaimsIdentity(claims));

--- a/src/WebJobs.Script.WebHost/Security/Authentication/SecurityConstants.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/SecurityConstants.cs
@@ -22,8 +22,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication
         public const string InvokeClaimType = "http://schemas.microsoft.com/2017/07/functions/claims/invoke";
 
         /// <summary>
-        /// Claim indicating whether a principal is authorized to invoke assign with an unencrypted payload.
+        /// Claim indicating if the principal has the role to perform platform-only operations
+        /// such as unencrypted assignment and triggers retrieval.
         /// </summary>
-        public const string AssignUnencryptedClaimType = "http://schemas.microsoft.com/2017/07/functions/claims/assign-unencrypted";
+        public const string FuncPlatformClaimType = "http://schemas.microsoft.com/2017/07/functions/claims/func-platform";
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceControllerTests.cs
@@ -262,7 +262,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 startupContextProvider, testmetricslogger);
             DefaultHttpContext context = new() { User = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]
             {
-                new Claim(SecurityConstants.AssignUnencryptedClaimType, "true")
+                new Claim(SecurityConstants.FuncPlatformClaimType, "true")
             })) };
             instanceController.ControllerContext = new() { HttpContext = context };
 

--- a/test/WebJobs.Script.Tests/Controllers/Admin/HostControllerTests.cs
+++ b/test/WebJobs.Script.Tests/Controllers/Admin/HostControllerTests.cs
@@ -1,13 +1,15 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
 using System.IO;
 using System.Net;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Scale;
@@ -17,6 +19,7 @@ using Microsoft.Azure.WebJobs.Script.Scale;
 using Microsoft.Azure.WebJobs.Script.WebHost.Controllers;
 using Microsoft.Azure.WebJobs.Script.WebHost.Management;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
@@ -400,6 +403,61 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             cts.Cancel();
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => _hostController.Resume(scriptHostManagerMock.Object, cts.Token));
             scriptHostManagerMock.Verify(p => p.RestartHostAsync("test", It.IsAny<CancellationToken>()), Times.Never());
+        }
+
+        [Fact]
+        public async Task GetTriggers_WithFuncPlatformClaim_ReturnsOk()
+        {
+            var expectedResult = new TriggersResult { Success = true, Content = "{}" };
+            _functionsSyncManager.Setup(p => p.GetTriggersAsync()).ReturnsAsync(expectedResult);
+
+            var httpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(
+                [
+                    new Claim(SecurityConstants.FuncPlatformClaimType, "true")
+                ]))
+            };
+            _hostController.ControllerContext.HttpContext = httpContext;
+
+            var result = await _hostController.GetTriggers();
+
+            var okResult = Assert.IsType<OkObjectResult>(result);
+            var triggersResult = Assert.IsType<TriggersResult>(okResult.Value);
+            Assert.True(triggersResult.Success);
+        }
+
+        [Fact]
+        public async Task GetTriggers_WithoutFuncPlatformClaim_ReturnsForbid()
+        {
+            var httpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity())
+            };
+
+            _hostController.ControllerContext.HttpContext = httpContext;
+
+            var result = await _hostController.GetTriggers();
+
+            Assert.IsType<ForbidResult>(result);
+        }
+
+        [Fact]
+        public async Task GetTriggers_WithAuthClaimOnly_ReturnsForbid()
+        {
+            var httpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(
+                [
+                    new Claim(SecurityConstants.AuthLevelClaimType, AuthorizationLevel.Admin.ToString())
+                ]))
+            };
+
+            _hostController.ControllerContext.HttpContext = httpContext;
+
+            var result = await _hostController.GetTriggers();
+
+            Assert.IsType<ForbidResult>(result);
         }
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

> Note: This PR supersedes #11697. The original PR was opened by @kamperiadis, who has since left Microsoft, which blocked the `license/cla` check. The commits have been re-authored and this PR is reopened from a current contributor so CLA can pass. Original author: Kirstyn Joy Amperiadis (@kamperiadis).

### Issue describing the changes in this PR

Restrict GET admin/host/triggers API so that it can only be called internally by the platform

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)