### PR TITLE
[Draft] Add /admin/health/connectivity endpoint + connectivity health check (Network Troubleshooter prototype)

### DIFF
--- a/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebJobsApplicationBuilderExtension.cs
@@ -170,6 +170,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                     Predicate = r => r.Tags.Contains(HealthCheckTags.Readiness),
                     ResponseWriter = HealthCheckResponseWriter.WriteResponseAsync,
                 });
+
+                app.UseHealthChecks($"{healthPrefix}/connectivity", new HealthCheckOptions
+                {
+                    Predicate = r => r.Tags.Contains(HealthCheckTags.Connectivity),
+                    ResponseWriter = HealthCheckResponseWriter.WriteResponseAsync,
+                });
             });
         }
     }

--- a/src/WebJobs.Script/Diagnostics/HealthChecks/ConnectivityHealthCheck.cs
+++ b/src/WebJobs.Script/Diagnostics/HealthChecks/ConnectivityHealthCheck.cs
@@ -1,0 +1,81 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
+{
+    /// <summary>
+    /// DRAFT host adapter (Flex Consumption Network Troubleshooter) that surfaces extension-provided
+    /// <see cref="IConnectivityValidator"/> implementations as a single connectivity health check.
+    /// It enumerates the app's triggers, matches each to a registered validator by trigger type,
+    /// invokes it with the binding's connection + settings, and aggregates the results.
+    /// </summary>
+    /// <remarks>
+    /// This keeps the <c>Microsoft.Extensions.Diagnostics.HealthChecks</c> dependency in the host (here)
+    /// and out of every extension: extensions register a plain <see cref="IConnectivityValidator"/>,
+    /// and this one adapter turns them into a <c>connectivity</c>-tagged <see cref="IHealthCheck"/>.
+    /// </remarks>
+    internal sealed class ConnectivityHealthCheck : IHealthCheck
+    {
+        private readonly IEnumerable<IConnectivityValidator> _validators;
+        private readonly IFunctionMetadataManager _metadataManager;
+
+        public ConnectivityHealthCheck(
+            IEnumerable<IConnectivityValidator> validators,
+            IFunctionMetadataManager metadataManager)
+        {
+            _validators = validators ?? throw new ArgumentNullException(nameof(validators));
+            _metadataManager = metadataManager ?? throw new ArgumentNullException(nameof(metadataManager));
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            Dictionary<string, object> data = new();
+            bool anyUnhealthy = false;
+
+            foreach (FunctionMetadata function in _metadataManager.GetFunctionMetadata())
+            {
+                BindingMetadata trigger = function.Trigger;
+                if (trigger is null || string.IsNullOrEmpty(trigger.Connection))
+                {
+                    // Not a remote trigger (e.g. HTTP/timer) or nothing to probe.
+                    continue;
+                }
+
+                IConnectivityValidator validator = _validators.FirstOrDefault(
+                    v => string.Equals(v.TriggerType, trigger.Type, StringComparison.OrdinalIgnoreCase));
+                if (validator is null)
+                {
+                    // No validator shipped for this trigger's extension (bundle-versioned coverage).
+                    continue;
+                }
+
+                ConnectivityContext probeContext = new(
+                    trigger.Type,
+                    trigger.Connection,
+                    new Dictionary<string, object>(trigger.Properties));
+
+                ConnectivityResult result = await validator
+                    .ValidateAsync(probeContext, cancellationToken)
+                    .ConfigureAwait(false);
+
+                data[function.Name] = result.IsHealthy ? "Healthy" : $"Unhealthy: {result.Details}";
+                anyUnhealthy |= !result.IsHealthy;
+            }
+
+            return anyUnhealthy
+                ? HealthCheckResult.Unhealthy("One or more trigger dependencies are unreachable.", data: data)
+                : HealthCheckResult.Healthy(data: data);
+        }
+    }
+}

