### PR TITLE
test: put csharp sample consuming fixtures in a collection

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/Controllers/ControllerScenarioTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/ControllerScenarioTestFixture.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 {
     public class ControllerScenarioTestFixture : IAsyncLifetime, IDisposable
     {
+        public const string Collection = "ControllerScenarioTests";
+
         private ScriptSettingsManager _settingsManager;
         private HttpConfiguration _config;
 

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/AuthDisabledScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/AuthDisabledScenario.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers.Keys
 {
+    [Collection(Fixture.Collection)]]
     [Trait("Requests are made with IsAuthDisabled: true", "")]
     public class AuthDisabledScenario : IClassFixture<AuthDisabledScenario.Fixture>
     {

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/DeleteFunctionKeysScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/DeleteFunctionKeysScenario.cs
@@ -1,15 +1,15 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
-using Microsoft.Azure.WebJobs.Script.WebHost.Filters;
 using Moq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 {
+    [Collection(Fixture.Collection)]
     [Trait("A DELETE request is made against the function key resource endpoint", "")]
     public class DeleteFunctionKeysScenario : IClassFixture<DeleteFunctionKeysScenario.Fixture>
     {

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/DeleteHostFunctionKeysScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/DeleteHostFunctionKeysScenario.cs
@@ -1,16 +1,12 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
+
 using Microsoft.Azure.WebJobs.Script.WebHost;
-using Microsoft.Azure.WebJobs.Script.WebHost.Filters;
-using Microsoft.Azure.WebJobs.Script.WebHost.Models;
-using Moq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 {
+    [Collection(HostFixture.Collection)]
     [Trait("A DELETE request is made against the host function key resource endpoint", "")]
     public class DeleteHostFunctionKeysScenario : DeleteFunctionKeysScenario, IClassFixture<DeleteHostFunctionKeysScenario.HostFixture>
     {
@@ -34,6 +30,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
         }
     }
 
+    [Collection(HostFixture.Collection)]
     [Trait("A DELETE request is made against the host function key (functionKeys) resource endpoint", "")]
     public class DeleteHostFunctionKeysNewEndpointScenario : DeleteFunctionKeysScenario, IClassFixture<DeleteHostFunctionKeysNewEndpointScenario.HostFixture>
     {

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/DeleteHostSystemKeysScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/DeleteHostSystemKeysScenario.cs
@@ -1,17 +1,12 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
 using Microsoft.Azure.WebJobs.Script.WebHost;
-using Microsoft.Azure.WebJobs.Script.WebHost.Filters;
-using Microsoft.Azure.WebJobs.Script.WebHost.Models;
-using Moq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 {
+    [Collection(Fixture.Collection)]
     [Trait("A DELETE request is made against the host system keys resource endpoint", "")]
     public class DeleteHostSystemKeysScenario : DeleteFunctionKeysScenario, IClassFixture<DeleteHostSystemKeysScenario.HostFixture>
     {

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/GetFunctionKeysScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/GetFunctionKeysScenario.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 {
+    [Collection(GetKeysFixture.Collection)]
     [Trait("A GET request is made against the function keys collection endpoint", "")]
     public class GetFunctionKeysScenario : IClassFixture<GetFunctionKeysScenario.GetKeysFixture>
     {

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/GetHostFunctionKeysScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/GetHostFunctionKeysScenario.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Xunit;
@@ -6,6 +6,7 @@ using Xunit;
 namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 {
     [Trait("A GET request is made against the host function keys collection endpoint", "")]
+    [Collection(HostFixture.Collection)]
     public class GetHostFunctionKeysScenario : GetFunctionKeysScenario, IClassFixture<GetHostFunctionKeysScenario.HostFixture>
     {
         public GetHostFunctionKeysScenario(GetKeysFixture fixture)

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/GetHostMasterKeyScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/GetHostMasterKeyScenario.cs
@@ -1,18 +1,15 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Net.Http;
 using Microsoft.Azure.WebJobs.Script.WebHost;
-using Microsoft.Azure.WebJobs.Script.WebHost.Filters;
-using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 using Moq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 {
+    [Collection(HostMasterKeyFixture.Collection)]
     [Trait("A GET request is made against the host master key resource endpoint", "")]
-    public class GetHostMasterKeyScenario : GetHostSystemKeyScenario,  IClassFixture<GetHostMasterKeyScenario.HostMasterKeyFixture>
+    public class GetHostMasterKeyScenario : GetHostSystemKeyScenario, IClassFixture<GetHostMasterKeyScenario.HostMasterKeyFixture>
     {
         public GetHostMasterKeyScenario(HostMasterKeyFixture fixture)
             : base(fixture)

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/GetHostSystemKeyScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/GetHostSystemKeyScenario.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -6,13 +6,13 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
-using Microsoft.Azure.WebJobs.Script.WebHost.Filters;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 using Moq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 {
+    [Collection(SystemKeyFixture.Collection)]
     [Trait("A GET request is made against the host system key resource endpoint", "")]
     public class GetHostSystemKeyScenario : IClassFixture<GetHostSystemKeyScenario.SystemKeyFixture>
     {

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/GetHostSystemKeysScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/GetHostSystemKeysScenario.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 {
+    [Collection(HostFixture.Collection)]
     [Trait("A GET request is made against the host function system keys collection endpoint", "")]
     public class GetHostSystemKeysScenario : GetFunctionKeysScenario, IClassFixture<GetHostSystemKeysScenario.HostFixture>
     {

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/PostFunctionKeysScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/PostFunctionKeysScenario.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System.Linq;
@@ -6,12 +6,12 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
-using Microsoft.Azure.WebJobs.Script.WebHost.Filters;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 {
+    [Collection(Fixture.Collection)]
     [Trait("A POST request is made against the function key resource endpoint", "")]
     public class PostFunctionKeysScenario : IClassFixture<PostFunctionKeysScenario.Fixture>
     {

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/PostHostFunctionKeyScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/PostHostFunctionKeyScenario.cs
@@ -1,15 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 {
+    [Collection(HostFixture.Collection)]
     [Trait("A POST request is made against the host function key resource endpoint", "")]
     public class PostHostFunctionKeyScenario : PostFunctionKeysScenario, IClassFixture<PostHostFunctionKeyScenario.HostFixture>
     {

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/PostHostSystemKeyScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/PostHostSystemKeyScenario.cs
@@ -1,15 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 {
+    [Collection(HostFixture.Collection)]
     [Trait("A POST request is made against the host system keys resource endpoint", "")]
     public class PostHostSystemKeyScenario : PostFunctionKeysScenario, IClassFixture<PostHostSystemKeyScenario.HostFixture>
     {

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/PutFunctionKeysScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/PutFunctionKeysScenario.cs
@@ -1,19 +1,17 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
-using Microsoft.Azure.WebJobs.Script.WebHost.Filters;
 using Microsoft.Azure.WebJobs.Script.WebHost.Models;
-using Moq;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 {
+    [Collection(Fixture.Collection)]
     [Trait("A PUT request is made against the function key resource endpoint", "")]
     public class PutFunctionKeysScenario : IClassFixture<PutFunctionKeysScenario.Fixture>
     {

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/PutHostFunctionKeyScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/PutHostFunctionKeyScenario.cs
@@ -1,15 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 {
+    [Collection(HostFixture.Collection)]
     [Trait("A PUT request is made against the host function key resource endpoint", "")]
     public class PutHostFunctionKeyScenario : PutFunctionKeysScenario, IClassFixture<PutHostFunctionKeyScenario.HostFixture>
     {

--- a/test/WebJobs.Script.Tests.Integration/Controllers/Keys/PutHostSystemKeyScenario.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/Keys/PutHostSystemKeyScenario.cs
@@ -1,15 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 {
+    [Collection(HostFixture.Collection)]
     [Trait("A PUT request is made against the host system keys resource endpoint", "")]
     public class PutHostSystemKeyScenario : PutFunctionKeysScenario, IClassFixture<PutHostSystemKeyScenario.HostFixture>
     {


### PR DESCRIPTION
Integration test runs are showing a file lock contention that is crashing the test host. Putting the csharp samples in a collection should help mitigate this issue by ensuring they do not run in parallel.

<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #issue_for_this_pr

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information
