### PR TITLE
Harden Linux specialization command execution against injection (in-proc backport of #11884)

### DIFF
--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/CommandExecutor.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/CommandExecutor.cs
@@ -2,44 +2,61 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
 {
-    public class BashCommandHandler : IBashCommandHandler
+    public class CommandExecutor : ICommandExecutor
     {
         public const string FileCommand = "file";
 
         private readonly IMetricsLogger _metricsLogger;
-        private readonly ILogger<BashCommandHandler> _logger;
+        private readonly ILogger<CommandExecutor> _logger;
 
-        public BashCommandHandler(IMetricsLogger metricsLogger, ILogger<BashCommandHandler> logger)
+        public CommandExecutor(IMetricsLogger metricsLogger, ILogger<CommandExecutor> logger)
         {
             _metricsLogger = metricsLogger ?? throw new ArgumentNullException(nameof(metricsLogger));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public (string Output, string Error, int ExitCode) RunBashCommand(string command, string metricName)
+        public (string Output, string Error, int ExitCode) RunCommand(string fileName, IEnumerable<string> arguments, string metricName)
         {
+            ArgumentNullException.ThrowIfNull(fileName);
+            ArgumentNullException.ThrowIfNull(arguments);
+
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = fileName,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+
+            // Pass each argument separately via ArgumentList so they are never
+            // interpreted by a shell. This prevents command injection (CodeQL SM04899)
+            // when arguments are derived from untrusted input (e.g. WEBSITE_RUN_FROM_PACKAGE).
+            foreach (var argument in arguments)
+            {
+                if (argument is null)
+                {
+                    throw new ArgumentException("Command arguments must not contain null values.", nameof(arguments));
+                }
+
+                process.StartInfo.ArgumentList.Add(argument);
+            }
+
             try
             {
                 using (_metricsLogger.LatencyEvent(metricName))
                 {
-                    var process = new Process
-                    {
-                        StartInfo = new ProcessStartInfo
-                        {
-                            FileName = "bash",
-                            Arguments = $"-c \"{command}\"",
-                            RedirectStandardOutput = true,
-                            RedirectStandardError = true,
-                            UseShellExecute = false,
-                            CreateNoWindow = true
-                        }
-                    };
-                    _logger.LogInformation($"Running: bash.exe (arguments omitted)");
+                    _logger.LogInformation("Running: {FileName} (arguments omitted)", fileName);
                     process.Start();
                     var output = process.StandardOutput.ReadToEnd().Trim();
                     var error = process.StandardError.ReadToEnd().Trim();
@@ -59,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
             }
             catch (Exception e)
             {
-                _logger.LogError(e, "Error running bash");
+                _logger.LogError(e, "Error running command");
             }
 
             return (string.Empty, string.Empty, -1);

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/ICommandExecutor.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/ICommandExecutor.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
 {
-    public interface IBashCommandHandler
+    public interface ICommandExecutor
     {
-        (string Output, string Error, int ExitCode) RunBashCommand(string command, string metricName);
+        (string Output, string Error, int ExitCode) RunCommand(string fileName, IEnumerable<string> arguments, string metricName);
     }
 }

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/PackageDownloadHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/PackageDownloadHandler.cs
@@ -26,19 +26,19 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
 
         private readonly HttpClient _httpClient;
         private readonly IManagedIdentityTokenProvider _managedIdentityTokenProvider;
-        private readonly IBashCommandHandler _bashCommandHandler;
+        private readonly ICommandExecutor _commandExecutor;
         private readonly ILogger<PackageDownloadHandler> _logger;
         private readonly IMetricsLogger _metricsLogger;
         private readonly IEnvironment _environment;
         private readonly IFileSystem _fileSystem;
 
         public PackageDownloadHandler(IHttpClientFactory httpClientFactory, IManagedIdentityTokenProvider managedIdentityTokenProvider,
-            IBashCommandHandler bashCommandHandler, IEnvironment environment, IFileSystem fileSystem, ILogger<PackageDownloadHandler> logger,
+            ICommandExecutor commandExecutor, IEnvironment environment, IFileSystem fileSystem, ILogger<PackageDownloadHandler> logger,
             IMetricsLogger metricsLogger)
         {
             _httpClient = httpClientFactory?.CreateClient() ?? throw new ArgumentNullException(nameof(httpClientFactory));
             _managedIdentityTokenProvider = managedIdentityTokenProvider ?? throw new ArgumentNullException(nameof(managedIdentityTokenProvider));
-            _bashCommandHandler = bashCommandHandler ?? throw new ArgumentNullException(nameof(bashCommandHandler));
+            _commandExecutor = commandExecutor ?? throw new ArgumentNullException(nameof(commandExecutor));
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
             _fileSystem = fileSystem ?? FileUtility.Instance;
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -126,9 +126,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
 
         private void AriaDownload(string directory, string fileName, Uri zipUri, bool isWarmupRequest, string downloadMetricName)
         {
-            var command = $"{Aria2CExecutable} --allow-overwrite -x12 -d {directory} -o {fileName} '{zipUri}'";
-            (string stdout, string stderr, int exitCode) = _bashCommandHandler.RunBashCommand(
-                command,
+            string[] arguments = new[] { "--allow-overwrite", "-x12", "-d", directory, "-o", fileName, zipUri.ToString() };
+            (string stdout, string stderr, int exitCode) = _commandExecutor.RunCommand(
+                Aria2CExecutable,
+                arguments,
                 downloadMetricName);
             if (exitCode != 0)
             {
@@ -136,7 +137,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
                 _logger.LogError(msg);
                 throw new InvalidOperationException(msg);
             }
-            _logger.LogInformation($"Executed: {Sanitizer.Sanitize(command)}");
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+                var command = $"{Aria2CExecutable} {string.Join(" ", arguments)}";
+                _logger.LogInformation($"Executed: {Sanitizer.Sanitize(command)}");
+            }
 
             var fileInfo = FileUtility.FileInfoFromFileName(Path.Combine(directory, fileName));
             _logger.LogInformation("'{fileInfo.Length}' bytes downloaded. IsWarmupRequest = '{isWarmupRequest}'",

--- a/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
+++ b/src/WebJobs.Script.WebHost/Management/LinuxSpecialization/RunFromPackageHandler.cs
@@ -23,18 +23,18 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
 
         private readonly IEnvironment _environment;
         private readonly IMeshServiceClient _meshServiceClient;
-        private readonly IBashCommandHandler _bashCommandHandler;
+        private readonly ICommandExecutor _commandExecutor;
         private readonly IUnZipHandler _unZipHandler;
         private readonly IPackageDownloadHandler _packageDownloadHandler;
         private readonly IMetricsLogger _metricsLogger;
         private readonly ILogger<RunFromPackageHandler> _logger;
 
         public RunFromPackageHandler(IEnvironment environment, IMeshServiceClient meshServiceClient,
-            IBashCommandHandler bashCommandHandler, IUnZipHandler unZipHandler, IPackageDownloadHandler packageDownloadHandler, IMetricsLogger metricsLogger, ILogger<RunFromPackageHandler> logger)
+            ICommandExecutor commandExecutor, IUnZipHandler unZipHandler, IPackageDownloadHandler packageDownloadHandler, IMetricsLogger metricsLogger, ILogger<RunFromPackageHandler> logger)
         {
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
             _meshServiceClient = meshServiceClient ?? throw new ArgumentNullException(nameof(meshServiceClient));
-            _bashCommandHandler = bashCommandHandler ?? throw new ArgumentNullException(nameof(bashCommandHandler));
+            _commandExecutor = commandExecutor ?? throw new ArgumentNullException(nameof(commandExecutor));
             _unZipHandler = unZipHandler ?? throw new ArgumentNullException(nameof(unZipHandler));
             _packageDownloadHandler = packageDownloadHandler ?? throw new ArgumentNullException(nameof(packageDownloadHandler));
             _metricsLogger = metricsLogger ?? throw new ArgumentNullException(nameof(metricsLogger));
@@ -151,8 +151,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
             }
 
             // Check file magic-number using `file` command.
-            (var output, _, _) = _bashCommandHandler.RunBashCommand($"{BashCommandHandler.FileCommand} -b {filePath}", MetricEventNames.LinuxContainerSpecializationFileCommand);
-            _logger.LogInformation(Sanitizer.Sanitize($"Executed: {BashCommandHandler.FileCommand} -b {filePath} {MetricEventNames.LinuxContainerSpecializationFileCommand}"));
+            (var output, _, _) = _commandExecutor.RunCommand(CommandExecutor.FileCommand, new[] { "-b", filePath }, MetricEventNames.LinuxContainerSpecializationFileCommand);
+            _logger.LogInformation(Sanitizer.Sanitize($"Executed: {CommandExecutor.FileCommand} -b {filePath} {MetricEventNames.LinuxContainerSpecializationFileCommand}"));
             if (output.StartsWith(SquashfsPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 return CodePackageType.Squashfs;
@@ -181,9 +181,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Management.LinuxSpecialization
         private void UnsquashImage(string filePath, string scriptPath)
         {
             _logger.LogDebug($"Unsquashing remote zip to {scriptPath}");
-            var command = $"{UnsquashFSExecutable} -f -d '{scriptPath}' '{filePath}'";
-            _bashCommandHandler.RunBashCommand(command, MetricEventNames.LinuxContainerSpecializationUnsquash);
-            _logger.LogInformation(Sanitizer.Sanitize($"Executed: {command}"));
+            _commandExecutor.RunCommand(UnsquashFSExecutable, new[] { "-f", "-d", scriptPath, filePath }, MetricEventNames.LinuxContainerSpecializationUnsquash);
+            _logger.LogInformation(Sanitizer.Sanitize($"Executed: {UnsquashFSExecutable} -f -d '{scriptPath}' '{filePath}'"));
         }
 
         public async Task<bool> MountAzureFileShare(HostAssignmentContext assignmentContext)

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -354,7 +354,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddSingleton<IPackageDownloadHandler, PackageDownloadHandler>();
             services.AddSingleton<IManagedIdentityTokenProvider, ManagedIdentityTokenProvider>();
             services.AddSingleton<IUnZipHandler, UnZipHandler>();
-            services.AddSingleton<IBashCommandHandler, BashCommandHandler>();
+            services.AddSingleton<ICommandExecutor, CommandExecutor>();
         }
 
         private static void AddAzureStorageProviders(this IServiceCollection services)

--- a/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/InstanceManagerTests.cs
@@ -56,10 +56,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             _packageDownloadHandler = new Mock<IPackageDownloadHandler>(MockBehavior.Strict);
 
             var metricsLogger = new MetricsLogger();
-            var bashCommandHandler = new BashCommandHandler(metricsLogger, new Logger<BashCommandHandler>(_loggerFactory));
+            var commandExecutor = new CommandExecutor(metricsLogger, new Logger<CommandExecutor>(_loggerFactory));
             var zipHandler = new UnZipHandler(metricsLogger, NullLogger<UnZipHandler>.Instance);
             _runFromPackageHandler = new RunFromPackageHandler(_environment, _meshServiceClientMock.Object,
-                bashCommandHandler, zipHandler, _packageDownloadHandler.Object, metricsLogger, new Logger<RunFromPackageHandler>(_loggerFactory));
+                commandExecutor, zipHandler, _packageDownloadHandler.Object, metricsLogger, new Logger<RunFromPackageHandler>(_loggerFactory));
 
             _instanceManager = new AtlasInstanceManager(_optionsFactory, _httpClientFactory, _scriptWebEnvironment, _environment,
                 _loggerFactory.CreateLogger<AtlasInstanceManager>(), new TestMetricsLogger(), _meshServiceClientMock.Object, _runFromPackageHandler, _packageDownloadHandler.Object);
@@ -244,7 +244,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                     p => Assert.EndsWith("points to an existing blob: True", p),
                     p => Assert.StartsWith("Unsquashing remote zip", p),
                     p => Assert.StartsWith("Running: ", p),
-                    p => Assert.StartsWith("Error running bash", p),
+                    p => Assert.StartsWith("Error running command", p),
                     p => Assert.StartsWith("Executed: ", p),
                     p => Assert.StartsWith("Triggering specialization", p));
             }
@@ -1629,7 +1629,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
                     p => Assert.EndsWith("points to an existing blob: True", p),
                     p => Assert.StartsWith("Unsquashing remote zip", p),
                     p => Assert.StartsWith("Running: ", p),
-                    p => Assert.StartsWith("Error running bash", p),
+                    p => Assert.StartsWith("Error running command", p),
                     p => Assert.StartsWith("Executed: ", p),
                     p => Assert.StartsWith("Triggering specialization", p));
             }

--- a/test/WebJobs.Script.Tests.Integration/Management/LegionInstanceManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/LegionInstanceManagerTests.cs
@@ -55,10 +55,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Managment
             _packageDownloadHandler = new Mock<IPackageDownloadHandler>(MockBehavior.Strict);
 
             var metricsLogger = new MetricsLogger();
-            var bashCommandHandler = new BashCommandHandler(metricsLogger, new Logger<BashCommandHandler>(_loggerFactory));
+            var commandExecutor = new CommandExecutor(metricsLogger, new Logger<CommandExecutor>(_loggerFactory));
             var zipHandler = new UnZipHandler(metricsLogger, NullLogger<UnZipHandler>.Instance);
             _runFromPackageHandler = new RunFromPackageHandler(_environment, _meshServiceClientMock.Object,
-                bashCommandHandler, zipHandler, _packageDownloadHandler.Object, metricsLogger, new Logger<RunFromPackageHandler>(_loggerFactory));
+                commandExecutor, zipHandler, _packageDownloadHandler.Object, metricsLogger, new Logger<RunFromPackageHandler>(_loggerFactory));
 
             _instanceManager = new LegionInstanceManager(_httpClientFactory, _scriptWebEnvironment, _environment,
                 _loggerFactory.CreateLogger<LegionInstanceManager>(), new TestMetricsLogger(), _meshServiceClientMock.Object);

--- a/test/WebJobs.Script.Tests.Integration/Management/PackageDownloadHandlerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/PackageDownloadHandlerTests.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -31,7 +33,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
         private const string HomePath = "home-path";
         private const string PackagePath = "source-package-path";
         private const string RunFromPackageOne = "1";
-        private readonly Mock<IBashCommandHandler> _bashCmdHandlerMock;
+        private readonly Mock<ICommandExecutor> _commandExecutorMock;
         private readonly Mock<IManagedIdentityTokenProvider> _managedIdentityTokenProvider;
         private readonly TestEnvironment _environment;
         private readonly ILogger<PackageDownloadHandler> _logger;
@@ -44,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
         public PackageDownloadHandlerTests()
         {
             _httpClientFactory = TestHelpers.CreateHttpClientFactory();
-            _bashCmdHandlerMock = new Mock<IBashCommandHandler>(MockBehavior.Strict);
+            _commandExecutorMock = new Mock<ICommandExecutor>(MockBehavior.Strict);
             _managedIdentityTokenProvider = new Mock<IManagedIdentityTokenProvider>(MockBehavior.Strict);
             _environment = new TestEnvironment();
             _logger = NullLogger<PackageDownloadHandler>.Instance;
@@ -60,7 +62,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
         public async Task ThrowsExceptionForInvalidUrls(string url)
         {
             var downloader = new PackageDownloadHandler(_httpClientFactory, _managedIdentityTokenProvider.Object,
-                _bashCmdHandlerMock.Object, _environment, _fileSystem.Object, _logger, _metricsLogger);
+                _commandExecutorMock.Object, _environment, _fileSystem.Object, _logger, _metricsLogger);
             var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage, url, null, true);
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await downloader.Download(runFromPackageContext));
         }
@@ -108,10 +110,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             {
                 if (expectedUsesAriaDownload)
                 {
-                    _bashCmdHandlerMock.Setup(b =>
-                        b.RunBashCommand(
-                            It.Is<string>(s =>
-                                s.StartsWith(PackageDownloadHandler.Aria2CExecutable) && s.Contains(url)),
+                    _commandExecutorMock.Setup(b =>
+                        b.RunCommand(
+                            PackageDownloadHandler.Aria2CExecutable,
+                            It.Is<IReadOnlyList<string>>(a => a.Contains(url)),
                             MetricEventNames.LinuxContainerSpecializationZipDownload)).Returns(("", "", 0));
                 }
                 else
@@ -129,7 +131,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             _httpClientFactory = TestHelpers.CreateHttpClientFactory(handlerMock.Object);
 
             var downloader = new PackageDownloadHandler(_httpClientFactory, _managedIdentityTokenProvider.Object,
-                _bashCmdHandlerMock.Object, _environment, _fileSystem.Object, _logger, _metricsLogger);
+                _commandExecutorMock.Object, _environment, _fileSystem.Object, _logger, _metricsLogger);
 
             var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage, url, fileSize, isWarmupRequest);
             await downloader.Download(runFromPackageContext);
@@ -154,10 +156,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
 
                 if (expectedUsesAriaDownload)
                 {
-                    _bashCmdHandlerMock.Verify(b =>
-                        b.RunBashCommand(
-                            It.Is<string>(s =>
-                                s.StartsWith(PackageDownloadHandler.Aria2CExecutable) && s.Contains(url)),
+                    _commandExecutorMock.Verify(b =>
+                        b.RunCommand(
+                            PackageDownloadHandler.Aria2CExecutable,
+                            It.Is<IReadOnlyList<string>>(a => a.Contains(url)),
                             MetricEventNames.LinuxContainerSpecializationZipDownload), Times.Once);
                 }
                 else
@@ -166,8 +168,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
                         ItExpr.Is<HttpRequestMessage>(s => MatchesVerb(s, HttpMethod.Get) && HasBearerToken(s) && MatchesTargetUri(s, url)),
                         ItExpr.IsAny<CancellationToken>());
 
-                    _bashCmdHandlerMock.Verify(b =>
-                        b.RunBashCommand(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+                    _commandExecutorMock.Verify(b =>
+                        b.RunCommand(It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<string>()), Times.Never);
                 }
 
                 _managedIdentityTokenProvider.Verify(p => p.GetManagedIdentityToken(It.IsAny<string>()), Times.Never);
@@ -201,7 +203,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             _managedIdentityTokenProvider.Setup(p => p.GetManagedIdentityToken(UriWithNoSasToken)).Returns(Task.FromResult(BearerToken));
 
             var downloader = new PackageDownloadHandler(_httpClientFactory, _managedIdentityTokenProvider.Object,
-                _bashCmdHandlerMock.Object, _environment, _fileSystem.Object, _logger, _metricsLogger);
+                _commandExecutorMock.Object, _environment, _fileSystem.Object, _logger, _metricsLogger);
 
             var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage, UriWithNoSasToken, 0, false);
             await downloader.Download(runFromPackageContext);
@@ -270,7 +272,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             }
 
             var downloader = new PackageDownloadHandler(_httpClientFactory, _managedIdentityTokenProvider.Object,
-                _bashCmdHandlerMock.Object, _environment, _fileSystem.Object, _logger, _metricsLogger);
+                _commandExecutorMock.Object, _environment, _fileSystem.Object, _logger, _metricsLogger);
 
             var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage, url, 0, false);
             await downloader.Download(runFromPackageContext);
