### PR TITLE
Updating issue templates with support case guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,8 +1,33 @@
 ---
 name: "Bug report"
-about: Create a report to help us improve
+about: Report a bug in the Azure Functions Host / Runtime
 
 ---
+
+<!-- 
+⚠️ IS THIS THE RIGHT PLACE FOR YOUR ISSUE? ⚠️
+
+This repository is for the Azure Functions **Host / Runtime** only. Please open an issue here
+only for clear, reproducible bugs or code issues in the Functions Host / Runtime itself.
+
+This is NOT the right place for Azure Functions **platform-level** concerns, such as:
+- Deployments (including remote build, OneDeploy, `RuntimeFailed`/`ExpectationFailed` controller errors)
+- Scaling, cold start, or instance/availability behavior
+- ARM / control plane operations, provisioning, or configuration
+- Portal, billing, quotas, networking, or storage infrastructure
+
+For platform-level issues, please open a formal Azure support case so the appropriate team can
+investigate with access to your resources and telemetry:
+https://learn.microsoft.com/azure/azure-portal/supportability/how-to-create-azure-support-request
+
+Support cases are the fastest path to resolution for these concerns and let us handle
+resource-specific data privately. Platform issues opened here will typically be redirected to support.
+
+If your issue isn't a Host/Runtime bug and isn't a clear platform-support case (for example, it
+belongs to a binding/trigger extension, the tooling, or another part of Azure Functions), please
+use the guidance here to find and file in the correct repository:
+https://github.com/Azure/Azure-Functions#issues--feature-requests
+-->
 
 #### Check for a solution in the Azure portal
 For issues in production, please check for a solution to common issues in the Azure portal before opening a bug. In the Azure portal, navigate to your function app, select `Diagnose and solve problems` from the left, and view relevant dashboards before opening your issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Azure Functions platform issue (deployments, scaling, ARM, provisioning)
+    url: https://learn.microsoft.com/azure/azure-portal/supportability/how-to-create-azure-support-request
+    about: >-
+      This repository is for the Azure Functions Host / Runtime only. For platform-level
+      concerns (deployments, remote build/OneDeploy, scaling, availability, ARM/control
+      plane, provisioning, portal, billing, quotas, networking, or storage), please open
+      a formal Azure support case so the appropriate team can investigate with access to
+      your resources and telemetry.


### PR DESCRIPTION
We're seeing users create issues in this repo for platform level issues. Adding instructions to help steer customers in the right direction so they get help faster.

Related supporting PR in the Azure-Functions repo here: https://github.com/Azure/Azure-Functions/pull/2667
