### PR TITLE
fixing host disposal test

### DIFF
--- a/test/WebJobs.Script.Tests/Diagnostics/FileWriterTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/FileWriterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -195,15 +195,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 await Task.Delay(5);
             }
 
-            await Task.Delay(100);
+            int GetLogLineCount()
+            {
+                var directory = new DirectoryInfo(_logFilePath);
+                int count = directory.EnumerateFiles().Count();
+                if (count < 1)
+                {
+                    return 0;
+                }
 
-            var directory = new DirectoryInfo(_logFilePath);
-            int count = directory.EnumerateFiles().Count();
-            Assert.Equal(1, count);
+                string logFile = directory.EnumerateFiles().First().FullName;
+                string[] fileLines = File.ReadAllLines(logFile);
+                return fileLines.Length;
+            }
 
-            string logFile = directory.EnumerateFiles().First().FullName;
-            string[] fileLines = File.ReadAllLines(logFile);
-            Assert.Equal(numLogs, fileLines.Length);
+            await TestHelpers.Await(() => GetLogLineCount() == numLogs, timeout: 5000);
         }
 
         [Fact]

--- a/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
+++ b/test/WebJobs.Script.Tests/WebJobsScriptHostServiceTests.cs
@@ -405,52 +405,59 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public async Task DisposesScriptHost()
         {
             var metricsLogger = new TestMetricsLogger();
+            using var disposedSemaphore = new SemaphoreSlim(0, 1);
+            TaskCompletionSource stopBlock = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            var services = new ServiceCollection()
-                .AddLogging(l =>
-                {
-                    l.Services.AddSingleton<ILoggerProvider, TestLoggerProvider>();
-                    l.AddFilter(_ => true);
-                })
-                .BuildServiceProvider();
+            var previousHost = CreateMockHost(disposedSemaphore);
+            previousHost.Setup(h => h.StartAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            previousHost.Setup(h => h.StopAsync(It.IsAny<CancellationToken>()))
+                .Returns(stopBlock.Task);
 
-            var host = new Mock<IHost>();
+            var replacementHost = CreateMockHost();
+            replacementHost.Setup(h => h.StartAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            replacementHost.Setup(h => h.StopAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
 
-            host.Setup(h => h.Services)
-                .Returns(services);
-
-            host.Setup(h => h.Dispose())
-                .Callback(() =>
-                {
-                    services.Dispose();
-                });
-
-            var hostBuilder = new Mock<IScriptHostBuilder>();
-            hostBuilder.Setup(b => b.BuildHost(It.IsAny<bool>(), It.IsAny<bool>()))
-                .Returns(host.Object);
+            var hostBuilder = new OrderedScriptHostBuilder(previousHost.Object, replacementHost.Object);
 
             _webHostLoggerProvider = new TestLoggerProvider();
             _loggerFactory = new LoggerFactory();
             _loggerFactory.AddProvider(_webHostLoggerProvider);
 
             _hostService = new WebJobsScriptHostService(
-                _monitor, hostBuilder.Object, _loggerFactory,
+                _monitor, hostBuilder, _loggerFactory,
                 _mockScriptWebHostEnvironment.Object, _mockEnvironment.Object,
                 _hostPerformanceManager, _healthMonitorOptions,
                 metricsLogger, new Mock<IHostApplicationLifetime>().Object,
                 _mockConfig, new TestScriptEventManager(), _hostMetrics, _mockWorkerRuntimeResolver.Object, _functionsHostingConfigOptions, _workerConfigCacheInvalidator, _mockAppCapabilitiesStore.Object);
 
-            var hostLogger = host.Object.GetTestLoggerProvider();
+            var hostLogger = previousHost.Object.GetTestLoggerProvider();
 
             await _hostService.StartAsync(CancellationToken.None);
-            await _hostService.RestartHostAsync("test", CancellationToken.None);
+
+            // Hold old-host disposal until the replacement is active to exercise the overlapping restart path.
+            try
+            {
+                await _hostService.RestartHostAsync("test", CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
+                previousHost.Verify(m => m.Dispose(), Times.Never);
+            }
+            finally
+            {
+                stopBlock.TrySetResult();
+            }
+
+            bool disposalCompleted = await disposedSemaphore.WaitAsync(TimeSpan.FromSeconds(10));
 
             Assert.True(AreRequiredMetricsGenerated(metricsLogger));
+            Assert.Same(replacementHost.Object.Services, _hostService.Services);
 
-            int stopAsyncCalls = host.Invocations.Count(i => string.Equals(i.Method.Name, nameof(IHost.StopAsync), StringComparison.Ordinal));
+            int stopAsyncCalls = previousHost.Invocations.Count(i => string.Equals(i.Method.Name, nameof(IHost.StopAsync), StringComparison.Ordinal));
             Assert.True(stopAsyncCalls == 1, BuildDisposesScriptHostFailureMessage(nameof(IHost.StopAsync), 1, stopAsyncCalls, hostLogger));
 
-            int disposeCalls = host.Invocations.Count(i => string.Equals(i.Method.Name, nameof(IDisposable.Dispose), StringComparison.Ordinal));
+            int disposeCalls = previousHost.Invocations.Count(i => string.Equals(i.Method.Name, nameof(IDisposable.Dispose), StringComparison.Ordinal));
+            Assert.True(disposalCompleted, BuildDisposesScriptHostFailureMessage(nameof(IDisposable.Dispose), 1, disposeCalls, hostLogger));
             Assert.True(disposeCalls == 1, BuildDisposesScriptHostFailureMessage(nameof(IDisposable.Dispose), 1, disposeCalls, hostLogger));
 
             var allLogMessages = _webHostLoggerProvider.GetAllLogMessages();
@@ -458,6 +465,10 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             Assert.Contains(allLogMessages,
                 m => m.FormattedMessage != null &&
                      m.FormattedMessage.Contains("ScriptHost disposed"));
+
+            await _hostService.StopAsync(CancellationToken.None);
+            replacementHost.Verify(m => m.StopAsync(It.IsAny<CancellationToken>()), Times.Once);
+            replacementHost.Verify(m => m.Dispose(), Times.Once);
         }
 
         private string BuildDisposesScriptHostFailureMessage(string methodName, int expectedCalls, int actualCalls, TestLoggerProvider hostLogger)


### PR DESCRIPTION
Fixing two flaky tests.

### DisposesScriptHost
Did some investigation and the issue was that it was verifying that `RestartAsync()` would dispose of the current host instance. However, it was mocking only a single host. That meant that it was possible for the disposal to occur before a new host started. That could result in an exception if anything tried to access the host as the mocked ServiceProvider was disposed.

This changes it to use two mocked hosts and an `OrderedScriptHostBuilder` (something that already existed) as well as some coordination with a Semaphore and a Task. This controls the ordering and ensures that we correctly replace the host with a valid one as well as verify the original host was disposed.

### LogsAreFlushedOnTimer
Should be a simple timing isisue. This one was hard-coded to wait 100ms. Changed to use `TestHelper.Await()`

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)