### PR TITLE
improving NodeProcessCount test

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcesses.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcesses.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                 var channelManager = _fixture.Host.JobHostServices.GetService<IJobHostRpcWorkerChannelManager>();
                 var channels = channelManager.GetChannels("node");
                 return channels is not null && channels.Count() == expectedCount;
-            }, pollingInterval: 1000, userMessageCallback: _fixture.Host.GetLog);
+            }, timeout: 60 * 1000, pollingInterval: 1000, userMessageCallback: _fixture.Host.GetLog);
         }
 
         public IEnumerable<int> GetCurrentWorkerPids()
@@ -140,13 +140,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             public override void ConfigureScriptHost(IWebJobsBuilder webJobsBuilder)
             {
                 base.ConfigureScriptHost(webJobsBuilder);
-                webJobsBuilder.Services.Configure<ScriptJobHostOptions>(o =>
+                webJobsBuilder.Services.PostConfigure<ScriptJobHostOptions>(o =>
                 {
                     o.Functions =
                     [
                         "HttpTrigger",
                         "HttpTrigger-Timeout",
                     ];
+                    o.FunctionTimeout = TimeSpan.FromSeconds(3);
                 });
 
                 webJobsBuilder.Services.AddOptions<LanguageWorkerOptions>()
@@ -156,6 +157,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                         if (nodeConfig is not null)
                         {
                             nodeConfig.CountOptions.ProcessStartupInterval = TimeSpan.FromSeconds(3);
+                            nodeConfig.CountOptions.ProcessRestartInterval = TimeSpan.FromSeconds(3);
                         }
                     });
             }


### PR DESCRIPTION
This NodeProcessCount_RemainsSame_AfterMultipleTimeouts test appeared to not be waiting long enough on some runs and was failing roughly 10% of CI runs. Extending the timeout and shrinking some other values to hopefully bring it within the timeout value for every run, even on loaded CI machines.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)