### PR TITLE
ci: onboard in-proc restores to Central Feed Service

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -12,6 +12,7 @@
   <packageSourceMapping>
     <packageSource key="upstream-public">
       <package pattern="*" />
+      <package pattern="Microsoft.Azure.WebJobs.Extensions.Storage" />
     </packageSource>
     <packageSource key="Microsoft.Azure.Functions.PowerShellWorker">
       <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,11 +2,45 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
     <add key="Microsoft.Azure.Functions.PowerShellWorker" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/Microsoft.Azure.Functions.PowerShellWorker/nuget/v3/index.json" />
     <add key="AzureFunctions@internalrelease" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctions%40internalrelease/nuget/v3/index.json" />
     <add key="AzureFunctionsRelease" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsRelease/nuget/v3/index.json" />
-    <add key="AzureFunctionsPreRelease" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsPreRelease/nuget/v3/index.json" />
     <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
+    <add key="AzureFunctionsInfra" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/infra/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="upstream-public">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="Microsoft.Azure.Functions.PowerShellWorker">
+      <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" />
+      <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" />
+    </packageSource>
+    <packageSource key="AzureFunctions@internalrelease">
+      <package pattern="Microsoft.Azure.AppService.Middleware" />
+      <package pattern="Microsoft.Azure.AppService.Middleware.Functions" />
+      <package pattern="Microsoft.Azure.AppService.Middleware.Modules" />
+      <package pattern="Microsoft.Azure.AppService.Middleware.NetCore" />
+    </packageSource>
+    <packageSource key="AzureFunctionsRelease">
+      <package pattern="Microsoft.Azure.Functions.ColdStartProfileAnalyzer" />
+      <package pattern="Microsoft.Azure.Functions.JavaWorker" />
+      <package pattern="Microsoft.Azure.Functions.NodeJsWorker" />
+      <package pattern="Microsoft.Azure.Functions.PythonWorker" />
+    </packageSource>
+    <packageSource key="AzureFunctionsTempStaging">
+      <package pattern="Microsoft.Azure.AppService.Proxy.Common" />
+      <package pattern="Microsoft.Azure.AppService.Proxy.Client" />
+      <package pattern="Microsoft.Azure.AppService.Proxy.Runtime" />
+      <package pattern="Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption" />
+      <package pattern="Microsoft.Azure.WebSites.DataProtection" />
+    </packageSource>
+    <packageSource key="AzureFunctionsInfra">
+      <package pattern="Microsoft.Azure.Functions.ColdStartDataWriter" />
+      <package pattern="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" />
+      <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" />
+      <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.6" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -16,6 +16,7 @@
     <packageSource key="Microsoft.Azure.Functions.PowerShellWorker">
       <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" />
       <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" />
+      <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" />
     </packageSource>
     <packageSource key="AzureFunctions@internalrelease">
       <package pattern="Microsoft.Azure.AppService.Middleware" />
@@ -25,21 +26,23 @@
     </packageSource>
     <packageSource key="AzureFunctionsRelease">
       <package pattern="Microsoft.Azure.Functions.ColdStartProfileAnalyzer" />
+      <package pattern="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" />
       <package pattern="Microsoft.Azure.Functions.JavaWorker" />
       <package pattern="Microsoft.Azure.Functions.NodeJsWorker" />
       <package pattern="Microsoft.Azure.Functions.PythonWorker" />
     </packageSource>
     <packageSource key="AzureFunctionsTempStaging">
+      <package pattern="appinsights.testlogger" />
       <package pattern="Microsoft.Azure.AppService.Proxy.Common" />
       <package pattern="Microsoft.Azure.AppService.Proxy.Client" />
       <package pattern="Microsoft.Azure.AppService.Proxy.Runtime" />
       <package pattern="Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption" />
+      <package pattern="Microsoft.Azure.WebJobs.Extensions.Storage" />
+      <package pattern="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" />
       <package pattern="Microsoft.Azure.WebSites.DataProtection" />
     </packageSource>
     <packageSource key="AzureFunctionsInfra">
       <package pattern="Microsoft.Azure.Functions.ColdStartDataWriter" />