@@ -300,7 +302,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             fileSystem.Setup(x => x.Directory.Exists(_environment.GetSitePackagesPath())).Returns(false);
 
             var downloader = new PackageDownloadHandler(_httpClientFactory, _managedIdentityTokenProvider.Object,
-                _bashCmdHandlerMock.Object, _environment, fileSystem.Object, _logger, _metricsLogger);
+                _commandExecutorMock.Object, _environment, fileSystem.Object, _logger, _metricsLogger);
             var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage, RunFromPackageOne, 0, false);
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await downloader.Download(runFromPackageContext));
         }
@@ -315,7 +317,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             fileSystem.Setup(x => x.File.Exists(_environment.GetSitePackageNameTxtPath())).Returns(false);
 
             var downloader = new PackageDownloadHandler(_httpClientFactory, _managedIdentityTokenProvider.Object,
-                _bashCmdHandlerMock.Object, _environment, fileSystem.Object, _logger, _metricsLogger);
+                _commandExecutorMock.Object, _environment, fileSystem.Object, _logger, _metricsLogger);
             var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage, RunFromPackageOne, 0, false);
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await downloader.Download(runFromPackageContext));
         }
@@ -331,7 +333,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             fileSystem.Setup(x => x.File.ReadAllText(_environment.GetSitePackageNameTxtPath())).Returns(string.Empty);
 
             var downloader = new PackageDownloadHandler(_httpClientFactory, _managedIdentityTokenProvider.Object,
-                _bashCmdHandlerMock.Object, _environment, fileSystem.Object, _logger, _metricsLogger);
+                _commandExecutorMock.Object, _environment, fileSystem.Object, _logger, _metricsLogger);
             var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage, RunFromPackageOne, 0, false);
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await downloader.Download(runFromPackageContext));
         }
