### PR TITLE
Update PS workers to latest

### DIFF
--- a/eng/build/Workers.Powershell.props
+++ b/eng/build/Workers.Powershell.props
@@ -3,8 +3,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.0" VersionOverride="4.0.3148" />
     <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.2" VersionOverride="4.0.4025" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" VersionOverride="4.0.5303" />
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.6" VersionOverride="4.0.5302" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" VersionOverride="4.0.5361" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.6" VersionOverride="4.0.5362" />
   </ItemGroup>
 
   <Target Name="RemovePowershellWorkerRuntimes" BeforeTargets="AssignTargetPaths" Condition="'$(RuntimeIdentifier)' != ''">

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,7 +4,7 @@
 - My change description (#PR)
 -->
 
-- Update PS 7.4 worker to [v4.0.5303](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5303) (#11905)
-- Update PS 7.6 worker to [v4.0.5302](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5302) (#11905)
+- Update PS 7.4 worker to [v4.0.5361](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5361)
+- Update PS 7.6 worker to [v4.0.5362](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5362)
 - Ensure the gRPC server is available when an app transitions online after starting with app_offline.htm.
 - Extract host-managed worker and Grpc Server behavior into Azure.Functions.Rpc.Server.csproj (#11916)

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,7 +4,7 @@
 - My change description (#PR)
 -->
 
-- Update PS 7.4 worker to [v4.0.5361](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5361)
-- Update PS 7.6 worker to [v4.0.5362](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5362)
+- Update PS 7.4 worker to [v4.0.5361](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5361) (#11931)
+- Update PS 7.6 worker to [v4.0.5362](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5362) (#11931)
 - Ensure the gRPC server is available when an app transitions online after starting with app_offline.htm.
 - Extract host-managed worker and Grpc Server behavior into Azure.Functions.Rpc.Server.csproj (#11916)


### PR DESCRIPTION
Updates PS workers to latest versions:
7.4 -> [4.0.5361](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5361)
7.6 -> [4.0.5362](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5362)
### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)