### PR TITLE
Fix worker process count not respecting MaxProcessCount on high core count machines

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,3 +7,4 @@
 - Add additive platform notification for sync triggers under `FUNCTIONS_NOTIFY_PLATFORM_ON_SYNC=true` (#11813)
 - fix: avoid health checks triggering secret-manager too early (#11816)
 - Restrict GET admin/host/triggers to platform claim (#11697)
+- fix: `SetProcessCountToNumberOfCpuCores` silently overriding `MaxProcessCount` on high core count machines (#11842)

--- a/src/WebJobs.Script/Workers/Rpc/Configuration/WorkerConfigurationProviderBase.cs
+++ b/src/WebJobs.Script/Workers/Rpc/Configuration/WorkerConfigurationProviderBase.cs
@@ -210,9 +210,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc.Configuration
 
             if (workerProcessCount.SetProcessCountToNumberOfCpuCores)
             {
-                workerProcessCount.ProcessCount = coresCount;
-                // set Max worker process count to Number of effective cores if MaxProcessCount is less than MinProcessCount
-                workerProcessCount.MaxProcessCount = workerProcessCount.ProcessCount > workerProcessCount.MaxProcessCount ? workerProcessCount.ProcessCount : workerProcessCount.MaxProcessCount;
+                workerProcessCount.ProcessCount = Math.Min(coresCount, workerProcessCount.MaxProcessCount);
             }
 
             // Env variable takes precedence over worker.config

--- a/test/WebJobs.Script.Tests/Workers/Rpc/WorkerConfigurationProviderBaseTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/WorkerConfigurationProviderBaseTests.cs
@@ -391,7 +391,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 }
                 else if (setProcessCountToNumberOfCpuCores)
                 {
-                    Assert.Equal(testEnvironment.GetEffectiveCoresCount(), result.ProcessCount);
+                    Assert.Equal(Math.Min(testEnvironment.GetEffectiveCoresCount(), maxProcessCount), result.ProcessCount);
                 }
             }
 

--- a/test/WebJobs.Script.Tests/Workers/Rpc/WorkerConfigurationProviderBaseTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/WorkerConfigurationProviderBaseTests.cs
@@ -431,6 +431,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.Contains("The TimeSpan must not be negative", resultEx3.Message);
         }
 
+        [Theory]
+        [InlineData(32, 15, 15)]
+        [InlineData(32, 8, 8)]
+        [InlineData(4, 15, 4)]
+        [InlineData(15, 15, 15)]
+        public void GetWorkerProcessCount_SetToNumberOfCores_ClampsToMaxProcessCount(int coresCount, int maxProcessCount, int expectedProcessCount)
+        {
+            JsonElement workerConfig = CreateWorkerConfig(1, maxProcessCount, "00:00:10", setProcessCountToCores: true);
+
+            var result = WorkerConfigurationProviderBase.GetWorkerProcessCount(workerConfig, functionsWorkerProcessCount: null, coresCount);
+
+            Assert.Equal(expectedProcessCount, result.ProcessCount);
+            Assert.Equal(maxProcessCount, result.MaxProcessCount);
+        }
+
         private static JsonElement CreateWorkerConfig(int processCount, int maxProcessCount, string processStartupInterval, bool setProcessCountToCores)
         {
             using var stream = new MemoryStream();


### PR DESCRIPTION
## Summary

Fixes #8014

When `SetProcessCountToNumberOfCpuCores` is `true`, the `GetWorkerProcessCount` method was setting `ProcessCount` to the raw core count and then *raising* `MaxProcessCount` to match if cores exceeded the configured max. This meant `MaxProcessCount` was silently overridden on high core count machines (e.g., 32+ cores).

## Changes

**`WorkerConfigurationProviderBase.cs`** — replaced the two-line block that set `ProcessCount = coresCount` and conditionally raised `MaxProcessCount` with a single line:

```csharp
workerProcessCount.ProcessCount = Math.Min(coresCount, workerProcessCount.MaxProcessCount);
```

`MaxProcessCount` is now a hard ceiling that is never overridden.

**`WorkerConfigurationProviderBaseTests.cs`** — updated the `GetWorkerProcessCount_Tests` assertion to expect `Math.Min(coresCount, maxProcessCount)` instead of the raw core count, so the test passes correctly regardless of the machine's core count.

## Testing

All 5 `GetWorkerProcessCount` tests pass.

## Checklist

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)