@@ -349,7 +351,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             fileSystem.Setup(x => x.File.Exists(PackagePath)).Returns(false);
 
             var downloader = new PackageDownloadHandler(_httpClientFactory, _managedIdentityTokenProvider.Object,
-                _bashCmdHandlerMock.Object, _environment, fileSystem.Object, _logger, _metricsLogger);
+                _commandExecutorMock.Object, _environment, fileSystem.Object, _logger, _metricsLogger);
             var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage, RunFromPackageOne, 0, false);
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await downloader.Download(runFromPackageContext));
         }
@@ -378,7 +380,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
 
 
             var downloader = new PackageDownloadHandler(_httpClientFactory, _managedIdentityTokenProvider.Object,
-                _bashCmdHandlerMock.Object, _environment, fileSystem.Object, _logger, _metricsLogger);
+                _commandExecutorMock.Object, _environment, fileSystem.Object, _logger, _metricsLogger);
             var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage, RunFromPackageOne, 0, false);
             var returnedDestPath = await downloader.Download(runFromPackageContext);
             fileSystem.Verify(x => x.File.Copy(PackagePath, destinationPath, true), Times.Once);
@@ -432,14 +434,14 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             }
             else
             {
-                _bashCmdHandlerMock.Setup(b => b.RunBashCommand(It.Is<string>(s => s.StartsWith(PackageDownloadHandler.Aria2CExecutable)),
+                _commandExecutorMock.Setup(b => b.RunCommand(PackageDownloadHandler.Aria2CExecutable, It.IsAny<IReadOnlyList<string>>(),
                     expectedMetricName)).Returns(("", "", 0));
             }
 
             var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage, url, fileSize, isWarmupRequest);
 
             var packageDownloadHandler = new PackageDownloadHandler(_httpClientFactory, _managedIdentityTokenProvider.Object,
-                _bashCmdHandlerMock.Object, _environment, fileSystem.Object, _logger, _metricsLogger);
+                _commandExecutorMock.Object, _environment, fileSystem.Object, _logger, _metricsLogger);
 
             var filePath = await packageDownloadHandler.Download(runFromPackageContext);
 
