### PR TITLE
Modifying Admin Isolation rules for Kudu sync triggers operations

### DIFF
--- a/src/WebJobs.Script.WebHost/Security/Authentication/ClaimsPrincipalExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/ClaimsPrincipalExtensions.cs
@@ -11,5 +11,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication
         {
             return principal.HasClaim(SecurityConstants.FuncPlatformClaimType, "true");
         }
+
+        public static bool IsScmSite(this ClaimsPrincipal principal)
+        {
+            return principal.HasClaim(SecurityConstants.ScmSiteTokenClaimType, "true");
+        }
     }
 }

--- a/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/Jwt/ScriptJwtBearerExtensions.cs
@@ -77,6 +77,12 @@ namespace Microsoft.Extensions.DependencyInjection
                         claims.Add(new Claim(SecurityConstants.FuncPlatformClaimType, "true"));
                     }
 
+                    string scmSiteIssuer = string.Format(ScmSiteUriFormat, ScriptSettingsManager.Instance.GetSetting(AzureWebsiteName));
+                    if (string.Equals(c.SecurityToken.Issuer, scmSiteIssuer, StringComparison.OrdinalIgnoreCase))
+                    {
+                        claims.Add(new Claim(SecurityConstants.ScmSiteTokenClaimType, "true"));
+                    }
+
                     c.Principal.AddIdentity(new ClaimsIdentity(claims));
                     c.Success();
 

--- a/src/WebJobs.Script.WebHost/Security/Authentication/SecurityConstants.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authentication/SecurityConstants.cs
@@ -26,5 +26,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication
         /// such as unencrypted assignment and triggers retrieval.
         /// </summary>
         public const string FuncPlatformClaimType = "http://schemas.microsoft.com/2017/07/functions/claims/func-platform";
+
+        /// <summary>
+        /// Claim indicating that the principal was authenticated via a site token issued by the
+        /// SCM (Kudu) site. This identifies the request as originating from the same-sandbox Kudu
+        /// peer.
+        /// </summary>
+        public const string ScmSiteTokenClaimType = "http://schemas.microsoft.com/2017/07/functions/claims/scm-site";
     }
 }

--- a/src/WebJobs.Script.WebHost/Security/Authorization/Policies/AuthorizationOptionsExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Security/Authorization/Policies/AuthorizationOptionsExtensions.cs
@@ -1,14 +1,19 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Script.Extensions;
 using Microsoft.Azure.WebJobs.Script.WebHost.Authentication;
 using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
+using Microsoft.Azure.WebJobs.Script.WebHost.Controllers;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -26,7 +31,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies
                 {
                     if (c.Resource is AuthorizationFilterContext filterContext)
                     {
-                        if (!EnforceAdminIsolation(filterContext.HttpContext, allowAppServiceInternal: true))
+                        if (!IsScmSyncTriggers(filterContext, c.User)
+                            && !EnforceAdminIsolation(filterContext.HttpContext, allowAppServiceInternal: true))
                         {
                             return false;
                         }
@@ -94,6 +100,22 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Determines whether the request targets the host SyncTriggers endpoint and is authenticated via an
+        /// SCM (Kudu) site token. Such requests are exempt from admin isolation enforcement. The endpoint accepts
+        /// no payload (it only signals the host to re-read trigger metadata from disk), so this is low risk.
+        /// </summary>
+        /// <param name="filterContext">The <see cref="AuthorizationFilterContext"/> for the current request.</param>
+        /// <param name="user">The authenticated principal for the current request.</param>
+        /// <returns>True if the request is an SCM-authenticated SyncTriggers call; otherwise, false.</returns>
+        private static bool IsScmSyncTriggers(AuthorizationFilterContext filterContext, ClaimsPrincipal user)
+        {
+            return filterContext.ActionDescriptor is ControllerActionDescriptor { MethodInfo: { } method }
+                && method.DeclaringType == typeof(HostController)
+                && string.Equals(method.Name, nameof(HostController.SyncTriggers), StringComparison.Ordinal)
+                && user.IsScmSite();
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_CSharp.cs
@@ -268,6 +268,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         {
             var environment = this._fixture.Host.WebHostServices.GetService<IEnvironment>();
             string originalWebsiteInstanceId = environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId);
+            string originalWebsiteSku = environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku);
+            string originalAdminIsolationEnabled = environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsAdminIsolationEnabled);
 
             environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, sku);
             environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, websiteInstanceId);
@@ -305,8 +307,96 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
             }
             finally
             {
-                environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionsAdminIsolationEnabled, null);
+                environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionsAdminIsolationEnabled, originalAdminIsolationEnabled);
                 environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, originalWebsiteInstanceId);
