### PR TITLE
Update powershell 7.4 worker to 4.0.5361 (inproc)

### DIFF
--- a/eng/build/Workers.Powershell.props
+++ b/eng/build/Workers.Powershell.props
@@ -7,7 +7,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" Version="4.0.4581" />
+    <PackageReference Include="Microsoft.Azure.Functions.PowerShellWorker.PS7.4" Version="4.0.5361" />
   </ItemGroup>
 
   <Target Name="RemovePowershellWorkerRuntimes" BeforeTargets="AssignTargetPaths" Condition="$(RuntimeIdentifier.StartsWith(win))">

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,4 +3,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
-- Update PowerShell 7.4 worker to [4.0.5361](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5361)
+- Update PowerShell 7.4 worker to [4.0.5361](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5361) (#11932)

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Update PowerShell 7.4 worker to [4.0.5361](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5361)


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Updates the PowerShell 7.4 worker to [4.0.5361](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5361).

This is the `in-proc` companion to #11931. PowerShell 7.6 is intentionally not added to `in-proc`.

### Pull request checklist

* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)