@@ -453,7 +455,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             }
             else
             {
-                _bashCmdHandlerMock.Verify(b => b.RunBashCommand(It.Is<string>(s => s.StartsWith(PackageDownloadHandler.Aria2CExecutable)),
+                _commandExecutorMock.Verify(b => b.RunCommand(PackageDownloadHandler.Aria2CExecutable, It.IsAny<IReadOnlyList<string>>(),
                     expectedMetricName), Times.Once);
             }
         }
@@ -481,7 +483,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             _httpClientFactory = TestHelpers.CreateHttpClientFactory(handlerMock.Object);
 
             var packageDownloadHandler = new PackageDownloadHandler(_httpClientFactory, _managedIdentityTokenProvider.Object,
-                _bashCmdHandlerMock.Object, _environment, fileSystem.Object, _logger, _metricsLogger);
+                _commandExecutorMock.Object, _environment, fileSystem.Object, _logger, _metricsLogger);
 
             var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage, url, fileSize, isWarmupRequest);
             var filePath = await packageDownloadHandler.Download(runFromPackageContext);;

--- a/test/WebJobs.Script.Tests.Integration/Management/RunFromPackageHandlerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Management/RunFromPackageHandlerTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
 
         private readonly TestEnvironment _environment;
         private readonly Mock<IMeshServiceClient> _meshServiceClientMock;