+                environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, originalWebsiteSku);
+            }
+        }
+
+        public enum SyncTriggersAuthMode
+        {
+            None,
+            ScmSiteToken,
+            NonScmSiteToken,
+            MasterKey
+        }
+
+        [Theory]
+        [Trait(TestTraits.Group, TestTraits.AdminIsolationTests)]
+        // The fix: isolation enabled, request routed through the Front End, authenticated with an SCM (Kudu)
+        // site token. The synctriggers exemption applies and the request succeeds where other admin endpoints would 403.
+        [InlineData(true, false, false, SyncTriggersAuthMode.ScmSiteToken, HttpStatusCode.OK)]
+        // The exemption is scoped to the SCM caller: a valid but non-SCM admin token is still rejected under isolation.
+        [InlineData(true, false, false, SyncTriggersAuthMode.NonScmSiteToken, HttpStatusCode.Forbidden)]
+        // A leaked master key is likewise still rejected under isolation - the exemption does not open the endpoint to it.
+        [InlineData(true, false, false, SyncTriggersAuthMode.MasterKey, HttpStatusCode.Forbidden)]
+        // The exemption does not bypass authentication - a request with no credentials is still rejected.
+        [InlineData(true, false, false, SyncTriggersAuthMode.None, HttpStatusCode.Unauthorized)]
+        // Existing isolation allowances are unaffected: platform-internal callers still succeed.
+        [InlineData(true, true, false, SyncTriggersAuthMode.MasterKey, HttpStatusCode.OK)]
+        // Existing isolation allowances are unaffected: AppService-internal (Front End bypassed) callers still succeed.
+        [InlineData(true, false, true, SyncTriggersAuthMode.MasterKey, HttpStatusCode.OK)]
+        // With isolation disabled, behavior is unchanged from today for both master key and SCM token callers.
+        [InlineData(false, false, false, SyncTriggersAuthMode.MasterKey, HttpStatusCode.OK)]
+        [InlineData(false, false, false, SyncTriggersAuthMode.ScmSiteToken, HttpStatusCode.OK)]
+        public async Task SyncTriggers_AdminIsolation_ReturnsExpectedStatus(bool enableIsolation, bool isPlatformInternal, bool bypassFE, SyncTriggersAuthMode authMode, HttpStatusCode expectedStatus)
+        {
+            var environment = _fixture.Host.WebHostServices.GetService<IEnvironment>();
+            string originalWebsiteInstanceId = environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId);
+            string originalWebsiteSku = environment.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku);
+            string originalAdminIsolationEnabled = environment.GetEnvironmentVariable(EnvironmentSettingNames.FunctionsAdminIsolationEnabled);
+
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, ScriptConstants.DynamicSku);
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, "1");
+
+            try
+            {
+                if (enableIsolation)
+                {
+                    environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionsAdminIsolationEnabled, "1");
+                    Assert.True(environment.IsAdminIsolationEnabled());
+                }
+
+                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "admin/host/synctriggers");
+
+                switch (authMode)
+                {
+                    case SyncTriggersAuthMode.ScmSiteToken:
+                        // Token issued by the SCM (Kudu) site - this is what unlocks the synctriggers isolation exemption.
+                        request.Headers.Add(ScriptConstants.SiteTokenHeaderName, _fixture.Host.GenerateAdminJwtToken());
+                        break;
+                    case SyncTriggersAuthMode.NonScmSiteToken:
+                        // Valid admin token, but issued by a non-SCM issuer, so the exemption must not apply.
+                        request.Headers.Add(ScriptConstants.SiteTokenHeaderName, _fixture.Host.GenerateAdminJwtToken(issuer: ScriptConstants.AppServiceCoreUri));
+                        break;
+                    case SyncTriggersAuthMode.MasterKey:
+                        request.Headers.Add(AuthenticationLevelHandler.FunctionsKeyHeaderName, await _fixture.Host.GetMasterKeyAsync());
+                        break;
+                    case SyncTriggersAuthMode.None:
+                        break;
+                }
+
+                if (isPlatformInternal)
+                {
+                    request.Headers.Add(ScriptConstants.AntaresPlatformInternal, "True");
+                }
+
+                if (!bypassFE)
+                {
+                    request.Headers.Add(ScriptConstants.AntaresLogIdHeaderName, Guid.NewGuid().ToString());
+                }
+
+                using (var httpClient = _fixture.Host.CreateHttpClient())
+                {
+                    HttpResponseMessage response = await httpClient.SendAsync(request);
+                    Assert.Equal(expectedStatus, response.StatusCode);
+                }
+            }
+            finally
+            {
+                environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionsAdminIsolationEnabled, originalAdminIsolationEnabled);
+                environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, originalWebsiteInstanceId);
+                environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, originalWebsiteSku);
             }
         }
 