--- a/src/WebJobs.Script/Diagnostics/HealthChecks/DnsConnectivityHealthCheck.cs
+++ b/src/WebJobs.Script/Diagnostics/HealthChecks/DnsConnectivityHealthCheck.cs
@@ -1,0 +1,62 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Extensions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
+{
+    /// <summary>
+    /// SDK-free connectivity check that verifies DNS resolution for a configured set of hosts.
+    /// </summary>
+    /// <remarks>
+    /// Prototype for the Network Troubleshooter (DRAFT). Hosts are read from the
+    /// <c>NETWORK_CHECK_DNS_HOSTS</c> setting (comma-separated); the production check will derive
+    /// targets from trigger binding metadata. Registered on the WebHost scope so it runs in
+    /// validation mode as well as on a normal worker.
+    /// </remarks>
+    internal sealed class DnsConnectivityHealthCheck : IHealthCheck
+    {
+        private const string DnsHostsSetting = "NETWORK_CHECK_DNS_HOSTS";
+
+        private readonly IConfiguration _configuration;
+
+        public DnsConnectivityHealthCheck(IConfiguration configuration)
+        {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            string hostsSetting = _configuration[DnsHostsSetting];
+            if (string.IsNullOrWhiteSpace(hostsSetting))
+            {
+                return HealthCheckResult.Healthy("No DNS hosts configured; connectivity check skipped.");
+            }
+
+            foreach (string host in hostsSetting.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                try
+                {
+                    await Dns.GetHostEntryAsync(host, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (!ex.IsFatal())
+                {
+                    HealthCheckData data = new() { Area = HealthCheckData.Areas.Connectivity };
+                    data.SetExceptionDetails(ex);
+                    return HealthCheckResult.Unhealthy($"DNS resolution failed for '{host}'.", ex, data);
+                }
+            }
+
+            return HealthCheckResult.Healthy();
+        }
+    }
+}

--- a/src/WebJobs.Script/Diagnostics/HealthChecks/HealthCheckExtensions.cs
+++ b/src/WebJobs.Script/Diagnostics/HealthChecks/HealthCheckExtensions.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
                 .AddWebHostHealthCheck()
                 .AddScriptHostHealthCheck()
                 .AddWebJobsStorageHealthCheck()
+                .AddDnsConnectivityHealthCheck()
                 .AddTelemetryPublisher(HealthCheckTags.Liveness, HealthCheckTags.Readiness)
                 .UseDynamicHealthCheckService();
             return builder;
@@ -142,6 +143,21 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
             builder.AddCheck<WebJobsStorageHealthCheck>(
                 HealthCheckNames.WebJobsStorage,
                 tags: [HealthCheckTags.Configuration, HealthCheckTags.Connectivity, HealthCheckTags.WebJobsStorage],
+                timeout: TimeSpan.FromSeconds(10));
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds an SDK-free DNS connectivity check (Network Troubleshooter prototype).
+        /// </summary>
+        /// <param name="builder">The builder to register health checks with.</param>
+        /// <returns>The original builder, for call chaining.</returns>
+        public static IHealthChecksBuilder AddDnsConnectivityHealthCheck(this IHealthChecksBuilder builder)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+            builder.AddCheck<DnsConnectivityHealthCheck>(
+                HealthCheckNames.DnsConnectivity,
+                tags: [HealthCheckTags.Connectivity],
                 timeout: TimeSpan.FromSeconds(10));
             return builder;
         }

--- a/src/WebJobs.Script/Diagnostics/HealthChecks/HealthCheckNames.cs
+++ b/src/WebJobs.Script/Diagnostics/HealthChecks/HealthCheckNames.cs
@@ -24,5 +24,10 @@ namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
         /// The 'azure.functions.webjobs.storage' check monitors connectivity to the WebJobs storage account.
         /// </summary>
         public const string WebJobsStorage = Prefix + "webjobs.storage";
+
+        /// <summary>
+        /// The 'azure.functions.connectivity.dns' check verifies DNS resolution for configured hosts (Network Troubleshooter prototype).
+        /// </summary>
+        public const string DnsConnectivity = Prefix + "connectivity.dns";
     }
 }

