### PR TITLE
Patch/4.51.200

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,14 +3,3 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-
-- Restore Workflows-bundle worker discovery on Logic App (#11759)
-- Ensure wwwroot directory exists on new slot and app creation w/ networking restrictions (#11757)
-- Update Node.js Worker Version to [3.14.1](https://github.com/Azure/azure-functions-nodejs-worker/releases/tag/v3.14.1) (#PR)
-- Update OpenTelemetry instrumentation and exporter packages (#11766)
-- Skip `WebJobsStorageHealthCheck` when no active script host is available (#11791)
-- Avoid false-positive connection string checks when constructing `BlobServiceClient` (#11794)
-- Fix .NET10 breaking change with connection-string prefixed env vars. (#11793)
-- Only register the host-name-fixup middleware on hosting environments where requests are routed through the Antares front end
-- Resolve correct `IHostApplicationLifetime` instance within certain ScriptHost services (#11798)
-- Fix function-key prefix matching in the Kubernetes secrets repository merge step

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,7 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+-->
+
+- fix: address config reload concurrent read/write race (#11815)
+- fix: avoid health checks triggering secret-manager too early (#11816)

--- a/release_notes.md
+++ b/release_notes.md
@@ -7,3 +7,5 @@
 
 - fix: address config reload concurrent read/write race (#11815)
 - fix: avoid health checks triggering secret-manager too early (#11816)
+
+- fix: address config reload concurrent read/write race (#11815)

--- a/src/Directory.Version.props
+++ b/src/Directory.Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.1051.100</VersionPrefix>
+    <VersionPrefix>4.1051.200</VersionPrefix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 </Project>

--- a/src/WebJobs.Script.WebHost/Diagnostics/HealthChecks/HealthCheckAuthMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/HealthChecks/HealthCheckAuthMiddleware.cs
@@ -22,6 +22,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.HealthChecks
         {
             ArgumentNullException.ThrowIfNull(context);
 
+            // We only authenticate if ?expand=true is present, as that reveals more information.
+            if (!HealthCheckHelpers.IsExpandedHealthCheck(context.Request))
+            {
+                await _next(context);
+                return;
+            }
+
             AuthorizationPolicy policy = await _provider.GetPolicyAsync(PolicyNames.AdminAuthLevel)
                 .ConfigureAwait(false);
 

--- a/src/WebJobs.Script.WebHost/Diagnostics/HealthChecks/HealthCheckHelpers.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/HealthChecks/HealthCheckHelpers.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.HealthChecks
+{
+    public static class HealthCheckHelpers
+    {
+        /// <summary>
+        /// Determines if the health check request is for an expanded view.
+        /// </summary>
+        /// <param name="request">The request to check.</param>
+        /// <returns>true if the request is for an expanded view; otherwise, false.</returns>
+        public static bool IsExpandedHealthCheck(HttpRequest request)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            return request.Query.TryGetValue("expand", out StringValues value)
+                && bool.TryParse(value, out bool expand) && expand;
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Diagnostics/HealthChecks/HealthCheckResponseWriter.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/HealthChecks/HealthCheckResponseWriter.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.HealthChecks
 {
@@ -19,8 +18,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.HealthChecks
             ArgumentNullException.ThrowIfNull(report);
 
             // We will write a detailed report if ?expand=true is present.
-            if (httpContext.Request.Query.TryGetValue("expand", out StringValues value)
-                && bool.TryParse(value, out bool expand) && expand)
+            if (HealthCheckHelpers.IsExpandedHealthCheck(httpContext.Request))
             {
                 return UIResponseWriter.WriteHealthCheckUIResponse(httpContext, report);
             }

--- a/src/WebJobs.Script/Config/ActiveHostConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/ActiveHostConfigurationSource.cs
@@ -7,14 +7,9 @@ using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.WebJobs.Script.Configuration
 {
-    public class ActiveHostConfigurationSource : IConfigurationSource
+    public class ActiveHostConfigurationSource(IScriptHostManager scriptHostManager) : IConfigurationSource
     {
-        private readonly IScriptHostManager _scriptHostManager;
-
-        public ActiveHostConfigurationSource(IScriptHostManager scriptHostManager)
-        {
-            _scriptHostManager = scriptHostManager;
-        }
+        private readonly IScriptHostManager _scriptHostManager = scriptHostManager;
 
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         {
@@ -28,27 +23,32 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
 
             public ActiveHostConfigurationProvider(IScriptHostManager scriptHostManager)
             {
-                _scriptHostManager = scriptHostManager ?? throw new ArgumentNullException(nameof(scriptHostManager));
+                ArgumentNullException.ThrowIfNull(scriptHostManager);
+                _scriptHostManager = scriptHostManager;
                 scriptHostManager.ActiveHostChanged += HandleActiveHostChange;
             }
 
             public override void Load()
             {
-                if ((_scriptHostManager as IServiceProvider)?.GetService(typeof(IConfiguration)) is IConfigurationRoot activeHostConfiguration)
+                if ((_scriptHostManager as IServiceProvider)?.GetService(typeof(IConfiguration))
+                    is not IConfigurationRoot activeHostConfiguration)
                 {
-                    Data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                    foreach (var kvp in activeHostConfiguration.AsEnumerable())
-                    {
-                        if (!Data.ContainsKey(kvp.Key))
-                        {
-                            Data[kvp.Key] = kvp.Value;
-                        }
-                    }
-
-                    _changeTokenRegistration?.Dispose();
-                    _changeTokenRegistration = activeHostConfiguration.GetReloadToken().RegisterChangeCallback(_ => Load(), null);
-                    OnReload();
+                    return;
                 }
+
+                Dictionary<string, string> data = new(StringComparer.OrdinalIgnoreCase);
+                foreach (var kvp in activeHostConfiguration.AsEnumerable())
+                {
+                    if (!data.ContainsKey(kvp.Key))
+                    {
+                        data[kvp.Key] = kvp.Value;
+                    }
+                }
+
+                Data = data;
+                _changeTokenRegistration?.Dispose();
+                _changeTokenRegistration = activeHostConfiguration.GetReloadToken().RegisterChangeCallback(_ => Load(), null);
+                OnReload();
             }
 
             private void HandleActiveHostChange(object sender, ActiveHostChangedEventArgs e)
@@ -59,6 +59,7 @@ namespace Microsoft.Azure.WebJobs.Script.Configuration
             public void Dispose()
             {
                 _changeTokenRegistration?.Dispose();
+                _changeTokenRegistration = null;
                 _scriptHostManager.ActiveHostChanged -= HandleActiveHostChange;
             }
         }

--- a/src/WebJobs.Script/Config/ScriptEnvironmentVariablesConfigurationSource.cs
+++ b/src/WebJobs.Script/Config/ScriptEnvironmentVariablesConfigurationSource.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.EnvironmentVariables;
 
@@ -46,8 +47,6 @@ namespace Microsoft.Azure.WebJobs.Script
 
             public override void Load()
             {
-                base.Load();
-
                 static string Normalize(string key)
                 {
                     return key.Replace("__", ConfigurationPath.KeyDelimiter);
@@ -64,6 +63,13 @@ namespace Microsoft.Azure.WebJobs.Script
                            key.StartsWith(ServiceBusPrefix, StringComparison.OrdinalIgnoreCase);
                 }
 
+                // First load config from base class.
+                // Then add the prefixed string, but update a separate dictionary so we can atomically
+                // update the Data property with all new config at once, and not write to a dictionary
+                // being potentially accessed by other threads.
+                base.Load();
+                Dictionary<string, string> data = new(Data, StringComparer.OrdinalIgnoreCase);
+
                 // .NET 10 changed to special case some prefixes, inserting it into the "ConnectionStrings" section.
                 // For backwards compatibility, we still want to include these in the configuration.
                 foreach (DictionaryEntry kvp in Environment.GetEnvironmentVariables())
@@ -72,10 +78,13 @@ namespace Microsoft.Azure.WebJobs.Script
                     {
                         if (IsPrefixedString(key))
                         {
-                            Data[Normalize(key)] = value;
+                            data[Normalize(key)] = value;
                         }
                     }
                 }
+
+                // Atomic swap to publish all config at once.
+                Data = data;
             }
         }
 

--- a/src/WebJobs.Script/StorageProvider/BlobServiceClientProvider.cs
+++ b/src/WebJobs.Script/StorageProvider/BlobServiceClientProvider.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <summary>
         /// Initializes a new instance of the <see cref="BlobServiceClientProvider"/> class that uses the registered Azure services to create a BlobServiceClient.
         /// </summary>
-        /// <param name="componentFactory">The Azure factory responsible for creating clients. <see cref="AzureComponentFactory"/></param>
-        /// <param name="logForwarder">Log forwarder that forwards events to ILogger. <see cref="AzureEventSourceLogForwarder"/></param>
+        /// <param name="componentFactory">The Azure factory responsible for creating clients. <see cref="AzureComponentFactory"/>.</param>
+        /// <param name="logForwarder">Log forwarder that forwards events to ILogger. <see cref="AzureEventSourceLogForwarder"/>.</param>
         public BlobServiceClientProvider(AzureComponentFactory componentFactory, AzureEventSourceLogForwarder logForwarder)
             : base(componentFactory, logForwarder) { }
 
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Script
         /// <param name="configuration">Configuration to retrieve settings from.</param>
         /// <param name="tokenCredential">Credential for the client.</param>
         /// <param name="options">Options to configure the client.</param>
-        /// <returns>An instance of <see cref="BlobServiceClient"/></returns>
+        /// <returns>An instance of <see cref="BlobServiceClient"/>.</returns>
         protected override BlobServiceClient CreateClient(IConfiguration configuration, TokenCredential tokenCredential, BlobClientOptions options)
         {
             // If connection string is present, it will be honored first; bypass creating a serviceUri

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
@@ -367,6 +367,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         }
 
         [Theory]
+        [InlineData("/admin/health")]
+        [InlineData("/admin/health/live")]
+        [InlineData("/admin/health/ready")]
+        public async Task HealthCheck_NoToken_Succeeds(string uri)
+        {
+            // token specified as bearer token
+            HttpRequestMessage request = new(HttpMethod.Get, uri);
+            HttpResponseMessage response = await _fixture.Host.HttpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            string body = await response.Content.ReadAsStringAsync();
+            Assert.Equal("{\"status\":\"Healthy\"}", body);
+        }
+
+        [Theory]
         [InlineData("/admin/health?expand=true", null)]
         [InlineData("/admin/health/live?expand=true", HealthCheckTags.Liveness)]
         [InlineData("/admin/health/ready?expand=true", HealthCheckTags.Readiness)]
@@ -404,9 +419,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         }
 
         [Theory]
-        [InlineData("/admin/health")]
-        [InlineData("/admin/health/live")]
-        [InlineData("/admin/health/ready")]
+        [InlineData("/admin/health?expand=true")]
+        [InlineData("/admin/health/live?expand=true")]
+        [InlineData("/admin/health/ready?expand=true")]
         public async Task HealthCheck_NoAdminToken_Fail(string uri)
         {
             // token specified as bearer token

--- a/test/WebJobs.Script.Tests/Diagnostics/HealthChecks/HealthCheckAuthMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/HealthChecks/HealthCheckAuthMiddlewareTests.cs
@@ -1,0 +1,158 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Policy;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.HealthChecks;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
+{
+    public class HealthCheckAuthMiddlewareTests
+    {
+        [Fact]
+        public void Constructor_NullNext_ThrowsArgumentNullException()
+        {
+            TestHelpers.Act(() => new HealthCheckAuthMiddleware(
+                null, Mock.Of<IPolicyEvaluator>(), Mock.Of<IAuthorizationPolicyProvider>()))
+                .Should().Throw<ArgumentNullException>().WithParameterName("next");
+        }
+
+        [Fact]
+        public void Constructor_NullPolicy_ThrowsArgumentNullException()
+        {
+            TestHelpers.Act(() => new HealthCheckAuthMiddleware(
+                Mock.Of<RequestDelegate>(), null, Mock.Of<IAuthorizationPolicyProvider>()))
+                .Should().Throw<ArgumentNullException>().WithParameterName("policy");
+        }
+
+        [Fact]
+        public void Constructor_NullProvider_ThrowsArgumentNullException()
+        {
+            TestHelpers.Act(() => new HealthCheckAuthMiddleware(
+                Mock.Of<RequestDelegate>(), Mock.Of<IPolicyEvaluator>(), null))
+                .Should().Throw<ArgumentNullException>().WithParameterName("provider");
+        }
+
+        [Fact]
+        public async Task InvokeAsync_NullContext_Throws()
+        {
+            HealthCheckAuthMiddleware middleware = new(
+                Mock.Of<RequestDelegate>(),
+                Mock.Of<IPolicyEvaluator>(),
+                Mock.Of<IAuthorizationPolicyProvider>());
+
+            await TestHelpers.Act(() => middleware.InvokeAsync(null))
+                .Should().ThrowAsync<ArgumentNullException>().WithParameterName("context");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("?other=true")]
+        [InlineData("?expand=false")]
+        [InlineData("?expand=notabool")]
+        public async Task InvokeAsync_NotExpanded_SkipsAuthAndCallsNext(string query)
+        {
+            Mock<RequestDelegate> next = new();
+            Mock<IPolicyEvaluator> policy = new(MockBehavior.Strict);
+            Mock<IAuthorizationPolicyProvider> provider = new(MockBehavior.Strict);
+            HttpContext context = CreateContext(query);
+            HealthCheckAuthMiddleware middleware = new(next.Object, policy.Object, provider.Object);
+
+            await middleware.InvokeAsync(context);
+
+            next.Verify(m => m(context), Times.Once);
+            next.VerifyNoOtherCalls();
+            policy.VerifyNoOtherCalls();
+            provider.VerifyNoOtherCalls();
+            context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_Expanded_AuthenticationFails_Returns401()
+        {
+            Mock<RequestDelegate> next = new();
+            AuthorizationPolicy authPolicy = new AuthorizationPolicyBuilder()
+                .RequireAssertion(_ => true).Build();
+            Mock<IPolicyEvaluator> policy = new(MockBehavior.Strict);
+            policy.Setup(p => p.AuthenticateAsync(authPolicy, It.IsAny<HttpContext>()))
+                .ReturnsAsync(AuthenticateResult.Fail("nope"));
+            Mock<IAuthorizationPolicyProvider> provider = new(MockBehavior.Strict);
+            provider.Setup(p => p.GetPolicyAsync(PolicyNames.AdminAuthLevel)).ReturnsAsync(authPolicy);
+
+            HttpContext context = CreateContext("?expand=true");
+            HealthCheckAuthMiddleware middleware = new(next.Object, policy.Object, provider.Object);
+
+            await middleware.InvokeAsync(context);
+
+            context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+            next.Verify(m => m(context), Times.Never);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_Expanded_AuthorizationFails_Returns403()
+        {
+            Mock<RequestDelegate> next = new();
+            AuthorizationPolicy authPolicy = new AuthorizationPolicyBuilder()
+                .RequireAssertion(_ => true).Build();
+            AuthenticateResult authSuccess = AuthenticateResult.Success(
+                new AuthenticationTicket(new ClaimsPrincipal(new ClaimsIdentity("test")), "test"));
+            Mock<IPolicyEvaluator> policy = new(MockBehavior.Strict);
+            policy.Setup(p => p.AuthenticateAsync(authPolicy, It.IsAny<HttpContext>()))
+                .ReturnsAsync(authSuccess);
+            policy.Setup(p => p.AuthorizeAsync(authPolicy, authSuccess, It.IsAny<HttpContext>(), null))
+                .ReturnsAsync(PolicyAuthorizationResult.Forbid());
+            Mock<IAuthorizationPolicyProvider> provider = new(MockBehavior.Strict);
+            provider.Setup(p => p.GetPolicyAsync(PolicyNames.AdminAuthLevel)).ReturnsAsync(authPolicy);
+
+            HttpContext context = CreateContext("?expand=true");
+            HealthCheckAuthMiddleware middleware = new(next.Object, policy.Object, provider.Object);
+
+            await middleware.InvokeAsync(context);
+
+            context.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+            next.Verify(m => m(context), Times.Never);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_Expanded_AuthorizationSucceeds_CallsNext()
+        {
+            Mock<RequestDelegate> next = new();
+            AuthorizationPolicy authPolicy = new AuthorizationPolicyBuilder()
+                .RequireAssertion(_ => true).Build();
+            AuthenticateResult authSuccess = AuthenticateResult.Success(
+                new AuthenticationTicket(new ClaimsPrincipal(new ClaimsIdentity("test")), "test"));
+            Mock<IPolicyEvaluator> policy = new(MockBehavior.Strict);
+            policy.Setup(p => p.AuthenticateAsync(authPolicy, It.IsAny<HttpContext>()))
+                .ReturnsAsync(authSuccess);
+            policy.Setup(p => p.AuthorizeAsync(authPolicy, authSuccess, It.IsAny<HttpContext>(), null))
+                .ReturnsAsync(PolicyAuthorizationResult.Success());
+            Mock<IAuthorizationPolicyProvider> provider = new(MockBehavior.Strict);
+            provider.Setup(p => p.GetPolicyAsync(PolicyNames.AdminAuthLevel)).ReturnsAsync(authPolicy);
+
+            HttpContext context = CreateContext("?expand=true");
+            HealthCheckAuthMiddleware middleware = new(next.Object, policy.Object, provider.Object);
+
+            await middleware.InvokeAsync(context);
+
+            next.Verify(m => m(context), Times.Once);
+            context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        }
+
+        private static DefaultHttpContext CreateContext(string query)
+        {
+            DefaultHttpContext context = new();
+            context.Request.QueryString = new QueryString(query);
+
+            return context;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

1. SecretManager initialization issue (case sensitivity workaround). We identifty the root issue for the SecretManager failing to initialize due to a small window on Linux SKUs where the app settings from specialization are case sensitive. We are not fixing the case sensitive due to the size of the change, but instead addressing the code path which causes SecretManager to be initialized earlier in Flex. Low risk change
[fix: avoid health check auth for non-expanded requests by jviau · Pull Request #11816 · Azure/azure…](https://github.com/Azure/azure-functions-host/pull/11816)

2. Config initialization race condition: we have an issue where we update configuration in place, which can lead to the "cannot edit collection while enumerating" issue in .NET. The fix is to simply edit a different collection and perform an atomic swap. Low risk change
[fix: atomic load for ActiveHostConfigurationProvider by jviau · Pull Request #11815 · Azure/azure-f…](https://github.com/Azure/azure-functions-host/pull/11815)

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
