### PR TITLE
Only cache positive SecretsEnabled results

### DIFF
--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/DefaultSecretManagerProvider.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/DefaultSecretManagerProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         private readonly StartupContextProvider _startupContextProvider;
         private readonly IAzureBlobStorageProvider _azureBlobStorageProvider;
         private Lazy<ISecretManager> _secretManagerLazy;
-        private Lazy<bool> _secretsEnabledLazy;
+        private volatile bool _secretsEnabled;
 
         public DefaultSecretManagerProvider(IOptionsMonitor<ScriptApplicationHostOptions> options, IHostIdProvider hostIdProvider, IEnvironment environment,
             ILoggerFactory loggerFactory, IMetricsLogger metricsLogger, HostNameProvider hostNameProvider, StartupContextProvider startupContextProvider,
@@ -44,7 +44,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
             _metricsLogger = metricsLogger ?? throw new ArgumentNullException(nameof(metricsLogger));
             _secretManagerLazy = new Lazy<ISecretManager>(Create);
-            _secretsEnabledLazy = new Lazy<bool>(GetSecretsEnabled);
 
             // When these options change (due to specialization), we need to reset the secret manager.
             options.OnChange(_ => ResetSecretManager());
@@ -56,11 +55,21 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         {
             get
             {
-                if (_secretManagerLazy.IsValueCreated)
+                if (_secretManagerLazy.IsValueCreated || _secretsEnabled)
                 {
                     return true;
                 }
-                return _secretsEnabledLazy.Value;
+
+                // Only cache positive results, to ensure we're responsive to changes in configuration that enable secrets.
+                // Re-evaluating on each call until we can confirm secrets are enabled allows the host to recover automatically
+                // once the underlying configuration becomes available.
+                bool secretsEnabled = GetSecretsEnabled();
+                if (secretsEnabled)
+                {
+                    _secretsEnabled = true;
+                }
+
+                return secretsEnabled;
             }
         }
 
@@ -68,7 +77,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         private void ResetSecretManager()
         {
-            Interlocked.Exchange(ref _secretsEnabledLazy, new Lazy<bool>(GetSecretsEnabled));
+            _secretsEnabled = false;
             Interlocked.Exchange(ref _secretManagerLazy, new Lazy<ISecretManager>(Create));
 
             _logger.LogDebug(new EventId(1, "ResetSecretManager"), "Reset SecretManager.");

--- a/test/WebJobs.Script.Tests.Integration/Security/SecretManagerProviderTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Security/SecretManagerProviderTests.cs
@@ -1,10 +1,12 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
 using System.IO;
 using System.Threading;
+using Azure.Storage.Blobs;
 using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Storage;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -84,6 +86,59 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
 
             // will short circuit here
             Assert.True(_provider.SecretsEnabled);
+        }
+
+        [Fact]
+        public void SecretsEnabled_InitialFailure_RecoversOnSubsequentCall()
+        {
+            // Simulate the startup race described in Azure/azure-functions-host#11787, where
+            // TryCreateHostingBlobContainerClient initially fails because the script host's
+            // IConfiguration has not yet been merged into HostAzureBlobStorageProvider via
+            // ActiveHostConfigurationSource, and then succeeds once the active host configuration
+            // becomes available. The provider must not cache the negative result, otherwise
+            // key-based auth would remain disabled for the lifetime of the host even after the
+            // configuration becomes valid.
+            var mockIdProvider = new Mock<IHostIdProvider>();
+            mockIdProvider.Setup(p => p.GetHostIdAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync("testhostid");
+
+            var options = new ScriptApplicationHostOptions
+            {
+                SecretsPath = Path.Combine("c:", "path1")
+            };
+            var factory = new TestOptionsFactory<ScriptApplicationHostOptions>(options);
+            var tokenSource = new TestChangeTokenSource<ScriptApplicationHostOptions>();
+            var optionsMonitor = new OptionsMonitor<ScriptApplicationHostOptions>(factory, new[] { tokenSource }, factory);
+
+            IEnvironment environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName, "test.azurewebsites.net");
+            var hostNameProvider = new HostNameProvider(environment);
+
+            BlobContainerClient containerClient = new BlobContainerClient(new Uri("https://example.blob.core.windows.net/azure-webjobs-hosts"));
+            bool shouldSucceed = false;
+            var mockBlobStorageProvider = new Mock<IAzureBlobStorageProvider>();
+            mockBlobStorageProvider
+                .Setup(p => p.TryCreateHostingBlobContainerClient(out containerClient))
+                .Returns(() => shouldSucceed);
+
+            var provider = new DefaultSecretManagerProvider(optionsMonitor, mockIdProvider.Object, environment, NullLoggerFactory.Instance,
+                new TestMetricsLogger(), hostNameProvider, new StartupContextProvider(environment, NullLoggerFactory.Instance.CreateLogger<StartupContextProvider>()),
+                mockBlobStorageProvider.Object);
+
+            Assert.False(provider.SecretsEnabled);
+            Assert.False(provider.SecretsEnabled);
+
+            // The active host configuration becomes available.
+            shouldSucceed = true;
+
+            Assert.True(provider.SecretsEnabled);
+
+            // Verify TryCreateHostingBlobContainerClient was probed for each call until it succeeded.
+            mockBlobStorageProvider.Verify(p => p.TryCreateHostingBlobContainerClient(out containerClient), Times.Exactly(3));
+
+            // After a successful result, subsequent calls should short-circuit and not re-probe.
+            Assert.True(provider.SecretsEnabled);
+            mockBlobStorageProvider.Verify(p => p.TryCreateHostingBlobContainerClient(out containerClient), Times.Exactly(3));
         }
     }
 }


### PR DESCRIPTION
Addresses startup time race condition issues described in https://github.com/Azure/azure-functions-host/issues/11787. Specifically, we recently saw a case where a configuration race condition during specialization lead to the host caching a failed result for SecretsEnabled, and the host didn't recover.