### PR TITLE
Enforce reserved host routes

### DIFF
--- a/src/WebJobs.Script.WebHost/Configuration/ReservedRouteOptions.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/ReservedRouteOptions.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
+{
+    internal sealed class ReservedRouteOptions
+    {
+        public bool DisableReservedRouteEnforcement { get; set; }
+
+        public bool AdminWarmupRouteEnabled { get; set; }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Configuration/ReservedRouteOptionsSetup.cs
+++ b/src/WebJobs.Script.WebHost/Configuration/ReservedRouteOptionsSetup.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Configuration
+{
+    internal sealed class ReservedRouteOptionsSetup(IEnvironment environment) : IConfigureOptions<ReservedRouteOptions>
+    {
+        public void Configure(ReservedRouteOptions options)
+        {
+            options.DisableReservedRouteEnforcement =
+                FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableReservedRouteEnforcement, environment);
+            options.AdminWarmupRouteEnabled = environment.IsAdminWarmupRouteEnabled();
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Middleware/ReservedRouteGuardMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/ReservedRouteGuardMiddleware.cs
@@ -1,0 +1,78 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Extensions;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
+{
+    internal sealed class ReservedRouteGuardMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly IEnvironment _environment;
+        private readonly ILogger<ReservedRouteGuardMiddleware> _logger;
+        private readonly RequestDelegate _invokeBeforeSpecialization;
+        private readonly RequestDelegate _invokeEnforcement;
+        private RequestDelegate _invoke;
+
+        public ReservedRouteGuardMiddleware(RequestDelegate next, IEnvironment environment, ILogger<ReservedRouteGuardMiddleware> logger)
+        {
+            ArgumentNullException.ThrowIfNull(next);
+            ArgumentNullException.ThrowIfNull(environment);
+            ArgumentNullException.ThrowIfNull(logger);
+
+            _next = next;
+            _environment = environment;
+            _logger = logger;
+            _invokeBeforeSpecialization = InvokeBeforeSpecialization;
+            _invokeEnforcement = InvokeEnforcement;
+            _invoke = _invokeBeforeSpecialization;
+        }
+
+        internal RequestDelegate InnerInvoke => _invoke;
+
+        public Task Invoke(HttpContext context)
+        {
+            return _invoke(context);
+        }
+
+        internal Task InvokeBeforeSpecialization(HttpContext context)
+        {
+            if (_environment.IsPlaceholderModeEnabled())
+            {
+                return _invokeEnforcement(context);
+            }
+
+            bool disabled = FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableReservedRouteEnforcement, _environment);
+            RequestDelegate target = disabled ? _next : _invokeEnforcement;
+            RequestDelegate previous = Interlocked.CompareExchange(ref _invoke, target, _invokeBeforeSpecialization);
+
+            if (disabled && ReferenceEquals(previous, _invokeBeforeSpecialization))
+            {
+                _logger.LogInformation(
+                    "Reserved route enforcement is disabled by feature flag '{featureFlag}'.",
+                    ScriptConstants.FeatureFlagDisableReservedRouteEnforcement);
+            }
+
+            return _invoke(context);
+        }
+
+        internal Task InvokeEnforcement(HttpContext context)
+        {
+            if (context.Request.IsReservedRouteRequest() &&
+                !(context.Request.IsAdminWarmupRequest() && _environment.IsAdminWarmupRouteEnabled()))
+            {
+                context.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                return Task.CompletedTask;
+            }
+
+            return _next(context);
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Middleware/ReservedRouteGuardMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/ReservedRouteGuardMiddleware.cs
@@ -2,12 +2,16 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Script.Extensions;
 using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -18,69 +22,123 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
         private readonly RequestDelegate _next;
         private readonly IOptionsMonitor<StandbyOptions> _standbyOptions;
         private readonly IOptionsMonitor<ReservedRouteOptions> _reservedRouteOptions;
-        private readonly ILogger<ReservedRouteGuardMiddleware> _logger;
-        private readonly RequestDelegate _invokeBeforeSpecialization;
-        private readonly RequestDelegate _invokeEnforcement;
-        private RequestDelegate _invoke;
+        private readonly IWebJobsRouter _router;
+        private readonly IScriptHostManager _scriptHostManager;
+        private readonly ConcurrentDictionary<string, byte> _reportedFunctionRouteCollisions = new(StringComparer.OrdinalIgnoreCase);
+        private int _disablementLogAttempted;
 
-        public ReservedRouteGuardMiddleware(
-            RequestDelegate next,
-            IOptionsMonitor<StandbyOptions> standbyOptions,
-            IOptionsMonitor<ReservedRouteOptions> reservedRouteOptions,
-            ILogger<ReservedRouteGuardMiddleware> logger)
+        public ReservedRouteGuardMiddleware(RequestDelegate next, IOptionsMonitor<StandbyOptions> standbyOptions,
+            IOptionsMonitor<ReservedRouteOptions> reservedRouteOptions, IWebJobsRouter router, IScriptHostManager scriptHostManager)
         {
             ArgumentNullException.ThrowIfNull(next);
             ArgumentNullException.ThrowIfNull(standbyOptions);
             ArgumentNullException.ThrowIfNull(reservedRouteOptions);
-            ArgumentNullException.ThrowIfNull(logger);
+            ArgumentNullException.ThrowIfNull(router);
+            ArgumentNullException.ThrowIfNull(scriptHostManager);
 
             _next = next;
             _standbyOptions = standbyOptions;
             _reservedRouteOptions = reservedRouteOptions;
-            _logger = logger;
-            _invokeBeforeSpecialization = InvokeBeforeSpecialization;
-            _invokeEnforcement = InvokeEnforcement;
-            _invoke = _invokeBeforeSpecialization;
+            _router = router;
+            _scriptHostManager = scriptHostManager;
         }
-
-        internal RequestDelegate InnerInvoke => _invoke;
 
         public Task Invoke(HttpContext context)
         {
-            return _invoke(context);
+            if (!context.Request.IsReservedRouteRequest())
+            {
+                return _next(context);
+            }
+
+            bool inStandbyMode = _standbyOptions.CurrentValue.InStandbyMode;
+            ReservedRouteOptions options = _reservedRouteOptions.CurrentValue;
+
+            if (!inStandbyMode && options.DisableReservedRouteEnforcement)
+            {
+                if (Interlocked.Exchange(ref _disablementLogAttempted, 1) == 0)
+                {
+                    TryLog(context, logger => logger.LogInformation("Reserved route enforcement is disabled by feature flag '{featureFlag}'.",
+                        ScriptConstants.FeatureFlagDisableReservedRouteEnforcement));
+                }
+
+                return _next(context);
+            }
+
+            if (context.Request.IsExactAdminWarmupRequest() && options.AdminWarmupRouteEnabled)
+            {
+                return _next(context);
+            }
+
+            return RejectReservedRouteAsync(context, inStandbyMode, options.AdminWarmupRouteEnabled);
         }
 
-        internal Task InvokeBeforeSpecialization(HttpContext context)
+        private async Task RejectReservedRouteAsync(HttpContext context, bool inStandbyMode, bool adminWarmupRouteEnabled)
         {
-            if (_standbyOptions.CurrentValue.InStandbyMode)
+            context.Response.StatusCode = (int)HttpStatusCode.NotFound;
+
+            if (inStandbyMode
+                || _scriptHostManager.State != ScriptHostState.Running
+                || (adminWarmupRouteEnabled && context.Request.IsAdminWarmupRouteMatch()))
             {
-                return _invokeEnforcement(context);
+                return;
             }
 
-            bool disabled = _reservedRouteOptions.CurrentValue.DisableReservedRouteEnforcement;
-            RequestDelegate target = disabled ? _next : _invokeEnforcement;
-            RequestDelegate previous = Interlocked.CompareExchange(ref _invoke, target, _invokeBeforeSpecialization);
-
-            if (disabled && ReferenceEquals(previous, _invokeBeforeSpecialization))
+            string functionName;
+            try
             {
-                _logger.LogInformation(
-                    "Reserved route enforcement is disabled by feature flag '{featureFlag}'.",
-                    ScriptConstants.FeatureFlagDisableReservedRouteEnforcement);
+                functionName = await GetMatchingFunctionNameAsync(context);
+            }
+            catch (Exception exception)
+            {
+                TryLog(context, logger => logger.LogWarning(
+                    exception,
+                    "An error occurred while checking whether the rejected request path '{requestPath}' matches a function route.",
+                    context.Request.Path.Value));
+
+                return;
             }
 
-            return _invoke(context);
+            if (functionName is not null && _reportedFunctionRouteCollisions.TryAdd(functionName, 0))
+            {
+                TryLog(context, logger => logger.LogError(
+                    "The request path '{requestPath}' was rejected because it uses a reserved host route and matches the route for function '{functionName}'. Update the function route to use a non-reserved path.",
+                    context.Request.Path.Value, functionName));
+            }
         }
 
-        internal Task InvokeEnforcement(HttpContext context)
+        private async Task<string> GetMatchingFunctionNameAsync(HttpContext context)
         {
-            if (context.Request.IsReservedRouteRequest() &&
-                !(context.Request.IsAdminWarmupRequest() && _reservedRouteOptions.CurrentValue.AdminWarmupRouteEnabled))
+            // Use the active router so route prefixes, constraints, and ordering remain the single source of truth.
+            var routeContext = new RouteContext(context);
+            await _router.RouteAsync(routeContext);
+
+            if (routeContext.Handler is not null
+                && routeContext.RouteData.DataTokens.TryGetValue(HttpExtensionConstants.FunctionNameRouteTokenKey, out object value)
+                && value is string functionName
+                && !string.IsNullOrEmpty(functionName))
             {
-                context.Response.StatusCode = (int)HttpStatusCode.NotFound;
-                return Task.CompletedTask;
+                return functionName;
             }
 
-            return _next(context);
+            return null;
+        }
+
+        private static void TryLog(HttpContext context, Action<ILogger<ReservedRouteGuardMiddleware>> log)
+        {
+            try
+            {
+                ILogger<ReservedRouteGuardMiddleware> logger = context.RequestServices
+                    .GetService<ILogger<ReservedRouteGuardMiddleware>>();
+
+                if (logger is not null)
+                {
+                    log(logger);
+                }
+            }
+            catch (Exception)
+            {
+                // Diagnostics must not change the reserved-route response.
+            }
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Middleware/ReservedRouteGuardMiddleware.cs
+++ b/src/WebJobs.Script.WebHost/Middleware/ReservedRouteGuardMiddleware.cs
@@ -6,29 +6,37 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Extensions;
+using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
 {
     internal sealed class ReservedRouteGuardMiddleware
     {
         private readonly RequestDelegate _next;
-        private readonly IEnvironment _environment;
+        private readonly IOptionsMonitor<StandbyOptions> _standbyOptions;
+        private readonly IOptionsMonitor<ReservedRouteOptions> _reservedRouteOptions;
         private readonly ILogger<ReservedRouteGuardMiddleware> _logger;
         private readonly RequestDelegate _invokeBeforeSpecialization;
         private readonly RequestDelegate _invokeEnforcement;
         private RequestDelegate _invoke;
 
-        public ReservedRouteGuardMiddleware(RequestDelegate next, IEnvironment environment, ILogger<ReservedRouteGuardMiddleware> logger)
+        public ReservedRouteGuardMiddleware(
+            RequestDelegate next,
+            IOptionsMonitor<StandbyOptions> standbyOptions,
+            IOptionsMonitor<ReservedRouteOptions> reservedRouteOptions,
+            ILogger<ReservedRouteGuardMiddleware> logger)
         {
             ArgumentNullException.ThrowIfNull(next);
-            ArgumentNullException.ThrowIfNull(environment);
+            ArgumentNullException.ThrowIfNull(standbyOptions);
+            ArgumentNullException.ThrowIfNull(reservedRouteOptions);
             ArgumentNullException.ThrowIfNull(logger);
 
             _next = next;
-            _environment = environment;
+            _standbyOptions = standbyOptions;
+            _reservedRouteOptions = reservedRouteOptions;
             _logger = logger;
             _invokeBeforeSpecialization = InvokeBeforeSpecialization;
             _invokeEnforcement = InvokeEnforcement;
@@ -44,12 +52,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
 
         internal Task InvokeBeforeSpecialization(HttpContext context)
         {
-            if (_environment.IsPlaceholderModeEnabled())
+            if (_standbyOptions.CurrentValue.InStandbyMode)
             {
                 return _invokeEnforcement(context);
             }
 
-            bool disabled = FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagDisableReservedRouteEnforcement, _environment);
+            bool disabled = _reservedRouteOptions.CurrentValue.DisableReservedRouteEnforcement;
             RequestDelegate target = disabled ? _next : _invokeEnforcement;
             RequestDelegate previous = Interlocked.CompareExchange(ref _invoke, target, _invokeBeforeSpecialization);
 
@@ -66,7 +74,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Middleware
         internal Task InvokeEnforcement(HttpContext context)
         {
             if (context.Request.IsReservedRouteRequest() &&
-                !(context.Request.IsAdminWarmupRequest() && _environment.IsAdminWarmupRouteEnabled()))
+                !(context.Request.IsAdminWarmupRequest() && _reservedRouteOptions.CurrentValue.AdminWarmupRouteEnabled))
             {
                 context.Response.StatusCode = (int)HttpStatusCode.NotFound;
                 return Task.CompletedTask;

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -233,6 +233,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.ConfigureOptions<StandbyOptionsSetup>();
             services.ConfigureOptionsWithChangeTokenSource<AppServiceOptions, AppServiceOptionsSetup, SpecializationChangeTokenSource<AppServiceOptions>>();
             services.ConfigureOptionsWithChangeTokenSource<HttpBodyControlOptions, HttpBodyControlOptionsSetup, SpecializationChangeTokenSource<HttpBodyControlOptions>>();
+            services.ConfigureOptionsWithChangeTokenSource<ReservedRouteOptions, ReservedRouteOptionsSetup, SpecializationChangeTokenSource<ReservedRouteOptions>>();
             services.ConfigureOptionsWithChangeTokenSource<ResponseCompressionOptions, ResponseCompressionOptionsSetup, SpecializationChangeTokenSource<ResponseCompressionOptions>>();
             services.ConfigureOptions<FlexConsumptionMetricsPublisherOptionsSetup>();
             services.ConfigureOptions<LinuxConsumptionLegionMetricsPublisherOptionsSetup>();

--- a/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
@@ -126,6 +126,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             // source here: https://github.com/aspnet/Mvc/blob/master/src/Microsoft.AspNetCore.Mvc.Core/Builder/MvcApplicationBuilderExtensions.cs
             builder.UseMvc();
 
+            builder.UseMiddleware<ReservedRouteGuardMiddleware>();
+
             // Ensure the HTTP binding routing is registered after all middleware
             builder.UseHttpBindingRouting(routes);
 

--- a/src/WebJobs.Script.WebHost/WebScriptHostHttpRoutesManager.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostHttpRoutesManager.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             WebJobsRouteBuilder proxiesRoutesBuilder = _router.CreateBuilder(new ScriptRouteHandler(_loggerFactory, host, _environment, true), routePrefix: null);
 
             WebJobsRouteBuilder warmupRouteBuilder = null;
-            if (!_environment.IsAnyLinuxConsumption() && !_environment.IsWindowsConsumption())
+            if (_environment.IsAdminWarmupRouteEnabled())
             {
                 warmupRouteBuilder = _router.CreateBuilder(new ScriptRouteHandler(_loggerFactory, host, _environment, isProxy: false, isWarmup: true), routePrefix: "admin");
             }
@@ -94,8 +94,6 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 }
             }
 
-            _router.AddFunctionRoutes(functionRouter, proxyRouter);
-
             if (warmupRouteBuilder != null)
             {
                 // Adding the default admin/warmup route when no warmup function is present
@@ -106,6 +104,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 IRouter warmupRouter = warmupRouteBuilder.Build();
                 _router.AddFunctionRoutes(warmupRouter, null);
             }
+
+            // The host warmup route must take precedence over customer catch-all routes.
+            _router.AddFunctionRoutes(functionRouter, proxyRouter);
 
             ILogger logger = _loggerFactory.CreateLogger<WebScriptHostHttpRoutesManager>();
             logger.LogInformation(routesLogBuilder.ToString());

--- a/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
+++ b/src/WebJobs.Script/Environment/EnvironmentExtensions.cs
@@ -225,6 +225,11 @@ namespace Microsoft.Azure.WebJobs.Script
             return IsWindowsConsumption(environment) || IsAnyLinuxConsumption(environment) || IsFlexConsumptionSku(environment);
         }
 
+        internal static bool IsAdminWarmupRouteEnabled(this IEnvironment environment)
+        {
+            return !environment.IsAnyLinuxConsumption() && !environment.IsWindowsConsumption();
+        }
+
         /// <summary>
         /// Gets a value indicating whether the application is running in the Flex Consumption Sku.
         /// </summary>

--- a/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs
+++ b/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs
@@ -48,9 +48,15 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
             return request.IsAdminRequest() || request.Path.StartsWithSegments(_runtimeRoot);
         }
 
-        internal static bool IsAdminWarmupRequest(this HttpRequest request)
+        internal static bool IsExactAdminWarmupRequest(this HttpRequest request)
         {
             return request.Path.Equals(_adminWarmupPath, StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static bool IsAdminWarmupRouteMatch(this HttpRequest request)
+        {
+            return request.Path.StartsWithSegments(_adminWarmupPath, StringComparison.OrdinalIgnoreCase, out PathString remaining)
+                && (!remaining.HasValue || string.Equals(remaining.Value, "/", StringComparison.Ordinal));
         }
 
         public static TValue GetRequestPropertyOrDefault<TValue>(this HttpRequest request, string key)

--- a/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs
+++ b/src/WebJobs.Script/Extensions/HttpRequestExtensions.cs
@@ -23,8 +23,10 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
     public static class HttpRequestExtensions
     {
         private static readonly PathString _adminRoot = new PathString("/admin");
+        private static readonly PathString _adminWarmupPath = new PathString("/admin/warmup");
         private static readonly PathString _adminDownloadRequestRoot = new PathString("/admin/functions/download");
         private static readonly PathString _adminResumeRequestRoot = new PathString("/admin/host/resume");
+        private static readonly PathString _runtimeRoot = new PathString("/runtime");
 
         public static bool IsAdminRequest(this HttpRequest request)
         {
@@ -39,6 +41,16 @@ namespace Microsoft.Azure.WebJobs.Script.Extensions
         public static bool IsAdminResumeRequest(this HttpRequest request)
         {
             return request.Path.StartsWithSegments(_adminResumeRequestRoot);
+        }
+
+        internal static bool IsReservedRouteRequest(this HttpRequest request)
+        {
+            return request.IsAdminRequest() || request.Path.StartsWithSegments(_runtimeRoot);
+        }
+
+        internal static bool IsAdminWarmupRequest(this HttpRequest request)
+        {
+            return request.Path.Equals(_adminWarmupPath, StringComparison.OrdinalIgnoreCase);
         }
 
         public static TValue GetRequestPropertyOrDefault<TValue>(this HttpRequest request, string key)

--- a/src/WebJobs.Script/Host/ScriptHost.cs
+++ b/src/WebJobs.Script/Host/ScriptHost.cs
@@ -922,9 +922,9 @@ namespace Microsoft.Azure.WebJobs.Script
             }
 
             // disallow custom routes in our own reserved route space
-            string httpRoute = httpTrigger.Route.Trim('/').ToLowerInvariant();
-            if (httpRoute.StartsWith("admin") ||
-                httpRoute.StartsWith("runtime"))
+            ReadOnlySpan<char> httpRoute = httpTrigger.Route.AsSpan().Trim('/');
+            if (httpRoute.StartsWith(ScriptConstants.Admin.AsSpan(), StringComparison.OrdinalIgnoreCase) ||
+                httpRoute.StartsWith(ScriptConstants.Runtime.AsSpan(), StringComparison.OrdinalIgnoreCase))
             {
                 throw new InvalidOperationException("The specified route conflicts with one or more built in routes.");
             }

--- a/src/WebJobs.Script/ScriptConstants.cs
+++ b/src/WebJobs.Script/ScriptConstants.cs
@@ -144,6 +144,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string FeatureFlagEnableResponseCompression = "EnableResponseCompression";
         public const string FeatureFlagEnableMcpCustomHandlerPreview = "EnableMcpCustomHandlerPreview";
         public const string FeatureFlagDisableOrderedInvocationMessages = "DisableOrderedInvocationMessages";
+        public const string FeatureFlagDisableReservedRouteEnforcement = "DisableReservedRouteEnforcement";
         public const string FeatureFlagEnableAzureMonitorTimeIsoFormat = "EnableAzureMonitorTimeIsoFormat";
         public const string FeatureFlagEnableTestDataSuppression = "EnableTestDataSuppression";
         public const string HostingConfigDisableLinuxAppServiceDetailedExecutionEvents = "DisableLinuxExecutionDetails";
@@ -160,6 +161,7 @@ namespace Microsoft.Azure.WebJobs.Script
         public const string LegionCoreUri = "https://legion.core.azurewebsites.net";
 
         public const string AzureFunctionsSystemDirectoryName = ".azurefunctions";
+        public const string Admin = "admin";
         public const string HttpMethodConstraintName = "httpMethod";
         public const string Snapshot = "snapshot";
         public const string Runtime = "runtime";

--- a/test/Resources/TestProjects/DotNetIsolated60/ReservedRouteCatchAll.cs
+++ b/test/Resources/TestProjects/DotNetIsolated60/ReservedRouteCatchAll.cs
@@ -1,0 +1,19 @@
+using System.Net;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+
+namespace DotNetIsolated60
+{
+    public class ReservedRouteCatchAll
+    {
+        [Function(nameof(ReservedRouteCatchAll))]
+        public async Task<HttpResponseData> Run(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "{*path}")] HttpRequestData request)
+        {
+            HttpResponseData response = request.CreateResponse(HttpStatusCode.OK);
+            await response.WriteStringAsync("customer catch-all");
+
+            return response;
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -31,6 +31,7 @@ using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Grpc;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
+using Microsoft.Azure.WebJobs.Script.WebHost.Middleware;
 using Microsoft.Azure.WebJobs.Script.Workers;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Azure.WebJobs.Script.Workers.Rpc.Configuration;
@@ -71,6 +72,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         private readonly TestEnvironment _environment;
         private readonly TestLoggerProvider _loggerProvider;
+        private TestLoggerProvider _scriptHostLoggerProvider;
         private readonly TestMetricsLogger _testMetricsLogger = new();
 
         private readonly ITestOutputHelper _testOutputHelper;
@@ -127,6 +129,56 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
             Assert.Empty(await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task ReservedRouteEnforcement_MatchingFunctionLogsErrorAfterSpecialization()
+        {
+            _scriptHostLoggerProvider = new TestLoggerProvider();
+            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, _loggerProvider, "ReservedRouteCatchAll")
+                .ConfigureScriptHostServices(services =>
+                {
+                    services.PostConfigure<HttpOptions>(options => options.RoutePrefix = string.Empty);
+                });
+
+            await using var stoppable = new StoppableHost(builder.Build());
+            IHost webHost = stoppable.Inner;
+            await webHost.StartAsync();
+            HttpClient client = webHost.GetTestClient();
+
+            HttpResponseMessage response = await client.GetAsync("admin/foo");
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.Empty(await response.Content.ReadAsStringAsync());
+            Assert.DoesNotContain(
+                _loggerProvider.GetAllLogMessages(),
+                p => string.Equals(p.Category, typeof(ReservedRouteGuardMiddleware).FullName, StringComparison.Ordinal));
+            Assert.DoesNotContain(
+                _scriptHostLoggerProvider.GetAllLogMessages(),
+                p => string.Equals(p.Category, typeof(ReservedRouteGuardMiddleware).FullName, StringComparison.Ordinal));
+
+            _environment.SetEnvironmentVariable(
+                EnvironmentSettingNames.AzureWebJobsFeatureFlags,
+                ScriptConstants.FeatureFlagEnableWorkerIndexing);
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+
+            response = await client.GetAsync("admin/foo");
+
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.Empty(await response.Content.ReadAsStringAsync());
+
+            response = await client.GetAsync("runtime/foo");
+
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.Empty(await response.Content.ReadAsStringAsync());
+            LogMessage log = Assert.Single(
+                _scriptHostLoggerProvider.GetAllLogMessages(),
+                p => string.Equals(p.Category, typeof(ReservedRouteGuardMiddleware).FullName, StringComparison.Ordinal) &&
+                     p.Level == LogLevel.Error);
+            Assert.Contains("function 'ReservedRouteCatchAll'", log.FormattedMessage, StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                _loggerProvider.GetAllLogMessages(),
+                p => string.Equals(p.Category, typeof(ReservedRouteGuardMiddleware).FullName, StringComparison.Ordinal));
         }
 
         [Fact]
@@ -1944,7 +1996,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
         private IHostBuilder CreateStandbyHostBuilder(TestLoggerProvider loggerProvider, params string[] functions)
         {
-            loggerProvider = loggerProvider ?? _loggerProvider;
+            loggerProvider ??= _loggerProvider;
             var builder = Program.CreateHostBuilder()
                 .ConfigureWebHost(webHostBuilder =>
                 {
@@ -1992,7 +2044,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 {
                     s.AddLogging(logging =>
                     {
-                        logging.AddProvider(loggerProvider);
+                        logging.AddProvider(_scriptHostLoggerProvider ?? loggerProvider);
                     });
 
                     s.PostConfigure<ScriptJobHostOptions>(o =>

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -95,6 +95,41 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public async Task ReservedRouteEnforcement_OptOutIsAppliedAfterSpecialization()
+        {
+            var builder = InitializeDotNetIsolatedPlaceholderBuilder(_dotnetIsolated60Path, _loggerProvider, "ReservedRouteCatchAll")
+                .ConfigureScriptHostServices(services =>
+                {
+                    services.PostConfigure<HttpOptions>(options => options.RoutePrefix = string.Empty);
+                });
+
+            await using var stoppable = new StoppableHost(builder.Build());
+            IHost webHost = stoppable.Inner;
+            await webHost.StartAsync();
+            HttpClient client = webHost.GetTestClient();
+
+            HttpResponseMessage response = await client.GetAsync("admin/foo");
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.Empty(await response.Content.ReadAsStringAsync());
+
+            _environment.SetEnvironmentVariable(
+                EnvironmentSettingNames.AzureWebJobsFeatureFlags,
+                $"{ScriptConstants.FeatureFlagEnableWorkerIndexing},{ScriptConstants.FeatureFlagDisableReservedRouteEnforcement}");
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady, "1");
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "0");
+
+            response = await client.GetAsync("admin/foo");
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("customer catch-all", await response.Content.ReadAsStringAsync());
+
+            response = await client.GetAsync("admin/host/status");
+
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.Empty(await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
         public async Task ApplicationInsights_InvocationsContainDifferentOperationIds()
         {
             // Verify that when a request specializes the host we don't capture the context

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WarmupFunctionEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WarmupFunctionEndToEndTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Empty(await response.Content.ReadAsStringAsync());
-            Assert.False(response.Headers.Contains("myversion"), "/admin/warmup cannot be overriden by proxies.");
+            Assert.False(response.Headers.Contains("myversion"), "/admin/warmup cannot be overridden by proxies.");
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
             Assert.Empty(await response.Content.ReadAsStringAsync());
-            Assert.False(response.Headers.Contains("myversion"), "/admin/warmup/ cannot be overriden by proxies.");
+            Assert.False(response.Headers.Contains("myversion"), "/admin/warmup/ cannot be overridden by proxies.");
         }
 
         [Fact]
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             string content = await response.Content.ReadAsStringAsync();
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
             Assert.Empty(content);
-            Assert.False(response.Headers.Contains("myversion"), "/admin/* endpoints cannot be overriden by proxies.");
+            Assert.False(response.Headers.Contains("myversion"), "/admin/* endpoints cannot be overridden by proxies.");
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WarmupFunctionEndToEndTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/WarmupFunctionEndToEndTests.cs
@@ -43,7 +43,18 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             HttpResponseMessage response = await _fixture.HttpClient.GetAsync($"/admin/warmup");
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Empty(await response.Content.ReadAsStringAsync());
             Assert.False(response.Headers.Contains("myversion"), "/admin/warmup cannot be overriden by proxies.");
+        }
+
+        [Fact]
+        public async Task Warmup_TrailingSlash_ReturnsNotFound()
+        {
+            HttpResponseMessage response = await _fixture.HttpClient.GetAsync("/admin/warmup/");
+
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.Empty(await response.Content.ReadAsStringAsync());
+            Assert.False(response.Headers.Contains("myversion"), "/admin/warmup/ cannot be overriden by proxies.");
         }
 
         [Fact]
@@ -62,7 +73,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             HttpResponseMessage response = await _fixture.HttpClient.GetAsync("/admin/123");
 
             string content = await response.Content.ReadAsStringAsync();
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.Empty(content);
             Assert.False(response.Headers.Contains("myversion"), "/admin/* endpoints cannot be overriden by proxies.");
+        }
+
+        [Fact]
+        public async Task FunctionRoutes_RuntimeOverride_Fails()
+        {
+            HttpResponseMessage response = await _fixture.HttpClient.GetAsync("/runtime/123");
+
+            string content = await response.Content.ReadAsStringAsync();
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.Empty(content);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Middleware/ReservedRouteGuardMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Middleware/ReservedRouteGuardMiddlewareTests.cs
@@ -1,0 +1,242 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Net;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Middleware;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
+{
+    public class ReservedRouteGuardMiddlewareTests
+    {
+        [Theory]
+        [InlineData("/admin")]
+        [InlineData("/admin/")]
+        [InlineData("/admin/foo")]
+        [InlineData("/ADMIN/foo")]
+        [InlineData("/runtime")]
+        [InlineData("/runtime/")]
+        [InlineData("/runtime/foo")]
+        [InlineData("/runtime/x/y")]
+        public async Task Invoke_ReservedPath_ReturnsNotFound(string path)
+        {
+            var environment = CreateEnvironment(inPlaceholderMode: false);
+            bool nextInvoked = false;
+            var middleware = CreateMiddleware(environment, _ =>
+            {
+                nextInvoked = true;
+                return Task.CompletedTask;
+            });
+            var context = CreateContext(path);
+
+            await middleware.Invoke(context);
+
+            Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+            Assert.Equal(0, context.Response.Body.Length);
+            Assert.False(nextInvoked);
+            Assert.Equal(middleware.InvokeEnforcement, middleware.InnerInvoke);
+        }
+
+        [Theory]
+        [InlineData("/")]
+        [InlineData("/api/foo")]
+        [InlineData("/administrator")]
+        [InlineData("/runtimefoo")]
+        public async Task Invoke_NonReservedPath_InvokesNext(string path)
+        {
+            var environment = CreateEnvironment(inPlaceholderMode: false);
+            bool nextInvoked = false;
+            var middleware = CreateMiddleware(environment, context =>
+            {
+                nextInvoked = true;
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return Task.CompletedTask;
+            });
+            var context = CreateContext(path);
+
+            await middleware.Invoke(context);
+
+            Assert.True(nextInvoked);
+            Assert.Equal(StatusCodes.Status202Accepted, context.Response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("/admin/warmup")]
+        [InlineData("/ADMIN/WARMUP")]
+        public async Task Invoke_AdminWarmupOnSupportedSku_InvokesNext(string path)
+        {
+            var environment = CreateEnvironment(inPlaceholderMode: false);
+            bool nextInvoked = false;
+            var middleware = CreateMiddleware(environment, context =>
+            {
+                nextInvoked = true;
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return Task.CompletedTask;
+            });
+            var context = CreateContext(path);
+            context.Request.QueryString = new QueryString("?key=value");
+
+            await middleware.Invoke(context);
+
+            Assert.True(nextInvoked);
+            Assert.Equal(StatusCodes.Status202Accepted, context.Response.StatusCode);
+        }
+
+        [Theory]
+        [InlineData("/admin/warmup/")]
+        [InlineData("/admin/warmup/foo")]
+        public async Task Invoke_AdminWarmupDescendant_ReturnsNotFound(string path)
+        {
+            var environment = CreateEnvironment(inPlaceholderMode: false);
+            bool nextInvoked = false;
+            var middleware = CreateMiddleware(environment, _ =>
+            {
+                nextInvoked = true;
+                return Task.CompletedTask;
+            });
+            var context = CreateContext(path);
+
+            await middleware.Invoke(context);
+
+            Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+            Assert.False(nextInvoked);
+        }
+
+        [Fact]
+        public async Task Invoke_AdminWarmupOnConsumptionSku_ReturnsNotFound()
+        {
+            var environment = CreateEnvironment(inPlaceholderMode: false);
+            environment.Platform = OSPlatform.Windows;
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, ScriptConstants.DynamicSku);
+            bool nextInvoked = false;
+            var middleware = CreateMiddleware(environment, _ =>
+            {
+                nextInvoked = true;
+                return Task.CompletedTask;
+            });
+            var context = CreateContext("/admin/warmup");
+
+            await middleware.Invoke(context);
+
+            Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+            Assert.False(nextInvoked);
+        }
+
+        [Fact]
+        public async Task Invoke_InPlaceholderMode_EnforcesWithoutRewiring()
+        {
+            var environment = CreateEnvironment(inPlaceholderMode: true);
+            bool nextInvoked = false;
+            var middleware = CreateMiddleware(environment, _ =>
+            {
+                nextInvoked = true;
+                return Task.CompletedTask;
+            });
+            var context = CreateContext("/admin/foo");
+
+            await middleware.Invoke(context);
+
+            Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+            Assert.False(nextInvoked);
+            Assert.Equal(middleware.InvokeBeforeSpecialization, middleware.InnerInvoke);
+        }
+
+        [Fact]
+        public async Task Invoke_AfterSpecializationWithOptOut_RewiresToNext()
+        {
+            var environment = CreateEnvironment(inPlaceholderMode: false);
+            environment.SetEnvironmentVariable(
+                EnvironmentSettingNames.AzureWebJobsFeatureFlags,
+                ScriptConstants.FeatureFlagDisableReservedRouteEnforcement);
+            int nextInvocations = 0;
+            RequestDelegate next = context =>
+            {
+                nextInvocations++;
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
+                return Task.CompletedTask;
+            };
+            var middleware = CreateMiddleware(environment, next);
+
+            await middleware.Invoke(CreateContext("/admin/foo"));
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, null);
+            var secondContext = CreateContext("/runtime/foo");
+            await middleware.Invoke(secondContext);
+
+            Assert.Equal(2, nextInvocations);
+            Assert.Equal(StatusCodes.Status202Accepted, secondContext.Response.StatusCode);
+            Assert.Equal(next, middleware.InnerInvoke);
+        }
+
+        [Fact]
+        public async Task Invoke_AfterSpecializationWithoutOptOut_RewiresToEnforcement()
+        {
+            var environment = CreateEnvironment(inPlaceholderMode: false);
+            bool nextInvoked = false;
+            var middleware = CreateMiddleware(environment, _ =>
+            {
+                nextInvoked = true;
+                return Task.CompletedTask;
+            });
+
+            await middleware.Invoke(CreateContext("/admin/foo"));
+            environment.SetEnvironmentVariable(
+                EnvironmentSettingNames.AzureWebJobsFeatureFlags,
+                ScriptConstants.FeatureFlagDisableReservedRouteEnforcement);
+            var secondContext = CreateContext("/runtime/foo");
+            await middleware.Invoke(secondContext);
+
+            Assert.Equal(StatusCodes.Status404NotFound, secondContext.Response.StatusCode);
+            Assert.False(nextInvoked);
+            Assert.Equal(middleware.InvokeEnforcement, middleware.InnerInvoke);
+        }
+
+        [Theory]
+        [InlineData(true, null, true)]
+        [InlineData(true, ScriptConstants.DynamicSku, false)]
+        [InlineData(false, ScriptConstants.FlexConsumptionSku, false)]
+        public void IsAdminWarmupRouteEnabled_ReturnsExpectedResult(bool isWindows, string sku, bool expected)
+        {
+            var environment = new TestEnvironment
+            {
+                Platform = isWindows ? OSPlatform.Windows : OSPlatform.Linux
+            };
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, sku);
+
+            Assert.Equal(expected, environment.IsAdminWarmupRouteEnabled());
+        }
+
+        private static ReservedRouteGuardMiddleware CreateMiddleware(TestEnvironment environment, RequestDelegate next)
+        {
+            return new ReservedRouteGuardMiddleware(
+                next,
+                environment,
+                Mock.Of<ILogger<ReservedRouteGuardMiddleware>>());
+        }
+
+        private static TestEnvironment CreateEnvironment(bool inPlaceholderMode)
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(
+                EnvironmentSettingNames.AzureWebsitePlaceholderMode,
+                inPlaceholderMode ? "1" : "0");
+            return environment;
+        }
+
+        private static DefaultHttpContext CreateContext(string path)
+        {
+            return new DefaultHttpContext
+            {
+                Request =
+                {
+                    Path = path
+                }
+            };
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Middleware/ReservedRouteGuardMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Middleware/ReservedRouteGuardMiddlewareTests.cs
@@ -1,14 +1,20 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+using System.IO;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Constraints;
+using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
 using Microsoft.Azure.WebJobs.Script.WebHost.Middleware;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -40,7 +46,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
             Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
             Assert.Equal(0, context.Response.Body.Length);
             Assert.False(nextInvoked);
-            Assert.Equal(middleware.InvokeEnforcement, middleware.InnerInvoke);
         }
 
         [Theory]
@@ -87,7 +92,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
         }
 
         [Theory]
-        [InlineData("/admin/warmup/")]
         [InlineData("/admin/warmup/foo")]
         public async Task Invoke_AdminWarmupDescendant_ReturnsNotFound(string path)
         {
@@ -103,6 +107,48 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
 
             Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
             Assert.False(nextInvoked);
+        }
+
+        [Theory]
+        [InlineData("/admin/warmup/")]
+        [InlineData("/ADMIN/WARMUP/")]
+        public async Task Invoke_AdminWarmupTrailingSlash_DoesNotLogHostWarmupRouteCollision(string path)
+        {
+            var (router, routeHandler) = CreateRouter("admin/warmup", "Warmup");
+            var logger = new TestLogger<ReservedRouteGuardMiddleware>();
+            var middleware = CreateMiddleware(_ => Task.CompletedTask, router: router);
+            var context = CreateContext(path, logger);
+
+            await middleware.Invoke(context);
+
+            Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+            Assert.Empty(logger.GetLogMessages());
+            routeHandler.Verify(p => p.InvokeAsync(It.IsAny<HttpContext>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Invoke_AdminWarmupTrailingSlashOnUnsupportedSku_LogsCustomerCollision()
+        {
+            const string functionName = "ReservedRouteCatchAll";
+            var (router, routeHandler) = CreateRouter("{*route}", functionName);
+            var logger = new TestLogger<ReservedRouteGuardMiddleware>();
+            var reservedRouteOptions = new ReservedRouteOptions
+            {
+                AdminWarmupRouteEnabled = false
+            };
+            var middleware = CreateMiddleware(
+                _ => Task.CompletedTask,
+                reservedRouteOptions: reservedRouteOptions,
+                router: router);
+            var context = CreateContext("/admin/warmup/", logger);
+
+            await middleware.Invoke(context);
+
+            LogMessage log = Assert.Single(logger.GetLogMessages());
+            Assert.Equal(LogLevel.Error, log.Level);
+            Assert.Contains($"function '{functionName}'", log.FormattedMessage, StringComparison.Ordinal);
+            Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+            routeHandler.Verify(p => p.InvokeAsync(It.IsAny<HttpContext>(), It.IsAny<string>()), Times.Never);
         }
 
         [Fact]
@@ -127,29 +173,186 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
         }
 
         [Fact]
-        public async Task Invoke_InPlaceholderMode_EnforcesWithoutRewiring()
+        public async Task Invoke_InPlaceholderMode_EnforcesDespiteOptOut()
         {
             bool nextInvoked = false;
+            var (router, routeHandler) = CreateRouter("{*route}", "ReservedRouteCatchAll");
+            var logger = new TestLogger<ReservedRouteGuardMiddleware>();
             var standbyOptions = new StandbyOptions
             {
                 InStandbyMode = true
+            };
+            var reservedRouteOptions = new ReservedRouteOptions
+            {
+                AdminWarmupRouteEnabled = true,
+                DisableReservedRouteEnforcement = true
             };
             var middleware = CreateMiddleware(_ =>
             {
                 nextInvoked = true;
                 return Task.CompletedTask;
-            }, standbyOptions: standbyOptions);
-            var context = CreateContext("/admin/foo");
+            }, standbyOptions: standbyOptions, reservedRouteOptions: reservedRouteOptions, router: router);
+            var context = CreateContext("/admin/foo", logger);
 
             await middleware.Invoke(context);
 
             Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
             Assert.False(nextInvoked);
-            Assert.Equal(middleware.InvokeBeforeSpecialization, middleware.InnerInvoke);
+            Assert.Empty(logger.GetLogMessages());
+            routeHandler.Verify(p => p.InvokeAsync(It.IsAny<HttpContext>(), It.IsAny<string>()), Times.Never);
         }
 
         [Fact]
-        public async Task Invoke_AfterSpecializationWithOptOut_RewiresToNext()
+        public async Task Invoke_ReservedPathMatchingFunction_LogsErrorOnceWithoutInvokingRouteHandler()
+        {
+            const string functionName = "ReservedRouteCatchAll";
+            var (router, routeHandler) = CreateRouter("{*route}", functionName);
+            var logger = new TestLogger<ReservedRouteGuardMiddleware>();
+            var middleware = CreateMiddleware(_ => Task.CompletedTask, router: router);
+            var context = CreateContext("/admin/foo", logger);
+            var secondContext = CreateContext("/runtime/foo", logger);
+
+            await middleware.Invoke(context);
+            await middleware.Invoke(secondContext);
+
+            LogMessage log = Assert.Single(logger.GetLogMessages());
+            Assert.Equal(LogLevel.Error, log.Level);
+            Assert.Equal(
+                $"The request path '/admin/foo' was rejected because it uses a reserved host route and matches the route for function '{functionName}'. Update the function route to use a non-reserved path.",
+                log.FormattedMessage);
+            Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+            Assert.Equal(StatusCodes.Status404NotFound, secondContext.Response.StatusCode);
+            routeHandler.Verify(p => p.InvokeAsync(It.IsAny<HttpContext>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Invoke_ReservedPathWithoutMatchingFunction_DoesNotLog()
+        {
+            var logger = new TestLogger<ReservedRouteGuardMiddleware>();
+            var middleware = CreateMiddleware(_ => Task.CompletedTask);
+            var context = CreateContext("/admin/foo", logger);
+
+            await middleware.Invoke(context);
+
+            Assert.Empty(logger.GetLogMessages());
+            Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+        }
+
+        [Fact]
+        public async Task Invoke_ReservedPathWithMethodMismatch_DoesNotLog()
+        {
+            var (router, routeHandler) = CreateRouter("{*route}", "ReservedRouteCatchAll", HttpMethods.Post);
+            var logger = new TestLogger<ReservedRouteGuardMiddleware>();
+            var middleware = CreateMiddleware(_ => Task.CompletedTask, router: router);
+            var context = CreateContext("/runtime/foo", logger);
+
+            await middleware.Invoke(context);
+
+            Assert.Empty(logger.GetLogMessages());
+            Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+            routeHandler.Verify(p => p.InvokeAsync(It.IsAny<HttpContext>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Invoke_HostNotRunning_DoesNotProbeOrLog()
+        {
+            var router = new Mock<IWebJobsRouter>(MockBehavior.Strict);
+            var scriptHostManager = Mock.Of<IScriptHostManager>(p => p.State == ScriptHostState.Default);
+            var logger = new TestLogger<ReservedRouteGuardMiddleware>();
+            var middleware = CreateMiddleware(
+                _ => Task.CompletedTask,
+                router: router.Object,
+                scriptHostManager: scriptHostManager);
+            var context = CreateContext("/admin/foo", logger);
+
+            await middleware.Invoke(context);
+
+            Assert.Empty(logger.GetLogMessages());
+            Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+            router.Verify(p => p.RouteAsync(It.IsAny<RouteContext>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Invoke_RouteProbeThrows_ReturnsNotFoundAndLogsWarning()
+        {
+            var router = new Mock<IWebJobsRouter>();
+            router
+                .Setup(p => p.RouteAsync(It.IsAny<RouteContext>()))
+                .ThrowsAsync(new InvalidOperationException("Route probe failed."));
+            var logger = new TestLogger<ReservedRouteGuardMiddleware>();
+            var middleware = CreateMiddleware(_ => Task.CompletedTask, router: router.Object);
+            var context = CreateContext("/admin/foo", logger);
+
+            await middleware.Invoke(context);
+
+            LogMessage log = Assert.Single(logger.GetLogMessages());
+            Assert.Equal(LogLevel.Warning, log.Level);
+            Assert.Equal(
+                "An error occurred while checking whether the rejected request path '/admin/foo' matches a function route.",
+                log.FormattedMessage);
+            Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+        }
+
+        [Fact]
+        public async Task Invoke_RouteProbeThrowsWithoutLogger_ReturnsNotFound()
+        {
+            var router = new Mock<IWebJobsRouter>();
+            router
+                .Setup(p => p.RouteAsync(It.IsAny<RouteContext>()))
+                .ThrowsAsync(new InvalidOperationException("Route probe failed."));
+            var middleware = CreateMiddleware(_ => Task.CompletedTask, router: router.Object);
+            var context = CreateContext("/admin/foo", registerLogger: false);
+
+            await middleware.Invoke(context);
+
+            Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+            router.VerifyAll();
+            Mock.Get(context.RequestServices).Verify(
+                p => p.GetService(typeof(ILogger<ReservedRouteGuardMiddleware>)),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task Invoke_LoggerResolutionThrows_ReturnsNotFound()
+        {
+            var (router, _) = CreateRouter("{*route}", "ReservedRouteCatchAll");
+            var middleware = CreateMiddleware(_ => Task.CompletedTask, router: router);
+            var context = CreateContext(
+                "/admin/foo",
+                loggerResolutionException: new ObjectDisposedException(nameof(IServiceProvider)));
+
+            await middleware.Invoke(context);
+
+            Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+            Mock.Get(context.RequestServices).Verify(
+                p => p.GetService(typeof(ILogger<ReservedRouteGuardMiddleware>)),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task Invoke_LoggerThrows_ReturnsNotFound()
+        {
+            var (router, _) = CreateRouter("{*route}", "ReservedRouteCatchAll");
+            var logger = new Mock<ILogger<ReservedRouteGuardMiddleware>>();
+            logger
+                .Setup(p => p.Log(
+                    It.IsAny<LogLevel>(),
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()))
+                .Throws(new InvalidOperationException("Logging failed."));
+            var middleware = CreateMiddleware(_ => Task.CompletedTask, router: router);
+            var context = CreateContext("/admin/foo", logger.Object);
+
+            await middleware.Invoke(context);
+
+            Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+            logger.VerifyAll();
+        }
+
+        [Fact]
+        public async Task Invoke_ReservedPath_WhenOptOutRemoved_EnforcesSubsequentRequest()
         {
             int nextInvocations = 0;
             RequestDelegate next = context =>
@@ -170,22 +373,22 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
             var secondContext = CreateContext("/runtime/foo");
             await middleware.Invoke(secondContext);
 
-            Assert.Equal(2, nextInvocations);
-            Assert.Equal(StatusCodes.Status202Accepted, secondContext.Response.StatusCode);
-            Assert.Equal(next, middleware.InnerInvoke);
+            Assert.Equal(1, nextInvocations);
+            Assert.Equal(StatusCodes.Status404NotFound, secondContext.Response.StatusCode);
         }
 
         [Fact]
-        public async Task Invoke_AfterSpecializationWithoutOptOut_RewiresToEnforcement()
+        public async Task Invoke_ReservedPath_WhenOptOutEnabled_AllowsSubsequentRequest()
         {
             bool nextInvoked = false;
             var reservedRouteOptions = new ReservedRouteOptions
             {
                 AdminWarmupRouteEnabled = true
             };
-            var middleware = CreateMiddleware(_ =>
+            var middleware = CreateMiddleware(context =>
             {
                 nextInvoked = true;
+                context.Response.StatusCode = StatusCodes.Status202Accepted;
                 return Task.CompletedTask;
             }, reservedRouteOptions: reservedRouteOptions);
 
@@ -194,9 +397,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
             var secondContext = CreateContext("/runtime/foo");
             await middleware.Invoke(secondContext);
 
-            Assert.Equal(StatusCodes.Status404NotFound, secondContext.Response.StatusCode);
-            Assert.False(nextInvoked);
-            Assert.Equal(middleware.InvokeEnforcement, middleware.InnerInvoke);
+            Assert.Equal(StatusCodes.Status202Accepted, secondContext.Response.StatusCode);
+            Assert.True(nextInvoked);
         }
 
         [Theory]
@@ -235,23 +437,74 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
         private static ReservedRouteGuardMiddleware CreateMiddleware(
             RequestDelegate next,
             StandbyOptions standbyOptions = null,
-            ReservedRouteOptions reservedRouteOptions = null)
+            ReservedRouteOptions reservedRouteOptions = null,
+            IWebJobsRouter router = null,
+            IScriptHostManager scriptHostManager = null)
         {
             return new ReservedRouteGuardMiddleware(
                 next,
                 new TestOptionsMonitor<StandbyOptions>(standbyOptions),
                 new TestOptionsMonitor<ReservedRouteOptions>(
                     reservedRouteOptions ?? new ReservedRouteOptions { AdminWarmupRouteEnabled = true }),
-                Mock.Of<ILogger<ReservedRouteGuardMiddleware>>());
+                router ?? new WebJobsRouter(Mock.Of<IInlineConstraintResolver>()),
+                scriptHostManager ?? Mock.Of<IScriptHostManager>(p => p.State == ScriptHostState.Running));
         }
 
-        private static DefaultHttpContext CreateContext(string path)
+        private static (IWebJobsRouter Router, Mock<IWebJobsRouteHandler> Handler) CreateRouter(
+            string route,
+            string functionName,
+            params string[] methods)
         {
+            var handler = new Mock<IWebJobsRouteHandler>(MockBehavior.Strict);
+            var router = new WebJobsRouter(Mock.Of<IInlineConstraintResolver>());
+            WebJobsRouteBuilder builder = router.CreateBuilder(handler.Object, routePrefix: string.Empty);
+            var constraints = new RouteValueDictionary();
+            if (methods.Length > 0)
+            {
+                constraints.Add("httpMethod", new HttpMethodRouteConstraint(methods));
+            }
+
+            builder.MapFunctionRoute(functionName, route, constraints, functionName);
+            router.AddFunctionRoutes(builder.Build(), null);
+
+            return (router, handler);
+        }
+
+        private static DefaultHttpContext CreateContext(
+            string path,
+            ILogger<ReservedRouteGuardMiddleware> logger = null,
+            bool registerLogger = true,
+            Exception loggerResolutionException = null)
+        {
+            var services = new Mock<IServiceProvider>();
+            if (loggerResolutionException is not null)
+            {
+                services
+                    .Setup(p => p.GetService(typeof(ILogger<ReservedRouteGuardMiddleware>)))
+                    .Throws(loggerResolutionException);
+            }
+            else if (registerLogger)
+            {
+                services
+                    .Setup(p => p.GetService(typeof(ILogger<ReservedRouteGuardMiddleware>)))
+                    .Returns(logger ?? Mock.Of<ILogger<ReservedRouteGuardMiddleware>>());
+            }
+
+            services
+                .Setup(p => p.GetService(typeof(ILoggerFactory)))
+                .Returns(NullLoggerFactory.Instance);
+
             return new DefaultHttpContext
             {
+                RequestServices = services.Object,
                 Request =
                 {
+                    Method = HttpMethods.Get,
                     Path = path
+                },
+                Response =
+                {
+                    Body = new MemoryStream()
                 }
             };
         }

--- a/test/WebJobs.Script.Tests/Middleware/ReservedRouteGuardMiddlewareTests.cs
+++ b/test/WebJobs.Script.Tests/Middleware/ReservedRouteGuardMiddlewareTests.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
 using Microsoft.Azure.WebJobs.Script.WebHost.Middleware;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -26,9 +27,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
         [InlineData("/runtime/x/y")]
         public async Task Invoke_ReservedPath_ReturnsNotFound(string path)
         {
-            var environment = CreateEnvironment(inPlaceholderMode: false);
             bool nextInvoked = false;
-            var middleware = CreateMiddleware(environment, _ =>
+            var middleware = CreateMiddleware(_ =>
             {
                 nextInvoked = true;
                 return Task.CompletedTask;
@@ -50,9 +50,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
         [InlineData("/runtimefoo")]
         public async Task Invoke_NonReservedPath_InvokesNext(string path)
         {
-            var environment = CreateEnvironment(inPlaceholderMode: false);
             bool nextInvoked = false;
-            var middleware = CreateMiddleware(environment, context =>
+            var middleware = CreateMiddleware(context =>
             {
                 nextInvoked = true;
                 context.Response.StatusCode = StatusCodes.Status202Accepted;
@@ -71,9 +70,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
         [InlineData("/ADMIN/WARMUP")]
         public async Task Invoke_AdminWarmupOnSupportedSku_InvokesNext(string path)
         {
-            var environment = CreateEnvironment(inPlaceholderMode: false);
             bool nextInvoked = false;
-            var middleware = CreateMiddleware(environment, context =>
+            var middleware = CreateMiddleware(context =>
             {
                 nextInvoked = true;
                 context.Response.StatusCode = StatusCodes.Status202Accepted;
@@ -93,9 +91,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
         [InlineData("/admin/warmup/foo")]
         public async Task Invoke_AdminWarmupDescendant_ReturnsNotFound(string path)
         {
-            var environment = CreateEnvironment(inPlaceholderMode: false);
             bool nextInvoked = false;
-            var middleware = CreateMiddleware(environment, _ =>
+            var middleware = CreateMiddleware(_ =>
             {
                 nextInvoked = true;
                 return Task.CompletedTask;
@@ -111,15 +108,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
         [Fact]
         public async Task Invoke_AdminWarmupOnConsumptionSku_ReturnsNotFound()
         {
-            var environment = CreateEnvironment(inPlaceholderMode: false);
-            environment.Platform = OSPlatform.Windows;
-            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, ScriptConstants.DynamicSku);
             bool nextInvoked = false;
-            var middleware = CreateMiddleware(environment, _ =>
+            var reservedRouteOptions = new ReservedRouteOptions
+            {
+                AdminWarmupRouteEnabled = false
+            };
+            var middleware = CreateMiddleware(_ =>
             {
                 nextInvoked = true;
                 return Task.CompletedTask;
-            });
+            }, reservedRouteOptions: reservedRouteOptions);
             var context = CreateContext("/admin/warmup");
 
             await middleware.Invoke(context);
@@ -131,13 +129,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
         [Fact]
         public async Task Invoke_InPlaceholderMode_EnforcesWithoutRewiring()
         {
-            var environment = CreateEnvironment(inPlaceholderMode: true);
             bool nextInvoked = false;
-            var middleware = CreateMiddleware(environment, _ =>
+            var standbyOptions = new StandbyOptions
+            {
+                InStandbyMode = true
+            };
+            var middleware = CreateMiddleware(_ =>
             {
                 nextInvoked = true;
                 return Task.CompletedTask;
-            });
+            }, standbyOptions: standbyOptions);
             var context = CreateContext("/admin/foo");
 
             await middleware.Invoke(context);
@@ -150,10 +151,6 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
         [Fact]
         public async Task Invoke_AfterSpecializationWithOptOut_RewiresToNext()
         {
-            var environment = CreateEnvironment(inPlaceholderMode: false);
-            environment.SetEnvironmentVariable(
-                EnvironmentSettingNames.AzureWebJobsFeatureFlags,
-                ScriptConstants.FeatureFlagDisableReservedRouteEnforcement);
             int nextInvocations = 0;
             RequestDelegate next = context =>
             {
@@ -161,10 +158,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
                 context.Response.StatusCode = StatusCodes.Status202Accepted;
                 return Task.CompletedTask;
             };
-            var middleware = CreateMiddleware(environment, next);
+            var reservedRouteOptions = new ReservedRouteOptions
+            {
+                AdminWarmupRouteEnabled = true,
+                DisableReservedRouteEnforcement = true
+            };
+            var middleware = CreateMiddleware(next, reservedRouteOptions: reservedRouteOptions);
 
             await middleware.Invoke(CreateContext("/admin/foo"));
-            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, null);
+            reservedRouteOptions.DisableReservedRouteEnforcement = false;
             var secondContext = CreateContext("/runtime/foo");
             await middleware.Invoke(secondContext);
 
@@ -176,18 +178,19 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
         [Fact]
         public async Task Invoke_AfterSpecializationWithoutOptOut_RewiresToEnforcement()
         {
-            var environment = CreateEnvironment(inPlaceholderMode: false);
             bool nextInvoked = false;
-            var middleware = CreateMiddleware(environment, _ =>
+            var reservedRouteOptions = new ReservedRouteOptions
+            {
+                AdminWarmupRouteEnabled = true
+            };
+            var middleware = CreateMiddleware(_ =>
             {
                 nextInvoked = true;
                 return Task.CompletedTask;
-            });
+            }, reservedRouteOptions: reservedRouteOptions);
 
             await middleware.Invoke(CreateContext("/admin/foo"));
-            environment.SetEnvironmentVariable(
-                EnvironmentSettingNames.AzureWebJobsFeatureFlags,
-                ScriptConstants.FeatureFlagDisableReservedRouteEnforcement);
+            reservedRouteOptions.DisableReservedRouteEnforcement = true;
             var secondContext = CreateContext("/runtime/foo");
             await middleware.Invoke(secondContext);
 
@@ -200,32 +203,46 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Middleware
         [InlineData(true, null, true)]
         [InlineData(true, ScriptConstants.DynamicSku, false)]
         [InlineData(false, ScriptConstants.FlexConsumptionSku, false)]
-        public void IsAdminWarmupRouteEnabled_ReturnsExpectedResult(bool isWindows, string sku, bool expected)
+        public void ReservedRouteOptionsSetup_ReturnsExpectedWarmupRouteValue(bool isWindows, string sku, bool expected)
         {
             var environment = new TestEnvironment
             {
                 Platform = isWindows ? OSPlatform.Windows : OSPlatform.Linux
             };
             environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteSku, sku);
+            var options = new ReservedRouteOptions();
 
-            Assert.Equal(expected, environment.IsAdminWarmupRouteEnabled());
+            new ReservedRouteOptionsSetup(environment).Configure(options);
+
+            Assert.Equal(expected, options.AdminWarmupRouteEnabled);
         }
 
-        private static ReservedRouteGuardMiddleware CreateMiddleware(TestEnvironment environment, RequestDelegate next)
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData("OtherFeature", false)]
+        [InlineData(ScriptConstants.FeatureFlagDisableReservedRouteEnforcement, true)]
+        public void ReservedRouteOptionsSetup_ReturnsExpectedFeatureFlagValue(string featureFlags, bool expected)
+        {
+            var environment = new TestEnvironment();
+            environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebJobsFeatureFlags, featureFlags);
+            var options = new ReservedRouteOptions();
+
+            new ReservedRouteOptionsSetup(environment).Configure(options);
+
+            Assert.Equal(expected, options.DisableReservedRouteEnforcement);
+        }
+
+        private static ReservedRouteGuardMiddleware CreateMiddleware(
+            RequestDelegate next,
+            StandbyOptions standbyOptions = null,
+            ReservedRouteOptions reservedRouteOptions = null)
         {
             return new ReservedRouteGuardMiddleware(
                 next,
-                environment,
+                new TestOptionsMonitor<StandbyOptions>(standbyOptions),
+                new TestOptionsMonitor<ReservedRouteOptions>(
+                    reservedRouteOptions ?? new ReservedRouteOptions { AdminWarmupRouteEnabled = true }),
                 Mock.Of<ILogger<ReservedRouteGuardMiddleware>>());
-        }
-
-        private static TestEnvironment CreateEnvironment(bool inPlaceholderMode)
-        {
-            var environment = new TestEnvironment();
-            environment.SetEnvironmentVariable(
-                EnvironmentSettingNames.AzureWebsitePlaceholderMode,
-                inPlaceholderMode ? "1" : "0");
-            return environment;
         }
 
         private static DefaultHttpContext CreateContext(string path)


### PR DESCRIPTION
Block unmatched admin and runtime paths before customer routing while preserving host endpoints, warmup ownership, and specialization opt-out behavior.

This does introduce a breaking change in behavior, but required for reliability. I've added a feature flag we can use if we need to revert to the previous behavior.

<!-- Please provide all the information below.  -->

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

