### PR TITLE
Fix host startup deadlock when worker start times out during retry

### DIFF
--- a/src/WebJobs.Script.Grpc/WorkerFunctionMetadataProvider.cs
+++ b/src/WebJobs.Script.Grpc/WorkerFunctionMetadataProvider.cs
@@ -175,8 +175,18 @@ namespace Microsoft.Azure.WebJobs.Script
             // The Error state can occur when the host is in a "final" state after completely starting,
             // or during a retry of a transient error. This check allows us to determine the difference. If
             // the host has not completely started, it means that it is still in the process of starting.
-            if (_currentJobHost is not null && _scriptHostManager.State == ScriptHostState.Error)
+            if (_scriptHostManager.State == ScriptHostState.Error)
             {
+                // No active host has been assigned yet, so the host is still being built or rebuilt as part
+                // of a start/restart (ActiveHost stays null until the new host is assigned). Requesting a
+                // restart here would re-enter host startup and deadlock on the start semaphore, so treat this
+                // as "starting" and let the worker channel be initialized directly while the host startup
+                // retry loop drives recovery.
+                if (_currentJobHost is null)
+                {
+                    return true;
+                }
+
                 var lifetime = _currentJobHost.Services?.GetService<IHostApplicationLifetime>();
 
                 if (lifetime is not null &&

--- a/test/WebJobs.Script.Tests/WorkerFunctionMetadataProviderTests.cs
+++ b/test/WebJobs.Script.Tests/WorkerFunctionMetadataProviderTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Workers;
@@ -299,6 +300,46 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             AssertFunction(function1);
             AssertFunction(function2);
+        }
+
+        [Fact]
+        public async Task GetFunctionMetadataAsync_HostInErrorStateWithNoActiveHost_InitializesChannelInsteadOfRestarting()
+        {
+            // Regression test for the host startup deadlock: when the JobHost is mid-startup (Error state
+            // during a retry) and no active host has been assigned yet, the provider must not call
+            // RestartHostAsync. GetFunctionMetadataAsync runs synchronously inside BuildHost while the start
+            // semaphore is held, so a restart would re-enter host startup and deadlock. It must initialize
+            // the worker channel directly instead.
+            var workerConfigs = TestHelpers.GetTestWorkerConfigs().ToImmutableArray();
+
+            var scriptApplicationHostOptions = new ScriptApplicationHostOptions();
+            var optionsMonitor = TestHelpers.CreateOptionsMonitor(scriptApplicationHostOptions);
+
+            var mockScriptHostManager = new Mock<IScriptHostManager>();
+            mockScriptHostManager.Setup(m => m.State).Returns(ScriptHostState.Error);
+
+            var mockChannelManager = new Mock<IWebHostRpcWorkerChannelManager>();
+            mockChannelManager.Setup(m => m.GetChannels(It.IsAny<string>()))
+                .Returns(() => new Dictionary<string, TaskCompletionSource<IRpcWorkerChannel>>());
+            mockChannelManager.Setup(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), It.IsAny<string>()))
+                .ReturnsAsync(Mock.Of<IRpcWorkerChannel>());
+
+            var environment = new TestEnvironment();
+            var mockRuntimeResolver = new Mock<IWorkerRuntimeResolver>();
+            mockRuntimeResolver.Setup(r => r.GetWorkerRuntime(It.IsAny<string>())).Returns("node");
+
+            var provider = new WorkerFunctionMetadataProvider(
+                optionsMonitor,
+                NullLogger<WorkerFunctionMetadataProvider>.Instance,
+                environment,
+                mockChannelManager.Object,
+                mockScriptHostManager.Object,
+                mockRuntimeResolver.Object);
+
+            await provider.GetFunctionMetadataAsync(workerConfigs, false);
+
+            mockChannelManager.Verify(m => m.InitializeChannelAsync(It.IsAny<IEnumerable<RpcWorkerConfig>>(), "node"), Times.Once);
+            mockScriptHostManager.Verify(m => m.RestartHostAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [Fact]


### PR DESCRIPTION
When a language worker start times out during host build and a retry occurs, the metadata provider called `RestartHostAsync` while the host start semaphore was held. That re-entered host startup and deadlocked, leaving the instance stuck with no script host (`NoScriptHost`) until a manual restart.

`IsJobHostStarting()` now treats the `Error` state with no active host as "starting", so the worker channel is initialized directly and the existing retry/backoff loop drives recovery instead of deadlocking.

Includes a regression test.

resolves #11824