### PR TITLE
Update PS workers to latest (inproc)

### DIFF
--- a/eng/build/Workers.Powershell.props
+++ b/eng/build/Workers.Powershell.props
@@ -7,7 +7,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" VersionOverride="4.0.5212" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" Version="4.0.5212" />
   </ItemGroup>
 
   <Target Name="RemovePowershellWorkerRuntimes" BeforeTargets="AssignTargetPaths" Condition="$(RuntimeIdentifier.StartsWith(win))">

--- a/eng/build/Workers.Powershell.props
+++ b/eng/build/Workers.Powershell.props
@@ -7,7 +7,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" Version="4.0.4581" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" VersionOverride="4.0.5212" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.6" VersionOverride="4.0.5213" />
   </ItemGroup>
 
   <Target Name="RemovePowershellWorkerRuntimes" BeforeTargets="AssignTargetPaths" Condition="$(RuntimeIdentifier.StartsWith(win))">

--- a/eng/build/Workers.Powershell.props
+++ b/eng/build/Workers.Powershell.props
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" VersionOverride="4.0.5212" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.6" VersionOverride="4.0.5213" />
   </ItemGroup>
 
   <Target Name="RemovePowershellWorkerRuntimes" BeforeTargets="AssignTargetPaths" Condition="$(RuntimeIdentifier.StartsWith(win))">

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,6 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+
+- Update PS 7.4 worker to [v4.0.5212](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5212) (#)
+- Update PS 7.6 worker to [v4.0.5213](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5213) (#)

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,5 +4,5 @@
 - My change description (#PR)
 -->
 
-- Update PS 7.4 worker to [v4.0.5212](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5212) (#)
-- Update PS 7.6 worker to [v4.0.5213](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5213) (#)
+- Update PS 7.4 worker to [v4.0.5212](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5212) (#11858)
+- Update PS 7.6 worker to [v4.0.5213](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5213) (#11858)

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,5 +4,5 @@
 - My change description (#PR)
 -->
 
-- Update PS 7.4 worker to [v4.0.5212](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5212) (#11858)
-- Update PS 7.6 worker to [v4.0.5213](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5213) (#11858)
+- Update PS 7.4 worker to [v4.0.5212](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5212) (#11859)
+- Update PS 7.6 worker to [v4.0.5213](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5213) (#11859)

--- a/release_notes.md
+++ b/release_notes.md
@@ -5,4 +5,3 @@
 -->
 
 - Update PS 7.4 worker to [v4.0.5212](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5212) (#11859)
-- Update PS 7.6 worker to [v4.0.5213](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5213) (#11859)


### PR DESCRIPTION
Cherry-picks change from #11858 to in-proc branch

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
