### PR TITLE
introducing RpcClientWorkerChannel

### DIFF
--- a/src/Functions.Rpc.Client/FunctionRpcDuplexChannelFactory.cs
+++ b/src/Functions.Rpc.Client/FunctionRpcDuplexChannelFactory.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Grpc;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Microsoft.Extensions.Logging;
 
@@ -30,7 +30,7 @@ internal sealed class FunctionRpcDuplexChannelFactory : IDuplexChannelFactory<St
     }
 
     /// <inheritdoc />
-    public async Task<Channel<StreamingMessage>> ConnectAsync(Uri endpoint, CancellationToken cancellationToken = default)
+    public async Task<DuplexChannel<StreamingMessage>> ConnectAsync(Uri endpoint, CancellationToken cancellationToken = default)
     {
         FunctionRpc.FunctionRpcClient client = await _clientFactory.CreateAsync(endpoint, cancellationToken);
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/Functions.Rpc.Client/Functions.Rpc.Client.csproj
+++ b/src/Functions.Rpc.Client/Functions.Rpc.Client.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\WebJobs.Script.Grpc\WebJobs.Script.Grpc.csproj" />
+    <ProjectReference Include="..\WebJobs.Script\WebJobs.Script.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Functions.Rpc.Client/GrpcDuplexChannel.cs
+++ b/src/Functions.Rpc.Client/GrpcDuplexChannel.cs
@@ -7,12 +7,13 @@ using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Grpc.Core;
+using Microsoft.Azure.WebJobs.Script.Grpc;
 
 namespace Azure.Functions.Rpc.Client;
 
 /// <summary>
 /// Adapts an SDK <see cref="AsyncDuplexStreamingCall{TRequest, TResponse}"/> to a bidirectional
-/// <see cref="Channel{T}"/>.
+/// <see cref="DuplexChannel{T}"/>.
 /// </summary>
 /// <remarks>
 /// Writes complete when a request is admitted to the outgoing queue, not when it reaches the peer.
@@ -20,7 +21,7 @@ namespace Azure.Functions.Rpc.Client;
 /// The channel supports one response reader and multiple concurrent request writers.
 /// </remarks>
 /// <typeparam name="T">The message type used in both directions.</typeparam>
-internal sealed class GrpcDuplexChannel<T> : Channel<T>, IAsyncDisposable
+internal sealed class GrpcDuplexChannel<T> : DuplexChannel<T>
     where T : class
 {
     private readonly AsyncDuplexStreamingCall<T, T> _call;
@@ -28,9 +29,7 @@ internal sealed class GrpcDuplexChannel<T> : Channel<T>, IAsyncDisposable
     private readonly Channel<T> _outgoing;
     private readonly Task _readPump;
     private readonly CancellationTokenSource _shutdownSource = new();
-    private readonly Lock _syncLock = new();
     private readonly Task _writePump;
-    private Task _disposeTask;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GrpcDuplexChannel{T}"/> class.
@@ -59,21 +58,7 @@ internal sealed class GrpcDuplexChannel<T> : Channel<T>, IAsyncDisposable
         _writePump = PumpRequestsAsync();
     }
 
-    /// <summary>
-    /// Aborts the duplex call, stops both message pumps, and releases the call lifetime.
-    /// Concurrent callers share the same cleanup operation.
-    /// </summary>
-    /// <returns>A task representing asynchronous cleanup.</returns>
-    public ValueTask DisposeAsync()
-    {
-        lock (_syncLock)
-        {
-            _disposeTask ??= DisposeCoreAsync();
-            return new ValueTask(_disposeTask);
-        }
-    }
-
-    private async Task DisposeCoreAsync()
+    protected override async ValueTask DisposeAsyncCore()
     {
         Exception cleanupException = null;
         _outgoing.Writer.TryComplete();

--- a/src/Functions.Rpc.Client/IDuplexChannelFactory.cs
+++ b/src/Functions.Rpc.Client/IDuplexChannelFactory.cs
@@ -3,18 +3,15 @@
 
 using System;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Grpc;
 
 namespace Azure.Functions.Rpc.Client;
 
 /// <summary>
 /// Creates connected duplex channels.
 /// </summary>
-/// <remarks>
-/// A returned channel that owns transport resources must also implement <see cref="System.IAsyncDisposable"/>.
-/// The caller owns the returned channel.
-/// </remarks>
+/// <remarks>The caller owns the returned channel.</remarks>
 /// <typeparam name="T">The message type used in both directions.</typeparam>
 internal interface IDuplexChannelFactory<T>
     where T : class
@@ -23,11 +20,11 @@ internal interface IDuplexChannelFactory<T>
     /// Connects to an endpoint and creates a duplex channel.
     /// </summary>
     /// <remarks>
-    /// Implementations backed by a cached transport can surface a later reconnection failure through the returned
+    /// Implementations backed by a cached connection can surface a later reconnection failure through the returned
     /// channel rather than from this method.
     /// </remarks>
     /// <param name="endpoint">The service endpoint.</param>
     /// <param name="cancellationToken">A token that bounds connection establishment.</param>
     /// <returns>The connected duplex channel.</returns>
-    Task<Channel<T>> ConnectAsync(Uri endpoint, CancellationToken cancellationToken = default);
+    Task<DuplexChannel<T>> ConnectAsync(Uri endpoint, CancellationToken cancellationToken = default);
 }

--- a/src/Functions.Rpc.Client/RpcClientWorkerChannel.cs
+++ b/src/Functions.Rpc.Client/RpcClientWorkerChannel.cs
@@ -1,0 +1,115 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.AppCapabilities;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.Grpc;
+using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using Microsoft.Azure.WebJobs.Script.Http;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Azure.Functions.Rpc.Client;
+
+/// <summary>
+/// Runs the shared worker protocol over a client-owned FunctionRpc channel.
+/// </summary>
+/// <remarks>
+/// Concurrent and repeated starts share one initialization attempt. A token already canceled when <see cref="StartAsync"/> is called does not
+/// begin initialization. Once initialization begins, cancellation only stops the individual caller's wait; shared initialization continues
+/// until it succeeds, fails, times out, or the channel is disposed.
+/// </remarks>
+internal sealed class RpcClientWorkerChannel(string workerId, DuplexChannel<StreamingMessage> ownedChannel, TimeSpan startStreamTimeout,
+    IScriptEventManager eventManager, IScriptHostManager hostManager, RpcWorkerConfig workerConfig, ILogger logger, IMetricsLogger metricsLogger,
+    int attemptCount, IEnvironment environment, IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions,
+    ISharedMemoryManager sharedMemoryManager, IOptions<WorkerConcurrencyOptions> workerConcurrencyOptions,
+    IOptions<FunctionsHostingConfigOptions> hostingConfigOptions, IAppCapabilitiesStore appCapabilitiesStore, IHttpProxyService httpProxyService)
+    : WorkerChannel(workerId, ownedChannel, eventManager, hostManager, workerConfig, logger, metricsLogger, attemptCount, environment,
+        applicationHostOptions, sharedMemoryManager, workerConcurrencyOptions, hostingConfigOptions, appCapabilitiesStore, httpProxyService)
+{
+    private const int NotStarted = 0;
+    private const int Started = 1;
+    private const int Disposed = 2;
+
+    private readonly TaskCompletionSource _startCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TimeSpan _startStreamTimeout = ValidateStartStreamTimeout(startStreamTimeout);
+    private int _lifecycleState;
+
+    /// <summary>
+    /// Starts inbound protocol processing and waits for the worker initialization handshake.
+    /// </summary>
+    /// <param name="cancellationToken">A token that cancels this caller's wait without canceling shared initialization.</param>
+    /// <returns>A task that completes after a successful WorkerInitResponse, is canceled for this caller, or faults when initialization cannot complete.</returns>
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled(cancellationToken);
+        }
+
+        int state = Interlocked.CompareExchange(ref _lifecycleState, Started, NotStarted);
+        ObjectDisposedException.ThrowIf(state == Disposed, this);
+
+        if (state == NotStarted)
+        {
+            try
+            {
+                MarkWorkerInitializing();
+                BeginInboundProcessing(_startStreamTimeout);
+                _ = CompleteStartAsync();
+            }
+            catch (Exception exception)
+            {
+                _startCompletion.TrySetException(exception);
+            }
+        }
+
+        return _startCompletion.Task.WaitAsync(cancellationToken);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        Interlocked.Exchange(ref _lifecycleState, Disposed);
+        base.Dispose(disposing);
+    }
+
+    private async Task CompleteStartAsync()
+    {
+        try
+        {
+            if (!await WorkerInitialization.ConfigureAwait(false))
+            {
+                throw new InvalidOperationException("The worker reported unsuccessful initialization.");
+            }
+
+            _startCompletion.TrySetResult();
+        }
+        catch (OperationCanceledException exception)
+        {
+            _startCompletion.TrySetCanceled(exception.CancellationToken);
+        }
+        catch (Exception exception)
+        {
+            _startCompletion.TrySetException(exception);
+        }
+    }
+
+    private static TimeSpan ValidateStartStreamTimeout(TimeSpan startStreamTimeout)
+    {
+        if (startStreamTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(startStreamTimeout), "The StartStream timeout must be greater than zero.");
+        }
+
+        return startStreamTimeout;
+    }
+}

