### PR TITLE
fix timeouttest log verification

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/EndToEndTimeoutTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/ScriptHostEndToEnd/EndToEndTimeoutTests.cs
@@ -39,12 +39,12 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         [Fact]
         public async Task TimeoutTest_UsingToken_CSharp()
         {
-            await RunTokenTest("useToken", async (logs) =>
+            await RunTokenTest("useToken", async () =>
              {
                  // The function should 'clean up' and write 'Done'
                  await TestHelpers.Await(() =>
                  {
-                     var doneLog = logs.SingleOrDefault(l => l.EndsWith("Done"));
+                     var doneLog = GetFormattedLogMessages().SingleOrDefault(l => l.EndsWith("Done"));
                      return doneLog != null;
                  });
              });
@@ -53,16 +53,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         [Fact]
         public async Task TimeoutTest_IgnoringToken_CSharp()
         {
-            await RunTokenTest("ignoreToken", (logs) =>
+            await RunTokenTest("ignoreToken", () =>
              {
                  // We do not expect 'Done' to be written here.
+                 var logs = GetFormattedLogMessages();
                  Assert.NotEmpty(logs);
                  Assert.False(logs.Any(l => l.EndsWith("Done")));
                  return Task.CompletedTask;
              });
         }
 
-        private async Task RunTokenTest(string scenario, Func<IEnumerable<string>, Task> verify)
+        private async Task RunTokenTest(string scenario, Func<Task> verify)
         {
             string functionName = "TimeoutToken";
             TestHelpers.ClearFunctionLogs(functionName);
@@ -81,8 +82,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                 var exception = GetExceptionHandler(host).TimeoutExceptionInfos.Single().SourceException;
                 Assert.IsType<FunctionTimeoutException>(exception);
 
-                await verify(_loggerProvider.GetAllLogMessages().Where(t => t.FormattedMessage != null).Select(t => t.FormattedMessage));
+                await verify();
             }
+        }
+
+        private IEnumerable<string> GetFormattedLogMessages()
+        {
+            return _loggerProvider.GetAllLogMessages()
+                .Where(t => t.FormattedMessage != null)
+                .Select(t => t.FormattedMessage);
         }
 
         private async Task RunTimeoutTest(string scriptLang, string functionName)


### PR DESCRIPTION
Turns out the timeout tests weren't recalculating logs while they were using `Await()` . So if they captured logs without 'Done' written in them at first, they'd never see them. 

This, plus previous cleanups hopefully fix this one for good.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)