### PR TITLE
fix(workers): treat Linux SIGTERM exit as normal

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -3,3 +3,4 @@
 <!-- Please add your release notes in the following format:
 - My change description (#PR)
 -->
+- Fixed Linux language worker SIGTERM exits being reported as worker failures. (#11944)

--- a/src/Functions.Rpc.Server/ProcessManagement/WorkerProcess.cs
+++ b/src/Functions.Rpc.Server/ProcessManagement/WorkerProcess.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
                 ThrowIfExitError();
 
                 exit = Process.ExitCode;
-                if (exit is WorkerConstants.IntentionalRestartExitCode or WorkerConstants.SuccessExitCode)
+                if (IsNormalExitCode(exit))
                 {
                     Process.WaitForExit();
                     Process.Close();
@@ -258,7 +258,7 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
 
         private void ThrowIfExitError()
         {
-            if (Process.ExitCode is WorkerConstants.SuccessExitCode or WorkerConstants.IntentionalRestartExitCode)
+            if (IsNormalExitCode(Process.ExitCode))
             {
                 return;
             }
@@ -274,6 +274,12 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
             };
 
             throw processExitEx;
+        }
+
+        private static bool IsNormalExitCode(int exitCode)
+        {
+            return exitCode is WorkerConstants.SuccessExitCode or WorkerConstants.IntentionalRestartExitCode
+                || (OperatingSystem.IsLinux() && exitCode is WorkerConstants.LinuxSigTermExitCode);
         }
 
         private void OnOutputDataReceived(object sender, DataReceivedEventArgs e)

--- a/src/WebJobs.Script/Workers/WorkerConstants.cs
+++ b/src/WebJobs.Script/Workers/WorkerConstants.cs
@@ -62,6 +62,11 @@ namespace Microsoft.Azure.WebJobs.Script.Workers
         public const int SuccessExitCode = 0;
         public const int IntentionalRestartExitCode = 200;
 
+        /// <summary>
+        /// The Linux exit code for a process terminated by SIGTERM (128 + 15).
+        /// </summary>
+        public const int LinuxSigTermExitCode = 143;
+
         // Http Constants
         public const string HttpBody = "body";
         public const string HttpHeaders = "headers";

--- a/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerProcessTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/RpcWorkerProcessTests.cs
@@ -211,6 +211,37 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
+        public async Task HandleWorkerProcessExit_LinuxSigTermExitCode_HandlesBasedOnOperatingSystem()
+        {
+            using Process process = GetProcess(WorkerConstants.LinuxSigTermExitCode);
+            _hostProcessMonitorMock.Setup(m => m.RegisterChildProcess(process));
+            _hostProcessMonitorMock.Setup(m => m.UnregisterChildProcess(process));
+            _workerProcessFactory.Setup(m => m.CreateWorkerProcess(It.IsNotNull<WorkerContext>())).Returns(process);
+            using var rpcWorkerProcess = GetRpcWorkerConfigProcess(
+                TestHelpers.GetTestWorkerConfigsWithExecutableWorkingDirectory().ElementAt(0));
+
+            await rpcWorkerProcess.StartProcessAsync();
+
+            if (OperatingSystem.IsLinux())
+            {
+                int exitCode = await rpcWorkerProcess.WaitForExitAsync();
+
+                Assert.Equal(WorkerConstants.LinuxSigTermExitCode, exitCode);
+                _eventManager.Verify(_ => _.Publish(It.IsAny<WorkerRestartEvent>()), Times.Once());
+                _eventManager.Verify(_ => _.Publish(It.IsAny<WorkerErrorEvent>()), Times.Never());
+            }
+            else
+            {
+                WorkerProcessExitException exception = await Assert.ThrowsAsync<WorkerProcessExitException>(
+                    () => rpcWorkerProcess.WaitForExitAsync());
+
+                Assert.Equal(WorkerConstants.LinuxSigTermExitCode, exception.ExitCode);
+                _eventManager.Verify(_ => _.Publish(It.IsAny<WorkerRestartEvent>()), Times.Never());
+                _eventManager.Verify(_ => _.Publish(It.IsAny<WorkerErrorEvent>()), Times.Once());
+            }
+        }
+
+        [Fact]
         public void WorkerProcess_Dispose()
         {
             var rpcWorkerProcess = GetRpcWorkerConfigProcess(TestHelpers.GetTestWorkerConfigs().ElementAt(0));


### PR DESCRIPTION
### Issue describing the changes in this PR

resolves #11942, #10479

### Pull request checklist

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [ ] My changes **should not** be added to the release notes for the next release
    * [x] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

### Additional information

Treats exit code 143 (`128 + SIGTERM`) as a normal language-worker exit on Linux and routes it through the existing restart path. Non-Linux platforms continue to surface exit code 143 as a worker error.

Validated with: `dotnet test test\WebJobs.Script.Tests\WebJobs.Script.Tests.csproj --filter FullyQualifiedName~RpcWorkerProcessTests --no-restore --nologo`