### PR TITLE
Patch/4.51.300: fix HostedServiceManager stop ordering under Generic Host LIFO

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,9 +3,3 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
--->
-
-- fix: address config reload concurrent read/write race (#11815)
-- fix: avoid health checks triggering secret-manager too early (#11816)
-
-- fix: address config reload concurrent read/write race (#11815)

--- a/src/Directory.Version.props
+++ b/src/Directory.Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.1051.200</VersionPrefix>
+    <VersionPrefix>4.1051.300</VersionPrefix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 </Project>

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -97,6 +97,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             .AddNewtonsoftJson()
             .AddXmlDataContractSerializerFormatters();
 
+            // Must stop last so the JobHost drains in-flight invocations before worker channels are
+            // torn down (via HostedServiceManager -> RpcInitializationService). The Generic Host stops
+            // IHostedServices in LIFO order, so register this before all other hosted services.
+            services.AddSingleton<IHostedService, HostedServiceManager>();
+
             // Standby services
             services.AddStandbyServices();
 
@@ -214,11 +219,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             // Manages a diagnostic listener that subscribes to diagnostic sources setup in the host
             // and persists events in the logging infrastructure.
             services.AddSingleton<IHostedService, DiagnosticListenerService>();
-
-            // Handles shutdown of services that need to happen after StopAsync() of all services of type IHostedService are complete.
-            // Order is important.
-            // All other IHostedService injections need to go before this.
-            services.AddSingleton<IHostedService, HostedServiceManager>();
 
             // Configuration
 


### PR DESCRIPTION
## Summary

Patch release **4.1051.300** for `release/4.51`. Cherry-picks the worker-shutdown ordering fix from `dev` (#11832) into the 4.51 servicing line, along with the version bump and release-notes reset.

## Fix: HostedServiceManager stop ordering

The .NET 10 migration moved the WebHost from the legacy ASP.NET Core `WebHost` (`IWebHost`, forward stop) to the Generic Host (`IHost`, **LIFO** stop). `HostedServiceManager` triggers language-worker channel shutdown (via `RpcInitializationService.OuterStopAsync`) and was registered **last** so it would stop **last** under the legacy forward-order shutdown.

Under the Generic Host's LIFO order, "registered last" became "stopped first", so worker channels were torn down **before** the JobHost drained in-flight invocations. Busy workers (e.g. long-running Durable activities) received `WorkerTerminate` mid-invocation and were force-killed at the 5s grace deadline, surfacing as `FunctionInvocationException` and "Did not find any initialized language workers".

**Fix:** register `HostedServiceManager` before all other Functions-owned `IHostedService`s so it stops **last** under LIFO, restoring the known-good 4.1048 ordering.

## Validation
- Stop ordering flipped 100% on the regressed build vs LKG (99.1% channel-shutdown-first vs 0.6%).
- Force-kills per recycle: 24.8% (regressed) vs 0.1% (LKG).

## Notes
- The regression test from #11832 is **not** included here — its test file does not exist on the 4.51 servicing branch. Test coverage remains on `dev`.
- Root cause was introduced with the Generic Host migration (present from 4.1050); customer impact surfaced on 4.1051.

Cherry-picked from commit 05f132d3d (PR #11832).
