### PR TITLE
Patch/4.48.300

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,7 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+-->
+
+- fix: address config reload concurrent read/write race (#11815)
+- fix: avoid health checks triggering secret-manager too early (#11816)

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,4 +3,3 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-- Fixed an issue where custom handler apps with extension bundles would fail to load binding types after specialization (#11676)

--- a/src/Directory.Version.props
+++ b/src/Directory.Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.1048.200</VersionPrefix>
+    <VersionPrefix>4.1048.300</VersionPrefix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 </Project>

--- a/src/WebJobs.Script.WebHost/Diagnostics/HealthChecks/HealthCheckAuthMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/HealthChecks/HealthCheckAuthMiddleware.cs
@@ -22,6 +22,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.HealthChecks
         {
             ArgumentNullException.ThrowIfNull(context);
 
+            // We only authenticate if ?expand=true is present, as that reveals more information.
+            if (!HealthCheckHelpers.IsExpandedHealthCheck(context.Request))
+            {
+                await _next(context);
+                return;
+            }
+
             AuthorizationPolicy policy = await _provider.GetPolicyAsync(PolicyNames.AdminAuthLevel)
                 .ConfigureAwait(false);
 

--- a/src/WebJobs.Script.WebHost/Diagnostics/HealthChecks/HealthCheckHelpers.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/HealthChecks/HealthCheckHelpers.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.HealthChecks
+{
+    public static class HealthCheckHelpers
+    {
+        /// <summary>
+        /// Determines if the health check request is for an expanded view.
+        /// </summary>
+        /// <param name="request">The request to check.</param>
+        /// <returns>true if the request is for an expanded view; otherwise, false.</returns>
+        public static bool IsExpandedHealthCheck(HttpRequest request)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+            return request.Query.TryGetValue("expand", out StringValues value)
+                && bool.TryParse(value, out bool expand) && expand;
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Diagnostics/HealthChecks/HealthCheckResponseWriter.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/HealthChecks/HealthCheckResponseWriter.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.HealthChecks
 {
@@ -19,8 +18,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.HealthChecks
             ArgumentNullException.ThrowIfNull(report);
 
             // We will write a detailed report if ?expand=true is present.
-            if (httpContext.Request.Query.TryGetValue("expand", out StringValues value)
-                && bool.TryParse(value, out bool expand) && expand)
+            if (HealthCheckHelpers.IsExpandedHealthCheck(httpContext.Request))
             {
                 return UIResponseWriter.WriteHealthCheckUIResponse(httpContext, report);
             }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
@@ -366,6 +366,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         }
 
         [Theory]
+        [InlineData("/admin/health")]
+        [InlineData("/admin/health/live")]
+        [InlineData("/admin/health/ready")]
+        public async Task HealthCheck_NoToken_Succeeds(string uri)
+        {
+            // token specified as bearer token
+            HttpRequestMessage request = new(HttpMethod.Get, uri);
+            HttpResponseMessage response = await _fixture.Host.HttpClient.SendAsync(request);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            string body = await response.Content.ReadAsStringAsync();
+            Assert.Equal("{\"status\":\"Healthy\"}", body);
+        }
+
+        [Theory]
         [InlineData("/admin/health?expand=true", null)]
         [InlineData("/admin/health/live?expand=true", HealthCheckTags.Liveness)]
         [InlineData("/admin/health/ready?expand=true", HealthCheckTags.Readiness)]
@@ -403,9 +418,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         }
 
         [Theory]
-        [InlineData("/admin/health")]
-        [InlineData("/admin/health/live")]
-        [InlineData("/admin/health/ready")]
+        [InlineData("/admin/health?expand=true")]
+        [InlineData("/admin/health/live?expand=true")]
+        [InlineData("/admin/health/ready?expand=true")]
         public async Task HealthCheck_NoAdminToken_Fail(string uri)
         {
             // token specified as bearer token

--- a/test/WebJobs.Script.Tests/Diagnostics/HealthChecks/HealthCheckAuthMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/HealthChecks/HealthCheckAuthMiddlewareTests.cs
@@ -1,0 +1,158 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Policy;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.HealthChecks;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
+{
+    public class HealthCheckAuthMiddlewareTests
+    {
+        [Fact]
+        public void Constructor_NullNext_ThrowsArgumentNullException()
+        {
+            TestHelpers.Act(() => new HealthCheckAuthMiddleware(
+                null, Mock.Of<IPolicyEvaluator>(), Mock.Of<IAuthorizationPolicyProvider>()))
+                .Should().Throw<ArgumentNullException>().WithParameterName("next");
+        }
+
+        [Fact]
+        public void Constructor_NullPolicy_ThrowsArgumentNullException()
+        {
+            TestHelpers.Act(() => new HealthCheckAuthMiddleware(
+                Mock.Of<RequestDelegate>(), null, Mock.Of<IAuthorizationPolicyProvider>()))
+                .Should().Throw<ArgumentNullException>().WithParameterName("policy");
+        }
+
+        [Fact]
+        public void Constructor_NullProvider_ThrowsArgumentNullException()
+        {
+            TestHelpers.Act(() => new HealthCheckAuthMiddleware(
+                Mock.Of<RequestDelegate>(), Mock.Of<IPolicyEvaluator>(), null))
+                .Should().Throw<ArgumentNullException>().WithParameterName("provider");
+        }
+
+        [Fact]
+        public async Task InvokeAsync_NullContext_Throws()
+        {
+            HealthCheckAuthMiddleware middleware = new(
+                Mock.Of<RequestDelegate>(),
+                Mock.Of<IPolicyEvaluator>(),
+                Mock.Of<IAuthorizationPolicyProvider>());
+
+            await TestHelpers.Act(() => middleware.InvokeAsync(null))
+                .Should().ThrowAsync<ArgumentNullException>().WithParameterName("context");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("?other=true")]
+        [InlineData("?expand=false")]
+        [InlineData("?expand=notabool")]
+        public async Task InvokeAsync_NotExpanded_SkipsAuthAndCallsNext(string query)
+        {
+            Mock<RequestDelegate> next = new();
+            Mock<IPolicyEvaluator> policy = new(MockBehavior.Strict);
+            Mock<IAuthorizationPolicyProvider> provider = new(MockBehavior.Strict);
+            HttpContext context = CreateContext(query);
+            HealthCheckAuthMiddleware middleware = new(next.Object, policy.Object, provider.Object);
+
+            await middleware.InvokeAsync(context);
+
+            next.Verify(m => m(context), Times.Once);
+            next.VerifyNoOtherCalls();
+            policy.VerifyNoOtherCalls();
+            provider.VerifyNoOtherCalls();
+            context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_Expanded_AuthenticationFails_Returns401()
+        {
+            Mock<RequestDelegate> next = new();
+            AuthorizationPolicy authPolicy = new AuthorizationPolicyBuilder()
+                .RequireAssertion(_ => true).Build();
+            Mock<IPolicyEvaluator> policy = new(MockBehavior.Strict);
+            policy.Setup(p => p.AuthenticateAsync(authPolicy, It.IsAny<HttpContext>()))
+                .ReturnsAsync(AuthenticateResult.Fail("nope"));
+            Mock<IAuthorizationPolicyProvider> provider = new(MockBehavior.Strict);
+            provider.Setup(p => p.GetPolicyAsync(PolicyNames.AdminAuthLevel)).ReturnsAsync(authPolicy);
+
+            HttpContext context = CreateContext("?expand=true");
+            HealthCheckAuthMiddleware middleware = new(next.Object, policy.Object, provider.Object);
+
+            await middleware.InvokeAsync(context);
+
+            context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+            next.Verify(m => m(context), Times.Never);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_Expanded_AuthorizationFails_Returns403()
+        {
+            Mock<RequestDelegate> next = new();
+            AuthorizationPolicy authPolicy = new AuthorizationPolicyBuilder()
+                .RequireAssertion(_ => true).Build();
+            AuthenticateResult authSuccess = AuthenticateResult.Success(
+                new AuthenticationTicket(new ClaimsPrincipal(new ClaimsIdentity("test")), "test"));
+            Mock<IPolicyEvaluator> policy = new(MockBehavior.Strict);
+            policy.Setup(p => p.AuthenticateAsync(authPolicy, It.IsAny<HttpContext>()))
+                .ReturnsAsync(authSuccess);
+            policy.Setup(p => p.AuthorizeAsync(authPolicy, authSuccess, It.IsAny<HttpContext>(), null))
+                .ReturnsAsync(PolicyAuthorizationResult.Forbid());
+            Mock<IAuthorizationPolicyProvider> provider = new(MockBehavior.Strict);
+            provider.Setup(p => p.GetPolicyAsync(PolicyNames.AdminAuthLevel)).ReturnsAsync(authPolicy);
+
+            HttpContext context = CreateContext("?expand=true");
+            HealthCheckAuthMiddleware middleware = new(next.Object, policy.Object, provider.Object);
+
+            await middleware.InvokeAsync(context);
+
+            context.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+            next.Verify(m => m(context), Times.Never);
+        }
+
+        [Fact]
+        public async Task InvokeAsync_Expanded_AuthorizationSucceeds_CallsNext()
+        {
+            Mock<RequestDelegate> next = new();
+            AuthorizationPolicy authPolicy = new AuthorizationPolicyBuilder()
+                .RequireAssertion(_ => true).Build();
+            AuthenticateResult authSuccess = AuthenticateResult.Success(
+                new AuthenticationTicket(new ClaimsPrincipal(new ClaimsIdentity("test")), "test"));
+            Mock<IPolicyEvaluator> policy = new(MockBehavior.Strict);
+            policy.Setup(p => p.AuthenticateAsync(authPolicy, It.IsAny<HttpContext>()))
+                .ReturnsAsync(authSuccess);
+            policy.Setup(p => p.AuthorizeAsync(authPolicy, authSuccess, It.IsAny<HttpContext>(), null))
+                .ReturnsAsync(PolicyAuthorizationResult.Success());
+            Mock<IAuthorizationPolicyProvider> provider = new(MockBehavior.Strict);
+            provider.Setup(p => p.GetPolicyAsync(PolicyNames.AdminAuthLevel)).ReturnsAsync(authPolicy);
+
+            HttpContext context = CreateContext("?expand=true");
+            HealthCheckAuthMiddleware middleware = new(next.Object, policy.Object, provider.Object);
+
+            await middleware.InvokeAsync(context);
+
+            next.Verify(m => m(context), Times.Once);
+            context.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        }
+
+        private static DefaultHttpContext CreateContext(string query)
+        {
+            DefaultHttpContext context = new();
+            context.Request.QueryString = new QueryString(query);
+
+            return context;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

1. SecretManager initialization issue (case sensitivity workaround). We identifty the root issue for the SecretManager failing to initialize due to a small window on Linux SKUs where the app settings from specialization are case sensitive. We are not fixing the case sensitive due to the size of the change, but instead addressing the code path which causes SecretManager to be initialized earlier in Flex. Low risk change
[fix: avoid health check auth for non-expanded requests by jviau · Pull Request #11816 · Azure/azure…](https://github.com/Azure/azure-functions-host/pull/11816)

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [ ] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [ ] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
