### PR TITLE
feat(grpc): add extension RPC protocol contract

### DIFF
--- a/src/Functions.WorkerProxy/Functions.WorkerProxy.csproj
+++ b/src/Functions.WorkerProxy/Functions.WorkerProxy.csproj
@@ -32,6 +32,11 @@
       Include="..\WebJobs.Script.Grpc\azure-functions-language-worker-protobuf\src\proto\**\*.proto"
       GrpcServices="server"
       ProtoRoot="..\WebJobs.Script.Grpc\azure-functions-language-worker-protobuf\src\proto" />
+    <Protobuf
+      Include="..\WebJobs.Script.Grpc\Protos\ExtensionRpc.proto"
+      AdditionalImportDirs="..\WebJobs.Script.Grpc\azure-functions-language-worker-protobuf\src\proto"
+      GrpcServices="server"
+      ProtoRoot="..\WebJobs.Script.Grpc\Protos" />
   </ItemGroup>
 
 </Project>

--- a/src/WebJobs.Script.Grpc/Protos/ExtensionRpc.proto
+++ b/src/WebJobs.Script.Grpc/Protos/ExtensionRpc.proto
@@ -1,0 +1,127 @@
+syntax = "proto3";
+
+option csharp_namespace = "Microsoft.Azure.WebJobs.Script.Grpc.Messages";
+
+package AzureFunctionsExtensionRpcMessages;
+
+import "google/protobuf/duration.proto";
+
+// Host-to-proxy service for multiplexed extension RPC calls.
+// The current runtime opens one stream; the contract remains shard-ready.
+service ExtensionRpc {
+  rpc EventStream (stream ExtensionRpcMessage) returns (stream ExtensionRpcMessage) {}
+}
+
+// A logical extension RPC event multiplexed over one ExtensionRpc.EventStream.
+message ExtensionRpcMessage {
+  string session_id = 1;
+  string call_id = 2;
+  // Identifies the physical stream for compatibility with future multi-stream expansion.
+  string shard_id = 13;
+
+  oneof content {
+    ExtensionRpcHello hello = 3;
+    ExtensionRpcReady ready = 4;
+    ExtensionRpcStart start = 5;
+    ExtensionRpcData data = 6;
+    ExtensionRpcHalfClose half_close = 7;
+    ExtensionRpcCancel cancel = 8;
+    ExtensionRpcHeaders headers = 9;
+    ExtensionRpcComplete complete = 10;
+    ExtensionRpcWindowUpdate window_update = 11;
+    ExtensionRpcSessionClosed session_closed = 12;
+  }
+}
+
+// Capabilities offered when an extension RPC session is established.
+message ExtensionRpcHello {
+  repeated uint32 supported_versions = 1;
+  uint64 initial_receive_window_bytes = 2;
+  uint32 max_data_chunk_bytes = 3;
+  uint64 max_message_bytes = 4;
+}
+
+// Negotiated extension RPC session settings.
+message ExtensionRpcReady {
+  uint32 selected_version = 1;
+  bool enabled = 2;
+  string rejection_reason = 3;
+  uint64 initial_receive_window_bytes = 4;
+  uint32 max_data_chunk_bytes = 5;
+  uint64 max_message_bytes = 6;
+}
+
+// Starts a logical extension RPC call.
+message ExtensionRpcStart {
+  string method = 1;
+  repeated ExtensionRpcMetadataEntry metadata = 2;
+  google.protobuf.Duration timeout = 3;
+}
+
+// A bounded chunk of a serialized extension RPC application message.
+message ExtensionRpcData {
+  uint64 message_id = 1;
+  uint64 offset = 2;
+  bytes payload = 3;
+  bool end_of_message = 4;
+  bool compressed = 5;
+  uint64 message_length = 6;
+}
+
+// Indicates that the caller has finished sending request messages.
+message ExtensionRpcHalfClose {
+}
+
+// Cancels both directions of a logical extension RPC call.
+message ExtensionRpcCancel {
+  string detail = 1;
+}
+
+// Response headers for a logical extension RPC call.
+message ExtensionRpcHeaders {
+  repeated ExtensionRpcMetadataEntry metadata = 1;
+}
+
+// Completes a logical extension RPC call.
+message ExtensionRpcComplete {
+  ExtensionRpcStatus status = 1;
+  string detail = 2;
+  repeated ExtensionRpcMetadataEntry trailers = 3;
+}
+
+// Returns flow-control credits to the sender.
+message ExtensionRpcWindowUpdate {
+  uint64 byte_count = 1;
+}
+
+// Ends an extension RPC session and all logical calls associated with it.
+message ExtensionRpcSessionClosed {
+  string detail = 1;
+}
+
+// A gRPC metadata entry. Values are bytes to support both ASCII and binary metadata.
+message ExtensionRpcMetadataEntry {
+  string key = 1;
+  bytes value = 2;
+}
+
+// Standard gRPC status codes represented without a Grpc.Core dependency.
+enum ExtensionRpcStatus {
+  EXTENSION_RPC_STATUS_OK = 0;
+  EXTENSION_RPC_STATUS_CANCELLED = 1;
+  EXTENSION_RPC_STATUS_UNKNOWN = 2;
+  EXTENSION_RPC_STATUS_INVALID_ARGUMENT = 3;
+  EXTENSION_RPC_STATUS_DEADLINE_EXCEEDED = 4;
+  EXTENSION_RPC_STATUS_NOT_FOUND = 5;
+  EXTENSION_RPC_STATUS_ALREADY_EXISTS = 6;
+  EXTENSION_RPC_STATUS_PERMISSION_DENIED = 7;
+  EXTENSION_RPC_STATUS_RESOURCE_EXHAUSTED = 8;
+  EXTENSION_RPC_STATUS_FAILED_PRECONDITION = 9;
+  EXTENSION_RPC_STATUS_ABORTED = 10;
+  EXTENSION_RPC_STATUS_OUT_OF_RANGE = 11;
+  EXTENSION_RPC_STATUS_UNIMPLEMENTED = 12;
+  EXTENSION_RPC_STATUS_INTERNAL = 13;
+  EXTENSION_RPC_STATUS_UNAVAILABLE = 14;
+  EXTENSION_RPC_STATUS_DATA_LOSS = 15;
+  EXTENSION_RPC_STATUS_UNAUTHENTICATED = 16;
+}

