### PR TITLE
adding composition extensibility for host

### DIFF
--- a/Azure.Functions.Host.slnx
+++ b/Azure.Functions.Host.slnx
@@ -5,6 +5,7 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/src/">
+    <Project Path="src/Functions.Host/Functions.Host.csproj" />
     <Project Path="src/Functions.Rpc.Client/Functions.Rpc.Client.csproj" />
     <Project Path="src/Functions.Rpc.Server/Functions.Rpc.Server.csproj" />
     <Project Path="src/Functions.WorkerProxy/Functions.WorkerProxy.csproj" />
@@ -13,6 +14,7 @@
     <Project Path="src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj" />
   </Folder>
   <Folder Name="/test/">
+    <Project Path="test/Functions.Host.Tests/Functions.Host.Tests.csproj" />
     <Project Path="test/Functions.Rpc.Client.Tests/Functions.Rpc.Client.Tests.csproj" />
     <Project Path="test/Functions.WorkerProxy.Tests/Functions.WorkerProxy.Tests.csproj" />
   </Folder>

--- a/src/Functions.Host/ClientWorkerComposition.cs
+++ b/src/Functions.Host/ClientWorkerComposition.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Script.Composition;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Azure.Functions.Host;
+
+/// <summary>
+/// Defines the Client-backed worker composition for the separate Functions Host.
+/// </summary>
+/// <remarks>
+/// Client-backed registrations land in later milestones. The throwing methods make the intentionally incomplete
+/// boundary visible until those registrations are supplied.
+/// </remarks>
+internal sealed class ClientWorkerComposition : IWorkerComposition
+{
+    private ClientWorkerComposition()
+    {
+    }
+
+    public static ClientWorkerComposition Instance { get; } = new();
+
+    public void ConfigureWebHostServices(IServiceCollection services, IMvcBuilder mvcBuilder)
+    {
+        throw new NotImplementedException("Client WebHost worker composition is not implemented.");
+    }
+
+    public void ConfigureScriptHostServices(IServiceCollection services, IServiceProvider rootServiceProvider)
+    {
+        throw new NotImplementedException("Client ScriptHost worker composition is not implemented.");
+    }
+}

--- a/src/Functions.Host/Functions.Host.csproj
+++ b/src/Functions.Host/Functions.Host.csproj
@@ -1,0 +1,56 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(WorkersProps)" />
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RuntimeIdentifiers>linux-x64</RuntimeIdentifiers>
+    <PackageId>Azure.Functions.Host</PackageId>
+    <AssemblyName>Azure.Functions.Host</AssemblyName>
+    <RootNamespace>Azure.Functions.Host</RootNamespace>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <TieredCompilation>false</TieredCompilation>
+    <UserRuntimeConfig>$(MSBuildThisFileDirectory)..\WebJobs.Script.WebHost\runtimeconfig.template.json</UserRuntimeConfig>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <PublishReadyToRunUseCrossgen2>true</PublishReadyToRunUseCrossgen2>
+    <PublishReadyToRunComposite>true</PublishReadyToRunComposite>
+    <PublishReadyToRunEmitSymbols>true</PublishReadyToRunEmitSymbols>
+    <PublishReadyToRunShowWarnings>true</PublishReadyToRunShowWarnings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- This interim reference makes the shared FunctionsHost entrypoint explicit. A later project split removes the
+         transitive Rpc.Server implementation from the compute publish graph. -->
+    <ProjectReference Include="..\WebJobs.Script.WebHost\WebJobs.Script.WebHost.csproj" />
+  </ItemGroup>
+
+  <!-- WebHost is referenced for its shared implementation, not as a second executable or IIS artifact. -->
+  <Target Name="RemoveStandardWebHostEntrypointFromPublish" AfterTargets="ComputeFilesToPublish">
+    <ItemGroup>
+      <ResolvedFileToPublish
+        Remove="@(ResolvedFileToPublish)"
+        Condition="'%(RelativePath)' == 'Microsoft.Azure.WebJobs.Script.WebHost' Or
+                   '%(RelativePath)' == 'Microsoft.Azure.WebJobs.Script.WebHost.exe' Or
+                   '%(RelativePath)' == 'Microsoft.Azure.WebJobs.Script.WebHost.deps.json' Or
+                   '%(RelativePath)' == 'Microsoft.Azure.WebJobs.Script.WebHost.runtimeconfig.json'" />
+      <ResolvedFileToPublish
+        Remove="@(ResolvedFileToPublish)"
+        Condition="'%(RelativePath)' == 'web.config' And
+                   $([System.String]::Copy('%(FullPath)').Contains('WebJobs.Script.WebHost'))" />
+    </ItemGroup>
+  </Target>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Azure.Functions.Host.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/Functions.Host/Program.cs
+++ b/src/Functions.Host/Program.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+
+namespace Azure.Functions.Host;
+
+internal static class Program
+{
+    public static async Task Main(string[] args)
+    {
+        await FunctionsHost.RunAsync(args, ClientWorkerComposition.Instance);
+    }
+}

--- a/src/Functions.Host/Program.cs
+++ b/src/Functions.Host/Program.cs
@@ -1,15 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Threading.Tasks;
+using Azure.Functions.Host;
 using Microsoft.Azure.WebJobs.Script.WebHost;
 
-namespace Azure.Functions.Host;
-
-internal static class Program
-{
-    public static async Task Main(string[] args)
-    {
-        await FunctionsHost.RunAsync(args, ClientWorkerComposition.Instance);
-    }
-}
+await FunctionsHost.RunAsync(args, ClientWorkerComposition.Instance);

--- a/src/WebJobs.Script.WebHost/Composition/SelectedWorkerComposition.cs
+++ b/src/WebJobs.Script.WebHost/Composition/SelectedWorkerComposition.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Script.Composition;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Composition;
+
+/// <summary>
+/// Preserves the composition that configured the root WebHost for use by later child ScriptHost builds.
+/// </summary>
+/// <remarks>
+/// The public <see cref="IWorkerComposition"/> interface is not used as the DI selection key because unrelated
+/// registrations could replace it after the root services were already configured. This internal holder keeps root
+/// and child composition aligned across ScriptHost restarts.
+/// </remarks>
+internal sealed class SelectedWorkerComposition(IWorkerComposition composition)
+{
+    public IWorkerComposition Value { get; } = composition ?? throw new ArgumentNullException(nameof(composition));
+}

--- a/src/WebJobs.Script.WebHost/Composition/ServerWorkerComposition.cs
+++ b/src/WebJobs.Script.WebHost/Composition/ServerWorkerComposition.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Azure.WebJobs.Script.Composition;
+using Microsoft.Azure.WebJobs.Script.Grpc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost.Composition;
+
+internal sealed class ServerWorkerComposition : IWorkerComposition
+{
+    private ServerWorkerComposition()
+    {
+    }
+
+    public static ServerWorkerComposition Instance { get; } = new();
+
+    public void ConfigureWebHostServices(IServiceCollection services, IMvcBuilder mvcBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(mvcBuilder);
+
+        services.AddScriptGrpc();
+        services.AddCommonRpcServices();
+        services.AddSingleton<IHostedService>(provider => provider.GetRequiredService<WebJobsScriptHostService>());
+    }
+
+    public void ConfigureScriptHostServices(IServiceCollection services, IServiceProvider rootServiceProvider)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(rootServiceProvider);
+
+        services.AddRpcScriptHostServices();
+    }
+}

--- a/src/WebJobs.Script.WebHost/DefaultScriptHostBuilder.cs
+++ b/src/WebJobs.Script.WebHost/DefaultScriptHostBuilder.cs
@@ -1,9 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
 using System.Linq;
 using Microsoft.Azure.WebJobs.Hosting;
+using Microsoft.Azure.WebJobs.Script.Composition;
+using Microsoft.Azure.WebJobs.Script.WebHost.Composition;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
@@ -13,6 +15,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
     public sealed class DefaultScriptHostBuilder : IScriptHostBuilder
     {
         private readonly IOptionsMonitor<ScriptApplicationHostOptions> _applicationHostOptions;
+        private readonly IWorkerComposition _composition;
         private readonly IServiceProvider _rootServiceProvider;
         private readonly IServiceCollection _rootServices;
 
@@ -21,6 +24,8 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             _applicationHostOptions = applicationHostOptions ?? throw new ArgumentNullException(nameof(applicationHostOptions));
             _rootServiceProvider = rootServiceProvider ?? throw new ArgumentNullException(nameof(rootServiceProvider));
             _rootServices = rootServices ?? throw new ArgumentNullException(nameof(rootServices));
+            _composition = rootServiceProvider.GetService<SelectedWorkerComposition>()?.Value
+                ?? ServerWorkerComposition.Instance;
         }
 
         public IHost BuildHost(bool skipHostStartup, bool skipHostConfigurationParsing)
@@ -41,7 +46,12 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             }
 
             builder.SetAzureFunctionsEnvironment()
