### PR TITLE
Update PublicRelease condition to include internal release

### DIFF
--- a/eng/build/Release.props
+++ b/eng/build/Release.props
@@ -45,7 +45,7 @@
 
     <!-- Only set public release if this is a release tag or a release branch -->
     <!-- tag must be either 'v{Version}' or {name}-v{Version} for a match -->
-    <!-- release branch must be refs/heads/release/* -->
+    <!-- release branch must be refs/heads/release/* or refs/heads/internal/release/* -->
     <PublicReleaseTag Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(BUILD_SOURCEBRANCH), `refs/tags/(?:.*-)?v.*`))">$(BUILD_SOURCEBRANCHNAME)</PublicReleaseTag>
     <PublicRelease>false</PublicRelease>
     <PublicRelease Condition="'$(PublicReleaseTag)' != ''">true</PublicRelease>

--- a/eng/build/Release.props
+++ b/eng/build/Release.props
@@ -49,7 +49,7 @@
     <PublicReleaseTag Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(BUILD_SOURCEBRANCH), `refs/tags/(?:.*-)?v.*`))">$(BUILD_SOURCEBRANCHNAME)</PublicReleaseTag>
     <PublicRelease>false</PublicRelease>
     <PublicRelease Condition="'$(PublicReleaseTag)' != ''">true</PublicRelease>
-    <PublicRelease Condition="'$(BUILD_SOURCEBRANCH)' != '' AND $(BUILD_SOURCEBRANCH.StartsWith('refs/heads/release/'))">true</PublicRelease>
+    <PublicRelease Condition="'$(BUILD_SOURCEBRANCH)' != '' AND ($(BUILD_SOURCEBRANCH.StartsWith('refs/heads/release/')) OR $(BUILD_SOURCEBRANCH.StartsWith('refs/heads/internal/release/')))">true</PublicRelease>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Please provide all the information below.  -->
This pull request updates the release build configuration to support an additional branch naming pattern. Now, builds from both `release/` and `internal/release/` branches will be marked as public releases.

Build configuration updates:

* [`eng/build/Release.props`](diffhunk://#diff-35f14678393f754dd785048f3efaba56fb5b8608f04db14fd79956053ad53380L52-R52): Modified the condition for setting the `PublicRelease` property to include branches starting with `refs/heads/internal/release/`, in addition to those starting with `refs/heads/release/`.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

