### PR TITLE
preventing SyncTriggers on placeholder hosts

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -5,6 +5,7 @@
 -->
 
 - Fixed a WebHost worker channel shutdown race that could hang host teardown when a language worker was still initializing. (#11853)
+- Fixed a race where a SyncTriggers request during specialization could publish placeholder (`WarmUp`) triggers. (#11874)
 - Update Python Worker Version to [4.45.1](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.45.1) (#11860)
 - Update Microsoft.Azure.AppService.Middleware to 1.5.11 (#11866)
 - Update PS 7.4 worker to [v4.0.5212](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5212) (#11858)

--- a/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
+++ b/src/WebJobs.Script.WebHost/Management/FunctionsSyncManager.cs
@@ -111,6 +111,18 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management
                 return result;
             }
 
+            // The active host may still be the placeholder/standby host (e.g. mid-specialization,
+            // after placeholder mode has been cleared but before RestartHostAsync swaps in the
+            // specialized host).
+            if (Utility.TryGetHostService(_scriptHostManager, out IOptions<ScriptJobHostOptions> jobHostOptions)
+                && jobHostOptions.Value.IsStandbyConfiguration)
+            {
+                result.Success = false;
+                result.Error = "Active host is in standby configuration. Skipping SyncTriggers to avoid publishing placeholder triggers.";
+                _logger.LogWarning(result.Error);
+                return result;
+            }
+
             try
             {
                 await _syncSemaphore.WaitAsync();

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -412,9 +412,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                 Assert.Equal(0, _mockHttpHandler.RequestCount);
                 Assert.Equal(0, _contentBuilder.Length);
 
-                // The operation is a successful no-op, not an error.
-                Assert.True(result.Success);
-                Assert.Null(result.Error);
+                // The standby guard blocks the publish and reports failure, matching the existing
+                // standby/placeholder skip contract (surfaced as a 500 by the admin/host/synctriggers endpoint).
+                Assert.False(result.Success);
+                Assert.Equal("Active host is in standby configuration. Skipping SyncTriggers to avoid publishing placeholder triggers.", result.Error);
             }
         }
 

--- a/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/FunctionsSyncManagerTests.cs
@@ -330,6 +330,95 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
         }
 
         [Fact]
+        public async Task TrySyncTriggers_PlaceholderWarmupPayload_DoesNotPublish()
+        {
+            // Repro for the SyncTriggers race in azure-functions-host#10169.
+            //
+            // When a specialization times out (the placeholder env-reload exceeds its 30s
+            // timeout), the host is torn down but an inbound (foreground) SyncTriggers request
+            // that raced the deploy can still be served by the host while it is only exposing
+            // the placeholder "WarmUp" function. InStandbyMode has already latched to false by
+            // this point (placeholder mode is cleared early during specialization), so the
+            // existing standby guard does NOT catch this window. The result is that the
+            // placeholder WarmUp trigger payload gets published via SetTriggers, and because
+            // foreground syncs bypass the hash blob the app can stay stuck showing only WarmUp.
+            //
+            // Fix 1: while the active host is still the placeholder/standby host (its job host
+            // options report IsStandbyConfiguration), SyncTriggers must never publish, so the
+            // placeholder WarmUp trigger payload can't reach the FrontEnd.
+            var warmupMetadata = new FunctionMetadata
+            {
+                Name = Microsoft.Azure.WebJobs.Script.WebHost.WarmUpConstants.FunctionName,
+                ScriptFile = "run.csx"
+            };
+            warmupMetadata.Bindings.Add(new BindingMetadata
+            {
+                Name = "req",
+                Type = "httpTrigger",
+                Direction = BindingDirection.In,
+                Raw = new JObject
+                {
+                    { "authLevel", "anonymous" },
+                    { "type", "httpTrigger" },
+                    { "direction", "in" },
+                    { "name", "req" },
+                    { "methods", new JArray("get", "post") },
+                    { "route", "{x:regex(^(warmup|csharphttpwarmup)$)}" }
+                }
+            });
+
+            var metadataManagerMock = new Mock<IFunctionMetadataManager>(MockBehavior.Strict);
+            metadataManagerMock
+                .Setup(m => m.GetFunctionMetadata(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Returns(ImmutableArray.Create(warmupMetadata));
+
+            // Keep the test on the minimal-payload path; the guard must prevent the publish
+            // regardless of whether the ARM cache (extended payload) is enabled.
+            _mockEnvironment.Setup(p => p.GetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteArmCacheEnabled)).Returns("0");
+
+            // The active host is still the placeholder/standby host during the specialization
+            // race window. Model that by exposing a job host whose options report the standby
+            // configuration - this is the reliable signal the guard checks (InStandbyMode and the
+            // webhost-level options both latch out of standby too early to catch this window).
+            var standbyJobHostOptions = new OptionsWrapper<ScriptJobHostOptions>(new ScriptJobHostOptions { IsStandbyConfiguration = true });
+            var standbyScriptHostManagerMock = new Mock<IScriptHostManager>(MockBehavior.Strict);
+            standbyScriptHostManagerMock.As<IServiceProvider>()
+                .Setup(p => p.GetService(typeof(IOptions<ScriptJobHostOptions>)))
+                .Returns(standbyJobHostOptions);
+
+            var syncManager = new FunctionsSyncManager(
+                _hostIdProvider,
+                _optionsMonitor,
+                _loggerFactory.CreateLogger<FunctionsSyncManager>(),
+                _httpClientFactory,
+                _secretManagerProviderMock.Object,
+                _mockWebHostEnvironment.Object,
+                _mockEnvironment.Object,
+                _hostNameProvider,
+                metadataManagerMock.Object,
+                _azureBlobStorageProvider,
+                _hostingConfigOptionsWrapper,
+                standbyScriptHostManagerMock.Object,
+                null);
+
+            using (var env = new TestScopedEnvironmentVariable(_vars))
+            {
+                _mockHttpHandler.Reset();
+
+                // Foreground sync (isBackgroundSync: false) - the racing inbound request.
+                var result = await syncManager.TrySyncTriggersAsync();
+
+                // No SetTriggers request should have been made for a placeholder-only payload.
+                Assert.Equal(0, _mockHttpHandler.RequestCount);
+                Assert.Equal(0, _contentBuilder.Length);
+
+                // The operation is a successful no-op, not an error.
+                Assert.True(result.Success);
+                Assert.Null(result.Error);
+            }
+        }
+
+        [Fact]
         public async Task TrySyncTriggers_MaxSyncTriggersPayloadSize_Succeeds()
         {
             // create a dummy file that pushes us over size

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -245,6 +245,72 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public async Task Specialization_SyncTriggers_DuringPlaceholderWindow_DoesNotPublishWarmup()
+        {
+            // E2E reproduction of the SyncTriggers race in azure-functions-host#10169.
+            //
+            // During specialization the placeholder-mode environment variable is cleared *before*
+            // the specialized host is built and its real functions are loaded. In that window the
+            // active host is still the standby host exposing only the placeholder "WarmUp" function,
+            // yet IsSyncTriggersEnvironment() now passes (InStandbyMode has already latched to false).
+            // A foreground SyncTriggers request that races a deploy therefore publishes the
+            // placeholder WarmUp trigger payload to the FrontEnd, which can leave the app stuck
+            // showing only WarmUp (foreground syncs bypass the hash blob so it never self-heals).
+            //
+            // Here we recreate that exact window deterministically: the InfiniteTimerStandbyManager
+            // never auto-specializes and we never send a request that would trigger specialization,
+            // so the standby (WarmUp-only) host stays active. We then flip the environment out of
+            // placeholder mode and drive a foreground SyncTriggers. The placeholder WarmUp trigger
+            // must NOT be published.
+            var capturedSetTriggersBodies = new System.Collections.Concurrent.ConcurrentBag<string>();
+
+            string encryptionKey = TestHelpers.GenerateKeyHexString();
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, encryptionKey);
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName, "testsite.azurewebsites.net");
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName, "testsite");
+
+            // Keep the payload on the minimal path (no per-function secret/file fetches) so the
+            // sync deterministically reaches SetTriggers with the placeholder trigger in current code.
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteArmCacheEnabled, "0");
+
+            var builder = CreateStandbyHostBuilder(_loggerProvider, "FunctionExecutionContext")
+                .ConfigureServices(services =>
+                {
+                    services.AddHttpClient(Options.DefaultName)
+                        .ConfigurePrimaryHttpMessageHandler(() => new CapturingHttpMessageHandler(capturedSetTriggersBodies));
+                });
+
+            using (new TestScopedEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, encryptionKey))
+            {
+                await using var stoppable = new StoppableHost(builder.Build());
+
+                var host = stoppable.Inner;
+
+                await host.StartAsync();
+
+                var client = host.GetTestClient();
+
+                // Build the standby host and load the placeholder WarmUp function.
+                var warmupResponse = await client.GetAsync("api/warmup");
+                warmupResponse.EnsureSuccessStatusCode();
+
+                // Exit placeholder mode WITHOUT specializing - this is the race window. The active
+                // host is still the standby host (WarmUp only), but InStandbyMode has latched false.
+                _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
+                _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+
+                var syncManager = host.Services.GetRequiredService<Microsoft.Azure.WebJobs.Script.WebHost.Management.IFunctionsSyncManager>();
+
+                // Foreground sync (the racing inbound request).
+                var result = await syncManager.TrySyncTriggersAsync();
+
+                // The placeholder WarmUp trigger must never be published to the FrontEnd.
+                Assert.DoesNotContain(capturedSetTriggersBodies, body =>
+                    body.IndexOf(WarmUpConstants.FunctionName, StringComparison.OrdinalIgnoreCase) >= 0);
+            }
+        }
+
+        [Fact]
         public async Task Specialization_WebHostOptionsAreLogged()
         {
             const string optionsCategory = "Microsoft.Azure.WebJobs.Hosting.OptionsLoggingService";
@@ -1924,6 +1990,26 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 .Where(p => p.FormattedMessage is not null && p.FormattedMessage.Contains("Starting worker process with FileName:"))
                 .ToArray();
             Assert.Equal(expected, workerStartLogs.Length);
+        }
+
+        private class CapturingHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly System.Collections.Concurrent.ConcurrentBag<string> _bodies;
+
+            public CapturingHttpMessageHandler(System.Collections.Concurrent.ConcurrentBag<string> bodies)
+            {
+                _bodies = bodies;
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                if (request.Content != null)
+                {
+                    _bodies.Add(await request.Content.ReadAsStringAsync());
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }
         }
 
         private class InfiniteTimerStandbyManager : StandbyManager


### PR DESCRIPTION
Fixes #11873

Certain flows (namely worker specialization failures) could result in a SyncTriggers call being made against a placeholder host. This would result in a Warmup function being sent to the platform and could cause issues with scaling and metadata.

This change checks whether the current host is a placeholder and if so, skip the sync. Previous behavior checked if the *environment* was a placeholder but did not validate the active host.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)