### PR TITLE
fixing host shutdown deadlock

### DIFF
--- a/src/WebJobs.Script.Grpc/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -607,9 +607,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 {
                     // Issue only one restart at a time.
                     await _startWorkerProcessLock.WaitAsync();
+
                     // After waiting on the lock (which could take some time), make sure we're not in a disposed state trying to start things up
-                    if (_disposing || _disposed)
+                    if (IsShuttingDown)
                     {
+                        _logger.LogDebug("Skipping worker channel start for runtime '{runtime}' because the host is shutting down.", runtime ?? _workerRuntime);
                         return;
                     }
                     await InitializeJobhostLanguageWorkerChannelAsync(_languageWorkerErrors.Count, _workerRuntime);

--- a/src/WebJobs.Script.Grpc/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
+++ b/src/WebJobs.Script.Grpc/Rpc/FunctionRegistration/RpcFunctionInvocationDispatcher.cs
@@ -9,7 +9,6 @@ using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Azure.WebJobs.Host.Executors.Internal;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Config;
@@ -124,6 +123,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
         internal ConcurrentStack<WorkerErrorEvent> LanguageWorkerErrors => _languageWorkerErrors;
 
         internal IWebHostRpcWorkerChannelManager WebHostLanguageWorkerChannelManager => _webHostLanguageWorkerChannelManager;
+
+        private bool IsShuttingDown =>
+            _disposing
+            || _disposed
+            || (_applicationLifetime?.ApplicationStopping.IsCancellationRequested ?? false);
 
         private async Task<int> GetMaxProcessCount()
         {
@@ -586,8 +590,9 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 
         private async Task StartWorkerChannel(string runtime)
         {
-            if (_disposing || _disposed)
+            if (IsShuttingDown)
             {
+                _logger.LogDebug("Skipping worker channel start for runtime '{runtime}' because the host is shutting down.", runtime ?? _workerRuntime);
                 return;
             }
 

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         private TestLoggerProvider _webHostLoggerProvider;
         private bool _timerFired = false;
         private bool _isDisposed = false;
+        private bool _webHostDisposed;
 
         public TestFunctionHost(string scriptPath,
             Action<IServiceCollection> configureWebHostServices = null,
@@ -507,12 +508,59 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             return JwtTokenHelper.CreateToken(validUntil, audience, issuer, key, notBefore);
         }
 
+
+        /// <summary>
+        /// Temporary method to dispose the web host. This is needed because the web host is not disposed 
+        /// when the test fixture is disposed, which can cause issues with subsequent tests. We are selectively
+        /// enabing this throughought tests and will eventually make it private and call it from DisposeAsync once
+        /// all issues are resolved.
+        /// </summary>        
+        internal async Task StopAndDisposeWebHostAsync()
+        {
+            if (_webHostDisposed)
+            {
+                return;
+            }
+
+            try
+            {
+                if (_webHost is not null)
+                {
+                    try
+                    {
+                        await _webHost.StopAsync();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // In case dispose has already run from elsewhere.
+                    }
+                    catch (AggregateException ex) when (ex.InnerExceptions.Count > 0 && ex.InnerExceptions.All(e => e is ObjectDisposedException))
+                    {
+                        // In case dispose has already run from elsewhere.
+                    }
+                }
+            }
+            finally
+            {
+                if (_webHost is IAsyncDisposable asyncDisposable)
+                {
+                    await asyncDisposable.DisposeAsync();
+                }
+                else
+                {
+                    _webHost?.Dispose();
+                }
+            }
+
+            _webHostDisposed = true;
+        }
+
         public void Dispose()
         {
             if (!_isDisposed)
             {
                 HttpClient.Dispose();
-                
+
                 _stillRunningTimer?.Change(-1, -1);
                 _stillRunningTimer?.Dispose();
 

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -512,7 +512,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         /// <summary>
         /// Temporary method to dispose the web host. This is needed because the web host is not disposed 
         /// when the test fixture is disposed, which can cause issues with subsequent tests. We are selectively
-        /// enabing this throughought tests and will eventually make it private and call it from DisposeAsync once
+        /// enabling this on some tests and will eventually make it private and call it from DisposeAsync once
         /// all issues are resolved.
         /// </summary>        
         internal async Task StopAndDisposeWebHostAsync()

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/NodeHostRestartEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/NodeHostRestartEndToEndTests.cs
@@ -125,5 +125,11 @@ public class NodeHostRestartEndToEndTests
                     nodeConfig.CountOptions.ProcessStartupInterval = ProcessStartupInterval;
                 });
         }
+
+        public override async Task DisposeAsync()
+        {
+            await Host.StopAndDisposeWebHostAsync();
+            await base.DisposeAsync();
+        }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node.cs
@@ -9,10 +9,8 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Storage.Blobs;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Models;
@@ -361,6 +359,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                         "proxyroute"
                     };
                 });
+            }
+
+            public override async Task DisposeAsync()
+            {
+                await Host.StopAndDisposeWebHostAsync();
+                await base.DisposeAsync();
             }
         }
     }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcessesNoBundle.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcessesNoBundle.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -73,6 +73,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                         "HttpTrigger"
                     };
                 });