--- a/src/Functions.Rpc.Client/RpcClientWorkerChannel.cs
+++ b/src/Functions.Rpc.Client/RpcClientWorkerChannel.cs
@@ -28,13 +28,39 @@ namespace Azure.Functions.Rpc.Client;
 /// begin initialization. Once initialization begins, cancellation only stops the individual caller's wait; shared initialization continues
 /// until it succeeds, fails, times out, or the channel is disposed.
 /// </remarks>
-internal sealed class RpcClientWorkerChannel(string workerId, DuplexChannel<StreamingMessage> ownedChannel, TimeSpan startStreamTimeout,
-    IScriptEventManager eventManager, IScriptHostManager hostManager, RpcWorkerConfig workerConfig, ILogger logger, IMetricsLogger metricsLogger,
-    int attemptCount, IEnvironment environment, IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions,
-    ISharedMemoryManager sharedMemoryManager, IOptions<WorkerConcurrencyOptions> workerConcurrencyOptions,
-    IOptions<FunctionsHostingConfigOptions> hostingConfigOptions, IAppCapabilitiesStore appCapabilitiesStore, IHttpProxyService httpProxyService)
-    : WorkerChannel(workerId, ownedChannel, eventManager, hostManager, workerConfig, logger, metricsLogger, attemptCount, environment,
-        applicationHostOptions, sharedMemoryManager, workerConcurrencyOptions, hostingConfigOptions, appCapabilitiesStore, httpProxyService)
+internal sealed class RpcClientWorkerChannel(
+    string workerId,
+    DuplexChannel<StreamingMessage> ownedChannel,
+    TimeSpan startStreamTimeout,
+    IScriptEventManager eventManager,
+    IScriptHostManager hostManager,
+    RpcWorkerConfig workerConfig,
+    ILogger logger,
+    IMetricsLogger metricsLogger,
+    int attemptCount,
+    IEnvironment environment,
+    IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions,
+    ISharedMemoryManager sharedMemoryManager,
+    IOptions<WorkerConcurrencyOptions> workerConcurrencyOptions,
+    IOptions<FunctionsHostingConfigOptions> hostingConfigOptions,
+    IAppCapabilitiesStore appCapabilitiesStore,
+    IHttpProxyService httpProxyService)
+    : WorkerChannel(
+        workerId,
+        ownedChannel,
+        eventManager,
+        hostManager,
+        workerConfig,
+        logger,
+        metricsLogger,
+        attemptCount,
+        environment,
+        applicationHostOptions,
+        sharedMemoryManager,
+        workerConcurrencyOptions,
+        hostingConfigOptions,
+        appCapabilitiesStore,
+        httpProxyService)
 {
     private readonly TaskCompletionSource _startCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly TimeSpan _startStreamTimeout = ValidateStartStreamTimeout(startStreamTimeout);

--- a/src/Functions.Rpc.Client/RpcClientWorkerChannel.cs
+++ b/src/Functions.Rpc.Client/RpcClientWorkerChannel.cs
@@ -62,9 +62,10 @@ internal sealed class RpcClientWorkerChannel(
         appCapabilitiesStore,
         httpProxyService)
 {
+    private readonly Lock _lifecycleLock = new();
     private readonly TaskCompletionSource _startCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly TimeSpan _startStreamTimeout = ValidateStartStreamTimeout(startStreamTimeout);
-    private int _lifecycleState;
+    private LifecycleState _lifecycleState;
 
     private enum LifecycleState
     {
@@ -85,21 +86,24 @@ internal sealed class RpcClientWorkerChannel(
             return Task.FromCanceled(cancellationToken);
         }
 
-        LifecycleState state = (LifecycleState)Interlocked.CompareExchange(
-            ref _lifecycleState, (int)LifecycleState.Started, (int)LifecycleState.NotStarted);
-        ObjectDisposedException.ThrowIf(state is LifecycleState.Disposed, this);
-
-        if (state is LifecycleState.NotStarted)
+        lock (_lifecycleLock)
         {
-            try
+            ObjectDisposedException.ThrowIf(_lifecycleState is LifecycleState.Disposed, this);
+
+            if (_lifecycleState is LifecycleState.NotStarted)
             {
-                MarkWorkerInitializing();
-                BeginInboundProcessing(_startStreamTimeout);
-                _ = CompleteStartAsync();
-            }
-            catch (Exception exception)
-            {
-                _startCompletion.TrySetException(exception);
+                _lifecycleState = LifecycleState.Started;
+
+                try
+                {
+                    MarkWorkerInitializing();
+                    BeginInboundProcessing(_startStreamTimeout);
+                    _ = CompleteStartAsync();
+                }
+                catch (Exception exception)
+                {
+                    _startCompletion.TrySetException(exception);
+                }
             }
         }
 
@@ -108,7 +112,11 @@ internal sealed class RpcClientWorkerChannel(
 
     protected override void Dispose(bool disposing)
     {
-        Interlocked.Exchange(ref _lifecycleState, (int)LifecycleState.Disposed);
+        lock (_lifecycleLock)
+        {
+            _lifecycleState = LifecycleState.Disposed;
+        }
+
         base.Dispose(disposing);
     }
 

--- a/src/Functions.Rpc.Client/RpcClientWorkerChannel.cs
+++ b/src/Functions.Rpc.Client/RpcClientWorkerChannel.cs
@@ -36,13 +36,16 @@ internal sealed class RpcClientWorkerChannel(string workerId, DuplexChannel<Stre
     : WorkerChannel(workerId, ownedChannel, eventManager, hostManager, workerConfig, logger, metricsLogger, attemptCount, environment,
         applicationHostOptions, sharedMemoryManager, workerConcurrencyOptions, hostingConfigOptions, appCapabilitiesStore, httpProxyService)
 {
-    private const int NotStarted = 0;
-    private const int Started = 1;
-    private const int Disposed = 2;
-
     private readonly TaskCompletionSource _startCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly TimeSpan _startStreamTimeout = ValidateStartStreamTimeout(startStreamTimeout);
     private int _lifecycleState;
+
+    private enum LifecycleState
+    {
+        NotStarted,
+        Started,
+        Disposed,
+    }
 
     /// <summary>
     /// Starts inbound protocol processing and waits for the worker initialization handshake.
@@ -56,10 +59,11 @@ internal sealed class RpcClientWorkerChannel(string workerId, DuplexChannel<Stre
             return Task.FromCanceled(cancellationToken);
         }
 
-        int state = Interlocked.CompareExchange(ref _lifecycleState, Started, NotStarted);
-        ObjectDisposedException.ThrowIf(state == Disposed, this);
+        LifecycleState state = (LifecycleState)Interlocked.CompareExchange(
+            ref _lifecycleState, (int)LifecycleState.Started, (int)LifecycleState.NotStarted);
+        ObjectDisposedException.ThrowIf(state is LifecycleState.Disposed, this);
 
-        if (state == NotStarted)
+        if (state is LifecycleState.NotStarted)
         {
             try
             {
@@ -78,7 +82,7 @@ internal sealed class RpcClientWorkerChannel(string workerId, DuplexChannel<Stre
 
     protected override void Dispose(bool disposing)
     {
-        Interlocked.Exchange(ref _lifecycleState, Disposed);
+        Interlocked.Exchange(ref _lifecycleState, (int)LifecycleState.Disposed);
         base.Dispose(disposing);
     }
 

--- a/src/Functions.Rpc.Client/RpcClientWorkerChannelFactory.cs
+++ b/src/Functions.Rpc.Client/RpcClientWorkerChannelFactory.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.AppCapabilities;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.Grpc;
+using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using Microsoft.Azure.WebJobs.Script.Http;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Azure.Functions.Rpc.Client;
+
+/// <summary>
+/// Creates client-backed worker channels with the shared protocol dependencies.
+/// </summary>
+internal sealed class RpcClientWorkerChannelFactory(IScriptEventManager eventManager, IScriptHostManager hostManager, IEnvironment environment,
+    ILoggerFactory loggerFactory, IOptionsMonitor<ScriptApplicationHostOptions> applicationHostOptions, ISharedMemoryManager sharedMemoryManager,
+    IOptions<WorkerConcurrencyOptions> workerConcurrencyOptions, IOptions<FunctionsHostingConfigOptions> hostingConfigOptions,
+    IAppCapabilitiesStore appCapabilitiesStore, IHttpProxyService httpProxyService)
+{
+    public RpcClientWorkerChannel Create(string workerId, DuplexChannel<StreamingMessage> ownedChannel, RpcWorkerConfig workerConfig,
+        IMetricsLogger metricsLogger, int attemptCount)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(workerId);
+        ArgumentNullException.ThrowIfNull(ownedChannel);
+        ArgumentNullException.ThrowIfNull(workerConfig);
+        ArgumentNullException.ThrowIfNull(metricsLogger);
+        ArgumentNullException.ThrowIfNull(eventManager);
+        ArgumentNullException.ThrowIfNull(hostManager);
+        ArgumentNullException.ThrowIfNull(environment);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+        ArgumentNullException.ThrowIfNull(applicationHostOptions);
+        ArgumentNullException.ThrowIfNull(sharedMemoryManager);
+        ArgumentNullException.ThrowIfNull(workerConcurrencyOptions);
+        ArgumentNullException.ThrowIfNull(hostingConfigOptions);
+        ArgumentNullException.ThrowIfNull(appCapabilitiesStore);
+        ArgumentNullException.ThrowIfNull(httpProxyService);
+
+        ILogger workerLogger = loggerFactory.CreateLogger($"Worker.LanguageWorkerChannel.{workerConfig.Description.Language}.{workerId}");
+        return new RpcClientWorkerChannel(workerId, ownedChannel, workerConfig.CountOptions.ProcessStartupTimeout, eventManager, hostManager,
+            workerConfig, workerLogger, metricsLogger, attemptCount, environment, applicationHostOptions, sharedMemoryManager,
+            workerConcurrencyOptions, hostingConfigOptions, appCapabilitiesStore, httpProxyService);
+    }
+}

--- a/src/Functions.Rpc.Client/RpcClientWorkerChannelFactory.cs
+++ b/src/Functions.Rpc.Client/RpcClientWorkerChannelFactory.cs
@@ -45,8 +45,22 @@ internal sealed class RpcClientWorkerChannelFactory(IScriptEventManager eventMan
         ArgumentNullException.ThrowIfNull(httpProxyService);
 
         ILogger workerLogger = loggerFactory.CreateLogger($"Worker.LanguageWorkerChannel.{workerConfig.Description.Language}.{workerId}");
-        return new RpcClientWorkerChannel(workerId, ownedChannel, workerConfig.CountOptions.ProcessStartupTimeout, eventManager, hostManager,
-            workerConfig, workerLogger, metricsLogger, attemptCount, environment, applicationHostOptions, sharedMemoryManager,
-            workerConcurrencyOptions, hostingConfigOptions, appCapabilitiesStore, httpProxyService);
+        return new RpcClientWorkerChannel(
+            workerId,
+            ownedChannel,
+            workerConfig.CountOptions.ProcessStartupTimeout,
+            eventManager,
+            hostManager,
+            workerConfig,
+            workerLogger,
+            metricsLogger,
+            attemptCount,
+            environment,
+            applicationHostOptions,
+            sharedMemoryManager,
+            workerConcurrencyOptions,
+            hostingConfigOptions,
+            appCapabilitiesStore,
+            httpProxyService);
     }
 }

--- a/src/Functions.Rpc.Server/Channel/GrpcWorkerChannel.cs
+++ b/src/Functions.Rpc.Server/Channel/GrpcWorkerChannel.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
 
         public IWorkerProcess WorkerProcess => _rpcWorkerProcess;
 
-        protected override int WorkerProcessId => _rpcWorkerProcess.Id;
+        internal override int WorkerProcessId => _rpcWorkerProcess.Id;
 
         public async Task StartWorkerProcessAsync(CancellationToken cancellationToken)
         {
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             await _rpcWorkerProcess.StartProcessAsync(cancellationToken);
             State |= RpcWorkerChannelState.Initializing;
             Task<int> exited = _rpcWorkerProcess.WaitForExitAsync(cancellationToken);
-            Task winner = await Task.WhenAny(WorkerInitTask.Task, exited).WaitAsync(cancellationToken);
+            Task winner = await Task.WhenAny(WorkerInitialization, exited).WaitAsync(cancellationToken);
             await winner;
 
             if (winner == exited)
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             base.Dispose(disposing);
         }
 
-        protected override void DisposeWorkerResources()
+        internal override void DisposeWorkerResources()
         {
             (_rpcWorkerProcess as IDisposable)?.Dispose();
         }

--- a/src/WebJobs.Script.Grpc/Channel/WorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/Channel/WorkerChannel.cs
@@ -41,7 +41,13 @@ using ParameterBindingType = Microsoft.Azure.WebJobs.Script.Grpc.Messages.Parame
 
 namespace Microsoft.Azure.WebJobs.Script.Grpc
 {
-    internal abstract partial class WorkerChannel : IFunctionRpcChannel, IDisposable, IAsyncDisposable
+    /// <summary>
+    /// Provides the shared Functions worker protocol over an owned duplex message channel.
+    /// </summary>
+    /// <remarks>
+    /// Derived channels choose when message processing starts. This base owns the supplied duplex channel and disposes it asynchronously.
+    /// </remarks>
+    public abstract partial class WorkerChannel : IFunctionRpcChannel, IDisposable, IAsyncDisposable
     {
         private readonly IScriptEventManager _eventManager;
         private readonly RpcWorkerConfig _workerConfig;
@@ -97,7 +103,25 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         private bool _functionMetadataRequestSent = false;
         private IOptions<ScriptJobHostOptions> _scriptHostOptions;
 
-        internal WorkerChannel(
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WorkerChannel"/> class over an owned duplex channel.
+        /// </summary>
+        /// <param name="workerId">The worker identifier.</param>
+        /// <param name="ownedChannel">The duplex channel owned by this worker channel.</param>
+        /// <param name="eventManager">The script event manager.</param>
+        /// <param name="hostManager">The script host manager.</param>
+        /// <param name="workerConfig">The worker configuration.</param>
+        /// <param name="logger">The worker channel logger.</param>
+        /// <param name="metricsLogger">The metrics logger.</param>
+        /// <param name="attemptCount">The worker startup attempt count.</param>
+        /// <param name="environment">The host environment.</param>
+        /// <param name="applicationHostOptions">The application host options.</param>
+        /// <param name="sharedMemoryManager">The shared memory manager.</param>
+        /// <param name="workerConcurrencyOptions">The worker concurrency options.</param>
+        /// <param name="hostingConfigOptions">The Functions hosting configuration.</param>
+        /// <param name="appCapabilitiesStore">The application capabilities store.</param>
+        /// <param name="httpProxyService">The HTTP proxy service.</param>
+        protected WorkerChannel(
             string workerId,
             DuplexChannel<StreamingMessage> ownedChannel,
             IScriptEventManager eventManager,
@@ -153,38 +177,59 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             LoadScriptJobHostOptions(_scriptHostManager as IServiceProvider);
         }
 
-        protected virtual int WorkerProcessId => -1;
+        internal virtual int WorkerProcessId => -1;
 
         private bool IsHttpProxyingWorker => _httpProxyEndpoint is not null;
 
+        /// <inheritdoc />
         public string Id => _workerId;
 
+        /// <inheritdoc />
         public IDictionary<string, BufferBlock<ScriptInvocationContext>> FunctionInputBuffers => _functionInputBuffers;
 
+        /// <inheritdoc />
         public RpcWorkerConfig WorkerConfig => _workerConfig;
 
+        /// <summary>
+        /// Gets the current script job host options.
+        /// </summary>
         public IOptions<ScriptJobHostOptions> JobHostOptions => _scriptHostOptions;
 
         internal bool IsSharedMemoryDataTransferEnabled => _isSharedMemoryDataTransferEnabled;
 
-        protected IScriptEventManager EventManager => _eventManager;
+        internal IScriptEventManager EventManager => _eventManager;
 
-        protected ILogger WorkerChannelLogger => _workerChannelLogger;
+        internal ILogger WorkerChannelLogger => _workerChannelLogger;
 
-        protected GrpcCapabilities WorkerCapabilities => _workerCapabilities;
+        internal GrpcCapabilities WorkerCapabilities => _workerCapabilities;
 
-        protected TaskCompletionSource<bool> WorkerInitTask => _workerInitTask;
+        /// <summary>
+        /// Gets the worker initialization task.
+        /// </summary>
+        protected Task<bool> WorkerInitialization => _workerInitTask.Task;
 
-        protected List<IDisposable> EventSubscriptions => _eventSubscriptions;
+        internal List<IDisposable> EventSubscriptions => _eventSubscriptions;
 
-        protected RpcWorkerChannelState State
+        internal RpcWorkerChannelState State
         {
             get => _state;
             set => _state = value;
         }
 
-        protected virtual void DisposeWorkerResources() { }
+        internal virtual void DisposeWorkerResources() { }
 
+        /// <summary>
+        /// Marks the worker channel as initializing.
+        /// </summary>
+        protected void MarkWorkerInitializing()
+        {
+            _state |= RpcWorkerChannelState.Initializing;
+        }
+
+        /// <summary>
+        /// Starts processing inbound protocol messages.
+        /// </summary>
+        /// <param name="startStreamTimeout">The maximum time to wait for the StartStream message.</param>
         protected void BeginInboundProcessing(TimeSpan startStreamTimeout)
         {
             RegisterCallbackForNextGrpcMessage(
@@ -342,10 +387,17 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             }
             catch (Exception ex)
             {
+                _workerInitTask.TrySetException(ex);
                 _workerChannelLogger.LogError(ex, "Error processing inbound messages");
             }
             finally
             {
+                if (!_workerInitTask.Task.IsCompleted)
+                {
+                    _workerInitTask.TrySetException(
+                        new InvalidOperationException("The RPC channel closed unexpectedly before the worker initialized."));
+                }
+
                 try
                 {
                     await _ownedChannel.DisposeAsync();
@@ -391,6 +443,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             }
         }
 
+        /// <inheritdoc />
         public bool IsChannelReadyForInvocations()
         {
             return !_disposing && !_disposed
@@ -398,6 +451,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
                     RpcWorkerChannelState.InvocationBuffersInitialized | RpcWorkerChannelState.Initialized);
         }
 
+        /// <inheritdoc />
         public async Task<WorkerStatus> GetWorkerStatusAsync()
         {
             var workerStatus = new WorkerStatus();
@@ -613,6 +667,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             }
         }
 
+        /// <inheritdoc />
         public void SetupFunctionInvocationBuffers(IEnumerable<FunctionMetadata> functions)
         {
             _functions = functions;
@@ -625,6 +680,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             _state |= RpcWorkerChannelState.InvocationBuffersInitialized;
         }
 
+        /// <inheritdoc />
         public void SendFunctionLoadRequests(ManagedDependencyOptions managedDependencyOptions, TimeSpan? functionTimeout)
         {
             if (_functions != null)
@@ -689,6 +745,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             return functionLoadRequestCollection;
         }
 
+        /// <inheritdoc />
         public Task<bool> SendFunctionEnvironmentReloadRequest()
         {
             _functionsIndexingTask = new TaskCompletionSource<List<RawFunctionMetadata>>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -712,6 +769,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             return _reloadTask.Task;
         }
 
+        /// <inheritdoc />
         public void SendWorkerWarmupRequest()
         {
             bool capabilityEnabled = !string.IsNullOrEmpty(_workerCapabilities.GetCapabilityState(RpcWorkerConstants.HandlesWorkerWarmupMessage));
@@ -957,6 +1015,8 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
         }
 
         // gets metadata from worker
+
+        /// <inheritdoc />
         public Task<List<RawFunctionMetadata>> GetFunctionMetadata()
         {
             return SendFunctionMetadataRequest();
@@ -1410,11 +1470,20 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             _workerChannelLogger.LogError(exc, "Worker warmup failed");
         }
 
+        /// <summary>
+        /// Sends a protocol message asynchronously.
+        /// </summary>
+        /// <param name="msg">The message to send.</param>
+        /// <returns>A task that completes when the message is accepted by the outbound channel.</returns>
         protected ValueTask SendStreamingMessageAsync(StreamingMessage msg)
         {
             return _outbound.TryWrite(msg) ? default : _outbound.WriteAsync(msg);
         }
 
+        /// <summary>
+        /// Sends a protocol message without waiting for asynchronous channel admission.
+        /// </summary>
+        /// <param name="msg">The message to send.</param>
         protected void SendStreamingMessage(StreamingMessage msg)
         {
             if (!_outbound.TryWrite(msg))
@@ -1465,6 +1534,10 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             }
         }
 
+        /// <summary>
+        /// Releases synchronous worker channel resources.
+        /// </summary>
+        /// <param name="disposing"><see langword="true"/> when called from managed disposal.</param>
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)
@@ -1527,12 +1600,14 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             }
         }
 
+        /// <inheritdoc />
         public void Dispose()
         {
             // The standard server channel completes disposal synchronously. Async channels should use DisposeAsync.
             DisposeAsync().AsTask().GetAwaiter().GetResult();
         }
 
+        /// <inheritdoc />
         public ValueTask DisposeAsync()
         {
             lock (_disposeLock)
@@ -1574,6 +1649,7 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             }
         }
 
+        /// <inheritdoc />
         public async Task DrainInvocationsAsync()
         {
             _workerChannelLogger.LogDebug("Count of in-buffer invocations waiting to be drained out: {invocationCount}", _executingInvocations.Count);
@@ -1583,11 +1659,13 @@ namespace Microsoft.Azure.WebJobs.Script.Grpc
             }
         }
 
+        /// <inheritdoc />
         public bool IsExecutingInvocation(string invocationId)
         {
             return _executingInvocations.ContainsKey(invocationId);
         }
 
+        /// <inheritdoc />
         public void Shutdown(Exception workerException)
         {
             TryFailPendingReload(workerException);

--- a/src/WebJobs.Script.Grpc/IWorkerChannel.cs
+++ b/src/WebJobs.Script.Grpc/IWorkerChannel.cs
@@ -5,10 +5,20 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Script.Workers
 {
+    /// <summary>
+    /// Represents a worker communication channel.
+    /// </summary>
     internal interface IWorkerChannel
     {
+        /// <summary>
+        /// Gets the worker identifier.
+        /// </summary>
         string Id { get; }
 
+        /// <summary>
+        /// Gets the current worker status.
+        /// </summary>
+        /// <returns>A task that produces the current worker status.</returns>
         Task<WorkerStatus> GetWorkerStatusAsync();
     }
 }

--- a/src/WebJobs.Script.Grpc/Rpc/IFunctionRpcChannel.cs
+++ b/src/WebJobs.Script.Grpc/Rpc/IFunctionRpcChannel.cs
@@ -10,28 +10,74 @@ using Microsoft.Azure.WebJobs.Script.ManagedDependencies;
 
 namespace Microsoft.Azure.WebJobs.Script.Workers.Rpc
 {
+    /// <summary>
+    /// Defines the shared Functions worker RPC protocol.
+    /// </summary>
     internal interface IFunctionRpcChannel : IWorkerChannel
     {
+        /// <summary>
+        /// Gets the worker configuration.
+        /// </summary>
         RpcWorkerConfig WorkerConfig { get; }
 
+        /// <summary>
+        /// Gets the invocation input buffers keyed by function identifier.
+        /// </summary>
         IDictionary<string, BufferBlock<ScriptInvocationContext>> FunctionInputBuffers { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether the channel can accept invocations.
+        /// </summary>
+        /// <returns><see langword="true"/> when the channel is ready; otherwise, <see langword="false"/>.</returns>
         bool IsChannelReadyForInvocations();
 
+        /// <summary>
+        /// Creates invocation input buffers for the supplied functions.
+        /// </summary>
+        /// <param name="functions">The functions that can be invoked through the channel.</param>
         void SetupFunctionInvocationBuffers(IEnumerable<FunctionMetadata> functions);
 
+        /// <summary>
+        /// Sends function load requests to the worker.
+        /// </summary>
+        /// <param name="managedDependencyOptions">The managed dependency configuration.</param>
+        /// <param name="functionTimeout">The configured function timeout, if any.</param>
         void SendFunctionLoadRequests(ManagedDependencyOptions managedDependencyOptions, TimeSpan? functionTimeout);
 
+        /// <summary>
+        /// Requests a worker environment reload.
+        /// </summary>
+        /// <returns>A task that produces <see langword="true"/> when the reload succeeds.</returns>
         Task<bool> SendFunctionEnvironmentReloadRequest();
 
+        /// <summary>
+        /// Sends a worker warmup request.
+        /// </summary>
         void SendWorkerWarmupRequest();
 
+        /// <summary>
+        /// Requests indexed function metadata from the worker.
+        /// </summary>
+        /// <returns>A task that produces the worker-provided function metadata.</returns>
         Task<List<RawFunctionMetadata>> GetFunctionMetadata();
 
+        /// <summary>
+        /// Waits for active invocations to drain.
+        /// </summary>
+        /// <returns>A task that completes after all active invocations finish.</returns>
         Task DrainInvocationsAsync();
 
+        /// <summary>
+        /// Gets a value indicating whether an invocation is executing.
+        /// </summary>
+        /// <param name="invocationId">The invocation identifier.</param>
+        /// <returns><see langword="true"/> when the invocation is executing; otherwise, <see langword="false"/>.</returns>
         bool IsExecutingInvocation(string invocationId);
 
+        /// <summary>
+        /// Shuts down active channel operations.
+        /// </summary>
+        /// <param name="workerException">The worker failure that caused shutdown, if any.</param>
         void Shutdown(Exception workerException);
     }
 }

--- a/test/Functions.Rpc.Client.Tests/DuplexChannelFactoryTests.cs
+++ b/test/Functions.Rpc.Client.Tests/DuplexChannelFactoryTests.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Threading.Channels;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Grpc;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Xunit;
 
@@ -18,7 +18,7 @@ public class DuplexChannelFactoryTests
         TestDuplexChannelFactory<StreamingMessage> factory = new(() => expected);
         Uri endpoint = new("https://localhost:5001");
 
-        Channel<StreamingMessage> actual = await factory.ConnectAsync(endpoint);
+        DuplexChannel<StreamingMessage> actual = await factory.ConnectAsync(endpoint);
         await actual.Writer.WriteAsync(new StreamingMessage { RequestId = "outbound" });
         StreamingMessage outbound = await expected.Requests.ReadAsync();
         await expected.SendResponseAsync(new StreamingMessage { RequestId = "inbound" });
@@ -37,8 +37,8 @@ public class DuplexChannelFactoryTests
         TestDuplexChannelFactory<StreamingMessage> factory = new(() => new TestDuplexChannel<StreamingMessage>());
         Uri endpoint = new("https://localhost:5001");
 
-        Channel<StreamingMessage> first = await factory.ConnectAsync(endpoint);
-        Channel<StreamingMessage> second = await factory.ConnectAsync(endpoint);
+        DuplexChannel<StreamingMessage> first = await factory.ConnectAsync(endpoint);
+        DuplexChannel<StreamingMessage> second = await factory.ConnectAsync(endpoint);
 
         Assert.NotSame(first, second);
         Assert.Equal(2, factory.InvocationCount);

--- a/test/Functions.Rpc.Client.Tests/FunctionRpcDuplexChannelIntegrationTests.cs
+++ b/test/Functions.Rpc.Client.Tests/FunctionRpcDuplexChannelIntegrationTests.cs
@@ -7,8 +7,8 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Grpc;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -25,8 +25,7 @@ public class FunctionRpcDuplexChannelIntegrationTests
         await using TestFunctionRpcServer server = await TestFunctionRpcServer.StartAsync();
         await using RpcClientFactory clientFactory = CreateClientFactory();
         FunctionRpcDuplexChannelFactory channelFactory = CreateChannelFactory(clientFactory);
-        Channel<StreamingMessage> channel = await channelFactory.ConnectAsync(server.Endpoint);
-        await using IAsyncDisposable channelLifetime = Assert.IsAssignableFrom<IAsyncDisposable>(channel);
+        await using DuplexChannel<StreamingMessage> channel = await channelFactory.ConnectAsync(server.Endpoint);
         await server.Service.Connected.WaitAsync(TestTimeout);
 
         StreamingMessage outbound = new() { RequestId = "outbound" };
@@ -48,8 +47,7 @@ public class FunctionRpcDuplexChannelIntegrationTests
         await using TestFunctionRpcServer server = await TestFunctionRpcServer.StartAsync();
         await using RpcClientFactory clientFactory = CreateClientFactory();
         FunctionRpcDuplexChannelFactory channelFactory = CreateChannelFactory(clientFactory);
-        Channel<StreamingMessage> channel = await channelFactory.ConnectAsync(server.Endpoint);
-        await using IAsyncDisposable channelLifetime = Assert.IsAssignableFrom<IAsyncDisposable>(channel);
+        await using DuplexChannel<StreamingMessage> channel = await channelFactory.ConnectAsync(server.Endpoint);
         await server.Service.Connected.WaitAsync(TestTimeout);
 
         server.Service.CompleteResponses();
@@ -64,8 +62,7 @@ public class FunctionRpcDuplexChannelIntegrationTests
         await using TestFunctionRpcServer server = await TestFunctionRpcServer.StartAsync();
         await using RpcClientFactory clientFactory = CreateClientFactory();
         FunctionRpcDuplexChannelFactory channelFactory = CreateChannelFactory(clientFactory);
-        Channel<StreamingMessage> channel = await channelFactory.ConnectAsync(server.Endpoint);
-        await using IAsyncDisposable channelLifetime = Assert.IsAssignableFrom<IAsyncDisposable>(channel);
+        await using DuplexChannel<StreamingMessage> channel = await channelFactory.ConnectAsync(server.Endpoint);
         await server.Service.Connected.WaitAsync(TestTimeout);
 
         await server.Service.SendResponseAsync(new StreamingMessage { RequestId = "one" });
@@ -85,8 +82,7 @@ public class FunctionRpcDuplexChannelIntegrationTests
         await using TestFunctionRpcServer server = await TestFunctionRpcServer.StartAsync();
         await using RpcClientFactory clientFactory = CreateClientFactory();
         FunctionRpcDuplexChannelFactory channelFactory = CreateChannelFactory(clientFactory);
-        Channel<StreamingMessage> channel = await channelFactory.ConnectAsync(server.Endpoint);
-        await using IAsyncDisposable channelLifetime = Assert.IsAssignableFrom<IAsyncDisposable>(channel);
+        await using DuplexChannel<StreamingMessage> channel = await channelFactory.ConnectAsync(server.Endpoint);
         await server.Service.Connected.WaitAsync(TestTimeout);
         server.Service.CompleteResponses(new InvalidOperationException("server failure"));
 
@@ -123,11 +119,10 @@ public class FunctionRpcDuplexChannelIntegrationTests
         await using TestFunctionRpcServer server = await TestFunctionRpcServer.StartAsync();
         await using RpcClientFactory clientFactory = CreateClientFactory();
         FunctionRpcDuplexChannelFactory channelFactory = CreateChannelFactory(clientFactory);
-        Channel<StreamingMessage> channel = await channelFactory.ConnectAsync(server.Endpoint);
-        IAsyncDisposable channelLifetime = Assert.IsAssignableFrom<IAsyncDisposable>(channel);
+        DuplexChannel<StreamingMessage> channel = await channelFactory.ConnectAsync(server.Endpoint);
         await server.Service.Connected.WaitAsync(TestTimeout);
 
-        await channelLifetime.DisposeAsync();
+        await channel.DisposeAsync();
 
         await channel.Reader.Completion.WaitAsync(TestTimeout);
     }
@@ -138,8 +133,7 @@ public class FunctionRpcDuplexChannelIntegrationTests
         await using TestFunctionRpcServer server = await TestFunctionRpcServer.StartAsync(mapService: false);
         await using RpcClientFactory clientFactory = CreateClientFactory();
         FunctionRpcDuplexChannelFactory channelFactory = CreateChannelFactory(clientFactory);
-        Channel<StreamingMessage> channel = await channelFactory.ConnectAsync(server.Endpoint);
-        await using IAsyncDisposable channelLifetime = Assert.IsAssignableFrom<IAsyncDisposable>(channel);
+        await using DuplexChannel<StreamingMessage> channel = await channelFactory.ConnectAsync(server.Endpoint);
 
         await Assert.ThrowsAsync<Grpc.Core.RpcException>(() => channel.Reader.Completion.WaitAsync(TestTimeout));
     }
@@ -160,7 +154,7 @@ public class FunctionRpcDuplexChannelIntegrationTests
         return port;
     }
 
-    private static async Task<IReadOnlyList<StreamingMessage>> ReadAllAsync(Channel<StreamingMessage> channel)
+    private static async Task<IReadOnlyList<StreamingMessage>> ReadAllAsync(DuplexChannel<StreamingMessage> channel)
     {
         List<StreamingMessage> messages = [];
         using CancellationTokenSource timeoutSource = new(TestTimeout);
@@ -172,7 +166,7 @@ public class FunctionRpcDuplexChannelIntegrationTests
         return messages;
     }
 
-    private static async Task<StreamingMessage> ReadNextAsync(Channel<StreamingMessage> channel)
+    private static async Task<StreamingMessage> ReadNextAsync(DuplexChannel<StreamingMessage> channel)
     {
         using CancellationTokenSource timeoutSource = new(TestTimeout);
         return await channel.Reader.ReadAsync(timeoutSource.Token);

--- a/test/Functions.Rpc.Client.Tests/Functions.Rpc.Client.Tests.csproj
+++ b/test/Functions.Rpc.Client.Tests/Functions.Rpc.Client.Tests.csproj
@@ -15,6 +15,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Grpc.AspNetCore" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" PrivateAssets="all" />
+    <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
   </ItemGroup>

--- a/test/Functions.Rpc.Client.Tests/RpcClientAssemblyTests.cs
+++ b/test/Functions.Rpc.Client.Tests/RpcClientAssemblyTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
+using Microsoft.Azure.WebJobs.Script.Grpc;
 using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
 using Xunit;
 
@@ -41,9 +42,20 @@ public class RpcClientAssemblyTests
     }
 
     [Fact]
+    public void RpcClientWorkerChannelDerivesPublicSharedWorkerChannel()
+    {
+        Assert.True(typeof(WorkerChannel).IsPublic);
+        Assert.Equal(typeof(WorkerChannel), typeof(RpcClientWorkerChannel).BaseType);
+        Assert.Equal("Azure.Functions.Rpc.Client", typeof(RpcClientWorkerChannel).Assembly.GetName().Name);
+    }
+
+    [Fact]
     public void ProductProjectReferencesPreserveSiblingBoundaries()
     {
-        Assert.Equal(["..\\WebJobs.Script.Grpc\\WebJobs.Script.Grpc.csproj"], GetProjectReferences("Functions.Rpc.Client.csproj"));
+        string[] clientReferences = GetProjectReferences("Functions.Rpc.Client.csproj");
+        string[] expectedClientReferences = ["..\\WebJobs.Script.Grpc\\WebJobs.Script.Grpc.csproj", "..\\WebJobs.Script\\WebJobs.Script.csproj"];
+        Assert.Equal(expectedClientReferences.OrderBy(reference => reference, StringComparer.Ordinal),
+            clientReferences.OrderBy(reference => reference, StringComparer.Ordinal));
         Assert.Equal(["..\\WebJobs.Script\\WebJobs.Script.csproj"], GetProjectReferences("WebJobs.Script.Grpc.csproj"));
         Assert.DoesNotContain(GetProjectReferences("Functions.Rpc.Server.csproj"),
             reference => reference.Contains("Functions.Rpc.Client", StringComparison.Ordinal));

--- a/test/Functions.Rpc.Client.Tests/RpcClientWorkerChannelTests.cs
+++ b/test/Functions.Rpc.Client.Tests/RpcClientWorkerChannelTests.cs
@@ -1,0 +1,308 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script;
+using Microsoft.Azure.WebJobs.Script.AppCapabilities;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.Eventing;
+using Microsoft.Azure.WebJobs.Script.Grpc.Messages;
+using Microsoft.Azure.WebJobs.Script.Http;
+using Microsoft.Azure.WebJobs.Script.Workers;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
+using Microsoft.Azure.WebJobs.Script.Workers.SharedMemoryDataTransfer;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+using RpcExceptionMessage = Microsoft.Azure.WebJobs.Script.Grpc.Messages.RpcException;
+
+namespace Azure.Functions.Rpc.Client.Tests;
+
+public sealed class RpcClientWorkerChannelTests
+{
+    private const string WorkerId = "test-worker";
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(10);
+
+    private readonly Mock<IAppCapabilitiesStore> _appCapabilitiesStore = new();
+    private readonly RpcClientWorkerChannelFactory _factory;
+    private readonly IMetricsLogger _metricsLogger = Mock.Of<IMetricsLogger>();
+    private readonly RpcWorkerConfig _workerConfig;
+
+    public RpcClientWorkerChannelTests()
+    {
+        Mock<IScriptHostManager> hostManager = new();
+        hostManager.As<IServiceProvider>()
+            .Setup(provider => provider.GetService(typeof(IOptions<ScriptJobHostOptions>)))
+            .Returns(Options.Create(new ScriptJobHostOptions { RootScriptPath = "c:\\test" }));
+
+        Mock<IOptionsMonitor<ScriptApplicationHostOptions>> applicationHostOptions = new();
+        applicationHostOptions.SetupGet(options => options.CurrentValue)
+            .Returns(new ScriptApplicationHostOptions { ScriptPath = "c:\\test" });
+
+        _workerConfig = new RpcWorkerConfig
+        {
+            Description = new RpcWorkerDescription
+            {
+                Language = "node",
+                WorkerDirectory = "c:\\worker",
+            },
+            CountOptions = new WorkerProcessCountOptions
+            {
+                ProcessStartupTimeout = TimeSpan.FromSeconds(5),
+                InitializationTimeout = TimeSpan.FromSeconds(5),
+            },
+        };
+        _appCapabilitiesStore.Setup(store => store.TrySetAll(It.IsAny<IEnumerable<KeyValuePair<string, string>>>()))
+            .Returns(true);
+
+        _factory = new RpcClientWorkerChannelFactory(
+            new ScriptEventManager(),
+            hostManager.Object,
+            Mock.Of<IEnvironment>(),
+            NullLoggerFactory.Instance,
+            applicationHostOptions.Object,
+            Mock.Of<ISharedMemoryManager>(),
+            Options.Create(new WorkerConcurrencyOptions()),
+            Options.Create(new FunctionsHostingConfigOptions()),
+            _appCapabilitiesStore.Object,
+            Mock.Of<IHttpProxyService>());
+    }
+
+    [Fact]
+    public async Task StartAsync_CompletesAfterHandshakeAndAppliesInitialization()
+    {
+        TestDuplexChannel<StreamingMessage> duplexChannel = new();
+        RpcClientWorkerChannel channel = CreateChannel(duplexChannel);
+        Task start = channel.StartAsync(CancellationToken.None);
+
+        StreamingMessage initRequest = await SendStartStreamAndReadInitRequestAsync(duplexChannel);
+        WorkerInitResponse initResponse = CreateSuccessfulInitResponse();
+        initResponse.Capabilities.Add("TestCapability", "enabled");
+        initResponse.AppCapabilities.Add("TestAppCapability", "enabled");
+        initResponse.WorkerMetadata = new WorkerMetadata
+        {
+            RuntimeName = "node",
+            RuntimeVersion = "24.0",
+        };
+
+        await duplexChannel.SendResponseAsync(new StreamingMessage { WorkerInitResponse = initResponse });
+        await start.WaitAsync(TestTimeout);
+
+        Assert.Equal(StreamingMessage.ContentOneofCase.WorkerInitRequest, initRequest.ContentCase);
+        Assert.Equal("c:\\test", initRequest.WorkerInitRequest.FunctionAppDirectory);
+        Assert.Equal("node", _workerConfig.Description.DefaultRuntimeName);
+        Assert.Equal("24.0", _workerConfig.Description.DefaultRuntimeVersion);
+        _appCapabilitiesStore.Verify(store => store.TrySetAll(
+            It.Is<IEnumerable<KeyValuePair<string, string>>>(capabilities =>
+                capabilities.Any(capability => string.Equals(capability.Key, "TestAppCapability", StringComparison.Ordinal) &&
+                    string.Equals(capability.Value, "enabled", StringComparison.Ordinal)))), Times.Once);
+
+        await channel.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_PropagatesWorkerInitializationFailure()
+    {
+        TestDuplexChannel<StreamingMessage> duplexChannel = new();
+        RpcClientWorkerChannel channel = CreateChannel(duplexChannel);
+        Task start = channel.StartAsync(CancellationToken.None);
+        await SendStartStreamAndReadInitRequestAsync(duplexChannel);
+        WorkerInitResponse initResponse = new()
+        {
+            Result = new StatusResult
+            {
+                Status = StatusResult.Types.Status.Failure,
+                Exception = new RpcExceptionMessage { Message = "worker initialization failed" },
+            },
+        };
+
+        await duplexChannel.SendResponseAsync(new StreamingMessage { WorkerInitResponse = initResponse });
+
+        Microsoft.Azure.WebJobs.Script.Workers.Rpc.RpcException exception =
+            await Assert.ThrowsAsync<Microsoft.Azure.WebJobs.Script.Workers.Rpc.RpcException>(() => start.WaitAsync(TestTimeout));
+        Assert.Contains("worker initialization failed", exception.Message, StringComparison.Ordinal);
+
+        await channel.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_StartStreamTimeout_PropagatesTimeout()
+    {
+        _workerConfig.CountOptions.ProcessStartupTimeout = TimeSpan.FromMilliseconds(50);
+        TestDuplexChannel<StreamingMessage> duplexChannel = new();
+        RpcClientWorkerChannel channel = CreateChannel(duplexChannel);
+
+        await Assert.ThrowsAsync<TimeoutException>(() => channel.StartAsync(CancellationToken.None).WaitAsync(TestTimeout));
+
+        await channel.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_InitializationTimeout_PropagatesTimeout()
+    {
+        _workerConfig.CountOptions.InitializationTimeout = TimeSpan.FromMilliseconds(50);
+        TestDuplexChannel<StreamingMessage> duplexChannel = new();
+        RpcClientWorkerChannel channel = CreateChannel(duplexChannel);
+        Task start = channel.StartAsync(CancellationToken.None);
+        await SendStartStreamAndReadInitRequestAsync(duplexChannel);
+
+        await Assert.ThrowsAsync<TimeoutException>(() => start.WaitAsync(TestTimeout));
+
+        await channel.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_CleanChannelCompletionBeforeInitialization_Throws()
+    {
+        TestDuplexChannel<StreamingMessage> duplexChannel = new();
+        RpcClientWorkerChannel channel = CreateChannel(duplexChannel);
+        Task start = channel.StartAsync(CancellationToken.None);
+
+        duplexChannel.CompleteResponses();
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() => start.WaitAsync(TestTimeout));
+        Assert.Equal("The RPC channel closed unexpectedly before the worker initialized.", exception.Message);
+        await duplexChannel.DisposeStarted.WaitAsync(TestTimeout);
+        Assert.Equal(1, duplexChannel.DisposeCount);
+
+        await channel.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_FaultedChannelBeforeInitialization_PropagatesFailure()
+    {
+        InvalidOperationException expected = new("channel failed");
+        TestDuplexChannel<StreamingMessage> duplexChannel = new();
+        RpcClientWorkerChannel channel = CreateChannel(duplexChannel);
+        Task start = channel.StartAsync(CancellationToken.None);
+
+        duplexChannel.CompleteResponses(expected);
+
+        InvalidOperationException actual = await Assert.ThrowsAsync<InvalidOperationException>(() => start.WaitAsync(TestTimeout));
+        Assert.Same(expected, actual);
+        await duplexChannel.DisposeStarted.WaitAsync(TestTimeout);
+        Assert.Equal(1, duplexChannel.DisposeCount);
+
+        await channel.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_ConcurrentAndRepeatedCallsShareInitialization()
+    {
+        TestDuplexChannel<StreamingMessage> duplexChannel = new();
+        RpcClientWorkerChannel channel = CreateChannel(duplexChannel);
+
+        Task first = channel.StartAsync(CancellationToken.None);
+        Task concurrent = channel.StartAsync(CancellationToken.None);
+        Assert.Same(first, concurrent);
+
+        await SendStartStreamAndReadInitRequestAsync(duplexChannel);
+        await duplexChannel.SendResponseAsync(new StreamingMessage { WorkerInitResponse = CreateSuccessfulInitResponse() });
+        await Task.WhenAll(first, concurrent).WaitAsync(TestTimeout);
+
+        Task repeated = channel.StartAsync(CancellationToken.None);
+        Assert.Same(first, repeated);
+        Assert.True(repeated.IsCompletedSuccessfully);
+        Assert.False(duplexChannel.Requests.TryRead(out _));
+
+        await channel.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_PreCanceledCallerDoesNotBeginInitialization()
+    {
+        TestDuplexChannel<StreamingMessage> duplexChannel = new();
+        RpcClientWorkerChannel channel = CreateChannel(duplexChannel);
+        using CancellationTokenSource cancellationSource = new();
+        cancellationSource.Cancel();
+
+        Task canceledStart = channel.StartAsync(cancellationSource.Token);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledStart);
+
+        Task sharedStart = channel.StartAsync(CancellationToken.None);
+        await SendStartStreamAndReadInitRequestAsync(duplexChannel);
+        await duplexChannel.SendResponseAsync(new StreamingMessage { WorkerInitResponse = CreateSuccessfulInitResponse() });
+        await sharedStart.WaitAsync(TestTimeout);
+
+        await channel.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_CanceledCallerDoesNotCancelSharedInitialization()
+    {
+        TestDuplexChannel<StreamingMessage> duplexChannel = new();
+        RpcClientWorkerChannel channel = CreateChannel(duplexChannel);
+        using CancellationTokenSource cancellationSource = new();
+
+        Task canceledWait = channel.StartAsync(cancellationSource.Token);
+        Task sharedStart = channel.StartAsync(CancellationToken.None);
+        cancellationSource.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledWait);
+        Assert.False(sharedStart.IsCompleted);
+
+        await SendStartStreamAndReadInitRequestAsync(duplexChannel);
+        await duplexChannel.SendResponseAsync(new StreamingMessage { WorkerInitResponse = CreateSuccessfulInitResponse() });
+        await sharedStart.WaitAsync(TestTimeout);
+
+        await channel.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_ConcurrentWithStartDisposesChannelOnce()
+    {
+        TestDuplexChannel<StreamingMessage> duplexChannel = new(blockDisposal: true);
+        RpcClientWorkerChannel channel = CreateChannel(duplexChannel);
+        Task start = channel.StartAsync(CancellationToken.None);
+
+        Task firstDispose = channel.DisposeAsync().AsTask();
+        Task concurrentDispose = channel.DisposeAsync().AsTask();
+        await duplexChannel.DisposeStarted.WaitAsync(TestTimeout);
+
+        Assert.Same(firstDispose, concurrentDispose);
+        Assert.Equal(1, duplexChannel.DisposeCount);
+        Assert.False(firstDispose.IsCompleted);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => start.WaitAsync(TestTimeout));
+
+        duplexChannel.AllowDispose();
+        await Task.WhenAll(firstDispose, concurrentDispose).WaitAsync(TestTimeout);
+        await channel.DisposeAsync();
+        Assert.Equal(1, duplexChannel.DisposeCount);
+    }
+
+    [Fact]
+    public async Task StartAsync_AfterDisposal_ThrowsObjectDisposedException()
+    {
+        TestDuplexChannel<StreamingMessage> duplexChannel = new();
+        RpcClientWorkerChannel channel = CreateChannel(duplexChannel);
+        await channel.DisposeAsync();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => channel.StartAsync(CancellationToken.None));
+        Assert.Equal(1, duplexChannel.DisposeCount);
+    }
+
+    private RpcClientWorkerChannel CreateChannel(TestDuplexChannel<StreamingMessage> duplexChannel)
+        => _factory.Create(WorkerId, duplexChannel, _workerConfig, _metricsLogger, attemptCount: 0);
+
+    private static WorkerInitResponse CreateSuccessfulInitResponse()
+        => new()
+        {
+            Result = new StatusResult { Status = StatusResult.Types.Status.Success },
+        };
+
+    private static async Task<StreamingMessage> SendStartStreamAndReadInitRequestAsync(TestDuplexChannel<StreamingMessage> duplexChannel)
+    {
+        await duplexChannel.SendResponseAsync(new StreamingMessage
+        {
+            StartStream = new StartStream { WorkerId = WorkerId },
+        });
+
+        return await duplexChannel.Requests.ReadAsync().AsTask().WaitAsync(TestTimeout);
+    }
+}

--- a/test/Functions.Rpc.Client.Tests/TestDuplexChannel.cs
+++ b/test/Functions.Rpc.Client.Tests/TestDuplexChannel.cs
@@ -55,7 +55,7 @@ internal sealed class TestDuplexChannel<T> : DuplexChannel<T>
     internal void AllowDispose() => _allowDispose.TrySetResult();
 
     /// <summary>
-    /// Completes the response boundary, optionally with a channel failure.
+    /// Completes both channel boundaries, optionally with a channel failure.
     /// </summary>
     /// <param name="exception">The channel failure, or <see langword="null"/> for clean completion.</param>
     internal void CompleteResponses(Exception exception = null)

--- a/test/Functions.Rpc.Client.Tests/TestDuplexChannel.cs
+++ b/test/Functions.Rpc.Client.Tests/TestDuplexChannel.cs
@@ -5,26 +5,33 @@ using System;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Grpc;
 
 namespace Azure.Functions.Rpc.Client.Tests;
 
 /// <summary>
 /// Provides a replaceable duplex channel without creating network or gRPC resources.
 /// </summary>
-internal sealed class TestDuplexChannel<T> : Channel<T>, IAsyncDisposable
+internal sealed class TestDuplexChannel<T> : DuplexChannel<T>
     where T : class
 {
+    private readonly TaskCompletionSource _allowDispose = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _disposeStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly Channel<T> _requests;
     private readonly Channel<T> _responses;
     private int _disposeCount;
-    private int _disposed;
 
-    internal TestDuplexChannel()
+    internal TestDuplexChannel(bool blockDisposal = false)
     {
         _requests = Channel.CreateUnbounded<T>();
         _responses = Channel.CreateUnbounded<T>();
         Reader = _responses.Reader;
         Writer = _requests.Writer;
+
+        if (!blockDisposal)
+        {
+            _allowDispose.TrySetResult();
+        }
     }
 
     /// <summary>
@@ -33,14 +40,24 @@ internal sealed class TestDuplexChannel<T> : Channel<T>, IAsyncDisposable
     internal int DisposeCount => Interlocked.CompareExchange(ref _disposeCount, 0, 0);
 
     /// <summary>
+    /// Gets a task that completes when asynchronous disposal starts.
+    /// </summary>
+    internal Task DisposeStarted => _disposeStarted.Task;
+
+    /// <summary>
     /// Gets requests written by the channel consumer.
     /// </summary>
     internal ChannelReader<T> Requests => _requests.Reader;
 
     /// <summary>
-    /// Completes the response boundary, optionally with a transport failure.
+    /// Allows a blocked asynchronous disposal operation to complete.
     /// </summary>
-    /// <param name="exception">The transport failure, or <see langword="null"/> for clean completion.</param>
+    internal void AllowDispose() => _allowDispose.TrySetResult();
+
+    /// <summary>
+    /// Completes the response boundary, optionally with a channel failure.
+    /// </summary>
+    /// <param name="exception">The channel failure, or <see langword="null"/> for clean completion.</param>
     internal void CompleteResponses(Exception exception = null)
     {
         _requests.Writer.TryComplete(exception);
@@ -56,19 +73,12 @@ internal sealed class TestDuplexChannel<T> : Channel<T>, IAsyncDisposable
     internal ValueTask SendResponseAsync(T response, CancellationToken cancellationToken = default)
         => _responses.Writer.WriteAsync(response, cancellationToken);
 
-    /// <summary>
-    /// Completes both channel boundaries.
-    /// </summary>
-    /// <returns>A completed task.</returns>
-    public ValueTask DisposeAsync()
+    protected override async ValueTask DisposeAsyncCore()
     {
-        if (Interlocked.Exchange(ref _disposed, 1) == 0)
-        {
-            Interlocked.Increment(ref _disposeCount);
-            _requests.Writer.TryComplete();
-            _responses.Writer.TryComplete();
-        }
-
-        return ValueTask.CompletedTask;
+        Interlocked.Increment(ref _disposeCount);
+        _requests.Writer.TryComplete();
+        _responses.Writer.TryComplete();
+        _disposeStarted.TrySetResult();
+        await _allowDispose.Task;
     }
 }

--- a/test/Functions.Rpc.Client.Tests/TestDuplexChannelFactory.cs
+++ b/test/Functions.Rpc.Client.Tests/TestDuplexChannelFactory.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.Grpc;
 
 namespace Azure.Functions.Rpc.Client.Tests;
 
@@ -14,9 +14,9 @@ namespace Azure.Functions.Rpc.Client.Tests;
 internal sealed class TestDuplexChannelFactory<T> : IDuplexChannelFactory<T>
     where T : class
 {
-    private readonly Func<Channel<T>> _channelFactory;
+    private readonly Func<DuplexChannel<T>> _channelFactory;
 
-    internal TestDuplexChannelFactory(Func<Channel<T>> channelFactory)
+    internal TestDuplexChannelFactory(Func<DuplexChannel<T>> channelFactory)
     {
         _channelFactory = channelFactory ?? throw new ArgumentNullException(nameof(channelFactory));
     }
@@ -26,7 +26,7 @@ internal sealed class TestDuplexChannelFactory<T> : IDuplexChannelFactory<T>
     internal int InvocationCount { get; private set; }
 
     /// <inheritdoc />
-    public Task<Channel<T>> ConnectAsync(Uri endpoint, CancellationToken cancellationToken = default)
+    public Task<DuplexChannel<T>> ConnectAsync(Uri endpoint, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         Endpoint = endpoint;

--- a/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
+++ b/test/WebJobs.Script.Tests/Workers/Rpc/GrpcWorkerChannelTests.cs
@@ -228,6 +228,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Workers.Rpc
         }
 
         [Fact]
+        public async Task StartWorkerProcessAsync_ChannelCompletesBeforeInitialization_Throws()
+        {
+            await CreateDefaultWorkerChannel(autoStart: false);
+            Task start = _workerChannel.StartWorkerProcessAsync(CancellationToken.None);
+
+            Assert.True(_serviceEndpoints.WorkerToHostWriter.TryComplete());
+
+            InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() => start)
+                .WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal("The RPC channel closed unexpectedly before the worker initialized.", exception.Message);
+            Assert.False(start.IsCanceled);
+        }
+
+        [Fact]
         public async Task StartWorkerProcessAsync_TimesOut()
         {
             await CreateDefaultWorkerChannel(autoStart: false); // suppress for timeout


### PR DESCRIPTION
Adds the client-backed `RpcClientWorkerChannel` used when the Functions runtime connects outbound to a worker endpoint supplied through `/link`. It reuses the existing shared `WorkerChannel` protocol while replacing the local-process/server channel with an outbound FunctionRpc client channel.

This PR adds the underlying channel and factories. The `/link` endpoint, channel registry, and dispatcher wiring will be added in later PRs.

Note there's a bunch of added doc comments here b/c WorkerChannel is now public to allow us to derive from it. That's a bunch of the changes you'll see...

## Changes

- Adds `RpcClientWorkerChannel : WorkerChannel` in `Azure.Functions.Rpc.Client`.
- Adds an internal, DI-ready `RpcClientWorkerChannelFactory`.
- Makes `WorkerChannel` publicly derivable while keeping server-only hooks internal.
- Changes `GrpcDuplexChannel<T>` to derive from shared `DuplexChannel<T>` and use its idempotent disposal implementation.
- Updates duplex-channel factories to return `DuplexChannel<T>`, making ownership explicit.
- Makes repeated and concurrent `StartAsync` calls share one initialization attempt.
- Keeps caller cancellation scoped to that caller’s wait.
- Preserves channel exceptions observed before initialization.
- Treats unexpected clean channel closure before initialization as startup failure.
- Preserves explicit disposal as cancellation rather than unexpected failure.
- Keeps the Client → Grpc/Script dependency direction; Grpc, Server, and WebHost do not reference Client.


**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)

Closes #11970