### PR TITLE
Forward buffered WebHost logs via a ScriptHost scoped service

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -10,4 +10,4 @@
 - Update Microsoft.Azure.AppService.Middleware to 1.5.11 (#11866)
 - Update PS 7.4 worker to [v4.0.5212](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5212) (#11858)
 - Update PS 7.6 worker to [v4.0.5213](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5213) (#11858)
-- - Fixed a race and reader leak in WebHost deferred startup-log forwarding across ScriptHost restarts/specialization, and fixed OpenTelemetry logs not being flushed on host shutdown. (#11847)
+- Fixed a race and reader leak in WebHost deferred startup-log forwarding across ScriptHost restarts/specialization, and fixed OpenTelemetry logs not being flushed on host shutdown. (#11847)

--- a/release_notes.md
+++ b/release_notes.md
@@ -10,3 +10,4 @@
 - Update Microsoft.Azure.AppService.Middleware to 1.5.11 (#11866)
 - Update PS 7.4 worker to [v4.0.5212](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5212) (#11858)
 - Update PS 7.6 worker to [v4.0.5213](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5213) (#11858)
+- - Fixed a race and reader leak in WebHost deferred startup-log forwarding across ScriptHost restarts/specialization, and fixed OpenTelemetry logs not being flushed on host shutdown. (#11847)

--- a/src/WebJobs.Script.WebHost/DependencyInjection/DependencyValidator/DependencyValidator.cs
+++ b/src/WebJobs.Script.WebHost/DependencyInjection/DependencyValidator/DependencyValidator.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection
                 .ExpectFactory<ExternalConfigurationStartupValidatorService>()
                 .ExpectFactory<IFileMonitoringService>()
                 .Expect<WorkerConsoleLogService>()
+                .Expect<DeferredLogForwardingService>()
                 .OptionalExternal("Microsoft.Azure.WebJobs.Script.Workers.FunctionInvocationDispatcherShutdownManager", "Microsoft.Azure.WebJobs.Script.Grpc", null)
                 .OptionalExternal("Microsoft.Azure.WebJobs.Script.Workers.WorkerConcurrencyManager", "Microsoft.Azure.WebJobs.Script.Grpc", null)
                 .Optional<FunctionAppValidationService>() // Conditionally registered.

--- a/src/WebJobs.Script.WebHost/Diagnostics/DeferredLogForwardingService.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DeferredLogForwardingService.cs
@@ -1,0 +1,184 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OpenTelemetry.Logs;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
+{
+    /// <summary>
+    /// Reads buffered WebHost logs from the shared <see cref="DeferredLogSource"/> and forwards them to the
+    /// active ScriptHost's Application Insights / OpenTelemetry providers. A new instance is created for each
+    /// ScriptHost and is stopped via <see cref="StopAsync"/> when the host is orphaned (restart or
+    /// specialization). During the default overlapping restart the previous host's forwarder can briefly read
+    /// concurrently with the new one (hence <see cref="DeferredLogSource"/> permits multiple readers); the
+    /// orphaned forwarder is awaited to completion before its providers are disposed. This replaces the
+    /// imperative per-host-build forwarding that leaked accumulating readers across restarts.
+    /// </summary>
+    internal sealed class DeferredLogForwardingService : IHostedService, IDisposable
+    {
+        private readonly DeferredLogSource _source;
+        private readonly IReadOnlyList<ILoggerProvider> _forwardingProviders;
+        private readonly ScriptApplicationHostOptions _options;
+        private readonly IEnvironment _environment;
+        private readonly CancellationTokenSource _cts = new();
+        private Task _processingTask;
+        private bool _disposed;
+
+        public DeferredLogForwardingService(DeferredLogSource source, IEnumerable<ILoggerProvider> loggerProviders,
+            IOptions<ScriptApplicationHostOptions> options, IEnvironment environment)
+            : this(source, FilterForwardingProviders(loggerProviders), options?.Value, environment)
+        {
+        }
+
+        internal DeferredLogForwardingService(DeferredLogSource source, IReadOnlyList<ILoggerProvider> forwardingProviders,
+            ScriptApplicationHostOptions options, IEnvironment environment)
+        {
+            _source = source ?? throw new ArgumentNullException(nameof(source));
+            _environment = environment ?? throw new ArgumentNullException(nameof(environment));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _forwardingProviders = forwardingProviders ?? throw new ArgumentNullException(nameof(forwardingProviders));
+        }
+
+        internal Task ProcessingTask => _processingTask;
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            // Don't forward logs in standby/placeholder mode. A placeholder host has no real (customer)
+            // telemetry providers, so forwarding would target no-op providers and compete with the
+            // specialized host for the same buffered logs. Only the active, specialized ScriptHost forwards.
+            if (_options.IsStandbyConfiguration ||
+                FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableWebHostLogForwarding, _environment))
+            {
+                return Task.CompletedTask;
+            }
+
+            // Nothing to forward to (no Application Insights / OpenTelemetry providers on this host). Don't
+            // start a reader and don't disable the shared buffer: a later host (e.g. after specialization, or
+            // a restart that adds providers) may still consume it. The buffer is bounded, so it self-limits.
+            if (_forwardingProviders.Count == 0)
+            {
+                return Task.CompletedTask;
+            }
+
+            // Offload to the thread pool so draining any already-buffered logs doesn't run inline on the
+            // ScriptHost startup path.
+            _processingTask = Task.Run(() => ProcessLogsAsync(_cts.Token));
+            return Task.CompletedTask;
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                _cts.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Already disposed; nothing to cancel.
+            }
+
+            if (_processingTask is not null)
+            {
+                await _processingTask;
+            }
+        }
+
+        private async Task ProcessLogsAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                ChannelReader<DeferredLogEntry> reader = _source.Reader;
+                while (await reader.WaitToReadAsync(cancellationToken))
+                {
+                    while (!cancellationToken.IsCancellationRequested && reader.TryRead(out DeferredLogEntry log))
+                    {
+                        foreach (ILoggerProvider forwardingProvider in _forwardingProviders)
+                        {
+                            try
+                            {
+                                ILogger logger = forwardingProvider.CreateLogger(log.Category);
+                                if (log.ScopeStorage?.Count > 0)
+                                {
+                                    ProcessLogWithScope(logger, log);
+                                }
+                                else
+                                {
+                                    logger.Log(log.LogLevel, log.EventId, log.Exception, log.Message);
+                                }
+                            }
+                            catch (Exception ex) when (!ex.IsFatal())
+                            {
+                                // A single misbehaving provider must not stop forwarding of subsequent logs.
+                            }
+                        }
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected when the ScriptHost is stopping or restarting.
+            }
+            catch (Exception ex) when (!ex.IsFatal())
+            {
+                // Never let log forwarding bring down the host.
+            }
+        }
+
+        private static void ProcessLogWithScope(ILogger logger, DeferredLogEntry log)
+        {
+            var scopes = new List<IDisposable>();
+            try
+            {
+                // Create a scope for each object in ScopeStorage so they are reapplied in the original order.
+                foreach (var scope in log.ScopeStorage)
+                {
+                    scopes.Add(logger.BeginScope(scope));
+                }
+
+                logger.Log(log.LogLevel, log.EventId, log.Exception, log.Message);
+            }
+            finally
+            {
+                // Dispose all scopes in reverse order to properly unwind them.
+                for (int i = scopes.Count - 1; i >= 0; i--)
+                {
+                    scopes[i].Dispose();
+                }
+            }
+        }
+
+        // Forward only to the Application Insights and OpenTelemetry providers. They are added in the
+        // ScriptHost and do not track these WebHost-level logs directly, so the deferred logs are forwarded
+        // to them here; other providers (file, system, etc.) already capture WebHost logs.
+        private static IReadOnlyList<ILoggerProvider> FilterForwardingProviders(IEnumerable<ILoggerProvider> loggerProviders)
+        {
+            return loggerProviders
+                .Where(provider => provider is ApplicationInsightsLoggerProvider or OpenTelemetryLoggerProvider)
+                .ToArray();
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+
+                // Cancel before disposing so a still-running processing task (e.g. if StopAsync never ran
+                // because host startup was aborted) doesn't stay parked on WaitToReadAsync.
+                _cts.Cancel();
+                _cts.Dispose();
+            }
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Diagnostics/DeferredLogForwardingService.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DeferredLogForwardingService.cs
@@ -20,21 +20,18 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
     /// <summary>
     /// Reads buffered WebHost logs from the shared <see cref="DeferredLogSource"/> and forwards them to the
     /// active ScriptHost's Application Insights / OpenTelemetry providers. A new instance is created for each
-    /// ScriptHost and is stopped via <see cref="StopAsync"/> when the host is orphaned (restart or
-    /// specialization). When the host has no Application Insights / OpenTelemetry providers, a no-op
+    /// ScriptHost and is stopped by the base <see cref="BackgroundService"/> when the host is orphaned
+    /// (restart or specialization). When the host has no Application Insights / OpenTelemetry providers, a no-op
     /// <see cref="NullLoggerProvider"/> is used so the shared buffer is still drained (and the entries
     /// discarded) rather than left to accumulate with no consumer.
     /// </summary>
-    internal sealed class DeferredLogForwardingService : IHostedService, IDisposable
+    internal sealed class DeferredLogForwardingService : BackgroundService
     {
         private readonly DeferredLogSource _source;
         private readonly IReadOnlyList<ILoggerProvider> _forwardingProviders;
         private readonly Dictionary<string, ILogger[]> _loggersByCategory = new(StringComparer.Ordinal);
         private readonly ScriptApplicationHostOptions _options;
         private readonly IEnvironment _environment;
-        private readonly CancellationTokenSource _cts = new();
-        private Task _processingTask;
-        private bool _disposed;
 
         public DeferredLogForwardingService(DeferredLogSource source, IEnumerable<ILoggerProvider> loggerProviders,
             IOptions<ScriptApplicationHostOptions> options, IEnvironment environment)
@@ -51,9 +48,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             _forwardingProviders = forwardingProviders ?? throw new ArgumentNullException(nameof(forwardingProviders));
         }
 
-        internal Task ProcessingTask => _processingTask;
+        // Exposes the base-class execution task for tests. Remains null when forwarding is skipped in
+        // StartAsync (standby/feature-flag), because ExecuteAsync is never started in that case.
+        internal Task ProcessingTask => ExecuteTask;
 
-        public Task StartAsync(CancellationToken cancellationToken)
+        public override Task StartAsync(CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
@@ -67,45 +66,26 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             if (_options.IsStandbyConfiguration ||
                 FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableWebHostLogForwarding, _environment))
             {
+                // Skip base.StartAsync so ExecuteAsync (and ExecuteTask) is never started.
                 return Task.CompletedTask;
             }
 
-            // Offload to the thread pool so draining any already-buffered logs doesn't run inline on the
-            // ScriptHost startup path.
-            CancellationToken token = _cts.Token;
-            _processingTask = Task.Run(() => ProcessLogsAsync(token));
-            return Task.CompletedTask;
+            // The base BackgroundService owns the lifetime CancellationTokenSource: it starts ExecuteAsync
+            // now and cancels that token from StopAsync/Dispose when this host is orphaned.
+            return base.StartAsync(cancellationToken);
         }
 
-        public async Task StopAsync(CancellationToken cancellationToken)
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            if (_processingTask is null)
-            {
-                return;
-            }
+            // Yield so draining any already-buffered logs doesn't run inline on the ScriptHost startup path.
+            await Task.Yield();
 
-            try
-            {
-                _cts.Cancel();
-            }
-            catch (ObjectDisposedException)
-            {
-                // Already disposed; nothing to cancel.
-            }
-
-            // Wait for the processing loop to observe cancellation and exit, but honor the host's shutdown
-            // timeout (cancellationToken) so a slow or stuck forward can't block graceful shutdown.
-            await Task.WhenAny(_processingTask, Task.Delay(Timeout.Infinite, cancellationToken));
-        }
-
-        private async Task ProcessLogsAsync(CancellationToken cancellationToken)
-        {
             try
             {
                 ChannelReader<DeferredLogEntry> reader = _source.Reader;
-                while (await reader.WaitToReadAsync(cancellationToken))
+                while (await reader.WaitToReadAsync(stoppingToken))
                 {
-                    while (!cancellationToken.IsCancellationRequested && reader.TryRead(out DeferredLogEntry log))
+                    while (!stoppingToken.IsCancellationRequested && reader.TryRead(out DeferredLogEntry log))
                     {
                         ILogger[] loggers = GetLoggers(log.Category);
                         foreach (ILogger logger in loggers)
@@ -201,19 +181,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             return providers.Length > 0
                 ? providers
                 : new ILoggerProvider[] { NullLoggerProvider.Instance };
-        }
-
-        public void Dispose()
-        {
-            if (!_disposed)
-            {
-                _disposed = true;
-
-                // Cancel before disposing so a still-running processing task (e.g. if StopAsync never ran
-                // because host startup was aborted) doesn't stay parked on WaitToReadAsync.
-                _cts.Cancel();
-                _cts.Dispose();
-            }
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/DeferredLogForwardingService.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DeferredLogForwardingService.cs
@@ -11,6 +11,7 @@ using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Logs;
 
@@ -20,15 +21,15 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
     /// Reads buffered WebHost logs from the shared <see cref="DeferredLogSource"/> and forwards them to the
     /// active ScriptHost's Application Insights / OpenTelemetry providers. A new instance is created for each
     /// ScriptHost and is stopped via <see cref="StopAsync"/> when the host is orphaned (restart or
-    /// specialization). During the default overlapping restart the previous host's forwarder can briefly read
-    /// concurrently with the new one (hence <see cref="DeferredLogSource"/> permits multiple readers); the
-    /// orphaned forwarder is awaited to completion before its providers are disposed. This replaces the
-    /// imperative per-host-build forwarding that leaked accumulating readers across restarts.
+    /// specialization). When the host has no Application Insights / OpenTelemetry providers, a no-op
+    /// <see cref="NullLoggerProvider"/> is used so the shared buffer is still drained (and the entries
+    /// discarded) rather than left to accumulate with no consumer.
     /// </summary>
     internal sealed class DeferredLogForwardingService : IHostedService, IDisposable
     {
         private readonly DeferredLogSource _source;
         private readonly IReadOnlyList<ILoggerProvider> _forwardingProviders;
+        private readonly Dictionary<string, ILogger[]> _loggersByCategory = new(StringComparer.Ordinal);
         private readonly ScriptApplicationHostOptions _options;
         private readonly IEnvironment _environment;
         private readonly CancellationTokenSource _cts = new();
@@ -54,6 +55,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                // Startup is being aborted; don't begin forwarding.
+                return Task.FromCanceled(cancellationToken);
+            }
+
             // Don't forward logs in standby/placeholder mode. A placeholder host has no real (customer)
             // telemetry providers, so forwarding would target no-op providers and compete with the
             // specialized host for the same buffered logs. Only the active, specialized ScriptHost forwards.
@@ -63,22 +70,20 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 return Task.CompletedTask;
             }
 
-            // Nothing to forward to (no Application Insights / OpenTelemetry providers on this host). Don't
-            // start a reader and don't disable the shared buffer: a later host (e.g. after specialization, or
-            // a restart that adds providers) may still consume it. The buffer is bounded, so it self-limits.
-            if (_forwardingProviders.Count == 0)
-            {
-                return Task.CompletedTask;
-            }
-
             // Offload to the thread pool so draining any already-buffered logs doesn't run inline on the
             // ScriptHost startup path.
-            _processingTask = Task.Run(() => ProcessLogsAsync(_cts.Token));
+            CancellationToken token = _cts.Token;
+            _processingTask = Task.Run(() => ProcessLogsAsync(token));
             return Task.CompletedTask;
         }
 
         public async Task StopAsync(CancellationToken cancellationToken)
         {
+            if (_processingTask is null)
+            {
+                return;
+            }
+
             try
             {
                 _cts.Cancel();
@@ -88,10 +93,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 // Already disposed; nothing to cancel.
             }
 
-            if (_processingTask is not null)
-            {
-                await _processingTask;
-            }
+            // Wait for the processing loop to observe cancellation and exit, but honor the host's shutdown
+            // timeout (cancellationToken) so a slow or stuck forward can't block graceful shutdown.
+            await Task.WhenAny(_processingTask, Task.Delay(Timeout.Infinite, cancellationToken));
         }
 
         private async Task ProcessLogsAsync(CancellationToken cancellationToken)
@@ -103,11 +107,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 {
                     while (!cancellationToken.IsCancellationRequested && reader.TryRead(out DeferredLogEntry log))
                     {
-                        foreach (ILoggerProvider forwardingProvider in _forwardingProviders)
+                        ILogger[] loggers = GetLoggers(log.Category);
+                        foreach (ILogger logger in loggers)
                         {
                             try
                             {
-                                ILogger logger = forwardingProvider.CreateLogger(log.Category);
                                 if (log.ScopeStorage?.Count > 0)
                                 {
                                     ProcessLogWithScope(logger, log);
@@ -158,14 +162,45 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             }
         }
 
+        private ILogger[] GetLoggers(string category)
+        {
+            category ??= string.Empty;
+            if (!_loggersByCategory.TryGetValue(category, out ILogger[] loggers))
+            {
+                loggers = new ILogger[_forwardingProviders.Count];
+                for (int i = 0; i < _forwardingProviders.Count; i++)
+                {
+                    try
+                    {
+                        loggers[i] = _forwardingProviders[i].CreateLogger(category);
+                    }
+                    catch (Exception ex) when (!ex.IsFatal())
+                    {
+                        loggers[i] = NullLogger.Instance;
+                    }
+                }
+
+                _loggersByCategory[category] = loggers;
+            }
+
+            return loggers;
+        }
+
         // Forward only to the Application Insights and OpenTelemetry providers. They are added in the
         // ScriptHost and do not track these WebHost-level logs directly, so the deferred logs are forwarded
         // to them here; other providers (file, system, etc.) already capture WebHost logs.
         private static IReadOnlyList<ILoggerProvider> FilterForwardingProviders(IEnumerable<ILoggerProvider> loggerProviders)
         {
-            return loggerProviders
+            ILoggerProvider[] providers = loggerProviders
                 .Where(provider => provider is ApplicationInsightsLoggerProvider or OpenTelemetryLoggerProvider)
                 .ToArray();
+
+            // When the host has no Application Insights / OpenTelemetry providers (e.g. an app without
+            // telemetry configured), forward to a no-op provider so the shared buffer is still continuously
+            // drained rather than accumulating entries with no consumer.
+            return providers.Length > 0
+                ? providers
+                : new ILoggerProvider[] { NullLoggerProvider.Instance };
         }
 
         public void Dispose()

--- a/src/WebJobs.Script.WebHost/Diagnostics/DeferredLogSource.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DeferredLogSource.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Channels;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
+{
+    /// <summary>
+    /// A process-wide buffer for deferred log entries. A single instance lives for the lifetime of the
+    /// WebHost so that buffered logs survive ScriptHost restarts and specialization. Loggers write to it
+    /// and the active ScriptHost's <see cref="DeferredLogForwardingService"/> reads from it.
+    /// </summary>
+    internal sealed class DeferredLogSource
+    {
+        // A single bounded buffer shared by all loggers (writers) and the active ScriptHost's forwarding
+        // service (reader). Oldest entries are dropped when full. SingleReader is false because readers can
+        // briefly overlap while one ScriptHost is being orphaned and the next one is starting up.
+        private readonly Channel<DeferredLogEntry> _channel = Channel.CreateBounded<DeferredLogEntry>(new BoundedChannelOptions(150)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleReader = false,
+            SingleWriter = false
+        });
+
+        private volatile bool _isEnabled = true;
+
+        public ChannelReader<DeferredLogEntry> Reader => _channel.Reader;
+
+        public bool IsEnabled => _isEnabled;
+
+        public void Write(DeferredLogEntry entry) => _channel.Writer.TryWrite(entry);
+
+        public void Disable()
+        {
+            _isEnabled = false;
+            _channel.Writer.TryComplete();
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Diagnostics/DeferredLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DeferredLogger.cs
@@ -3,17 +3,16 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 {
     /// <summary>
-    /// A logger that defers log entries to a channel.
+    /// A logger that defers log entries to a shared <see cref="DeferredLogSource"/>.
     /// </summary>
-    public class DeferredLogger : ILogger
+    internal class DeferredLogger : ILogger
     {
-        private readonly Channel<DeferredLogEntry> _channel;
+        private readonly DeferredLogSource _source;
         private readonly string _categoryName;
         private readonly IExternalScopeProvider _scopeProvider;
         private readonly IEnvironment _environment;
@@ -21,9 +20,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
         // Cached placeholder mode flag
         private bool _isPlaceholderModeDisabled = false;
 
-        public DeferredLogger(Channel<DeferredLogEntry> channel, string categoryName, IExternalScopeProvider scopeProvider, IEnvironment environment)
+        public DeferredLogger(DeferredLogSource source, string categoryName, IExternalScopeProvider scopeProvider, IEnvironment environment)
         {
-            _channel = channel;
+            _source = source;
             _categoryName = categoryName;
             _scopeProvider = scopeProvider;
             _environment = environment;
@@ -74,7 +73,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 state.ScopeStorage.Add(scope);
             }, log);
 
-            _channel.Writer.TryWrite(log);
+            _source.Write(log);
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Diagnostics/DeferredLogger.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DeferredLogger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -66,12 +66,17 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
                 EventId = eventId
             };
 
-            // Persist the scope state so it can be reapplied in the original order when forwarding logs to the logging provider.
-            _scopeProvider?.ForEachScope((scope, state) =>
+            // Persist the scope state so it can be reapplied in the original order when forwarding logs to the
+            // logging provider.
+            if (_scopeProvider is not null)
             {
-                state.ScopeStorage ??= new List<object>();
-                state.ScopeStorage.Add(scope);
-            }, log);
+                var scopeStorage = new List<object>();
+                _scopeProvider.ForEachScope(static (scope, state) => state.Add(scope), scopeStorage);
+                if (scopeStorage.Count > 0)
+                {
+                    log.ScopeStorage = scopeStorage;
+                }
+            }
 
             _source.Write(log);
         }

--- a/src/WebJobs.Script.WebHost/Diagnostics/DeferredLoggerProvider.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/DeferredLoggerProvider.cs
@@ -1,82 +1,28 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Threading.Channels;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
 {
-    public sealed class DeferredLoggerProvider : ILoggerProvider, ISupportExternalScope
+    internal sealed class DeferredLoggerProvider : ILoggerProvider, ISupportExternalScope
     {
-        private readonly Channel<DeferredLogEntry> _channel = Channel.CreateBounded<DeferredLogEntry>(new BoundedChannelOptions(150)
-        {
-            FullMode = BoundedChannelFullMode.DropOldest,
-            // Avoids locks and interlocked operations when reading from the channel.
-            SingleReader = true,
-            SingleWriter = false
-        });
-
+        private readonly DeferredLogSource _source;
         private readonly IEnvironment _environment;
         private IExternalScopeProvider _scopeProvider;
-        private bool _isEnabled = true;
 
-        public DeferredLoggerProvider(IEnvironment environment)
+        public DeferredLoggerProvider(DeferredLogSource source, IEnvironment environment)
         {
+            _source = source;
             _environment = environment;
         }
 
-        public int Count => _channel.Reader.Count;
+        public int Count => _source.Reader.Count;
 
         public ILogger CreateLogger(string categoryName)
         {
-            return _isEnabled ? new DeferredLogger(_channel, categoryName, _scopeProvider, _environment) : NullLogger.Instance;
-        }
-
-        public async Task ProcessBufferedLogsAsync(IReadOnlyCollection<ILoggerProvider> forwardingProviders)
-        {
-            // Forward all buffered logs to the new provider
-            try
-            {
-                if (forwardingProviders is null || forwardingProviders.Count == 0)
-                {
-                    // No providers, just drain the messages without logging and disable the channel.
-                    _isEnabled = false;
-                    _channel.Writer.TryComplete();
-                    while (_channel.Reader.TryRead(out _))
-                    {
-                        // Drain the channel
-                    }
-                    return;
-                }
-
-                while (await _channel.Reader.WaitToReadAsync())
-                {
-                    while (_channel.Reader.TryRead(out var log))
-                    {
-                        foreach (var forwardingProvider in forwardingProviders)
-                        {
-                            var logger = forwardingProvider.CreateLogger(log.Category);
-                            if (log.ScopeStorage?.Count > 0)
-                            {
-                                ProcessLogWithScope(logger, log);
-                            }
-                            else
-                            {
-                                // No scopes
-                                logger.Log(log.LogLevel, log.EventId, log.Exception, log.Message);
-                            }
-                        }
-                    }
-                }
-            }
-            catch (Exception ex) when (!ex.IsFatal())
-            {
-                // Ignore exceptions
-            }
+            return _source.IsEnabled ? new DeferredLogger(_source, categoryName, _scopeProvider, _environment) : NullLogger.Instance;
         }
 
         public void SetScopeProvider(IExternalScopeProvider scopeProvider)
@@ -84,39 +30,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics
             _scopeProvider = scopeProvider;
         }
 
-        private static void ProcessLogWithScope(ILogger logger, DeferredLogEntry log)
-        {
-            List<IDisposable> scopes = null;
-            try
-            {
-                // Create a scope for each object in ScopeObject
-                scopes ??= new List<IDisposable>();
-                foreach (var scope in log.ScopeStorage)
-                {
-                    // Create and store each scope
-                    scopes.Add(logger.BeginScope(scope));
-                }
-
-                // Log the message
-                logger.Log(log.LogLevel, log.EventId, log.Exception, log.Message);
-            }
-            finally
-            {
-                if (scopes is not null)
-                {
-                    // Dispose all scopes in reverse order to properly unwind them
-                    for (int i = scopes.Count - 1; i >= 0; i--)
-                    {
-                        scopes[i].Dispose();
-                    }
-                }
-            }
-        }
-
         public void Dispose()
         {
-            _isEnabled = false;
-            _channel.Writer.TryComplete();
+            _source.Disable();
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Program.cs
+++ b/src/WebJobs.Script.WebHost/Program.cs
@@ -130,6 +130,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                             loggingBuilder.AddDefaultWebJobsFilters();
                             loggingBuilder.AddWebJobsSystem<WebHostSystemLoggerProvider>();
                             loggingBuilder.AddForwardingLogger();
+                            loggingBuilder.Services.AddSingleton<DeferredLogSource>();
                             loggingBuilder.Services.AddSingleton<DeferredLoggerProvider>();
                             loggingBuilder.Services.AddSingleton<ILoggerProvider>(s => s.GetRequiredService<DeferredLoggerProvider>());
                             loggingBuilder.Services.AddSingleton<ISystemLoggerFactory, SystemLoggerFactory>();

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -1051,10 +1051,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 tracerProvider.ForceFlush();
             }
 
-            foreach (var logProvider in host.Services.GetServices<ILoggerProvider>().Where(i => i is OpenTelemetryLoggerProvider))
+            foreach (var loggerProvider in host.Services.GetServices<LoggerProvider>())
             {
-                logger.LogDebug(@"Disposing {providerName} ...", logProvider);
-                logProvider.Dispose();
+                logger.LogDebug(@"Flushing {providerName} ...", loggerProvider);
+                loggerProvider.ForceFlush();
             }
         }
 

--- a/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsScriptHostService.cs
@@ -18,7 +18,6 @@ using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Azure.WebJobs.Logging;
-using Microsoft.Azure.WebJobs.Logging.ApplicationInsights;
 using Microsoft.Azure.WebJobs.Script.AppCapabilities;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Configuration;
@@ -399,19 +398,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 }
 
                 ActiveHost = localHost;
-
-                if (!FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableWebHostLogForwarding, _environment))
-                {
-                    // Forward logs to AppInsights/OpenTelemetry.
-                    // These are not tracked by the AppInsights and OpenTelemetry logger provider as these are added in the script host.
-                    var loggerProviders = ActiveHost.Services.GetServices<ILoggerProvider>();
-                    var deferredLogProvider = ActiveHost.Services.GetService<DeferredLoggerProvider>();
-                    if (deferredLogProvider is not null)
-                    {
-                        var selectedProviders = loggerProviders.Where(provider => provider is ApplicationInsightsLoggerProvider or OpenTelemetryLoggerProvider).ToArray();
-                        _ = Task.Run(() => deferredLogProvider.ProcessBufferedLogsAsync(selectedProviders));
-                    }
-                }
                 _workerConfigCacheInvalidator.InvalidateCachePostBuildIfEnabled();
 
                 var scriptHost = (ScriptHost)ActiveHost.Services.GetService<ScriptHost>();

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -167,6 +167,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     services.AddSingleton<IFileMonitoringService, FileMonitoringService>();
                     services.TryAddEnumerable(ServiceDescriptor.Singleton<IHostedService, IFileMonitoringService>(p => p.GetService<IFileMonitoringService>()));
 
+                    // Forwards buffered WebHost logs to this ScriptHost's telemetry providers. Scoped to the
+                    // ScriptHost so it stops reading automatically when the host is orphaned (restart/specialization).
+                    services.AddSingleton<IHostedService, DeferredLogForwardingService>();
+
                     IOptions<FunctionsHostingConfigOptions> hostingConfigOptions = rootServiceProvider.GetService<IOptions<FunctionsHostingConfigOptions>>();
                     IOptionsMonitor<FunctionsHostingConfigOptions> hostingConfigOptionsMonitor = rootServiceProvider.GetService<IOptionsMonitor<FunctionsHostingConfigOptions>>();
                     services.AddSingleton(hostingConfigOptions);

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -169,6 +169,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                     // Forwards buffered WebHost logs to this ScriptHost's telemetry providers. Scoped to the
                     // ScriptHost so it stops reading automatically when the host is orphaned (restart/specialization).
+                    // The DependencyValidator requires this hosted service to always be registered, so forward the
+                    // WebHost's shared DeferredLogSource (falling back to a local, empty buffer for host builds that
+                    // don't register one, e.g. tests) so the service can always be constructed.
+                    services.AddSingleton(rootServiceProvider.GetService<DeferredLogSource>() ?? new DeferredLogSource());
                     services.AddSingleton<IHostedService, DeferredLogForwardingService>();
 
                     IOptions<FunctionsHostingConfigOptions> hostingConfigOptions = rootServiceProvider.GetService<IOptions<FunctionsHostingConfigOptions>>();

--- a/test/WebJobs.Script.Tests/Eventing/DeferredLogForwardingServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Eventing/DeferredLogForwardingServiceTests.cs
@@ -203,6 +203,72 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
         }
 
         [Fact]
+        public async Task ForwardsNestedScopes_ReappliedOuterToInner()
+        {
+            var environment = new TestEnvironment();
+            var source = new DeferredLogSource();
+
+            // Two stacked scopes must be reapplied in the captured outer -> inner order, then unwound in reverse.
+            source.Write(new DeferredLogEntry
+            {
+                LogLevel = LogLevel.Error,
+                Category = "TestCategory",
+                Message = "Error Log",
+                ScopeStorage = new List<object> { "outer", "inner" }
+            });
+
+            var recordingProvider = new ScopeRecordingLoggerProvider();
+            var service = new DeferredLogForwardingService(source, new ILoggerProvider[] { recordingProvider },
+                CreateOptions(isStandby: false), environment);
+
+            await service.StartAsync(CancellationToken.None);
+            await TestHelpers.Await(() => recordingProvider.Logger.ScopesAtLog is not null);
+
+            Assert.Equal(new[] { "outer", "inner" }, recordingProvider.Logger.ScopesAtLog);
+            Assert.Empty(recordingProvider.Logger.ActiveScopes);
+
+            await service.StopAsync(CancellationToken.None);
+            service.Dispose();
+        }
+
+        [Fact]
+        public async Task MultipleForwarders_SharingSource_ForwardEachEntryOnce()
+        {
+            var environment = new TestEnvironment();
+            var source = new DeferredLogSource();
+
+            const int count = 50;
+            for (int i = 0; i < count; i++)
+            {
+                source.Write(CreateErrorEntry("TestCategory", $"Log {i}"));
+            }
+
+            // The shared buffer sets SingleReader=false to tolerate overlapping ScriptHosts during restart.
+            var provider1 = new TestLoggerProvider();
+            var provider2 = new TestLoggerProvider();
+            var service1 = new DeferredLogForwardingService(source, new ILoggerProvider[] { provider1 }, CreateOptions(isStandby: false), environment);
+            var service2 = new DeferredLogForwardingService(source, new ILoggerProvider[] { provider2 }, CreateOptions(isStandby: false), environment);
+
+            await service1.StartAsync(CancellationToken.None);
+            await service2.StartAsync(CancellationToken.None);
+
+            // Complete the shared channel so both readers drain what's buffered and exit.
+            source.Disable();
+            await service1.ProcessingTask;
+            await service2.ProcessingTask;
+
+            var forwarded = provider1.GetAllLogMessages().Concat(provider2.GetAllLogMessages())
+                .Select(m => m.FormattedMessage).ToList();
+
+            // Two concurrent readers on one channel: each entry is delivered to exactly one reader (no loss, no duplication).
+            Assert.Equal(count, forwarded.Count);
+            Assert.Equal(count, forwarded.Distinct().Count());
+
+            service1.Dispose();
+            service2.Dispose();
+        }
+
+        [Fact]
         public async Task StopAsync_HonorsCancellationToken_WhenProcessingIsBlocked()
         {
             var environment = new TestEnvironment();
@@ -283,6 +349,47 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
                     _provider.LogEntered.Set();
                     _provider._release.Wait();
                 }
+            }
+        }
+
+        private sealed class ScopeRecordingLoggerProvider : ILoggerProvider
+        {
+            public ScopeRecordingLogger Logger { get; } = new ScopeRecordingLogger();
+
+            public ILogger CreateLogger(string categoryName) => Logger;
+
+            public void Dispose()
+            {
+            }
+        }
+
+        private sealed class ScopeRecordingLogger : ILogger
+        {
+            public List<object> ActiveScopes { get; } = new List<object>();
+
+            public string[] ScopesAtLog { get; private set; }
+
+            public IDisposable BeginScope<TState>(TState state)
+            {
+                ActiveScopes.Add(state);
+                return new ScopePopper(ActiveScopes);
+            }
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                // Snapshot the active scopes (outer -> inner) at the moment the entry is written.
+                ScopesAtLog = ActiveScopes.Select(scope => scope?.ToString()).ToArray();
+            }
+
+            private sealed class ScopePopper : IDisposable
+            {
+                private readonly List<object> _scopes;
+
+                public ScopePopper(List<object> scopes) => _scopes = scopes;
+
+                public void Dispose() => _scopes.RemoveAt(_scopes.Count - 1);
             }
         }
     }

--- a/test/WebJobs.Script.Tests/Eventing/DeferredLogForwardingServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Eventing/DeferredLogForwardingServiceTests.cs
@@ -2,10 +2,14 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
 using Xunit;
 
@@ -78,21 +82,45 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
         }
 
         [Fact]
-        public async Task NoForwardingProviders_DoesNotStartReaderOrDisableSource()
+        public async Task NoForwardingProviders_DrainsSourceAndLeavesItEnabled()
         {
             var environment = new TestEnvironment();
             var source = new DeferredLogSource();
             source.Write(CreateErrorEntry("TestCategory", "Error Log"));
 
+            // With no forwarding providers the reader still runs and drains (discards) buffered entries so
+            // they don't accumulate, without disabling the shared buffer.
             var service = new DeferredLogForwardingService(source, Array.Empty<ILoggerProvider>(), CreateOptions(isStandby: false), environment);
 
             await service.StartAsync(CancellationToken.None);
 
-            // No reader is started, and the shared buffer is left intact (not disabled, not drained) so a
-            // later host that does have providers can still forward the buffered logs.
-            Assert.Null(service.ProcessingTask);
+            Assert.NotNull(service.ProcessingTask);
+            await TestHelpers.Await(() => source.Reader.Count == 0);
             Assert.True(source.IsEnabled);
-            Assert.Equal(1, source.Reader.Count);
+
+            await service.StopAsync(CancellationToken.None);
+            service.Dispose();
+        }
+
+        [Fact]
+        public async Task NoAiOrOtelProviders_DrainsViaNoOpProvider()
+        {
+            var environment = new TestEnvironment();
+            var source = new DeferredLogSource();
+            source.Write(CreateErrorEntry("TestCategory", "Error Log"));
+
+            // A non-AI/OTel provider is filtered out and a no-op provider is substituted, so the buffer is
+            // still drained but the passed-in provider must not receive the forwarded logs.
+            var testLoggerProvider = new TestLoggerProvider();
+            var service = new DeferredLogForwardingService(source, new ILoggerProvider[] { testLoggerProvider },
+                Options.Create(CreateOptions(isStandby: false)), environment);
+
+            await service.StartAsync(CancellationToken.None);
+
+            Assert.NotNull(service.ProcessingTask);
+            await TestHelpers.Await(() => source.Reader.Count == 0);
+            Assert.True(source.IsEnabled);
+            Assert.Empty(testLoggerProvider.GetAllLogMessages());
 
             await service.StopAsync(CancellationToken.None);
             service.Dispose();
@@ -116,6 +144,90 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
             service.Dispose();
         }
 
+        [Fact]
+        public async Task ForwardingContinues_WhenProviderCreateLoggerThrows()
+        {
+            var environment = new TestEnvironment();
+            var source = new DeferredLogSource();
+            source.Write(CreateErrorEntry("TestCategory", "Error Log"));
+
+            // The first provider throws from CreateLogger; forwarding must still reach the healthy provider and
+            // must not terminate the processing loop (which would silently stop all future forwarding).
+            var healthyProvider = new TestLoggerProvider();
+            var service = new DeferredLogForwardingService(source,
+                new ILoggerProvider[] { new ThrowingLoggerProvider(), healthyProvider },
+                CreateOptions(isStandby: false), environment);
+
+            await service.StartAsync(CancellationToken.None);
+
+            await TestHelpers.Await(() => healthyProvider.GetAllLogMessages().Any());
+            Assert.Equal("Error Log", healthyProvider.GetAllLogMessages().Single().FormattedMessage);
+
+            await service.StopAsync(CancellationToken.None);
+            service.Dispose();
+        }
+
+        [Fact]
+        public async Task ForwardsScopes_WhenEntryHasScopeStorage()
+        {
+            var environment = new TestEnvironment();
+            var source = new DeferredLogSource();
+
+            // An entry carrying captured scopes must have them reapplied when forwarded so the provider
+            // observes them (exercises ProcessLogWithScope).
+            source.Write(new DeferredLogEntry
+            {
+                LogLevel = LogLevel.Error,
+                Category = "TestCategory",
+                Message = "Error Log",
+                ScopeStorage = new List<object>
+                {
+                    new Dictionary<string, object> { ["ScopeKey"] = "ScopeValue" }
+                }
+            });
+
+            var testLoggerProvider = new TestLoggerProvider();
+            var service = new DeferredLogForwardingService(source, new ILoggerProvider[] { testLoggerProvider },
+                CreateOptions(isStandby: false), environment);
+
+            await service.StartAsync(CancellationToken.None);
+            await TestHelpers.Await(() => testLoggerProvider.GetAllLogMessages().Any());
+
+            LogMessage message = testLoggerProvider.GetAllLogMessages().Single();
+            Assert.Equal("Error Log", message.FormattedMessage);
+            Assert.NotNull(message.Scope);
+            Assert.Equal("ScopeValue", message.Scope["ScopeKey"]);
+
+            await service.StopAsync(CancellationToken.None);
+            service.Dispose();
+        }
+
+        [Fact]
+        public async Task StopAsync_HonorsCancellationToken_WhenProcessingIsBlocked()
+        {
+            var environment = new TestEnvironment();
+            var source = new DeferredLogSource();
+            source.Write(CreateErrorEntry("TestCategory", "Error Log"));
+
+            // Block the processing loop inside the provider's Log so it cannot complete on its own.
+            var blockingProvider = new BlockingLoggerProvider();
+            var service = new DeferredLogForwardingService(source, new ILoggerProvider[] { blockingProvider },
+                CreateOptions(isStandby: false), environment);
+
+            await service.StartAsync(CancellationToken.None);
+            Assert.True(blockingProvider.LogEntered.Wait(TimeSpan.FromSeconds(30)));
+
+            // With an already-cancelled shutdown token, StopAsync must return promptly rather than waiting for
+            // the (blocked) processing task.
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            await service.StopAsync(cts.Token).WaitAsync(TimeSpan.FromSeconds(30));
+
+            blockingProvider.Release();
+            await service.ProcessingTask.WaitAsync(TimeSpan.FromSeconds(30));
+            service.Dispose();
+        }
+
         private static ScriptApplicationHostOptions CreateOptions(bool isStandby)
         {
             return new ScriptApplicationHostOptions { IsStandbyConfiguration = isStandby };
@@ -129,6 +241,49 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
                 Category = category,
                 Message = message
             };
+        }
+
+        private sealed class ThrowingLoggerProvider : ILoggerProvider
+        {
+            public ILogger CreateLogger(string categoryName) => throw new InvalidOperationException("Simulated CreateLogger failure.");
+
+            public void Dispose()
+            {
+            }
+        }
+
+        private sealed class BlockingLoggerProvider : ILoggerProvider
+        {
+            private readonly ManualResetEventSlim _release = new(false);
+
+            public ManualResetEventSlim LogEntered { get; } = new(false);
+
+            public ILogger CreateLogger(string categoryName) => new BlockingLogger(this);
+
+            public void Release() => _release.Set();
+
+            public void Dispose()
+            {
+                _release.Dispose();
+                LogEntered.Dispose();
+            }
+
+            private sealed class BlockingLogger : ILogger
+            {
+                private readonly BlockingLoggerProvider _provider;
+
+                public BlockingLogger(BlockingLoggerProvider provider) => _provider = provider;
+
+                public IDisposable BeginScope<TState>(TState state) => NullLogger.Instance.BeginScope(state);
+
+                public bool IsEnabled(LogLevel logLevel) => true;
+
+                public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+                {
+                    _provider.LogEntered.Set();
+                    _provider._release.Wait();
+                }
+            }
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Eventing/DeferredLogForwardingServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Eventing/DeferredLogForwardingServiceTests.cs
@@ -1,0 +1,134 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.WebJobs.Script.Tests;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
+{
+    public class DeferredLogForwardingServiceTests
+    {
+        [Fact]
+        public async Task ForwardsBufferedLogs_ToForwardingProviders()
+        {
+            var environment = new TestEnvironment();
+            var source = new DeferredLogSource();
+            source.Write(CreateErrorEntry("TestCategory", "Error Log"));
+
+            var testLoggerProvider = new TestLoggerProvider();
+            testLoggerProvider.SetScopeProvider(new LoggerExternalScopeProvider());
+
+            var service = new DeferredLogForwardingService(source, new ILoggerProvider[] { testLoggerProvider }, CreateOptions(isStandby: false), environment);
+
+            await service.StartAsync(CancellationToken.None);
+
+            // Complete the channel so the processing loop drains and exits.
+            source.Disable();
+            await service.ProcessingTask;
+
+            var message = Assert.Single(testLoggerProvider.GetAllLogMessages());
+            Assert.Equal("Error Log", message.FormattedMessage);
+
+            await service.StopAsync(CancellationToken.None);
+            service.Dispose();
+        }
+
+        [Fact]
+        public async Task DoesNotForward_InStandbyConfiguration()
+        {
+            var environment = new TestEnvironment();
+            var source = new DeferredLogSource();
+
+            var testLoggerProvider = new TestLoggerProvider();
+            var service = new DeferredLogForwardingService(source, new ILoggerProvider[] { testLoggerProvider }, CreateOptions(isStandby: true), environment);
+
+            await service.StartAsync(CancellationToken.None);
+
+            Assert.Null(service.ProcessingTask);
+
+            source.Write(CreateErrorEntry("TestCategory", "Error Log"));
+            Assert.Empty(testLoggerProvider.GetAllLogMessages());
+            Assert.Equal(1, source.Reader.Count);
+
+            await service.StopAsync(CancellationToken.None);
+            service.Dispose();
+        }
+
+        [Fact]
+        public async Task DoesNotForward_WhenForwardingDisabledByFeatureFlag()
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagDisableWebHostLogForwarding);
+            var source = new DeferredLogSource();
+
+            var testLoggerProvider = new TestLoggerProvider();
+            var service = new DeferredLogForwardingService(source, new ILoggerProvider[] { testLoggerProvider }, CreateOptions(isStandby: false), environment);
+
+            await service.StartAsync(CancellationToken.None);
+
+            Assert.Null(service.ProcessingTask);
+
+            await service.StopAsync(CancellationToken.None);
+            service.Dispose();
+        }
+
+        [Fact]
+        public async Task NoForwardingProviders_DoesNotStartReaderOrDisableSource()
+        {
+            var environment = new TestEnvironment();
+            var source = new DeferredLogSource();
+            source.Write(CreateErrorEntry("TestCategory", "Error Log"));
+
+            var service = new DeferredLogForwardingService(source, Array.Empty<ILoggerProvider>(), CreateOptions(isStandby: false), environment);
+
+            await service.StartAsync(CancellationToken.None);
+
+            // No reader is started, and the shared buffer is left intact (not disabled, not drained) so a
+            // later host that does have providers can still forward the buffered logs.
+            Assert.Null(service.ProcessingTask);
+            Assert.True(source.IsEnabled);
+            Assert.Equal(1, source.Reader.Count);
+
+            await service.StopAsync(CancellationToken.None);
+            service.Dispose();
+        }
+
+        [Fact]
+        public async Task StopAsync_StopsForwarding()
+        {
+            var environment = new TestEnvironment();
+            var source = new DeferredLogSource();
+
+            var testLoggerProvider = new TestLoggerProvider();
+            var service = new DeferredLogForwardingService(source, new ILoggerProvider[] { testLoggerProvider }, CreateOptions(isStandby: false), environment);
+
+            await service.StartAsync(CancellationToken.None);
+
+            // The service is parked waiting for logs; StopAsync should cancel and complete it.
+            await service.StopAsync(CancellationToken.None);
+
+            Assert.True(service.ProcessingTask.IsCompleted);
+            service.Dispose();
+        }
+
+        private static ScriptApplicationHostOptions CreateOptions(bool isStandby)
+        {
+            return new ScriptApplicationHostOptions { IsStandbyConfiguration = isStandby };
+        }
+
+        private static DeferredLogEntry CreateErrorEntry(string category, string message)
+        {
+            return new DeferredLogEntry
+            {
+                LogLevel = LogLevel.Error,
+                Category = category,
+                Message = message
+            };
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Eventing/DeferredLoggerProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Eventing/DeferredLoggerProviderTests.cs
@@ -1,15 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
-using Moq;
-using OpenTelemetry.Logs;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
@@ -22,89 +17,54 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
             var testEnvironment = new TestEnvironment();
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
 
-            // Arrange
-            var provider = new DeferredLoggerProvider(testEnvironment);
+            var provider = new DeferredLoggerProvider(new DeferredLogSource(), testEnvironment);
 
-            // Act
             var logger = provider.CreateLogger("TestCategory");
 
-            // Assert
             Assert.IsType<DeferredLogger>(logger);
         }
 
         [Fact]
-        public async Task CreateLogger_ReturnsNullLogger_WhenDisabled()
+        public void CreateLogger_ReturnsNullLogger_AfterDispose()
         {
             var testEnvironment = new TestEnvironment();
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
 
-            // Arrange
-            var provider = new DeferredLoggerProvider(testEnvironment);
-            await provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>());
+            var provider = new DeferredLoggerProvider(new DeferredLogSource(), testEnvironment);
+            provider.Dispose();
 
-            // Act
             var logger = provider.CreateLogger("TestCategory");
 
-            // Assert
             Assert.IsType<NullLogger>(logger);
         }
 
         [Fact]
-        public async Task ProcessBufferedLogs_DrainsChannelWithoutProviders()
+        public void Count_ReflectsBufferedErrorLogs()
         {
             var testEnvironment = new TestEnvironment();
-            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
 
-            // Arrange
-            var provider = new DeferredLoggerProvider(testEnvironment);
+            var provider = new DeferredLoggerProvider(new DeferredLogSource(), testEnvironment);
 
             var logger = provider.CreateLogger("TestCategory");
-            logger.LogInformation("Test Log Message");
+            logger.LogError("Test Log 1");
+            logger.LogError("Test Log 2");
 
-            // Act
-            await provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>());
-
-            // Assert
-            Assert.Equal(0, provider.Count); // Ensure channel is drained
+            Assert.Equal(2, provider.Count);
         }
 
         [Fact]
-        public async Task Dispose_DisablesProviderAndCompletesChannel()
+        public void Count_IgnoresLogsBelowError()
         {
             var testEnvironment = new TestEnvironment();
-            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
 
-            // Arrange
-            var provider = new DeferredLoggerProvider(testEnvironment);
-            var logger = provider.CreateLogger("TestCategory");
-            logger.LogInformation("Log before disposal");
-
-            // Act
-            await provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>());
-
-            // Assert
-            Assert.False(provider.CreateLogger("TestCategory") is DeferredLogger);
-            Assert.Equal(0, provider.Count); // Ensure channel is drained
-        }
-
-        [Fact]
-        public void Count_ShouldReturnNumberOfBufferedLogs()
-        {
-            var testEnvironment = new TestEnvironment();
-            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
-
-            // Arrange
-            var provider = new DeferredLoggerProvider(testEnvironment);
+            var provider = new DeferredLoggerProvider(new DeferredLogSource(), testEnvironment);
 
             var logger = provider.CreateLogger("TestCategory");
-            logger.LogInformation("Test Log 1");
-            logger.LogInformation("Test Log 2");
+            logger.LogInformation("Information is below the Error threshold");
 
-            // Act
-            int count = provider.Count;
-
-            // Assert
-            Assert.Equal(0, count);
+            Assert.Equal(0, provider.Count);
         }
 
         [Fact]
