### PR TITLE
fixing flaky filewatcher test

### DIFF
--- a/test/WebJobs.Script.Tests/FileMonitoringServiceTests.cs
+++ b/test/WebJobs.Script.Tests/FileMonitoringServiceTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 string tempDir = directory.Path;
                 Directory.CreateDirectory(Path.Combine(tempDir, "Host"));
 
-                var fileMonitoringService = GetFileMonitoringService(tempDir, rootScriptPath);
+                using var fileMonitoringService = GetFileMonitoringService(tempDir, rootScriptPath);
                 Assert.False(fileMonitoringService.GetDirectorySnapshot().IsDefault);
                 Assert.True(fileMonitoringService.GetDirectorySnapshot().IsEmpty);
             }
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             {
                 string tempDir = directory.Path;
                 Directory.CreateDirectory(Path.Combine(tempDir, "Host"));
-                var fileMonitoringService = GetFileMonitoringService(tempDir, tempDir);
+                using var fileMonitoringService = GetFileMonitoringService(tempDir, tempDir);
                 Assert.Equal(fileMonitoringService.GetDirectorySnapshot().Length, 1);
                 Assert.Equal(fileMonitoringService.GetDirectorySnapshot()[0], Path.Combine(tempDir, "Host"));
             }
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 var environment = new TestEnvironment();
 
                 // Act
-                FileMonitoringService fileMonitoringService = new FileMonitoringService(new OptionsWrapper<ScriptJobHostOptions>(jobHostOptions),
+                using FileMonitoringService fileMonitoringService = new FileMonitoringService(new OptionsWrapper<ScriptJobHostOptions>(jobHostOptions),
                     loggerFactory, mockEventManager, mockApplicationLifetime.Object, mockScriptHostManager.Object, environment);
                 await fileMonitoringService.StartAsync(new CancellationToken(canceled: false));
 
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 var environment = new TestEnvironment();
 
                 // Act
-                FileMonitoringService fileMonitoringService = new FileMonitoringService(new OptionsWrapper<ScriptJobHostOptions>(jobHostOptions),
+                using FileMonitoringService fileMonitoringService = new FileMonitoringService(new OptionsWrapper<ScriptJobHostOptions>(jobHostOptions),
                     loggerFactory, mockEventManager, mockApplicationLifetime.Object, mockScriptHostManager.Object, environment);
                 await fileMonitoringService.StartAsync(new CancellationToken(canceled: false));
 
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 var environment = new TestEnvironment();
 
                 // Act
-                FileMonitoringService fileMonitoringService = new FileMonitoringService(new OptionsWrapper<ScriptJobHostOptions>(jobHostOptions),
+                using FileMonitoringService fileMonitoringService = new FileMonitoringService(new OptionsWrapper<ScriptJobHostOptions>(jobHostOptions),
                     loggerFactory, mockEventManager, mockApplicationLifetime.Object, mockScriptHostManager.Object, environment);
                 await fileMonitoringService.StartAsync(new CancellationToken(canceled: false));
 
@@ -243,7 +243,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 var environment = new TestEnvironment();
 
                 // Act
-                FileMonitoringService fileMonitoringService = new FileMonitoringService(new OptionsWrapper<ScriptJobHostOptions>(jobHostOptions),
+                using FileMonitoringService fileMonitoringService = new FileMonitoringService(new OptionsWrapper<ScriptJobHostOptions>(jobHostOptions),
                     loggerFactory, mockEventManager, mockApplicationLifetime.Object, mockScriptHostManager.Object, environment);
                 await fileMonitoringService.StartAsync(new CancellationToken(canceled: false));
 
@@ -325,7 +325,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 var environment = new TestEnvironment();
 
                 // Act
-                FileMonitoringService fileMonitoringService = new FileMonitoringService(new OptionsWrapper<ScriptJobHostOptions>(jobHostOptions),
+                using FileMonitoringService fileMonitoringService = new FileMonitoringService(new OptionsWrapper<ScriptJobHostOptions>(jobHostOptions),
                     loggerFactory, mockEventManager, mockApplicationLifetime.Object, mockScriptHostManager.Object, environment);
                 await fileMonitoringService.StartAsync(new CancellationToken(canceled: false));
 

--- a/test/WebJobs.Script.Tests/FileMonitoringServiceTests.cs
+++ b/test/WebJobs.Script.Tests/FileMonitoringServiceTests.cs
@@ -367,6 +367,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         public static async Task OnFileChanged_DirectoryDeleted_DoesNotThrow_AndTriggersRestart()
         {
             using (var directory = new TempDirectory())
+            using (var logDirectory = new TempDirectory())
             {
                 // The root script path is intentionally left empty. Deleting an empty watched
                 // directory does not raise child change notifications from the real file watcher,
@@ -377,7 +378,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
                 var jobHostOptions = new ScriptJobHostOptions
                 {
-                    RootLogPath = tempDir,
+                    RootLogPath = logDirectory.Path,
                     RootScriptPath = tempDir,
                     FileWatchingEnabled = true
                 };
@@ -396,7 +397,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 var mockEventManager = new ScriptEventManager();
                 var environment = new TestEnvironment();
 
-                FileMonitoringService fileMonitoringService = new FileMonitoringService(new OptionsWrapper<ScriptJobHostOptions>(jobHostOptions),
+                using FileMonitoringService fileMonitoringService = new FileMonitoringService(new OptionsWrapper<ScriptJobHostOptions>(jobHostOptions),
                     loggerFactory, mockEventManager, mockApplicationLifetime.Object, mockScriptHostManager.Object, environment);
                 await fileMonitoringService.StartAsync(new CancellationToken(canceled: false));
 


### PR DESCRIPTION
Another flaky test. This one had a race where a log directory may be created under the root directory. If it was, the deletion of that folder would trigger a filechanged event that was not expected.

The fix is to actually put the logs elsewhere, as is expected.

Also cleans up the FileMonitoringService class itself, which wasn't being disposed previously (but didn't seem to have problems, just doing it opportunistically).

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)