### PR TITLE
Fix user-code exception telemetry losing problem id, context, and sampling

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -11,3 +11,4 @@
 - Update PS 7.6 worker to [v4.0.5213](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5213) (#11858)
 - Update `Microsoft.Azure.Functions.DotNetIsolatedNativeHost` to `1.0.15` (#11881)
 - Update Python Worker Version to [4.46.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.46.0) (#11885)
+- Fixed isolated-worker user-code exception telemetry collapsing into a literal "ProblemId" group in Application Insights and losing its sampling decision, operation correlation, and cloud role. (#11887)

--- a/src/WebJobs.Script/Config/ScriptTelemetryProcessor.cs
+++ b/src/WebJobs.Script/Config/ScriptTelemetryProcessor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using Microsoft.ApplicationInsights.Channel;
@@ -12,6 +13,9 @@ namespace Microsoft.Azure.WebJobs.Script.Config
 {
     internal class ScriptTelemetryProcessor : ITelemetryProcessor
     {
+        // Matches the Application Insights limit for the problemId field.
+        private const int MaxProblemIdLength = 1024;
+
         internal static readonly AsyncLocal<bool> SuppressDependencyTelemetry = new();
 
         public ScriptTelemetryProcessor(ITelemetryProcessor next)
@@ -35,26 +39,68 @@ namespace Microsoft.Azure.WebJobs.Script.Config
                 && exceptionTelemetry?.Exception?.InnerException is RpcException rpcException
                 && (rpcException?.IsUserException).GetValueOrDefault())
             {
-                item = ToUserException(rpcException, item);
+                item = ToUserException(rpcException, exceptionTelemetry);
             }
             this.Next.Process(item);
         }
 
-        private ITelemetry ToUserException(RpcException rpcException, ITelemetry originalItem)
+        private static ITelemetry ToUserException(RpcException rpcException, ExceptionTelemetry originalItem)
         {
             string typeName = string.IsNullOrEmpty(rpcException.RemoteTypeName) ? rpcException.GetType().ToString() : rpcException.RemoteTypeName;
 
             var userExceptionDetails = new ExceptionDetailsInfo(1, -1, typeName, rpcException.RemoteMessage, true, rpcException.RemoteStackTrace, new StackFrame[] { });
 
+            // Compute a real problem id (type + top user frame) so these exceptions group like any
+            // other exception in the portal instead of collapsing into one literal "ProblemId" bucket.
             ExceptionTelemetry newET = new ExceptionTelemetry(new[] { userExceptionDetails },
-            SeverityLevel.Error, "ProblemId",
-            new Dictionary<string, string>() { },
+            originalItem.SeverityLevel ?? SeverityLevel.Error, ComputeProblemId(typeName, rpcException.RemoteStackTrace),
+            originalItem.Properties,
             new Dictionary<string, double>() { });
 
+            // This telemetry is created after initializers and (when configured) sampling have already
+            // run on the original item, so anything not copied here is lost: carry over the correlation
+            // and cloud context, and the sampling decision so weighted counts stay accurate.
             newET.Context.InstrumentationKey = originalItem.Context.InstrumentationKey;
+            newET.Context.Operation.Id = originalItem.Context.Operation.Id;
+            newET.Context.Operation.Name = originalItem.Context.Operation.Name;
+            newET.Context.Operation.ParentId = originalItem.Context.Operation.ParentId;
+            newET.Context.Operation.SyntheticSource = originalItem.Context.Operation.SyntheticSource;
+            newET.Context.Cloud.RoleName = originalItem.Context.Cloud.RoleName;
+            newET.Context.Cloud.RoleInstance = originalItem.Context.Cloud.RoleInstance;
             newET.Timestamp = originalItem.Timestamp;
 
+            ((ISupportSampling)newET).SamplingPercentage = ((ISupportSampling)originalItem).SamplingPercentage;
+
             return newET;
+        }
+
+        private static string ComputeProblemId(string typeName, string stackTrace)
+        {
+            if (!string.IsNullOrEmpty(stackTrace))
+            {
+                foreach (string line in stackTrace.Split('\n'))
+                {
+                    string trimmed = line.Trim();
+                    if (!trimmed.StartsWith("at ", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    string frame = trimmed.Substring(3);
+                    int argumentListStart = frame.IndexOf('(');
+                    if (argumentListStart > 0)
+                    {
+                        frame = frame.Substring(0, argumentListStart);
+                    }
+
+                    string problemId = $"{typeName} at {frame.Trim()}";
+                    return problemId.Length <= MaxProblemIdLength ? problemId : problemId.Substring(0, MaxProblemIdLength);
+                }
+            }
+
+            // No parsable frame (empty stack, or a non-.NET worker's stack format): the type name still
+            // groups far better than a constant.
+            return typeName;
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Configuration/ScriptTelemetryProcessorTests.cs
+++ b/test/WebJobs.Script.Tests/Configuration/ScriptTelemetryProcessorTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -70,6 +71,86 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Configuration
             }
 
             Assert.Single(items);
+        }
+
+        [Fact]
+        public void Process_UserCodeException_ComputesProblemIdAndPreservesContext()
+        {
+            var rpcEx = new RpcException(
+                "failure",
+                "boom",
+                "   at My.Namespace.MyFunction.Run(String input) in /src/MyFunction.cs:line 42\n   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)",
+                "My.Namespace.MyException",
+                isUserException: true);
+
+            var original = new ExceptionTelemetry(new Exception("outer", rpcEx))
+            {
+                SeverityLevel = SeverityLevel.Critical,
+            };
+            original.Context.InstrumentationKey = "ikey";
+            original.Context.Operation.Id = "op-id";
+            original.Context.Operation.Name = "MyFunction";
+            original.Context.Operation.ParentId = "parent-id";
+            original.Context.Cloud.RoleName = "my-function-app";
+            original.Context.Cloud.RoleInstance = "instance-0";
+            original.Properties["Category"] = "Host.Results";
+            ((ISupportSampling)original).SamplingPercentage = 25;
+
+            var items = new List<ITelemetry>();
+            var processor = new ScriptTelemetryProcessor(new TestTelemetryProcessor(items));
+
+            processor.Process(original);
+
+            var result = Assert.IsType<ExceptionTelemetry>(Assert.Single(items));
+            Assert.NotSame(original, result);
+            Assert.Equal("My.Namespace.MyException at My.Namespace.MyFunction.Run", result.ProblemId);
+            Assert.Equal(SeverityLevel.Critical, result.SeverityLevel);
+            Assert.Equal("ikey", result.Context.InstrumentationKey);
+            Assert.Equal("op-id", result.Context.Operation.Id);
+            Assert.Equal("MyFunction", result.Context.Operation.Name);
+            Assert.Equal("parent-id", result.Context.Operation.ParentId);
+            Assert.Equal("my-function-app", result.Context.Cloud.RoleName);
+            Assert.Equal("instance-0", result.Context.Cloud.RoleInstance);
+            Assert.Equal(original.Timestamp, result.Timestamp);
+            Assert.Equal("Host.Results", result.Properties["Category"]);
+            Assert.Equal(25, ((ISupportSampling)result).SamplingPercentage);
+
+            var details = Assert.Single(result.ExceptionDetailsInfoList);
+            Assert.Equal("My.Namespace.MyException", details.TypeName);
+            Assert.Equal("boom", details.Message);
+        }
+
+        [Fact]
+        public void Process_UserCodeException_NoParsableStack_ProblemIdFallsBackToTypeName()
+        {
+            var rpcEx = new RpcException(
+                "failure",
+                "boom",
+                "Traceback (most recent call last):\n  File \"main.py\", line 3, in handler",
+                "MyPythonError",
+                isUserException: true);
+
+            var items = new List<ITelemetry>();
+            var processor = new ScriptTelemetryProcessor(new TestTelemetryProcessor(items));
+
+            processor.Process(new ExceptionTelemetry(new Exception("outer", rpcEx)));
+
+            var result = Assert.IsType<ExceptionTelemetry>(Assert.Single(items));
+            Assert.Equal("MyPythonError", result.ProblemId);
+        }
+
+        [Fact]
+        public void Process_NonUserException_IsPassedThroughUnchanged()
+        {
+            var rpcEx = new RpcException("failure", "boom", "stack", "My.Type", isUserException: false);
+            var original = new ExceptionTelemetry(new Exception("outer", rpcEx));
+
+            var items = new List<ITelemetry>();
+            var processor = new ScriptTelemetryProcessor(new TestTelemetryProcessor(items));
+
+            processor.Process(original);
+
+            Assert.Same(original, Assert.Single(items));
         }
 
         [Fact]


### PR DESCRIPTION
### Issue describing the changes in this PR

The bug is fully described below under "Additional information" (issue to be filed separately; will link here once created).

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

`ScriptTelemetryProcessor.ToUserException` (used when the isolated worker's `EnableUserCodeException` capability is on — the default in .NET worker 2.x) rebuilds the exception telemetry with the literal string `"ProblemId"` as the problem id and copies only the instrumentation key and timestamp. Consequences in Application Insights:

1. Every user-code exception type from every function collapses into a single Failures-blade group literally named `ProblemId` (ingestion does not recompute a non-empty problem id).
2. The rebuild runs after the sampling processor in the chain built by `AddApplicationInsightsWebJobs`, so the stamped `SamplingPercentage` is discarded — items always ship with `itemCount = 1` and weighted counts silently under-report (observed in production: ~79k rows/12h in one unsampled `ProblemId` group).
3. `operation_Id`, `operation_Name`, `cloud_RoleName`, `cloud_RoleInstance`, severity, and custom properties are dropped, so these exceptions cannot be correlated or filtered.

This PR computes the problem id from the remote type name plus the first parsable stack frame (`Type at Method`, matching the ingestion convention), falls back to the type name for stacks without .NET-style frames (e.g. Python/Node workers), and carries over the operation context, cloud context, severity, properties, and `ISupportSampling.SamplingPercentage` from the original item. Backport to `in-proc` is not required: the user-code exception path is isolated-worker only.

Tests: three new unit tests in `ScriptTelemetryProcessorTests` (problem id + context/sampling preservation, non-.NET stack fallback, non-user exceptions untouched); `dotnet test --filter ScriptTelemetryProcessorTests` passes 11/11.