@@ -113,90 +73,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
             var testEnvironment = new TestEnvironment();
             testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
 
-            // Arrange
-            var provider = new DeferredLoggerProvider(testEnvironment);
+            var provider = new DeferredLoggerProvider(new DeferredLogSource(), testEnvironment);
 
-            // Act & Assert
-            provider.Dispose(); // First disposal
-            provider.Dispose(); // Second disposal, should not throw
-        }
-
-        [Fact]
-        public async Task ProcessBufferedLogs_ThrowsNoExceptionsWhenChannelIsEmpty()
-        {
-            var testEnvironment = new TestEnvironment();
-            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
-
-            // Arrange
-            var provider = new DeferredLoggerProvider(testEnvironment);
-            var mockLoggerProvider = new Mock<ILoggerProvider>();
-
-            var task = provider.ProcessBufferedLogsAsync(new[] { mockLoggerProvider.Object });
-
-            // Close the channel so that ProcessBufferedLogsAsync can complete
             provider.Dispose();
-
-            // Act & Assert (no exceptions should be thrown)
-            var exception = await Record.ExceptionAsync(() => task);
-            Assert.Null(exception);
-        }
-
-        [Fact]
-        public async Task Dispose_DoNotDisablesProviderAndCompletesChannel()
-        {
-            var testEnvironment = new TestEnvironment();
-            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
-
-            // Arrange
-            var provider = new DeferredLoggerProvider(testEnvironment);
-            var logger = provider.CreateLogger("TestCategory");
-            logger.LogError("Error Log");
-
-            // Create an instance of IOptionsMonitor<OpenTelemetryLoggerOptions>
-            var optionsMonitor = Mock.Of<IOptionsMonitor<OpenTelemetryLoggerOptions>>();
-
-            // Pass the optionsMonitor to the OpenTelemetryLoggerProvider constructor
-            //OpenTelemetryLoggerProvider openTelemetryLoggerProvider = new(optionsMonitor);
-            TestLoggerProvider testLoggerProvider = new TestLoggerProvider();
-            testLoggerProvider.SetScopeProvider(new LoggerExternalScopeProvider());
-
-            // Act
-            var task = provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>() { testLoggerProvider });
-
-            // Close the channel so that ProcessBufferedLogsAsync can complete
             provider.Dispose();