-                .AddWebScriptHost(_rootServiceProvider, _rootServices, _applicationHostOptions.CurrentValue);
+                .AddWebScriptHost(
+                    _rootServiceProvider,
+                    _rootServices,
+                    _applicationHostOptions.CurrentValue,
+                    configureWebJobs: null,
+                    composition: _composition);
 
             if (skipHostStartup)
             {

--- a/src/WebJobs.Script.WebHost/FunctionsHost.cs
+++ b/src/WebJobs.Script.WebHost/FunctionsHost.cs
@@ -1,0 +1,265 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Azure.WebJobs.Script.Composition;
+using Microsoft.Azure.WebJobs.Script.Config;
+using Microsoft.Azure.WebJobs.Script.Diagnostics;
+using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
+using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using DataProtectionConstants = Microsoft.Azure.Web.DataProtection.Constants;
+
+namespace Microsoft.Azure.WebJobs.Script.WebHost;
+
+/// <summary>
+/// Builds and runs the Functions WebHost with a statically selected composition.
+/// </summary>
+public static class FunctionsHost
+{
+    /// <summary>
+    /// Builds and runs the Functions WebHost asynchronously with the specified composition.
+    /// </summary>
+    /// <param name="args">Command-line arguments for the host.</param>
+    /// <param name="composition">The composition selected by the product entrypoint.</param>
+    /// <returns>A task that completes when the host stops.</returns>
+    public static Task RunAsync(string[] args, IWorkerComposition composition)
+    {
+        ArgumentNullException.ThrowIfNull(composition);
+
+        InitializeProcess();
+        IHost host = BuildHost(args, composition);
+        return RunHostAsync(host);
+    }
+
+    internal static IHost BuildHost(string[] args, IWorkerComposition composition)
+    {
+        return CreateHostBuilder(args, composition)
+            .Build();
+    }
+
+    internal static async Task RunHostAsync(IHost host)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+
+        // This mirrors Generic Host's RunAsync, but ensures StopAsync is called if StopApplication occurs during StartAsync.
+        // See https://github.com/Azure/azure-functions-host/issues/11954 for details.
+        try
+        {
+            IHostApplicationLifetime applicationLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+
+            try
+            {
+                await host.StartAsync();
+            }
+            catch (Exception startupException) when (applicationLifetime.ApplicationStopping.IsCancellationRequested)
+            {
+                // Generic Host's RunAsync skips StopAsync when StopApplication cancels startup.
+                try
+                {
+                    await host.StopAsync(CancellationToken.None);
+                }
+                catch (Exception shutdownException)
+                {
+                    throw new AggregateException("Host startup failed and shutdown also failed.", startupException, shutdownException);
+                }
+
+                throw;
+            }
+
+            await host.WaitForShutdownAsync();
+        }
+        finally
+        {
+            if (host is IAsyncDisposable asyncDisposable)
+            {
+                await asyncDisposable.DisposeAsync();
+            }
+            else
+            {
+                host.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates an <see cref="IHostBuilder"/> with only the services the Functions host requires.
+    /// </summary>
+    /// <remarks>
+    /// A bare <see cref="HostBuilder"/> is used instead of <c>Host.CreateDefaultBuilder</c>
+    /// because the Functions host manages its own logging, configuration, and metrics.
+    /// </remarks>
+    internal static IHostBuilder CreateHostBuilder(string[] args, IWorkerComposition composition)
+    {
+        ArgumentNullException.ThrowIfNull(composition);
+
+#if PLACEHOLDER_SIMULATION
+        SystemEnvironment.Instance.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
+        SystemEnvironment.Instance.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady, "0");
+#endif
+
+        return new HostBuilder()
+            .UseContentRoot(Directory.GetCurrentDirectory())
+            .ConfigureHostConfiguration(config =>
+            {
+                if (args is { Length: > 0 })
+                {
+                    config.AddCommandLine(args);
+                }
+            })
+            // Scope and build validation are disabled because the host uses a two-level
+            // DI hierarchy with cross-boundary service resolution. The custom
+            // DependencyValidator provides bespoke validation instead.
+            .UseDefaultServiceProvider((context, options) =>
+            {
+                options.ValidateScopes = false;
+                options.ValidateOnBuild = false;
+            })
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder
+                    .ConfigureKestrel(o =>
+                    {
+                        o.Limits.MaxRequestBodySize = ScriptConstants.DefaultMaxRequestBodySize;
+                    })
+                    .UseSetting(WebHostDefaults.EnvironmentKey, Environment.GetEnvironmentVariable(EnvironmentSettingNames.EnvironmentNameKey))
+                    .ConfigureServices(services =>
+                    {
+                        services.Configure<IISServerOptions>(o =>
+                        {
+                            o.MaxRequestBodySize = ScriptConstants.DefaultMaxRequestBodySize;
+                        });
+                    })
+                    .ConfigureAppConfiguration((builderContext, config) =>
+                    {
+                        // Replace the default environment variables source with one
+                        // that is aware of Functions-specific settings.
+                        IConfigurationSource envVarsSource = config.Sources.OfType<EnvironmentVariablesConfigurationSource>().FirstOrDefault();
+                        if (envVarsSource is not null)
+                        {
+                            config.Sources.Remove(envVarsSource);
+                        }
+
+                        config.Add(new ScriptEnvironmentVariablesConfigurationSource());
+
+                        config.Add(new WebScriptHostConfigurationSource
+                        {
+                            IsAppServiceEnvironment = SystemEnvironment.Instance.IsAppService(),
+                            IsLinuxContainerEnvironment = SystemEnvironment.Instance.IsAnyLinuxConsumption(),
+                            IsLinuxAppServiceEnvironment = SystemEnvironment.Instance.IsLinuxAppService()
+                        });
+                        config.Add(new FunctionsHostingConfigSource(SystemEnvironment.Instance));
+
+                        if (builderContext.HostingEnvironment.IsDevelopment())
+                        {
+                            config.AddUserSecrets<Program>(optional: true);
+                        }
+
+                        var hostingEnvironmentConfigFilePath = SystemEnvironment.Instance.GetFunctionsHostingEnvironmentConfigFilePath();
+                        if (!string.IsNullOrEmpty(hostingEnvironmentConfigFilePath))
+                        {
+                            config.AddJsonFile(hostingEnvironmentConfigFilePath, optional: true, reloadOnChange: false);
+                        }
+                    })
+                    .ConfigureLogging((context, loggingBuilder) =>
+                    {
+                        loggingBuilder.Configure(options =>
+                        {
+                            options.ActivityTrackingOptions =
+                                ActivityTrackingOptions.SpanId |
+                                ActivityTrackingOptions.TraceId |
+                                ActivityTrackingOptions.ParentId;
+                        });
+
+                        loggingBuilder.ClearProviders();
+
+                        loggingBuilder.AddDefaultWebJobsFilters();
+                        loggingBuilder.AddWebJobsSystem<WebHostSystemLoggerProvider>();
+                        loggingBuilder.AddForwardingLogger();
+                        loggingBuilder.Services.AddSingleton<DeferredLogSource>();
+                        loggingBuilder.Services.AddSingleton<DeferredLoggerProvider>();
+                        loggingBuilder.Services.AddSingleton<ILoggerProvider>(s => s.GetRequiredService<DeferredLoggerProvider>());
+                        loggingBuilder.Services.AddSingleton<ISystemLoggerFactory, SystemLoggerFactory>();
+                        if (context.HostingEnvironment.IsDevelopment())
+                        {
+                            loggingBuilder.AddConsole();
+                        }
+                    })
+                    .UseStartup(context => new Startup(context.Configuration, composition))
+                    .UseIIS();
+            });
+    }
+
+    /// <summary>
+    /// Perform any process level initialization that needs to happen BEFORE
+    /// the WebHost is initialized.
+    /// </summary>
+    private static void InitializeProcess()
+    {
+        if (SystemEnvironment.Instance.IsLinuxConsumptionOnAtlas())
+        {
+            AppDomain.CurrentDomain.UnhandledException += CurrentDomainOnUnhandledExceptionInLinuxConsumption;
+        }
+        else if (SystemEnvironment.Instance.IsFlexConsumptionSku() ||
+            SystemEnvironment.Instance.IsLinuxConsumptionOnLegion())
+        {
+            // TODO: Replace with legion specific logger?
+            AppDomain.CurrentDomain.UnhandledException += CurrentDomainOnUnhandledExceptionInLinuxConsumption;
+        }
+        else if (SystemEnvironment.Instance.IsLinuxAppService())
+        {
+            AppDomain.CurrentDomain.UnhandledException += CurrentDomainOnUnhandledExceptionInLinuxAppService;
+        }
+
+        // Some environments only set the auth key. Ensure that is used as the encryption key if that is not set
+        string authEncryptionKey = SystemEnvironment.Instance.GetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey);
+        if (authEncryptionKey is not null &&
+            SystemEnvironment.Instance.GetEnvironmentVariable(DataProtectionConstants.AzureWebsiteEnvironmentMachineKey) is null)
+        {
+            SystemEnvironment.Instance.SetEnvironmentVariable(DataProtectionConstants.AzureWebsiteEnvironmentMachineKey, authEncryptionKey);
+        }
+
+        ConfigureMinimumThreads(SystemEnvironment.Instance);
+    }
+
+    private static void CurrentDomainOnUnhandledExceptionInLinuxConsumption(object sender, UnhandledExceptionEventArgs e)
+    {
+        // Fallback console logs in case kusto logging fails.
+        Console.WriteLine($"{nameof(CurrentDomainOnUnhandledExceptionInLinuxConsumption)}: {e.ExceptionObject}");
+
+        LinuxContainerEventGenerator.LogUnhandledException((Exception)e.ExceptionObject);
+    }
+
+    private static void CurrentDomainOnUnhandledExceptionInLinuxAppService(object sender, UnhandledExceptionEventArgs e)
+    {
+        LinuxAppServiceEventGenerator.LogUnhandledException((Exception)e.ExceptionObject);
+    }
+
+    private static void ConfigureMinimumThreads(IEnvironment environment)
+    {
+        // For information on MinThreads, see:
+        // https://docs.microsoft.com/en-us/dotnet/api/system.threading.threadpool.setminthreads?view=netcore-2.2
+        // https://docs.microsoft.com/en-us/azure/redis-cache/cache-faq#important-details-about-threadpool-growth
+        // https://blogs.msdn.microsoft.com/perfworld/2010/01/13/how-can-i-improve-the-performance-of-asp-net-by-adjusting-the-clr-thread-throttling-properties/
+        //
+        // This behavior can be overridden by using the "ComPlus_ThreadPool_ForceMinWorkerThreads" environment variable (honored by the .NET threadpool).
+
+        var effectiveCores = environment.GetEffectiveCoresCount();
+
+        // This value was derived by looking at the thread count for several function apps running load on a multicore machine and dividing by the number of cores.
+        const int minThreadsPerLogicalProcessor = 6;
+
+        int minThreadCount = effectiveCores * minThreadsPerLogicalProcessor;
+        ThreadPool.SetMinThreads(minThreadCount, minThreadCount);
+    }
+}

