### PR TITLE
test: use reserved hostname for JWT integration tests

### DIFF
--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/JwtTokenAuthTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/JwtTokenAuthTests.cs
@@ -236,7 +236,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                     { EnvironmentSettingNames.WebSiteAuthEncryptionKey, testKey },
                     { "AzureWebJobsStorage", null },
                     { EnvironmentSettingNames.AzureWebsiteName, "testsite" },
-                    { EnvironmentSettingNames.AzureWebsiteHostName, "site.azurewebsites.test" }
+                    { EnvironmentSettingNames.AzureWebsiteHostName, "testsite.azurewebsites.test" }
                 };
                 _scopedEnvironment = new TestScopedEnvironmentVariable(settings);
             }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/JwtTokenAuthTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/JwtTokenAuthTests.cs
@@ -235,7 +235,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                     { "AzureWebEncryptionKey", testKey },
                     { EnvironmentSettingNames.WebSiteAuthEncryptionKey, testKey },
                     { "AzureWebJobsStorage", null },
-                    { EnvironmentSettingNames.AzureWebsiteName, "testsite" }
+                    { EnvironmentSettingNames.AzureWebsiteName, "testsite" },
+                    { EnvironmentSettingNames.AzureWebsiteHostName, "site.azurewebsites.test" }
                 };
                 _scopedEnvironment = new TestScopedEnvironmentVariable(settings);
             }

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/JwtTokenAuthTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/JwtTokenAuthTests.cs
@@ -16,6 +16,7 @@ using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.WebJobs.Script.Tests;
 using Newtonsoft.Json;
 using Xunit;
@@ -263,6 +264,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.WebHostEndToEnd
                 var service = services.FirstOrDefault(d => d.ServiceType == typeof(IFunctionsSyncManager));
                 services.Remove(service);
                 services.AddSingleton<IFunctionsSyncManager, FunctionsSyncManager>();
+
+                services.AddHttpClient(Options.DefaultName)
+                    .ConfigurePrimaryHttpMessageHandler(() => new TestHandler());
             }
 
             public override void ConfigureWebHost(IServiceCollection services)

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/SpecializationE2ETests.cs
@@ -353,7 +353,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             string encryptionKey = TestHelpers.GenerateKeyHexString();
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, encryptionKey);
-            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName, "testsite.azurewebsites.net");
+            _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteHostName, "testsite.azurewebsites.test");
             _environment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteName, "testsite");
 
             // Keep the payload on the minimal path (no per-function secret/file fetches) so the


### PR DESCRIPTION
## Summary

- configure the JWT integration-test fixture with the reserved `site.azurewebsites.test` hostname
- prevent its real `FunctionsSyncManager` from targeting `testsite.azurewebsites.net` during SyncTriggers
- retain `testsite` as the site name so JWT issuer and audience coverage remains unchanged

## Testing

- `dotnet test test\WebJobs.Script.Tests.Integration\WebJobs.Script.Tests.Integration.csproj -c Release --no-restore --filter "FullyQualifiedName~JwtTokenAuthTests"`