-            await task;
-            Assert.Equal(0, provider.Count); // Ensure channel is drained
-
-            // Assert that the log was forwarded to the testLoggerProvider
-            Assert.Equal(1, testLoggerProvider.GetAllLogMessages().Count);
-            Assert.Equal(Assert.Single(testLoggerProvider.GetAllLogMessages()).FormattedMessage, "Error Log");
-        }
-
-        [Fact]
-        public void Dispose_DoNotDisablesProvider()
-        {
-            var testEnvironment = new TestEnvironment();
-            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
-
-            // Arrange
-            var provider = new DeferredLoggerProvider(testEnvironment);
-            var logger = provider.CreateLogger("TestCategory");
-            logger.LogError("Error Log");
-
-            // Create an instance of IOptionsMonitor<OpenTelemetryLoggerOptions>
-            var optionsMonitor = Mock.Of<IOptionsMonitor<OpenTelemetryLoggerOptions>>();
-
-            // Pass the optionsMonitor to the OpenTelemetryLoggerProvider constructor
-            //OpenTelemetryLoggerProvider openTelemetryLoggerProvider = new(optionsMonitor);
-            TestLoggerProvider testLoggerProvider = new TestLoggerProvider();
-            testLoggerProvider.SetScopeProvider(new LoggerExternalScopeProvider());
-
-            // Act
-            _ = provider.ProcessBufferedLogsAsync(new List<ILoggerProvider>() { testLoggerProvider });
-
-            // Ensure that the LoggerProvider is not disabled and still returns DeferredLogger
-            Assert.True(provider.CreateLogger("TestCategory") is DeferredLogger);
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Eventing/DeferredLoggerProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Eventing/DeferredLoggerProviderTests.cs
@@ -25,6 +25,27 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
         }
 
         [Fact]
