### PR TITLE
centralizing TestFunctionHost disposal; making disposal async where possible

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/AppCapabilities/ScriptHostRestartCapabilitiesTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/AppCapabilities/ScriptHostRestartCapabilitiesTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.AppCapabilities
         [Fact]
         public async Task ScriptHostRestart_ClearsCapabilities()
         {
-            using var testHost = new TestFunctionHost(@"TestScripts\Empty");
+            await using var testHost = new TestFunctionHost(@"TestScripts\Empty");
 
             var capabilitiesStore = testHost.JobHostServices.GetRequiredService<IAppCapabilitiesStore>();
 

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.Azure.WebJobs.Script.AppCapabilities;

--- a/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/ApplicationInsights/ApplicationInsightsTestFixture.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.Azure.WebJobs.Script.AppCapabilities;
 using Microsoft.Azure.WebJobs.Script.Config;
@@ -21,10 +22,11 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
+using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
 {
-    public abstract class ApplicationInsightsTestFixture : IDisposable
+    public abstract class ApplicationInsightsTestFixture : IAsyncLifetime
     {
         public const string ApplicationInsightsKey = "some_key";
 
@@ -86,13 +88,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
 
         public HttpClient HttpClient { get; private set; }
 
-        public void Dispose()
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        public async Task DisposeAsync()
         {
             try
             {
-                TestHost.WebHost.StopAsync().GetAwaiter().GetResult();
-                TestHost.WebHost.Dispose();
-                TestHost?.Dispose();
+                if (TestHost is not null)
+                {
+                    await TestHost.DisposeAsync();
+                }
+
                 HttpClient?.Dispose();
             }
             catch (Exception)
@@ -102,7 +108,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.ApplicationInsights
             // App Insights takes 2 seconds to flush telemetry and because our container
             // is disposed on a background task, it doesn't block. So waiting here to ensure
             // everything is flushed and can't affect subsequent tests.
-            Thread.Sleep(2000);
+            await Task.Delay(2000);
         }
 
         private class TestGrpcWorkerChannelFactory : GrpcWorkerChannelFactory

--- a/test/WebJobs.Script.Tests.Integration/Controllers/WarmupScenarios.cs
+++ b/test/WebJobs.Script.Tests.Integration/Controllers/WarmupScenarios.cs
@@ -14,7 +14,7 @@ using Xunit;
 namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Controllers
 {
     [Trait(TestTraits.Group, TestTraits.NonE2EControllers)]
-    public class WarmupScenarios : IDisposable
+    public class WarmupScenarios : IAsyncLifetime
     {
         private static readonly TimeSpan SemaphoreWaitTimeout = TimeSpan.FromSeconds(30);
 
@@ -64,13 +64,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Controllers
                 $"Instead found {response.StatusCode}");
         }
 
-        public void Dispose()
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        public async Task DisposeAsync()
         {
             if (_testHost is not null)
             {
-                try { _testHost.WebHost.StopAsync().GetAwaiter().GetResult(); } catch { }
-                try { _testHost.WebHost.Dispose(); } catch { }
-                _testHost.Dispose();
+                await _testHost.DisposeAsync();
             }
         }
 

--- a/test/WebJobs.Script.Tests.Integration/Host/ScriptApplicationLifetimeTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/ScriptApplicationLifetimeTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Host
         [Fact]
         public async Task IScriptApplicationLifetime_ResolvedFromJobHostServices_StopsOuterWebHost()
         {
-            using var testHost = new TestFunctionHost(_testScriptPath, _testLogPath);
+            await using var testHost = new TestFunctionHost(_testScriptPath, _testLogPath);
 
             var innerLifetime = testHost.JobHostServices.GetRequiredService<IScriptApplicationLifetime>();
             var outerLifetime = testHost.WebHostServices.GetRequiredService<IHostApplicationLifetime>();

--- a/test/WebJobs.Script.Tests.Integration/Host/WebJobsScriptHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/WebJobsScriptHostServiceTests.cs
@@ -29,7 +29,7 @@ using Xunit;
 namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Host
 {
     [Trait(TestTraits.Group, TestTraits.NonE2EControllers)]
-    public class WebJobsScriptHostServiceTests : IDisposable
+    public class WebJobsScriptHostServiceTests : IAsyncLifetime
     {
         private readonly string TestScriptPath = @"TestScripts\CSharp";
         private readonly string TestLogPath = Path.Combine(TestHelpers.FunctionsTestDirectory, "Logs", Guid.NewGuid().ToString(), @"Functions");
@@ -285,10 +285,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Host
         public async Task Restarts_CanCancel_Restarts()
         {
             // We need a custom setup.
-            _testHost.Dispose();
+            await _testHost.DisposeAsync();
             int buildCalls = 0;
 
-            using (var testHost = new TestFunctionHost(TestScriptPath, TestLogPath,
+            await using (var testHost = new TestFunctionHost(TestScriptPath, TestLogPath,
               configureWebHostServices: services =>
               {
                   services.Configure<LoggerFilterOptions>(o =>
@@ -349,13 +349,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Host
             }
         }
 
-        public void Dispose()
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        public async Task DisposeAsync()
         {
             if (_testHost is not null)
             {
-                try { _testHost.WebHost.StopAsync().GetAwaiter().GetResult(); } catch { }
-                try { _testHost.WebHost.Dispose(); } catch { }
-                _testHost.Dispose();
+                await _testHost.DisposeAsync();
             }
         }
 

--- a/test/WebJobs.Script.Tests.Integration/Host/WebScriptHostManagerTimeoutTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/WebScriptHostManagerTimeoutTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Host
         [Fact]
         public async Task OnTimeoutException_IgnoreToken_StopsManager()
         {
-            using (var host = await RunTimeoutExceptionTest(handleCancellation: false))
+            await using (var host = await RunTimeoutExceptionTest(handleCancellation: false))
             {
                 var jobHostManager = host.WebHostServices.GetService<IScriptHostManager>();
 
@@ -34,7 +34,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Host
                 Assert.DoesNotContain(messages, t => t.FormattedMessage.StartsWith("Done"));
                 Assert.Contains(messages, t => t.FormattedMessage.StartsWith("Timeout value of 00:00:03 exceeded by function 'Functions.TimeoutToken' (Id: "));
                 Assert.Contains(messages, t => t.FormattedMessage == "A function timeout has occurred. Host is shutting down.");
-                host.WebHost.Dispose();
             }
 
             // Validates a bug where WebHost services were not being disposed on a function timeout
@@ -44,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Host
         [Fact]
         public async Task OnTimeoutException_UsesToken_ManagerKeepsRunning()
         {
-            using (var host = await RunTimeoutExceptionTest(handleCancellation: true))
+            await using (var host = await RunTimeoutExceptionTest(handleCancellation: true))
             {
                 var jobHostManager = host.WebHostServices.GetService<IScriptHostManager>();
 
@@ -65,7 +64,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Host
             Environment.SetEnvironmentVariable(EnvironmentSettingNames.FunctionWorkerRuntime, "node");
             try
             {
-                using (var host = await RunTimeoutExceptionTest(handleCancellation: false, timeoutFunctionName: "TimeoutSync", path: @"TestScripts\Node"))
+                await using (var host = await RunTimeoutExceptionTest(handleCancellation: false, timeoutFunctionName: "TimeoutSync", path: @"TestScripts\Node"))
                 {
                     var jobHostManager = host.WebHostServices.GetService<IScriptHostManager>();
 

--- a/test/WebJobs.Script.Tests.Integration/Middleware/AllowSynchronousIOMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Middleware/AllowSynchronousIOMiddlewareTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Middleware
         [Fact(Skip = "Seems very difficult to trigger this failure now.")]
         public async Task SyncRead_Fails_ByDefault()
         {
-            using (var host = GetHost())
+            await using (var host = GetHost())
             {
                 HostSecretsInfo secrets = await host.SecretManager.GetHostSecretsAsync();
                 var response = await MakeRequest(host.HttpClient, secrets.MasterKey);
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Middleware
         [Fact]
         public async Task SyncRead_Succeeds_WithFlag()
         {
-            using (var host = GetHost(d => d.Add(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagAllowSynchronousIO)))
+            await using (var host = GetHost(d => d.Add(EnvironmentSettingNames.AzureWebJobsFeatureFlags, ScriptConstants.FeatureFlagAllowSynchronousIO)))
             {
                 HostSecretsInfo secrets = await host.SecretManager.GetHostSecretsAsync();
                 var response = await MakeRequest(host.HttpClient, secrets.MasterKey);
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Middleware
         [Fact]
         public async Task SyncRead_Succeeds_InV2CompatMode()
         {
-            using (var host = GetHost(d => d.Add(EnvironmentSettingNames.FunctionsV2CompatibilityModeKey, "true")))
+            await using (var host = GetHost(d => d.Add(EnvironmentSettingNames.FunctionsV2CompatibilityModeKey, "true")))
             {
                 HostSecretsInfo secrets = await host.SecretManager.GetHostSecretsAsync();
                 var response = await MakeRequest(host.HttpClient, secrets.MasterKey);
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Middleware
         [Fact]
         public async Task SyncDownload_Succeeds()
         {
-            using (var host = GetHost())
+            await using (var host = GetHost())
             {
                 HostSecretsInfo secrets = await host.SecretManager.GetHostSecretsAsync();
                 var response = await MakeDownloadRequest(host.HttpClient, secrets.MasterKey);

--- a/test/WebJobs.Script.Tests.Integration/Rpc/FunctionDispatcherShutdownEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Rpc/FunctionDispatcherShutdownEndToEndTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Rpc
         [Fact]
         public async Task FunctionDispatcher_ExceededRestartRetryCount_StopsOuterWebHost()
         {
-            using var testHost = new TestFunctionHost(_testScriptPath, _testLogPath);
+            await using var testHost = new TestFunctionHost(_testScriptPath, _testLogPath);
 
             RpcFunctionInvocationDispatcher dispatcher = null;
             await TestHelpers.Await(() =>

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -40,7 +40,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Script.Tests
 {
-    public class TestFunctionHost : IDisposable
+    public class TestFunctionHost : IDisposable, IAsyncDisposable
     {
         private readonly ScriptApplicationHostOptions _hostOptions;
         private readonly IHost _webHost;
@@ -510,12 +510,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
 
         /// <summary>
-        /// Temporary method to dispose the web host. This is needed because the web host is not disposed 
-        /// when the test fixture is disposed, which can cause issues with subsequent tests. We are selectively
-        /// enabling this on some tests and will eventually make it private and call it from DisposeAsync once
-        /// all issues are resolved.
-        /// </summary>        
-        internal async Task StopAndDisposeWebHostAsync()
+        /// Stops and disposes the internal WebHost. This is idempotent so repeated disposal calls are safe.
+        /// </summary>
+        private async Task StopAndDisposeWebHostAsync()
         {
             if (_webHostDisposed)
             {
@@ -557,19 +554,31 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         public void Dispose()
         {
+            DisposeAsync().GetAwaiter().GetResult();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
             if (!_isDisposed)
             {
-                HttpClient.Dispose();
-
-                _stillRunningTimer?.Change(-1, -1);
-                _stillRunningTimer?.Dispose();
-
-                if (_timerFired)
+                try
                 {
-                    Console.WriteLine($"The test host with id {_id} is now disposed.");
+                    await StopAndDisposeWebHostAsync();
                 }
+                finally
+                {
+                    HttpClient.Dispose();
 
-                _isDisposed = true;
+                    _stillRunningTimer?.Change(-1, -1);
+                    _stillRunningTimer?.Dispose();
+
+                    if (_timerFired)
+                    {
+                        Console.WriteLine($"The test host with id {_id} is now disposed.");
+                    }
+
+                    _isDisposed = true;
+                }
             }
         }
 

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -561,6 +561,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             if (!_isDisposed)
             {
+                _stillRunningTimer?.Change(-1, -1);
+                _stillRunningTimer?.Dispose();
+
                 try
                 {
                     await StopAndDisposeWebHostAsync();
@@ -568,9 +571,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 finally
                 {
                     HttpClient.Dispose();
-
-                    _stillRunningTimer?.Change(-1, -1);
-                    _stillRunningTimer?.Dispose();
 
                     if (_timerFired)
                     {

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpEndToEndTests.cs
@@ -362,7 +362,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
         public async Task HttpTrigger_Model_Binding_V2CompatMode()
         {
             // We need a custom host to set this to v2 compat mode.
-            using (var host = new TestFunctionHost(@"TestScripts\CSharp", Path.Combine(Path.GetTempPath(), "Functions"),
+            await using (var host = new TestFunctionHost(@"TestScripts\CSharp", Path.Combine(Path.GetTempPath(), "Functions"),
                 configureWebHostServices: webHostServices =>
                 {
                     var environment = new TestEnvironment();

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpPrecompiledTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CSharpPrecompiledTestFixture.cs
@@ -28,18 +28,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
         {
             _dispose?.Dispose();
 
-            try
-            {
-                if (Host.WebHost is not null)
-                {
-                    await Host.WebHost.StopAsync();
-                    Host.WebHost.Dispose();
-                }
-            }
-            finally
-            {
-                await base.DisposeAsync();
-            }
+            await base.DisposeAsync();
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CodelessEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/CodelessEndToEndTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                 var provider = new TestCodelessFunctionProvider(metadata, null);
 
                 var functions = allowedList != null ? new[] { allowedList, "testFn" } : null;
-                using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { provider }, testEnvironment))
+                await using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { provider }, testEnvironment))
                 {
 
                     // Make sure unauthorized does not work
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                 var provider = new TestCodelessFunctionProvider(metadata, null);
 
                 var functions = allowedList != null ? new[] { "testFn2", allowedList } : new[] { "testFn2" };
-                using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { provider }, testEnvironment))
+                await using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { provider }, testEnvironment))
                 {
                     // Make sure unauthorized does not work
                     var unauthResponse = await host.HttpClient.GetAsync("http://localhost/api/testFn2?name=Ankit");
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                 var providerTwo = new TestCodelessFunctionProvider(metadataList2, null);
 
                 var functions = allowedList != null ? new[] { allowedList, "testFn2", "testFn1" } : null;
-                using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { providerOne, providerTwo }, testEnvironment))
+                await using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { providerOne, providerTwo }, testEnvironment))
                 {
                     var testFn1Key = await host.GetFunctionSecretAsync("testFn1");
                     var testFn2Key = await host.GetFunctionSecretAsync("testFn2");
@@ -189,7 +189,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                 var providerTwo = new TestCodelessFunctionProvider(metadataList2, null);
 
                 var functions = allowedList != null ? new[] { allowedList, "testFn2", "testFn1" } : null;
-                using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { providerOne, providerTwo }, testEnvironment))
+                await using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { providerOne, providerTwo }, testEnvironment))
                 {
                     var masterKey = await host.GetMasterKeyAsync();
                     var listFunctionsResponse = await host.HttpClient.GetAsync($"http://localhost/admin/functions?code={masterKey}");
@@ -229,7 +229,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                 var providerTwo = new TestCodelessFunctionProvider(metadataList2, null);
 
                 var functions = allowedList != null ? new[] { allowedList, "testFn2", "testFn1" } : null;
-                using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { providerOne, providerTwo }, testEnvironment))
+                await using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { providerOne, providerTwo }, testEnvironment))
                 {
                     // Sanity check for sync triggers
                     string uri = "admin/host/synctriggers";

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/DiagnosticsEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/DiagnosticsEndToEndTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                     throw new IOException();
                 });
 
-            using (var host = new TestFunctionHost(_scriptRoot, _testLogPath,
+            await using (var host = new TestFunctionHost(_scriptRoot, _testLogPath,
                 configureWebHostServices: s =>
                 {
                     s.AddSingleton<IEventGenerator>(_ => _eventGenerator);

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
@@ -304,15 +304,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         {
             if (Host is not null)
             {
-                await Host.StopAndDisposeWebHostAsync();
-
                 var fileMonitoringService = Host.JobHostServices?.GetService<IFileMonitoringService>();
                 if (fileMonitoringService is not null)
                 {
                     await fileMonitoringService.StopAsync(default);
                 }
 
-                Host.Dispose();
+                await Host.DisposeAsync();
             }
 
             _scriptRoot?.Dispose();

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/HostConfigurationExceptionTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/HostConfigurationExceptionTests.cs
@@ -77,12 +77,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                 {
                     await _host.DisposeAsync();
                 }
-
-                Directory.Delete(_hostPath, true);
             }
             catch (Exception ex)
             {
                 Console.WriteLine(ex.Message);
+            }
+            finally
+            {
+                try
+                {
+                    Directory.Delete(_hostPath, true);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex.Message);
+                }
             }
         }
     }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/HostConfigurationExceptionTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/HostConfigurationExceptionTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
 {
     [Trait(TestTraits.Group, TestTraits.NonE2EWebHost)]
-    public class HostConfigurationExceptionTests : IDisposable
+    public class HostConfigurationExceptionTests : IAsyncLifetime
     {
         private readonly string _hostPath;
         private TestFunctionHost _host;
@@ -67,13 +67,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
             Assert.Null(status.Errors);
         }
 
-        public void Dispose()
+        public Task InitializeAsync() => Task.CompletedTask;
+
+        public async Task DisposeAsync()
         {
             try
             {
-                try { _host.WebHost.StopAsync().GetAwaiter().GetResult(); } catch { }
-                try { _host.WebHost.Dispose(); } catch { }
-                _host.Dispose();
+                if (_host is not null)
+                {
+                    await _host.DisposeAsync();
+                }
+
                 Directory.Delete(_hostPath, true);
             }
             catch (Exception ex)

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/HostDisposedExceptionTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/HostDisposedExceptionTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration
             await jobhost.StopAsync();
             await host.WebHost.StopAsync();
             host.WebHost.Dispose();
-            host.Dispose();
+            await host.DisposeAsync();
 
             // Capture log state after dispose so we have diagnostic context if the expected
             // HostDisposedException does not surface (the test has historically been flaky here).

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/MultiLanguageEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/MultiLanguageEndToEndTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                 var javaFunctionProvider = new TestCodelessFunctionProvider(javaMetadataList, null);
 
                 var functions = new[] { "InProcCSFunction", "JavascriptFunction", "JavaFunction" };
-                using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { cSharpFunctionProvider, javascriptFunctionProvider, javaFunctionProvider }, testEnvironment))
+                await using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { cSharpFunctionProvider, javascriptFunctionProvider, javaFunctionProvider }, testEnvironment))
                 {
                     var cSharpFunctionKey = await host.GetFunctionSecretAsync("InProcCSFunction");
                     using var cSharpHttpTriggerResponse = await host.HttpClient.GetAsync($"http://localhost/api/InProcCSFunction?name=Azure&code={cSharpFunctionKey}");
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                 var javaFunctionProvider = new TestCodelessFunctionProvider(javaMetadataList, null);
 
                 var functions = new[] { "InProcCSFunction", "JavaFunction" };
-                using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { cSharpFunctionProvider, javaFunctionProvider }, testEnvironment))
+                await using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { cSharpFunctionProvider, javaFunctionProvider }, testEnvironment))
                 {
                     var cSharpFunctionKey = await host.GetFunctionSecretAsync("InProcCSFunction");
                     using var cSharpHttpTriggerResponse = await host.HttpClient.GetAsync($"http://localhost/api/InProcCSFunction?name=Azure&code={cSharpFunctionKey}");
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                 var javascriptFunctionProvider = new TestCodelessFunctionProvider(javascriptMetadataList, null);
 
                 var functions = new[] { "InProcCSFunction", "JavascriptFunction" };
-                using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { cSharpFunctionProvider, javascriptFunctionProvider }, testEnvironment, enableDynamicWorkerResolution))
+                await using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { cSharpFunctionProvider, javascriptFunctionProvider }, testEnvironment, enableDynamicWorkerResolution))
                 {
                     var services = host.WebHostServices.GetServices<IWorkerConfigurationProvider>();
                     Assert.Equal(3, services.Count());
@@ -196,7 +196,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                 var cSharpFunctionProvider = new TestCodelessFunctionProvider(cSharpMetadataList, null);
 
                 var functions = new[] { "InProcCSFunction" };
-                using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { cSharpFunctionProvider }, testEnvironment, enableDynamicWorkerResolution))
+                await using (var host = StartLocalHost(baseTestPath, sourceFunctionApp, functions, new List<IFunctionProvider>() { cSharpFunctionProvider }, testEnvironment, enableDynamicWorkerResolution))
                 {
                     var cSharpFunctionKey = await host.GetFunctionSecretAsync("InProcCSFunction");
                     using var cSharpHttpTriggerResponse = await host.HttpClient.GetAsync($"http://localhost/api/InProcCSFunction?name=Azure&code={cSharpFunctionKey}");

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/NodeHostRestartEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/NodeHostRestartEndToEndTests.cs
@@ -126,10 +126,5 @@ public class NodeHostRestartEndToEndTests
                 });
         }
 
-        public override async Task DisposeAsync()
-        {
-            await Host.StopAndDisposeWebHostAsync();
-            await base.DisposeAsync();
-        }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/ProxyEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/ProxyEndToEndTests.cs
@@ -454,15 +454,13 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 try
                 {
-                    if (TestHost.WebHost is not null)
+                    if (TestHost is not null)
                     {
-                        await TestHost.WebHost.StopAsync();
-                        TestHost.WebHost.Dispose();
+                        await TestHost.DisposeAsync();
                     }
                 }
                 finally
                 {
-                    TestHost?.Dispose();
                     HttpServer?.Dispose();
                     HttpClient?.Dispose();
 

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SamplesEndToEndTests_Node.cs
@@ -361,11 +361,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.EndToEnd
                 });
             }
 
-            public override async Task DisposeAsync()
-            {
-                await Host.StopAndDisposeWebHostAsync();
-                await base.DisposeAsync();
-            }
         }
     }
 }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WorkflowAppEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WorkflowAppEndToEndTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
             try
             {
                 using var envScope = new TestScopedEnvironmentVariable(envVars);
-                using var host = new TestFunctionHost(s_scriptRootPath);
+                await using var host = new TestFunctionHost(s_scriptRootPath);
 
                 // Sanity check: the bundle's IWebJobsConfigurationStartup must have run and added
                 // its languageWorkers:<name>:workerDirectory entry to the JobHost-scope


### PR DESCRIPTION
Now that other test improvement PRs have stabilized our TestFunctionHost disposal patterns, I'm centralizing that behavior and cleaning up anywhere that was disposing explicitly. This should ensure that we're properly cleaning up in many more places now.

Also, just as a nice cleanup, making as many disposal calls asynchronous as I can just to prevent sync-over-async disposal when possible.

Note there's a bunch of file changes here but this is all test files... and it's a pretty mechanical change. Nothing significant should have been changed here (ideally) but please give it a sanity check.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)