### PR TITLE
Improve Key Vault secret name validation and cache consistency

### DIFF
--- a/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceSecurityExtension.cs
+++ b/src/WebJobs.Script.WebHost/Diagnostics/Extensions/ScriptHostServiceSecurityExtension.cs
@@ -27,6 +27,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
                 new EventId(602, nameof(KeyVaultSecretRepoDeleteKey)),
                 "Deleting key '{key}' on the KeyVault Secret Repository.");
 
+        private static readonly Action<ILogger, string, Exception> _keyVaultSecretRepoSkipNonCanonical =
+            LoggerMessage.Define<string>(
+                LogLevel.Warning,
+                new EventId(603, nameof(KeyVaultSecretRepoSkipNonCanonical)),
+                "Skipping Key Vault secret '{secretName}' because it contains a non-canonical escape sequence.");
+
         public static void BlobStorageSecretRepoError(this ILogger logger, string operation, Exception exception)
         {
             _blobStorageSecretRepoError(logger, operation, exception);
@@ -40,6 +46,11 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics.Extensions
         public static void KeyVaultSecretRepoDeleteKey(this ILogger logger, string key)
         {
             _keyVaultSecretRepoDeleteKey(logger, key, null);
+        }
+
+        public static void KeyVaultSecretRepoSkipNonCanonical(this ILogger logger, string secretName)
+        {
+            _keyVaultSecretRepoSkipNonCanonical(logger, secretName, null);
         }
     }
 }

--- a/src/WebJobs.Script.WebHost/Extensions/DictionaryExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Extensions/DictionaryExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
@@ -19,7 +21,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             Func<TSource, TKey> keySelector,
             Func<TSource, TValue> valueSelector,
             IEqualityComparer<TKey> comparer,
-            ILogger logger)
+            ILogger? logger)
+            where TKey : notnull
         {
             var dictionary = new Dictionary<TKey, TValue>(comparer);
 

--- a/src/WebJobs.Script.WebHost/Extensions/DictionaryExtensions.cs
+++ b/src/WebJobs.Script.WebHost/Extensions/DictionaryExtensions.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost
+{
+    internal static class DictionaryExtensions
+    {
+        /// <summary>
+        /// Converts a sequence to a <see cref="Dictionary{TKey, TValue}"/> using the specified
+        /// <paramref name="comparer"/>, keeping the first value when duplicate keys are encountered
+        /// instead of throwing <see cref="ArgumentException"/>.
+        /// </summary>
+        public static Dictionary<TKey, TValue> ToDictionarySafe<TSource, TKey, TValue>(
+            this IEnumerable<TSource> source,
+            Func<TSource, TKey> keySelector,
+            Func<TSource, TValue> valueSelector,
+            IEqualityComparer<TKey> comparer,
+            ILogger logger)
+        {
+            var dictionary = new Dictionary<TKey, TValue>(comparer);
+
+            foreach (TSource item in source)
+            {
+                TKey key = keySelector(item);
+                if (!dictionary.TryAdd(key, valueSelector(item)))
+                {
+                    logger?.LogWarning("Duplicate key '{keyName}' encountered when building secret cache; keeping the first value.", key);
+                }
+            }
+
+            return dictionary;
+        }
+    }
+}

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/KeyVaultSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/KeyVaultSecretsRepository.cs
@@ -206,16 +206,39 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             foreach (Task<Response<KeyVaultSecret>> task in tasks)
             {
                 KeyVaultSecret item = task.Result;
-                if (item.Name.StartsWith(MasterKey, StringComparison.OrdinalIgnoreCase))
+                string secretName = item.Name;
+
+                if (secretName.StartsWith(MasterKey, StringComparison.OrdinalIgnoreCase))
                 {
+                    string token = secretName.Substring(MasterKey.Length);
+                    if (!IsCanonicalToken(token))
+                    {
+                        Logger?.KeyVaultSecretRepoSkipNonCanonical(secretName);
+                        continue;
+                    }
+
                     hostSecrets.MasterKey = KeyVaultSecretToKey(item, MasterKey);
                 }
-                else if (item.Name.StartsWith(FunctionKeyPrefix, StringComparison.OrdinalIgnoreCase))
+                else if (secretName.StartsWith(FunctionKeyPrefix, StringComparison.OrdinalIgnoreCase))
                 {
+                    string token = secretName.Substring(FunctionKeyPrefix.Length);
+                    if (!IsCanonicalToken(token))
+                    {
+                        Logger?.KeyVaultSecretRepoSkipNonCanonical(secretName);
+                        continue;
+                    }
+
                     hostSecrets.FunctionKeys.Add(KeyVaultSecretToKey(item, FunctionKeyPrefix));
                 }
-                else if (item.Name.StartsWith(SystemKeyPrefix, StringComparison.OrdinalIgnoreCase))
+                else if (secretName.StartsWith(SystemKeyPrefix, StringComparison.OrdinalIgnoreCase))
                 {
+                    string token = secretName.Substring(SystemKeyPrefix.Length);
+                    if (!IsCanonicalToken(token))
+                    {
+                        Logger?.KeyVaultSecretRepoSkipNonCanonical(secretName);
+                        continue;
+                    }
+
                     hostSecrets.SystemKeys.Add(KeyVaultSecretToKey(item, SystemKeyPrefix));
                 }
             }
@@ -248,6 +271,13 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             foreach (Task<Response<KeyVaultSecret>> task in tasks)
             {
                 KeyVaultSecret item = task.Result;
+                string token = item.Name.Substring(prefix.Length);
+                if (!IsCanonicalToken(token))
+                {
+                    Logger?.KeyVaultSecretRepoSkipNonCanonical(item.Name);
+                    continue;
+                }
+
                 functionSecrets.Keys.Add(KeyVaultSecretToKey(item, prefix));
             }
 
@@ -365,6 +395,25 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 }
             }
             return result;
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> when the encoded <paramref name="token"/>
+        /// round-trips through <see cref="Denormalize"/>/<see cref="Normalize"/>,
+        /// meaning it contains only canonical escape sequences.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// // Canonical: Normalize(Denormalize("eventgrid-095extension")) == "eventgrid-095extension"
+        /// IsCanonicalToken("eventgrid-095extension"); // true
+        ///
+        /// // Non-canonical: -069 decodes to 'E' (a letter), which Normalize leaves unescaped
+        /// IsCanonicalToken("-069ventgrid-095extension"); // false
+        /// </code>
+        /// </example>
+        public static bool IsCanonicalToken(string token)
+        {
+            return string.Equals(Normalize(Denormalize(token)), token, StringComparison.Ordinal);
         }
 
         private static Key KeyVaultSecretToKey(KeyVaultSecret item, string prefix)

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/KeyVaultSecretsRepository.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/KeyVaultSecretsRepository.cs
@@ -411,7 +411,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         /// IsCanonicalToken("-069ventgrid-095extension"); // false
         /// </code>
         /// </example>
