### PR TITLE
copy controller test apps to temp folder to prevent races

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/Controllers/ControllerScenarioTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/ControllerScenarioTestFixture.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 using System;
 using System.IO;
@@ -8,6 +8,7 @@ using System.Web.Http;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Tests.Integration.Fixtures;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,6 +21,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
     {
         private ScriptSettingsManager _settingsManager;
         private HttpConfiguration _config;
+        private TemporaryScriptRoot _scriptRoot;
 
         public ScriptApplicationHostOptions HostOptions { get; private set; }
 
@@ -45,12 +47,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 
                 Host.Dispose();
             }
+
+            _scriptRoot?.Dispose();
         }
 
         public virtual async Task InitializeAsync()
         {
             _config = new HttpConfiguration();
             _settingsManager = ScriptSettingsManager.Instance;
+
+            string sourcePath = Path.Combine(Environment.CurrentDirectory, "..", "..", "..", "..", "sample", "csharp");
+            _scriptRoot = new TemporaryScriptRoot(sourcePath, "FunctionsControllerScenarios");
 
             var webHostBuilder = Program.CreateHostBuilder()
                 .ConfigureWebHost(webBuilder =>
@@ -63,15 +70,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
                 {
                     services.AddSingleton<IDiagnosticEventRepository, DiagnosticEventNullRepository>();
                     services.AddSingleton<IDiagnosticEventRepositoryFactory, TestDiagnosticEventRepositoryFactory>();
-                    services.PostConfigure<ScriptApplicationHostOptions>(o=>
+                    services.PostConfigure<ScriptApplicationHostOptions>(o =>
                     {
                         o.IsSelfHost = true;
-                        o.ScriptPath = Path.Combine(Environment.CurrentDirectory, "..", "..", "..", "..", "sample", "csharp");
+                        o.ScriptPath = _scriptRoot.RootPath;
                         o.LogPath = Path.Combine(Path.GetTempPath(), @"Functions", "ControllerScenarioTests");
                         o.SecretsPath = Path.Combine(Path.GetTempPath(), @"FunctionsTests\Secrets");
                         o.HasParentScope = true;
 
                         HostOptions = o;
+                    });
+
+                    services.PostConfigure<ScriptJobHostOptions>(o =>
+                    {
+                        o.Functions = ["HttpTrigger"];
                     });
                 });
 
@@ -86,7 +98,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
         }
 
         public Task DisposeAsync()
-        { 
+        {
             return Task.CompletedTask;
         }
     }

--- a/test/WebJobs.Script.Tests.Integration/Controllers/ControllerScenarioTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/ControllerScenarioTestFixture.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
 {
-    public class ControllerScenarioTestFixture : IAsyncLifetime, IDisposable
+    public class ControllerScenarioTestFixture : IAsyncLifetime
     {
         private ScriptSettingsManager _settingsManager;
         private HttpConfiguration _config;
@@ -30,26 +30,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
         public IHost Host { get; set; }
 
         protected virtual void ConfigureWebHostBuilder(IWebHostBuilder webHostBuilder) { }
-
-        public void Dispose()
-        {
-            HttpClient?.Dispose();
-
-            if (Host is not null)
-            {
-                try
-                {
-                    Host.StopAsync().GetAwaiter().GetResult();
-                }
-                catch
-                {
-                }
-
-                Host.Dispose();
-            }
-
-            _scriptRoot?.Dispose();
-        }
 
         public virtual async Task InitializeAsync()
         {
@@ -97,9 +77,24 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Controllers
             await manager.DelayUntilHostReadyAsync();
         }
 
-        public Task DisposeAsync()
+        public async Task DisposeAsync()
         {
-            return Task.CompletedTask;
+            HttpClient?.Dispose();
+
+            if (Host is not null)
+            {
+                try
+                {
+                    await Host.StopAsync();
+                }
+                catch
+                {
+                }
+
+                Host.Dispose();
+            }
+
+            _scriptRoot?.Dispose();
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/Fixtures/TemporaryScriptRoot.cs
+++ b/test/WebJobs.Script.Tests.Integration/Fixtures/TemporaryScriptRoot.cs
@@ -1,0 +1,85 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Fixtures
+{
+    /// <summary>
+    /// Copies a source script root to a unique per-instance directory under
+    /// <c>%TEMP%\{bucketName}\{yyMMdd-HHmmss}_{counter}</c> so that concurrent
+    /// or sequential test fixtures do not race on shared on-disk artifacts
+    /// (most notably the CSX <c>project.assets.json</c> file written back into
+    /// the function directory by <c>PackageManager.RestorePackagesAsync</c>).
+    /// </summary>
+    /// <remarks>
+    /// On <see cref="Dispose"/>, the most recent <paramref name="keepLastCopies"/>
+    /// copies under the bucket are kept for post-failure inspection and the rest
+    /// are best-effort deleted.
+    /// </remarks>
+    public sealed class TemporaryScriptRoot : IDisposable
+    {
+        private const int DefaultKeepLastCopies = 5;
+
+        private readonly int _keepLastCopies;
+
+        public TemporaryScriptRoot(string sourcePath, string bucketName, int keepLastCopies = DefaultKeepLastCopies)
+        {
+            ArgumentException.ThrowIfNullOrEmpty(sourcePath);
+            ArgumentException.ThrowIfNullOrEmpty(bucketName);
+
+            _keepLastCopies = keepLastCopies;
+
+            string nowString = DateTime.UtcNow.ToString("yyMMdd-HHmmss", CultureInfo.InvariantCulture);
+            string GetDestPath(int counter) =>
+                Path.Combine(Path.GetTempPath(), bucketName, $"{nowString}_{counter}");
+
+            int i = 0;
+            string destPath = GetDestPath(i++);
+            while (Directory.Exists(destPath))
+            {
+                destPath = GetDestPath(i++);
+            }
+
+            FileUtility.CopyDirectory(sourcePath, destPath);
+            RootPath = destPath;
+        }
+
+        public string RootPath { get; }
+
+        public void Dispose()
+        {
+            string parent = System.IO.Path.GetDirectoryName(RootPath);
+            if (string.IsNullOrEmpty(parent) || !Directory.Exists(parent))
+            {
+                return;
+            }
+
+            try
+            {
+                var directoriesToDelete = Directory.EnumerateDirectories(parent)
+                    .OrderByDescending(p => p, StringComparer.Ordinal)
+                    .Skip(_keepLastCopies);
+
+                foreach (string directory in directoriesToDelete)
+                {
+                    try
+                    {
+                        Directory.Delete(directory, recursive: true);
+                    }
+                    catch
+                    {
+                        // best effort
+                    }
+                }
+            }
+            catch
+            {
+                // best effort
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
     {
         private readonly AzuriteFixture _azurite = new();
         private readonly string _rootPath;
+        private TemporaryScriptRoot _scriptRoot;
         private string _copiedRootPath;
         private string _functionsWorkerRuntime;
         private int _workerProcessCount;
@@ -109,21 +110,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public virtual async Task InitializeAsync()
         {
             await _azurite.InitializeAsync();
-            string nowString = DateTime.UtcNow.ToString("yyMMdd-HHmmss");
-            string GetDestPath(int counter)
-            {
-                return Path.Combine(Path.GetTempPath(), "FunctionsE2E", $"{nowString}_{counter}");
-            }
 
-            // Prevent collisions.
-            int i = 0;
-            _copiedRootPath = GetDestPath(i++);
-            while (Directory.Exists(_copiedRootPath))
-            {
-                _copiedRootPath = GetDestPath(i++);
-            }
-
-            FileUtility.CopyDirectory(_rootPath, _copiedRootPath);
+            _scriptRoot = new TemporaryScriptRoot(_rootPath, "FunctionsE2E");
+            _copiedRootPath = _scriptRoot.RootPath;
 
             var extensionsToInstall = GetExtensionsToInstall();
             if (extensionsToInstall != null && extensionsToInstall.Length > 0)
@@ -324,22 +313,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Host.Dispose();
             }
 
-            // Clean up all but the last 5 directories for debugging failures.
-            var directoriesToDelete = Directory.EnumerateDirectories(Path.GetDirectoryName(_copiedRootPath))
-                .OrderByDescending(p => p)
-                .Skip(5);
-
-            foreach (string directory in directoriesToDelete)
-            {
-                try
-                {
-                    Directory.Delete(directory, true);
-                }
-                catch
-                {
-                    // best effort
-                }
-            }
+            _scriptRoot?.Dispose();
 
             Environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, null);
             Environment.SetEnvironmentVariable(RpcWorkerConstants.FunctionsWorkerProcessCountSettingName, null);


### PR DESCRIPTION
## Fix `project.assets.json` race in integration test fixtures

### The bug

Multiple test fixtures (`ControllerScenarioTestFixture`, fixtures derived from `EndToEndTestFixture`) point the host's `ScriptPath` at a shared source directory under `sample\csharp` and `TestScripts\`. When that directory contains a CSX function with a `function.proj` (e.g. `HttpTrigger-Compat`), the host kicks off `dotnet restore` as a background process during indexing. When the restore exits, the [`Process.Exited` handler in `PackageManager.cs`](https://github.com/Azure/azure-functions-host/blob/455594d5c25191c644a0ced055e08f4c0434f2ff/src/WebJobs.Script/Description/DotNet/PackageManager.cs#L83-L100) does an unguarded `File.Copy` into the shared script folder.

If the next fixture has already started and is reading that same `project.assets.json`, the copy throws `IOException` on a threadpool thread, which crashes the test host and aborts the run.

### The fix

This is a **targeted test-side fix**: each affected fixture now copies its script root into a unique `%TEMP%` directory before the host starts, so fixtures no longer share writable state. The copy/cleanup logic was already in `EndToEndTestFixture`; it's extracted into a small `TemporaryScriptRoot` helper and reused by `ControllerScenarioTestFixture`.

We deliberately are not changing `PackageManager`. The unguarded handler is real, but it's in legacy CSX-restore code that's been in production for years and is risky to modify just to satisfy a test setup. Isolating the fixtures is the smaller, lower-risk change and fully eliminates the race we're seeing in CI.

Also sets `ScriptJobHostOptions.Functions = ["HttpTrigger"]` so the host only indexes the single function these tests actually exercise — this avoids the CSX restore entirely and drops the suite runtime down.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)