### PR TITLE
perf(health): use cheaper storage connectivity API

### DIFF
--- a/src/WebJobs.Script/Diagnostics/HealthChecks/WebJobsStorageHealthCheck.cs
+++ b/src/WebJobs.Script/Diagnostics/HealthChecks/WebJobsStorageHealthCheck.cs
@@ -104,17 +104,12 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
             try
             {
                 // Right now we only check if we can access blobs. The functions host doesn't use queues or tables directly (although extensions may).
-                // We use this API to check connectivity to Blob storage. We don't check permissions/role assignments in depth for a couple reasons:
+                // We don't check permissions/role assignments in depth for a couple reasons:
                 // 1. It is expensive
                 // 2. Permissions/role assignments needed by the host can change over time.
                 // So we settle for just connectivity here. Insufficient permissions will show up as errors elsewhere.
                 // See https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-app?tabs=dotnet#configure-permissions-for-access-to-blob-and-queue-data
-                await client
-                    .GetBlobContainersAsync(cancellationToken: cancellation)
-                    .AsPages(pageSizeHint: 1)
-                    .GetAsyncEnumerator(cancellation)
-                    .MoveNextAsync()
-                    .ConfigureAwait(false);
+                await client.GetPropertiesAsync(cancellationToken: cancellation).ConfigureAwait(false);
 
                 return HealthCheckResult.Healthy();
             }

--- a/test/WebJobs.Script.Tests/Diagnostics/HealthChecks/WebJobsStorageHealthCheckTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/HealthChecks/WebJobsStorageHealthCheckTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
             HealthCheckResult result = await healthCheck.CheckHealthAsync(_healthCheckContext, default);
 
             // Assert
-            VerifyGetContainersCalled(Times.Never());
+            VerifyGetPropertiesCalled(Times.Never());
             result.Status.Should().Be(HealthStatus.Healthy);
             result.Description.Should().Be("No active script host. Check skipped.");
             result.Exception.Should().BeNull();
@@ -105,9 +105,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
         public async Task CheckHealthAsync_ChecksBlobConnectivity()
         {
             // Arrange
-            Page<BlobContainerItem> page = Page<BlobContainerItem>.FromValues([], null, Mock.Of<Response>());
-            AsyncPageable<BlobContainerItem> pageable = AsyncPageable<BlobContainerItem>.FromPages([page]);
-            SetupGetContainers(pageable);
+            SetupGetProperties();
             BlobServiceClient client = _mockBlobServiceClient.Object;
             _provider.Setup(p => p.TryCreateBlobServiceClientFromConnection(
                 ConnectionStringNames.Storage, out client)).Returns(true);
@@ -118,7 +116,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
             HealthCheckResult result = await healthCheck.CheckHealthAsync(_healthCheckContext, default);
 
             // Assert
-            VerifyGetContainersCalled(Times.Once());
+            VerifyGetPropertiesCalled(Times.Once());
             result.Status.Should().Be(HealthStatus.Healthy);
             result.Exception.Should().BeNull();
         }
@@ -127,9 +125,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
         public async Task CheckHealthAsync_Twice_ReturnsCachedResult()
         {
             // Arrange
-            Page<BlobContainerItem> page = Page<BlobContainerItem>.FromValues([], null, Mock.Of<Response>());
-            AsyncPageable<BlobContainerItem> pageable = AsyncPageable<BlobContainerItem>.FromPages([page]);
-            SetupGetContainers(pageable);
+            SetupGetProperties();
             BlobServiceClient client = _mockBlobServiceClient.Object;
             _provider.Setup(p => p.TryCreateBlobServiceClientFromConnection(
                 ConnectionStringNames.Storage, out client)).Returns(true);
@@ -148,7 +144,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
             HealthCheckResult result2 = await healthCheck.CheckHealthAsync(context, default);
 
             // Assert
-            VerifyGetContainersCalled(Times.Once());
+            VerifyGetPropertiesCalled(Times.Once());
             result1.Status.Should().Be(HealthStatus.Healthy);
             result1.Exception.Should().BeNull();
             result2.Status.Should().Be(HealthStatus.Healthy);
@@ -182,7 +178,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
             // Arrange
             RequestFailedException rfe = new(
                 401, "Some exception message", "SomeErrorCode", null);
-            SetupGetContainers(rfe);
+            SetupGetProperties(rfe);
             BlobServiceClient client = _mockBlobServiceClient.Object;
             _provider.Setup(p => p.TryCreateBlobServiceClientFromConnection(
                 ConnectionStringNames.Storage, out client)).Returns(true);
@@ -193,7 +189,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
             HealthCheckResult result = await healthCheck.CheckHealthAsync(_healthCheckContext, default);
 
             // Assert
-            VerifyGetContainersCalled(Times.Once());
+            VerifyGetPropertiesCalled(Times.Once());
             result.Status.Should().Be(HealthStatus.Unhealthy);
             result.Exception.Should().Be(rfe);
             result.Description.Should().Be("Unable to access AzureWebJobsStorage");
@@ -203,24 +199,21 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
             result.Data.Should().Contain("ErrorCode", "SomeErrorCode");
         }
 
-        private void SetupGetContainers(AsyncPageable<BlobContainerItem> pageable)
+        private void SetupGetProperties()
         {
-            _mockBlobServiceClient.Setup(c => c.GetBlobContainersAsync(
-                BlobContainerTraits.None, BlobContainerStates.None, null, It.IsAny<CancellationToken>()))
-                .Returns(pageable);
+            _mockBlobServiceClient.Setup(c => c.GetPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Response<BlobServiceProperties>)null);
         }
 
-        private void SetupGetContainers(RequestFailedException ex)
+        private void SetupGetProperties(RequestFailedException ex)
         {
-            _mockBlobServiceClient.Setup(c => c.GetBlobContainersAsync(
-                BlobContainerTraits.None, BlobContainerStates.None, null, It.IsAny<CancellationToken>()))
-                .Throws(ex);
+            _mockBlobServiceClient.Setup(c => c.GetPropertiesAsync(It.IsAny<CancellationToken>()))
+                .ThrowsAsync(ex);
         }
 
-        private void VerifyGetContainersCalled(Times times)
+        private void VerifyGetPropertiesCalled(Times times)
         {
-            _mockBlobServiceClient.Verify(c => c.GetBlobContainersAsync(
-                BlobContainerTraits.None, BlobContainerStates.None, null, It.IsAny<CancellationToken>()), times);
+            _mockBlobServiceClient.Verify(c => c.GetPropertiesAsync(It.IsAny<CancellationToken>()), times);
         }
     }
 }


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

resolves #11765

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

The WebJobs storage health check now uses the cheaper blob service properties read instead of listing containers for its periodic connectivity probe.

Validated with:

`dotnet test test\WebJobs.Script.Tests\WebJobs.Script.Tests.csproj --filter "FullyQualifiedName~Diagnostics.HealthChecks.WebJobsStorageHealthCheckTests|FullyQualifiedName~Diagnostics.HealthChecks.HealthCheckExtensionsTests" --logger "console;verbosity=minimal"`