### PR TITLE
Update Microsoft.Azure.Functions.DotNetIsolatedNativeHost to 1.0.15

### DIFF
--- a/eng/build/Workers.Dotnet.props
+++ b/eng/build/Workers.Dotnet.props
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" VersionOverride="1.0.14" />
+    <PackageReference Include="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" VersionOverride="1.0.15" />
   </ItemGroup>
 
   <Target Name="CleanDotnetWorkerFiles" BeforeTargets="AssignTargetPaths" Condition="'$(RuntimeIdentifier)' != ''">

--- a/release_notes.md
+++ b/release_notes.md
@@ -9,3 +9,4 @@
 - Update Microsoft.Azure.AppService.Middleware to 1.5.11 (#11866)
 - Update PS 7.4 worker to [v4.0.5212](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5212) (#11858)
 - Update PS 7.6 worker to [v4.0.5213](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5213) (#11858)
+- Update `Microsoft.Azure.Functions.DotNetIsolatedNativeHost` to `1.0.15` (#11881)


### PR DESCRIPTION
bumping DotNetIsolatedNativeHost to take https://github.com/Azure/azure-functions-dotnet-worker/pull/3413

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)