### PR TITLE
fixing file monitoring race

### DIFF
--- a/src/WebJobs.Script.WebHost/FileMonitoringService.cs
+++ b/src/WebJobs.Script.WebHost/FileMonitoringService.cs
@@ -336,9 +336,10 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 }
 
                 string fileChangeMsg = string.Format(CultureInfo.InvariantCulture, "{0} change of type '{1}' detected for '{2}'", changeDescription, e.ChangeType.ToString(), e.FullPath);
-                TraceFileChangeRestart(fileChangeMsg, shutdown);
-                ScheduleRestartAsync(fileChangeMsg, shutdown)
-                    .ContinueWith(t => _logger.LogError(t.Exception, $"Error restarting host (full shutdown: {shutdown})"),
+                bool shutdownRequested = shutdown || Interlocked.Read(ref _shutdownScheduled) == 1;
+                TraceFileChangeRestart(fileChangeMsg, shutdownRequested);
+                ScheduleRestartAsync(fileChangeMsg, shutdownRequested)
+                    .ContinueWith(t => _logger.LogError(t.Exception, $"Error restarting host (full shutdown: {shutdownRequested})"),
                         TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted);
             }
         }

--- a/src/WebJobs.Script.WebHost/FileMonitoringService.cs
+++ b/src/WebJobs.Script.WebHost/FileMonitoringService.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         private AutoRecoveringFileSystemWatcher _diagnosticModeFileWatcher;
         private FileWatcherEventSource _fileEventSource;
         private bool _restartScheduled;
-        private bool _shutdownScheduled;
+        private long _shutdownScheduled;
         private long _restartRequested;
         private bool _disposed = false;
         private bool _watchersStopped = false;
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             _restartScheduled = true;
             if (shutdown)
             {
-                _shutdownScheduled = true;
+                Interlocked.Exchange(ref _shutdownScheduled, 1);
             }
 
             await ScheduleRestartAsync(reason);
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
             else
             {
-                if (_shutdownScheduled)
+                if (Interlocked.Read(ref _shutdownScheduled) == 1)
                 {
                     _shutdown();
                 }
@@ -296,9 +296,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 changeDescription = "File";
                 if (File.Exists(e.FullPath))
                 {
+                    // Ensure a previously queued restart cannot win after app_offline.htm is detected.
+                    Interlocked.Exchange(ref _shutdownScheduled, 1);
                     string fileChangeMsg = string.Format(CultureInfo.InvariantCulture, "{0} change of type '{1}' detected for '{2}'", changeDescription, e.ChangeType.ToString(), e.FullPath);
                     TraceFileChangeRestart(fileChangeMsg, isShutdown: true);
                     Shutdown();
+                    return;
                 }
             }
             else if (_scriptOptions.WatchFiles.Any(f => string.Equals(fileName, f, StringComparison.OrdinalIgnoreCase)))