-        private readonly Mock<IBashCommandHandler> _bashCmdHandlerMock;
+        private readonly Mock<ICommandExecutor> _commandExecutorMock;
         private readonly TestMetricsLogger _metricsLogger;
         private readonly ILogger<RunFromPackageHandler> _logger;
         private readonly Mock<IUnZipHandler> _zipHandler;
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             _environment = new TestEnvironment();
 
             _meshServiceClientMock = new Mock<IMeshServiceClient>(MockBehavior.Strict);
-            _bashCmdHandlerMock = new Mock<IBashCommandHandler>(MockBehavior.Strict);
+            _commandExecutorMock = new Mock<ICommandExecutor>(MockBehavior.Strict);
             _zipHandler = new Mock<IUnZipHandler>(MockBehavior.Strict);
             _metricsLogger = new TestMetricsLogger();
 
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             _packageDownloadHandler = new Mock<IPackageDownloadHandler>(MockBehavior.Strict);
 
             _runFromPackageHandler = new RunFromPackageHandler(_environment, _meshServiceClientMock.Object, 
-                _bashCmdHandlerMock.Object, _zipHandler.Object, _packageDownloadHandler.Object, _metricsLogger, _logger);
+                _commandExecutorMock.Object, _zipHandler.Object, _packageDownloadHandler.Object, _metricsLogger, _logger);
 
             _fileSystem = GetFileSystem();
         }
