### PR TITLE
ci: migrate pipelines to Windows 2025 image

### DIFF
--- a/eng/ci/integration-tests.yml
+++ b/eng/ci/integration-tests.yml
@@ -30,7 +30,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
 
     sdl:

--- a/eng/ci/official-build.yml
+++ b/eng/ci/official-build.yml
@@ -40,7 +40,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:

--- a/eng/ci/public-build.yml
+++ b/eng/ci/public-build.yml
@@ -50,7 +50,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc-public
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
       ${{ if eq( variables['Build.Reason'], 'Schedule' ) }}:
         demands:

--- a/eng/ci/templates/official/jobs/build-artifacts-windows.yml
+++ b/eng/ci/templates/official/jobs/build-artifacts-windows.yml
@@ -4,7 +4,7 @@ jobs:
 
   pool:
     name: 1es-pool-azfunc
-    image: 1es-windows-2022 
+    image: 1es-windows-2025-min
     os: windows
 
   variables:

--- a/eng/ci/templates/official/jobs/run-integration-tests.yml
+++ b/eng/ci/templates/official/jobs/run-integration-tests.yml
@@ -4,7 +4,7 @@ jobs:
 
   pool:
     name: 1es-pool-azfunc
-    image: 1es-windows-2022
+    image: 1es-windows-2025-min
     os: windows
 
   variables:

--- a/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
+++ b/eng/ci/templates/official/jobs/run-non-e2e-tests.yml
@@ -4,7 +4,7 @@ jobs:
 
   pool:
     name: 1es-pool-azfunc
-    image: 1es-windows-2022
+    image: 1es-windows-2025-min
     os: windows
 
   variables:

--- a/eng/ci/webjobs-script-abstractions-release.yml
+++ b/eng/ci/webjobs-script-abstractions-release.yml
@@ -30,7 +30,7 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-windows-2022
+      image: 1es-windows-2025-min
       os: windows
 
     stages:


### PR DESCRIPTION
## Summary

- migrate pipelines using `1es-windows-2022` to `1es-windows-2025-min`
- leave specialized Windows 2022 benchmark images unchanged