--- a/src/WebJobs.Script.WebHost/FunctionsHost.cs
+++ b/src/WebJobs.Script.WebHost/FunctionsHost.cs
@@ -44,8 +44,7 @@ public static class FunctionsHost
 
     internal static IHost BuildHost(string[] args, IWorkerComposition composition)
     {
-        return CreateHostBuilder(args, composition)
-            .Build();
+        return CreateHostBuilder(args, composition).Build();
     }
 
     internal static async Task RunHostAsync(IHost host)

--- a/src/WebJobs.Script.WebHost/Program.cs
+++ b/src/WebJobs.Script.WebHost/Program.cs
@@ -1,253 +1,29 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
-using System.IO;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Azure.WebJobs.Script.Config;
-using Microsoft.Azure.WebJobs.Script.Diagnostics;
-using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
-using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Configuration.EnvironmentVariables;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Azure.WebJobs.Script.WebHost.Composition;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using DataProtectionConstants = Microsoft.Azure.Web.DataProtection.Constants;
 
-namespace Microsoft.Azure.WebJobs.Script.WebHost
+namespace Microsoft.Azure.WebJobs.Script.WebHost;
+
+public class Program
 {
-    public class Program
+    public static async Task Main(string[] args)
     {
-        public static async Task Main(string[] args)
-        {
-            InitializeProcess();
+        await FunctionsHost.RunAsync(args, ServerWorkerComposition.Instance);
+    }
 
-            IHost host = BuildHost(args);
-            await RunHostAsync(host);
-        }
+    public static IHost BuildHost(string[] args)
+    {
+        return FunctionsHost.BuildHost(args, ServerWorkerComposition.Instance);
+    }
 
-        public static IHost BuildHost(string[] args)
-        {
-            return CreateHostBuilder(args)
-                .Build();
-        }
-
-        internal static async Task RunHostAsync(IHost host)
-        {
-            ArgumentNullException.ThrowIfNull(host);
-
-            // This mirrors Generic Host's RunAsync, but ensures StopAsync is called if StopApplication occurs during StartAsync.
-            // See https://github.com/Azure/azure-functions-host/issues/11954 for details.
-            try
-            {
-                IHostApplicationLifetime applicationLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
-
-                try
-                {
-                    await host.StartAsync();
-                }
-                catch (Exception startupException) when (applicationLifetime.ApplicationStopping.IsCancellationRequested)
-                {
-                    // Generic Host's RunAsync skips StopAsync when StopApplication cancels startup.
-                    try
-                    {
-                        await host.StopAsync(CancellationToken.None);
-                    }
-                    catch (Exception shutdownException)
-                    {
-                        throw new AggregateException("Host startup failed and shutdown also failed.", startupException, shutdownException);
-                    }
-
-                    throw;
-                }
-
-                await host.WaitForShutdownAsync();
-            }
-            finally
-            {
-                if (host is IAsyncDisposable asyncDisposable)
-                {
-                    await asyncDisposable.DisposeAsync();
-                }
-                else
-                {
-                    host.Dispose();
-                }
-            }
-        }
-
-        /// <summary>
-        /// Creates an <see cref="IHostBuilder"/> with only the services the Functions host requires.
-        /// </summary>
-        /// <remarks>
-        /// A bare <see cref="HostBuilder"/> is used instead of <c>Host.CreateDefaultBuilder</c>
-        /// because the Functions host manages its own logging, configuration, and metrics.
-        /// </remarks>
-        public static IHostBuilder CreateHostBuilder(string[] args = null)
-        {
-#if PLACEHOLDER_SIMULATION
-            SystemEnvironment.Instance.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsitePlaceholderMode, "1");
-            SystemEnvironment.Instance.SetEnvironmentVariable(EnvironmentSettingNames.AzureWebsiteContainerReady, "0");
-#endif
-
-            return new HostBuilder()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .ConfigureHostConfiguration(config =>
-                {
-                    if (args is { Length: > 0 })
-                    {
-                        config.AddCommandLine(args);
-                    }
-                })
-                // Scope and build validation are disabled because the host uses a two-level
-                // DI hierarchy with cross-boundary service resolution. The custom
-                // DependencyValidator provides bespoke validation instead.
-                .UseDefaultServiceProvider((context, options) =>
-                {
-                    options.ValidateScopes = false;
-                    options.ValidateOnBuild = false;
-                })
-                .ConfigureWebHostDefaults(webBuilder =>
-                {
-                    webBuilder
-                        .ConfigureKestrel(o =>
-                        {
-                            o.Limits.MaxRequestBodySize = ScriptConstants.DefaultMaxRequestBodySize;
-                        })
-                        .UseSetting(WebHostDefaults.EnvironmentKey, Environment.GetEnvironmentVariable(EnvironmentSettingNames.EnvironmentNameKey))
-                        .ConfigureServices(services =>
-                        {
-                            services.Configure<IISServerOptions>(o =>
-                            {
-                                o.MaxRequestBodySize = ScriptConstants.DefaultMaxRequestBodySize;
-                            });
-                        })
-                        .ConfigureAppConfiguration((builderContext, config) =>
-                        {
-                            // Replace the default environment variables source with one
-                            // that is aware of Functions-specific settings.
-                            IConfigurationSource envVarsSource = config.Sources.OfType<EnvironmentVariablesConfigurationSource>().FirstOrDefault();
-                            if (envVarsSource is not null)
-                            {
-                                config.Sources.Remove(envVarsSource);
-                            }
-
-                            config.Add(new ScriptEnvironmentVariablesConfigurationSource());
-
-                            config.Add(new WebScriptHostConfigurationSource
-                            {
-                                IsAppServiceEnvironment = SystemEnvironment.Instance.IsAppService(),
-                                IsLinuxContainerEnvironment = SystemEnvironment.Instance.IsAnyLinuxConsumption(),
-                                IsLinuxAppServiceEnvironment = SystemEnvironment.Instance.IsLinuxAppService()
-                            });
-                            config.Add(new FunctionsHostingConfigSource(SystemEnvironment.Instance));
-
-                            if (builderContext.HostingEnvironment.IsDevelopment())
-                            {
-                                config.AddUserSecrets<Program>(optional: true);
-                            }
-
-                            var hostingEnvironmentConfigFilePath = SystemEnvironment.Instance.GetFunctionsHostingEnvironmentConfigFilePath();
-                            if (!string.IsNullOrEmpty(hostingEnvironmentConfigFilePath))
-                            {
-                                config.AddJsonFile(hostingEnvironmentConfigFilePath, optional: true, reloadOnChange: false);
-                            }
-                        })
-                        .ConfigureLogging((context, loggingBuilder) =>
-                        {
-                            loggingBuilder.Configure(options =>
-                            {
-                                options.ActivityTrackingOptions =
-                                    ActivityTrackingOptions.SpanId |
-                                    ActivityTrackingOptions.TraceId |
-                                    ActivityTrackingOptions.ParentId;
-                            });
-
-                            loggingBuilder.ClearProviders();
-
-                            loggingBuilder.AddDefaultWebJobsFilters();
-                            loggingBuilder.AddWebJobsSystem<WebHostSystemLoggerProvider>();
-                            loggingBuilder.AddForwardingLogger();
-                            loggingBuilder.Services.AddSingleton<DeferredLogSource>();
-                            loggingBuilder.Services.AddSingleton<DeferredLoggerProvider>();
-                            loggingBuilder.Services.AddSingleton<ILoggerProvider>(s => s.GetRequiredService<DeferredLoggerProvider>());
-                            loggingBuilder.Services.AddSingleton<ISystemLoggerFactory, SystemLoggerFactory>();
-                            if (context.HostingEnvironment.IsDevelopment())
-                            {
-                                loggingBuilder.AddConsole();
-                            }
-                        })
-                        .UseStartup<Startup>()
-                        .UseIIS();
-                });
-        }
-
-        /// <summary>
-        /// Perform any process level initialization that needs to happen BEFORE
-        /// the WebHost is initialized.
-        /// </summary>
-        private static void InitializeProcess()
-        {
-            if (SystemEnvironment.Instance.IsLinuxConsumptionOnAtlas())
-            {
-                AppDomain.CurrentDomain.UnhandledException += CurrentDomainOnUnhandledExceptionInLinuxConsumption;
-            }
-            else if (SystemEnvironment.Instance.IsFlexConsumptionSku() ||
-                SystemEnvironment.Instance.IsLinuxConsumptionOnLegion())
-            {
-                // TODO: Replace with legion specific logger?
-                AppDomain.CurrentDomain.UnhandledException += CurrentDomainOnUnhandledExceptionInLinuxConsumption;
-            }
-            else if (SystemEnvironment.Instance.IsLinuxAppService())
-            {
-                AppDomain.CurrentDomain.UnhandledException += CurrentDomainOnUnhandledExceptionInLinuxAppService;
-            }
-
-            // Some environments only set the auth key. Ensure that is used as the encryption key if that is not set
-            string authEncryptionKey = SystemEnvironment.Instance.GetEnvironmentVariable(EnvironmentSettingNames.WebSiteAuthEncryptionKey);
-            if (authEncryptionKey != null &&
-                SystemEnvironment.Instance.GetEnvironmentVariable(DataProtectionConstants.AzureWebsiteEnvironmentMachineKey) == null)
-            {
-                SystemEnvironment.Instance.SetEnvironmentVariable(DataProtectionConstants.AzureWebsiteEnvironmentMachineKey, authEncryptionKey);
-            }
-
-            ConfigureMinimumThreads(SystemEnvironment.Instance);
-        }
-
-        private static void CurrentDomainOnUnhandledExceptionInLinuxConsumption(object sender, UnhandledExceptionEventArgs e)
-        {
-            // Fallback console logs in case kusto logging fails.
-            Console.WriteLine($"{nameof(CurrentDomainOnUnhandledExceptionInLinuxConsumption)}: {e.ExceptionObject}");
-
-            LinuxContainerEventGenerator.LogUnhandledException((Exception)e.ExceptionObject);
-        }
-
-        private static void CurrentDomainOnUnhandledExceptionInLinuxAppService(object sender, UnhandledExceptionEventArgs e)
-        {
-            LinuxAppServiceEventGenerator.LogUnhandledException((Exception)e.ExceptionObject);
-        }
-
-        private static void ConfigureMinimumThreads(IEnvironment environment)
-        {
-            // For information on MinThreads, see:
-            // https://docs.microsoft.com/en-us/dotnet/api/system.threading.threadpool.setminthreads?view=netcore-2.2
-            // https://docs.microsoft.com/en-us/azure/redis-cache/cache-faq#important-details-about-threadpool-growth
-            // https://blogs.msdn.microsoft.com/perfworld/2010/01/13/how-can-i-improve-the-performance-of-asp-net-by-adjusting-the-clr-thread-throttling-properties/
-            //
-            // This behavior can be overridden by using the "ComPlus_ThreadPool_ForceMinWorkerThreads" environment variable (honored by the .NET threadpool).
-
-            var effectiveCores = environment.GetEffectiveCoresCount();
-
-            // This value was derived by looking at the thread count for several function apps running load on a multicore machine and dividing by the number of cores.
-            const int minThreadsPerLogicalProcessor = 6;
-
-            int minThreadCount = effectiveCores * minThreadsPerLogicalProcessor;
-            ThreadPool.SetMinThreads(minThreadCount, minThreadCount);
-        }
+    /// <summary>
+    /// Creates an <see cref="IHostBuilder"/> with only the services the Functions host requires.
+    /// </summary>
+    public static IHostBuilder CreateHostBuilder(string[] args = null)
+    {
+        return FunctionsHost.CreateHostBuilder(args, ServerWorkerComposition.Instance);
     }
 }

