### PR TITLE
Never re-mint a system key that already exists in the secrets store

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,3 +4,4 @@
 - My change description (#PR)
 -->
 - Update Python Worker Version to [4.45.1](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.45.1) (#11860)
+- Fixed extension system keys being overwritten on host restart when the startup context supplies an incomplete secrets snapshot, which broke Event Grid and other webhook deliveries with 401s (#11904)

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,6 +3,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-- Update Python Worker Version to [4.45.1](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.45.1) (#11860)
 - Fixed extension system keys being overwritten on host restart when the startup context supplies an incomplete secrets snapshot, which broke Event Grid and other webhook deliveries with 401s (#11904)
--->

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/ISecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/ISecretManager.cs
@@ -70,6 +70,16 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         Task PurgeOldSecretsAsync(string rootScriptPath, ILogger logger);
 
         /// <summary>
+        /// Returns the value of the specified system key, creating and persisting one only after an
+        /// authoritative read shows none exists. Unlike <see cref="AddOrUpdateFunctionSecretAsync"/>
+        /// it will not replace a key it can observe; the create path remains a last-writer-wins
+        /// upsert, so a key persisted concurrently by another host instance can still be replaced.
+        /// </summary>
+        /// <param name="keyName">The name of the system key.</param>
+        /// <returns>The decrypted value of the persisted key.</returns>
+        Task<string> GetOrCreateSystemKeyAsync(string keyName);
+
+        /// <summary>
         /// If secrets have been loaded and cached, clear all cached secrets so they'll
         /// be reloaded next time they're requested.
         /// </summary>

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
@@ -291,6 +291,46 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
         }
 
+        public async Task<string> GetOrCreateSystemKeyAsync(string keyName)
+        {
+            // A cached hit is as trustworthy as it is today. Only a cached MISS is challenged,
+            // because the startup context may contain a partial host secret snapshot.
+            var cached = _hostSecrets;
+            if (cached != null && cached.SystemKeys.TryGetValue(keyName, out string value))
+            {
+                return value;
+            }
+
+            if (cached != null)
+            {
+                // Discard only the snapshot we missed on - another caller may already have
+                // replaced it with a complete load.
+                Interlocked.CompareExchange(ref _hostSecrets, null, cached);
+            }
+
+            // Single authoritative load: locking, repository read, decryption, validation, repopulation.
+            var hostSecrets = await GetHostSecretsAsync();
+            if (hostSecrets.SystemKeys.TryGetValue(keyName, out value))
+            {
+                return value;
+            }
+
+            var result = await AddOrUpdateFunctionSecretAsync(
+                keyName,
+                SecretGenerator.GenerateSystemKeyValue(),
+                HostKeyScopes.SystemKeys,
+                ScriptSecretsType.Host);
+
+            if (result.Result is not (OperationResult.Created or OperationResult.Updated))
+            {
+                // Nothing was persisted, so returning the value would mint a webhook URL that
+                // authorizes nothing and fails silently at request time.
+                throw new InvalidOperationException($"Unable to persist system key '{keyName}'. Result: {result.Result}.");
+            }
+
+            return result.Secret;
+        }
+
         public async Task<KeyOperationResult> SetMasterKeyAsync(string value = null)
         {
             using (_metricsLogger.LatencyEvent(GetMetricEventName(MetricEventNames.SecretManagerSetMasterKey)))

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
@@ -293,6 +293,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         public async Task<string> GetOrCreateSystemKeyAsync(string keyName)
         {
+            if (string.IsNullOrEmpty(keyName))
+            {
+                throw new ArgumentNullException(nameof(keyName));
+            }
+
             // A cached hit is as trustworthy as it is today. Only a cached MISS is challenged,
             // because the startup context may contain a partial host secret snapshot.
             var cached = _hostSecrets;

--- a/src/WebJobs.Script.WebHost/WebHooks/DefaultScriptWebHookProvider.cs
+++ b/src/WebJobs.Script.WebHost/WebHooks/DefaultScriptWebHookProvider.cs
@@ -83,20 +83,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             return new Uri($"{scheme}://{hostName}/runtime/webhooks/{extensionName}?code={keyValue}");
         }
 
-        private async Task<string> GetOrCreateExtensionKey(string extensionName)
+        private Task<string> GetOrCreateExtensionKey(string extensionName)
         {
-            ISecretManager secretManager = _secretManagerProvider.Current;
-            var hostSecrets = await secretManager.GetHostSecretsAsync();
-            string keyName = GetKeyName(extensionName);
-            string keyValue;
-            if (!hostSecrets.SystemKeys.TryGetValue(keyName, out keyValue))
-            {
-                // if the requested secret doesn't exist, create it on demand
-                keyValue = SecretGenerator.GenerateSystemKeyValue();
-                await secretManager.AddOrUpdateFunctionSecretAsync(keyName, keyValue, HostKeyScopes.SystemKeys, ScriptSecretsType.Host);
-            }
-
-            return keyValue;
+            return _secretManagerProvider.Current.GetOrCreateSystemKeyAsync(GetKeyName(extensionName));
         }
 
         internal static string GetKeyName(string extensionName)

--- a/test/WebJobs.Script.Tests.Shared/TestSecretManager.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestSecretManager.cs
@@ -69,6 +69,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             return Task.FromResult(new KeyOperationResult(resultSecret, OperationResult.Created));
         }
 
+        public virtual Task<string> GetOrCreateSystemKeyAsync(string keyName)
+        {
+            if (!_hostSystemKeys.TryGetValue(keyName, out string value))
+            {
+                value = $"{keyName}_generated";
+                _hostSystemKeys[keyName] = value;
+            }
+
+            return Task.FromResult(value);
+        }
+
         public virtual Task<KeyOperationResult> SetMasterKeyAsync(string value)
         {
             throw new NotImplementedException();

--- a/test/WebJobs.Script.Tests/DefaultScriptWebHookProviderTests.cs
+++ b/test/WebJobs.Script.Tests/DefaultScriptWebHookProviderTests.cs
@@ -31,6 +31,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             hostSecrets.FunctionKeys = new Dictionary<string, string>();
             var mockSecretManagerProvider = new Mock<ISecretManagerProvider>(MockBehavior.Strict);
             mockSecretManagerProvider.Setup(p => p.Current).Returns(mockSecretManager.Object);
+
+            // The provider delegates key resolution wholesale; tests that care override this.
+            mockSecretManager.Setup(p => p.GetOrCreateSystemKeyAsync(It.IsAny<string>())).ReturnsAsync("abc123");
             var loggerProvider = new TestLoggerProvider();
             var loggerFactory = new LoggerFactory();
             loggerFactory.AddProvider(loggerProvider);
@@ -43,47 +46,15 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         [Fact]
         public void GetUrl_ReturnsExpectedResult()
         {
-            var webHookProvider = CreateDefaultScriptWebHookProvider(out Mock<ISecretManager> mockSecretManager, out HostSecretsInfo hostSecrets);
-            mockSecretManager.Setup(p => p.GetHostSecretsAsync()).ReturnsAsync(hostSecrets);
-
-            // When an extension has an existing secret, it should be returned.
-            hostSecrets.SystemKeys = new Dictionary<string, string>
-            {
-                { "testextension_extension", "abc123" }
-            };
+            var webHookProvider = CreateDefaultScriptWebHookProvider(out Mock<ISecretManager> mockSecretManager, out _);
+            mockSecretManager.Setup(p => p.GetOrCreateSystemKeyAsync("testextension_extension")).ReturnsAsync("abc123");
 
             var configProvider = new TestExtensionConfigProvider();
             var url = webHookProvider.GetUrl(configProvider);
             Assert.Equal($"{TestUrlRoot}abc123", url.ToString());
-        }
 
-        [Fact]
-        public void GetUrl_GeneratesIdentifiableSystemSecret()
-        {
-            string secretValue = string.Empty;
-
-            var webHookProvider = CreateDefaultScriptWebHookProvider(out Mock<ISecretManager> mockSecretManager, out HostSecretsInfo hostSecrets);
-            mockSecretManager.Setup(p => p.GetHostSecretsAsync()).ReturnsAsync(hostSecrets);
-
-            mockSecretManager.Setup(p =>
-                p.AddOrUpdateFunctionSecretAsync(
-                    "testextension_extension",
-                    It.IsAny<string>(),
-                    HostKeyScopes.SystemKeys,
-                    ScriptSecretsType.Host))
-                        .Callback<string, string, string, ScriptSecretsType>((key, secret, scope, type) => secretValue = secret)
-                        .Returns(() => Task.FromResult(new KeyOperationResult(secretValue, OperationResult.Created)));
-
-            // When an extension has no existing secret, one should be generated using
-            // the Azure Functions system key seed and standard fixed signature.
-
-            var configProvider = new TestExtensionConfigProvider();
-            var url = webHookProvider.GetUrl(configProvider);
-            Assert.Equal($"{TestUrlRoot}{secretValue}", url.ToString());
-            Assert.True(IdentifiableSecrets.ValidateBase64Key(secretValue,
-                                                              SecretGenerator.SystemKeySeed,
-                                                              SecretGenerator.AzureFunctionsSignature,
-                                                              encodeForUrl: true));
+            // The default setup answers any name, so only this pins the derived key name.
+            mockSecretManager.Verify(p => p.GetOrCreateSystemKeyAsync("testextension_extension"), Times.Once);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
@@ -1838,6 +1838,123 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             }
         }
 
+        [Fact]
+        public async Task GetOrCreateSystemKeyAsync_PartialStartupCacheHidesPersistedKey_ReturnsDecryptedStoredKeyWithoutOverwriting()
+        {
+            const string KeyName = "eventgrid_extension";
+            const string StoredPlaintext = "already-shared-with-event-grid";
+
+            // The store already holds, at rest and encrypted, the key Event Grid presents.
+            var repository = new Mock<ISecretsRepository>();
+            repository.Setup(r => r.ReadAsync(ScriptSecretsType.Host, It.IsAny<string>())).ReturnsAsync(new HostSecrets
+            {
+                MasterKey = new Key("master", "enc:master") { IsEncrypted = true },
+                FunctionKeys = new List<Key>(),
+                SystemKeys = new List<Key> { new Key(KeyName, "enc:" + StoredPlaintext) { IsEncrypted = true } }
+            });
+
+            using (var secretManager = CreateSecretManagerWithStartupSystemKeys(repository.Object, new Dictionary<string, string>()))
+            {
+                string result = await secretManager.GetOrCreateSystemKeyAsync(KeyName);
+
+                // The incident was a spurious write against a key Event Grid already held.
+                repository.Verify(r => r.WriteAsync(It.IsAny<ScriptSecretsType>(), It.IsAny<string>(), It.IsAny<ScriptSecrets>()), Times.Never);
+                repository.Verify(r => r.WriteSnapshotAsync(It.IsAny<ScriptSecretsType>(), It.IsAny<string>(), It.IsAny<ScriptSecrets>()), Times.Never);
+
+                // Decrypted, and the key the store already holds - not a freshly minted one.
+                Assert.Equal(StoredPlaintext, result);
+
+                // The invalidated cache healed, so the next caller reads nothing further.
+                var hostSecrets = await secretManager.GetHostSecretsAsync();
+                Assert.Equal(StoredPlaintext, hostSecrets.SystemKeys[KeyName]);
+                repository.Verify(r => r.ReadAsync(ScriptSecretsType.Host, It.IsAny<string>()), Times.Once);
+            }
+        }
+
+        [Fact]
+        public async Task GetOrCreateSystemKeyAsync_KeyInCache_ReturnsItWithoutTouchingRepository()
+        {
+            const string KeyName = "eventgrid_extension";
+
+            var repository = new Mock<ISecretsRepository>();
+            var startupSystemKeys = new Dictionary<string, string> { { KeyName, "cached-value" } };
+
+            using (var secretManager = CreateSecretManagerWithStartupSystemKeys(repository.Object, startupSystemKeys))
+            {
+                Assert.Equal("cached-value", await secretManager.GetOrCreateSystemKeyAsync(KeyName));
+
+                // A hit must stay a hit; challenging it would put the repository on every webhook URL build.
+                repository.Verify(r => r.ReadAsync(It.IsAny<ScriptSecretsType>(), It.IsAny<string>()), Times.Never);
+                repository.Verify(r => r.WriteAsync(It.IsAny<ScriptSecretsType>(), It.IsAny<string>(), It.IsAny<ScriptSecrets>()), Times.Never);
+            }
+        }
+
+        // Flex Consumption specialization seeds the cache from a startup context whose SystemKeys may be partial.
+        private SecretManager CreateSecretManagerWithStartupSystemKeys(ISecretsRepository repository, Dictionary<string, string> systemKeys)
+        {
+            var startupContext = new Mock<StartupContextProvider>(_testEnvironment, new LoggerFactory().CreateLogger<StartupContextProvider>());
+            startupContext.Setup(p => p.GetHostSecretsOrNull()).Returns(new HostSecretsInfo
+            {
+                MasterKey = "master",
+                FunctionKeys = new Dictionary<string, string>(),
+                SystemKeys = systemKeys
+            });
+
+            return new SecretManager(repository, GetRoundTrippingConverterFactoryMock().Object, _logger, new TestMetricsLogger(), _hostNameProvider, startupContext.Object);
+        }
+
+        [Fact]
+        public async Task GetOrCreateSystemKeyAsync_KeyAbsent_PersistsIdentifiableKeyMatchingReturnedValue()
+        {
+            const string KeyName = "testextension_extension";
+
+            // Host secrets already exist and only the extension key is missing, so exactly one write should follow.
+            var repository = new Mock<ISecretsRepository>();
+            repository.Setup(r => r.ReadAsync(ScriptSecretsType.Host, It.IsAny<string>())).ReturnsAsync(() => new HostSecrets
+            {
+                MasterKey = new Key("master", "enc:master") { IsEncrypted = true },
+                FunctionKeys = new List<Key>(),
+                SystemKeys = new List<Key>()
+            });
+
+            ScriptSecrets written = null;
+            repository.Setup(r => r.WriteAsync(ScriptSecretsType.Host, It.IsAny<string>(), It.IsAny<ScriptSecrets>()))
+                .Callback<ScriptSecretsType, string, ScriptSecrets>((_, _, secrets) => written = secrets)
+                .Returns(Task.CompletedTask);
+
+            using (var secretManager = CreateSecretManagerWithStartupSystemKeys(repository.Object, new Dictionary<string, string>()))
+            {
+                string result = await secretManager.GetOrCreateSystemKeyAsync(KeyName);
+
+                // Generation moved here from the provider, so the system key seed moved with it.
+                SecretGeneratorTests.ValidateSecret(result, SecretGenerator.SystemKeySeed);
+
+                repository.Verify(r => r.WriteAsync(ScriptSecretsType.Host, It.IsAny<string>(), It.IsAny<ScriptSecrets>()), Times.Once);
+
+                // The returned value is worthless unless the store holds that same key, encrypted.
+                var persisted = ((HostSecrets)written).SystemKeys.Single(k => k.Name == KeyName);
+                Assert.True(persisted.IsEncrypted);
+                Assert.Equal("enc:" + result, persisted.Value);
+            }
+        }
+
+        // The shared GetConverterFactoryMock reader is identity, so it cannot tell ciphertext from plaintext.
+        private static Mock<IKeyValueConverterFactory> GetRoundTrippingConverterFactoryMock()
+        {
+            var reader = new Mock<IKeyValueReader>();
+            reader.Setup(r => r.ReadValue(It.IsAny<Key>()))
+                .Returns<Key>(k => new Key(k.Name, k.Value.StartsWith("enc:") ? k.Value.Substring(4) : k.Value) { IsStale = false });
+
+            var writer = new Mock<IKeyValueWriter>();
+            writer.Setup(w => w.WriteValue(It.IsAny<Key>()))
+                .Returns<Key>(k => new Key(k.Name, "enc:" + k.Value) { IsEncrypted = true });
+
+            var factory = new Mock<IKeyValueConverterFactory>();
+            factory.Setup(f => f.GetValueReader(It.IsAny<Key>())).Returns(reader.Object);
+            factory.Setup(f => f.GetValueWriter(It.IsAny<Key>())).Returns(writer.Object);
+            return factory;
+        }
+
         private Mock<IKeyValueConverterFactory> GetConverterFactoryMock(bool simulateWriteConversion = true, bool setStaleValue = true)
         {
             var mockValueReader = new Mock<IKeyValueReader>();

--- a/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
@@ -1943,7 +1943,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
         {
             var reader = new Mock<IKeyValueReader>();
             reader.Setup(r => r.ReadValue(It.IsAny<Key>()))
-                .Returns<Key>(k => new Key(k.Name, k.Value.StartsWith("enc:") ? k.Value.Substring(4) : k.Value) { IsStale = false });
+                .Returns<Key>(k => new Key(k.Name, k.Value.StartsWith("enc:", StringComparison.Ordinal) ? k.Value.Substring(4) : k.Value) { IsStale = false });
 
             var writer = new Mock<IKeyValueWriter>();
             writer.Setup(w => w.WriteValue(It.IsAny<Key>()))


### PR DESCRIPTION
### Issue describing the changes in this PR

No public issue - found while investigating an internal incident where Event Grid deliveries to a Functions app started returning 401 after a host restart. Happy to open a tracking issue if the team prefers one.

Related but distinct: #11834 reports EventGrid 401s during Flex Consumption cold start. That failure is transient - the reporter notes retries succeed once the key finishes loading. This one is permanent, because the key is overwritten rather than merely not-yet-loaded, so retries never recover. **This PR does not fix #11834.**

### What's wrong

`DefaultScriptWebHookProvider` looked up an extension's system key in the in-memory host-secrets cache. On Flex Consumption, specialization seeds that cache from a startup context whose `SystemKeys` can be incomplete. When it is: the lookup misses, the provider generates a replacement, and `AddOrUpdateFunctionSecretAsync` blindly upserts it - overwriting the key the subscribing service already holds.

The webhook URL then carries a key the subscription doesn't have, so every delivery 401s. It is not self-healing: the host has no way to notify Event Grid, and the subscription stores the full URL, so recovery requires re-creating the subscription by hand.

The root cause is that a **present-but-incomplete** cache was treated as authoritative. A stale "no" was indistinguishable from a real one, and only one of those should authorize a write.

### The fix

Move get-or-create into `SecretManager`, the only component that can tell them apart:

- `GetOrCreateSystemKeyAsync` returns a cached hit unchanged. On a miss it invalidates only the snapshot it missed on (`Interlocked.CompareExchange`, so a concurrent reload isn't discarded), then performs one authoritative repository read before concluding the key doesn't exist.
- Creation is gated on `Created`/`Updated`. Any other result means nothing was persisted, and returning the value would mint a webhook URL carrying a key that authorizes nothing.
- `DefaultScriptWebHookProvider` now only derives the key name.

`AddOrUpdateFunctionSecretAsync` is unchanged - `KeysController` still depends on its result codes for HTTP status mapping.

### Known limitation

The create path is still a last-writer-wins upsert, so a key persisted concurrently by another instance can be replaced. That window only opens during true first creation - not on restarts, scale-out, or specialization. Closing it needs an ETag/CAS write no `ISecretsRepository` exposes today. The interface documents this rather than over-promising.

### Tests

On the miss path: zero `WriteAsync`/`WriteSnapshotAsync`, exactly one `ReadAsync`, and the invalidated cache heals. A second test proves a cached hit never touches the repository. A third seeds a host document missing only the target key and asserts exactly one write whose persisted ciphertext decrypts to the returned value. `DefaultScriptWebHookProviderTests` verifies the exact derived key name.

Mutation-checked: disabling the invalidation fails with `Expected invocation on the mock should never have been performed, but was 1 times: WriteAsync` - the incident itself, caught by assertion rather than inferred from a returned value.

### Pull request checklist

* [ ] Backporting to the `in-proc` branch is not required
    * **Maintainer input wanted.** The trigger is Flex-specific (specialization seeding a partial cache) but the code path is shared. I don't know whether in-proc can reach the same state, so I'm not asserting either way.
* [x] My changes **do not** require documentation changes
* [ ] My changes **should not** be added to the release notes for the next release
    * This is customer-visible, so it should be - the `release_notes.md` entry is included in this PR.
* [ ] My changes **do not** need to be backported to a previous version
    * **Maintainer input wanted** - depends on which released versions carry the same path.
* [x] My changes **do not** require diagnostic events changes
    * No events added or changed. The existing `Host secret ... Updated` event simply stops firing spuriously.
* [x] I have added all required tests (Unit tests, E2E tests)