--- a/test/WebJobs.Script.Tests/Security/Authorization/AuthorizationOptionsExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/Security/Authorization/AuthorizationOptionsExtensionsTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Script.WebHost.Controllers;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authentication;
+using Microsoft.Azure.WebJobs.Script.WebHost.Security.Authorization.Policies;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Security.Authorization
+{
+    public class AuthorizationOptionsExtensionsTests
+    {
+        [Theory]
+        // The fix: the SyncTriggers action, with isolation enabled and the request routed through the
+        // Front End, is allowed when the caller presents an SCM (Kudu) site token.
+        [InlineData(nameof(HostController.SyncTriggers), true, true, false, true)]
+        // Caller scoping: the same SyncTriggers request without an SCM token remains blocked under isolation.
+        [InlineData(nameof(HostController.SyncTriggers), true, false, false, false)]
+        // Endpoint scoping: a different admin action is still blocked under isolation even with an SCM token.
+        [InlineData(nameof(HostController.GetHostStatus), true, true, false, false)]
+        // With isolation disabled, the assertion always allows the request.
+        [InlineData(nameof(HostController.SyncTriggers), false, false, false, true)]
+        // Existing allowance is unaffected: an AppService-internal request (Front End bypassed) is allowed.
+        [InlineData(nameof(HostController.SyncTriggers), true, false, true, true)]
+        [InlineData(nameof(HostController.GetHostStatus), true, false, true, true)]
+        public async Task AdminAuthLevelPolicy_SyncTriggersExemption_ScopedToScmCaller(string actionName, bool isolationEnabled, bool isScmToken, bool bypassFrontEnd, bool expectSuccess)
+        {
+            AssertionRequirement assertion = GetAdminAuthLevelAssertion();
+
+            var user = CreateUser(isScmToken);
+            AuthorizationFilterContext filterContext = CreateFilterContext(actionName, isolationEnabled, bypassFrontEnd, user);
+            var context = new AuthorizationHandlerContext(new[] { assertion }, user, filterContext);
+
+            await assertion.HandleAsync(context);
+
+            Assert.Equal(expectSuccess, context.HasSucceeded);
+        }
+
+        private static AssertionRequirement GetAdminAuthLevelAssertion()
+        {
+            var options = new AuthorizationOptions();
+            options.AddScriptPolicies();
+
+            AuthorizationPolicy policy = options.GetPolicy(PolicyNames.AdminAuthLevel);
+            return policy.Requirements.OfType<AssertionRequirement>().Single();
+        }
+
+        private static ClaimsPrincipal CreateUser(bool isScmToken)
+        {
+            var claims = new List<Claim>
+            {
+                new Claim(SecurityConstants.AuthLevelClaimType, AuthorizationLevel.Admin.ToString())
+            };
+
+            if (isScmToken)
+            {
+                claims.Add(new Claim(SecurityConstants.ScmSiteTokenClaimType, "true"));
+            }
+
+            return new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+        }
+
+        private static AuthorizationFilterContext CreateFilterContext(string actionName, bool isolationEnabled, bool bypassFrontEnd, ClaimsPrincipal user)
+        {
+            var environment = new TestEnvironment();
+
+            // Populating the instance id makes the host treat itself as App Service, which ensures all
+            // requests are expected to flow through the Front End (so admin isolation is enforced).
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteInstanceId, "1");
+
+            if (isolationEnabled)
+            {
+                environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionsAdminIsolationEnabled, "1");
+            }
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IEnvironment>(environment);
+
+            var httpContext = new DefaultHttpContext
+            {
+                RequestServices = services.BuildServiceProvider(),
+                User = user
+            };
+
+            if (!bypassFrontEnd)
+            {
+                // The presence of this header indicates the request was routed through the Front End,
+                // i.e. it is not an internal (Front End bypassing) request.
+                httpContext.Request.Headers[ScriptConstants.AntaresLogIdHeaderName] = Guid.NewGuid().ToString();
+            }
+
+            var method = typeof(HostController).GetMethod(actionName)
+                 ?? throw new InvalidOperationException($"Action '{actionName}' not found on {nameof(HostController)}.");
+
+            var actionDescriptor = new ControllerActionDescriptor
+            {
+                MethodInfo = method
+            };
+
+            var actionContext = new ActionContext(httpContext, new RouteData(), actionDescriptor);
+            return new AuthorizationFilterContext(actionContext, new List<IFilterMetadata>());
+        }
+    }
+}


### PR DESCRIPTION
Currently when Admin Isolation is enabled, SCM (Kudu) invoked Sync Trigger operations are rejected on a technicality since they go through the Antares Front End. From an operations point of view they are platform internal requests and should be allowed.

MSFT Internal: The full design doc for this feature can be found on https://eng.ms/ - search for "**Admin Isolation: Kudu Sync Triggers Fix**". This PR implements "Option A".
