### PR TITLE
Fix authorization cache key collisions

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -8,3 +8,4 @@
 - Update PS 7.6 worker to [v4.0.5302](https://github.com/Azure/azure-functions-powershell-worker/releases/tag/v4.0.5302) (#11905)
 - Ensure the gRPC server is available when an app transitions online after starting with app_offline.htm.
 - Extract host-managed worker and Grpc Server behavior into Azure.Functions.Rpc.Server.csproj (#11916)
+- Use a structured composite key for the authorization cache to prevent cache key collisions.

--- a/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
+++ b/src/WebJobs.Script.WebHost/Security/KeyManagement/SecretManager.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         private readonly Lazy<bool> _strictHISWarnFeatureEnabled = new Lazy<bool>(() => FeatureFlags.IsEnabled(ScriptConstants.FeatureFlagStrictHISModeWarn));
         private readonly HashSet<string> _invalidNonHISKeys = new HashSet<string>();
         private ConcurrentDictionary<string, IDictionary<string, string>> _functionSecrets;
-        private ConcurrentDictionary<string, (string, AuthorizationLevel)> _authorizationCache = new ConcurrentDictionary<string, (string, AuthorizationLevel)>(StringComparer.OrdinalIgnoreCase);
+        private ConcurrentDictionary<AuthorizationCacheKey, (string, AuthorizationLevel)> _authorizationCache = new ConcurrentDictionary<AuthorizationCacheKey, (string, AuthorizationLevel)>();
         private HostSecretsInfo _hostSecrets;
         private SemaphoreSlim _hostSecretsLock = new SemaphoreSlim(1, 1);
         private ConcurrentDictionary<string, SemaphoreSlim> _functionSecretsLocks = new ConcurrentDictionary<string, SemaphoreSlim>(StringComparer.OrdinalIgnoreCase);
@@ -513,7 +513,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
             if (keyValue != null)
             {
-                string cacheKey = $"{keyValue}{functionName}";
+                var cacheKey = new AuthorizationCacheKey(keyValue, functionName);
                 if (_authorizationCache.TryGetValue(cacheKey, out (string, AuthorizationLevel) value))
                 {
                     // we've already authorized this key value so return the cached result
@@ -932,6 +932,22 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             // We're only serializing access to secrets per-function, not across all functions,
             // so we need to ensure we're using a single shared lock per-function.
             return _functionSecretsLocks.GetOrAdd(functionName, static k => new SemaphoreSlim(1, 1));
+        }
+
+        private readonly record struct AuthorizationCacheKey(string KeyValue, string FunctionName)
+        {
+            public bool Equals(AuthorizationCacheKey other)
+            {
+                return string.Equals(KeyValue, other.KeyValue, StringComparison.Ordinal)
+                    && string.Equals(FunctionName, other.FunctionName, StringComparison.OrdinalIgnoreCase);
+            }
+
+            public override int GetHashCode()
+            {
+                return HashCode.Combine(
+                    KeyValue is null ? 0 : StringComparer.Ordinal.GetHashCode(KeyValue),
+                    FunctionName is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(FunctionName));
+            }
         }
     }
 }

--- a/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
+++ b/test/WebJobs.Script.Tests/Security/SecretManagerTests.cs
@@ -538,24 +538,93 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
             }
         }
 
-        private FunctionAppSecrets WriteStartContextCache(string path)
+        [Fact]
+        public async Task GetAuthorizationLevelOrNullAsync_DoesNotReuseCachedAuthorizationForCollidingInputs()
         {
-            var secrets = new FunctionAppSecrets();
-            secrets.Host = new FunctionAppSecrets.HostSecrets
+            using var directory = new TempDirectory();
+
+            string startupContextPath = Path.Combine(directory.Path, Guid.NewGuid().ToString());
+            _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteStartupContextCache, startupContextPath);
+            _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestHelpers.EncryptionKey);
+
+            WriteStartContextCache(
+                startupContextPath,
+                new FunctionAppSecrets.FunctionSecrets
+                {
+                    Name = "functiondata",
+                    Secrets = new Dictionary<string, string>
+                    {
+                            { "test-source-key", "sourcekeyvalue" }
+                    }
+                },
+                new FunctionAppSecrets.FunctionSecrets
+                {
+                    Name = "data",
+                    Secrets = new Dictionary<string, string>
+                    {
+                            { "test-target-key", "targetkeyvalue" }
+                    }
+                });
+
+            using var secretManager = CreateSecretManager(directory.Path);
+
+            var (keyName, level) = await secretManager.GetAuthorizationLevelOrNullAsync("sourcekeyvalue", "functiondata");
+
+            Assert.Equal(AuthorizationLevel.Function, level);
+            Assert.Equal("test-source-key", keyName);
+
+            var result = await secretManager.GetAuthorizationLevelOrNullAsync("sourcekeyvaluefunction", "data");
+
+            Assert.Equal(AuthorizationLevel.Anonymous, result.Level);
+            Assert.Null(result.KeyName);
+        }
+
+        [Fact]
+        public async Task GetAuthorizationLevelOrNullAsync_DoesNotReuseCachedAuthorizationForKeyValueWithDifferentCasing()
+        {
+            using var directory = new TempDirectory();
+
+            string startupContextPath = Path.Combine(directory.Path, Guid.NewGuid().ToString());
+            _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteStartupContextCache, startupContextPath);
+            _testEnvironment.SetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey, TestHelpers.EncryptionKey);
+
+            WriteStartContextCache(startupContextPath);
+
+            using var secretManager = CreateSecretManager(directory.Path);
+            var (keyName, level) = await secretManager.GetAuthorizationLevelOrNullAsync("function1value1", "function1");
+
+            Assert.Equal(AuthorizationLevel.Function, level);
+            Assert.Equal("test-function1-1", keyName);
+
+            var result = await secretManager.GetAuthorizationLevelOrNullAsync("FUNCTION1VALUE1", "function1");
+
+            Assert.Equal(AuthorizationLevel.Anonymous, result.Level);
+            Assert.Null(result.KeyName);
+        }
+
+        private FunctionAppSecrets WriteStartContextCache(string path, params FunctionAppSecrets.FunctionSecrets[] additionalFunctionSecrets)
+        {
+            var secrets = new FunctionAppSecrets
             {
-                Master = "test-master-key"
+                Host = new FunctionAppSecrets.HostSecrets
+                {
+                    Master = "test-master-key"
+                }
             };
+
             secrets.Host.Function = new Dictionary<string, string>
             {
                 { "test-host-function-1", "hostfunction1value" },
                 { "test-host-function-2", "hostfunction2value" }
             };
+
             secrets.Host.System = new Dictionary<string, string>
             {
                 { "test-system-1", "system1value" },
                 { "test-system-2", "system2value" }
             };
-            secrets.Function = new FunctionAppSecrets.FunctionSecrets[]
+
+            var functionSecrets = new List<FunctionAppSecrets.FunctionSecrets>
             {
                 new FunctionAppSecrets.FunctionSecrets
                 {
@@ -576,6 +645,9 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Security
                     }
                 }
             };
+
+            functionSecrets.AddRange(additionalFunctionSecrets);
+            secrets.Function = [.. functionSecrets];
 
             var context = new JObject
             {


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

Replace the authorization cache's concatenated string key with a structured composite key.

**Changes:** 
- Introduce `AuthorizationCacheKey` for authorization cache entries. 
- Align cache key comparison behavior with existing authorization logic. 
- Add regression tests covering cache key collision and casing scenarios.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [ ] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [ ] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

Additional PR information