-        public static bool IsCanonicalToken(string token)
+        internal static bool IsCanonicalToken(string token)
         {
             return string.Equals(Normalize(Denormalize(token)), token, StringComparison.Ordinal);
         }

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
@@ -146,8 +146,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
                         // before caching  any secrets, validate them
                         string masterKeyValue = hostSecrets.MasterKey?.Value;
-                        var functionKeys = hostSecrets.FunctionKeys.ToDictionary(p => p.Name, p => p.Value);
-                        var systemKeys = hostSecrets.SystemKeys.ToDictionary(p => p.Name, p => p.Value);
+                        var functionKeys = hostSecrets.FunctionKeys.ToDictionarySafe(p => p.Name, p => p.Value, StringComparer.OrdinalIgnoreCase, _logger);
+                        var systemKeys = hostSecrets.SystemKeys.ToDictionarySafe(p => p.Name, p => p.Value, StringComparer.OrdinalIgnoreCase, _logger);
                         ValidateHostSecrets(masterKeyValue, functionKeys, systemKeys);
 
                         _hostSecrets = new HostSecretsInfo
@@ -239,7 +239,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                         }
 
                         // before caching any secrets, validate them
-                        var result = secrets.Keys.ToDictionary(s => s.Name, s => s.Value);
+                        var result = secrets.Keys.ToDictionarySafe(s => s.Name, s => s.Value, StringComparer.OrdinalIgnoreCase, _logger);
                         ValidateSecrets(result, SecretGenerator.FunctionKeySeed, functionName);
 
                         functionSecrets = _functionSecrets.AddOrUpdate(functionName, result, (n, r) => result);
@@ -257,7 +257,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 // prioritizing function specific keys
                 var hostSecrets = await GetHostSecretsAsync();
                 functionSecrets = functionSecrets.Union(hostSecrets.FunctionKeys.Where(s => !functionSecrets.ContainsKey(s.Key)))
-                    .ToDictionary(kv => kv.Key, kv => kv.Value);
+                    .ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.OrdinalIgnoreCase);
             }
 
             return functionSecrets;

--- a/test/WebJobs.Script.Tests/Security/KeyVaultSecretsRepositoryTests.cs
+++ b/test/WebJobs.Script.Tests/Security/KeyVaultSecretsRepositoryTests.cs
@@ -227,6 +227,96 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             return mockClient;
         }
 