--- a/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
+++ b/src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj
@@ -22,6 +22,11 @@
       Include=".\azure-functions-language-worker-protobuf\src\proto\**\*.proto"
       GrpcServices="both"
       ProtoRoot=".\azure-functions-language-worker-protobuf\src\proto" />
+    <Protobuf
+      Include=".\Protos\ExtensionRpc.proto"
+      AdditionalImportDirs=".\azure-functions-language-worker-protobuf\src\proto"
+      GrpcServices="both"
+      ProtoRoot=".\Protos" />
   </ItemGroup>
 
 </Project>

--- a/test/WebJobs.Script.Tests/Workers/Rpc/ExtensionRpcProtocolTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/ExtensionRpcProtocolTests.cs
@@ -1,0 +1,125 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
+{
+    public class ExtensionRpcProtocolTests
+    {
+        [Fact]
+        public void ExtensionTraffic_UsesDedicatedService()
+        {
+            Assert.Equal(ExtensionRpcMessage.Descriptor, ExtensionRpc.Descriptor.Methods[0].InputType);
+        }
+
+        [Fact]
+        public void ExtensionCallStart_RoundTripsCorrelationMetadataAndTimeout()
+        {
+            ExtensionRpcMessage message = new()
+            {
+                SessionId = "session-1",
+                ShardId = "shard-1",
+                CallId = "call-1",
+                Start = new ExtensionRpcStart
+                {
+                    Method = "/azure.functions.extensions.Test/Invoke",
+                    Timeout = Duration.FromTimeSpan(TimeSpan.FromSeconds(30)),
+                    Metadata =
+                    {
+                        new ExtensionRpcMetadataEntry
+                        {
+                            Key = "trace-bin",
+                            Value = ByteString.CopyFrom([0x01, 0x02, 0x03]),
+                        },
+                    },
+                },
+            };
+
+            ExtensionRpcMessage parsed = ExtensionRpcMessage.Parser.ParseFrom(message.ToByteArray());
+
+            Assert.Equal("session-1", parsed.SessionId);
+            Assert.Equal("shard-1", parsed.ShardId);
+            Assert.Equal("call-1", parsed.CallId);
+            Assert.Equal(ExtensionRpcMessage.ContentOneofCase.Start, parsed.ContentCase);
+            Assert.Equal("/azure.functions.extensions.Test/Invoke", parsed.Start.Method);
+            Assert.Equal(TimeSpan.FromSeconds(30), parsed.Start.Timeout.ToTimeSpan());
+            Assert.Equal(ByteString.CopyFrom([0x01, 0x02, 0x03]), parsed.Start.Metadata[0].Value);
+        }
+
+        [Fact]
+        public void ExtensionCallCompletion_RoundTripsStatusAndTrailers()
+        {
+            ExtensionRpcMessage message = new()
+            {
+                SessionId = "session-1",
+                ShardId = "shard-1",
+                CallId = "call-1",
+                Complete = new ExtensionRpcComplete
+                {
+                    Status = ExtensionRpcStatus.Unavailable,
+                    Detail = "endpoint unavailable",
+                    Trailers =
+                    {
+                        new ExtensionRpcMetadataEntry
+                        {
+                            Key = "retry-after",
+                            Value = ByteString.CopyFromUtf8("1"),
+                        },
+                    },
+                },
+            };
+
+            ExtensionRpcMessage parsed = ExtensionRpcMessage.Parser.ParseFrom(message.ToByteArray());
+
+            Assert.Equal(ExtensionRpcStatus.Unavailable, parsed.Complete.Status);
+            Assert.Equal("endpoint unavailable", parsed.Complete.Detail);
+            Assert.Equal("1", parsed.Complete.Trailers[0].Value.ToStringUtf8());
+        }
+
+        [Fact]
+        public void ExtensionFlowControl_RoundTripsPerCallCredit()
+        {
+            ExtensionRpcMessage message = new()
+            {
+                SessionId = "session-1",
+                ShardId = "shard-1",
+                CallId = "call-2",
+                WindowUpdate = new ExtensionRpcWindowUpdate { ByteCount = 64 * 1024 },
+            };
+
+            ExtensionRpcMessage parsed = ExtensionRpcMessage.Parser.ParseFrom(message.ToByteArray());
+
+            Assert.Equal("call-2", parsed.CallId);
+            Assert.Equal((ulong)(64 * 1024), parsed.WindowUpdate.ByteCount);
+        }
+
+        [Fact]
+        public void ExtensionData_RoundTripsMessageLength()
+        {
+            ExtensionRpcMessage message = new()
+            {
+                SessionId = "session-1",
+                ShardId = "shard-1",
+                CallId = "call-1",
+                Data = new ExtensionRpcData
+                {
+                    MessageId = 2,
+                    Offset = 64,
+                    Payload = ByteString.CopyFrom([0x01, 0x02]),
+                    EndOfMessage = true,
+                    Compressed = false,
+                    MessageLength = 66,
+                },
+            };
+
+            ExtensionRpcMessage parsed = ExtensionRpcMessage.Parser.ParseFrom(message.ToByteArray());
+
+            Assert.Equal((ulong)66, parsed.Data.MessageLength);
+        }
+    }
+}

