### PR TITLE
ci: complete CFS migration: drop PSGallery and add npm feed config

### DIFF
--- a/eng/ci/templates/official/jobs/run-integration-tests.yml
+++ b/eng/ci/templates/official/jobs/run-integration-tests.yml
@@ -40,12 +40,6 @@ jobs:
     env:
       NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/eng/ci/.npmrc
 
-  - task: PowerShell@2
-    displayName: Install Az.Storage Powershell module
-    inputs:
-      targetType: inline
-      script: 'Install-Module -Name Az.Storage -RequiredVersion 1.11.0 -Scope CurrentUser -Force -AllowClobber'
-
   - task: Npm@1
     displayName: npm ci
     inputs:

--- a/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
+++ b/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
@@ -33,12 +33,6 @@ jobs:
     env:
       NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/eng/ci/.npmrc
 
-  - task: PowerShell@2
-    displayName: Install Az.Storage Powershell module
-    inputs:
-      targetType: inline
-      script: 'Install-Module -Name Az.Storage -RequiredVersion 1.11.0 -Scope CurrentUser -Force -AllowClobber'
-
   - task: DotNetCoreCLI@2
     displayName: Restore
     inputs:

--- a/eng/script/checkin-secrets.ps1
+++ b/eng/script/checkin-secrets.ps1
@@ -15,9 +15,10 @@ if ($leaseToken -eq "") {
 
 Write-Host "Breaking lease for $leaseBlob."
 
+Import-Module Az.Storage
+
 $storageContext = New-AzStorageContext -StorageAccountName "azurefunctionshostci0" -UseConnectedAccount
 $blob = Get-AzStorageBlob -Context $storageContext -Container "ci-locks" -Blob $leaseBlob
 
-$accessCondition = New-Object -TypeName Microsoft.Azure.Storage.AccessCondition
-$accessCondition.LeaseId = $leaseToken
-$blob.ICloudBlob.ReleaseLease($accessCondition)
+$leaseClient = New-Object Azure.Storage.Blobs.Specialized.BlobLeaseClient($blob.BlobBaseClient, $leaseToken)
+$leaseClient.Release() | Out-Null

--- a/eng/script/checkout-secrets.ps1
+++ b/eng/script/checkout-secrets.ps1
@@ -1,6 +1,8 @@
 function AcquireLease($blob) {
   try {
-    return $blob.ICloudBlob.AcquireLease($null, $null, $null, $null, $null)
+    $leaseClient = New-Object Azure.Storage.Blobs.Specialized.BlobLeaseClient($blob.BlobBaseClient, $null)
+    $response = $leaseClient.Acquire([System.TimeSpan]::FromSeconds(-1))
+    return $response.Value.LeaseId
   } catch {
     Write-Host "  Error: $_"
     return $null
@@ -26,21 +28,22 @@ While($true) {
   Write-Host "Looking for unleased ci-lock blobs (list is shuffled):"
   Foreach ($blob in $blobs) {
     $name = $blob.Name
-    $leaseStatus = $blob.ICloudBlob.Properties.LeaseStatus
+    $leaseStatus = $blob.BlobProperties.LeaseStatus
     
     Write-Host "  ${name}: $leaseStatus"
     
     if ($leaseStatus -eq "Locked") {
       try {
-        $blob.ICloudBlob.FetchAttributes()
-        $lastModified = $blob.ICloudBlob.Properties.LastModified
-        if ($lastModified -ne $null -and $lastModified.UtcDateTime -lt (Get-Date).AddHours(-6).ToUniversalTime()) {
+        $props = $blob.BlobBaseClient.GetProperties().Value
+        $lastModified = $props.LastModified
+        if ($lastModified.UtcDateTime -lt (Get-Date).AddHours(-6).ToUniversalTime()) {
           $age = [math]::Round(((Get-Date).ToUniversalTime() - $lastModified.UtcDateTime).TotalHours, 1)
-          $build = $blob.ICloudBlob.Metadata["Build"]
-          $url = $blob.ICloudBlob.Metadata["BuildUrl"]
+          $build = $props.Metadata["Build"]
+          $url = $props.Metadata["BuildUrl"]
           Write-Host "##vso[task.logissue type=warning]Stale lease detected on '${name}' (locked for ${age}h). Build: ${build} | URL: ${url}"
           Write-Host "  Breaking stale lease on ${name}."
-          $blob.ICloudBlob.BreakLease([TimeSpan]::Zero, $null, $null, $null)
+          $leaseClient = New-Object Azure.Storage.Blobs.Specialized.BlobLeaseClient($blob.BlobBaseClient, $null)
+          $leaseClient.Break([System.TimeSpan]::Zero) | Out-Null
           Write-Host "  Lease broken. Will attempt to acquire on next pass."
         }
       } catch {
@@ -56,12 +59,15 @@ While($true) {
       Write-Host "##vso[task.setvariable variable=LeaseBlob]$name"
       Write-Host "##vso[task.setvariable variable=LeaseToken]$token"
       try {
-        $blob.ICloudBlob.FetchAttributes()
-        $blob.ICloudBlob.Metadata["Build"] = $buildName
-        $blob.ICloudBlob.Metadata["BuildUrl"] = $buildUrl
-        $accessCondition = New-Object -TypeName Microsoft.Azure.Storage.AccessCondition
-        $accessCondition.LeaseId = $token
-        $blob.ICloudBlob.SetMetadata($accessCondition)
+        $conditions = New-Object Azure.Storage.Blobs.Models.BlobRequestConditions
+        $conditions.LeaseId = $token
+        $metadata = New-Object 'System.Collections.Generic.Dictionary[string,string]'
+        foreach ($kvp in $blob.BlobBaseClient.GetProperties().Value.Metadata.GetEnumerator()) {
+          $metadata[$kvp.Key] = $kvp.Value
+        }
+        $metadata["Build"] = $buildName
+        $metadata["BuildUrl"] = $buildUrl
+        $blob.BlobClient.SetMetadata($metadata, $conditions) | Out-Null
       } catch {
         # best effort
         Write-Host "Warning: unable to update blob metadata. Continuing. $_"

--- a/sample/CustomHandlerRetry/.npmrc
+++ b/sample/CustomHandlerRetry/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/test/Resources/TestScripts/Node/.npmrc
+++ b/test/Resources/TestScripts/Node/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/


### PR DESCRIPTION
### Issue describing the changes in this PR

N/A — CFS (Central Feed Services) compliance follow-up. Routes the remaining public-package-feed traffic through the `azfunc/public/upstream-public` feed so the `host.integration-tests` and `host.public` pipelines become CFS-compliant. The NuGet + npm-CI migration already landed on `dev`; this PR closes the remaining gaps.

**What changed**

- **PowerShell Gallery (the last real CI violation):** both test pipelines installed `Az.Storage` **1.11.0** from powershellgallery.com, pinned to 1.x because `checkout-secrets.ps1` / `checkin-secrets.ps1` used the legacy `$blob.ICloudBlob.AcquireLease/BreakLease/ReleaseLease` + `Microsoft.Azure.Storage.AccessCondition` APIs removed in Az.Storage 2.x. `upstream-public` has no PSGallery upstream, so there's no drop-in URL. Rewrote both scripts to the `Azure.Storage.Blobs.Specialized.BlobLeaseClient` / `BlobRequestConditions` model provided by the `AzurePowerShell@5` task, and removed the `Install-Module Az.Storage 1.11.0` step from `run-integration-tests.yml` and `run-non-e2e-tests.yml`. Behavior preserved: `ci-locks` container, blob shuffle, 30s retry loop, stale (>6h) lease break, `Build`/`BuildUrl` metadata, and the `##vso[...]LeaseBlob/LeaseToken` contract.
- **npm:** added project-local `.npmrc` beside `sample/CustomHandlerRetry/package.json` and `test/Resources/TestScripts/Node/package.json` pointing at the `upstream-public` npm registry (npm reads the project-dir `.npmrc`, not a repo-root one), matching the existing repo `.npmrc` convention.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

These are CI/build-infra changes (Azure Pipelines YAML, `eng/script` lease helpers, `.npmrc`) with no product-code surface, so no unit/E2E tests apply. The lease-script rewrite is CI-critical and can only be **fully** validated by a live pipeline run (it needs the CI storage account + connected-account auth) — please confirm via a green `host.integration-tests` run.

### Additional information

**Out of scope (not changed):** `src/WebJobs.Script/FileProvisioning/PowerShell/PowerShellFileProvisioner.cs` queries powershellgallery.com at runtime to resolve the latest supported `Az` major version for generated `requirements.psd1`. That is customer-facing product behavior, and its tests mock the network, so it is not a CI CFS violation. Redirecting it would change what customers get — it needs a separate product decision.

**Contributor note:** `upstream-public` is anonymous-read for already-cached packages. Adding a new dependency or bumping to a version not yet cached returns **401** (needs ingestion) until a maintainer or a branch CI run restores it once, after which it's cached for everyone.