@@ -368,7 +371,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         private Task RestartAsync(string reason)
         {
-            if (!_shutdownScheduled && Interlocked.Exchange(ref _restartRequested, 1) == 0)
+            if (Interlocked.Read(ref _shutdownScheduled) == 0 && Interlocked.Exchange(ref _restartRequested, 1) == 0)
             {
                 return _scriptHostManager.RestartHostAsync(reason);
             }

--- a/src/WebJobs.Script/IO/AutoRecoveringFileSystemWatcher.cs
+++ b/src/WebJobs.Script/IO/AutoRecoveringFileSystemWatcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Script.IO
         private readonly object _syncRoot = new object();
         private CancellationTokenSource _cancellationTokenSource;
         private FileSystemWatcher _fileWatcher;
-        private bool _disposed = false;
+        private int _disposed = 0;
         private int _recovering = 0;
 
         public AutoRecoveringFileSystemWatcher(string path, string filter = "*.*",
@@ -97,7 +97,10 @@ namespace Microsoft.Azure.WebJobs.Script.IO
 
         protected void OnFileChanged(object sender, FileSystemEventArgs e)
         {
-            Changed?.Invoke(this, e);
+            if (Interlocked.CompareExchange(ref _disposed, 0, 0) == 0)
+            {
+                Changed?.Invoke(this, e);
+            }
         }
 
         protected void OnFileWatcherError(ErrorEventArgs args)
@@ -167,7 +170,7 @@ namespace Microsoft.Azure.WebJobs.Script.IO
 
         private void Dispose(bool disposing)
         {
-            if (!_disposed)
+            if (Interlocked.Exchange(ref _disposed, 1) == 0)
             {
                 if (disposing)
                 {
@@ -179,7 +182,6 @@ namespace Microsoft.Azure.WebJobs.Script.IO
 
                 _cancellationTokenSource = null;
                 _fileWatcher = null;
-                _disposed = true;
             }
         }
 

--- a/test/WebJobs.Script.Tests/FileMonitoringServiceTests.cs
+++ b/test/WebJobs.Script.Tests/FileMonitoringServiceTests.cs
@@ -364,6 +364,113 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public static async Task AppOfflineCreated_ShutdownWinsOverRestart()
+        {
+            using (var directory = new TempDirectory())
+            using (var logDirectory = new TempDirectory())
+            {
+                string tempDir = directory.Path;
+                File.WriteAllText(Path.Combine(tempDir, ScriptConstants.AppOfflineFileName), string.Empty);
+
+                var jobHostOptions = new ScriptJobHostOptions
+                {
+                    RootLogPath = logDirectory.Path,
+                    RootScriptPath = tempDir,
+                    FileWatchingEnabled = true,
+                    WatchFiles = { "host.json" }
+                };
+                var loggerProvider = new TestLoggerProvider();
+                var loggerFactory = new LoggerFactory();
+                loggerFactory.AddProvider(loggerProvider);
+
+                int shutdownCount = 0;
+                TaskCompletionSource firstShutdown = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                TaskCompletionSource secondShutdown = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                var mockApplicationLifetime = new Mock<IScriptApplicationLifetime>();
+                mockApplicationLifetime.Setup(m => m.StopApplication()).Callback(() =>
+                {
+                    switch (Interlocked.Increment(ref shutdownCount))
+                    {
+                        case 1:
+                            firstShutdown.TrySetResult();
+                            break;
+                        case 2:
+                            secondShutdown.TrySetResult();
+                            break;
+                    }
+                });
+
+                TaskCompletionSource restart = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                var mockScriptHostManager = new Mock<IScriptHostManager>();
+                mockScriptHostManager.Setup(m => m.RestartHostAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .Callback<string, CancellationToken>((reason, ct) => restart.TrySetResult())
+                    .Returns(Task.CompletedTask);
+
+                var mockEventManager = new ScriptEventManager();
+                var environment = new TestEnvironment();
+
+                using FileMonitoringService fileMonitoringService = new FileMonitoringService(new OptionsWrapper<ScriptJobHostOptions>(jobHostOptions),
+                    loggerFactory, mockEventManager, mockApplicationLifetime.Object, mockScriptHostManager.Object, environment);
+                await fileMonitoringService.StartAsync(CancellationToken.None);
+
+                mockEventManager.Publish(new FileEvent(EventSources.ScriptFiles,
+                    new FileSystemEventArgs(WatcherChangeTypes.Created, tempDir, ScriptConstants.AppOfflineFileName)));
+                await firstShutdown.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                Assert.Contains(loggerProvider.GetAllLogMessages(),
+                    m => string.Equals(m.FormattedMessage, "Host configuration has changed. Signaling shutdown", StringComparison.Ordinal));
+                Assert.DoesNotContain(loggerProvider.GetAllLogMessages(),
+                    m => string.Equals(m.FormattedMessage, "Host configuration has changed. Signaling restart", StringComparison.Ordinal));
+
+                mockEventManager.Publish(new FileEvent(EventSources.ScriptFiles,
+                    new FileSystemEventArgs(WatcherChangeTypes.Changed, tempDir, "host.json")));
+
+                Task completedTask = await Task.WhenAny(secondShutdown.Task, restart.Task).WaitAsync(TimeSpan.FromSeconds(5));
+                Assert.Same(secondShutdown.Task, completedTask);
+                mockApplicationLifetime.Verify(m => m.StopApplication(), Times.Exactly(2));
+                mockScriptHostManager.Verify(m => m.RestartHostAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+            }
+        }
+
+        [Fact]
+        public static async Task AppOfflineDeleted_RestartsHost()
+        {
+            using (var directory = new TempDirectory())
+            using (var logDirectory = new TempDirectory())
+            {
+                string tempDir = directory.Path;
+                var jobHostOptions = new ScriptJobHostOptions
+                {
+                    RootLogPath = logDirectory.Path,
+                    RootScriptPath = tempDir,
+                    FileWatchingEnabled = true
+                };
+                var loggerFactory = new LoggerFactory();
+                var mockApplicationLifetime = new Mock<IScriptApplicationLifetime>();
+
+                TaskCompletionSource restart = new(TaskCreationOptions.RunContinuationsAsynchronously);
+                var mockScriptHostManager = new Mock<IScriptHostManager>();
+                mockScriptHostManager.Setup(m => m.RestartHostAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .Callback<string, CancellationToken>((reason, ct) => restart.TrySetResult())
+                    .Returns(Task.CompletedTask);
+
+                var mockEventManager = new ScriptEventManager();
+                var environment = new TestEnvironment();
+
+                using FileMonitoringService fileMonitoringService = new FileMonitoringService(new OptionsWrapper<ScriptJobHostOptions>(jobHostOptions),
+                    loggerFactory, mockEventManager, mockApplicationLifetime.Object, mockScriptHostManager.Object, environment);
+                await fileMonitoringService.StartAsync(CancellationToken.None);
+
+                mockEventManager.Publish(new FileEvent(EventSources.ScriptFiles,
+                    new FileSystemEventArgs(WatcherChangeTypes.Deleted, tempDir, ScriptConstants.AppOfflineFileName)));
+
+                await restart.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                string expectedReason = $"File change of type 'Deleted' detected for '{Path.Combine(tempDir, ScriptConstants.AppOfflineFileName)}'";
+                mockScriptHostManager.Verify(m => m.RestartHostAsync(expectedReason, default), Times.Once);
+                mockApplicationLifetime.Verify(m => m.StopApplication(), Times.Never);
+            }
+        }
+
+        [Fact]
         public static async Task OnFileChanged_DirectoryDeleted_DoesNotThrow_AndTriggersRestart()
         {
             using (var directory = new TempDirectory())

--- a/test/WebJobs.Script.Tests/FileMonitoringServiceTests.cs
+++ b/test/WebJobs.Script.Tests/FileMonitoringServiceTests.cs
@@ -416,7 +416,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 mockEventManager.Publish(new FileEvent(EventSources.ScriptFiles,
                     new FileSystemEventArgs(WatcherChangeTypes.Created, tempDir, ScriptConstants.AppOfflineFileName)));
                 await firstShutdown.Task.WaitAsync(TimeSpan.FromSeconds(5));
-                Assert.Contains(loggerProvider.GetAllLogMessages(),
+                Assert.Single(loggerProvider.GetAllLogMessages(),
                     m => string.Equals(m.FormattedMessage, "Host configuration has changed. Signaling shutdown", StringComparison.Ordinal));
                 Assert.DoesNotContain(loggerProvider.GetAllLogMessages(),
                     m => string.Equals(m.FormattedMessage, "Host configuration has changed. Signaling restart", StringComparison.Ordinal));
@@ -428,6 +428,8 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 Assert.Same(secondShutdown.Task, completedTask);
                 mockApplicationLifetime.Verify(m => m.StopApplication(), Times.Exactly(2));
                 mockScriptHostManager.Verify(m => m.RestartHostAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+                Assert.DoesNotContain(loggerProvider.GetAllLogMessages(),
+                    m => string.Equals(m.FormattedMessage, "Host configuration has changed. Signaling restart", StringComparison.Ordinal));
             }
         }
 

--- a/test/WebJobs.Script.Tests/IO/AutoRecoveringFileSystemWatcherTests.cs
+++ b/test/WebJobs.Script.Tests/IO/AutoRecoveringFileSystemWatcherTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
@@ -65,6 +65,17 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.IO
         public async Task AutoRecovery_StopsWhenDisposed()
         {
             await RecoveryTest(4, true);
+        }
+
+        [Fact]
+        public void DisposedWatcher_DoesNotSendNotification()
+        {
+            using var directory = new TempDirectory();
+            using var watcher = new TestFileSystemWatcher(directory.Path);
+            watcher.Changed += (_, _) => throw new InvalidOperationException("A disposed watcher must not invoke callbacks.");
+
+            watcher.Dispose();
+            watcher.TriggerChange(new FileSystemEventArgs(WatcherChangeTypes.Changed, directory.Path, "file.txt"));
         }
 
         public async Task RecoveryTest(int expectedNumberOfAttempts, bool isFailureScenario)
@@ -213,6 +224,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.IO
             internal void TriggerHandleError(ErrorEventArgs args)
             {
                 OnFileWatcherError(args);
+            }
+
+            internal void TriggerChange(FileSystemEventArgs args)
+            {
+                OnFileChanged(this, args);
             }
         }
     }


### PR DESCRIPTION
Flaky test caught this. There's a race in the FileMonitoringService where we call `Shutdown()`  but don't return. Shutdown isn't synchronous; it signals that the application should begin shutdown. So there's a chance that another `Restart()` call comes in and causes unintended behavior. This is what is happening in the test, causing sporadic failures.

The fix here:
- returns after calling `Shutdown()`
- properly tracks that a shutdown has been called
- changes some `_shutdownScheduled` checks to use Interlocked like `_restartRequested`

Edit: added a second improvement to prevent firing notifications when we're disposed. Tests had another race here.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)