-      <package pattern="Microsoft.Azure.Functions.DotNetIsolatedNativeHost" />
-      <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" />
       <package pattern="Microsoft.Azure.Functions.PowerShellWorker.PS7.6" />
     </packageSource>
   </packageSourceMapping>

--- a/eng/ci/.npmrc
+++ b/eng/ci/.npmrc
@@ -1,0 +1,11 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure-rest:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@colors:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@dabh:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@js-joda:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@microsoft:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@opentelemetry:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@so-ric:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@types:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@typespec:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/eng/ci/templates/install-dotnet.yml
+++ b/eng/ci/templates/install-dotnet.yml
@@ -17,3 +17,5 @@ steps:
   inputs:
     packageType: sdk
     useGlobalJson: true
+
+- task: NuGetAuthenticate@1

--- a/eng/ci/templates/official/jobs/build-artifacts-linux.yml
+++ b/eng/ci/templates/official/jobs/build-artifacts-linux.yml
@@ -32,6 +32,8 @@ jobs:
       packageType: sdk
       version: 8.x
 
+  - task: NuGetAuthenticate@1
+
   - task: DotNetCoreCLI@2
     displayName: Restore
     inputs:

--- a/eng/ci/templates/official/jobs/run-integration-tests.yml
+++ b/eng/ci/templates/official/jobs/run-integration-tests.yml
@@ -200,7 +200,7 @@ jobs:
       projects: $(IntegrationProject)
 
   - task: AzurePowerShell@5
-    condition: always()
+    condition: and(always(), ne(variables['LeaseBlob'], ''))
     displayName: Checkin secrets
     inputs:
       azureSubscription: Azure-Functions-Host-CI-internal

--- a/eng/ci/templates/official/jobs/run-integration-tests.yml
+++ b/eng/ci/templates/official/jobs/run-integration-tests.yml
@@ -14,6 +14,8 @@ jobs:
   steps:
   - template: /eng/ci/templates/install-dotnet.yml@self
 
+  - template: /eng/ci/templates/steps/configure-user-nuget-cfs.yml@self
+
   - task: UseNode@1
     inputs:
       version: 22.x

--- a/eng/ci/templates/official/jobs/run-integration-tests.yml
+++ b/eng/ci/templates/official/jobs/run-integration-tests.yml
@@ -29,21 +29,23 @@ jobs:
       jdkArchitectureOption: x64
       jdkSourceOption: PreInstalled
 
+  - task: npmAuthenticate@0
+    inputs:
+      workingFile: $(Build.SourcesDirectory)/eng/ci/.npmrc
+
   - script: |
       npm install -g azurite
     displayName: Install Azurite
-
-  - task: PowerShell@2
-    displayName: Install Az.Storage Powershell module
-    inputs:
-      targetType: inline
-      script: 'Install-Module -Name Az.Storage -RequiredVersion 1.11.0 -Scope CurrentUser -Force -AllowClobber'
+    env:
+      NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/eng/ci/.npmrc
 
   - task: Npm@1
     displayName: npm ci
     inputs:
       command: ci
       workingDir: sample/CustomHandlerRetry
+    env:
+      NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/eng/ci/.npmrc
 
   - task: DotNetCoreCLI@2
     displayName: Build Integration.csproj

--- a/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
+++ b/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
@@ -91,7 +91,7 @@ jobs:
       AzureWebJobsSecretStorageKeyVaultClientSecret: $(AzureClientSecret)
 
   - task: AzurePowerShell@5
-    condition: always()
+    condition: and(always(), ne(variables['LeaseBlob'], ''))
     displayName: Checkin secrets
     inputs:
       azureSubscription: Azure-Functions-Host-CI-internal

--- a/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
+++ b/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
@@ -13,6 +13,8 @@ jobs:
   steps:
   - template: /eng/ci/templates/install-dotnet.yml@self
 