--- a/src/WebJobs.Script/Diagnostics/HealthChecks/IConnectivityValidator.cs
+++ b/src/WebJobs.Script/Diagnostics/HealthChecks/IConnectivityValidator.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks
+{
+    /// <summary>
+    /// DRAFT abstraction for the Flex Consumption Network Troubleshooter. An extension implements this to
+    /// validate connectivity to its trigger dependency using its own SDK and connection resolution,
+    /// without taking a dependency on <c>Microsoft.Extensions.Diagnostics.HealthChecks</c>. The host
+    /// adapts all registered validators into a single connectivity <see cref="Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck"/>.
+    /// </summary>
+    /// <remarks>
+    /// Final home is <c>Microsoft.Azure.WebJobs</c> (the WebJobs SDK), which both the host and the
+    /// extensions already reference — so extensions add no new package dependency. Defined here in the
+    /// host only to prototype the mechanism end-to-end.
+    /// </remarks>
+    internal interface IConnectivityValidator
+    {
+        /// <summary>Gets the trigger binding type this validator handles, e.g. <c>"eventHubTrigger"</c>.</summary>
+        string TriggerType { get; }
+
+        /// <summary>Performs a non-mutating connectivity + auth probe for a single trigger binding.</summary>
+        Task<ConnectivityResult> ValidateAsync(ConnectivityContext context, CancellationToken cancellationToken);
+    }
+
+    /// <summary>The target of a connectivity probe, supplied by the host from a trigger binding.</summary>
+    internal sealed class ConnectivityContext
+    {
+        public ConnectivityContext(string triggerType, string connection, IReadOnlyDictionary<string, object> properties)
+        {
+            TriggerType = triggerType;
+            Connection = connection;
+            Properties = properties;
+        }
+
+        /// <summary>Gets the trigger binding type, e.g. <c>"eventHubTrigger"</c>.</summary>
+        public string TriggerType { get; }
+
+        /// <summary>Gets the connection setting name from the binding; the extension resolves it.</summary>
+        public string Connection { get; }
+
+        /// <summary>Gets the raw binding settings (e.g. <c>eventHubName</c>, <c>queueName</c>); the extension reads what it needs.</summary>
+        public IReadOnlyDictionary<string, object> Properties { get; }
+    }
+
+    /// <summary>The result of a connectivity probe.</summary>
+    internal sealed class ConnectivityResult
+    {
+        private ConnectivityResult(bool isHealthy, string details)
+        {
+            IsHealthy = isHealthy;
+            Details = details;
+        }
+
+        public bool IsHealthy { get; }
+
+        public string Details { get; }
+
+        public static ConnectivityResult Healthy(string details = null) => new(true, details);
+
+        public static ConnectivityResult Unhealthy(string details) => new(false, details);
+    }
+}

