### PR TITLE
Bump Microsoft.Azure.AppService.Middleware 1.5.8 -> 1.5.11

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="Azure.Identity" Version="1.17.1" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.22.1" />
-    <PackageVersion Include="Microsoft.Azure.AppService.Middleware.Functions" Version="1.5.8" />
+    <PackageVersion Include="Microsoft.Azure.AppService.Middleware.Functions" Version="1.5.11" />
     <PackageVersion Include="Microsoft.Azure.AppService.Proxy.Client" Version="2.3.20240307.67" />
     <PackageVersion Include="Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption" Version="1.0.5" />
     <PackageVersion Include="Azure.Storage.Files.Shares" Version="12.24.0" />

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,3 +4,4 @@
 - My change description (#PR)
 -->
 - Update Python Worker Version to [4.45.1](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.45.1) (#11860)
+- Update Microsoft.Azure.AppService.Middleware to 1.5.11 (#PR)

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,4 +4,4 @@
 - My change description (#PR)
 -->
 - Update Python Worker Version to [4.45.1](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.45.1) (#11860)
-- Update Microsoft.Azure.AppService.Middleware to 1.5.11 (#PR)
+- Update Microsoft.Azure.AppService.Middleware to 1.5.11 (#11866)

--- a/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
+++ b/test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json
@@ -14,7 +14,7 @@
           "Microsoft.AspNet.WebApi.Client": "5.2.9",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "10.0.0",
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "10.0.0",
-          "Microsoft.Azure.AppService.Middleware.Functions": "1.5.8",
+          "Microsoft.Azure.AppService.Middleware.Functions": "1.5.11",
           "Microsoft.Azure.AppService.Proxy.Client": "2.3.20240307.67",
           "Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption": "1.0.5",
           "Microsoft.Azure.WebJobs.Script": "4.1051.100-dev",
@@ -391,54 +391,54 @@
           }
         }
       },
-      "Microsoft.Azure.AppService.Middleware/1.5.8": {
+      "Microsoft.Azure.AppService.Middleware/1.5.11": {
         "dependencies": {
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.AppService.Middleware.dll": {
-            "assemblyVersion": "1.5.8.0",
-            "fileVersion": "1.5.8.0"
+            "assemblyVersion": "1.5.11.0",
+            "fileVersion": "1.5.11.0"
           }
         }
       },
-      "Microsoft.Azure.AppService.Middleware.Functions/1.5.8": {
+      "Microsoft.Azure.AppService.Middleware.Functions/1.5.11": {
         "dependencies": {
-          "Microsoft.Azure.AppService.Middleware": "1.5.8",
-          "Microsoft.Azure.AppService.Middleware.Modules": "1.5.8",
-          "Microsoft.Azure.AppService.Middleware.NetCore": "1.5.8"
+          "Microsoft.Azure.AppService.Middleware": "1.5.11",
+          "Microsoft.Azure.AppService.Middleware.Modules": "1.5.11",
+          "Microsoft.Azure.AppService.Middleware.NetCore": "1.5.11"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.AppService.Middleware.Functions.dll": {
-            "assemblyVersion": "1.5.8.0",
-            "fileVersion": "1.5.8.0"
+            "assemblyVersion": "1.5.11.0",
+            "fileVersion": "1.5.11.0"
           }
         }
       },
-      "Microsoft.Azure.AppService.Middleware.Modules/1.5.8": {
+      "Microsoft.Azure.AppService.Middleware.Modules/1.5.11": {
         "dependencies": {
-          "Microsoft.Azure.AppService.Middleware": "1.5.8",
+          "Microsoft.Azure.AppService.Middleware": "1.5.11",
           "Microsoft.IdentityModel.Validators": "6.32.0",
           "Newtonsoft.Json": "13.0.3",
           "System.IdentityModel.Tokens.Jwt": "8.15.0"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.AppService.Middleware.Modules.dll": {
-            "assemblyVersion": "1.5.8.0",
-            "fileVersion": "1.5.8.0"
+            "assemblyVersion": "1.5.11.0",
+            "fileVersion": "1.5.11.0"
           }
         }
       },
-      "Microsoft.Azure.AppService.Middleware.NetCore/1.5.8": {
+      "Microsoft.Azure.AppService.Middleware.NetCore/1.5.11": {
         "dependencies": {
-          "Microsoft.Azure.AppService.Middleware": "1.5.8",
-          "Microsoft.Azure.AppService.Middleware.Modules": "1.5.8",
+          "Microsoft.Azure.AppService.Middleware": "1.5.11",
+          "Microsoft.Azure.AppService.Middleware.Modules": "1.5.11",
           "Newtonsoft.Json": "13.0.3"
         },
         "runtime": {
           "lib/netstandard2.0/Microsoft.Azure.AppService.Middleware.NetCore.dll": {
-            "assemblyVersion": "1.5.8.0",
-            "fileVersion": "1.5.8.0"
+            "assemblyVersion": "1.5.11.0",
+            "fileVersion": "1.5.11.0"
           }
         }
       },
@@ -1868,33 +1868,33 @@
       "path": "microsoft.aspnetcore.razor.language/2.2.0",
       "hashPath": "microsoft.aspnetcore.razor.language.2.2.0.nupkg.sha512"
     },
-    "Microsoft.Azure.AppService.Middleware/1.5.8": {
+    "Microsoft.Azure.AppService.Middleware/1.5.11": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-EZQhCc2ZE9ZHtJ1nvk4qv7V7YmrY45bxh24nGLn757PAdLKpCRmrXBoPg9h4MKkqIVJ7dvvkdvvIqKeYgzS+6A==",
-      "path": "microsoft.azure.appservice.middleware/1.5.8",
-      "hashPath": "microsoft.azure.appservice.middleware.1.5.8.nupkg.sha512"
+      "sha512": "sha512-Qpwoquy42hdcetme32YX4WG/Ld8BC3gMW1oTK9Aqpet0UwfBrBoFbpAMoxix29okq1Bydy7kjhrnRE3DCNM1oA==",
+      "path": "microsoft.azure.appservice.middleware/1.5.11",
+      "hashPath": "microsoft.azure.appservice.middleware.1.5.11.nupkg.sha512"
     },
-    "Microsoft.Azure.AppService.Middleware.Functions/1.5.8": {
+    "Microsoft.Azure.AppService.Middleware.Functions/1.5.11": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-OsElGrdo08r4+7GDHXU74tySUKRHV759w5A70ICyKC/vHJ3ZWDkcJcscdo4oDQggDkfC/A8N8DRc6h1jXi0Zaw==",
-      "path": "microsoft.azure.appservice.middleware.functions/1.5.8",
-      "hashPath": "microsoft.azure.appservice.middleware.functions.1.5.8.nupkg.sha512"
+      "sha512": "sha512-h8aUKefWIdQlclCl2GFyf/7c3ToCqx9KAapiyBXc2xNw+bz9rn49AH9mzDSwEdX7GaIY+h77Ia6AkchuXKZGGQ==",
+      "path": "microsoft.azure.appservice.middleware.functions/1.5.11",
+      "hashPath": "microsoft.azure.appservice.middleware.functions.1.5.11.nupkg.sha512"
     },
-    "Microsoft.Azure.AppService.Middleware.Modules/1.5.8": {
+    "Microsoft.Azure.AppService.Middleware.Modules/1.5.11": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-3ZgU3kqSL5omZNYeQMs8HTqHb0B/zVBsMFVtlZ1kMS+HKN7mArDUVSAH9yyQLa1wuOyu3ZOBcBCXFHH7INLelA==",
-      "path": "microsoft.azure.appservice.middleware.modules/1.5.8",
-      "hashPath": "microsoft.azure.appservice.middleware.modules.1.5.8.nupkg.sha512"
+      "sha512": "sha512-AeTkI+Evf/wG4YeLGOaVDQPrNZWuHNjU2rDCwKe1ecG7j7CYccuxYKvsr4CnFAq+9SktxN3o76yCPLCwYwPF8g==",
+      "path": "microsoft.azure.appservice.middleware.modules/1.5.11",
+      "hashPath": "microsoft.azure.appservice.middleware.modules.1.5.11.nupkg.sha512"
     },
-    "Microsoft.Azure.AppService.Middleware.NetCore/1.5.8": {
+    "Microsoft.Azure.AppService.Middleware.NetCore/1.5.11": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sha512-fUALieepnnukp6GlZJNdGSnKaoCk6+nsn2nE/w9dXZASg/nZRlA9vbDKs/BQGQxjTlGfWq2b20I/5KQ+QNS3SA==",
-      "path": "microsoft.azure.appservice.middleware.netcore/1.5.8",
-      "hashPath": "microsoft.azure.appservice.middleware.netcore.1.5.8.nupkg.sha512"
+      "sha512": "sha512-Yombcf2oQZMirp99FTxWcXjJtRi4UqsmfynKMrO6ZMPlSUfyh4sToTy9JY7Y0mVvwhldgq4Jn4i3UF5s9L/qaw==",
+      "path": "microsoft.azure.appservice.middleware.netcore/1.5.11",
+      "hashPath": "microsoft.azure.appservice.middleware.netcore.1.5.11.nupkg.sha512"
     },
     "Microsoft.Azure.AppService.Proxy.Client/2.3.20240307.67": {
       "type": "package",


### PR DESCRIPTION
### Issue describing the changes in this PR

Bumps `Microsoft.Azure.AppService.Middleware.Functions` (and its transitive packages `Microsoft.Azure.AppService.Middleware`, `.Modules`, `.NetCore`) from `1.5.8` to `1.5.11`.

### Pull request checklist

* [ ] Backporting to the `in-proc` branch is not required
    * NOTE: Please confirm — unsure whether this EasyAuth middleware bump must ship in `in-proc` for Core Tools / non-Flex deployments.
* [x] My changes **do not** require documentation changes
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I have added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
* [x] My changes **do not** require diagnostic events changes
* [x] I have added all required tests (Unit tests, E2E tests)
    * Version-only bump; the existing `Verify_DepsJsonChanges` test guards the WebHost dependency graph and passes.

### Additional information

* Only `Microsoft.Azure.AppService.Middleware.Functions` is referenced directly in `Directory.Packages.props`; `.Middleware`, `.Modules`, and `.NetCore` are transitive and move to `1.5.11` automatically.
* Transitive dependencies are unchanged between `1.5.8` and `1.5.11` (`Newtonsoft.Json` 13.0.3, `Microsoft.IdentityModel.Validators` 6.32.0, `System.IdentityModel.Tokens.Jwt` 8.15.0), so this is a low-risk bump.
* Refreshed the WebHost `deps.json` test baseline (`test/WebJobs.Script.Tests/Microsoft.Azure.WebJobs.Script.WebHost.deps.json`) to `1.5.11`; unrelated first-party dev-version numbers were intentionally left untouched.