--- a/test/WebJobs.Script.Tests/Workers/Rpc/ExtensionRpcProtocolTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/ExtensionRpcProtocolTests.cs
@@ -14,7 +14,11 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         [Fact]
         public void ExtensionTraffic_UsesDedicatedService()
         {
-            Assert.Equal(ExtensionRpcMessage.Descriptor, ExtensionRpc.Descriptor.Methods[0].InputType);
+            var method = Assert.Single(
+                ExtensionRpc.Descriptor.Methods,
+                method => string.Equals(method.Name, "EventStream", StringComparison.Ordinal));
+
+            Assert.Equal(ExtensionRpcMessage.Descriptor, method.InputType);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- Please provide all the information below.  -->

### Issue describing the changes in this PR

This is layer 1 of the four-PR WorkerProxy extension-RPC stack.

The extension RPC approach for compute separation will use a new gRPC bidirectional stream between runtime & proxy to multi-plex all extension calls from worker to proxy back to the runtime. Then on the host side the extension calls will be reconstructed into an `HttpContext` and the existing RPC endpoints invoked.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

<!-- Optional: delete if not applicable  -->
### Additional information

#### Summary

This PR contains only the shared extension-RPC wire contract and protobuf build generation:

- Adds `ExtensionRpc.proto` under `WebJobs.Script.Grpc`.
- Generates host-side contract types in `WebJobs.Script.Grpc`.
- Generates server types in `Functions.WorkerProxy`.
- Adds protocol serialization and descriptor tests.

Host dispatch, catalog/coordinator logic, WorkerProxy stream transport, ingress, telemetry, and relay changes are intentionally deferred to later layers.

#### Validation

- `dotnet build .\src\Functions.WorkerProxy\Functions.WorkerProxy.csproj --configuration Debug --nologo` — succeeded with 0 warnings and 0 errors.
- `dotnet test .\test\WebJobs.Script.Tests\WebJobs.Script.Tests.csproj --configuration Debug --filter "FullyQualifiedName~ExtensionRpcProtocolTests" --nologo` — 5 passed, 0 failed, 0 skipped.