### PR TITLE
fail env reload fast on worker exit during specialization

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,6 +7,8 @@
 - fix: eliminate noisy restart logs during worker channel shutdown (#11846)
 - Fixed a WebHost worker channel shutdown race that could hang host teardown when a language worker was still initializing. (#11853)
 - Fixed a race where a SyncTriggers request during specialization could publish placeholder (`WarmUp`) triggers. (#11874)
+- Fixed specialization waiting the full environment reload timeout when a language worker crashed mid-reload (#11883)
+- Update Python Worker Version to [4.45.1](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.45.1) (#11860)
 - Update Microsoft.Azure.AppService.Middleware to 1.5.11 (#11866)
 - Update PS 7.4 worker to [v4.0.5212](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5212) (#11858)
 - Update PS 7.6 worker to [v4.0.5213](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5213) (#11858)

--- a/release_notes.md
+++ b/release_notes.md
@@ -8,7 +8,6 @@
 - Fixed a WebHost worker channel shutdown race that could hang host teardown when a language worker was still initializing. (#11853)
 - Fixed a race where a SyncTriggers request during specialization could publish placeholder (`WarmUp`) triggers. (#11874)
 - Fixed specialization waiting the full environment reload timeout when a language worker crashed mid-reload (#11883)
-- Update Python Worker Version to [4.45.1](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.45.1) (#11860)
 - Update Microsoft.Azure.AppService.Middleware to 1.5.11 (#11866)
 - Update PS 7.4 worker to [v4.0.5212](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5212) (#11858)
 - Update PS 7.6 worker to [v4.0.5213](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5213) (#11858)

--- a/src/WebJobs.Script.Grpc/Channel/WorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/WorkerChannel.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reactive.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Channels;
@@ -83,6 +84,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         private IDisposable _startLatencyMetric;
         private IEnumerable<FunctionMetadata> _functions;
         private TaskCompletionSource<bool> _reloadTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private volatile bool _reloadRequestSent;
         private TaskCompletionSource<List<RawFunctionMetadata>> _functionsIndexingTask = new TaskCompletionSource<List<RawFunctionMetadata>>(TaskCreationOptions.RunContinuationsAsynchronously);
         private TimeSpan _functionLoadTimeout = TimeSpan.FromMinutes(1);
         private bool _isSharedMemoryDataTransferEnabled;
@@ -152,6 +154,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             _workerInvocationFailedMetric = string.Format(MetricEventNames.WorkerInvokeFailed, Id);
 
             LoadScriptJobHostOptions(_scriptHostManager as IServiceProvider);
+            _eventSubscriptions.Add(_eventManager.OfType<WorkerErrorEvent>().Subscribe(OnWorkerError));
         }
 
         protected virtual int WorkerProcessId => -1;
@@ -496,12 +499,14 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                 {
                     _workerChannelLogger.LogWarning(reloadEnvironmentVariablesException, reloadEnvironmentVariablesException.Message);
                 }
-                _reloadTask.SetResult(false);
+                _reloadTask.TrySetResult(false);
             }
             else
             {
-                _reloadTask.SetResult(true);
+                _reloadTask.TrySetResult(true);
             }
+
+            _reloadRequestSent = false;
             latencyEvent.Dispose();
         }
 
@@ -689,6 +694,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
         public Task<bool> SendFunctionEnvironmentReloadRequest()
         {
+            _reloadTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _reloadRequestSent = true;
             _functionsIndexingTask = new TaskCompletionSource<List<RawFunctionMetadata>>(TaskCreationOptions.RunContinuationsAsynchronously);
             _functionMetadataRequestSent = false;
 
@@ -1364,7 +1371,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         internal void HandleWorkerEnvReloadError(Exception exc)
         {
             _workerChannelLogger.LogError(exc, "Reloading environment variables failed");
-            _reloadTask.SetException(exc);
+            _reloadTask.TrySetException(exc);
+            _reloadRequestSent = false;
         }
 
         internal void HandleWorkerInitError(Exception exc)
@@ -1391,6 +1399,20 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                 return;
             }
             _eventManager.Publish(new WorkerErrorEvent(_runtime, Id, exc));
+        }
+
+        private void OnWorkerError(WorkerErrorEvent workerError)
+        {
+            if (workerError is null ||
+                !_reloadRequestSent ||
+                !string.Equals(workerError.WorkerId, Id, StringComparison.Ordinal) ||
+                workerError.Exception is null)
+            {
+                return;
+            }
+
+            _reloadTask.TrySetException(workerError.Exception);
+            _reloadRequestSent = false;
         }
 
         internal void HandleWorkerMetadataRequestError(Exception exc)

--- a/src/WebJobs.Script.Grpc/Channel/WorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/WorkerChannel.cs
@@ -7,7 +7,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Reactive.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Channels;
@@ -1482,6 +1481,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
                     _startLatencyMetric?.Dispose();
                     _workerInitTask?.TrySetCanceled();
+                    _reloadTask?.TrySetCanceled();
                     _timer?.Dispose();
                     _scriptHostManager.ActiveHostChanged -= HandleActiveHostChange;
 

--- a/src/WebJobs.Script.Grpc/Channel/WorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/WorkerChannel.cs
@@ -690,7 +690,6 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
         public Task<bool> SendFunctionEnvironmentReloadRequest()
         {
-            _reloadTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             _functionsIndexingTask = new TaskCompletionSource<List<RawFunctionMetadata>>(TaskCreationOptions.RunContinuationsAsynchronously);
             _functionMetadataRequestSent = false;
 

--- a/src/WebJobs.Script.Grpc/Channel/WorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/WorkerChannel.cs
@@ -84,7 +84,6 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         private IDisposable _startLatencyMetric;
         private IEnumerable<FunctionMetadata> _functions;
         private TaskCompletionSource<bool> _reloadTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        private volatile bool _reloadRequestSent;
         private TaskCompletionSource<List<RawFunctionMetadata>> _functionsIndexingTask = new TaskCompletionSource<List<RawFunctionMetadata>>(TaskCreationOptions.RunContinuationsAsynchronously);
         private TimeSpan _functionLoadTimeout = TimeSpan.FromMinutes(1);
         private bool _isSharedMemoryDataTransferEnabled;
@@ -505,7 +504,6 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                 _reloadTask.TrySetResult(true);
             }
 
-            _reloadRequestSent = false;
             latencyEvent.Dispose();
         }
 
@@ -694,7 +692,6 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         public Task<bool> SendFunctionEnvironmentReloadRequest()
         {
             _reloadTask = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            _reloadRequestSent = true;
             _functionsIndexingTask = new TaskCompletionSource<List<RawFunctionMetadata>>(TaskCreationOptions.RunContinuationsAsynchronously);
             _functionMetadataRequestSent = false;
 
@@ -1579,13 +1576,12 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
         private void TryFailPendingReload(Exception exception)
         {
-            if (!_reloadRequestSent || exception is null)
+            if (exception is null)
             {
                 return;
             }
 
             _reloadTask.TrySetException(exception);
-            _reloadRequestSent = false;
         }
 
         /// <summary>

--- a/src/WebJobs.Script.Grpc/Channel/WorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/WorkerChannel.cs
@@ -154,7 +154,6 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             _workerInvocationFailedMetric = string.Format(MetricEventNames.WorkerInvokeFailed, Id);
 
             LoadScriptJobHostOptions(_scriptHostManager as IServiceProvider);
-            _eventSubscriptions.Add(_eventManager.OfType<WorkerErrorEvent>().Subscribe(OnWorkerError));
         }
 
         protected virtual int WorkerProcessId => -1;
@@ -1371,8 +1370,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         internal void HandleWorkerEnvReloadError(Exception exc)
         {
             _workerChannelLogger.LogError(exc, "Reloading environment variables failed");
-            _reloadTask.TrySetException(exc);
-            _reloadRequestSent = false;
+            TryFailPendingReload(exc);
         }
 
         internal void HandleWorkerInitError(Exception exc)
@@ -1399,20 +1397,6 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                 return;
             }
             _eventManager.Publish(new WorkerErrorEvent(_runtime, Id, exc));
-        }
-
-        private void OnWorkerError(WorkerErrorEvent workerError)
-        {
-            if (workerError is null ||
-                !_reloadRequestSent ||
-                !string.Equals(workerError.WorkerId, Id, StringComparison.Ordinal) ||
-                workerError.Exception is null)
-            {
-                return;
-            }
-
-            _reloadTask.TrySetException(workerError.Exception);
-            _reloadRequestSent = false;
         }
 
         internal void HandleWorkerMetadataRequestError(Exception exc)
@@ -1574,6 +1558,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
         public void Shutdown(Exception workerException)
         {
+            TryFailPendingReload(workerException);
+
             var shutdownException = workerException;
 
             if (workerException is null || workerException is FunctionTimeoutException)
@@ -1589,6 +1575,17 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                 invocation.Context?.SetException(shutdownException);
                 RemoveExecutingInvocation(invocationId);
             }
+        }
+
+        private void TryFailPendingReload(Exception exception)
+        {
+            if (!_reloadRequestSent || exception is null)
+            {
+                return;
+            }
+
+            _reloadTask.TrySetException(exception);
+            _reloadRequestSent = false;
         }
 
         /// <summary>

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -23,11 +23,14 @@ using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Microsoft.Azure.WebJobs.Script.Http;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.FunctionDataCache;
+using Microsoft.Azure.WebJobs.Script.Workers.Profiles;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.WebJobs.Script.Tests;
 using Moq;
 using OpenTelemetry;
 using Xunit;
@@ -1073,6 +1076,80 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
 
             var actualException = await Assert.ThrowsAsync<WorkerProcessExitException>(() => reloadTask.WaitAsync(TimeSpan.FromSeconds(1)));
             Assert.Equal(expectedException, actualException);
+        }
+
+        // Repro for the crash-during-specialization hang (issue #10169 / PR #11878). On specialization the
+        // host awaits SendFunctionEnvironmentReloadRequest. When the worker crashes mid-reload it publishes a
+        // WorkerErrorEvent; the dispatcher handles it and disposes the channel via
+        // WebHostRpcWorkerChannelManager.ShutdownChannelIfExistsAsync -> ShutdownAndDispose -> Shutdown(exc)
+        // (verified in production: "Disposing WebHost channel for workerId:..."). Before the fix, Shutdown did
+        // not fault the in-flight reload, so it only completed 30s later via EnvironmentReloadTimeout with a
+        // TimeoutException that masked the real crash. With the fix (Shutdown -> TryFailPendingReload) the
+        // reload fails fast with the real WorkerProcessExitException.
+        [Fact]
+        public async Task SendFunctionEnvironmentReloadRequest_WorkerCrashDuringSpecialization_FailsFast()
+        {
+            // Set high so the reload's own timeout cannot satisfy the assertion; the fix must fail it fast.
+            _testWorkerConfig.CountOptions.EnvironmentReloadTimeout = TimeSpan.FromSeconds(30);
+
+            const string runtime = RpcWorkerConstants.DotNetIsolatedLanguageWorkerName;
+            var channelManager = CreateWebHostChannelManager();
+
+            await CreateDefaultWorkerChannel();
+
+            // Register the specializing channel exactly as the WebHost manager tracks it.
+            channelManager.AddOrUpdateWorkerChannels(runtime, _workerChannel);
+            channelManager.SetInitializedWorkerChannel(runtime, _workerChannel);
+
+            var reloadTask = _workerChannel.SendFunctionEnvironmentReloadRequest();
+
+            var workerExit = new WorkerProcessExitException("Language Worker Process exited.")
+            {
+                Pid = 910
+            };
+
+            // The exact call RpcFunctionInvocationDispatcher.DisposeAndRestartWorkerChannel makes when it
+            // handles the crash WorkerErrorEvent (runtime:dotnet-isolated).
+            await channelManager.ShutdownChannelIfExistsAsync(runtime, _workerId, workerExit);
+
+            var actualException = await Assert.ThrowsAsync<WorkerProcessExitException>(() => reloadTask.WaitAsync(TimeSpan.FromSeconds(3)));
+            Assert.Same(workerExit, actualException);
+        }
+
+        // If a channel with an in-flight reload is disposed directly (without going through Shutdown(exception)),
+        // the pending reload should be canceled rather than left to hang until EnvironmentReloadTimeout.
+        [Fact]
+        public async Task Dispose_WithPendingReload_CancelsReload()
+        {
+            _testWorkerConfig.CountOptions.EnvironmentReloadTimeout = TimeSpan.FromSeconds(30);
+
+            await CreateDefaultWorkerChannel();
+            var reloadTask = _workerChannel.SendFunctionEnvironmentReloadRequest();
+
+            _workerChannel.Dispose();
+
+            await Assert.ThrowsAsync<TaskCanceledException>(() => reloadTask.WaitAsync(TimeSpan.FromSeconds(3)));
+        }
+
+        private WebHostRpcWorkerChannelManager CreateWebHostChannelManager()
+        {
+            var workerRuntimeResolver = new Mock<IWorkerRuntimeResolver>();
+            workerRuntimeResolver.Setup(m => m.GetWorkerRuntime(It.IsAny<string>())).Returns(RpcWorkerConstants.DotNetIsolatedLanguageWorkerName);
+
+            var languageWorkerOptions = TestHelpers.CreateOptionsMonitor(new LanguageWorkerOptions { WorkerConfigs = TestHelpers.GetTestWorkerConfigs() });
+
+            return new WebHostRpcWorkerChannelManager(
+                _eventManager,
+                _testEnvironment,
+                _loggerFactory,
+                new Mock<IRpcWorkerChannelFactory>().Object,
+                _hostOptionsMonitor,
+                _metricsLogger,
+                new ConfigurationBuilder().Build(),
+                new Mock<IWorkerProfileManager>().Object,
+                languageWorkerOptions,
+                _hostingConfigOptions,
+                workerRuntimeResolver.Object);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -1078,6 +1078,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.Equal(expectedException, actualException);
         }
 
+        [Fact]
+        public async Task SendFunctionEnvironmentReloadRequest_CalledTwice_ReturnsSameTask()
+        {
+            await CreateDefaultWorkerChannel();
+
+            var firstReloadTask = _workerChannel.SendFunctionEnvironmentReloadRequest();
+            var secondReloadTask = _workerChannel.SendFunctionEnvironmentReloadRequest();
+
+            Assert.Same(firstReloadTask, secondReloadTask);
+
+            _testFunctionRpcService.PublishFunctionEnvironmentReloadResponseEvent(workerSupportsSpecialization: true);
+            _testFunctionRpcService.PublishFunctionEnvironmentReloadResponseEvent(workerSupportsSpecialization: true);
+
+            Assert.True(await firstReloadTask.WaitAsync(TimeSpan.FromSeconds(1)));
+        }
+
         // Repro for the crash-during-specialization hang (issue #10169 / PR #11878). On specialization the
         // host awaits SendFunctionEnvironmentReloadRequest. When the worker crashes mid-reload it publishes a
         // WorkerErrorEvent; the dispatcher handles it and disposes the channel via

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -1059,7 +1059,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
-        public async Task SendFunctionEnvironmentReloadRequest_WorkerErrorEvent_FailsFast()
+        public async Task SendFunctionEnvironmentReloadRequest_ShutdownWithWorkerException_FailsFast()
         {
             await CreateDefaultWorkerChannel();
 
@@ -1069,7 +1069,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
                 Pid = 910
             };
 
-            _eventManager.Publish(new WorkerErrorEvent(_testWorkerConfig.Description.Language, _workerId, expectedException));
+            _workerChannel.Shutdown(expectedException);
 
             var actualException = await Assert.ThrowsAsync<WorkerProcessExitException>(() => reloadTask.WaitAsync(TimeSpan.FromSeconds(1)));
             Assert.Equal(expectedException, actualException);

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -1059,6 +1059,23 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
+        public async Task SendSendFunctionEnvironmentReloadRequest_WorkerErrorEvent_FailsFast()
+        {
+            await CreateDefaultWorkerChannel();
+
+            var reloadTask = _workerChannel.SendFunctionEnvironmentReloadRequest();
+            var expectedException = new WorkerProcessExitException("Language Worker Process exited.")
+            {
+                Pid = 910
+            };
+
+            _eventManager.Publish(new WorkerErrorEvent(_testWorkerConfig.Description.Language, _workerId, expectedException));
+
+            var actualException = await Assert.ThrowsAsync<WorkerProcessExitException>(() => reloadTask.WaitAsync(TimeSpan.FromSeconds(1)));
+            Assert.Equal(expectedException, actualException);
+        }
+
+        [Fact]
         public void SendFunctionEnvironmentReloadRequest_SanitizedEnvironmentVariables()
         {
             CreateDefaultWorkerChannel();

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -1094,7 +1094,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
             Assert.True(await firstReloadTask.WaitAsync(TimeSpan.FromSeconds(1)));
         }
 
-        // Repro for the crash-during-specialization hang (issue #10169 / PR #11878). On specialization the
+        // Repro for the crash-during-specialization hang (issue #11876). On specialization the
         // host awaits SendFunctionEnvironmentReloadRequest. When the worker crashes mid-reload it publishes a
         // WorkerErrorEvent; the dispatcher handles it and disposes the channel via
         // WebHostRpcWorkerChannelManager.ShutdownChannelIfExistsAsync -> ShutdownAndDispose -> Shutdown(exc)

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -1059,7 +1059,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
-        public async Task SendSendFunctionEnvironmentReloadRequest_WorkerErrorEvent_FailsFast()
+        public async Task SendFunctionEnvironmentReloadRequest_WorkerErrorEvent_FailsFast()
         {
             await CreateDefaultWorkerChannel();
 


### PR DESCRIPTION
fixes https://github.com/Azure/azure-functions-host/issues/11876

If an app crashed during env reload, we'd sit and wait 30 seconds for the timeout before continuing. This change fails that Task quickly now so that recovery happens quicker.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)