### PR TITLE
Fix Kubernetes lease renewal duration

### DIFF
--- a/src/WebJobs.Script/Host/Kubernetes/KubernetesClient.cs
+++ b/src/WebJobs.Script/Host/Kubernetes/KubernetesClient.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -54,11 +55,12 @@ namespace Microsoft.Azure.WebJobs.Script
                 throw new ArgumentNullException(nameof(ownerId));
             }
 
+            string lockPeriodSeconds = lockPeriod.TotalSeconds.ToString(CultureInfo.InvariantCulture);
             var lockHandle = new KubernetesLockHandle();
             var request = new HttpRequestMessage()
             {
                 Method = HttpMethod.Post,
-                RequestUri = GetRequestUri($"/acquire?name={lockId}&owner={ownerId}&duration={lockPeriod.TotalSeconds}&renewDeadline={LeaseRenewDeadline}"),
+                RequestUri = GetRequestUri($"/acquire?name={lockId}&owner={ownerId}&duration={lockPeriodSeconds}&renewDeadline={LeaseRenewDeadline}"),
             };
 
             var response = await _httpClient.SendAsync(request, cancellationToken);
@@ -66,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.Script
             {
                 lockHandle.LockId = lockId;
                 lockHandle.Owner = ownerId;
-                lockHandle.LockPeriod = lockPeriod.TotalSeconds.ToString();
+                lockHandle.LockPeriod = lockPeriodSeconds;
             }
             return lockHandle;
         }

--- a/src/WebJobs.Script/Host/Kubernetes/KubernetesDistributedLockManager.cs
+++ b/src/WebJobs.Script/Host/Kubernetes/KubernetesDistributedLockManager.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host;
@@ -44,7 +45,9 @@ namespace Microsoft.Azure.WebJobs.Script
         public async Task<bool> RenewAsync(IDistributedLock lockHandle, CancellationToken cancellationToken)
         {
             var kubernetesLock = (KubernetesLockHandle)lockHandle;
-            var renewedLockHandle = await _kubernetesClient.TryAcquireLock(kubernetesLock.LockId, kubernetesLock.Owner, TimeSpan.Parse(kubernetesLock.LockPeriod), cancellationToken);
+            double lockPeriodSeconds = double.Parse(kubernetesLock.LockPeriod, NumberStyles.Float, CultureInfo.InvariantCulture);
+            var renewedLockHandle = await _kubernetesClient.TryAcquireLock(kubernetesLock.LockId, kubernetesLock.Owner, TimeSpan.FromSeconds(lockPeriodSeconds), cancellationToken);
+
             return !string.IsNullOrEmpty(renewedLockHandle.LockId);
         }
 

--- a/test/WebJobs.Script.Tests.Integration/KubernetesDistributedLockManagerTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/KubernetesDistributedLockManagerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;
@@ -87,6 +88,95 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             Assert.Equal(lockId, lockHandle.LockId);
             Assert.Equal(instanceId, ((KubernetesLockHandle)lockHandle).Owner);
+        }
+
+        [Fact]
+        public async Task AcquireAndRenewLockRequest_PreservesLeaseDurationInSeconds()
+        {
+            const string lockId = "test-lock";
+            const string ownerId = "test-owner";
+            string expectedRequestUri =
+                $"{TestHttpLeaderEndpoint}/lock/acquire?name={lockId}&owner={ownerId}&duration=5&renewDeadline=10";
+            var environment = new Mock<IEnvironment>();
+            environment.Setup(p => p.GetEnvironmentVariable(HttpLeaderEndpoint)).Returns(TestHttpLeaderEndpoint);
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(request =>
+                        request.Method == HttpMethod.Post
+                        && string.Equals(request.RequestUri.AbsoluteUri, expectedRequestUri, StringComparison.Ordinal)),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK
+                });
+
+            var lockClient = new KubernetesClient(environment.Object, new HttpClient(handlerMock.Object));
+            var lockManager = new KubernetesDistributedLockManager(lockClient, ScriptSettingsManager.Instance);
+
+            var lockHandle = await lockManager.TryLockAsync(
+                "", lockId, ownerId, "", TimeSpan.FromSeconds(5), CancellationToken.None);
+            bool renewed = await lockManager.RenewAsync(lockHandle, CancellationToken.None);
+
+            Assert.True(renewed);
+            handlerMock.Protected().Verify(
+                "SendAsync",
+                Times.Exactly(2),
+                ItExpr.Is<HttpRequestMessage>(request =>
+                    string.Equals(request.RequestUri.AbsoluteUri, expectedRequestUri, StringComparison.Ordinal)),
+                ItExpr.IsAny<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task AcquireAndRenewLockRequest_UsesInvariantCultureForLeaseDuration()
+        {
+            const string lockId = "test-lock";
+            const string ownerId = "test-owner";
+            string expectedRequestUri =
+                $"{TestHttpLeaderEndpoint}/lock/acquire?name={lockId}&owner={ownerId}&duration=5.5&renewDeadline=10";
+            var originalCulture = CultureInfo.CurrentCulture;
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+
+            try
+            {
+                var environment = new Mock<IEnvironment>();
+                environment.Setup(p => p.GetEnvironmentVariable(HttpLeaderEndpoint)).Returns(TestHttpLeaderEndpoint);
+
+                var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+                handlerMock.Protected()
+                    .Setup<Task<HttpResponseMessage>>(
+                        "SendAsync",
+                        ItExpr.Is<HttpRequestMessage>(request =>
+                            request.Method == HttpMethod.Post
+                            && string.Equals(request.RequestUri.AbsoluteUri, expectedRequestUri, StringComparison.Ordinal)),
+                        ItExpr.IsAny<CancellationToken>())
+                    .ReturnsAsync(new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.OK
+                    });
+
+                var lockClient = new KubernetesClient(environment.Object, new HttpClient(handlerMock.Object));
+                var lockManager = new KubernetesDistributedLockManager(lockClient, ScriptSettingsManager.Instance);
+
+                var lockHandle = await lockManager.TryLockAsync(
+                    "", lockId, ownerId, "", TimeSpan.FromSeconds(5.5), CancellationToken.None);
+                bool renewed = await lockManager.RenewAsync(lockHandle, CancellationToken.None);
+
+                Assert.True(renewed);
+                Assert.Equal("5.5", ((KubernetesLockHandle)lockHandle).LockPeriod);
+                handlerMock.Protected().Verify(
+                    "SendAsync",
+                    Times.Exactly(2),
+                    ItExpr.Is<HttpRequestMessage>(request =>
+                        string.Equals(request.RequestUri.AbsoluteUri, expectedRequestUri, StringComparison.Ordinal)),
+                    ItExpr.IsAny<CancellationToken>());
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+            }
         }
 
         [Theory]


### PR DESCRIPTION
## Summary

- preserve Kubernetes lease periods as invariant-culture seconds in lock handles and acquire requests
- reconstruct renewal durations from seconds instead of parsing them as `TimeSpan` strings
- add regression coverage for five-second renewals and culture-invariant fractional durations

## Testing

- `dotnet test test\WebJobs.Script.Tests.Integration\WebJobs.Script.Tests.Integration.csproj --no-restore --filter "FullyQualifiedName~KubernetesDistributedLockManagerTests" --logger "console;verbosity=minimal"` (18 passed)