+  - template: /eng/ci/templates/steps/configure-user-nuget-cfs.yml@self
+
   - task: UseNode@1
     inputs:
       version: 22.x

--- a/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
+++ b/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
@@ -23,15 +23,15 @@ jobs:
       jdkArchitectureOption: x64
       jdkSourceOption: PreInstalled
 
+  - task: npmAuthenticate@0
+    inputs:
+      workingFile: $(Build.SourcesDirectory)/eng/ci/.npmrc
+
   - script: |
       npm install -g azurite
     displayName: Install Azurite
-
-  - task: PowerShell@2
-    displayName: Install Az.Storage Powershell module
-    inputs:
-      targetType: inline
-      script: 'Install-Module -Name Az.Storage -RequiredVersion 1.11.0 -Scope CurrentUser -Force -AllowClobber'
+    env:
+      NPM_CONFIG_USERCONFIG: $(Build.SourcesDirectory)/eng/ci/.npmrc
 
   - task: DotNetCoreCLI@2
     displayName: Build Integration.csproj

--- a/eng/ci/templates/steps/configure-user-nuget-cfs.yml
+++ b/eng/ci/templates/steps/configure-user-nuget-cfs.yml
@@ -1,0 +1,34 @@
+steps:
+# CFS: the Functions host copies a C# script app's function.proj to %TEMP%\<guid>\ and runs
+# `dotnet restore` there (see src/WebJobs.Script/Description/DotNet/PackageManager.cs), so NuGet
+# config discovery walks up a temp path outside the repo and falls back to nuget.org. Seed the
+# repo NuGet.config at the user level so those out-of-tree restores resolve through the compliant
+# upstream-public feed. In-repo restores are unaffected: the repo-root config's <clear /> wins.
+- pwsh: |
+    $baseDirectory = if ($IsWindows)
+    {
+      [Environment]::GetFolderPath([Environment+SpecialFolder]::ApplicationData)
+    }
+    else
+    {
+      [Environment]::GetFolderPath([Environment+SpecialFolder]::UserProfile)
+    }
+
+    if ([string]::IsNullOrWhiteSpace($baseDirectory))
+    {
+      throw 'Unable to determine the user directory for NuGet configuration.'
+    }
+
+    $nugetDirectory = if ($IsWindows)
+    {
+      Join-Path $baseDirectory 'NuGet'
+    }
+    else
+    {
+      Join-Path (Join-Path $baseDirectory '.nuget') 'NuGet'
+    }
+
+    New-Item -ItemType Directory -Force -Path $nugetDirectory | Out-Null
+    Copy-Item (Join-Path '$(Build.SourcesDirectory)' 'NuGet.config') (Join-Path $nugetDirectory 'NuGet.Config') -Force
+    Write-Host "Seeded user-level NuGet.Config at $nugetDirectory for CFS-compliant out-of-tree restores."
+  displayName: Configure user-level NuGet feed (CFS)

