### PR TITLE
fix channel init/shutdown race

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Fixed a WebHost worker channel shutdown race that could hang host teardown when a language worker was still initializing. (#11853)

--- a/src/WebJobs.Script.Grpc/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script.Grpc/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -86,6 +86,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                         _logger.LogError("Failed to start language worker process for runtime: {language}. workerId:{id}", runtime, rpcWorkerChannel.Id);
                         SetExceptionOnInitializedWorkerChannel(runtime, rpcWorkerChannel, processStartTask.Exception);
                     }
+                    else if (processStartTask.Status == TaskStatus.Canceled)
+                    {
+                        _logger.LogDebug("Language worker process start was canceled for runtime: {language}. workerId:{id}", runtime, rpcWorkerChannel.Id);
+                        SetExceptionOnInitializedWorkerChannel(runtime, rpcWorkerChannel, new TaskCanceledException(processStartTask));
+                    }
                 });
             }
             catch (Exception ex)
@@ -345,6 +350,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     {
                         if (standbyChannels.TryGetValue(workerId, out TaskCompletionSource<IRpcWorkerChannel> channelTask))
                         {
+                            // Signal any in-flight initialization that we are shutting down.
+                            // If the ContinueWith in InitializeLanguageWorkerChannel hasn't completed yet,
+                            // TrySetCanceled resolves the TCS immediately so we don't block forever.
+                            // If it already ran (SetResult or SetException), TrySetCanceled is a no-op.
+                            channelTask.TrySetCanceled();
+
                             IRpcWorkerChannel workerChannel = null;
 
                             try
@@ -398,8 +409,15 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                 if (channel.TryGetValue(initializedLanguageWorkerChannel.Id, out TaskCompletionSource<IRpcWorkerChannel> value))
                 {
                     value.SetResult(initializedLanguageWorkerChannel);
+                    return;
                 }
             }
+
+            // The runtime was already removed from _workerChannels by ShutdownChannelsAsync.
+            // The TCS was canceled so ShutdownChannelsAsync won't dispose this channel.
+            // Dispose it here to avoid leaking the worker process.
+            _logger.LogDebug("Channel for workerId:{id} initialized after shutdown removed it from the dictionary. Disposing.", initializedLanguageWorkerChannel.Id);
+            initializedLanguageWorkerChannel.ShutdownAndDispose(null, _logger);
         }
 
         internal void SetExceptionOnInitializedWorkerChannel(string initializedRuntime, IRpcWorkerChannel initializedLanguageWorkerChannel, Exception exception)
@@ -412,6 +430,13 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
                     value.SetException(exception);
                 }
             }
+
+            // The worker process may have started and registered with the process registry before
+            // StartWorkerProcessAsync faulted. Dispose the channel so the underlying WorkerProcess
+            // is cleaned up; otherwise the channel reference falls out of scope and the worker
+            // process leaks until the WebHost shuts down — at which point JobObjectRegistry.Close
+            // blocks forever waiting on ProcessWaitingForTermination.
+            initializedLanguageWorkerChannel.ShutdownAndDispose(null, _logger);
         }
     }
 }

--- a/src/WebJobs.Script.Grpc/Rpc/WebHostRpcWorkerChannelManager.cs
+++ b/src/WebJobs.Script.Grpc/Rpc/WebHostRpcWorkerChannelManager.cs
@@ -408,16 +408,20 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             {
                 if (channel.TryGetValue(initializedLanguageWorkerChannel.Id, out TaskCompletionSource<IRpcWorkerChannel> value))
                 {
-                    value.SetResult(initializedLanguageWorkerChannel);
-                    return;
+                    if (value.TrySetResult(initializedLanguageWorkerChannel))
+                    {
+                        return;
+                    }
+
+                    _logger.LogDebug("Channel for workerId:{id} initialized after its initialization task was already completed. Disposing.", initializedLanguageWorkerChannel.Id);
                 }
             }
+            else
+            {
+                _logger.LogDebug("Channel for workerId:{id} initialized after shutdown removed it from the dictionary. Disposing.", initializedLanguageWorkerChannel.Id);
+            }
 
-            // The runtime was already removed from _workerChannels by ShutdownChannelsAsync.
-            // The TCS was canceled so ShutdownChannelsAsync won't dispose this channel.
-            // Dispose it here to avoid leaking the worker process.
-            _logger.LogDebug("Channel for workerId:{id} initialized after shutdown removed it from the dictionary. Disposing.", initializedLanguageWorkerChannel.Id);
-            initializedLanguageWorkerChannel.ShutdownAndDispose(null, _logger);
+            ShutdownAndDisposeChannel(initializedLanguageWorkerChannel);
         }
 
         internal void SetExceptionOnInitializedWorkerChannel(string initializedRuntime, IRpcWorkerChannel initializedLanguageWorkerChannel, Exception exception)
@@ -427,7 +431,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             {
                 if (channel.TryGetValue(initializedLanguageWorkerChannel.Id, out TaskCompletionSource<IRpcWorkerChannel> value))
                 {
-                    value.SetException(exception);
+                    value.TrySetException(exception);
                 }
             }
 
@@ -436,7 +440,19 @@ namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
             // is cleaned up; otherwise the channel reference falls out of scope and the worker
             // process leaks until the WebHost shuts down — at which point JobObjectRegistry.Close
             // blocks forever waiting on ProcessWaitingForTermination.