--- a/test/WebJobs.Script.Tests/Diagnostics/HealthChecks/ConnectivityHealthCheckTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/HealthChecks/ConnectivityHealthCheckTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Microsoft.Azure.WebJobs.Script.Description;
+using Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
+{
+    // Demonstrates the extension-owned connectivity abstraction end-to-end (Network Troubleshooter):
+    // an extension registers a plain IConnectivityValidator (no HealthChecks dependency); the host
+    // adapter enumerates the app's triggers, matches the validator by trigger type, and hands it the
+    // binding's connection + settings — turning it into a connectivity health check result.
+    public class ConnectivityHealthCheckTests
+    {
+        [Fact]
+        public async Task CheckHealthAsync_InvokesMatchingValidator_WithBindingConnectionAndSettings()
+        {
+            // Arrange: an app with one Event Hub trigger.
+            BindingMetadata trigger = new()
+            {
+                Name = "events",
+                Type = "eventHubTrigger",
+                Connection = "MyEventHubConnection",
+                Direction = BindingDirection.In,
+            };
+            trigger.Properties["eventHubName"] = "my-hub";
+            FunctionMetadata function = new() { Name = "ProcessEvents" };
+            function.Bindings.Add(trigger);
+
+            Mock<IFunctionMetadataManager> metadataManager = new();
+            metadataManager
+                .Setup(m => m.GetFunctionMetadata(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Returns(ImmutableArray.Create(function));
+
+            RecordingValidator validator = new("eventHubTrigger");
+            ConnectivityHealthCheck check = new(new[] { validator }, metadataManager.Object);
+
+            // Act
+            HealthCheckResult result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            // Assert: the adapter found the Event Hub trigger, matched the validator by trigger type,
+            // and handed it the binding's connection + settings.
+            result.Status.Should().Be(HealthStatus.Healthy);
+            validator.Invoked.Should().BeTrue();
+            validator.LastContext.Connection.Should().Be("MyEventHubConnection");
+            validator.LastContext.Properties["eventHubName"].Should().Be("my-hub");
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_UnhealthyValidator_ReportsUnhealthy()
+        {
+            BindingMetadata trigger = new()
+            {
+                Name = "events",
+                Type = "eventHubTrigger",
+                Connection = "MyEventHubConnection",
+                Direction = BindingDirection.In,
+            };
+            FunctionMetadata function = new() { Name = "ProcessEvents" };
+            function.Bindings.Add(trigger);
+
+            Mock<IFunctionMetadataManager> metadataManager = new();
+            metadataManager
+                .Setup(m => m.GetFunctionMetadata(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Returns(ImmutableArray.Create(function));
+
+            RecordingValidator validator = new("eventHubTrigger")
+            {
+                Result = ConnectivityResult.Unhealthy("Auth failed"),
+            };
+            ConnectivityHealthCheck check = new(new[] { validator }, metadataManager.Object);
+
+            HealthCheckResult result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            result.Status.Should().Be(HealthStatus.Unhealthy);
+        }
+
+        [Fact]
+        public async Task CheckHealthAsync_NoValidatorForTrigger_SkipsAndReportsHealthy()
+        {
+            BindingMetadata trigger = new()
+            {
+                Name = "events",
+                Type = "serviceBusTrigger",
+                Connection = "MyServiceBusConnection",
+                Direction = BindingDirection.In,
+            };
+            FunctionMetadata function = new() { Name = "ProcessMessages" };
+            function.Bindings.Add(trigger);
+
+            Mock<IFunctionMetadataManager> metadataManager = new();
+            metadataManager
+                .Setup(m => m.GetFunctionMetadata(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .Returns(ImmutableArray.Create(function));
+
+            // Only an Event Hubs validator is registered; the Service Bus trigger has no validator yet.
+            RecordingValidator validator = new("eventHubTrigger");
+            ConnectivityHealthCheck check = new(new[] { validator }, metadataManager.Object);
+
+            HealthCheckResult result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            validator.Invoked.Should().BeFalse();
+            result.Status.Should().Be(HealthStatus.Healthy);
+        }
+
+        private sealed class RecordingValidator : IConnectivityValidator
+        {
+            public RecordingValidator(string triggerType) => TriggerType = triggerType;
+
+            public string TriggerType { get; }
+
+            public bool Invoked { get; private set; }
+
+            public ConnectivityContext LastContext { get; private set; }
+
+            public ConnectivityResult Result { get; set; } = ConnectivityResult.Healthy();
+
+            public Task<ConnectivityResult> ValidateAsync(ConnectivityContext context, CancellationToken cancellationToken)
+            {
+                Invoked = true;
+                LastContext = context;
+                return Task.FromResult(Result);
+            }
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Diagnostics/HealthChecks/DynamicHealthCheckServiceTests.cs
+++ b/test/WebJobs.Script.Tests/Diagnostics/HealthChecks/DynamicHealthCheckServiceTests.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using AwesomeAssertions;
 using Microsoft.Azure.WebJobs.Script.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -196,6 +197,60 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Diagnostics.HealthChecks
                 .ReturnsAsync(report);
             _mockServices.Setup(s => s.GetService(typeof(HealthCheckService)))
                 .Returns(mockScriptHostHealthService.Object);
+        }
+
+        // Demonstrates the extension-owned connectivity model (Network Troubleshooter): an extension
+        // registers a connectivity IHealthCheck in the ScriptHost (JobHost) DI scope—exactly as its
+        // IWebJobsStartup.Configure would via services.AddHealthChecks().AddCheck(...)—and the check
+        // flows through the WebHost/ScriptHost merge and the /admin/health/connectivity tag filter,
+        // with no host dependency on the extension's SDK.
+        [Fact]
+        public async Task CheckHealthAsync_ExtensionRegistersConnectivityCheckInScriptHostScope_FlowsThroughConnectivityFilter()
+        {
+            // WebHost scope: a host-owned connectivity check plus a non-connectivity (liveness) check.
+            ServiceCollection webHostServices = new();
+            webHostServices.AddLogging();
+            webHostServices.AddHealthChecks()
+                .AddCheck<FakeHostConnectivityCheck>("host.dns.connectivity", tags: [HealthCheckTags.Connectivity])
+                .AddCheck<FakeLivenessCheck>("host.liveness", tags: [HealthCheckTags.Liveness]);
+            using ServiceProvider webHostProvider = webHostServices.BuildServiceProvider();
+            HealthCheckService webHostHealth = webHostProvider.GetRequiredService<HealthCheckService>();
+
+            // ScriptHost scope: an extension registers its own connectivity check.
+            ServiceCollection scriptHostServices = new();
+            scriptHostServices.AddLogging();
+            scriptHostServices.AddHealthChecks()
+                .AddCheck<FakeExtensionConnectivityCheck>("ext.eventhubs.connectivity", tags: [HealthCheckTags.Connectivity]);
+            using ServiceProvider scriptHostProvider = scriptHostServices.BuildServiceProvider();
+            _mockManager.Setup(m => m.Services).Returns(scriptHostProvider);
+
+            DynamicHealthCheckService service = new(webHostHealth, _mockManager.Object, _logger);
+
+            // Query with the same predicate the /admin/health/connectivity route uses.
+            HealthReport result = await service.CheckHealthAsync(r => r.Tags.Contains(HealthCheckTags.Connectivity));
+
+            // Both connectivity checks flow through the merge; the non-connectivity check is filtered out.
+            result.Entries.Should().ContainKey("host.dns.connectivity");
+            result.Entries.Should().ContainKey("ext.eventhubs.connectivity");
+            result.Entries.Should().NotContainKey("host.liveness");
+        }
+
+        private sealed class FakeHostConnectivityCheck : IHealthCheck
+        {
+            public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+                => Task.FromResult(HealthCheckResult.Healthy());
+        }
+
+        private sealed class FakeExtensionConnectivityCheck : IHealthCheck
+        {
+            public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+                => Task.FromResult(HealthCheckResult.Healthy());
+        }
+
+        private sealed class FakeLivenessCheck : IHealthCheck
+        {
+            public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+                => Task.FromResult(HealthCheckResult.Healthy());
         }
     }
 }


### PR DESCRIPTION
**Draft — for design discussion, not for merge.**

Prototype for the Flex Consumption Network Troubleshooter (host side of "Approach 1").

## What this adds
- A `/admin/health/connectivity` route (tag-filtered on the `connectivity` tag), alongside `/admin/health/live` and `/ready`.
- An SDK-free `DnsConnectivityHealthCheck` (host-owned), registered on the WebHost scope so it runs in validation mode as well as on a normal worker.
- **`IConnectivityValidator` abstraction** (+ `ConnectivityContext`/`ConnectivityResult`): a plain contract an extension implements with its own SDK + connection resolution — no `Microsoft.Extensions.Diagnostics.HealthChecks` dependency on extensions. Final home is `Microsoft.Azure.WebJobs`; prototyped in the host here.
- **`ConnectivityHealthCheck` host adapter**: enumerates the app's triggers (`IFunctionMetadataManager` + `BindingMetadata.Connection`), matches each to a registered validator by trigger type, invokes it with the binding's connection + settings, and aggregates into a `connectivity`-tagged `IHealthCheck`. Keeps HealthChecks host-side, once.
- Tests: an extension-registered check flows through `DynamicHealthCheckService`'s merge + tag filter; and the adapter invokes registered validators with the right binding context.

## Why
Flex Consumption needs per-dependency connectivity checks run from the app's network context. This demonstrates building on the existing health-check framework: host-owned SDK-free checks plus extension-owned provider checks via `IConnectivityValidator`, invoked on a validation-mode worker.

Companion extension probe (Event Hubs): Azure/azure-sdk-for-net#62329.
