### PR TITLE
Patch/4.53.200: Upgdate PS worker 7.4 and 7.6 to latest version

### DIFF
--- a/eng/build/Workers.Powershell.props
+++ b/eng/build/Workers.Powershell.props
@@ -3,8 +3,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" VersionOverride="4.0.3148" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" VersionOverride="4.0.4025" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" VersionOverride="4.0.5212" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.6" VersionOverride="4.0.5213" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" VersionOverride="4.0.5303" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.6" VersionOverride="4.0.5302" />
   </ItemGroup>
 
   <Target Name="RemovePowershellWorkerRuntimes" BeforeTargets="AssignTargetPaths" Condition="'$(RuntimeIdentifier)' != ''">

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,6 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+
+- Update PS 7.4 worker to [v4.0.5303](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5303) (#11905)
+- Update PS 7.6 worker to [v4.0.5302](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5302) (#11905)

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,15 +3,3 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-
-- fix: eliminate noisy restart logs during worker channel shutdown (#11846)
-- Fixed a WebHost worker channel shutdown race that could hang host teardown when a language worker was still initializing. (#11853)
-- Fixed a race where a SyncTriggers request during specialization could publish placeholder (`WarmUp`) triggers. (#11874)
-- Fixed specialization waiting the full environment reload timeout when a language worker crashed mid-reload (#11883)
-- Update Microsoft.Azure.AppService.Middleware to 1.5.11 (#11866)
-- Update PS 7.4 worker to [v4.0.5212](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5212) (#11858)
-- Update PS 7.6 worker to [v4.0.5213](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5213) (#11858)
-- Fixed a race and reader leak in WebHost deferred startup-log forwarding across ScriptHost restarts/specialization, and fixed OpenTelemetry logs not being flushed on host shutdown. (#11847)
-- Update `Microsoft.Azure.Functions.DotNetIsolatedNativeHost` to `1.0.15` (#11881)
-- Update Python Worker Version to [4.46.0](https://github.com/Azure/azure-functions-python-worker/releases/tag/4.46.0) (#11885)
-- Update Java Worker Version to [2.19.5](https://github.com/Azure/azure-functions-java-worker/releases/tag/2.19.5)

--- a/src/Directory.Version.props
+++ b/src/Directory.Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>4.1053.100</VersionPrefix>
+    <VersionPrefix>4.1053.200</VersionPrefix>
     <UpdateBuildNumber>true</UpdateBuildNumber>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

Promotes `patch/4.53.200` into `release/4.53` for host version 4.1053.200.

- Update the host version to 4.1053.200
- Update the PowerShell 7.4 worker to 4.0.5303
- Update the PowerShell 7.6 worker to 4.0.5302
- Refresh the release notes