@@ -160,17 +160,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             _httpClientFactory = TestHelpers.CreateHttpClientFactory(handlerMock.Object);
 
             var packageDownloadHandler = new PackageDownloadHandler(_httpClientFactory,
-                new Mock<IManagedIdentityTokenProvider>(MockBehavior.Strict).Object, _bashCmdHandlerMock.Object, 
+                new Mock<IManagedIdentityTokenProvider>(MockBehavior.Strict).Object, _commandExecutorMock.Object, 
                 _environment, _fileSystem.Object, NullLogger<PackageDownloadHandler>.Instance, _metricsLogger);
 
             _runFromPackageHandler = new RunFromPackageHandler(_environment, _meshServiceClientMock.Object,
-                _bashCmdHandlerMock.Object, _zipHandler.Object, packageDownloadHandler, _metricsLogger, _logger);
+                _commandExecutorMock.Object, _zipHandler.Object, packageDownloadHandler, _metricsLogger, _logger);
+
+            var expectedDownloadedFilePath = Path.Combine(Path.GetTempPath(), $"zip-file.{extension}");
 
             if (azureFilesMounted)
             {
-                _bashCmdHandlerMock
-                    .Setup(b => b.RunBashCommand(
-                        It.Is<string>(s => s.StartsWith($"{RunFromPackageHandler.UnsquashFSExecutable} -f -d '{EnvironmentSettingNames.DefaultLocalSitePackagesPath}'")),
+                _commandExecutorMock
+                    .Setup(b => b.RunCommand(
+                        RunFromPackageHandler.UnsquashFSExecutable,
+                        It.Is<IReadOnlyList<string>>(a => a.Count == 4 && a[0] == "-f" && a[1] == "-d" && a[2] == EnvironmentSettingNames.DefaultLocalSitePackagesPath && a[3] == expectedDownloadedFilePath),
                         MetricEventNames.LinuxContainerSpecializationUnsquash)).Returns((string.Empty, string.Empty, 0));
 
                 _meshServiceClientMock
@@ -179,9 +182,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             }
             else
             {
-                _bashCmdHandlerMock
-                    .Setup(b => b.RunBashCommand(
-                        It.Is<string>(s => s.StartsWith($"{RunFromPackageHandler.UnsquashFSExecutable} -f -d '{TargetScriptPath}'")),
+                _commandExecutorMock
+                    .Setup(b => b.RunCommand(
+                        RunFromPackageHandler.UnsquashFSExecutable,
+                        It.Is<IReadOnlyList<string>>(a => a.Count == 4 && a[0] == "-f" && a[1] == "-d" && a[2] == TargetScriptPath && a[3] == expectedDownloadedFilePath),
                         MetricEventNames.LinuxContainerSpecializationUnsquash)).Returns((string.Empty, string.Empty, 0));
             }
 
@@ -198,11 +202,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
 
             if (azureFilesMounted)
             {
-                _bashCmdHandlerMock
-                    .Verify(b => b.RunBashCommand(
-                        It.Is<string>(s =>
-                            s.StartsWith(
-                                $"{RunFromPackageHandler.UnsquashFSExecutable} -f -d '{EnvironmentSettingNames.DefaultLocalSitePackagesPath}'")),
+                _commandExecutorMock
+                    .Verify(b => b.RunCommand(
+                        RunFromPackageHandler.UnsquashFSExecutable,
+                        It.Is<IReadOnlyList<string>>(a => a.Count == 4 && a[0] == "-f" && a[1] == "-d" && a[2] == EnvironmentSettingNames.DefaultLocalSitePackagesPath && a[3] == expectedDownloadedFilePath),
                         MetricEventNames.LinuxContainerSpecializationUnsquash), Times.Once);
 
                 _meshServiceClientMock
@@ -211,10 +214,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             }
             else
             {
-                _bashCmdHandlerMock
-                    .Verify(b => b.RunBashCommand(
-                        It.Is<string>(s =>
-                            s.StartsWith($"{RunFromPackageHandler.UnsquashFSExecutable} -f -d '{TargetScriptPath}'")),
+                _commandExecutorMock
+                    .Verify(b => b.RunCommand(
+                        RunFromPackageHandler.UnsquashFSExecutable,
+                        It.Is<IReadOnlyList<string>>(a => a.Count == 4 && a[0] == "-f" && a[1] == "-d" && a[2] == TargetScriptPath && a[3] == expectedDownloadedFilePath),
                         MetricEventNames.LinuxContainerSpecializationUnsquash), Times.Once);
             }
         }
@@ -244,11 +247,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             _httpClientFactory = TestHelpers.CreateHttpClientFactory(handlerMock.Object);
 
             var packageDownloadHandler = new PackageDownloadHandler(_httpClientFactory,
-                new Mock<IManagedIdentityTokenProvider>(MockBehavior.Strict).Object, _bashCmdHandlerMock.Object,
+                new Mock<IManagedIdentityTokenProvider>(MockBehavior.Strict).Object, _commandExecutorMock.Object,
                 _environment, _fileSystem.Object, NullLogger<PackageDownloadHandler>.Instance, _metricsLogger);
 
             _runFromPackageHandler = new RunFromPackageHandler(_environment, _meshServiceClientMock.Object,
-                _bashCmdHandlerMock.Object, _zipHandler.Object, packageDownloadHandler, _metricsLogger, _logger);
+                _commandExecutorMock.Object, _zipHandler.Object, packageDownloadHandler, _metricsLogger, _logger);
 
             var url = $"http://url/zip-file.{extension}";
             var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage,
@@ -292,11 +295,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             _httpClientFactory = TestHelpers.CreateHttpClientFactory(handlerMock.Object);
 
             var packageDownloadHandler = new PackageDownloadHandler(_httpClientFactory,
-                new Mock<IManagedIdentityTokenProvider>(MockBehavior.Strict).Object, _bashCmdHandlerMock.Object,
+                new Mock<IManagedIdentityTokenProvider>(MockBehavior.Strict).Object, _commandExecutorMock.Object,
                 _environment, _fileSystem.Object, NullLogger<PackageDownloadHandler>.Instance, _metricsLogger);
 
             _runFromPackageHandler = new RunFromPackageHandler(_environment, _meshServiceClientMock.Object,
-                _bashCmdHandlerMock.Object, _zipHandler.Object, packageDownloadHandler, _metricsLogger, _logger);
+                _commandExecutorMock.Object, _zipHandler.Object, packageDownloadHandler, _metricsLogger, _logger);
 
             var url = $"http://url/zip-file.{extension}";
             var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage,
@@ -345,11 +348,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             _httpClientFactory = TestHelpers.CreateHttpClientFactory(handlerMock.Object);
 
             var packageDownloadHandler = new PackageDownloadHandler(_httpClientFactory,
-                new Mock<IManagedIdentityTokenProvider>(MockBehavior.Strict).Object, _bashCmdHandlerMock.Object,
+                new Mock<IManagedIdentityTokenProvider>(MockBehavior.Strict).Object, _commandExecutorMock.Object,
                 _environment, _fileSystem.Object, NullLogger<PackageDownloadHandler>.Instance, _metricsLogger);
 
             _runFromPackageHandler = new RunFromPackageHandler(_environment, _meshServiceClientMock.Object,
-                _bashCmdHandlerMock.Object, _zipHandler.Object, packageDownloadHandler, _metricsLogger, _logger);
+                _commandExecutorMock.Object, _zipHandler.Object, packageDownloadHandler, _metricsLogger, _logger);
 
             var url = $"http://url/zip-file.{extension}";
             var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage,
@@ -438,11 +441,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             _httpClientFactory = TestHelpers.CreateHttpClientFactory(handlerMock.Object);
 
             var packageDownloadHandler = new PackageDownloadHandler(_httpClientFactory,
-                new Mock<IManagedIdentityTokenProvider>(MockBehavior.Strict).Object, _bashCmdHandlerMock.Object,
+                new Mock<IManagedIdentityTokenProvider>(MockBehavior.Strict).Object, _commandExecutorMock.Object,
                 _environment, _fileSystem.Object, NullLogger<PackageDownloadHandler>.Instance, _metricsLogger);
 
             _runFromPackageHandler = new RunFromPackageHandler(_environment, _meshServiceClientMock.Object,
-                _bashCmdHandlerMock.Object, _zipHandler.Object, packageDownloadHandler, _metricsLogger, _logger);
+                _commandExecutorMock.Object, _zipHandler.Object, packageDownloadHandler, _metricsLogger, _logger);
 
             var url = $"http://url/zip-file.{extension}";
             var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage,
@@ -453,11 +456,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
                     It.Is<string>(s => url.EndsWith(Path.GetFileName(s))), TargetScriptPath))
                 .Returns(Task.FromResult(true));
 
-            _bashCmdHandlerMock.Setup(b =>
-                b.RunBashCommand(
-                    It.Is<string>(s =>
-                        s.StartsWith(BashCommandHandler.FileCommand) && url.EndsWith(Path.GetFileName(s),
-                            StringComparison.OrdinalIgnoreCase)),
+            _commandExecutorMock.Setup(b =>
+                b.RunCommand(
+                    CommandExecutor.FileCommand,
+                    It.Is<IReadOnlyList<string>>(a => a.Count == 2 && a[0] == "-b" && url.EndsWith(Path.GetFileName(a[1]),
+                        StringComparison.OrdinalIgnoreCase)),
                     MetricEventNames.LinuxContainerSpecializationFileCommand)).Returns(("zip", string.Empty, 0));
 
             var applyBlobContextResult = await _runFromPackageHandler.ApplyRunFromPackageContext(runFromPackageContext, TargetScriptPath, azureFilesMounted, true);
@@ -472,11 +475,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
                     It.Is<string>(s => url.EndsWith(Path.GetFileName(s))), TargetScriptPath))
                 .Returns(Task.FromResult(true));
 
-            _bashCmdHandlerMock.Verify(b =>
-                b.RunBashCommand(
-                    It.Is<string>(s =>
-                        s.StartsWith(BashCommandHandler.FileCommand) && url.EndsWith(Path.GetFileName(s),
-                            StringComparison.OrdinalIgnoreCase)),
+            _commandExecutorMock.Verify(b =>
+                b.RunCommand(
+                    CommandExecutor.FileCommand,
+                    It.Is<IReadOnlyList<string>>(a => a.Count == 2 && a[0] == "-b" && url.EndsWith(Path.GetFileName(a[1]),
+                        StringComparison.OrdinalIgnoreCase)),
                     MetricEventNames.LinuxContainerSpecializationFileCommand), Times.Once);
         }
 
@@ -506,21 +509,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
             _httpClientFactory = TestHelpers.CreateHttpClientFactory(handlerMock.Object);
 
             var packageDownloadHandler = new PackageDownloadHandler(_httpClientFactory,
-                new Mock<IManagedIdentityTokenProvider>(MockBehavior.Strict).Object, _bashCmdHandlerMock.Object,
+                new Mock<IManagedIdentityTokenProvider>(MockBehavior.Strict).Object, _commandExecutorMock.Object,
                 _environment, _fileSystem.Object, NullLogger<PackageDownloadHandler>.Instance, _metricsLogger);
 
             _runFromPackageHandler = new RunFromPackageHandler(_environment, _meshServiceClientMock.Object,
-                _bashCmdHandlerMock.Object, _zipHandler.Object, packageDownloadHandler, _metricsLogger, _logger);
+                _commandExecutorMock.Object, _zipHandler.Object, packageDownloadHandler, _metricsLogger, _logger);
 
             var url = $"http://url/zip-file.{extension}";
             var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage,
                 url, packageLength, isWarmUpRequest);
 