+        [Theory]
+        [InlineData("eventgrid-095extension", true)] // canonical: underscore encoded as -095
+        [InlineData("simplekey", true)] // no escapes at all
+        [InlineData("key-045name", true)] // canonical: hyphen encoded as -045
+        [InlineData("-069ventgrid-095extension", false)] // non-canonical: -069 is 'E' (letter, should not be escaped)
+        [InlineData("-048key", false)] // non-canonical: -048 is '0' (digit, should not be escaped)
+        [InlineData("-097bc", false)] // non-canonical: -097 is 'a' (letter, should not be escaped)
+        public void IsCanonicalToken_ValidatesRoundTrip(string token, bool expected)
+        {
+            Assert.Equal(expected, KeyVaultSecretsRepository.IsCanonicalToken(token));
+        }
+
+        [Fact]
+        public async Task ReadHostKeys_SkipsNonCanonicalSystemKey()
+        {
+            // Arrange: one canonical and one non-canonical system key
+            var keyVaultSecrets = new List<KeyVaultSecret>
+            {
+                SecretModelFactory.KeyVaultSecret(new SecretProperties("host--masterKey--master"), "masterVal"),
+                SecretModelFactory.KeyVaultSecret(new SecretProperties("host--systemKey--eventgrid-095extension"), "canonicalVal"),
+                SecretModelFactory.KeyVaultSecret(new SecretProperties("host--systemKey---069ventgrid-095extension"), "forgedVal"),
+                SecretModelFactory.KeyVaultSecret(new SecretProperties("host--functionKey--default"), "funcVal"),
+            };
+
+            using var secretSentinelDirectory = new TempDirectory();
+            Mock<SecretClient> mockClient = ConfigureSecretClientMock(keyVaultSecrets);
+            var loggerFactory = MockNullLoggerFactory.CreateLoggerFactory();
+            var repository = new KeyVaultSecretsRepository(mockClient.Object, secretSentinelDirectory.Path, loggerFactory.CreateLogger<KeyVaultSecretsRepository>(), new TestEnvironment());
+
+            // Act
+            var secrets = await repository.ReadAsync(ScriptSecretsType.Host, string.Empty);
+            var hostSecrets = secrets as HostSecrets;
+
+            // Assert: canonical system key is present
+            Assert.Single(hostSecrets.SystemKeys);
+            Assert.Equal("eventgrid_extension", hostSecrets.SystemKeys[0].Name);
+            Assert.Equal("canonicalVal", hostSecrets.SystemKeys[0].Value);
+
+            // Assert: forged non-canonical key was skipped
+            Assert.DoesNotContain(hostSecrets.SystemKeys, k => string.Equals(k.Name, "Eventgrid_extension", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public async Task ReadHostKeys_SkipsNonCanonicalFunctionKey()
+        {
+            var keyVaultSecrets = new List<KeyVaultSecret>
+            {
+                SecretModelFactory.KeyVaultSecret(new SecretProperties("host--masterKey--master"), "masterVal"),
+                SecretModelFactory.KeyVaultSecret(new SecretProperties("host--functionKey--default"), "funcVal"),
+                SecretModelFactory.KeyVaultSecret(new SecretProperties("host--functionKey---068efault"), "forgedFuncVal"),
+            };
+
+            using var secretSentinelDirectory = new TempDirectory();
+            Mock<SecretClient> mockClient = ConfigureSecretClientMock(keyVaultSecrets);
+            var loggerFactory = MockNullLoggerFactory.CreateLoggerFactory();
+            var repository = new KeyVaultSecretsRepository(mockClient.Object, secretSentinelDirectory.Path, loggerFactory.CreateLogger<KeyVaultSecretsRepository>(), new TestEnvironment());
+
+            var secrets = await repository.ReadAsync(ScriptSecretsType.Host, string.Empty);
+            var hostSecrets = secrets as HostSecrets;
+
+            Assert.Single(hostSecrets.FunctionKeys);
+            Assert.Equal("default", hostSecrets.FunctionKeys[0].Name);
+            Assert.Equal("funcVal", hostSecrets.FunctionKeys[0].Value);
+        }
+
+        [Fact]
+        public async Task ReadFunctionKeys_SkipsNonCanonicalKey()
+        {
+            string functionName = "Function1";
+            string prefix = $"function--{functionName}--";
+
+            var keyVaultSecrets = new List<KeyVaultSecret>
+            {
+                SecretModelFactory.KeyVaultSecret(new SecretProperties($"{prefix}mykey"), "goodVal"),
+                SecretModelFactory.KeyVaultSecret(new SecretProperties($"{prefix}-077ykey"), "forgedVal"),
+            };
+
+            using var secretSentinelDirectory = new TempDirectory();
+            Mock<SecretClient> mockClient = ConfigureSecretClientMock(keyVaultSecrets);
+            var loggerFactory = MockNullLoggerFactory.CreateLoggerFactory();
+            var repository = new KeyVaultSecretsRepository(mockClient.Object, secretSentinelDirectory.Path, loggerFactory.CreateLogger<KeyVaultSecretsRepository>(), new TestEnvironment());
+
+            var secrets = await repository.ReadAsync(ScriptSecretsType.Function, functionName);
+            var functionSecrets = secrets as FunctionSecrets;
+
+            Assert.Single(functionSecrets.Keys);
+            Assert.Equal("mykey", functionSecrets.Keys[0].Name);
+            Assert.Equal("goodVal", functionSecrets.Keys[0].Value);
+        }
+
         public class FindSecretsDataProvider
         {
             public static IEnumerable<object[]> TestCases


### PR DESCRIPTION
This change adds stricter validation when loading secrets from Key Vault and improves consistency of internal secret caching.

### Changes
- Added round-trip validation for encoded secret name tokens during read operations
- Secret cache dictionaries now use case-insensitive key comparison, aligning with the behavior used elsewhere in the secrets pipeline
- Added `ToDictionarySafe` extension to gracefully handle unexpected key collisions
- Added unit tests for the new validation logic