### PR TITLE
Update BaseSecretsRepository to check full file paths

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -9,3 +9,4 @@
 - Update Microsoft.Azure.AppService.Middleware to 1.5.11 (#11866)
 - Update PS 7.4 worker to [v4.0.5212](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5212) (#11858)
 - Update PS 7.6 worker to [v4.0.5213](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5213) (#11858)
+- Update BaseSecretsRepository to conduct full file path checks and guard against file system traversal (#11872)

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/BaseSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/BaseSecretsRepository.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         private readonly object _sentinelWatcherInitializationLock = new object();
         private readonly string _hostSecretsSentinelFilePath;
         private readonly string _secretsSentinelFilePath;
+        private readonly string _normalizedSecretsSentinelFilePath;
 
         private AutoRecoveringFileSystemWatcher _sentinelFileWatcher;
         private bool _disposing = false;
@@ -27,6 +28,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             ArgumentNullException.ThrowIfNull(logger);
 
             _secretsSentinelFilePath = secretsSentinelFilePath;
+            _normalizedSecretsSentinelFilePath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(_secretsSentinelFilePath)) + Path.DirectorySeparatorChar;
             Logger = logger;
             _hostSecretsSentinelFilePath = Path.Combine(_secretsSentinelFilePath, ScriptConstants.HostMetadataFileName);
 
@@ -48,9 +50,21 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         protected string GetSecretsSentinelFilePath(ScriptSecretsType secretsType, string functionName = null)
         {
-            return secretsType == ScriptSecretsType.Host
-                ? _hostSecretsSentinelFilePath
-                : Path.Combine(_secretsSentinelFilePath, GetSecretFileName(functionName));
+            if (secretsType == ScriptSecretsType.Host)
+            {
+                return _hostSecretsSentinelFilePath;
+            }
+
+            ArgumentException.ThrowIfNullOrEmpty(functionName);
+
+            string fullPath = Path.GetFullPath(Path.Combine(_normalizedSecretsSentinelFilePath, GetSecretFileName(functionName)));
+
+            if (!fullPath.StartsWith(_normalizedSecretsSentinelFilePath, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException($"Invalid function name '{functionName}'. The resolved path is outside the secrets directory.", nameof(functionName));
+            }
+
+            return fullPath;
         }
 
         protected static string GetSecretFileName(string functionName)

--- a/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -1838,6 +1838,73 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             }
         }
 
+        [Theory]
+        [InlineData("../../../etc/shadow")]
+        [InlineData("foo/../../etc/passwd")]
+        public void GetSecretsSentinelFilePath_PathTraversal_Throws(string maliciousFunctionName)
+        {
+            using (var directory = new TempDirectory())
+            {
+                var repository = new TestBaseSecretsRepository(directory.Path, _logger, _testEnvironment);
+
+                var ex = Assert.Throws<ArgumentException>(
+                    () => repository.GetSentinelFilePath(ScriptSecretsType.Function, maliciousFunctionName));
+
+                Assert.Contains("outside the secrets directory", ex.Message);
+            }
+        }
+
+        [Fact]
+        public void GetSecretsSentinelFilePath_ValidFunctionName_ReturnsPathInsideDirectory()
+        {
+            using (var directory = new TempDirectory())
+            {
+                var repository = new TestBaseSecretsRepository(directory.Path, _logger, _testEnvironment);
+
+                string result = repository.GetSentinelFilePath(ScriptSecretsType.Function, "MyFunction");
+
+                Assert.StartsWith(Path.GetFullPath(directory.Path), result, StringComparison.OrdinalIgnoreCase);
+                Assert.EndsWith("myfunction.json", result, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        [Fact]
+        public void GetSecretsSentinelFilePath_Host_DoesNotValidateFunctionName()
+        {
+            using (var directory = new TempDirectory())
+            {
+                var repository = new TestBaseSecretsRepository(directory.Path, _logger, _testEnvironment);
+
+                string result = repository.GetSentinelFilePath(ScriptSecretsType.Host);
+
+                Assert.EndsWith(ScriptConstants.HostMetadataFileName, result, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        [Fact]
+        public void GetSecretsSentinelFilePath_NullFunctionName_Throws()
+        {
+            using (var directory = new TempDirectory())
+            {
+                var repository = new TestBaseSecretsRepository(directory.Path, _logger, _testEnvironment);
+
+                Assert.Throws<ArgumentNullException>(
+                    () => repository.GetSentinelFilePath(ScriptSecretsType.Function, null));
+            }
+        }
+
+        [Fact]
+        public void GetSecretsSentinelFilePath_EmptyFunctionName_Throws()
+        {
+            using (var directory = new TempDirectory())
+            {
+                var repository = new TestBaseSecretsRepository(directory.Path, _logger, _testEnvironment);
+
+                Assert.Throws<ArgumentException>(
+                    () => repository.GetSentinelFilePath(ScriptSecretsType.Function, string.Empty));
+            }
+        }
+
         private Mock<IKeyValueConverterFactory> GetConverterFactoryMock(bool simulateWriteConversion = true, bool setStaleValue = true)
         {
             var mockValueReader = new Mock<IKeyValueReader>();
@@ -1958,6 +2025,33 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
         {
             string expectedMessage = string.Format(Resources.NonHISSecret, keyType, keyName, functionName);
             Assert.Equal(expectedMessage, message);
+        }
+
+        private sealed class TestBaseSecretsRepository : BaseSecretsRepository
+        {
+            public TestBaseSecretsRepository(string secretsSentinelFilePath, ILogger logger, IEnvironment environment)
+                : base(secretsSentinelFilePath, logger, environment)
+            {
+            }
+
+            public override bool IsEncryptionSupported => false;
+
+            public override string Name => nameof(TestBaseSecretsRepository);
+
+            public string GetSentinelFilePath(ScriptSecretsType secretsType, string functionName = null)
+            {
+                return GetSecretsSentinelFilePath(secretsType, functionName);
+            }
+
+            public override Task<ScriptSecrets> ReadAsync(ScriptSecretsType type, string functionName) => throw new NotImplementedException();
+
+            public override Task WriteAsync(ScriptSecretsType type, string functionName, ScriptSecrets secrets) => throw new NotImplementedException();
+
+            public override Task WriteSnapshotAsync(ScriptSecretsType type, string functionName, ScriptSecrets secrets) => throw new NotImplementedException();
+
+            public override Task PurgeOldSecretsAsync(IList<string> currentFunctions, ILogger logger) => throw new NotImplementedException();
+
+            public override Task<string[]> GetSecretSnapshots(ScriptSecretsType type, string functionName) => throw new NotImplementedException();
         }
 
         private class TestSecretsRepository : ISecretsRepository


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Checks against file traversal in BaseSecretsRepository (similar to #11840).

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)