### PR TITLE
Update Java Worker Version to 2.19.5

### DIFF
--- a/eng/build/Workers.Java.props
+++ b/eng/build/Workers.Java.props
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" VersionOverride="2.19.4" />
+    <PackageReference Include="Microsoft.Azure.Functions.JavaWorker" VersionOverride="2.19.5" />
   </ItemGroup>
 
 </Project>

--- a/release_notes.md
+++ b/release_notes.md
@@ -13,3 +13,4 @@
 - Fixed a race and reader leak in WebHost deferred startup-log forwarding across ScriptHost restarts/specialization, and fixed OpenTelemetry logs not being flushed on host shutdown. (#11847)
 - Update `Microsoft.Azure.Functions.DotNetIsolatedNativeHost` to `1.0.15` (#11881)
 - Update Python Worker Version to [4.46.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.46.0) (#11885)
+- Update Java Worker Version to [2.19.5](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.5)


### PR DESCRIPTION
### Issue describing the changes in this PR

Update Java Worker Version to 2.19.5

Java Worker Release note [2.19.5](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.5)

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the in-proc branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the in-proc branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to 
elease_notes.md
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)