+        public void Log_CapturesActiveScopes()
+        {
+            var testEnvironment = new TestEnvironment();
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+
+            var source = new DeferredLogSource();
+            var provider = new DeferredLoggerProvider(source, testEnvironment);
+            provider.SetScopeProvider(new LoggerExternalScopeProvider());
+
+            ILogger logger = provider.CreateLogger("TestCategory");
+
+            using (logger.BeginScope("scope-1"))
+            {
+                logger.LogError("message");
+            }
+
+            Assert.True(source.Reader.TryRead(out DeferredLogEntry entry));
+            Assert.Equal("scope-1", Assert.Single(entry.ScopeStorage));
+        }
+
+        [Fact]
         public void CreateLogger_ReturnsNullLogger_AfterDispose()
         {
             var testEnvironment = new TestEnvironment();

--- a/test/WebJobs.Script.Tests/Eventing/DeferredLoggerProviderTests.cs
+++ b/test/WebJobs.Script.Tests/Eventing/DeferredLoggerProviderTests.cs
@@ -46,6 +46,32 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Eventing
         }
 
         [Fact]
+        public void Log_CapturesNestedScopes_OuterToInner()
+        {
+            var testEnvironment = new TestEnvironment();
+            testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+
+            var source = new DeferredLogSource();
+            var provider = new DeferredLoggerProvider(source, testEnvironment);
+            provider.SetScopeProvider(new LoggerExternalScopeProvider());
+
+            ILogger logger = provider.CreateLogger("TestCategory");
+
+            using (logger.BeginScope("outer"))
+            using (logger.BeginScope("inner"))
+            {
+                logger.LogError("message");
+            }
+
+            // Nested scopes must be captured in outer -> inner order so they can be reapplied in order when forwarded.
+            Assert.True(source.Reader.TryRead(out DeferredLogEntry entry));
+            Assert.Collection(
+                entry.ScopeStorage,
+                scope => Assert.Equal("outer", scope),
+                scope => Assert.Equal("inner", scope));
+        }
+
+        [Fact]
         public void CreateLogger_ReturnsNullLogger_AfterDispose()
         {
             var testEnvironment = new TestEnvironment();

--- a/test/WebJobs.Script.Tests/WebScriptHostBuilderExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/WebScriptHostBuilderExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.WebJobs.Script.Tests;
@@ -34,6 +35,33 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var hostingEnvironment = host.Services.GetRequiredService<IHostEnvironment>();
 
             Assert.False(hostingEnvironment.IsDevelopment());
+        }
+
+        [Fact]
+        public void AddWebScriptHost_ForwardsRootDeferredLogSource_ToScriptHost()
+        {
+            var rootSource = new DeferredLogSource();
+
+            var host = new HostBuilder()
+                .ConfigureDefaultTestWebScriptHost(null, null, false, configureRootServices: s =>
+                {
+                    s.AddSingleton(rootSource);
+                })
+                .Build();
+
+            // The ScriptHost's forwarding service must read the WebHost's shared buffer, not a separate instance.
+            Assert.Same(rootSource, host.Services.GetService<DeferredLogSource>());
+        }
+
+        [Fact]
+        public void AddWebScriptHost_UsesFallbackDeferredLogSource_WhenRootHasNone()
+        {
+            // ConfigureDefaultTestWebScriptHost doesn't register a DeferredLogSource; the ScriptHost falls back to a local buffer.
+            var host = new HostBuilder()
+                .ConfigureDefaultTestWebScriptHost()
+                .Build();
+
+            Assert.NotNull(host.Services.GetService<DeferredLogSource>());
         }
     }
 }


