### PR TITLE
isolating and improving timeout tests

### DIFF
--- a/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
+++ b/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
@@ -112,6 +112,17 @@ jobs:
       arguments: '--filter "Category!=E2E&Group=NonE2E_WebHost" -c release --no-build'
       projects: $(test_projects)
     env:
+      AzureWebJobsStorage: $(Storage) 
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Timeout tests'
+    condition: succeededOrFailed()
+    inputs:
+      command: test
+      testRunTitle: 'Timeout'
+      arguments: '--filter "Category!=E2E&Group=NonE2E_Timeout" -c release --no-build'
+      projects: $(test_projects)
+    env:
       AzureWebJobsStorage: $(Storage)
 
   - task: DotNetCoreCLI@2
@@ -154,7 +165,7 @@ jobs:
     inputs:
       command: test
       testRunTitle: 'Ungrouped'
-      arguments: '--filter "Category!=E2E&Group!=NonE2E_Specialization&Group!=NonE2E_WebHost&Group!=NonE2E_AppInsights&Group!=NonE2E_Controllers&Group!=NonE2E_Storage" -c release --no-build'
+      arguments: '--filter "Category!=E2E&Group!=NonE2E_Specialization&Group!=NonE2E_WebHost&Group!=NonE2E_AppInsights&Group!=NonE2E_Timeout&Group!=NonE2E_Controllers&Group!=NonE2E_Storage" -c release --no-build'
       projects: $(test_projects)
     env:
       AzureWebJobsStorage: $(Storage)

--- a/test/Resources/TestScripts/CSharp/TimeoutToken/run.csx
+++ b/test/Resources/TestScripts/CSharp/TimeoutToken/run.csx
@@ -5,7 +5,11 @@ public static async Task Run(string input, TraceWriter log, CancellationToken to
     switch (input)
     {
         case "useToken":
-            while (!token.IsCancellationRequested)
+            try
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+            }
+            catch (OperationCanceledException)
             {
             }
             break;
@@ -14,7 +18,7 @@ public static async Task Run(string input, TraceWriter log, CancellationToken to
             while (count < 15)
             {
                 count++;
-                Thread.Sleep(1000);
+                await Task.Delay(1000);
             }
             break;
         default:

--- a/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/EndToEndTimeoutTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/EndToEndTimeoutTests.cs
@@ -11,7 +11,6 @@ using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Host.Timers;
 using Microsoft.Azure.WebJobs.Script.AppCapabilities;
 using Microsoft.Azure.WebJobs.Script.Config;
-using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -20,7 +19,7 @@ using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 {
-    [Trait(TestTraits.Group, TestTraits.NonE2EAppInsights)]
+    [Trait(TestTraits.Group, TestTraits.NonE2ETimeout)]
     public class EndToEndTimeoutTests
     {
         private static readonly ScriptSettingsManager SettingsManager = ScriptSettingsManager.Instance;
@@ -121,7 +120,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
 
         private IHostBuilder CreateTimeoutHostBuilder(string scriptPath, TimeSpan timeout, string functionName)
         {
-            var builder = Program.CreateHostBuilder()
+            var builder = new HostBuilder()
                .ConfigureDefaultTestWebScriptHost(b =>
                {
                    b.Services.Configure<ScriptJobHostOptions>(o =>

--- a/test/WebJobs.Script.Tests.Shared/TestTraits.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestTraits.cs
@@ -70,6 +70,7 @@ namespace Microsoft.WebJobs.Script.Tests
         public const string NonE2ESpecialization = "NonE2E_Specialization";
         public const string NonE2EWebHost = "NonE2E_WebHost";
         public const string NonE2EAppInsights = "NonE2E_AppInsights";
+        public const string NonE2ETimeout = "NonE2E_Timeout";
         public const string NonE2EControllers = "NonE2E_Controllers";
         public const string NonE2EStorage = "NonE2E_Storage";
     }


### PR DESCRIPTION
~~The `TimeoutTest_UsingToken_CSharp` would sometimes fail -- and it seemed to be whenever the CI machine was reporting health issues (low-memory). Analysis suggests that the tight while loop this test used may have caused it to fail in such conditions by consuming a thread while waiting for the test scenario to run.~~

~~Changing the behavior in the test function to be more cpu-friendly by reacting directly to the token rather than spinning. Also swapping the other test scenario to use a `Task` rather than blocking a thread.~~

~~Not 100% guaranteed that this will fix the issue, but it seems like the right direction.~~

~~It's entirely possible that the low-memory conditions are caused by other tests leaking somewhere, but that's analysis I'll be doing elsewhere.~~

Edited:
It turns out that the 3 timeout tests were leaking massive memory. During some runs they'd use upwards of 2.4gb. Dump analysis showed tens of thousands of CancellationToken registrations that appeared to come from configuration somewhere. 

The one big oddity with these tests was that they wired up both the *production* configuration and the *test* configurations. It's possible that something in there was causing some cyclical change token registration causing chaos.

In reality, these tests are testing *in-proc cancellation* and likely don't even impact anything we do today which is strictly out-of-proc. So rather than chase it down to the exact culprit, I:
- removed the production registration from the tests (memory usage plummetted)
- kept the optimization from before with the test method itself to avoid spinning
- separated the timeout tests into their own process

I've run this several times, both with and without memory diagnostics running and it seems stable now.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)