### PR TITLE
Register HostedServiceManager first so it stops last under Generic Host LIFO shutdown

### DIFF
--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -97,6 +97,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             .AddNewtonsoftJson()
             .AddXmlDataContractSerializerFormatters();
 
+            // Must stop last so the JobHost drains in-flight invocations before worker channels are
+            // torn down (via HostedServiceManager -> RpcInitializationService). The Generic Host stops
+            // IHostedServices in LIFO order, so register this before all other hosted services.
+            services.AddSingleton<IHostedService, HostedServiceManager>();
+
             // Standby services
             services.AddStandbyServices();
 
@@ -214,11 +219,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             // Manages a diagnostic listener that subscribes to diagnostic sources setup in the host
             // and persists events in the logging infrastructure.
             services.AddSingleton<IHostedService, DiagnosticListenerService>();
-
-            // Handles shutdown of services that need to happen after StopAsync() of all services of type IHostedService are complete.
-            // Order is important.
-            // All other IHostedService injections need to go before this.
-            services.AddSingleton<IHostedService, HostedServiceManager>();
 
             // Configuration
 

--- a/test/WebJobs.Script.Tests/WebHost/WebHostServiceCollectionExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/WebHost/WebHostServiceCollectionExtensionsTests.cs
@@ -1,10 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Linq;
 using Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
@@ -49,6 +52,40 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             Assert.IsType<LinuxContainerActivityPublisher>(provider.GetRequiredService<ILinuxContainerActivityPublisher>());
             Assert.NotNull(provider.GetService<ILinuxConsumptionMetricsTracker>());
+        }
+
+        [Fact]
+        public void AddWebJobsScriptHost_RegistersHostedServiceManagerBeforeFunctionsHostedServices_SoItStopsLastUnderLifoShutdown()
+        {
+            var services = new ServiceCollection();
+
+            services.AddWebJobsScriptHost(new ConfigurationBuilder().Build());
+
+            var hostedServiceDescriptors = services
+                .Where(d => d.ServiceType == typeof(IHostedService))
+                .ToList();
+
+            int managerIndex = hostedServiceDescriptors.FindIndex(d => d.ImplementationType == typeof(HostedServiceManager));
+            Assert.True(managerIndex >= 0, $"{nameof(HostedServiceManager)} should be registered as an {nameof(IHostedService)}.");
+
+            // The Generic Host stops IHostedServices in LIFO (reverse registration) order, so the
+            // first-registered service stops last. HostedServiceManager runs the language worker channel
+            // shutdown and must stop last so the JobHost finishes draining in-flight invocations before the
+            // worker channels are torn down. No Functions-owned hosted service may be registered before it
+            // (framework services such as DataProtection are fine; they are unrelated to the drain ordering).
+            var functionsAssemblies = new[]
+            {
+                typeof(HostedServiceManager).Assembly,
+                typeof(WebJobsScriptHostService).Assembly,
+            };
+
+            for (int i = 0; i < managerIndex; i++)
+            {
+                var implementationType = hostedServiceDescriptors[i].ImplementationType;
+                Assert.False(
+                    implementationType is not null && functionsAssemblies.Contains(implementationType.Assembly),
+                    $"'{implementationType}' is registered before {nameof(HostedServiceManager)} and would stop after it under the Generic Host's LIFO shutdown order.");
+            }
         }
 
         private static ServiceProvider BuildServiceProvider(IEnvironment environment)


### PR DESCRIPTION

The move from the legacy ASP.NET Core WebHost (IWebHost) to the Generic Host (IHost) changed IHostedService shutdown from forward order to LIFO (reverse registration) order. HostedServiceManager runs the language worker channel shutdown (RpcInitializationService.OuterStopAsync) and was registered last so that, under the legacy WebHost's forward-order stop, it ran after the JobHost drained in-flight invocations.

Under the Generic Host's LIFO stop, "registered last" now means "stopped first", so worker channels were torn down before the JobHost drained. Busy workers (e.g. long-running Durable activities) received WorkerTerminate mid-invocation and were force-killed at the 5s grace deadline, surfacing as FunctionInvocationExceptions and "Did not find any initialized language workers".

Register HostedServiceManager before all other Functions-owned IHostedServices so it stops last under LIFO, restoring the known-good ordering. Adds a regression test asserting no Functions-owned hosted service is registered before it.

<!-- Please provide all the information below.  -->


### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [ ] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