--- a/eng/script/checkin-secrets.ps1
+++ b/eng/script/checkin-secrets.ps1
@@ -15,9 +15,10 @@ if ($leaseToken -eq "") {
 
 Write-Host "Breaking lease for $leaseBlob."
 
+Import-Module Az.Storage
+
 $storageContext = New-AzStorageContext -StorageAccountName "azurefunctionshostci0" -UseConnectedAccount
 $blob = Get-AzStorageBlob -Context $storageContext -Container "ci-locks" -Blob $leaseBlob
 
-$accessCondition = New-Object -TypeName Microsoft.Azure.Storage.AccessCondition
-$accessCondition.LeaseId = $leaseToken
-$blob.ICloudBlob.ReleaseLease($accessCondition)
+$leaseClient = New-Object Azure.Storage.Blobs.Specialized.BlobLeaseClient($blob.BlobBaseClient, $leaseToken)
+$leaseClient.Release() | Out-Null

--- a/eng/script/checkout-secrets.ps1
+++ b/eng/script/checkout-secrets.ps1
@@ -1,6 +1,8 @@
 function AcquireLease($blob) {
   try {
-    return $blob.ICloudBlob.AcquireLease($null, $null, $null, $null, $null)
+    $leaseClient = New-Object Azure.Storage.Blobs.Specialized.BlobLeaseClient($blob.BlobBaseClient, $null)
+    $response = $leaseClient.Acquire([System.TimeSpan]::FromSeconds(-1))
+    return $response.Value.LeaseId
   } catch {
     Write-Host "  Error: $_"
     return $null
@@ -25,7 +27,7 @@ While($true) {
   Write-Host "Looking for unleased ci-lock blobs (list is shuffled):"
   Foreach ($blob in $blobs) {
     $name = $blob.Name
-    $leaseStatus = $blob.ICloudBlob.Properties.LeaseStatus
+    $leaseStatus = $blob.BlobProperties.LeaseStatus
     
     Write-Host "  ${name}: $leaseStatus"
     
@@ -40,11 +42,14 @@ While($true) {
       Write-Host "##vso[task.setvariable variable=LeaseBlob]$name"
       Write-Host "##vso[task.setvariable variable=LeaseToken]$token"
       try {
-        $blob.ICloudBlob.FetchAttributes()
-        $blob.ICloudBlob.Metadata["Build"] = $buildName
-        $accessCondition = New-Object -TypeName Microsoft.Azure.Storage.AccessCondition
-        $accessCondition.LeaseId = $token
-        $blob.ICloudBlob.SetMetadata($accessCondition)
+        $conditions = New-Object Azure.Storage.Blobs.Models.BlobRequestConditions
+        $conditions.LeaseId = $token
+        $metadata = New-Object 'System.Collections.Generic.Dictionary[string,string]'
+        foreach ($kvp in $blob.BlobBaseClient.GetProperties().Value.Metadata.GetEnumerator()) {
+          $metadata[$kvp.Key] = $kvp.Value
+        }
+        $metadata["Build"] = $buildName
+        $blob.BlobClient.SetMetadata($metadata, $conditions) | Out-Null
       } catch {
         # best effort
         Write-Host "Warning: unable to update blob metadata. Continuing. $_"

--- a/perf/Apps/HelloHttpNode/.npmrc
+++ b/perf/Apps/HelloHttpNode/.npmrc
@@ -1,0 +1,2 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/
+@azure:registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/sample/CustomHandlerRetry/.npmrc
+++ b/sample/CustomHandlerRetry/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/test/Resources/TestScripts/Node/.npmrc
+++ b/test/Resources/TestScripts/Node/.npmrc
@@ -1,0 +1,1 @@
+registry=https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/npm/registry/

--- a/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
+++ b/test/WebJobs.Script.Tests.Integration/TestFunctionHost.cs
@@ -327,6 +327,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 writer.WriteStartElement("configuration");
                 writer.WriteStartElement("packageSources");
+                writer.WriteStartElement("clear");
+                writer.WriteEndElement();
                 for (int i = 0; i < sources.Length; i++)
                 {
                     writer.WriteStartElement("add");

--- a/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
+++ b/test/WebJobs.Script.Tests.Integration/WebHostEndToEnd/EndToEndTestFixture.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             var extensionsToInstall = GetExtensionsToInstall();
             if (extensionsToInstall != null && extensionsToInstall.Length > 0)
             {
-                TestFunctionHost.WriteNugetPackageSources(_copiedRootPath, "https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json", "https://api.nuget.org/v3/index.json");
+                TestFunctionHost.WriteNugetPackageSources(_copiedRootPath, "https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json");
                 var options = new OptionsWrapper<ScriptJobHostOptions>(new ScriptJobHostOptions
                 {
                     RootScriptPath = _copiedRootPath


### PR DESCRIPTION
## Summary

- route NuGet and npm dependency restores through Central Feed Service
- centralize NuGet authentication in the .NET setup template
- update Az.Storage lease handling for hosted build agents

Backports #11903 and #11909 to the `in-proc` branch.