-            _bashCmdHandlerMock.Setup(b =>
-                b.RunBashCommand(
-                    It.Is<string>(s =>
-                        s.StartsWith(BashCommandHandler.FileCommand) && url.EndsWith(Path.GetFileName(s),
-                            StringComparison.OrdinalIgnoreCase)),
+            _commandExecutorMock.Setup(b =>
+                b.RunCommand(
+                    CommandExecutor.FileCommand,
+                    It.Is<IReadOnlyList<string>>(a => a.Count == 2 && a[0] == "-b" && url.EndsWith(Path.GetFileName(a[1]),
+                        StringComparison.OrdinalIgnoreCase)),
                     MetricEventNames.LinuxContainerSpecializationFileCommand)).Returns(("squashfs", string.Empty, 0));
 
             _meshServiceClientMock.Setup(m => m.MountFuse(MeshServiceClient.SquashFsOperation, It.Is<string>(s => url.EndsWith(Path.GetFileName(s))), TargetScriptPath))
@@ -533,11 +536,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
                 ItExpr.Is<HttpRequestMessage>(r => IsZipDownloadRequest(r, url)),
                 ItExpr.IsAny<CancellationToken>());
 
-            _bashCmdHandlerMock.Verify(b =>
-                b.RunBashCommand(
-                    It.Is<string>(s =>
-                        s.StartsWith(BashCommandHandler.FileCommand) && url.EndsWith(Path.GetFileName(s),
-                            StringComparison.OrdinalIgnoreCase)),
+            _commandExecutorMock.Verify(b =>
+                b.RunCommand(
+                    CommandExecutor.FileCommand,
+                    It.Is<IReadOnlyList<string>>(a => a.Count == 2 && a[0] == "-b" && url.EndsWith(Path.GetFileName(a[1]),
+                        StringComparison.OrdinalIgnoreCase)),
                     MetricEventNames.LinuxContainerSpecializationFileCommand), Times.Once);
 
             _meshServiceClientMock.Verify(m => m.MountFuse(MeshServiceClient.SquashFsOperation, It.Is<string>(s => url.EndsWith(Path.GetFileName(s))), TargetScriptPath), Times.Once);
@@ -571,21 +574,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
                 .Returns(Task.FromResult(string.Empty));
 
             var downloadHandler = new PackageDownloadHandler(_httpClientFactory,
-                new Mock<IManagedIdentityTokenProvider>(MockBehavior.Strict).Object, _bashCmdHandlerMock.Object,
+                new Mock<IManagedIdentityTokenProvider>(MockBehavior.Strict).Object, _commandExecutorMock.Object,
                 _environment, _fileSystem.Object, NullLogger<PackageDownloadHandler>.Instance, _metricsLogger);
 
             _runFromPackageHandler = new RunFromPackageHandler(_environment, _meshServiceClientMock.Object,
-                _bashCmdHandlerMock.Object, _zipHandler.Object, downloadHandler, _metricsLogger, _logger);
+                _commandExecutorMock.Object, _zipHandler.Object, downloadHandler, _metricsLogger, _logger);
 
             var url = $"http://url/zip-file.{extension}";
             var runFromPackageContext = new RunFromPackageContext(EnvironmentSettingNames.AzureWebsiteRunFromPackage,
                 url, packageLength, isWarmUpRequest);
 
-            _bashCmdHandlerMock.Setup(b =>
-                b.RunBashCommand(
-                    It.Is<string>(s =>
-                        s.StartsWith(BashCommandHandler.FileCommand) && url.EndsWith(Path.GetFileName(s),
-                            StringComparison.OrdinalIgnoreCase)),
+            _commandExecutorMock.Setup(b =>
+                b.RunCommand(
+                    CommandExecutor.FileCommand,
+                    It.Is<IReadOnlyList<string>>(a => a.Count == 2 && a[0] == "-b" && url.EndsWith(Path.GetFileName(a[1]),
+                        StringComparison.OrdinalIgnoreCase)),
                     MetricEventNames.LinuxContainerSpecializationFileCommand)).Returns(("unknown", string.Empty, 0));
 
 
@@ -597,11 +600,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Management
                 ItExpr.Is<HttpRequestMessage>(r => IsZipDownloadRequest(r, url)),
                 ItExpr.IsAny<CancellationToken>());
 
-            _bashCmdHandlerMock.Verify(b =>
-                b.RunBashCommand(
-                    It.Is<string>(s =>
-                        s.StartsWith(BashCommandHandler.FileCommand) && url.EndsWith(Path.GetFileName(s),
-                            StringComparison.OrdinalIgnoreCase)),
+            _commandExecutorMock.Verify(b =>
+                b.RunCommand(
+                    CommandExecutor.FileCommand,
+                    It.Is<IReadOnlyList<string>>(a => a.Count == 2 && a[0] == "-b" && url.EndsWith(Path.GetFileName(a[1]),
+                        StringComparison.OrdinalIgnoreCase)),
                     MetricEventNames.LinuxContainerSpecializationFileCommand), Times.Once);
         }
 


### PR DESCRIPTION
Backports the command-injection hardening from #11884 (squash-merged to `dev` as `22cc6f2`) onto the `in-proc` branch.

## What
- Replaces shell-string command execution in Linux specialization with an argument-array `Process` invocation (`ICommandExecutor` / `CommandExecutor.RunCommand`, `UseShellExecute=false`, populated `ArgumentList`), removing the injection vector flagged by CodeQL **SM04899**.
- Renames `IBashCommandHandler` / `BashCommandHandler` → `ICommandExecutor` / `CommandExecutor` and updates all consumers + DI registration.

## In-proc-specific adaptations vs. the dev change
- Converted the new collection-expression literals to `new[] { ... }`: in-proc ships StyleCop `1.2.0-beta.435`, which flags `[ ... ]` (SA1010) and treats warnings as errors under CI.
- Dropped the dev-only `LocalSitePackagesPath` log assertion from two InstanceManager tests — in-proc's `RunFromPackageHandler.ApplyRunFromPackageContext` uses `GetEnvironmentVariableOrDefault` and does not emit that log line.

## Verification
- `dotnet build ...WebHost.csproj -c Release -p:CI=true` → 0 warnings / 0 errors (net8.0 + net6.0).
- 58/58 affected LinuxSpecialization integration tests pass (RunFromPackageHandlerTests, PackageDownloadHandlerTests, and the ScmRunFromPackage_Blob InstanceManager tests).

Cherry-pick of `22cc6f2` (squash-merge of #11884).