--- a/src/WebJobs.Script.WebHost/Startup.cs
+++ b/src/WebJobs.Script.WebHost/Startup.cs
@@ -1,8 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Azure.WebJobs.Script.Composition;
+using Microsoft.Azure.WebJobs.Script.WebHost.Composition;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -12,9 +15,17 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 {
     public class Startup
     {
+        private readonly IWorkerComposition _composition;
+
         public Startup(IConfiguration configuration)
+            : this(configuration, ServerWorkerComposition.Instance)
+        {
+        }
+
+        internal Startup(IConfiguration configuration, IWorkerComposition composition)
         {
             Configuration = configuration;
+            _composition = composition ?? throw new ArgumentNullException(nameof(composition));
         }
 
         public IConfiguration Configuration { get; }
@@ -24,7 +35,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         {
             services.AddWebJobsScriptHostAuthentication();
             services.AddWebJobsScriptHostAuthorization();
-            services.AddWebJobsScriptHost(Configuration);
+            services.AddWebJobsScriptHost(Configuration, _composition);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
+++ b/src/WebJobs.Script.WebHost/WebHostServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO.Abstractions;
+using System.Linq;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Authorization;
@@ -12,6 +13,7 @@ using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Host.Storage;
 using Microsoft.Azure.WebJobs.Hosting;
 using Microsoft.Azure.WebJobs.Script.AppCapabilities;
+using Microsoft.Azure.WebJobs.Script.Composition;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
@@ -20,6 +22,7 @@ using Microsoft.Azure.WebJobs.Script.ExtensionBundle;
 using Microsoft.Azure.WebJobs.Script.Grpc;
 using Microsoft.Azure.WebJobs.Script.Metrics;
 using Microsoft.Azure.WebJobs.Script.Middleware;
+using Microsoft.Azure.WebJobs.Script.WebHost.Composition;
 using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
 using Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement;
 using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
@@ -80,6 +83,29 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
 
         public static void AddWebJobsScriptHost(this IServiceCollection services, IConfiguration configuration)
         {
+            services.AddWebJobsScriptHost(configuration, ServerWorkerComposition.Instance);
+        }
+
+        /// <summary>
+        /// Adds the WebHost and ScriptHost services using the specified host composition.
+        /// </summary>
+        /// <param name="services">The service collection to update.</param>
+        /// <param name="configuration">The WebHost configuration.</param>
+        /// <param name="composition">The statically selected host composition.</param>
+        public static void AddWebJobsScriptHost(
+            this IServiceCollection services,
+            IConfiguration configuration,
+            IWorkerComposition composition)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(composition);
+
+            if (services.Any(descriptor => descriptor.ServiceType == typeof(SelectedWorkerComposition)))
+            {
+                throw new InvalidOperationException("A Functions Host composition has already been selected.");
+            }
+
+            services.AddSingleton(new SelectedWorkerComposition(composition));
             services.AddHttpContextAccessor();
             services.AddResponseCompression(options =>
             {
@@ -89,13 +115,14 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             });
             services.AddWebJobsScriptHostRouting();
 
-            services.AddMvc(o =>
-            {
-                o.EnableEndpointRouting = false;
-                o.Filters.Add(new ArmExtensionResourceFilter());
-            })
-            .AddNewtonsoftJson()
-            .AddXmlDataContractSerializerFormatters();
+            IMvcBuilder mvcBuilder = services
+                .AddMvc(o =>
+                {
+                    o.EnableEndpointRouting = false;
+                    o.Filters.Add(new ArmExtensionResourceFilter());
+                })
+                .AddNewtonsoftJson()
+                .AddXmlDataContractSerializerFormatters();
 
             // Must stop last so the JobHost drains in-flight invocations before worker channels are
             // torn down (via HostedServiceManager -> RpcInitializationService). The Generic Host stops
@@ -195,20 +222,18 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             services.AddSingleton<ISharedMemoryManager, SharedMemoryManager>();
             services.AddSingleton<IFunctionDataCache, FunctionDataCache>();
 
-            // Grpc
-            services.AddScriptGrpc();
-
             // Register common services with the WebHost
-            // Language Worker Hosted Services need to be intialized before WebJobsScriptHostService
             ScriptHostBuilderExtensions.AddCommonServices(services);
-            services.AddCommonRpcServices();
 
             services.AddSingleton<IHostFunctionMetadataProvider, HostFunctionMetadataProvider>();
             services.AddSingleton<IFunctionMetadataProvider, FunctionMetadataProvider>();
 
             // Core script host services
             services.AddSingleton<WebJobsScriptHostService>();
-            services.AddSingleton<IHostedService>(s => s.GetRequiredService<WebJobsScriptHostService>());
+
+            // The composition registers worker lifecycle services before ScriptHost activation so workers start first
+            // and stop only after the ScriptHost has drained in-flight invocations.
+            composition.ConfigureWebHostServices(services, mvcBuilder);
 
             // Performs function assembly analysis to generete log use of unoptimized assemblies.
             services.AddSingleton<IHostedService, AssemblyAnalyzer.AssemblyAnalysisService>();

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -12,11 +12,13 @@ using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Azure.WebJobs.Host.Storage;
 using Microsoft.Azure.WebJobs.Host.Timers;
 using Microsoft.Azure.WebJobs.Logging;
+using Microsoft.Azure.WebJobs.Script.Composition;
 using Microsoft.Azure.WebJobs.Script.Config;
 using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
 using Microsoft.Azure.WebJobs.Script.Middleware;
+using Microsoft.Azure.WebJobs.Script.WebHost.Composition;
 using Microsoft.Azure.WebJobs.Script.WebHost.Configuration;
 using Microsoft.Azure.WebJobs.Script.WebHost.DependencyInjection;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
@@ -37,6 +39,37 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         public static IHostBuilder AddWebScriptHost(this IHostBuilder builder, IServiceProvider rootServiceProvider, IServiceCollection rootServices,
            ScriptApplicationHostOptions webHostOptions, Action<IWebJobsBuilder> configureWebJobs = null)
         {
+            IWorkerComposition composition = rootServiceProvider?.GetService<SelectedWorkerComposition>()?.Value
+                ?? ServerWorkerComposition.Instance;
+
+            return builder.AddWebScriptHost(
+                rootServiceProvider,
+                rootServices,
+                webHostOptions,
+                configureWebJobs,
+                composition);
+        }
+
+        /// <summary>
+        /// Adds a ScriptHost using the specified host composition.
+        /// </summary>
+        /// <param name="builder">The host builder to update.</param>
+        /// <param name="rootServiceProvider">The root WebHost service provider.</param>
+        /// <param name="rootServices">The root WebHost service collection.</param>
+        /// <param name="webHostOptions">The application host options.</param>
+        /// <param name="configureWebJobs">An optional action that configures WebJobs services.</param>
+        /// <param name="composition">The statically selected host composition.</param>
+        /// <returns>The updated host builder.</returns>
+        public static IHostBuilder AddWebScriptHost(
+            this IHostBuilder builder,
+            IServiceProvider rootServiceProvider,
+            IServiceCollection rootServices,
+            ScriptApplicationHostOptions webHostOptions,
+            Action<IWebJobsBuilder> configureWebJobs,
+            IWorkerComposition composition)
+        {
+            ArgumentNullException.ThrowIfNull(composition);
+
             ILoggerFactory configLoggerFactory = rootServiceProvider.GetService<ILoggerFactory>();
             IDependencyValidator validator = rootServiceProvider.GetService<IDependencyValidator>();
             IMetricsLogger metricsLogger = rootServiceProvider.GetService<IMetricsLogger>();
@@ -59,7 +92,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
                 })
                 .AddScriptHost(webHostOptions, configLoggerFactory, metricsLogger, webJobsBuilder =>
                 {
-                    webJobsBuilder.Services.AddRpcScriptHostServices();
+                    composition.ConfigureScriptHostServices(webJobsBuilder.Services, rootServiceProvider);
 
                     // Adds necessary Azure-based services to the ScriptHost, which will use the host-provided IAzureBlobStorageProvider registered below.
                     webJobsBuilder.AddAzureStorageCoreServices();

--- a/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
+++ b/src/WebJobs.Script.WebHost/WebScriptHostBuilderExtension.cs
@@ -39,7 +39,9 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
         public static IHostBuilder AddWebScriptHost(this IHostBuilder builder, IServiceProvider rootServiceProvider, IServiceCollection rootServices,
            ScriptApplicationHostOptions webHostOptions, Action<IWebJobsBuilder> configureWebJobs = null)
         {
-            IWorkerComposition composition = rootServiceProvider?.GetService<SelectedWorkerComposition>()?.Value
+            ArgumentNullException.ThrowIfNull(rootServiceProvider);
+
+            IWorkerComposition composition = rootServiceProvider.GetService<SelectedWorkerComposition>()?.Value
                 ?? ServerWorkerComposition.Instance;
 
             return builder.AddWebScriptHost(
@@ -68,6 +70,7 @@ namespace Microsoft.Azure.WebJobs.Script.WebHost
             Action<IWebJobsBuilder> configureWebJobs,
             IWorkerComposition composition)
         {
+            ArgumentNullException.ThrowIfNull(rootServiceProvider);
             ArgumentNullException.ThrowIfNull(composition);
 
             ILoggerFactory configLoggerFactory = rootServiceProvider.GetService<ILoggerFactory>();

--- a/src/WebJobs.Script/Composition/IWorkerComposition.cs
+++ b/src/WebJobs.Script/Composition/IWorkerComposition.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.Azure.WebJobs.Script.Composition;
+
+/// <summary>
+/// Configures worker transport, dispatch, metadata, and lifecycle services for a Functions Host.
+/// </summary>
+public interface IWorkerComposition
+{
+    /// <summary>
+    /// Adds worker-specific services, MVC application parts, and ScriptHost activation to the root WebHost container.
+    /// </summary>
+    /// <param name="services">The root WebHost service collection.</param>
+    /// <param name="mvcBuilder">The WebHost MVC builder.</param>
+    /// <remarks>
+    /// Worker lifecycle hosted services must be registered before ScriptHost activation so workers start before the
+    /// ScriptHost and stop after it has drained in-flight invocations.
+    /// </remarks>
+    void ConfigureWebHostServices(IServiceCollection services, IMvcBuilder mvcBuilder);
+
+    /// <summary>
+    /// Adds worker-specific services to a child ScriptHost container.
+    /// </summary>
+    /// <param name="services">The child ScriptHost service collection.</param>
+    /// <param name="rootServiceProvider">
+    /// The root WebHost service provider, used only when a root-owned service must be deliberately forwarded.
+    /// </param>
+    void ConfigureScriptHostServices(IServiceCollection services, IServiceProvider rootServiceProvider);
+}

--- a/test/Functions.Host.Tests/ClientWorkerCompositionTests.cs
+++ b/test/Functions.Host.Tests/ClientWorkerCompositionTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -13,14 +12,6 @@ namespace Azure.Functions.Host.Tests;
 
 public class ClientWorkerCompositionTests
 {
-    [Fact]
-    public async Task Program_SelectsClientWorkerComposition()
-    {
-        NotImplementedException exception = await Assert.ThrowsAsync<NotImplementedException>(() => Program.Main([]));
-
-        Assert.True(exception.Message.Contains("Client WebHost worker composition", StringComparison.Ordinal));
-    }
-
     [Fact]
     public void ConfigureWebHostServices_ThrowsUntilClientWorkerCompositionIsImplemented()
     {

--- a/test/Functions.Host.Tests/ClientWorkerCompositionTests.cs
+++ b/test/Functions.Host.Tests/ClientWorkerCompositionTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Azure.Functions.Host.Tests;
+
+public class ClientWorkerCompositionTests
+{
+    [Fact]
+    public async Task Program_SelectsClientWorkerComposition()
+    {
+        NotImplementedException exception = await Assert.ThrowsAsync<NotImplementedException>(() => Program.Main([]));
+
+        Assert.True(exception.Message.Contains("Client WebHost worker composition", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ConfigureWebHostServices_ThrowsUntilClientWorkerCompositionIsImplemented()
+    {
+        var services = new ServiceCollection();
+        IMvcBuilder mvcBuilder = services.AddMvc();
+
+        Assert.Throws<NotImplementedException>(
+            () => ClientWorkerComposition.Instance.ConfigureWebHostServices(services, mvcBuilder));
+    }
+
+    [Fact]
+    public void ConfigureScriptHostServices_ThrowsUntilClientWorkerCompositionIsImplemented()
+    {
+        var services = new ServiceCollection();
+        using ServiceProvider rootServiceProvider = new ServiceCollection().BuildServiceProvider();
+
+        Assert.Throws<NotImplementedException>(
+            () => ClientWorkerComposition.Instance.ConfigureScriptHostServices(services, rootServiceProvider));
+    }
+
+    [Fact]
+    public void FunctionsHostReferencesSharedWebHostEntryPointWithoutDirectServer()
+    {
+        string[] references = typeof(ClientWorkerComposition).Assembly.GetReferencedAssemblies()
+            .Select(assembly => assembly.Name)
+            .OfType<string>()
+            .ToArray();
+
+        Assert.Contains("Microsoft.Azure.WebJobs.Script", references);
+        Assert.Contains("Microsoft.Azure.WebJobs.Script.WebHost", references);
+        Assert.DoesNotContain("Azure.Functions.Rpc.Server", references);
+        Assert.DoesNotContain("Azure.Functions.WorkerProxy", references);
+    }
+
+    [Fact]
+    public void FunctionsHostProjectDefinesSharedWebHostEntrypointSettings()
+    {
+        XDocument project = XDocument.Load(Path.Combine(AppContext.BaseDirectory, "ProjectFiles", "Functions.Host.csproj"));
+        XElement root = project.Root ?? throw new InvalidDataException("Functions.Host.csproj is missing its root Project element.");
+        XElement frameworkReference = Assert.Single(project.Descendants("FrameworkReference"));
+        XElement projectReference = Assert.Single(project.Descendants("ProjectReference"));
+        XElement publishFilter = Assert.Single(project.Descendants("Target")
+            .Where(target => string.Equals(
+                target.Attribute("Name")?.Value,
+                "RemoveStandardWebHostEntrypointFromPublish",
+                StringComparison.Ordinal)));
+
+        Assert.True(string.Equals("Microsoft.NET.Sdk", root.Attribute("Sdk")?.Value, StringComparison.Ordinal));
+        Assert.True(string.Equals("$(WorkersProps)", root.Elements("Import").Single().Attribute("Project")?.Value, StringComparison.Ordinal));
+        Assert.True(string.Equals("linux-x64", GetProperty(project, "RuntimeIdentifiers"), StringComparison.Ordinal));
+        Assert.True(string.Equals("true", GetProperty(project, "ServerGarbageCollection"), StringComparison.OrdinalIgnoreCase));
+        Assert.True(string.Equals("false", GetProperty(project, "TieredCompilation"), StringComparison.OrdinalIgnoreCase));
+        Assert.True(string.Equals(
+            "$(MSBuildThisFileDirectory)..\\WebJobs.Script.WebHost\\runtimeconfig.template.json",
+            GetProperty(project, "UserRuntimeConfig"),
+            StringComparison.Ordinal));
+        Assert.True(string.Equals(
+            "..\\WebJobs.Script.WebHost\\WebJobs.Script.WebHost.csproj",
+            projectReference.Attribute("Include")?.Value,
+            StringComparison.Ordinal));
+        Assert.True(string.Equals("Microsoft.AspNetCore.App", frameworkReference.Attribute("Include")?.Value, StringComparison.Ordinal));
+        Assert.True(string.Equals("ComputeFilesToPublish", publishFilter.Attribute("AfterTargets")?.Value, StringComparison.Ordinal));
+    }
+
+    private static string GetProperty(XDocument project, string name)
+        => project.Descendants(name).Select(element => element.Value).First();
+}

--- a/test/Functions.Host.Tests/Functions.Host.Tests.csproj
+++ b/test/Functions.Host.Tests/Functions.Host.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <AssemblyName>Azure.Functions.Host.Tests</AssemblyName>
+    <RootNamespace>Azure.Functions.Host.Tests</RootNamespace>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" PrivateAssets="all" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\src\Functions.Host\Functions.Host.csproj"
+          Link="ProjectFiles\Functions.Host.csproj"
+          CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Functions.Host\Functions.Host.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Functions.Rpc.Client.Tests/RpcClientAssemblyTests.cs
+++ b/test/Functions.Rpc.Client.Tests/RpcClientAssemblyTests.cs
@@ -28,6 +28,7 @@ public class RpcClientAssemblyTests
 
         Assert.Contains("Microsoft.Azure.WebJobs.Script.Grpc", references);
         Assert.DoesNotContain("Azure.Functions.Rpc.Server", references);
+        Assert.DoesNotContain("Azure.Functions.WorkerProxy", references);
     }
 
     [Fact]
@@ -47,15 +48,19 @@ public class RpcClientAssemblyTests
         Assert.Equal(["..\\WebJobs.Script\\WebJobs.Script.csproj"], GetProjectReferences("WebJobs.Script.Grpc.csproj"));
         Assert.DoesNotContain(GetProjectReferences("Functions.Rpc.Server.csproj"),
             reference => reference.Contains("Functions.Rpc.Client", StringComparison.Ordinal));
-        Assert.DoesNotContain(GetProjectReferences("WebJobs.Script.WebHost.csproj"),
-            reference => reference.Contains("Functions.Rpc.Client", StringComparison.Ordinal));
+        string[] webHostReferences = GetProjectReferences("WebJobs.Script.WebHost.csproj");
+        Assert.Contains("..\\Functions.Rpc.Server\\Functions.Rpc.Server.csproj", webHostReferences);
+        Assert.DoesNotContain(webHostReferences, reference => reference.Contains("Functions.Rpc.Client", StringComparison.Ordinal));
+        Assert.DoesNotContain(webHostReferences, reference => reference.Contains("Functions.WorkerProxy", StringComparison.Ordinal));
     }
 
     [Fact]
     public void StandardSolutionDoesNotContainClient()
     {
         string solution = File.ReadAllText(GetProjectFilePath("WebJobs.Script.sln"));
+        Assert.DoesNotContain("Functions.Host", solution, StringComparison.Ordinal);
         Assert.DoesNotContain("Functions.Rpc.Client", solution, StringComparison.Ordinal);
+        Assert.DoesNotContain("Functions.WorkerProxy", solution, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -69,9 +74,11 @@ public class RpcClientAssemblyTests
 
         Assert.Contains("src/Functions.Rpc.Client/Functions.Rpc.Client.csproj", projects);
         Assert.Contains("src/Functions.Rpc.Server/Functions.Rpc.Server.csproj", projects);
+        Assert.Contains("src/Functions.Host/Functions.Host.csproj", projects);
         Assert.Contains("src/WebJobs.Script/WebJobs.Script.csproj", projects);
         Assert.Contains("src/WebJobs.Script.Grpc/WebJobs.Script.Grpc.csproj", projects);
         Assert.Contains("src/WebJobs.Script.WebHost/WebJobs.Script.WebHost.csproj", projects);
+        Assert.Contains("test/Functions.Host.Tests/Functions.Host.Tests.csproj", projects);
         Assert.Contains("test/Functions.Rpc.Client.Tests/Functions.Rpc.Client.Tests.csproj", projects);
     }
 

--- a/test/WebJobs.Script.Tests.Integration/Host/ScriptApplicationLifetimeTests.cs
+++ b/test/WebJobs.Script.Tests.Integration/Host/ScriptApplicationLifetimeTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Host
                 .Build();
             var timeoutService = host.Services.GetRequiredService<WorkerStartupTimeoutHostedService>();
 
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => Program.RunHostAsync(host));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => FunctionsHost.RunHostAsync(host));
 
             Assert.True(startedService.Started);
             Assert.True(startedService.Stopped);
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Host
             var startupService = host.Services.GetRequiredService<StopApplicationAndThrowHostedService>();
 
             InvalidOperationException exception =
-                await Assert.ThrowsAsync<InvalidOperationException>(() => Program.RunHostAsync(host));
+                await Assert.ThrowsAsync<InvalidOperationException>(() => FunctionsHost.RunHostAsync(host));
 
             Assert.Same(startupService.StartupException, exception);
             Assert.True(startedService.Started);
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Host
                 .Build();
 
             AggregateException exception =
-                await Assert.ThrowsAsync<AggregateException>(() => Program.RunHostAsync(host));
+                await Assert.ThrowsAsync<AggregateException>(() => FunctionsHost.RunHostAsync(host));
 
             Assert.StartsWith("Host startup failed and shutdown also failed.", exception.Message);
             Assert.Collection(
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.WebJobs.Script.Tests.Integration.Host
             using CancellationTokenRegistration registration =
                 applicationLifetime.ApplicationStarted.Register(() => applicationStarted.TrySetResult());
 
-            Task runTask = Program.RunHostAsync(host);
+            Task runTask = FunctionsHost.RunHostAsync(host);
             await applicationStarted.Task.TestWaitAsync(TimeSpan.FromSeconds(5));
 
             Assert.False(runTask.IsCompleted);

--- a/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
+++ b/test/WebJobs.Script.Tests.Shared/TestHostBuilderExtensions.cs
@@ -10,6 +10,7 @@ using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Host.Storage;
 using Microsoft.Azure.WebJobs.Script;
 using Microsoft.Azure.WebJobs.Script.AppCapabilities;
+using Microsoft.Azure.WebJobs.Script.Composition;
 using Microsoft.Azure.WebJobs.Script.Configuration;
 using Microsoft.Azure.WebJobs.Script.Description;
 using Microsoft.Azure.WebJobs.Script.Diagnostics;
@@ -43,7 +44,8 @@ namespace Microsoft.WebJobs.Script.Tests
         }
 
         public static IHostBuilder ConfigureDefaultTestWebScriptHost(this IHostBuilder builder, Action<IWebJobsBuilder> configureWebJobs,
-            Action<ScriptApplicationHostOptions> configure = null, bool runStartupHostedServices = false, Action<IServiceCollection> configureRootServices = null)
+            Action<ScriptApplicationHostOptions> configure = null, bool runStartupHostedServices = false,
+            Action<IServiceCollection> configureRootServices = null, IWorkerComposition composition = null)
         {
             var webHostOptions = new ScriptApplicationHostOptions()
             {
@@ -112,14 +114,25 @@ namespace Microsoft.WebJobs.Script.Tests
 
             var rootProvider = services.BuildServiceProvider();
 
-            builder
-                .AddWebScriptHost(rootProvider, services, webHostOptions,
-                    webJobsBuilder =>
-                    {
-                        configureWebJobs?.Invoke(webJobsBuilder);
-                        webJobsBuilder.Services.AddCommonRpcServices();
-                    })
-                .ConfigureAppConfiguration(c =>
+            Action<IWebJobsBuilder> configureWebJobsAction = webJobsBuilder =>
+            {
+                configureWebJobs?.Invoke(webJobsBuilder);
+                if (composition is null)
+                {
+                    webJobsBuilder.Services.AddCommonRpcServices();
+                }
+            };
+
+            if (composition is null)
+            {
+                builder.AddWebScriptHost(rootProvider, services, webHostOptions, configureWebJobsAction);
+            }
+            else
+            {
+                builder.AddWebScriptHost(rootProvider, services, webHostOptions, configureWebJobsAction, composition);
+            }
+
+            builder.ConfigureAppConfiguration(c =>
                 {
                     c.AddTestSettings();
                 })

--- a/test/WebJobs.Script.Tests/Composition/ServerWorkerCompositionTests.cs
+++ b/test/WebJobs.Script.Tests/Composition/ServerWorkerCompositionTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Azure.WebJobs.Script.Grpc;
+using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.Composition;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Script.Tests.Composition;
+
+public class ServerWorkerCompositionTests
+{
+    [Fact]
+    public void ConfigureWebHostServices_RegistersExistingStandardServices()
+    {
+        var expected = new ServiceCollection();
+        expected.AddScriptGrpc();
+        expected.AddCommonRpcServices();
+        expected.AddSingleton<IHostedService>(provider => provider.GetRequiredService<WebJobsScriptHostService>());
+
+        var actual = new ServiceCollection();
+        IMvcBuilder mvcBuilder = new ServiceCollection().AddMvc();
+
+        ServerWorkerComposition.Instance.ConfigureWebHostServices(actual, mvcBuilder);
+
+        Assert.Equal(expected.Select(GetDescriptorSignature), actual.Select(GetDescriptorSignature));
+
+        ServiceDescriptor activationDescriptor = actual.Last();
+        using ServiceProvider serviceProvider = new ServiceCollection().BuildServiceProvider();
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => activationDescriptor.ImplementationFactory(serviceProvider));
+        Assert.True(exception.Message.Contains(typeof(WebJobsScriptHostService).FullName, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ConfigureScriptHostServices_RegistersExistingStandardServices()
+    {
+        var expected = new ServiceCollection();
+        expected.AddRpcScriptHostServices();
+
+        var actual = new ServiceCollection();
+        using ServiceProvider rootServiceProvider = new ServiceCollection().BuildServiceProvider();
+
+        ServerWorkerComposition.Instance.ConfigureScriptHostServices(actual, rootServiceProvider);
+
+        Assert.Equal(expected.Select(GetDescriptorSignature), actual.Select(GetDescriptorSignature));
+    }
+
+    private static string GetDescriptorSignature(ServiceDescriptor descriptor)
+    {
+        string implementation = descriptor.ImplementationFactory is not null
+            ? "factory"
+            : descriptor.ImplementationType?.AssemblyQualifiedName
+                ?? descriptor.ImplementationInstance?.GetType().AssemblyQualifiedName
+                ?? "unknown";
+
+        return $"{descriptor.ServiceType.AssemblyQualifiedName}|{descriptor.Lifetime}|{implementation}";
+    }
+}

--- a/test/WebJobs.Script.Tests/WebHost/WebHostServiceCollectionExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/WebHost/WebHostServiceCollectionExtensionsTests.cs
@@ -1,10 +1,21 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
+using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.Azure.Functions.Platform.Metrics.LinuxConsumption;
+using Microsoft.Azure.WebJobs.Script.Composition;
+using Microsoft.Azure.WebJobs.Script.Grpc;
+using Microsoft.Azure.WebJobs.Script.Host;
+using Microsoft.Azure.WebJobs.Script.Rpc;
 using Microsoft.Azure.WebJobs.Script.WebHost;
+using Microsoft.Azure.WebJobs.Script.WebHost.AssemblyAnalyzer;
+using Microsoft.Azure.WebJobs.Script.WebHost.Composition;
 using Microsoft.Azure.WebJobs.Script.WebHost.ContainerManagement;
+using Microsoft.Azure.WebJobs.Script.Workers.Rpc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -88,6 +99,93 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
             }
         }
 
+        [Fact]
+        public void AddWebJobsScriptHost_UsesStandardComposition()
+        {
+            var services = new ServiceCollection();
+
+            services.AddWebJobsScriptHost(new ConfigurationBuilder().Build());
+
+            ServiceDescriptor compositionDescriptor = Assert.Single(services.Where(d => d.ServiceType == typeof(SelectedWorkerComposition)));
+            var selectedComposition = Assert.IsType<SelectedWorkerComposition>(compositionDescriptor.ImplementationInstance);
+            Assert.Same(ServerWorkerComposition.Instance, selectedComposition.Value);
+            AssertService<IRpcServer, AspNetCoreGrpcServer>(services);
+            AssertService<IWorkerFunctionMetadataProvider, WorkerFunctionMetadataProvider>(services);
+            AssertService<IWebHostRpcWorkerChannelManager, WebHostRpcWorkerChannelManager>(services);
+            AssertService<IWebHostWorkerManager, RpcWebHostWorkerManager>(services);
+
+            ServiceDescriptor initializationService = Assert.Single(services.Where(d => d.ServiceType == typeof(RpcInitializationService)));
+            Assert.Equal(ServiceLifetime.Singleton, initializationService.Lifetime);
+            Assert.Equal(typeof(RpcInitializationService), initializationService.ImplementationType);
+        }
+
+        [Fact]
+        public void AddWebJobsScriptHost_AllowsCompositionToRegisterServicesAndControllers()
+        {
+            var services = new ServiceCollection();
+            var composition = new TestWorkerComposition();
+
+            services.AddWebJobsScriptHost(new ConfigurationBuilder().Build(), composition);
+
+            Assert.Equal(1, composition.WebHostConfigurationCount);
+            var selectedComposition = Assert.IsType<SelectedWorkerComposition>(
+                services.Single(d => d.ServiceType == typeof(SelectedWorkerComposition)).ImplementationInstance);
+            Assert.Same(composition, selectedComposition.Value);
+            AssertService<CompositionMarker, CompositionMarker>(services);
+
+            var controllerFeature = new ControllerFeature();
+            composition.MvcBuilder.PartManager.PopulateFeature(controllerFeature);
+            Assert.Contains(typeof(CompositionTestController), controllerFeature.Controllers.Select(type => type.AsType()));
+        }
+
+        [Fact]
+        public void AddWebJobsScriptHost_SelectedCompositionCannotBeOverriddenByLaterInterfaceRegistration()
+        {
+            var services = new ServiceCollection();
+            var selectedComposition = new TestWorkerComposition();
+
+            services.AddWebJobsScriptHost(new ConfigurationBuilder().Build(), selectedComposition);
+            services.AddSingleton<IWorkerComposition>(new TestWorkerComposition());
+
+            using ServiceProvider provider = services.BuildServiceProvider();
+
+            Assert.Same(selectedComposition, provider.GetRequiredService<SelectedWorkerComposition>().Value);
+        }
+
+        [Fact]
+        public void AddWebJobsScriptHost_ThrowsWhenCompositionIsSelectedTwice()
+        {
+            var services = new ServiceCollection();
+            IConfiguration configuration = new ConfigurationBuilder().Build();
+            services.AddWebJobsScriptHost(configuration);
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+                () => services.AddWebJobsScriptHost(configuration));
+
+            Assert.True(string.Equals(
+                "A Functions Host composition has already been selected.",
+                exception.Message,
+                StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void AddWebJobsScriptHost_RegistersScriptHostActivationBeforeDependentHostedServices()
+        {
+            var services = new ServiceCollection();
+
+            services.AddWebJobsScriptHost(new ConfigurationBuilder().Build());
+
+            var hostedServiceDescriptors = services.Where(d => d.ServiceType == typeof(IHostedService)).ToList();
+            int assemblyAnalysisIndex = hostedServiceDescriptors.FindIndex(d => d.ImplementationType == typeof(AssemblyAnalysisService));
+            Assert.True(assemblyAnalysisIndex > 0);
+
+            ServiceDescriptor scriptHostActivation = hostedServiceDescriptors[assemblyAnalysisIndex - 1];
+            using ServiceProvider serviceProvider = new ServiceCollection().BuildServiceProvider();
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+                () => scriptHostActivation.ImplementationFactory(serviceProvider));
+            Assert.True(exception.Message.Contains(typeof(WebJobsScriptHostService).FullName, StringComparison.Ordinal));
+        }
+
         private static ServiceProvider BuildServiceProvider(IEnvironment environment)
         {
             var services = new ServiceCollection();
@@ -99,5 +197,39 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
 
             return services.BuildServiceProvider();
         }
+
+        private static void AssertService<TService, TImplementation>(IServiceCollection services)
+        {
+            ServiceDescriptor descriptor = Assert.Single(services.Where(d => d.ServiceType == typeof(TService)));
+            Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+            Assert.Equal(typeof(TImplementation), descriptor.ImplementationType);
+        }
+
+        private sealed class TestWorkerComposition : IWorkerComposition
+        {
+            public IMvcBuilder MvcBuilder { get; private set; }
+
+            public int WebHostConfigurationCount { get; private set; }
+
+            public void ConfigureWebHostServices(IServiceCollection services, IMvcBuilder mvcBuilder)
+            {
+                WebHostConfigurationCount++;
+                MvcBuilder = mvcBuilder;
+                services.AddSingleton<CompositionMarker>();
+                mvcBuilder.AddApplicationPart(typeof(CompositionTestController).Assembly);
+            }
+
+            public void ConfigureScriptHostServices(IServiceCollection services, System.IServiceProvider rootServiceProvider)
+            {
+            }
+        }
+
+        private sealed class CompositionMarker
+        {
+        }
+    }
+
+    public sealed class CompositionTestController : ControllerBase
+    {
     }
 }

--- a/test/WebJobs.Script.Tests/WebHost/WebHostServiceCollectionExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/WebHost/WebHostServiceCollectionExtensionsTests.cs
@@ -120,6 +120,16 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
         }
 
         [Fact]
+        public void AddWebJobsScriptHost_AllowsNullConfiguration()
+        {
+            var services = new ServiceCollection();
+
+            services.AddWebJobsScriptHost(configuration: null);
+
+            Assert.Contains(services, descriptor => descriptor.ServiceType == typeof(SelectedWorkerComposition));
+        }
+
+        [Fact]
         public void AddWebJobsScriptHost_AllowsCompositionToRegisterServicesAndControllers()
         {
             var services = new ServiceCollection();

--- a/test/WebJobs.Script.Tests/WebScriptHostBuilderExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/WebScriptHostBuilderExtensionsTests.cs
@@ -1,6 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+using Microsoft.Azure.WebJobs.Script.Composition;
+using Microsoft.Azure.WebJobs.Script.WebHost.Composition;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -62,6 +65,59 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 .Build();
 
             Assert.NotNull(host.Services.GetService<DeferredLogSource>());
+        }
+
+        [Fact]
+        public void AddWebScriptHost_UsesSelectedComposition()
+        {
+            var composition = new RecordingWorkerComposition(addCommonRpcServices: true);
+
+            using IHost host = new HostBuilder()
+                .ConfigureDefaultTestWebScriptHost(configureWebJobs: null, composition: composition)
+                .Build();
+
+            Assert.Equal(1, composition.ScriptHostConfigurationCount);
+        }
+
+        [Fact]
+        public void AddWebScriptHost_CompatibilityOverloadUsesRootSelection()
+        {
+            var composition = new RecordingWorkerComposition(addCommonRpcServices: false);
+
+            using IHost host = new HostBuilder()
+                .ConfigureDefaultTestWebScriptHost(
+                    configureWebJobs: null,
+                    configureRootServices: services => services.AddSingleton(new SelectedWorkerComposition(composition)))
+                .Build();
+
+            Assert.Equal(1, composition.ScriptHostConfigurationCount);
+        }
+
+        private sealed class RecordingWorkerComposition : IWorkerComposition
+        {
+            private readonly bool _addCommonRpcServices;
+
+            public RecordingWorkerComposition(bool addCommonRpcServices)
+            {
+                _addCommonRpcServices = addCommonRpcServices;
+            }
+
+            public int ScriptHostConfigurationCount { get; private set; }
+
+            public void ConfigureWebHostServices(IServiceCollection services, IMvcBuilder mvcBuilder)
+            {
+                ServerWorkerComposition.Instance.ConfigureWebHostServices(services, mvcBuilder);
+            }
+
+            public void ConfigureScriptHostServices(IServiceCollection services, IServiceProvider rootServiceProvider)
+            {
+                ScriptHostConfigurationCount++;
+                ServerWorkerComposition.Instance.ConfigureScriptHostServices(services, rootServiceProvider);
+                if (_addCommonRpcServices)
+                {
+                    services.AddCommonRpcServices();
+                }
+            }
         }
     }
 }

--- a/test/WebJobs.Script.Tests/WebScriptHostBuilderExtensionsTests.cs
+++ b/test/WebJobs.Script.Tests/WebScriptHostBuilderExtensionsTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Azure.WebJobs.Script.Composition;
+using Microsoft.Azure.WebJobs.Script.WebHost;
 using Microsoft.Azure.WebJobs.Script.WebHost.Composition;
 using Microsoft.Azure.WebJobs.Script.WebHost.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
@@ -65,6 +66,20 @@ namespace Microsoft.Azure.WebJobs.Script.Tests
                 .Build();
 
             Assert.NotNull(host.Services.GetService<DeferredLogSource>());
+        }
+
+        [Fact]
+        public void AddWebScriptHost_ThrowsWhenRootServiceProviderIsNull()
+        {
+            var builder = new HostBuilder();
+
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(
+                () => builder.AddWebScriptHost(
+                    rootServiceProvider: null,
+                    rootServices: new ServiceCollection(),
+                    webHostOptions: new ScriptApplicationHostOptions()));
+
+            Assert.True(string.Equals("rootServiceProvider", exception.ParamName, StringComparison.Ordinal));
         }
 
         [Fact]


### PR DESCRIPTION
Completes #11984

Adds an explicit worker-composition seam so worker architecture is selected statically by each executable rather than through runtime flags or DI replacement ordering.

- Adds `IWorkerComposition`.
- Adds the existing Server-backed behavior as `ServerWorkerComposition`.
- Adds an intentionally incomplete `ClientWorkerComposition`.
- Moves process initialization, host construction, startup, shutdown, and disposal into `FunctionsHost`.
- Adds the Linux-only `Azure.Functions.Host` executable.
- Keeps Rpc.Client and WorkerProxy out of the standard WebHost dependency graph.

## Why

Rpc.Server and Rpc.Client should remain sibling implementations over the shared gRPC contracts. The existing WebHost must continue using Rpc.Server without referencing incomplete Client functionality.

Each executable now selects its worker composition explicitly:

- `Microsoft.Azure.WebJobs.Script.WebHost` selects `ServerWorkerComposition`.
- `Azure.Functions.Host` selects `ClientWorkerComposition`.

This avoids:

- runtime topology flags
- last-registration-wins service replacement
- accidentally shipping Rpc.Client in the standard WebHost
- mixing Server and Client worker lifecycles in one process

`SelectedWorkerComposition` preserves the root selection for subsequent child ScriptHost builds and restarts. It uses an internal DI key so unrelated `IWorkerComposition` registrations cannot silently replace the selected worker architecture.

## Design

`IWorkerComposition` controls the worker-specific registration points:

- root WebHost worker services, MVC application parts, and ScriptHost activation
- child ScriptHost worker services

`ServerWorkerComposition` retains the current behavior:

- inbound FunctionRpc server
- local worker process and channel management
- process-backed metadata
- standard invocation dispatch
- automatic ScriptHost startup

`FunctionsHost` now owns the shared executable flow:

- process initialization
- host construction and configuration
- startup
- shutdown handling
- host disposal

Both product entrypoints call `FunctionsHost.RunAsync` with their selected composition.

## Azure.Functions.Host

Adds a Linux-only `Azure.Functions.Host` executable to make the future Client-backed flow explicit.

Its `ClientWorkerComposition` currently throws `NotImplementedException`. This is intentional: the assembly and static composition path exist, but no incomplete Client behavior is registered or runnable.

The Linux build:

- supports only `linux-x64`
- uses the ASP.NET shared framework
- preserves the existing runtime and ReadyToRun settings
- publishes one extensionless `Azure.Functions.Host` apphost
- excludes `web.config` and referenced standard WebHost entrypoint artifacts

## Deliberate limitations

This PR does not implement the Client-backed runtime.

`Azure.Functions.Host` currently references WebHost and therefore receives Rpc.Server transitively. A future `WebHost.Core` extraction can remove that dependency, but that larger assembly/package split is not required for this behavior-neutral seam.

Future work will add Client-backed metadata, dispatch, deferred ScriptHost startup, configuration delivery, lifecycle management, and compute-specific controllers exclusively through `Azure.Functions.Host`.

JIT/PreJIT changes are also deferred until the Client composition becomes runnable.

### Pull request checklist

**IMPORTANT**: Currently, changes must be backported to the `in-proc` branch to be included in Core Tools and non-Flex deployments.

* [x] Backporting to the `in-proc` branch is not required
    * Otherwise: Link to backporting PR
* [x] My changes **do not** require documentation changes
    * [ ] Otherwise: Documentation issue linked to PR
* [x] My changes **should not** be added to the release notes for the next release
    * [ ] Otherwise: I've added my notes to `release_notes.md`
* [x] My changes **do not** need to be backported to a previous version
    * [ ] Otherwise: Backport tracked by issue/PR #issue_or_pr
* [x] My changes **do not** require diagnostic events changes
    * Otherwise: I have added/updated all related diagnostic events and their documentation (Documentation issue linked to PR)
* [x] I have added all required tests (Unit tests, E2E tests)