+            }
+
+            public override async Task DisposeAsync()
+            {
+                await Host.StopAndDisposeWebHostAsync();
+                await base.DisposeAsync();
             }
         }
     }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcessesNoBundle.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcessesNoBundle.cs
@@ -74,12 +74,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                     };
                 });
             }
-
-            public override async Task DisposeAsync()
-            {
-                await Host.StopAndDisposeWebHostAsync();
-                await base.DisposeAsync();
-            }
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcFunctionInvocationDispatcherTests.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.Azure.WebJobs.Host.Executors.Internal;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Description;
@@ -711,6 +710,51 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.Equal(FunctionInvocationScope.User, FunctionInvoker.CurrentScope);
         }
 
+        [Fact]
+        public async Task WorkerRestart_DuringApplicationStopping_DisposesChannel_DoesNotRestart()
+        {
+            // This test exercises the scenario where Host.StopAsync() fires ApplicationStopping,
+            // a worker exits (e.g. due to WorkerTerminate message), and the OnProcessExited handler
+            // publishes a WorkerRestartEvent before disposal. Without the fix, the dispatcher would
+            // restart the worker — creating a new channel during shutdown that will never be disposed
+            // and leads to a JobObjectRegistry deadlock.
+
+            int expectedProcessCount = 1;
+            var stoppingSource = new CancellationTokenSource();
+            RpcFunctionInvocationDispatcher functionDispatcher = GetTestFunctionDispatcher(
+                expectedProcessCount,
+                runtime: RpcWorkerConstants.NodeLanguageWorkerName,
+                applicationStoppingSource: stoppingSource);
+
+            await functionDispatcher.InitializeAsync(GetTestFunctionsList(RpcWorkerConstants.NodeLanguageWorkerName));
+            await WaitForJobhostWorkerChannelsToStartup(functionDispatcher, expectedProcessCount);
+
+            TestRpcWorkerChannel testWorkerChannel = (TestRpcWorkerChannel)functionDispatcher
+                .JobHostLanguageWorkerChannelManager.GetChannels().FirstOrDefault();
+            Assert.NotNull(testWorkerChannel);
+
+            // Simulate Host.StopAsync() beginning — fires ApplicationStopping before any
+            // hosted services stop or the dispatcher is disposed.
+            stoppingSource.Cancel();
+
+            // Worker exits and publishes WorkerRestartEvent (same as OnProcessExited with exit code 0).
+            // The event subscription is still alive — only Dispose() detaches it.
+            testWorkerChannel.RaiseWorkerRestart();
+
+            // Wait for the log that proves StartWorkerChannel was entered and skipped.
+            await TestHelpers.Await(
+                () => _testLoggerProvider.GetAllLogMessages().Any(m =>
+                    m.FormattedMessage.Contains("Skipping worker channel start") &&
+                    m.FormattedMessage.Contains("shutting down")),
+                timeout: 5000,
+                pollingInterval: 100);
+
+            // The original channel should be disposed (removed by ShutdownChannelIfExistsAsync).
+            // No new channel should be created — restart was blocked by IsShuttingDown.
+            int channelCount = functionDispatcher.JobHostLanguageWorkerChannelManager.GetChannels().Count();
+            Assert.Equal(0, channelCount);
+        }
+
         private static RpcFunctionInvocationDispatcher GetTestFunctionDispatcher(
             int maxProcessCountValue = 1,
             bool addWebhostChannel = false,
@@ -720,11 +764,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             string runtime = null,
             bool workerIndexing = false,
             bool placeholder = false,
-            IRpcWorkerChannelFactory channelFactory = null)
+            IRpcWorkerChannelFactory channelFactory = null,
+            CancellationTokenSource applicationStoppingSource = null)
         {
             var eventManager = new ScriptEventManager();
             var metricsLogger = new Mock<IMetricsLogger>();
             var mockApplicationLifetime = new Mock<IHostApplicationLifetime>();
+            var stoppingSource = applicationStoppingSource ?? new CancellationTokenSource();
+            mockApplicationLifetime.Setup(m => m.ApplicationStopping).Returns(stoppingSource.Token);
             var testEnv = new TestEnvironment();
             TimeSpan intervals = startupIntervals ?? TimeSpan.FromMilliseconds(100);
 


### PR DESCRIPTION
One of the overarching issues with our test runs is that we do not stop and dispose WebHosts all the time, specifically from the TestFunctionsHost. When I attempted to do this, I ran into several deadlocks and/or process crashes that broke the tests. I'll be spot-fixing these over the next few PRs to hopefully allow us to stop and dispose the WebHost with every usage of TestFunctionsHost.

In this fix, there was a scenario best explained in the comment in the test that was added:

```
 // This test exercises the scenario where Host.StopAsync() fires ApplicationStopping,
 // a worker exits (e.g. due to WorkerTerminate message), and the OnProcessExited handler
 // publishes a WorkerRestartEvent before disposal. Without the fix, the dispatcher would
 // restart the worker — creating a new channel during shutdown that will never be disposed
 // and leads to a JobObjectRegistry deadlock.
```

The fix is very targeted -- we skip restarts when we know ApplicationStopping has already fired (rather thanjust on disposal).

I've enabled WebHost stop/dispose on some tests that hit this error, and now they are passing after the fix.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)