### PR DESCRIPTION
### Issue describing the changes in this PR

Fixes #11880. This fixes a race and a resource leak in WebHost deferred-log forwarding across ScriptHost restarts and specialization.

WebHost-level startup logs (Error level, captured outside placeholder/standby) are buffered and forwarded to the active ScriptHost's Application Insights / OpenTelemetry providers, which live in the ScriptHost DI scope and do not otherwise capture WebHost logs.

**Problem**

The bounded buffer lived inside the singleton `DeferredLoggerProvider`, and forwarding was started imperatively via a fire-and-forget `Task.Run(() => ProcessBufferedLogsAsync(...))` in `WebJobsScriptHostService` on every ScriptHost start. Across restart/specialization this:

- spun up multiple readers on a `SingleReader = true` channel, and
- leaked orphaned reader tasks that were never stopped, which competed for and dropped buffered entries (and forwarded to disposed providers).

**Changes**

- Extract the buffer into a non-disposable WebHost singleton `DeferredLogSource`.
- Add `DeferredLogForwardingService` (`IHostedService`) registered per ScriptHost (`WebScriptHostBuilderExtension`); forwarding starts/stops with the host, so only the active host reads the buffer. It skips standby/placeholder and the `DisableWebHostLogForwarding` feature flag, and forwards only to Application Insights / OpenTelemetry providers.
- Remove the imperative forwarding from `WebJobsScriptHostService`.
- Fix OpenTelemetry log flush on shutdown: `FlushOpenTelemetry` now `ForceFlush`-es the DI-owned OpenTelemetry `LoggerProvider` (alongside `MeterProvider`/`TracerProvider`) instead of disposing the `ILoggerProvider` wrapper.
- Cache `ILogger` per category per provider to avoid re-creating loggers (and their allocations) on every forwarded entry.
- Drain the shared buffer via `NullLoggerProvider` when a host has no AI/OTel providers, so entries aren't left unconsumed and a later host that does have providers can still forward — no host permanently disables the shared buffer.

**Testing**

- New `DeferredLogForwardingServiceTests` + reworked `DeferredLoggerProviderTests` cover host-scoped forwarding, standby/feature-flag skipping, scope capture/reapplication, no-op drain, per-provider resilience, and `StopAsync` honoring a cancelled token: 15/15 pass.
- `dotnet build` of WebHost + `WebJobs.Script.Tests` (Debug): 0 warnings, 0 errors.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
