### PR TITLE
Add function name validation to KeysController.IsFunction

### DIFF
--- a/src/WebJobs.Script.WebHost/Controllers/KeysController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/KeysController.cs
@@ -285,6 +285,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
         private bool IsFunction(string functionName)
         {
+            if (!Utility.IsValidFunctionName(functionName))
+            {
+                return false;
+            }
+
             string functionPath = Path.Combine(_applicationOptions.Value.ScriptPath, functionName);
             if (Utility.TryReadFunctionConfig(functionPath, out _, _fileSystem))
             {

--- a/src/WebJobs.Script.WebHost/Controllers/KeysController.cs
+++ b/src/WebJobs.Script.WebHost/Controllers/KeysController.cs
@@ -285,7 +285,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Controllers
 
         private bool IsFunction(string functionName)
         {
-            if (!Utility.IsValidFunctionName(functionName))
+            if (string.IsNullOrEmpty(functionName) || !Utility.IsValidFunctionName(functionName))
             {
                 return false;
             }

--- a/test/WebJobs.Script.Tests/Controllers/Admin/KeysControllerTests.cs
+++ b/test/WebJobs.Script.Tests/Controllers/Admin/KeysControllerTests.cs
@@ -209,6 +209,61 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             _functionsSyncManagerMock.Verify(p => p.TrySyncTriggersAsync(false), Times.Never);
         }
 
+        [Theory]
+        [InlineData("../etc/passwd")]
+        [InlineData("..\\windows\\system32")]
+        [InlineData("func/../../secret")]
+        [InlineData("host")]
+        [InlineData("")]
+        [InlineData("123startsWithDigit")]
+        [InlineData("-startsWithDash")]
+        [InlineData("has spaces")]
+        [InlineData("has!special@chars")]
+        public async Task GetKeys_InvalidFunctionName_ReturnsNotFound(string functionName)
+        {
+            var result = (StatusCodeResult)await _testController.Get(functionName);
+
+            Assert.Equal(StatusCodes.Status404NotFound, result.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("../etc/passwd")]
+        [InlineData("..\\windows\\system32")]
+        [InlineData("func/../../secret")]
+        [InlineData("host")]
+        [InlineData("")]
+        [InlineData("123startsWithDigit")]
+        [InlineData("-startsWithDash")]
+        [InlineData("has spaces")]
+        [InlineData("has!special@chars")]
+        public async Task PutKey_InvalidFunctionName_ReturnsNotFound(string functionName)
+        {
+            var key = new Key("key1", "secret1");
+
+            var result = (StatusCodeResult)(await _testController.Put(functionName, key.Name, key));
+            Assert.Equal(StatusCodes.Status404NotFound, result.StatusCode);
+
+            _functionsSyncManagerMock.Verify(p => p.TrySyncTriggersAsync(false), Times.Never);
+        }
+
+        [Theory]
+        [InlineData("../etc/passwd")]
+        [InlineData("..\\windows\\system32")]
+        [InlineData("func/../../secret")]
+        [InlineData("host")]
+        [InlineData("")]
+        [InlineData("123startsWithDigit")]
+        [InlineData("-startsWithDash")]
+        [InlineData("has spaces")]
+        [InlineData("has!special@chars")]
+        public async Task DeleteKey_InvalidFunctionName_ReturnsNotFound(string functionName)
+        {
+            var result = (StatusCodeResult)(await _testController.Delete(functionName, "key1"));
+            Assert.Equal(StatusCodes.Status404NotFound, result.StatusCode);
+
+            _functionsSyncManagerMock.Verify(p => p.TrySyncTriggersAsync(false), Times.Never);
+        }
+
         protected virtual void Dispose(bool disposing)
         {
             if (disposing)


### PR DESCRIPTION
## Summary

Adds an early `Utility.IsValidFunctionName()` check at the top of `KeysController.IsFunction()` to reject invalid function names before any filesystem access occurs.

## Motivation

The `IsFunction` method is the primary gate for all function-scoped key management endpoints (`GET`/`POST`/`PUT`/`DELETE` on `/admin/functions/{name}/keys/...`). Previously, it would perform `Path.Combine` with the raw user-supplied function name and attempt to read a `function.json` from that path before checking the function metadata manager.

## Changes

- `KeysController.IsFunction()`: Added `Utility.IsValidFunctionName(functionName)` check that returns `false` early if the name doesn't match the existing regex `^[a-z][a-z0-9_\-]{0,127}$(?<!^host$)`.

## Testing

Existing tests continue to pass. The validation regex is already well-tested in `UtilityTests.IsValidFunctionNameTests`.