-            initializedLanguageWorkerChannel.ShutdownAndDispose(null, _logger);
+            ShutdownAndDisposeChannel(initializedLanguageWorkerChannel);
+        }
+
+        private void ShutdownAndDisposeChannel(IRpcWorkerChannel workerChannel)
+        {
+            try
+            {
+                workerChannel.ShutdownAndDispose(null, _logger);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Error disposing worker channel");
+            }
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
@@ -302,6 +302,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public virtual async Task DisposeAsync()
         {
+            await Host.StopAndDisposeWebHostAsync();
+
             if (Host is not null)
             {
                 var fileMonitoringService = Host.JobHostServices?.GetService<IFileMonitoringService>();

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
@@ -302,10 +302,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public virtual async Task DisposeAsync()
         {
-            await Host.StopAndDisposeWebHostAsync();
-
             if (Host is not null)
             {
+                await Host.StopAndDisposeWebHostAsync();
+
                 var fileMonitoringService = Host.JobHostServices?.GetService<IFileMonitoringService>();
                 if (fileMonitoringService is not null)
                 {

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcessesNoBundle.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcessesNoBundle.cs
@@ -74,6 +74,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                     };
                 });
             }
+
+            public override async Task DisposeAsync()
+            {
+                await Host.StopAndDisposeWebHostAsync();
+                await base.DisposeAsync();
+            }
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcessesNoBundle.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node_MultipleProcessesNoBundle.cs
@@ -75,11 +75,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                 });
             }
 
-            public override async Task DisposeAsync()
-            {
-                await Host.StopAndDisposeWebHostAsync();
-                await base.DisposeAsync();
-            }
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
@@ -800,6 +800,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             var completed = await Task.WhenAny(shutdownTask, Task.Delay(TimeSpan.FromSeconds(15)));
 
             Assert.True(ReferenceEquals(completed, shutdownTask), "ShutdownChannelsAsync deadlocked waiting on an uninitialized channel's TCS.");
+            await shutdownTask;
         }
 
         private WebHostRpcWorkerChannelManager CreateChannelManager(string workerRuntime, IRpcWorkerChannelFactory channelFactory = null, IMetricsLogger metrics = null,

--- a/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/WebHostRpcWorkerChannelManagerTests.cs
@@ -773,6 +773,35 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.Null(_rpcWorkerChannelManager.GetChannels(RpcWorkerConstants.JavaLanguageWorkerName));
         }
 
+        [Fact]
+        public async Task ShutdownChannelsAsync_UninitializedChannel_DoesNotDeadlock()
+        {
+            // This test reproduces the race condition where ShutdownChannelsAsync runs while a
+            // channel is still initializing (TCS has not been completed). In production this happens
+            // when the host shuts down before all worker processes finish their init handshake.
+            //
+            // The bug: ShutdownChannelsAsync does TryRemove on the runtime key, then awaits the
+            // TCS. Meanwhile, the ContinueWith (which would call SetInitializedWorkerChannel) can
+            // no longer find the TCS in the dict to call SetResult — so the TCS is never completed
+            // and ShutdownChannelsAsync blocks forever.
+            //
+            // Without a fix, this test will time out.
+
+            var testChannel = _rpcWorkerChannelFactory.Create(
+                _scriptRootPath, RpcWorkerConstants.NodeLanguageWorkerName, null, 0,
+                _workerOptionsMonitor.CurrentValue.WorkerConfigs);
+
+            // Add the channel to the dict (creates the TCS) but do NOT call
+            // SetInitializedWorkerChannel — simulating a channel mid-initialization.
+            _rpcWorkerChannelManager.AddOrUpdateWorkerChannels(RpcWorkerConstants.NodeLanguageWorkerName, testChannel);
+
+            // ShutdownChannelsAsync should complete within a reasonable time, not block forever.
+            var shutdownTask = _rpcWorkerChannelManager.ShutdownChannelsAsync();
+            var completed = await Task.WhenAny(shutdownTask, Task.Delay(TimeSpan.FromSeconds(15)));
+
+            Assert.True(ReferenceEquals(completed, shutdownTask), "ShutdownChannelsAsync deadlocked waiting on an uninitialized channel's TCS.");
+        }
+
         private WebHostRpcWorkerChannelManager CreateChannelManager(string workerRuntime, IRpcWorkerChannelFactory channelFactory = null, IMetricsLogger metrics = null,
             IConfiguration config = null)
         {


### PR DESCRIPTION
## Summary

Fixes a WebHost RPC worker channel shutdown race where `ShutdownChannelsAsync` could wait forever on a worker channel that was added to the channel dictionary but had not finished initializing yet.

The race was exposed by explicitly stopping and disposing WebHost instances in E2E fixture cleanup. If shutdown removed the runtime entry while initialization was still in flight, the initialization continuation could no longer complete the pending channel task, leaving shutdown blocked.

## Changes

- Cancels pending worker channel initialization tasks during `ShutdownChannelsAsync` so shutdown does not wait indefinitely.
- Disposes worker channels that finish initializing after shutdown has already removed their runtime entry.
- Disposes channels whose worker startup faults or is canceled, preventing worker process leaks.
- Adds a regression test for an uninitialized worker channel during shutdown.
- Stops and disposes WebHost instances from E2E fixture cleanup to exercise the shutdown path more broadly.

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)